### PR TITLE
Inbox design critique fixes: color, a11y, layout, logo, polish

### DIFF
--- a/apps/web/app/(claude-inbox)/_components/claude-icons.tsx
+++ b/apps/web/app/(claude-inbox)/_components/claude-icons.tsx
@@ -146,33 +146,30 @@ export function LogOutIcon(props: IconProps) {
 }
 
 /**
- * Adventure Scientists monogram logo. Drawn inline so the prototype has no
- * binary dependency — the outer circle has a small satellite dot at the
- * top-left and a simple two-peak mountain silhouette inside.
+ * Adventure Scientists monogram — inlined from the official AS-Mark SVG.
+ * The artwork is authored in a Y-flipped coordinate system (typical of
+ * converted Illustrator exports); we preserve the source `translate/scale`
+ * transform rather than re-projecting, so the paths stay pixel-identical to
+ * the asset on disk. Fill is `currentColor` so the caller can recolor via
+ * Tailwind text classes.
  */
 export function AdventureScientistsLogo(props: IconProps) {
   const { className, ...rest } = props;
   return (
     <svg
-      viewBox="0 0 24 24"
-      fill="none"
+      viewBox="0 0 1200 1200"
       aria-hidden="true"
       className={className}
       {...rest}
     >
-      <circle
-        cx="12"
-        cy="12"
-        r="9.25"
-        stroke="currentColor"
-        strokeWidth={1.4}
-        fill="none"
-      />
-      <circle cx="4.8" cy="6.3" r="1.5" fill="currentColor" />
-      <path
-        d="M6 16.25l3.9-5.3 2.6 3.1 2.1-2.5 3.4 4.7z"
+      <g
+        transform="translate(0,1200) scale(0.1,-0.1)"
         fill="currentColor"
-      />
+        stroke="none"
+      >
+        <path d="M5735 10984 c-705 -46 -1339 -214 -1944 -515 l-195 -97 -60 49 c-107 87 -223 129 -356 129 -392 0 -659 -393 -514 -756 l25 -63 -159 -156 c-503 -489 -890 -1066 -1151 -1712 -452 -1121 -475 -2393 -65 -3531 551 -1527 1813 -2692 3382 -3122 636 -175 1370 -218 2030 -120 1480 220 2785 1097 3554 2389 83 140 228 425 293 576 537 1254 535 2679 -7 3930 -192 444 -436 840 -756 1225 -130 156 -478 501 -640 635 -294 243 -587 433 -937 611 -546 276 -1132 447 -1745 510 -147 14 -627 26 -755 18z m616 -204 c611 -48 1173 -198 1714 -459 232 -112 357 -184 585 -336 272 -181 471 -345 716 -590 215 -214 311 -324 460 -522 645 -860 979 -1909 950 -2978 -7 -264 -23 -434 -66 -692 -73 -437 -204 -845 -404 -1258 -115 -236 -187 -363 -332 -580 -396 -595 -900 -1076 -1519 -1450 -971 -587 -2129 -805 -3255 -614 -1246 211 -2380 927 -3105 1960 -198 282 -424 697 -540 994 -296 753 -397 1567 -295 2372 115 897 481 1732 1074 2448 101 121 435 468 469 487 14 7 30 2 71 -27 119 -82 290 -114 430 -81 309 73 501 396 411 692 -14 45 -13 50 3 63 36 29 385 192 542 254 429 170 903 279 1370 316 154 12 566 13 721 1z" />
+        <path d="M5348 7940 c-9 -6 -497 -600 -1085 -1320 -713 -875 -1071 -1322 -1077 -1344 -13 -48 18 -107 65 -123 26 -9 672 -12 2747 -12 2949 -1 2754 -5 2800 54 31 39 28 86 -5 127 -96 114 -1650 1905 -1662 1915 -9 7 -34 13 -57 13 -48 0 -40 8 -373 -362 -118 -131 -217 -238 -221 -238 -4 0 -229 282 -501 628 -272 345 -504 637 -516 650 -24 24 -83 30 -115 12z" />
+      </g>
     </svg>
   );
 }

--- a/apps/web/app/(claude-inbox)/_components/claude-inbox-composer.tsx
+++ b/apps/web/app/(claude-inbox)/_components/claude-inbox-composer.tsx
@@ -61,7 +61,7 @@ export function ClaudeInboxComposer({
         </div>
         <button
           type="button"
-          className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 text-xs font-medium text-slate-700 shadow-sm hover:bg-slate-50"
+          className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition-colors duration-150 hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 motion-reduce:transition-none"
         >
           <SparkleIcon className="h-3.5 w-3.5 text-violet-600" />
           Draft with AI
@@ -117,22 +117,26 @@ export function ClaudeInboxComposer({
         />
       </div>
 
-      <div className="flex items-center justify-between border-t border-slate-100 px-5 py-3">
-        <p className="text-[11px] text-slate-500">
-          {mode === "note"
-            ? "Internal notes are visible only to operators."
-            : ""}
-        </p>
+      <div
+        className={`flex items-center border-t border-slate-100 px-5 py-3 ${
+          mode === "note" ? "justify-between" : "justify-end"
+        }`}
+      >
+        {mode === "note" ? (
+          <p className="text-[11px] text-slate-500">
+            Internal notes are visible only to operators.
+          </p>
+        ) : null}
         <div className="flex items-center gap-2">
           <button
             type="button"
-            className="rounded-lg px-3 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-100"
+            className="rounded-lg px-2.5 py-1.5 text-xs font-medium text-slate-600 transition-colors duration-150 hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 motion-reduce:transition-none"
           >
             Save draft
           </button>
           <button
             type="button"
-            className="inline-flex items-center gap-1.5 rounded-lg bg-slate-900 px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-slate-800"
+            className="inline-flex items-center gap-1.5 rounded-lg bg-slate-900 px-2.5 py-1.5 text-xs font-semibold text-white shadow-sm transition-colors duration-150 hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 motion-reduce:transition-none"
           >
             <SendIcon className="h-3.5 w-3.5" />
             {mode === "note" ? "Save note" : "Send"}

--- a/apps/web/app/(claude-inbox)/_components/claude-inbox-detail.tsx
+++ b/apps/web/app/(claude-inbox)/_components/claude-inbox-detail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import type { ClaudeInboxDetailViewModel } from "../_lib/view-models";
 import {
@@ -71,10 +71,10 @@ export function ClaudeInboxDetail({ detail }: DetailProps) {
               {contact.displayName}
             </h1>
             <div className="hidden h-5 w-px bg-slate-200 sm:block" />
-            <div className="hidden min-w-0 sm:block">
+            <div className="hidden min-w-0 flex-1 sm:block">
               {activeProject ? (
-                <div className="flex items-center gap-2 text-xs">
-                  <span className="truncate font-medium text-slate-700">
+                <div className="flex min-w-0 items-center gap-2 text-xs">
+                  <span className="min-w-0 truncate font-medium text-slate-700">
                     {activeProject.projectName} {activeProject.year.toString()}
                   </span>
                   <ProjectStatusBadge status={activeProject.status} />
@@ -92,9 +92,9 @@ export function ClaudeInboxDetail({ detail }: DetailProps) {
               onClick={() => {
                 toggleFollowUp(contact.contactId);
               }}
-              className={`inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs font-medium shadow-sm transition-colors duration-150 ${
+              className={`inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs font-medium shadow-sm transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 motion-reduce:transition-none ${
                 isFollowUp
-                  ? "border-amber-300 bg-amber-50 text-amber-800 hover:bg-amber-100"
+                  ? "border-rose-300 bg-rose-50 text-rose-800 hover:bg-rose-100"
                   : "border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
               }`}
             >
@@ -103,26 +103,37 @@ export function ClaudeInboxDetail({ detail }: DetailProps) {
             </button>
 
             <div className="relative">
-              <button
-                type="button"
-                aria-haspopup="dialog"
-                aria-expanded={reminderOpen}
-                onClick={() => {
-                  setReminderOpen((open) => !open);
-                }}
-                className={`inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs font-medium shadow-sm transition-colors duration-150 ${
-                  existingReminder
-                    ? "border-sky-300 bg-sky-50 text-sky-800 hover:bg-sky-100"
-                    : reminderOpen
+              {existingReminder ? (
+                <button
+                  type="button"
+                  aria-haspopup="dialog"
+                  aria-expanded={reminderOpen}
+                  onClick={() => {
+                    setReminderOpen((open) => !open);
+                  }}
+                  className="inline-flex items-center gap-1.5 rounded-lg border border-sky-300 bg-sky-50 px-2.5 py-1.5 text-xs font-medium text-sky-800 shadow-sm transition-colors duration-150 hover:bg-sky-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 motion-reduce:transition-none"
+                >
+                  <ClockIcon className="h-3.5 w-3.5" />
+                  Reminder · {formatShortReminder(existingReminder)}
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  aria-label="Set a reminder"
+                  aria-haspopup="dialog"
+                  aria-expanded={reminderOpen}
+                  onClick={() => {
+                    setReminderOpen((open) => !open);
+                  }}
+                  className={`inline-flex h-8 w-8 items-center justify-center rounded-lg border shadow-sm transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 motion-reduce:transition-none ${
+                    reminderOpen
                       ? "border-slate-300 bg-slate-100 text-slate-900"
                       : "border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
-                }`}
-              >
-                <ClockIcon className="h-3.5 w-3.5" />
-                {existingReminder
-                  ? `Reminder · ${formatShortReminder(existingReminder)}`
-                  : "Set a Reminder"}
-              </button>
+                  }`}
+                >
+                  <ClockIcon className="h-4 w-4" />
+                </button>
+              )}
               {reminderOpen ? (
                 <ReminderPopover
                   existing={existingReminder}
@@ -139,34 +150,30 @@ export function ClaudeInboxDetail({ detail }: DetailProps) {
               ) : null}
             </div>
 
-            {railOpen ? (
-              <button
-                type="button"
-                aria-label="Collapse volunteer details"
-                aria-expanded={true}
-                aria-controls="claude-inbox-contact-rail"
-                onClick={() => {
-                  setRailOpen(false);
-                }}
-                className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-slate-300 bg-slate-100 text-slate-900 shadow-sm transition-colors duration-150 hover:bg-slate-200"
-              >
+            <button
+              type="button"
+              aria-label={
+                railOpen
+                  ? "Collapse volunteer details"
+                  : "Expand volunteer details"
+              }
+              aria-expanded={railOpen}
+              aria-controls="claude-inbox-contact-rail"
+              onClick={() => {
+                setRailOpen((open) => !open);
+              }}
+              className={`inline-flex h-8 w-8 items-center justify-center rounded-lg border shadow-sm transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 motion-reduce:transition-none ${
+                railOpen
+                  ? "border-slate-300 bg-slate-100 text-slate-900 hover:bg-slate-200"
+                  : "border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
+              }`}
+            >
+              {railOpen ? (
                 <PanelRightCloseIcon className="h-4 w-4" />
-              </button>
-            ) : (
-              <button
-                type="button"
-                aria-label="Expand volunteer details"
-                aria-expanded={false}
-                aria-controls="claude-inbox-contact-rail"
-                onClick={() => {
-                  setRailOpen(true);
-                }}
-                className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition-colors duration-150 hover:bg-slate-50"
-              >
-                <PanelRightOpenIcon className="h-3.5 w-3.5" />
-                Volunteer Details
-              </button>
-            )}
+              ) : (
+                <PanelRightOpenIcon className="h-4 w-4" />
+              )}
+            </button>
           </div>
         </header>
 
@@ -214,6 +221,34 @@ function ReminderPopover({
   const numeric = Number(value);
   const canSet = value.length > 0 && Number.isFinite(numeric) && numeric > 0;
   const preview = canSet ? previewForDelta(numeric, unit) : null;
+
+  // Keyboard dismissal: bind an Escape listener while the popover is mounted
+  // so keyboard users have parity with the click-outside backdrop. The
+  // project tsconfig omits the DOM lib, so we narrow `globalThis` through
+  // unknown to reach `addEventListener` the same way the composer narrows
+  // input events.
+  useEffect(() => {
+    type KeyListener = (event: { readonly key: string }) => void;
+    const target = globalThis as unknown as {
+      readonly addEventListener: (
+        type: "keydown",
+        listener: KeyListener
+      ) => void;
+      readonly removeEventListener: (
+        type: "keydown",
+        listener: KeyListener
+      ) => void;
+    };
+    const handleKeyDown: KeyListener = (event) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+    target.addEventListener("keydown", handleKeyDown);
+    return () => {
+      target.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose]);
 
   return (
     <>
@@ -314,7 +349,7 @@ function ReminderPopover({
               <button
                 type="button"
                 onClick={onClose}
-                className="rounded-lg px-2.5 py-1.5 text-xs font-medium text-slate-600 transition-colors duration-150 hover:bg-slate-100"
+                className="rounded-lg px-2.5 py-1.5 text-xs font-medium text-slate-600 transition-colors duration-150 hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 motion-reduce:transition-none"
               >
                 Cancel
               </button>
@@ -322,7 +357,7 @@ function ReminderPopover({
                 type="button"
                 disabled={!canSet}
                 onClick={onSet}
-                className="inline-flex items-center gap-1.5 rounded-lg bg-slate-900 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-colors duration-150 hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-300"
+                className="inline-flex items-center gap-1.5 rounded-lg bg-slate-900 px-2.5 py-1.5 text-xs font-semibold text-white shadow-sm transition-colors duration-150 hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:bg-slate-300 motion-reduce:transition-none"
               >
                 Set reminder
               </button>

--- a/apps/web/app/(claude-inbox)/_components/claude-inbox-icon-rail.tsx
+++ b/apps/web/app/(claude-inbox)/_components/claude-inbox-icon-rail.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ComponentType, SVGProps } from "react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import {
   AdventureScientistsLogo,
@@ -60,14 +60,14 @@ export function ClaudeInboxIconRail() {
               type="button"
               aria-label={item.label}
               aria-current={item.active ? "page" : undefined}
-              className={`group relative flex h-10 w-10 items-center justify-center rounded-xl transition-colors duration-150 ${
+              className={`group relative flex h-10 w-10 items-center justify-center rounded-xl transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 motion-reduce:transition-none ${
                 item.active
                   ? "bg-slate-900 text-white"
                   : "text-slate-500 hover:bg-slate-100 hover:text-slate-900"
               }`}
             >
               <Icon className="h-5 w-5" />
-              <span className="pointer-events-none absolute left-12 z-30 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-xs font-medium text-white opacity-0 shadow-sm transition-opacity duration-150 group-hover:opacity-100">
+              <span className="pointer-events-none absolute left-12 z-30 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-xs font-medium text-white opacity-0 shadow-sm transition-opacity duration-150 group-hover:opacity-100 group-focus-visible:opacity-100 motion-reduce:transition-none">
                 {item.label}
               </span>
             </button>
@@ -82,16 +82,43 @@ export function ClaudeInboxIconRail() {
 
 function OperatorMenu() {
   const [open, setOpen] = useState(false);
+  // The menu is absolutely positioned ~12px to the right of the 36px avatar
+  // button, so the cursor briefly traverses empty space on its way from the
+  // avatar to "Log out". A naive `onMouseLeave={close}` fires during that
+  // transit and the menu disappears before the user can click. Debouncing
+  // the close with a short timer lets the cursor cross the gap without
+  // flicker; any re-entry (avatar OR menu) clears the pending close.
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancelClose = () => {
+    if (closeTimerRef.current !== null) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  };
+
+  const scheduleClose = () => {
+    cancelClose();
+    closeTimerRef.current = setTimeout(() => {
+      setOpen(false);
+      closeTimerRef.current = null;
+    }, 150);
+  };
+
+  useEffect(() => {
+    return () => {
+      cancelClose();
+    };
+  }, []);
 
   return (
     <div
       className="relative mt-2"
       onMouseEnter={() => {
+        cancelClose();
         setOpen(true);
       }}
-      onMouseLeave={() => {
-        setOpen(false);
-      }}
+      onMouseLeave={scheduleClose}
     >
       <button
         type="button"

--- a/apps/web/app/(claude-inbox)/_components/claude-inbox-list.tsx
+++ b/apps/web/app/(claude-inbox)/_components/claude-inbox-list.tsx
@@ -2,7 +2,7 @@
 
 import { usePathname } from "next/navigation";
 import type { ComponentType, SVGProps } from "react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import type {
   ClaudeInboxFilterId,
@@ -34,6 +34,16 @@ const FILTER_ICONS: Record<ClaudeInboxFilterId, IconComponent> = {
 };
 
 /**
+ * Internal active-filter state. The disclosure panel lets the operator pick
+ * one of the base filters OR one of the project buckets derived from the
+ * current `items` list. The two are mutually exclusive so there's only ever
+ * one active selection.
+ */
+type ActiveFilter =
+  | { readonly kind: "base"; readonly id: ClaudeInboxFilterId }
+  | { readonly kind: "project"; readonly label: string };
+
+/**
  * Client island: owns local view state for the Inbox column — active filter
  * selection and the inline filter-panel open/close. The underlying `items`
  * flow from the server-side selector; follow-up flags come from the shared
@@ -49,8 +59,10 @@ export function ClaudeInboxList({
   const activeContactId = extractContactId(pathname);
   const { followUp } = useClaudeInboxClient();
 
-  const [activeFilterId, setActiveFilterId] =
-    useState<ClaudeInboxFilterId>(initialFilterId);
+  const [activeFilter, setActiveFilter] = useState<ActiveFilter>({
+    kind: "base",
+    id: initialFilterId
+  });
   const [filtersOpen, setFiltersOpen] = useState(false);
 
   // Follow-up is client state, so we recompute its count here instead of
@@ -62,12 +74,32 @@ export function ClaudeInboxList({
     filter.id === "follow-up" ? { ...filter, count: followUpCount } : filter
   );
 
+  // Derive the project buckets from the current items list. Each distinct
+  // `projectLabel` becomes a filter option; null labels are excluded.
+  const projectBuckets = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const item of items) {
+      if (item.projectLabel) {
+        counts.set(item.projectLabel, (counts.get(item.projectLabel) ?? 0) + 1);
+      }
+    }
+    return Array.from(counts.entries())
+      .map(([label, count]) => ({ label, count }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [items]);
+
   const filteredItems = items.filter((item) =>
-    matchesFilter(item, activeFilterId, followUp)
+    matchesActiveFilter(item, activeFilter, followUp)
   );
-  const activeFilter =
-    filtersWithLiveCounts.find((filter) => filter.id === activeFilterId) ?? null;
-  const columnTitle = activeFilter?.label ?? "Inbox";
+
+  const columnTitle =
+    activeFilter.kind === "base"
+      ? (filtersWithLiveCounts.find((filter) => filter.id === activeFilter.id)
+          ?.label ?? "Inbox")
+      : activeFilter.label;
+
+  const isFilterActive =
+    activeFilter.kind === "project" || activeFilter.id !== "all";
 
   return (
     <section className="relative flex w-[22rem] shrink-0 flex-col overflow-hidden border-r border-slate-200 bg-white">
@@ -84,14 +116,14 @@ export function ClaudeInboxList({
             onClick={() => {
               setFiltersOpen((open) => !open);
             }}
-            className={`relative inline-flex h-8 w-8 items-center justify-center rounded-lg border shadow-sm transition-colors duration-150 ${
+            className={`relative inline-flex h-8 w-8 items-center justify-center rounded-lg border shadow-sm transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 motion-reduce:transition-none ${
               filtersOpen
                 ? "border-slate-300 bg-slate-100 text-slate-900"
                 : "border-slate-200 bg-white text-slate-600 hover:bg-slate-50"
             }`}
           >
             <FilterIcon className="h-4 w-4" />
-            {activeFilterId !== "all" ? (
+            {isFilterActive ? (
               <span className="absolute -right-1 -top-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-slate-900 px-1 text-[10px] font-semibold text-white tabular-nums ring-2 ring-white">
                 1
               </span>
@@ -112,36 +144,39 @@ export function ClaudeInboxList({
 
         {/*
           Inline disclosure panel: rendered as a sibling below the search row
-          but still inside the sticky header, so it sits between the top div
-          and the scrollable list rows. We animate `grid-template-rows` from
-          0fr → 1fr, a shadcn/Radix-style collapse trick that works with pure
-          Tailwind and keeps the panel's intrinsic height.
+          but still inside the sticky header. We animate `grid-template-rows`
+          from 0fr → 1fr, a shadcn/Radix-style collapse trick that works with
+          pure Tailwind and keeps the panel's intrinsic height. The panel
+          holds the base filters on top and a PROJECTS section underneath,
+          derived from the active project labels in the current list.
         */}
         <div
           id="claude-inbox-filters-panel"
           aria-hidden={!filtersOpen}
-          className={`grid overflow-hidden border-slate-200 transition-all duration-200 ease-out ${
+          className={`grid overflow-hidden border-slate-200 transition-all duration-200 ease-out motion-reduce:transition-none ${
             filtersOpen
               ? "grid-rows-[1fr] border-t opacity-100"
               : "grid-rows-[0fr] border-t-0 opacity-0"
           }`}
         >
           <div className="min-h-0">
-            <div className="px-5 py-4">
+            <div className="max-h-[60vh] overflow-y-auto px-5 py-4">
               <ul className="space-y-0.5">
                 {filtersWithLiveCounts.map((filter) => {
                   const Icon = FILTER_ICONS[filter.id];
-                  const isActive = filter.id === activeFilterId;
+                  const isActive =
+                    activeFilter.kind === "base" &&
+                    activeFilter.id === filter.id;
                   return (
                     <li key={filter.id}>
                       <button
                         type="button"
                         aria-pressed={isActive}
                         onClick={() => {
-                          setActiveFilterId(filter.id);
+                          setActiveFilter({ kind: "base", id: filter.id });
                           setFiltersOpen(false);
                         }}
-                        className={`flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left text-sm transition-colors duration-150 ${
+                        className={`flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left text-sm transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 motion-reduce:transition-none ${
                           isActive
                             ? "bg-slate-900 font-semibold text-white"
                             : "text-slate-600 hover:bg-slate-100 hover:text-slate-900"
@@ -151,7 +186,7 @@ export function ClaudeInboxList({
                         <span className="flex-1 truncate">{filter.label}</span>
                         <span
                           className={`text-xs tabular-nums ${
-                            isActive ? "text-white" : "text-slate-400"
+                            isActive ? "text-white" : "text-slate-500"
                           }`}
                         >
                           {filter.count}
@@ -161,6 +196,56 @@ export function ClaudeInboxList({
                   );
                 })}
               </ul>
+
+              {projectBuckets.length > 0 ? (
+                <>
+                  <div
+                    role="separator"
+                    className="my-3 border-t border-slate-100"
+                  />
+                  <p className="mb-1 px-2.5 text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+                    Projects
+                  </p>
+                  <ul className="space-y-0.5">
+                    {projectBuckets.map((bucket) => {
+                      const isActive =
+                        activeFilter.kind === "project" &&
+                        activeFilter.label === bucket.label;
+                      return (
+                        <li key={bucket.label}>
+                          <button
+                            type="button"
+                            aria-pressed={isActive}
+                            onClick={() => {
+                              setActiveFilter({
+                                kind: "project",
+                                label: bucket.label
+                              });
+                              setFiltersOpen(false);
+                            }}
+                            className={`flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left text-sm transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 motion-reduce:transition-none ${
+                              isActive
+                                ? "bg-slate-900 font-semibold text-white"
+                                : "text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+                            }`}
+                          >
+                            <span className="flex-1 truncate">
+                              {bucket.label}
+                            </span>
+                            <span
+                              className={`text-xs tabular-nums ${
+                                isActive ? "text-white" : "text-slate-500"
+                              }`}
+                            >
+                              {bucket.count}
+                            </span>
+                          </button>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </>
+              ) : null}
             </div>
           </div>
         </div>
@@ -196,12 +281,15 @@ function extractContactId(pathname: string | null): string | null {
   return match ? (match[1] ?? null) : null;
 }
 
-function matchesFilter(
+function matchesActiveFilter(
   item: ClaudeInboxListItemViewModel,
-  filterId: ClaudeInboxFilterId,
+  activeFilter: ActiveFilter,
   followUp: ReadonlySet<string>
 ): boolean {
-  switch (filterId) {
+  if (activeFilter.kind === "project") {
+    return item.projectLabel === activeFilter.label;
+  }
+  switch (activeFilter.id) {
     case "all":
       return true;
     case "unread":

--- a/apps/web/app/(claude-inbox)/_components/claude-inbox-row.tsx
+++ b/apps/web/app/(claude-inbox)/_components/claude-inbox-row.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import type { ClaudeInboxListItemViewModel } from "../_lib/view-models";
 import { ClaudeInboxAvatar } from "./claude-inbox-avatar";
 import { useClaudeInboxClient } from "./claude-inbox-client-provider";
-import { CornerUpLeftIcon, MailIcon, PhoneIcon } from "./claude-icons";
+import { MailIcon, PhoneIcon } from "./claude-icons";
 
 interface RowProps {
   readonly item: ClaudeInboxListItemViewModel;
@@ -15,9 +15,10 @@ interface RowProps {
 /**
  * List row for a contact. Stripped of starred / unresolved / stage badges
  * — those are no longer part of the inbox surface. The left accent bar is
- * sky when the row is unread and amber when the operator has flagged the
- * contact for follow-up; the follow-up case also surfaces a reply arrow
- * next to the channel icon so the state reads at a glance during a scan.
+ * sky when the row is unread and rose when the operator has flagged the
+ * contact for follow-up. The channel icon (mail/phone) is always preserved
+ * in the leading slot so operators keep their at-a-glance channel cue even
+ * on the rows most likely to need triaging.
  */
 export function ClaudeInboxRow({ item, isActive }: RowProps) {
   const { followUp } = useClaudeInboxClient();
@@ -26,7 +27,7 @@ export function ClaudeInboxRow({ item, isActive }: RowProps) {
   const ChannelIcon = item.latestChannel === "email" ? MailIcon : PhoneIcon;
 
   const accentClass = isFollowUp
-    ? "bg-amber-500"
+    ? "bg-rose-500"
     : isUnread
       ? "bg-sky-500"
       : null;
@@ -36,7 +37,7 @@ export function ClaudeInboxRow({ item, isActive }: RowProps) {
       <Link
         href={`/inbox/${item.contactId}`}
         aria-current={isActive ? "page" : undefined}
-        className={`relative flex gap-3 border-b border-slate-100 px-5 py-3.5 transition-colors duration-150 ${
+        className={`relative flex gap-3 border-b border-slate-100 px-5 py-3.5 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 motion-reduce:transition-none ${
           isActive
             ? "bg-sky-50/60 ring-1 ring-inset ring-sky-200"
             : "hover:bg-slate-50/80"
@@ -66,7 +67,7 @@ export function ClaudeInboxRow({ item, isActive }: RowProps) {
             </p>
             <span
               className={`shrink-0 text-[11px] tabular-nums ${
-                isUnread ? "font-semibold text-sky-700" : "text-slate-400"
+                isUnread ? "font-semibold text-sky-700" : "text-slate-500"
               }`}
             >
               {item.lastActivityLabel}
@@ -74,18 +75,14 @@ export function ClaudeInboxRow({ item, isActive }: RowProps) {
           </div>
 
           <div className="mt-0.5 flex items-center gap-1.5">
-            {isFollowUp ? (
-              <CornerUpLeftIcon
-                className="h-3 w-3 shrink-0 text-amber-600"
-                aria-label="Needs follow up"
-              />
-            ) : (
-              <ChannelIcon
-                className={`h-3 w-3 shrink-0 ${
-                  isUnread ? "text-sky-600" : "text-slate-400"
-                }`}
-              />
-            )}
+            <ChannelIcon
+              className={`h-3 w-3 shrink-0 ${
+                isUnread ? "text-sky-600" : "text-slate-400"
+              }`}
+              aria-label={
+                item.latestChannel === "email" ? "Email" : "SMS"
+              }
+            />
             <p
               className={`truncate text-[13px] ${
                 isUnread ? "font-medium text-slate-800" : "text-slate-600"


### PR DESCRIPTION
## Summary
- **Amber → rose-500** for follow-up accents (row bar, detail button, reply arrow) to resolve collision with internal-note amber
- **Always show channel icon** on follow-up rows; rose accent bar is the primary signal
- **Detail header horizontal budget**: flex-based project-name truncation, icon-only reminder button, unified Volunteer Details toggle
- **Filter disclosure restored** with base filters + derived PROJECTS section (discriminated-union state)
- **AS-Mark SVG** inlined as top-left logo (replaces placeholder monogram)
- **Operator menu hover gap** fixed with debounced 150ms close timer
- **Accessibility**: focus-visible rings on all interactive elements, Escape-to-dismiss on reminder popover, keyboard tooltip reveal on icon rail
- **Polish**: timestamp contrast slate-400→500, composer footer asymmetry fix, button padding standardized to px-2.5

## Test plan
- [ ] Open `/inbox`, verify AS-Mark logo renders top-left in the icon rail
- [ ] Click a conversation → confirm follow-up button uses rose (not amber) in pressed state
- [ ] Confirm follow-up rows show channel icon (mail/phone) with rose accent bar
- [ ] Resize browser to ~1200px width → long project name should ellipsize in detail header
- [ ] Set a Reminder button: icon-only square when no reminder, pill when reminder exists
- [ ] Open reminder popover → press Escape → popover closes
- [ ] Hover operator avatar (bottom-left) → move cursor to "Log out" → menu stays open
- [ ] Tab through header, icon rail, list rows → visible focus rings on all elements
- [ ] Icon rail: keyboard-focus a button → tooltip appears
- [ ] Filter button → disclosure opens with All / Unread / Needs Follow-Up + PROJECTS section
- [ ] Select a project filter → list filters to that project; column title updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)