### PR TITLE
Implement inbox UI product states and interactive composer

### DIFF
--- a/apps/web/app/(claude-inbox)/_components/claude-icons.tsx
+++ b/apps/web/app/(claude-inbox)/_components/claude-icons.tsx
@@ -1,0 +1,86 @@
+import type { SVGProps } from "react";
+
+/**
+ * Icon re-exports from lucide-react, plus the Adventure Scientists monogram.
+ *
+ * All inbox components import icons from this barrel so swapping the
+ * underlying icon library is a single-file change.
+ */
+export {
+  Inbox as InboxIcon,
+  Megaphone as MegaphoneIcon,
+  Settings as SettingsIcon,
+  Search as SearchIcon,
+  SlidersHorizontal as FilterIcon,
+  Mail as MailIcon,
+  Phone as PhoneIcon,
+  FileText as NoteIcon,
+  Sparkles as SparkleIcon,
+  Send as SendIcon,
+  ChevronRight as ChevronRightIcon,
+  MapPin as MapPinIcon,
+  Calendar as CalendarIcon,
+  Clock as ClockIcon,
+  PanelRightOpen as PanelRightOpenIcon,
+  PanelRightClose as PanelRightCloseIcon,
+  CornerUpLeft as CornerUpLeftIcon,
+  X as XIcon,
+  LogOut as LogOutIcon,
+  Loader2 as LoaderIcon,
+  CheckCircle2 as CheckCircleIcon,
+  AlertCircle as AlertCircleIcon,
+  AlertTriangle as AlertTriangleIcon,
+  XCircle as XCircleIcon,
+  RefreshCw as RefreshCwIcon,
+  Pencil as PencilIcon,
+  Trash2 as TrashIcon,
+  Wand2 as WandIcon,
+  Bot as BotIcon,
+  WifiOff as WifiOffIcon,
+  Save as SaveIcon,
+  RotateCcw as RotateCcwIcon,
+  ChevronDown as ChevronDownIcon,
+  ChevronUp as ChevronUpIcon,
+  SearchX as SearchXIcon,
+  Bold as BoldIcon,
+  Italic as ItalicIcon,
+  Link as LinkIcon,
+  Image as ImageIcon,
+  Paperclip as PaperclipIcon,
+  List as ListIcon,
+  ListOrdered as ListOrderedIcon,
+  Upload as UploadIcon,
+  FileIcon as FileDocIcon
+
+} from "lucide-react";
+
+type IconProps = Omit<SVGProps<SVGSVGElement>, "children">;
+
+/**
+ * Adventure Scientists monogram — inlined from the official AS-Mark SVG.
+ * The artwork is authored in a Y-flipped coordinate system (typical of
+ * converted Illustrator exports); we preserve the source `translate/scale`
+ * transform rather than re-projecting, so the paths stay pixel-identical to
+ * the asset on disk. Fill is `currentColor` so the caller can recolor via
+ * Tailwind text classes.
+ */
+export function AdventureScientistsLogo(props: IconProps) {
+  const { className, ...rest } = props;
+  return (
+    <svg
+      viewBox="0 0 1200 1200"
+      aria-hidden="true"
+      className={className}
+      {...rest}
+    >
+      <g
+        transform="translate(0,1200) scale(0.1,-0.1)"
+        fill="currentColor"
+        stroke="none"
+      >
+        <path d="M5735 10984 c-705 -46 -1339 -214 -1944 -515 l-195 -97 -60 49 c-107 87 -223 129 -356 129 -392 0 -659 -393 -514 -756 l25 -63 -159 -156 c-503 -489 -890 -1066 -1151 -1712 -452 -1121 -475 -2393 -65 -3531 551 -1527 1813 -2692 3382 -3122 636 -175 1370 -218 2030 -120 1480 220 2785 1097 3554 2389 83 140 228 425 293 576 537 1254 535 2679 -7 3930 -192 444 -436 840 -756 1225 -130 156 -478 501 -640 635 -294 243 -587 433 -937 611 -546 276 -1132 447 -1745 510 -147 14 -627 26 -755 18z m616 -204 c611 -48 1173 -198 1714 -459 232 -112 357 -184 585 -336 272 -181 471 -345 716 -590 215 -214 311 -324 460 -522 645 -860 979 -1909 950 -2978 -7 -264 -23 -434 -66 -692 -73 -437 -204 -845 -404 -1258 -115 -236 -187 -363 -332 -580 -396 -595 -900 -1076 -1519 -1450 -971 -587 -2129 -805 -3255 -614 -1246 211 -2380 927 -3105 1960 -198 282 -424 697 -540 994 -296 753 -397 1567 -295 2372 115 897 481 1732 1074 2448 101 121 435 468 469 487 14 7 30 2 71 -27 119 -82 290 -114 430 -81 309 73 501 396 411 692 -14 45 -13 50 3 63 36 29 385 192 542 254 429 170 903 279 1370 316 154 12 566 13 721 1z" />
+        <path d="M5348 7940 c-9 -6 -497 -600 -1085 -1320 -713 -875 -1071 -1322 -1077 -1344 -13 -48 18 -107 65 -123 26 -9 672 -12 2747 -12 2949 -1 2754 -5 2800 54 31 39 28 86 -5 127 -96 114 -1650 1905 -1662 1915 -9 7 -34 13 -57 13 -48 0 -40 8 -373 -362 -118 -131 -217 -238 -221 -238 -4 0 -229 282 -501 628 -272 345 -504 637 -516 650 -24 24 -83 30 -115 12z" />
+      </g>
+    </svg>
+  );
+}

--- a/apps/web/app/(claude-inbox)/_components/claude-inbox-avatar.tsx
+++ b/apps/web/app/(claude-inbox)/_components/claude-inbox-avatar.tsx
@@ -1,0 +1,41 @@
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { cn } from "@/lib/utils";
+
+import type { ClaudeAvatarTone } from "../_lib/view-models";
+
+const TONE_CLASSES: Record<ClaudeAvatarTone, string> = {
+  indigo: "bg-indigo-100 text-indigo-800 ring-indigo-200",
+  emerald: "bg-emerald-100 text-emerald-800 ring-emerald-200",
+  amber: "bg-amber-100 text-amber-800 ring-amber-200",
+  rose: "bg-rose-100 text-rose-800 ring-rose-200",
+  sky: "bg-sky-100 text-sky-800 ring-sky-200",
+  violet: "bg-violet-100 text-violet-800 ring-violet-200",
+  teal: "bg-teal-100 text-teal-800 ring-teal-200",
+  slate: "bg-slate-200 text-slate-700 ring-slate-300"
+};
+
+const SIZE_CLASSES = {
+  sm: "h-8 w-8 text-xs",
+  md: "h-10 w-10 text-sm",
+  lg: "h-14 w-14 text-base"
+} as const;
+
+interface ClaudeInboxAvatarProps {
+  readonly initials: string;
+  readonly tone: ClaudeAvatarTone;
+  readonly size?: keyof typeof SIZE_CLASSES;
+}
+
+export function ClaudeInboxAvatar({
+  initials,
+  tone,
+  size = "md"
+}: ClaudeInboxAvatarProps) {
+  return (
+    <Avatar className={cn("ring-1", SIZE_CLASSES[size])} aria-hidden="true">
+      <AvatarFallback className={cn("font-semibold", TONE_CLASSES[tone])}>
+        {initials}
+      </AvatarFallback>
+    </Avatar>
+  );
+}

--- a/apps/web/app/(claude-inbox)/_components/claude-inbox-badge.tsx
+++ b/apps/web/app/(claude-inbox)/_components/claude-inbox-badge.tsx
@@ -1,0 +1,58 @@
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+import type { ClaudeInboxBucket, ClaudeVolunteerStage } from "../_lib/view-models";
+
+const BUCKET_CLASSES: Record<ClaudeInboxBucket, string> = {
+  new: "bg-sky-600 text-white border-transparent hover:bg-sky-600",
+  opened: "bg-slate-200 text-slate-700 border-transparent hover:bg-slate-200"
+};
+
+const BUCKET_LABEL: Record<ClaudeInboxBucket, string> = {
+  new: "New",
+  opened: "Opened"
+};
+
+export function ClaudeBucketBadge({ bucket }: { readonly bucket: ClaudeInboxBucket }) {
+  return (
+    <Badge
+      className={cn(
+        "rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
+        BUCKET_CLASSES[bucket]
+      )}
+    >
+      {BUCKET_LABEL[bucket]}
+    </Badge>
+  );
+}
+
+const STAGE_CLASSES: Record<ClaudeVolunteerStage, string> = {
+  active: "bg-emerald-50 text-emerald-700 ring-emerald-200 border-transparent hover:bg-emerald-50",
+  alumni: "bg-violet-50 text-violet-700 ring-violet-200 border-transparent hover:bg-violet-50",
+  applicant: "bg-amber-50 text-amber-800 ring-amber-200 border-transparent hover:bg-amber-50",
+  prospect: "bg-sky-50 text-sky-700 ring-sky-200 border-transparent hover:bg-sky-50",
+  lead: "bg-indigo-50 text-indigo-700 ring-indigo-200 border-transparent hover:bg-indigo-50",
+  "non-volunteer": "bg-slate-100 text-slate-700 ring-slate-200 border-transparent hover:bg-slate-100"
+};
+
+const STAGE_LABEL: Record<ClaudeVolunteerStage, string> = {
+  active: "Active",
+  alumni: "Alumni",
+  applicant: "Applicant",
+  prospect: "Prospect",
+  lead: "Lead",
+  "non-volunteer": "Non-volunteer"
+};
+
+export function ClaudeStageBadge({ stage }: { readonly stage: ClaudeVolunteerStage }) {
+  return (
+    <Badge
+      className={cn(
+        "rounded-full px-2 py-0.5 text-[10px] font-medium ring-1 ring-inset",
+        STAGE_CLASSES[stage]
+      )}
+    >
+      {STAGE_LABEL[stage]}
+    </Badge>
+  );
+}

--- a/apps/web/app/(claude-inbox)/_components/claude-inbox-chip.tsx
+++ b/apps/web/app/(claude-inbox)/_components/claude-inbox-chip.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+
+type ChipTone = "neutral" | "info" | "warn" | "success";
+
+const TONE_CLASSES: Record<ChipTone, string> = {
+  neutral: "bg-slate-100 text-slate-700 ring-slate-200",
+  info: "bg-sky-50 text-sky-700 ring-sky-200",
+  warn: "bg-amber-50 text-amber-800 ring-amber-200",
+  success: "bg-emerald-50 text-emerald-700 ring-emerald-200"
+};
+
+interface ClaudeInboxChipProps {
+  readonly tone?: ChipTone;
+  readonly children: ReactNode;
+  readonly icon?: ReactNode;
+}
+
+export function ClaudeInboxChip({
+  tone = "neutral",
+  children,
+  icon
+}: ClaudeInboxChipProps) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium leading-5 ring-1 ring-inset ${TONE_CLASSES[tone]}`}
+    >
+      {icon ? <span className="flex h-3 w-3 items-center">{icon}</span> : null}
+      {children}
+    </span>
+  );
+}

--- a/apps/web/app/(claude-inbox)/_components/claude-inbox-client-provider.tsx
+++ b/apps/web/app/(claude-inbox)/_components/claude-inbox-client-provider.tsx
@@ -1,0 +1,357 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode
+} from "react";
+
+import type { ClaudeInboxBucket } from "../_lib/view-models";
+
+/**
+ * Prototype-local client state shared across the Inbox list column and
+ * Detail workspace. In a real build these would round-trip through server
+ * actions; for the prototype we keep them in React context so toggling a
+ * button in one panel immediately reflects in the other.
+ *
+ * Extended to cover every interactive state the UI needs:
+ *   - follow-up flags and reminders (original)
+ *   - search query + results
+ *   - active bucket tab (new / opened)
+ *   - composer status (idle → saving → saved / error → sending → sent / failed)
+ *   - AI draft lifecycle (idle → generating → inserted → edited / discarded)
+ *   - queue & timeline loading flags
+ */
+
+// ---------- Reminder ----------
+
+export interface Reminder {
+  readonly value: number;
+  readonly unit: "hours" | "days" | "weeks";
+  readonly firesAt: string;
+}
+
+// ---------- Composer status ----------
+
+export type ComposerStatus =
+  | "idle"
+  | "saving-draft"
+  | "draft-saved"
+  | "validation-error"
+  | "sending"
+  | "sent-success"
+  | "send-failure";
+
+export interface ComposerValidationError {
+  readonly field: "subject" | "body" | "recipient";
+  readonly message: string;
+}
+
+// ---------- AI draft lifecycle ----------
+
+export type AiDraftStatus =
+  | "idle"
+  | "generating"
+  | "inserted"
+  | "reprompting"
+  | "edited-after-generation"
+  | "discarded"
+  | "unavailable"
+  | "error";
+
+export interface AiDraftState {
+  readonly status: AiDraftStatus;
+  readonly prompt: string;
+  readonly generatedText: string;
+  readonly errorMessage: string | null;
+}
+
+const INITIAL_AI_DRAFT: AiDraftState = {
+  status: "idle",
+  prompt: "",
+  generatedText: "",
+  errorMessage: null
+};
+
+// ---------- Search ----------
+
+export interface SearchState {
+  readonly query: string;
+  readonly isActive: boolean;
+  readonly resultContactIds: readonly string[];
+}
+
+const INITIAL_SEARCH: SearchState = {
+  query: "",
+  isActive: false,
+  resultContactIds: []
+};
+
+// ---------- Context shape ----------
+
+interface ClaudeInboxClientState {
+  // Follow-up & reminders
+  readonly followUp: ReadonlySet<string>;
+  readonly reminders: ReadonlyMap<string, Reminder>;
+  readonly toggleFollowUp: (contactId: string) => void;
+  readonly setReminder: (contactId: string, reminder: Reminder) => void;
+  readonly clearReminder: (contactId: string) => void;
+
+  // Bucket tabs
+  readonly activeBucket: ClaudeInboxBucket | "all";
+  readonly setActiveBucket: (bucket: ClaudeInboxBucket | "all") => void;
+
+  // Search
+  readonly search: SearchState;
+  readonly setSearchQuery: (query: string) => void;
+  readonly setSearchResults: (contactIds: readonly string[]) => void;
+  readonly clearSearch: () => void;
+
+  // Loading flags
+  readonly isQueueLoading: boolean;
+  readonly setQueueLoading: (loading: boolean) => void;
+  readonly isTimelineLoading: boolean;
+  readonly setTimelineLoading: (loading: boolean) => void;
+
+  // Composer status
+  readonly composerStatus: ComposerStatus;
+  readonly composerErrors: readonly ComposerValidationError[];
+  readonly setComposerStatus: (status: ComposerStatus) => void;
+  readonly setComposerErrors: (errors: readonly ComposerValidationError[]) => void;
+
+  // AI drafting
+  readonly aiDraft: AiDraftState;
+  readonly startAiGeneration: (prompt: string) => void;
+  readonly insertAiDraft: (text: string) => void;
+  readonly markAiDraftEdited: () => void;
+  readonly discardAiDraft: () => void;
+  readonly repromptAi: (prompt: string) => void;
+  readonly setAiUnavailable: () => void;
+  readonly setAiError: (message: string) => void;
+  readonly resetAiDraft: () => void;
+}
+
+const ClaudeInboxClientContext = createContext<ClaudeInboxClientState | null>(
+  null
+);
+
+export function ClaudeInboxClientProvider({
+  children
+}: {
+  readonly children: ReactNode;
+}) {
+  // Follow-up & reminders
+  const [followUp, setFollowUp] = useState<ReadonlySet<string>>(
+    () => new Set<string>()
+  );
+  const [reminders, setReminders] = useState<ReadonlyMap<string, Reminder>>(
+    () => new Map<string, Reminder>()
+  );
+
+  const toggleFollowUp = useCallback((contactId: string) => {
+    setFollowUp((prev) => {
+      const next = new Set(prev);
+      if (next.has(contactId)) {
+        next.delete(contactId);
+      } else {
+        next.add(contactId);
+      }
+      return next;
+    });
+  }, []);
+
+  const setReminder = useCallback((contactId: string, reminder: Reminder) => {
+    setReminders((prev) => {
+      const next = new Map(prev);
+      next.set(contactId, reminder);
+      return next;
+    });
+  }, []);
+
+  const clearReminder = useCallback((contactId: string) => {
+    setReminders((prev) => {
+      if (!prev.has(contactId)) return prev;
+      const next = new Map(prev);
+      next.delete(contactId);
+      return next;
+    });
+  }, []);
+
+  // Bucket tabs
+  const [activeBucket, setActiveBucket] = useState<ClaudeInboxBucket | "all">(
+    "all"
+  );
+
+  // Search
+  const [search, setSearch] = useState<SearchState>(INITIAL_SEARCH);
+
+  const setSearchQuery = useCallback((query: string) => {
+    setSearch((prev) => ({
+      ...prev,
+      query,
+      isActive: query.length > 0
+    }));
+  }, []);
+
+  const setSearchResults = useCallback((contactIds: readonly string[]) => {
+    setSearch((prev) => ({
+      ...prev,
+      resultContactIds: contactIds
+    }));
+  }, []);
+
+  const clearSearch = useCallback(() => {
+    setSearch(INITIAL_SEARCH);
+  }, []);
+
+  // Loading flags
+  const [isQueueLoading, setQueueLoading] = useState(false);
+  const [isTimelineLoading, setTimelineLoading] = useState(false);
+
+  // Composer status
+  const [composerStatus, setComposerStatus] = useState<ComposerStatus>("idle");
+  const [composerErrors, setComposerErrors] = useState<
+    readonly ComposerValidationError[]
+  >([]);
+
+  // AI draft lifecycle
+  const [aiDraft, setAiDraft] = useState<AiDraftState>(INITIAL_AI_DRAFT);
+
+  const startAiGeneration = useCallback((prompt: string) => {
+    setAiDraft({
+      status: "generating",
+      prompt,
+      generatedText: "",
+      errorMessage: null
+    });
+  }, []);
+
+  const insertAiDraft = useCallback((text: string) => {
+    setAiDraft((prev) => ({
+      ...prev,
+      status: "inserted",
+      generatedText: text
+    }));
+  }, []);
+
+  const markAiDraftEdited = useCallback(() => {
+    setAiDraft((prev) => ({
+      ...prev,
+      status: "edited-after-generation"
+    }));
+  }, []);
+
+  const discardAiDraft = useCallback(() => {
+    setAiDraft((prev) => ({
+      ...prev,
+      status: "discarded",
+      generatedText: ""
+    }));
+  }, []);
+
+  const repromptAi = useCallback((prompt: string) => {
+    setAiDraft({
+      status: "reprompting",
+      prompt,
+      generatedText: "",
+      errorMessage: null
+    });
+  }, []);
+
+  const setAiUnavailable = useCallback(() => {
+    setAiDraft((prev) => ({
+      ...prev,
+      status: "unavailable",
+      errorMessage: "AI drafting is currently unavailable."
+    }));
+  }, []);
+
+  const setAiError = useCallback((message: string) => {
+    setAiDraft((prev) => ({
+      ...prev,
+      status: "error",
+      errorMessage: message
+    }));
+  }, []);
+
+  const resetAiDraft = useCallback(() => {
+    setAiDraft(INITIAL_AI_DRAFT);
+  }, []);
+
+  const value = useMemo<ClaudeInboxClientState>(
+    () => ({
+      followUp,
+      reminders,
+      toggleFollowUp,
+      setReminder,
+      clearReminder,
+      activeBucket,
+      setActiveBucket,
+      search,
+      setSearchQuery,
+      setSearchResults,
+      clearSearch,
+      isQueueLoading,
+      setQueueLoading,
+      isTimelineLoading,
+      setTimelineLoading,
+      composerStatus,
+      composerErrors,
+      setComposerStatus,
+      setComposerErrors,
+      aiDraft,
+      startAiGeneration,
+      insertAiDraft,
+      markAiDraftEdited,
+      discardAiDraft,
+      repromptAi,
+      setAiUnavailable,
+      setAiError,
+      resetAiDraft
+    }),
+    [
+      followUp,
+      reminders,
+      toggleFollowUp,
+      setReminder,
+      clearReminder,
+      activeBucket,
+      search,
+      setSearchQuery,
+      setSearchResults,
+      clearSearch,
+      isQueueLoading,
+      isTimelineLoading,
+      composerStatus,
+      composerErrors,
+      aiDraft,
+      startAiGeneration,
+      insertAiDraft,
+      markAiDraftEdited,
+      discardAiDraft,
+      repromptAi,
+      setAiUnavailable,
+      setAiError,
+      resetAiDraft
+    ]
+  );
+
+  return (
+    <ClaudeInboxClientContext.Provider value={value}>
+      {children}
+    </ClaudeInboxClientContext.Provider>
+  );
+}
+
+export function useClaudeInboxClient(): ClaudeInboxClientState {
+  const value = useContext(ClaudeInboxClientContext);
+  if (!value) {
+    throw new Error(
+      "useClaudeInboxClient must be used inside ClaudeInboxClientProvider"
+    );
+  }
+  return value;
+}

--- a/apps/web/app/(claude-inbox)/_components/claude-inbox-composer.tsx
+++ b/apps/web/app/(claude-inbox)/_components/claude-inbox-composer.tsx
@@ -1,0 +1,1170 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { cn } from "@/lib/utils";
+
+import {
+  useClaudeInboxClient,
+  type AiDraftStatus,
+  type ComposerStatus
+} from "./claude-inbox-client-provider";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger
+} from "@/components/ui/popover";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger
+} from "@/components/ui/tooltip";
+
+import {
+  AlertCircleIcon,
+  BoldIcon,
+  BotIcon,
+  CheckCircleIcon,
+  ChevronDownIcon,
+  FileDocIcon,
+  ImageIcon,
+  ItalicIcon,
+  LinkIcon,
+  ListIcon,
+  ListOrderedIcon,
+  LoaderIcon,
+  MailIcon,
+  NoteIcon,
+  PaperclipIcon,
+  PhoneIcon,
+  RefreshCwIcon,
+  RotateCcwIcon,
+  SendIcon,
+  SparkleIcon,
+  TrashIcon,
+  UploadIcon,
+  WifiOffIcon,
+  XCircleIcon,
+  XIcon
+} from "./claude-icons";
+
+type ComposerMode = "email" | "sms" | "note";
+
+interface ComposerProps {
+  readonly contactDisplayName: string;
+  readonly smsEligible: boolean;
+  readonly onOpenChange?: (open: boolean) => void;
+}
+
+const EMAIL_ALIASES = [
+  { id: "jordan", label: "Jordan Cole", email: "jordan@adventurescientists.org" },
+  { id: "team", label: "AS Team", email: "team@adventurescientists.org" },
+  { id: "noreply", label: "No Reply", email: "noreply@adventurescientists.org" }
+] as const;
+
+export function ClaudeInboxComposer({
+  contactDisplayName,
+  smsEligible,
+  onOpenChange
+}: ComposerProps) {
+  const [isOpen, setIsOpenRaw] = useState(false);
+
+  const setIsOpen = (open: boolean) => {
+    setIsOpenRaw(open);
+    onOpenChange?.(open);
+  };
+  const [mode, setMode] = useState<ComposerMode>("email");
+  const [draft, setDraft] = useState("");
+  const [subject, setSubject] = useState("");
+  const [fromAlias, setFromAlias] = useState<string>(EMAIL_ALIASES[0]!.id);
+  const [aiPrompt, setAiPrompt] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const {
+    composerStatus,
+    composerErrors,
+    setComposerStatus,
+    setComposerErrors,
+    aiDraft,
+    startAiGeneration,
+    insertAiDraft,
+    markAiDraftEdited,
+    discardAiDraft,
+    repromptAi,
+    resetAiDraft
+  } = useClaudeInboxClient();
+
+  const placeholder = placeholderForMode(mode, contactDisplayName);
+  const firstName =
+    contactDisplayName.split(" ")[0] ?? contactDisplayName;
+
+  // When AI finishes generating, place the text into the textarea
+  const prevStatus = useRef(aiDraft.status);
+  useEffect(() => {
+    if (
+      prevStatus.current !== "inserted" &&
+      aiDraft.status === "inserted" &&
+      aiDraft.generatedText
+    ) {
+      setDraft(aiDraft.generatedText);
+    }
+    if (
+      aiDraft.status === "generating" ||
+      aiDraft.status === "reprompting"
+    ) {
+      setIsOpen(true);
+    }
+    prevStatus.current = aiDraft.status;
+  }, [aiDraft.status, aiDraft.generatedText]);
+
+  // Auto-collapse after successful send
+  useEffect(() => {
+    if (composerStatus !== "sent-success") return undefined;
+    const timer = setTimeout(() => {
+      setIsOpen(false);
+    }, 2000);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [composerStatus]);
+
+  const handleSend = () => {
+    if (mode === "email" && !subject.trim()) {
+      setComposerErrors([
+        { field: "subject", message: "Subject is required" }
+      ]);
+      setComposerStatus("validation-error");
+      return;
+    }
+    if (!draft.trim()) {
+      setComposerErrors([
+        { field: "body", message: "Message body cannot be empty" }
+      ]);
+      setComposerStatus("validation-error");
+      return;
+    }
+    setComposerErrors([]);
+    setComposerStatus("sending");
+    setTimeout(() => {
+      if (Math.random() > 0.2) {
+        setComposerStatus("sent-success");
+        setDraft("");
+        setSubject("");
+        resetAiDraft();
+        setTimeout(() => {
+          setComposerStatus("idle");
+        }, 2500);
+      } else {
+        setComposerStatus("send-failure");
+      }
+    }, 1200);
+  };
+
+  const handleDraftWithAi = () => {
+    if (
+      aiDraft.status === "idle" ||
+      aiDraft.status === "discarded" ||
+      aiDraft.status === "error"
+    ) {
+      startAiGeneration("Draft a helpful reply");
+      setTimeout(() => {
+        insertAiDraft(
+          `Hi ${firstName},\n\nThanks for reaching out. I've looked into this and wanted to follow up with some next steps.\n\nLet me know if you have any questions.\n\nBest,\nJordan`
+        );
+      }, 2000);
+    }
+  };
+
+  const handleReprompt = () => {
+    repromptAi(aiPrompt || "Make it more concise");
+    setAiPrompt("");
+    setTimeout(() => {
+      insertAiDraft(
+        `Hi ${firstName},\n\nFollowing up on your message — here are the next steps. Let me know if questions come up.\n\nBest,\nJordan`
+      );
+    }, 1500);
+  };
+
+  const handleDiscard = () => {
+    setDraft("");
+    discardAiDraft();
+  };
+
+  const isShowingAiDraft =
+    aiDraft.status === "inserted" && draft === aiDraft.generatedText;
+  const isAiEdited = aiDraft.status === "edited-after-generation";
+  const isAiGenerating =
+    aiDraft.status === "generating" || aiDraft.status === "reprompting";
+  const hasAiDraftActive = isShowingAiDraft || isAiEdited;
+
+  // ───── Collapsed reply bar ─────
+  if (!isOpen) {
+    return (
+      <div className="border-t border-slate-200 bg-white">
+        <button
+          type="button"
+          onClick={() => {
+            setIsOpen(true);
+          }}
+          className="flex w-full items-center gap-2.5 px-5 py-3 text-left text-sm text-slate-400 transition-colors hover:bg-slate-50 hover:text-slate-600"
+        >
+          <MailIcon className="h-4 w-4 shrink-0" />
+          <span className="flex-1 truncate">
+            Reply to {contactDisplayName}…
+          </span>
+        </button>
+      </div>
+    );
+  }
+
+  // ───── Expanded composer ─────
+  return (
+    <div className="border-t border-slate-200 bg-white">
+      {/* Toolbar: mode tabs | AI button + minimize */}
+      <div className="flex items-center justify-between border-b border-slate-100 px-5 py-2">
+        <ToggleGroup
+          type="single"
+          value={mode}
+          onValueChange={(value) => {
+            if (value) setMode(value as ComposerMode);
+          }}
+          size="sm"
+          className="gap-1 rounded-lg bg-slate-100 p-0.5"
+        >
+          <ToggleGroupItem
+            value="email"
+            className="gap-1.5 rounded-md px-2.5 text-xs data-[state=on]:bg-white data-[state=on]:text-slate-900 data-[state=on]:shadow-sm [&_svg]:size-3.5"
+          >
+            <MailIcon className="h-3.5 w-3.5" />
+            Email
+          </ToggleGroupItem>
+          <ToggleGroupItem
+            value="sms"
+            disabled={!smsEligible}
+            title={smsEligible ? undefined : "No verified phone"}
+            className="gap-1.5 rounded-md px-2.5 text-xs data-[state=on]:bg-white data-[state=on]:text-slate-900 data-[state=on]:shadow-sm [&_svg]:size-3.5"
+          >
+            <PhoneIcon className="h-3.5 w-3.5" />
+            SMS
+          </ToggleGroupItem>
+          <ToggleGroupItem
+            value="note"
+            className="gap-1.5 rounded-md px-2.5 text-xs data-[state=on]:bg-white data-[state=on]:text-slate-900 data-[state=on]:shadow-sm [&_svg]:size-3.5"
+          >
+            <NoteIcon className="h-3.5 w-3.5" />
+            Note
+          </ToggleGroupItem>
+        </ToggleGroup>
+
+        <div className="flex items-center gap-1.5">
+          {/* Draft with AI — ALWAYS visible, state changes label */}
+          <AiButton
+            status={aiDraft.status}
+            onDraftWithAi={handleDraftWithAi}
+          />
+          <button
+            type="button"
+            aria-label="Minimize composer"
+            onClick={() => {
+              setIsOpen(false);
+            }}
+            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600"
+          >
+            <ChevronDownIcon className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* Inline AI status banners */}
+      {aiDraft.status === "error" ? (
+        <div className="flex items-center gap-2 border-b border-red-100 bg-red-50/60 px-5 py-2">
+          <AlertCircleIcon className="h-3.5 w-3.5 shrink-0 text-red-500" />
+          <p className="flex-1 text-xs text-red-700">
+            {aiDraft.errorMessage ?? "Something went wrong."}
+          </p>
+          <button
+            type="button"
+            onClick={resetAiDraft}
+            className="text-xs font-medium text-red-700 hover:text-red-900"
+          >
+            Try again
+          </button>
+        </div>
+      ) : null}
+
+      {aiDraft.status === "unavailable" ? (
+        <div className="flex items-center gap-2 border-b border-slate-100 bg-slate-50 px-5 py-2">
+          <WifiOffIcon className="h-3.5 w-3.5 shrink-0 text-slate-400" />
+          <p className="text-xs text-slate-500">
+            AI drafting is temporarily unavailable.
+          </p>
+        </div>
+      ) : null}
+
+      {/* Compose area */}
+      <div className={mode === "note" ? "bg-amber-50/50" : ""}>
+        {mode === "email" ? (
+          <>
+            <div className="flex items-center gap-2 border-b border-slate-100 px-5 py-2 text-xs">
+              <span className="w-12 shrink-0 font-medium text-slate-700">
+                From:
+              </span>
+              <select
+                value={fromAlias}
+                onChange={(e) => {
+                  const target = e.currentTarget as unknown as {
+                    readonly value: string;
+                  };
+                  setFromAlias(target.value);
+                }}
+                className="flex-1 bg-transparent text-xs text-slate-900 focus:outline-none"
+              >
+                {EMAIL_ALIASES.map((alias) => (
+                  <option key={alias.id} value={alias.id}>
+                    {alias.label} &lt;{alias.email}&gt;
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex items-center gap-2 border-b border-slate-100 px-5 py-2 text-xs">
+              <span className="w-12 shrink-0 font-medium text-slate-700">
+                To:
+              </span>
+              <span className="text-slate-600">{contactDisplayName}</span>
+            </div>
+            <div className="flex items-center gap-2 border-b border-slate-100 px-5 py-2 text-xs">
+              <label
+                htmlFor="claude-inbox-subject"
+                className="w-12 shrink-0 font-medium text-slate-700"
+              >
+                Subject:
+              </label>
+              <input
+                id="claude-inbox-subject"
+                type="text"
+                value={subject}
+                onChange={(event) => {
+                  const target = event.currentTarget as unknown as {
+                    readonly value: string;
+                  };
+                  setSubject(target.value);
+                  if (composerStatus === "validation-error") {
+                    setComposerStatus("idle");
+                    setComposerErrors([]);
+                  }
+                }}
+                placeholder="Add a subject"
+                className={cn(
+                  "flex-1 bg-transparent text-xs text-slate-900 placeholder:text-slate-400 focus:outline-none",
+                  composerStatus === "validation-error" &&
+                    composerErrors.some((e) => e.field === "subject") &&
+                    "text-red-700 placeholder:text-red-400"
+                )}
+              />
+            </div>
+          </>
+        ) : null}
+
+        {/* Textarea — or AI generating indicator */}
+        <div className="relative">
+          {isAiGenerating ? (
+            <div className="flex min-h-[8rem] items-center justify-center gap-3 px-5">
+              <BotIcon className="h-4 w-4 text-violet-500" />
+              <span className="text-xs text-violet-600">
+                {aiDraft.status === "reprompting"
+                  ? "Regenerating draft…"
+                  : "Writing a draft…"}
+              </span>
+              <div className="flex gap-1">
+                <span className="h-1 w-1 animate-bounce rounded-full bg-violet-400 [animation-delay:0ms]" />
+                <span className="h-1 w-1 animate-bounce rounded-full bg-violet-400 [animation-delay:150ms]" />
+                <span className="h-1 w-1 animate-bounce rounded-full bg-violet-400 [animation-delay:300ms]" />
+              </div>
+            </div>
+          ) : (
+            <textarea
+              ref={textareaRef}
+              value={draft}
+              onChange={(event) => {
+                const target = event.currentTarget as unknown as {
+                  readonly value: string;
+                };
+                setDraft(target.value);
+                if (composerStatus === "validation-error") {
+                  setComposerStatus("idle");
+                  setComposerErrors([]);
+                }
+                if (
+                  aiDraft.status === "inserted" &&
+                  target.value !== aiDraft.generatedText
+                ) {
+                  markAiDraftEdited();
+                }
+              }}
+              placeholder={placeholder}
+              rows={6}
+              className={cn(
+                "block w-full resize-none bg-transparent px-5 py-3 text-sm leading-6 text-slate-900 placeholder:text-slate-400 focus:outline-none",
+                composerStatus === "validation-error" &&
+                  composerErrors.some((e) => e.field === "body") &&
+                  "ring-1 ring-inset ring-red-200"
+              )}
+            />
+          )}
+
+          {hasAiDraftActive ? (
+            <div className="absolute left-0 top-0 h-full w-0.5 bg-violet-300" />
+          ) : null}
+        </div>
+      </div>
+
+      {/* Formatting toolbar */}
+      {!isAiGenerating ? <FormattingToolbar mode={mode} /> : null}
+
+      {/* AI draft toolbar — shown when AI content is in the textarea */}
+      {hasAiDraftActive ? (
+        <AiToolbar
+          isEdited={isAiEdited}
+          aiPrompt={aiPrompt}
+          onPromptChange={setAiPrompt}
+          onReprompt={handleReprompt}
+          onDiscard={handleDiscard}
+          disabled={isAiGenerating}
+        />
+      ) : null}
+
+      {/* Validation errors */}
+      {composerStatus === "validation-error" && composerErrors.length > 0 ? (
+        <div className="border-t border-red-100 bg-red-50/50 px-5 py-2">
+          {composerErrors.map((error) => (
+            <p
+              key={error.field}
+              className="flex items-center gap-1.5 text-xs text-red-700"
+            >
+              <AlertCircleIcon className="h-3 w-3 shrink-0" />
+              {error.message}
+            </p>
+          ))}
+        </div>
+      ) : null}
+
+      {/* Footer: status left, send right */}
+      <div className="flex items-center border-t border-slate-100 px-5 py-2.5">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <ComposerStatusIndicator
+            status={composerStatus}
+            onRetry={handleSend}
+            onDismiss={() => {
+              setComposerStatus("idle");
+            }}
+          />
+
+          {mode === "note" && composerStatus === "idle" ? (
+            <p className="text-[11px] text-slate-500">
+              Only visible to operators.
+            </p>
+          ) : null}
+
+          {composerStatus === "idle" &&
+          draft.length > 0 &&
+          !hasAiDraftActive ? (
+            <span className="flex items-center gap-1 text-[11px] text-slate-400">
+              <CheckCircleIcon className="h-3 w-3" />
+              Auto-saved
+            </span>
+          ) : null}
+        </div>
+
+        <Button
+          size="sm"
+          className="ml-3 gap-1.5"
+          disabled={
+            composerStatus === "sending" ||
+            composerStatus === "sent-success" ||
+            isAiGenerating
+          }
+          onClick={handleSend}
+        >
+          {composerStatus === "sending" ? (
+            <>
+              <LoaderIcon className="h-3.5 w-3.5 animate-spin" />
+              Sending…
+            </>
+          ) : composerStatus === "sent-success" ? (
+            <>
+              <CheckCircleIcon className="h-3.5 w-3.5" />
+              Sent
+            </>
+          ) : (
+            <>
+              <SendIcon className="h-3.5 w-3.5" />
+              {mode === "note" ? "Save note" : "Send"}
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ───── AI button (always visible in toolbar) ─────
+
+function AiButton({
+  status,
+  onDraftWithAi
+}: {
+  readonly status: AiDraftStatus;
+  readonly onDraftWithAi: () => void;
+}) {
+  // Generating / reprompting — show spinner
+  if (status === "generating" || status === "reprompting") {
+    return (
+      <Button variant="outline" size="sm" className="gap-1.5" disabled>
+        <LoaderIcon className="h-3.5 w-3.5 animate-spin text-violet-600" />
+        <span className="text-xs">Generating…</span>
+      </Button>
+    );
+  }
+
+  // Unavailable — disabled with note
+  if (status === "unavailable") {
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        className="gap-1.5 text-slate-400"
+        disabled
+      >
+        <WifiOffIcon className="h-3.5 w-3.5" />
+        <span className="text-xs">AI unavailable</span>
+      </Button>
+    );
+  }
+
+  // Draft is active (inserted or edited) — button still visible but secondary
+  if (status === "inserted" || status === "edited-after-generation") {
+    return (
+      <Button
+        variant="ghost"
+        size="sm"
+        className="gap-1.5 text-slate-400"
+        disabled
+      >
+        <SparkleIcon className="h-3.5 w-3.5" />
+        <span className="text-xs">AI active</span>
+      </Button>
+    );
+  }
+
+  // Default — ready to use
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      className="gap-1.5"
+      onClick={onDraftWithAi}
+    >
+      <SparkleIcon className="h-3.5 w-3.5 text-violet-600" />
+      <span className="text-xs">Draft with AI</span>
+    </Button>
+  );
+}
+
+// ───── Composer status indicator ─────
+
+function ComposerStatusIndicator({
+  status,
+  onRetry,
+  onDismiss
+}: {
+  readonly status: ComposerStatus;
+  readonly onRetry: () => void;
+  readonly onDismiss: () => void;
+}) {
+  switch (status) {
+    case "idle":
+      return null;
+    case "saving-draft":
+      return (
+        <span className="flex items-center gap-1.5 text-xs text-slate-500">
+          <LoaderIcon className="h-3 w-3 animate-spin" />
+          Saving…
+        </span>
+      );
+    case "draft-saved":
+      return (
+        <span className="flex items-center gap-1.5 text-xs text-emerald-700">
+          <CheckCircleIcon className="h-3 w-3" />
+          Saved
+        </span>
+      );
+    case "validation-error":
+      return (
+        <span className="flex items-center gap-1.5 text-xs text-red-600">
+          <AlertCircleIcon className="h-3 w-3" />
+          Fix errors above
+        </span>
+      );
+    case "sending":
+      return (
+        <span className="flex items-center gap-1.5 text-xs text-slate-500">
+          <LoaderIcon className="h-3 w-3 animate-spin" />
+          Sending…
+        </span>
+      );
+    case "sent-success":
+      return (
+        <span className="flex items-center gap-1.5 text-xs text-emerald-700">
+          <CheckCircleIcon className="h-3 w-3" />
+          Sent
+        </span>
+      );
+    case "send-failure":
+      return (
+        <div className="flex items-center gap-2">
+          <span className="flex items-center gap-1.5 text-xs text-red-600">
+            <XCircleIcon className="h-3 w-3" />
+            Failed
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-2 text-xs text-red-700 hover:text-red-900"
+            onClick={onRetry}
+          >
+            <RefreshCwIcon className="mr-1 h-3 w-3" />
+            Retry
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-2 text-xs text-slate-500"
+            onClick={onDismiss}
+          >
+            Dismiss
+          </Button>
+        </div>
+      );
+  }
+}
+
+// ───── AI draft toolbar ─────
+
+function AiToolbar({
+  isEdited,
+  aiPrompt,
+  onPromptChange,
+  onReprompt,
+  onDiscard,
+  disabled
+}: {
+  readonly isEdited: boolean;
+  readonly aiPrompt: string;
+  readonly onPromptChange: (v: string) => void;
+  readonly onReprompt: () => void;
+  readonly onDiscard: () => void;
+  readonly disabled: boolean;
+}) {
+  const [repromptOpen, setRepromptOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const openReprompt = () => {
+    setRepromptOpen(true);
+    setTimeout(() => {
+      const el = inputRef.current;
+      if (el && "focus" in el) {
+        (el as unknown as { focus: () => void }).focus();
+      }
+    }, 50);
+  };
+
+  const submitReprompt = () => {
+    onReprompt();
+    setRepromptOpen(false);
+  };
+
+  return (
+    <div className="flex items-center gap-2 border-t border-violet-100 bg-violet-50/40 px-5 py-1.5">
+      <SparkleIcon className="h-3 w-3 shrink-0 text-violet-500" />
+      <span className="text-[11px] font-medium text-violet-700">
+        {isEdited ? "AI draft · edited" : "AI draft"}
+      </span>
+
+      <div className="ml-auto flex items-center gap-1">
+        {repromptOpen ? (
+          <>
+            <div className="flex items-center overflow-hidden rounded-md border border-violet-200 bg-white shadow-sm">
+              <input
+                ref={inputRef}
+                type="text"
+                value={aiPrompt}
+                onChange={(e) => {
+                  const target = e.currentTarget as unknown as {
+                    readonly value: string;
+                  };
+                  onPromptChange(target.value);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") submitReprompt();
+                  if (e.key === "Escape") setRepromptOpen(false);
+                }}
+                placeholder="e.g. Make it shorter…"
+                className="w-48 px-2.5 py-1 text-[11px] text-slate-800 placeholder:text-slate-400 focus:outline-none"
+              />
+              <button
+                type="button"
+                onClick={submitReprompt}
+                disabled={disabled}
+                className="flex items-center border-l border-violet-200 bg-violet-50 px-2 py-1 text-violet-600 transition-colors hover:bg-violet-100 disabled:opacity-50"
+              >
+                <SendIcon className="h-3 w-3" />
+              </button>
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                setRepromptOpen(false);
+              }}
+              className="inline-flex h-6 w-6 items-center justify-center rounded text-slate-400 hover:text-slate-600"
+            >
+              <XIcon className="h-3 w-3" />
+            </button>
+          </>
+        ) : (
+          <button
+            type="button"
+            onClick={openReprompt}
+            disabled={disabled}
+            className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] font-medium text-violet-700 transition-colors hover:bg-violet-100 hover:text-violet-900 disabled:opacity-50"
+          >
+            <RotateCcwIcon className="h-3 w-3" />
+            Redo
+          </button>
+        )}
+        <div className="mx-0.5 h-3 w-px bg-violet-200" />
+        <button
+          type="button"
+          onClick={onDiscard}
+          className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] font-medium text-slate-500 transition-colors hover:text-red-600"
+        >
+          <TrashIcon className="h-3 w-3" />
+          Discard
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ───── Formatting toolbar ─────
+
+type LinkState = "idle" | "editing" | "inserted";
+type ImageState = "idle" | "picking" | "uploading" | "uploaded" | "error";
+type AttachState = "idle" | "picking" | "uploading" | "attached" | "error";
+
+interface AttachedFile {
+  readonly name: string;
+  readonly size: string;
+}
+
+function FormattingToolbar({ mode }: { readonly mode: ComposerMode }) {
+  // Text formatting (toggle states)
+  const [bold, setBold] = useState(false);
+  const [italic, setItalic] = useState(false);
+  const [list, setList] = useState<"none" | "bullet" | "ordered">("none");
+
+  // Link state
+  const [linkState, setLinkState] = useState<LinkState>("idle");
+  const [linkUrl, setLinkUrl] = useState("");
+  const [linkText, setLinkText] = useState("");
+
+  // Image embed state
+  const [imageState, setImageState] = useState<ImageState>("idle");
+  const [imagePreview, setImagePreview] = useState<string | null>(null);
+
+  // File attach state
+  const [attachState, setAttachState] = useState<AttachState>("idle");
+  const [attachedFiles, setAttachedFiles] = useState<readonly AttachedFile[]>(
+    []
+  );
+
+  const handleInsertLink = () => {
+    if (linkUrl.trim()) {
+      setLinkState("inserted");
+      setTimeout(() => {
+        setLinkState("idle");
+        setLinkUrl("");
+        setLinkText("");
+      }, 1500);
+    }
+  };
+
+  const handleImagePick = () => {
+    setImageState("uploading");
+    setTimeout(() => {
+      setImagePreview("landscape-photo.jpg");
+      setImageState("uploaded");
+    }, 1200);
+  };
+
+  const handleAttachFile = () => {
+    setAttachState("uploading");
+    setTimeout(() => {
+      setAttachedFiles((prev) => [
+        ...prev,
+        { name: "training-schedule.pdf", size: "245 KB" }
+      ]);
+      setAttachState("attached");
+    }, 1000);
+  };
+
+  const handleRemoveFile = (name: string) => {
+    setAttachedFiles((prev) => prev.filter((f) => f.name !== name));
+    if (attachedFiles.length <= 1) {
+      setAttachState("idle");
+    }
+  };
+
+  const handleRemoveImage = () => {
+    setImagePreview(null);
+    setImageState("idle");
+  };
+
+  const isSms = mode === "sms";
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <div className="border-t border-slate-100">
+        {/* Attached files strip */}
+        {attachedFiles.length > 0 ? (
+          <div className="flex flex-wrap gap-2 border-b border-slate-100 px-5 py-2">
+            {attachedFiles.map((file) => (
+              <span
+                key={file.name}
+                className="inline-flex items-center gap-1.5 rounded-md bg-slate-100 px-2 py-1 text-[11px] text-slate-700"
+              >
+                <FileDocIcon className="h-3 w-3 text-slate-500" />
+                {file.name}
+                <span className="text-slate-400">{file.size}</span>
+                <button
+                  type="button"
+                  onClick={() => {
+                    handleRemoveFile(file.name);
+                  }}
+                  className="ml-0.5 rounded p-0.5 text-slate-400 hover:text-red-500"
+                >
+                  <XIcon className="h-2.5 w-2.5" />
+                </button>
+              </span>
+            ))}
+          </div>
+        ) : null}
+
+        {/* Embedded image preview */}
+        {imagePreview ? (
+          <div className="border-b border-slate-100 px-5 py-2">
+            <div className="inline-flex items-center gap-2 rounded-md bg-emerald-50 px-2.5 py-1.5 text-[11px] text-emerald-700">
+              <ImageIcon className="h-3 w-3" />
+              <span className="font-medium">{imagePreview}</span>
+              <span className="text-emerald-500">embedded</span>
+              <button
+                type="button"
+                onClick={handleRemoveImage}
+                className="ml-1 rounded p-0.5 text-emerald-500 hover:text-red-500"
+              >
+                <XIcon className="h-2.5 w-2.5" />
+              </button>
+            </div>
+          </div>
+        ) : null}
+
+        {/* Toolbar buttons */}
+        <div className="flex items-center gap-0.5 px-4 py-1.5">
+          {/* Text formatting — email and note only */}
+          {!isSms ? (
+            <>
+              <ToolbarButton
+                icon={<BoldIcon className="h-3.5 w-3.5" />}
+                label="Bold"
+                active={bold}
+                onClick={() => {
+                  setBold((b) => !b);
+                }}
+              />
+              <ToolbarButton
+                icon={<ItalicIcon className="h-3.5 w-3.5" />}
+                label="Italic"
+                active={italic}
+                onClick={() => {
+                  setItalic((i) => !i);
+                }}
+              />
+              <ToolbarButton
+                icon={<ListIcon className="h-3.5 w-3.5" />}
+                label="Bullet list"
+                active={list === "bullet"}
+                onClick={() => {
+                  setList((l) => (l === "bullet" ? "none" : "bullet"));
+                }}
+              />
+              <ToolbarButton
+                icon={<ListOrderedIcon className="h-3.5 w-3.5" />}
+                label="Numbered list"
+                active={list === "ordered"}
+                onClick={() => {
+                  setList((l) => (l === "ordered" ? "none" : "ordered"));
+                }}
+              />
+
+              <div className="mx-1 h-4 w-px bg-slate-200" />
+            </>
+          ) : null}
+
+          {/* Add Link */}
+          <Popover
+            open={linkState === "editing"}
+            onOpenChange={(open) => {
+              setLinkState(open ? "editing" : "idle");
+            }}
+          >
+            <PopoverTrigger asChild>
+              <span>
+                <ToolbarButton
+                  icon={<LinkIcon className="h-3.5 w-3.5" />}
+                  label={
+                    linkState === "inserted" ? "Link inserted" : "Add link"
+                  }
+                  active={linkState === "editing"}
+                  success={linkState === "inserted"}
+                  onClick={() => {
+                    setLinkState("editing");
+                  }}
+                />
+              </span>
+            </PopoverTrigger>
+            <PopoverContent
+              align="start"
+              className="w-72"
+              onOpenAutoFocus={(e) => {
+                e.preventDefault();
+              }}
+            >
+              <div className="space-y-2">
+                <p className="text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+                  Insert link
+                </p>
+                <input
+                  type="text"
+                  value={linkUrl}
+                  onChange={(e) => {
+                    const target = e.currentTarget as unknown as {
+                      readonly value: string;
+                    };
+                    setLinkUrl(target.value);
+                  }}
+                  placeholder="https://…"
+                  className="w-full rounded-md border border-slate-200 px-2.5 py-1.5 text-xs text-slate-900 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-300"
+                />
+                <input
+                  type="text"
+                  value={linkText}
+                  onChange={(e) => {
+                    const target = e.currentTarget as unknown as {
+                      readonly value: string;
+                    };
+                    setLinkText(target.value);
+                  }}
+                  placeholder="Display text (optional)"
+                  className="w-full rounded-md border border-slate-200 px-2.5 py-1.5 text-xs text-slate-900 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-300"
+                />
+                <div className="flex justify-end gap-2 pt-1">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 text-xs"
+                    onClick={() => {
+                      setLinkState("idle");
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    size="sm"
+                    className="h-7 text-xs"
+                    disabled={!linkUrl.trim()}
+                    onClick={handleInsertLink}
+                  >
+                    Insert
+                  </Button>
+                </div>
+              </div>
+            </PopoverContent>
+          </Popover>
+
+          {/* Embed Image — email and note only */}
+          {!isSms ? (
+            <Popover
+              open={imageState === "picking"}
+              onOpenChange={(open) => {
+                setImageState(open ? "picking" : "idle");
+              }}
+            >
+              <PopoverTrigger asChild>
+                <span>
+                  <ToolbarButton
+                    icon={
+                      imageState === "uploading" ? (
+                        <LoaderIcon className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <ImageIcon className="h-3.5 w-3.5" />
+                      )
+                    }
+                    label={
+                      imageState === "uploading"
+                        ? "Uploading…"
+                        : imageState === "uploaded"
+                          ? "Image embedded"
+                          : imageState === "error"
+                            ? "Upload failed"
+                            : "Embed image"
+                    }
+                    active={imageState === "picking"}
+                    success={imageState === "uploaded"}
+                    error={imageState === "error"}
+                    disabled={imageState === "uploading"}
+                    onClick={() => {
+                      if (
+                        imageState === "idle" ||
+                        imageState === "error"
+                      ) {
+                        setImageState("picking");
+                      }
+                    }}
+                  />
+                </span>
+              </PopoverTrigger>
+              <PopoverContent align="start" className="w-64">
+                <div className="space-y-3">
+                  <p className="text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+                    Embed image
+                  </p>
+                  <button
+                    type="button"
+                    onClick={handleImagePick}
+                    className="flex w-full items-center justify-center gap-2 rounded-lg border-2 border-dashed border-slate-300 py-6 text-xs text-slate-500 transition-colors hover:border-slate-400 hover:bg-slate-50 hover:text-slate-700"
+                  >
+                    <UploadIcon className="h-4 w-4" />
+                    Choose image or drag here
+                  </button>
+                  <p className="text-center text-[10px] text-slate-400">
+                    PNG, JPG, GIF up to 5 MB
+                  </p>
+                </div>
+              </PopoverContent>
+            </Popover>
+          ) : null}
+
+          {/* Attach File */}
+          <ToolbarButton
+            icon={
+              attachState === "uploading" ? (
+                <LoaderIcon className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <PaperclipIcon className="h-3.5 w-3.5" />
+              )
+            }
+            label={
+              attachState === "uploading"
+                ? "Uploading…"
+                : attachState === "attached"
+                  ? `${attachedFiles.length.toString()} attached`
+                  : attachState === "error"
+                    ? "Attach failed"
+                    : "Attach file"
+            }
+            error={attachState === "error"}
+            disabled={attachState === "uploading"}
+            onClick={() => {
+              if (
+                attachState === "idle" ||
+                attachState === "attached" ||
+                attachState === "error"
+              ) {
+                handleAttachFile();
+              }
+            }}
+          />
+        </div>
+      </div>
+    </TooltipProvider>
+  );
+}
+
+// ───── Toolbar button primitive ─────
+
+function ToolbarButton({
+  icon,
+  label,
+  active = false,
+  success = false,
+  error = false,
+  disabled = false,
+  onClick
+}: {
+  readonly icon: React.ReactNode;
+  readonly label: string;
+  readonly active?: boolean;
+  readonly success?: boolean;
+  readonly error?: boolean;
+  readonly disabled?: boolean;
+  readonly onClick?: () => void;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label={label}
+          aria-pressed={active}
+          disabled={disabled}
+          onClick={onClick}
+          className={cn(
+            "inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400",
+            "disabled:pointer-events-none disabled:opacity-40",
+            active
+              ? "bg-slate-200 text-slate-900"
+              : success
+                ? "text-emerald-600"
+                : error
+                  ? "text-red-500"
+                  : "text-slate-500 hover:bg-slate-100 hover:text-slate-900"
+          )}
+        >
+          {icon}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent
+        side="top"
+        className="rounded bg-slate-900 px-2 py-1 text-[11px] text-white"
+      >
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+// ───── Helpers ─────
+
+function placeholderForMode(mode: ComposerMode, name: string): string {
+  switch (mode) {
+    case "email":
+      return `Reply to ${name}…`;
+    case "sms":
+      return `Text ${name}…`;
+    case "note":
+      return "Write a note for the team — not visible to the contact.";
+  }
+}

--- a/apps/web/app/(claude-inbox)/_components/claude-inbox-contact-rail.tsx
+++ b/apps/web/app/(claude-inbox)/_components/claude-inbox-contact-rail.tsx
@@ -1,0 +1,223 @@
+import type {
+  ClaudeContactSummaryViewModel,
+  ClaudeProjectMembershipViewModel,
+  ClaudeProjectStatus
+} from "../_lib/view-models";
+import { Button } from "@/components/ui/button";
+
+import {
+  CalendarIcon,
+  ChevronRightIcon,
+  MailIcon,
+  MapPinIcon,
+  PanelRightCloseIcon,
+  PhoneIcon
+} from "./claude-icons";
+
+interface RailProps {
+  readonly contact: ClaudeContactSummaryViewModel;
+  readonly onClose?: () => void;
+}
+
+/**
+ * Server component: renders volunteer reference data for the detail workspace.
+ *
+ * Starts with a minimal name + volunteer ID header (no avatar placeholder,
+ * no stage badge), then contact details, active and past project
+ * participations, and milestone activity. Visibility is controlled by the
+ * parent detail component via conditional render.
+ */
+export function ClaudeInboxContactRail({ contact, onClose }: RailProps) {
+  return (
+    <aside
+      id="claude-inbox-contact-rail"
+      className="flex min-h-0 w-80 shrink-0 flex-col bg-slate-50/40"
+      aria-label="Volunteer details"
+    >
+      <header className="flex h-[65px] shrink-0 items-center gap-2 border-b border-slate-200 bg-white px-5">
+        <div className="min-w-0 flex-1">
+          <h2 className="truncate text-sm font-semibold text-slate-900">
+            {contact.displayName}
+          </h2>
+          <p className="mt-0.5 text-[11px] font-medium uppercase tracking-wide text-slate-500">
+            Volunteer ID · {contact.volunteerId}
+          </p>
+        </div>
+        {onClose ? (
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-8 w-8 shrink-0"
+            aria-label="Collapse volunteer details"
+            onClick={onClose}
+          >
+            <PanelRightCloseIcon className="h-4 w-4" />
+          </Button>
+        ) : null}
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+      <section className="border-b border-slate-200 px-5 py-4">
+        <h3 className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+          Contact
+        </h3>
+        <dl className="mt-2 space-y-1.5 text-[13px]">
+          {contact.primaryEmail ? (
+            <ContactLine icon={<MailIcon className="h-3.5 w-3.5" />}>
+              {contact.primaryEmail}
+            </ContactLine>
+          ) : null}
+          {contact.primaryPhone ? (
+            <ContactLine icon={<PhoneIcon className="h-3.5 w-3.5" />}>
+              {contact.primaryPhone}
+            </ContactLine>
+          ) : null}
+          {contact.cityState ? (
+            <ContactLine icon={<MapPinIcon className="h-3.5 w-3.5" />}>
+              {contact.cityState}
+            </ContactLine>
+          ) : null}
+          <ContactLine icon={<CalendarIcon className="h-3.5 w-3.5" />}>
+            {contact.joinedAtLabel}
+          </ContactLine>
+        </dl>
+      </section>
+
+      <ProjectsSection
+        title="Active Projects"
+        projects={contact.activeProjects}
+        emptyLabel="No active projects"
+      />
+      <ProjectsSection
+        title="Past Projects"
+        projects={contact.pastProjects}
+        emptyLabel="No past projects"
+      />
+
+      {contact.recentActivity.length > 0 ? (
+        <section className="px-5 py-4">
+          <h3 className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+            Recent activity
+          </h3>
+          <ul className="mt-3 space-y-0">
+            {contact.recentActivity.map((entry, index) => (
+              <li
+                key={entry.id}
+                className="relative flex gap-3 pb-4 last:pb-0"
+              >
+                {/* Vertical connector line */}
+                {index < contact.recentActivity.length - 1 ? (
+                  <div className="absolute left-[5px] top-3 h-full w-px bg-slate-200" />
+                ) : null}
+                {/* Dot */}
+                <div className="relative mt-1.5 h-[11px] w-[11px] shrink-0 rounded-full border-2 border-slate-300 bg-white" />
+                <div className="min-w-0 flex-1">
+                  <p className="text-[13px] leading-snug text-slate-700">
+                    {entry.label}
+                  </p>
+                  <p className="text-[11px] text-slate-400">
+                    {entry.occurredAtLabel}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+      </div>
+    </aside>
+  );
+}
+
+interface ProjectsSectionProps {
+  readonly title: string;
+  readonly projects: readonly ClaudeProjectMembershipViewModel[];
+  readonly emptyLabel: string;
+}
+
+function ProjectsSection({ title, projects, emptyLabel }: ProjectsSectionProps) {
+  return (
+    <section className="border-b border-slate-200 px-5 py-4">
+      <h3 className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+        {title}
+      </h3>
+      {projects.length === 0 ? (
+        <p className="mt-2 text-[12px] text-slate-400">{emptyLabel}</p>
+      ) : (
+        <ul className="mt-2 space-y-1">
+          {projects.map((project) => (
+            <li key={project.membershipId}>
+              <a
+                href={project.crmUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="group flex items-center gap-2 rounded-lg px-2 py-1.5 transition hover:bg-white hover:ring-1 hover:ring-slate-200"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-[13px] font-medium text-slate-800 group-hover:text-slate-900">
+                    {project.projectName}
+                  </p>
+                  <p className="mt-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
+                    <span className="tabular-nums">
+                      {project.year.toString()}
+                    </span>
+                    <span className="text-slate-300">·</span>
+                    <ProjectStatusBadge status={project.status} />
+                  </p>
+                </div>
+                <ChevronRightIcon className="h-3.5 w-3.5 shrink-0 text-slate-300 group-hover:text-slate-500" />
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+const PROJECT_STATUS_STYLE: Record<ClaudeProjectStatus, string> = {
+  lead: "bg-slate-100 text-slate-600",
+  applied: "bg-sky-50 text-sky-700",
+  "in-training": "bg-indigo-50 text-indigo-700",
+  "trip-planning": "bg-amber-50 text-amber-700",
+  "in-field": "bg-emerald-50 text-emerald-700",
+  successful: "bg-violet-50 text-violet-700"
+};
+
+const PROJECT_STATUS_LABEL: Record<ClaudeProjectStatus, string> = {
+  lead: "Lead",
+  applied: "Applied",
+  "in-training": "In Training",
+  "trip-planning": "Trip Planning",
+  "in-field": "In the Field",
+  successful: "Successful"
+};
+
+export function ProjectStatusBadge({
+  status
+}: {
+  readonly status: ClaudeProjectStatus;
+}) {
+  return (
+    <span
+      className={`inline-flex items-center rounded px-1.5 py-px text-[10px] font-medium ${PROJECT_STATUS_STYLE[status]}`}
+    >
+      {PROJECT_STATUS_LABEL[status]}
+    </span>
+  );
+}
+
+function ContactLine({
+  icon,
+  children
+}: {
+  readonly icon: React.ReactNode;
+  readonly children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-2 text-slate-700">
+      <span className="text-slate-400">{icon}</span>
+      <span className="truncate">{children}</span>
+    </div>
+  );
+}

--- a/apps/web/app/(claude-inbox)/_components/claude-inbox-detail.tsx
+++ b/apps/web/app/(claude-inbox)/_components/claude-inbox-detail.tsx
@@ -1,0 +1,515 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+import type { ClaudeInboxDetailViewModel } from "../_lib/view-models";
+import {
+  useClaudeInboxClient,
+  type Reminder
+} from "./claude-inbox-client-provider";
+import { ClaudeInboxComposer } from "./claude-inbox-composer";
+import {
+  ClaudeInboxContactRail,
+  ProjectStatusBadge
+} from "./claude-inbox-contact-rail";
+import { TimelineSkeleton } from "./claude-inbox-loading";
+import { ClaudeInboxTimeline } from "./claude-inbox-timeline";
+import {
+  AlertTriangleIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+  ClockIcon,
+  CornerUpLeftIcon,
+  PanelRightOpenIcon,
+  XIcon
+} from "./claude-icons";
+
+interface DetailProps {
+  readonly detail: ClaudeInboxDetailViewModel;
+}
+
+type ReminderUnit = "hours" | "days" | "weeks";
+
+export function ClaudeInboxDetail({ detail }: DetailProps) {
+  const { contact, timeline, smsEligible } = detail;
+  const timelineRef = useRef<HTMLDivElement>(null);
+  const {
+    followUp,
+    toggleFollowUp,
+    reminders,
+    setReminder,
+    clearReminder,
+    isTimelineLoading
+  } = useClaudeInboxClient();
+
+  const [railOpen, setRailOpen] = useState(false);
+  const [reminderOpen, setReminderOpen] = useState(false);
+  const [reminderValue, setReminderValue] = useState("");
+  const [reminderUnit, setReminderUnit] = useState<ReminderUnit>("hours");
+
+  const activeProject = contact.activeProjects[0] ?? null;
+  const firstName = contact.displayName.split(" ")[0] ?? contact.displayName;
+
+  const isFollowUp = followUp.has(contact.contactId);
+  const existingReminder = reminders.get(contact.contactId) ?? null;
+
+  const handleSetReminder = () => {
+    const numeric = Number(reminderValue);
+    if (!Number.isFinite(numeric) || numeric <= 0) return;
+    setReminder(contact.contactId, buildReminder(numeric, reminderUnit));
+    setReminderValue("");
+    setReminderOpen(false);
+  };
+
+  const handleClearReminder = () => {
+    clearReminder(contact.contactId);
+    setReminderOpen(false);
+  };
+
+  return (
+    <div className="flex min-h-0 flex-1">
+      <section className="flex min-w-0 flex-1 flex-col border-r border-slate-200 bg-white">
+        {/* Detail header */}
+        <header className="flex h-[65px] items-center justify-between gap-4 border-b border-slate-200 px-6">
+          <div className="flex min-w-0 items-center gap-4">
+            <h1 className="truncate text-lg font-semibold text-slate-900">
+              {contact.displayName}
+            </h1>
+            <div className="hidden h-5 w-px bg-slate-200 sm:block" />
+            <div className="hidden min-w-0 flex-1 sm:block">
+              {activeProject ? (
+                <div className="flex min-w-0 items-center gap-2 text-xs">
+                  <span className="min-w-0 truncate font-medium text-slate-700">
+                    {activeProject.projectName}{" "}
+                    {activeProject.year.toString()}
+                  </span>
+                  <ProjectStatusBadge status={activeProject.status} />
+                </div>
+              ) : (
+                <span className="text-xs text-slate-400">
+                  No active project
+                </span>
+              )}
+            </div>
+          </div>
+
+          <div className="flex shrink-0 items-center gap-2">
+            {/* Needs Follow Up toggle — off / on */}
+            <Button
+              variant="outline"
+              size="sm"
+              aria-pressed={isFollowUp}
+              onClick={() => {
+                toggleFollowUp(contact.contactId);
+              }}
+              className={cn(
+                "gap-1.5",
+                isFollowUp &&
+                  "border-rose-300 bg-rose-50 text-rose-800 hover:bg-rose-100 hover:text-rose-800"
+              )}
+            >
+              <CornerUpLeftIcon className="h-3.5 w-3.5" />
+              Needs Follow Up
+            </Button>
+
+            {/* Reminder popover */}
+            <Popover open={reminderOpen} onOpenChange={setReminderOpen}>
+              <PopoverTrigger asChild>
+                {existingReminder ? (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="gap-1.5 border-sky-300 bg-sky-50 text-sky-800 hover:bg-sky-100 hover:text-sky-800"
+                  >
+                    <ClockIcon className="h-3.5 w-3.5" />
+                    Reminder · {formatShortReminder(existingReminder)}
+                  </Button>
+                ) : (
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    className="h-8 w-8"
+                    aria-label="Set a reminder"
+                  >
+                    <ClockIcon className="h-4 w-4" />
+                  </Button>
+                )}
+              </PopoverTrigger>
+              <PopoverContent align="end" className="w-72">
+                <ReminderPopoverBody
+                  existing={existingReminder}
+                  value={reminderValue}
+                  unit={reminderUnit}
+                  onChangeValue={setReminderValue}
+                  onChangeUnit={setReminderUnit}
+                  onClose={() => {
+                    setReminderOpen(false);
+                  }}
+                  onSet={handleSetReminder}
+                  onClear={handleClearReminder}
+                />
+              </PopoverContent>
+            </Popover>
+
+            {!railOpen ? (
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-8 w-8"
+                aria-label="Expand volunteer details"
+                aria-expanded={false}
+                aria-controls="claude-inbox-contact-rail"
+                onClick={() => {
+                  setRailOpen(true);
+                }}
+              >
+                <PanelRightOpenIcon className="h-4 w-4" />
+              </Button>
+            ) : null}
+          </div>
+        </header>
+
+        {/* Unresolved banner */}
+        {contact.hasUnresolved ? <UnresolvedBanner /> : null}
+
+        {/* Timeline area */}
+        <div
+          ref={timelineRef}
+          className="min-h-0 flex-1 overflow-y-auto bg-slate-50/40 px-6 py-6"
+        >
+          {isTimelineLoading ? (
+            <TimelineSkeleton />
+          ) : (
+            <ClaudeInboxTimeline
+              entries={timeline}
+              volunteerFirstName={firstName}
+            />
+          )}
+        </div>
+
+        <div className="shrink-0">
+          <ClaudeInboxComposer
+            contactDisplayName={contact.displayName}
+            smsEligible={smsEligible}
+            onOpenChange={(open) => {
+              if (open && timelineRef.current) {
+                // Scroll timeline to bottom when composer opens
+                // so the latest messages stay visible
+                setTimeout(() => {
+                  const el = timelineRef.current as unknown as
+                    | { scrollTop: number; scrollHeight: number }
+                    | null;
+                  if (el) el.scrollTop = el.scrollHeight;
+                }, 50);
+              }
+            }}
+          />
+        </div>
+      </section>
+
+      {/* Animated contact rail — width transitions from 0 → 20rem */}
+      <div
+        className={cn(
+          "overflow-hidden border-l transition-all duration-200 ease-out motion-reduce:transition-none",
+          railOpen
+            ? "w-80 border-slate-200 opacity-100"
+            : "w-0 border-transparent opacity-0"
+        )}
+      >
+        <div className="w-80">
+          <ClaudeInboxContactRail
+            contact={contact}
+            onClose={() => {
+              setRailOpen(false);
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------- Unresolved banner ----------
+
+function UnresolvedBanner() {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="border-b border-amber-200 bg-amber-50/80">
+      <button
+        type="button"
+        onClick={() => {
+          setExpanded((e) => !e);
+        }}
+        className="flex w-full items-center gap-2 px-6 py-2.5 text-left transition-colors hover:bg-amber-100/60"
+        aria-expanded={expanded}
+      >
+        <AlertTriangleIcon className="h-4 w-4 shrink-0 text-amber-600" />
+        <span className="flex-1 text-sm font-medium text-amber-900">
+          Unresolved items need attention
+        </span>
+        <span className="text-xs text-amber-600">
+          {expanded ? "Hide" : "Details"}
+        </span>
+      </button>
+
+      {expanded ? (
+        <div className="border-t border-amber-200 px-6 py-3">
+          <p className="text-xs leading-5 text-amber-800">
+            This contact has open items that require action before the
+            conversation can be considered resolved. Review the timeline
+            for pending requests and routing notices.
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// ---------- Reminder popover body ----------
+
+interface ReminderPopoverBodyProps {
+  readonly existing: Reminder | null;
+  readonly value: string;
+  readonly unit: ReminderUnit;
+  readonly onChangeValue: (value: string) => void;
+  readonly onChangeUnit: (unit: ReminderUnit) => void;
+  readonly onClose: () => void;
+  readonly onSet: () => void;
+  readonly onClear: () => void;
+}
+
+const REMINDER_UNITS: readonly ReminderUnit[] = ["hours", "days", "weeks"];
+
+function ReminderPopoverBody({
+  existing,
+  value,
+  unit,
+  onChangeValue,
+  onChangeUnit,
+  onClose,
+  onSet,
+  onClear
+}: ReminderPopoverBodyProps) {
+  const numeric = Number(value);
+  const canSet = value.length > 0 && Number.isFinite(numeric) && numeric > 0;
+  const preview = canSet ? previewForDelta(numeric, unit) : null;
+
+  if (existing) {
+    return (
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+            Reminder set
+          </p>
+          <p className="mt-1 text-sm font-medium text-slate-900">
+            {formatLongReminder(existing)}
+          </p>
+          <p className="mt-0.5 text-[11px] text-slate-500">
+            In {formatShortReminder(existing)}
+          </p>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 shrink-0 text-slate-400 hover:text-slate-700"
+          aria-label="Cancel reminder"
+          onClick={onClear}
+        >
+          <XIcon className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <p className="text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+        Remind me in
+      </p>
+      <div className="mt-2 flex items-center gap-2">
+        {/* Number stepper */}
+        <div className="flex h-9 w-16 items-center overflow-hidden rounded-md border border-slate-200 shadow-sm">
+          <span
+            className="flex-1 select-none text-center text-sm font-semibold tabular-nums text-slate-900"
+            aria-live="polite"
+          >
+            {value || "0"}
+          </span>
+          <div className="flex flex-col border-l border-slate-200">
+            <button
+              type="button"
+              aria-label="Increase"
+              onClick={() => {
+                const n = Math.min(99, (Number(value) || 0) + 1);
+                onChangeValue(n.toString());
+              }}
+              className="flex h-[18px] w-6 items-center justify-center text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900"
+            >
+              <ChevronUpIcon className="h-3.5 w-3.5" />
+            </button>
+            <button
+              type="button"
+              aria-label="Decrease"
+              onClick={() => {
+                const n = Math.max(0, (Number(value) || 0) - 1);
+                onChangeValue(n.toString());
+              }}
+              className="flex h-[18px] w-6 items-center justify-center border-t border-slate-200 text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900"
+            >
+              <ChevronDownIcon className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+        <div className="flex flex-1 items-center gap-1 rounded-lg bg-slate-100 p-0.5 text-[11px] font-medium">
+          {REMINDER_UNITS.map((option) => {
+            const isActive = option === unit;
+            return (
+              <button
+                key={option}
+                type="button"
+                aria-pressed={isActive}
+                onClick={() => {
+                  onChangeUnit(option);
+                }}
+                className={cn(
+                  "flex-1 rounded-md px-1.5 py-1 capitalize transition-colors duration-150",
+                  isActive
+                    ? "bg-white text-slate-900 shadow-sm"
+                    : "text-slate-500 hover:text-slate-900"
+                )}
+              >
+                {option}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      <p
+        className={cn(
+          "mt-2 min-h-4 text-[11px]",
+          preview ? "text-slate-500" : "text-transparent"
+        )}
+        aria-live="polite"
+      >
+        {preview ?? "—"}
+      </p>
+      <div className="mt-3 flex items-center justify-end gap-2">
+        <Button variant="ghost" size="sm" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button size="sm" disabled={!canSet} onClick={onSet}>
+          Set reminder
+        </Button>
+      </div>
+    </>
+  );
+}
+
+// ---------- Reminder helpers ----------
+
+function buildReminder(value: number, unit: ReminderUnit): Reminder {
+  const ms = value * millisPerUnit(unit);
+  const firesAt = new Date(Date.now() + ms).toISOString();
+  return { value, unit, firesAt };
+}
+
+function millisPerUnit(unit: ReminderUnit): number {
+  switch (unit) {
+    case "hours":
+      return 60 * 60 * 1000;
+    case "days":
+      return 24 * 60 * 60 * 1000;
+    case "weeks":
+      return 7 * 24 * 60 * 60 * 1000;
+  }
+}
+
+function previewForDelta(value: number, unit: ReminderUnit): string {
+  const ms = value * millisPerUnit(unit);
+  const target = new Date(Date.now() + ms);
+  return formatAbsolute(target);
+}
+
+function formatShortReminder(reminder: Reminder): string {
+  const unitLabel =
+    reminder.value === 1 ? reminder.unit.slice(0, -1) : reminder.unit;
+  return `${reminder.value.toString()} ${unitLabel}`;
+}
+
+function formatLongReminder(reminder: Reminder): string {
+  return formatAbsolute(new Date(reminder.firesAt));
+}
+
+function formatAbsolute(target: Date): string {
+  const now = new Date();
+  const startOfToday = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate()
+  ).getTime();
+  const startOfTarget = new Date(
+    target.getFullYear(),
+    target.getMonth(),
+    target.getDate()
+  ).getTime();
+  const dayDelta = Math.round(
+    (startOfTarget - startOfToday) / (24 * 60 * 60 * 1000)
+  );
+
+  const time = formatTime(target);
+
+  if (dayDelta === 0) return `Today at ${time}`;
+  if (dayDelta === 1) return `Tomorrow at ${time}`;
+  if (dayDelta > 1 && dayDelta < 7) {
+    return `${weekdayName(target.getDay())} at ${time}`;
+  }
+  return `${monthName(target.getMonth())} ${target.getDate().toString()} at ${time}`;
+}
+
+function formatTime(target: Date): string {
+  const hours24 = target.getHours();
+  const minutes = target.getMinutes();
+  const ampm = hours24 >= 12 ? "pm" : "am";
+  const hours12 = hours24 % 12 === 0 ? 12 : hours24 % 12;
+  if (minutes === 0) return `${hours12.toString()} ${ampm}`;
+  const padded = minutes < 10 ? `0${minutes.toString()}` : minutes.toString();
+  return `${hours12.toString()}:${padded} ${ampm}`;
+}
+
+function weekdayName(day: number): string {
+  return [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday"
+  ][day] ?? "";
+}
+
+function monthName(month: number): string {
+  return [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec"
+  ][month] ?? "";
+}

--- a/apps/web/app/(claude-inbox)/_components/claude-inbox-empty-state.tsx
+++ b/apps/web/app/(claude-inbox)/_components/claude-inbox-empty-state.tsx
@@ -1,0 +1,19 @@
+import { InboxIcon } from "./claude-icons";
+
+export function ClaudeInboxEmptyState() {
+  return (
+    <div className="flex h-full flex-col items-center justify-center px-10 text-center">
+      <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-slate-100 text-slate-500">
+        <InboxIcon className="h-7 w-7" />
+      </div>
+      <h2 className="mt-5 text-base font-semibold text-slate-900">
+        Select a person to begin
+      </h2>
+      <p className="mt-1 max-w-sm text-sm leading-6 text-slate-500">
+        The Inbox is organized by person. Choose anyone on the left to see
+        their full communication history, context, and reply workflow in
+        one place.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/app/(claude-inbox)/_components/claude-inbox-icon-rail.tsx
+++ b/apps/web/app/(claude-inbox)/_components/claude-inbox-icon-rail.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import type { LucideIcon } from "lucide-react";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger
+} from "@/components/ui/tooltip";
+
+import {
+  AdventureScientistsLogo,
+  InboxIcon,
+  LogOutIcon,
+  MegaphoneIcon,
+  SettingsIcon
+} from "./claude-icons";
+
+interface RailItem {
+  readonly id: string;
+  readonly label: string;
+  readonly Icon: LucideIcon;
+  readonly active?: boolean;
+}
+
+/**
+ * Prototype left nav. Kept to three destinations per product brief — Inbox,
+ * Campaigns, Settings — so the icon strip doesn't drift into speculative
+ * sections. The bottom slot hosts a user circle that reveals the operator's
+ * name and a Log out affordance on hover.
+ */
+const ITEMS: readonly RailItem[] = [
+  { id: "inbox", label: "Inbox", Icon: InboxIcon, active: true },
+  { id: "campaigns", label: "Campaigns", Icon: MegaphoneIcon },
+  { id: "settings", label: "Settings", Icon: SettingsIcon }
+];
+
+const OPERATOR = {
+  initials: "JC",
+  displayName: "Jordan Cole",
+  email: "jordan@adventurescientists.org"
+};
+
+export function ClaudeInboxIconRail() {
+  return (
+    <TooltipProvider delayDuration={200}>
+      <nav
+        className="flex w-14 shrink-0 flex-col items-center border-r border-slate-200 bg-white py-4"
+        aria-label="Primary"
+      >
+        <div
+          className="mb-4 flex h-9 w-9 items-center justify-center text-slate-900"
+          aria-label="Adventure Scientists"
+        >
+          <AdventureScientistsLogo className="h-8 w-8" />
+        </div>
+
+        <div className="flex flex-1 flex-col items-center gap-1">
+          {ITEMS.map((item) => {
+            const Icon = item.Icon;
+            return (
+              <Tooltip key={item.id}>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label={item.label}
+                    aria-current={item.active ? "page" : undefined}
+                    className={`flex h-10 w-10 items-center justify-center rounded-xl transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 motion-reduce:transition-none ${
+                      item.active
+                        ? "bg-slate-900 text-white"
+                        : "text-slate-500 hover:bg-slate-100 hover:text-slate-900"
+                    }`}
+                  >
+                    <Icon className="h-5 w-5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="right" className="rounded-md bg-slate-900 px-2 py-1 text-xs font-medium text-white">
+                  {item.label}
+                </TooltipContent>
+              </Tooltip>
+            );
+          })}
+        </div>
+
+        <OperatorMenu />
+      </nav>
+    </TooltipProvider>
+  );
+}
+
+function OperatorMenu() {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label={`${OPERATOR.displayName} · account menu`}
+          className="mt-2 flex h-9 w-9 items-center justify-center rounded-full bg-slate-900 text-[11px] font-semibold text-white shadow-sm transition-colors duration-150 hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2"
+        >
+          {OPERATOR.initials}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent side="right" align="end" className="w-56">
+        <DropdownMenuLabel className="font-normal">
+          <div className="flex items-center gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-slate-900 text-[11px] font-semibold text-white">
+              {OPERATOR.initials}
+            </div>
+            <div className="min-w-0">
+              <p className="truncate text-sm font-semibold text-slate-900">
+                {OPERATOR.displayName}
+              </p>
+              <p className="truncate text-[11px] text-slate-500">
+                {OPERATOR.email}
+              </p>
+            </div>
+          </div>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem className="gap-2 text-xs font-medium">
+          <LogOutIcon className="h-3.5 w-3.5" />
+          Log out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/web/app/(claude-inbox)/_components/claude-inbox-list.tsx
+++ b/apps/web/app/(claude-inbox)/_components/claude-inbox-list.tsx
@@ -1,0 +1,380 @@
+"use client";
+
+import type { LucideIcon } from "lucide-react";
+import { usePathname } from "next/navigation";
+import { useMemo, useState } from "react";
+
+import type {
+  ClaudeInboxFilterId,
+  ClaudeInboxFilterViewModel,
+  ClaudeInboxListItemViewModel
+} from "../_lib/view-models";
+import { Separator } from "@/components/ui/separator";
+
+import { useClaudeInboxClient } from "./claude-inbox-client-provider";
+import {
+  CornerUpLeftIcon,
+  FilterIcon,
+  InboxIcon,
+  MailIcon,
+  SearchIcon,
+  SearchXIcon,
+  XIcon
+} from "./claude-icons";
+import { QueueLoadingSkeleton } from "./claude-inbox-loading";
+import { ClaudeInboxRow } from "./claude-inbox-row";
+
+interface ListColumnProps {
+  readonly items: readonly ClaudeInboxListItemViewModel[];
+  readonly filters: readonly ClaudeInboxFilterViewModel[];
+  readonly initialFilterId?: ClaudeInboxFilterId;
+}
+
+const FILTER_ICONS: Record<ClaudeInboxFilterId, LucideIcon> = {
+  all: InboxIcon,
+  unread: MailIcon,
+  "follow-up": CornerUpLeftIcon
+};
+
+type ActiveFilter =
+  | { readonly kind: "base"; readonly id: ClaudeInboxFilterId }
+  | { readonly kind: "project"; readonly label: string };
+
+export function ClaudeInboxList({
+  items,
+  filters,
+  initialFilterId = "all"
+}: ListColumnProps) {
+  const pathname = usePathname();
+  const activeContactId = extractContactId(pathname);
+  const {
+    followUp,
+    search,
+    setSearchQuery,
+    clearSearch,
+    isQueueLoading
+  } = useClaudeInboxClient();
+
+  const [activeFilter, setActiveFilter] = useState<ActiveFilter>({
+    kind: "base",
+    id: initialFilterId
+  });
+  const [filtersOpen, setFiltersOpen] = useState(false);
+
+  const followUpCount = items.filter((item) =>
+    followUp.has(item.contactId)
+  ).length;
+  const filtersWithLiveCounts = filters.map((filter) =>
+    filter.id === "follow-up" ? { ...filter, count: followUpCount } : filter
+  );
+
+  const projectBuckets = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const item of items) {
+      if (item.projectLabel) {
+        counts.set(item.projectLabel, (counts.get(item.projectLabel) ?? 0) + 1);
+      }
+    }
+    return Array.from(counts.entries())
+      .map(([label, count]) => ({ label, count }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [items]);
+
+  // Apply filters: base/project filter → search
+  const filteredItems = useMemo(() => {
+    let result = items.filter((item) =>
+      matchesActiveFilter(item, activeFilter, followUp)
+    );
+
+    // Search filter
+    if (search.isActive && search.resultContactIds.length > 0) {
+      const ids = new Set(search.resultContactIds);
+      result = result.filter((item) => ids.has(item.contactId));
+    }
+
+    return result;
+  }, [items, activeFilter, followUp, search]);
+
+  // For local search simulation: filter by query string matching
+  const searchFilteredItems = useMemo(() => {
+    if (!search.isActive || search.query.length === 0) return filteredItems;
+    const q = search.query.toLowerCase();
+    return filteredItems.filter(
+      (item) =>
+        item.displayName.toLowerCase().includes(q) ||
+        item.latestSubject.toLowerCase().includes(q) ||
+        item.snippet.toLowerCase().includes(q) ||
+        (item.projectLabel?.toLowerCase().includes(q) ?? false)
+    );
+  }, [filteredItems, search]);
+
+  const displayItems = search.isActive ? searchFilteredItems : filteredItems;
+
+  const columnTitle =
+    activeFilter.kind === "base"
+      ? (filtersWithLiveCounts.find((filter) => filter.id === activeFilter.id)
+          ?.label ?? "Inbox")
+      : activeFilter.label;
+
+  const isFilterActive =
+    activeFilter.kind === "project" || activeFilter.id !== "all";
+
+  return (
+    <section className="relative flex w-[22rem] shrink-0 flex-col overflow-hidden border-r border-slate-200 bg-white">
+      <div className="sticky top-0 z-10 bg-white/95 backdrop-blur">
+        {/* Header */}
+        <div className="flex h-[65px] items-center gap-2 border-b border-slate-200 px-5">
+          <h1 className="min-w-0 flex-1 truncate text-lg font-semibold text-slate-900">
+            {columnTitle}
+          </h1>
+          <button
+            type="button"
+            aria-label="Filter"
+            aria-expanded={filtersOpen}
+            aria-controls="claude-inbox-filters-panel"
+            onClick={() => {
+              setFiltersOpen((open) => !open);
+            }}
+            className={`relative inline-flex h-8 w-8 items-center justify-center rounded-lg border shadow-sm transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 motion-reduce:transition-none ${
+              filtersOpen
+                ? "border-slate-300 bg-slate-100 text-slate-900"
+                : "border-slate-200 bg-white text-slate-600 hover:bg-slate-50"
+            }`}
+          >
+            <FilterIcon className="h-4 w-4" />
+            {isFilterActive ? (
+              <span className="absolute -right-1 -top-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-slate-900 px-1 text-[10px] font-semibold text-white tabular-nums ring-2 ring-white">
+                1
+              </span>
+            ) : null}
+          </button>
+        </div>
+
+        {/* Search bar */}
+        <div className="px-5 pb-4 pt-3">
+          <label className="flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm shadow-sm transition-colors duration-150 focus-within:border-slate-400 focus-within:ring-1 focus-within:ring-slate-300">
+            <SearchIcon className="h-4 w-4 text-slate-400" />
+            <input
+              type="text"
+              placeholder="Search people, subjects, projects"
+              value={search.query}
+              onChange={(e) => {
+                const target = e.currentTarget as unknown as {
+                  readonly value: string;
+                };
+                setSearchQuery(target.value);
+              }}
+              className="flex-1 bg-transparent text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none"
+            />
+            {search.isActive ? (
+              <button
+                type="button"
+                aria-label="Clear search"
+                onClick={clearSearch}
+                className="rounded p-0.5 text-slate-400 hover:text-slate-700"
+              >
+                <XIcon className="h-3.5 w-3.5" />
+              </button>
+            ) : null}
+          </label>
+        </div>
+
+        {/* Search active indicator */}
+        {search.isActive ? (
+          <div className="border-t border-slate-100 px-5 py-2">
+            <p className="text-xs text-slate-500">
+              {searchFilteredItems.length === 0 ? (
+                <span className="text-slate-400">
+                  No results for &ldquo;{search.query}&rdquo;
+                </span>
+              ) : (
+                <>
+                  <span className="font-medium text-slate-700">
+                    {searchFilteredItems.length}
+                  </span>{" "}
+                  {searchFilteredItems.length === 1 ? "result" : "results"} for
+                  &ldquo;{search.query}&rdquo;
+                </>
+              )}
+            </p>
+          </div>
+        ) : null}
+
+        {/* Filter disclosure panel */}
+        <div
+          id="claude-inbox-filters-panel"
+          aria-hidden={!filtersOpen}
+          className={`grid overflow-hidden border-slate-200 transition-all duration-200 ease-out motion-reduce:transition-none ${
+            filtersOpen
+              ? "grid-rows-[1fr] border-t opacity-100"
+              : "grid-rows-[0fr] border-t-0 opacity-0"
+          }`}
+        >
+          <div className="min-h-0">
+            <div className="max-h-[60vh] overflow-y-auto px-5 py-4">
+              <ul className="space-y-0.5">
+                {filtersWithLiveCounts.map((filter) => {
+                  const Icon = FILTER_ICONS[filter.id];
+                  const isActive =
+                    activeFilter.kind === "base" &&
+                    activeFilter.id === filter.id;
+                  return (
+                    <li key={filter.id}>
+                      <button
+                        type="button"
+                        aria-pressed={isActive}
+                        onClick={() => {
+                          setActiveFilter({ kind: "base", id: filter.id });
+                          setFiltersOpen(false);
+                        }}
+                        className={`flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left text-sm transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 motion-reduce:transition-none ${
+                          isActive
+                            ? "bg-slate-900 font-semibold text-white"
+                            : "text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+                        }`}
+                      >
+                        <Icon className="h-4 w-4 shrink-0" />
+                        <span className="flex-1 truncate">{filter.label}</span>
+                        <span
+                          className={`text-xs tabular-nums ${
+                            isActive ? "text-white" : "text-slate-500"
+                          }`}
+                        >
+                          {filter.count}
+                        </span>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+
+              {projectBuckets.length > 0 ? (
+                <>
+                  <Separator className="my-3 bg-slate-100" />
+                  <p className="mb-1 px-2.5 text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+                    Projects
+                  </p>
+                  <ul className="space-y-0.5">
+                    {projectBuckets.map((bucket) => {
+                      const isActive =
+                        activeFilter.kind === "project" &&
+                        activeFilter.label === bucket.label;
+                      return (
+                        <li key={bucket.label}>
+                          <button
+                            type="button"
+                            aria-pressed={isActive}
+                            onClick={() => {
+                              setActiveFilter({
+                                kind: "project",
+                                label: bucket.label
+                              });
+                              setFiltersOpen(false);
+                            }}
+                            className={`flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left text-sm transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 motion-reduce:transition-none ${
+                              isActive
+                                ? "bg-slate-900 font-semibold text-white"
+                                : "text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+                            }`}
+                          >
+                            <span className="flex-1 truncate">
+                              {bucket.label}
+                            </span>
+                            <span
+                              className={`text-xs tabular-nums ${
+                                isActive ? "text-white" : "text-slate-500"
+                              }`}
+                            >
+                              {bucket.count}
+                            </span>
+                          </button>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* List body */}
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {isQueueLoading ? (
+          <QueueLoadingSkeleton />
+        ) : search.isActive && searchFilteredItems.length === 0 ? (
+          <SearchEmptyState query={search.query} />
+        ) : displayItems.length === 0 ? (
+          <QueueEmptyState />
+        ) : (
+          <ul className="divide-y divide-slate-100">
+            {displayItems.map((item) => (
+              <ClaudeInboxRow
+                key={item.contactId}
+                item={item}
+                isActive={item.contactId === activeContactId}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}
+
+// ---------- Empty states ----------
+
+function QueueEmptyState() {
+  return (
+    <div className="px-5 py-16 text-center">
+      <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-slate-100">
+        <InboxIcon className="h-6 w-6 text-slate-400" />
+      </div>
+      <p className="mt-4 text-sm font-medium text-slate-700">All caught up</p>
+      <p className="mt-1 text-xs text-slate-500">
+        No conversations match the current filter.
+      </p>
+    </div>
+  );
+}
+
+function SearchEmptyState({ query }: { readonly query: string }) {
+  return (
+    <div className="px-5 py-16 text-center">
+      <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-slate-100">
+        <SearchXIcon className="h-6 w-6 text-slate-400" />
+      </div>
+      <p className="mt-4 text-sm font-medium text-slate-700">No results</p>
+      <p className="mt-1 text-xs text-slate-500">
+        Nothing matches &ldquo;{query}&rdquo;. Try a different search.
+      </p>
+    </div>
+  );
+}
+
+// ---------- Helpers ----------
+
+function extractContactId(pathname: string | null): string | null {
+  if (!pathname) return null;
+  const match = /^\/inbox\/([^/]+)/.exec(pathname);
+  return match ? (match[1] ?? null) : null;
+}
+
+function matchesActiveFilter(
+  item: ClaudeInboxListItemViewModel,
+  activeFilter: ActiveFilter,
+  followUp: ReadonlySet<string>
+): boolean {
+  if (activeFilter.kind === "project") {
+    return item.projectLabel === activeFilter.label;
+  }
+  switch (activeFilter.id) {
+    case "all":
+      return true;
+    case "unread":
+      return item.unreadCount > 0;
+    case "follow-up":
+      return followUp.has(item.contactId);
+  }
+}

--- a/apps/web/app/(claude-inbox)/_components/claude-inbox-loading.tsx
+++ b/apps/web/app/(claude-inbox)/_components/claude-inbox-loading.tsx
@@ -1,0 +1,140 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * Full-screen app loading skeleton. Mirrors the 3-column layout
+ * (icon rail + list column + detail workspace) with pulsing placeholders
+ * so the user sees a recognizable structure while data loads.
+ */
+export function ClaudeInboxAppLoading() {
+  return (
+    <div className="flex h-screen w-screen overflow-hidden bg-slate-100 antialiased">
+      {/* Icon rail skeleton */}
+      <div className="flex w-14 shrink-0 flex-col items-center border-r border-slate-200 bg-white py-4">
+        <Skeleton className="h-9 w-9 rounded-xl" />
+        <div className="mt-4 flex flex-1 flex-col items-center gap-1">
+          <Skeleton className="h-10 w-10 rounded-xl" />
+          <Skeleton className="h-10 w-10 rounded-xl" />
+          <Skeleton className="h-10 w-10 rounded-xl" />
+        </div>
+        <Skeleton className="mt-2 h-9 w-9 rounded-full" />
+      </div>
+
+      {/* List column skeleton */}
+      <div className="flex w-[22rem] shrink-0 flex-col border-r border-slate-200 bg-white">
+        <div className="border-b border-slate-200 px-5">
+          <div className="flex h-[65px] items-center gap-2">
+            <Skeleton className="h-5 w-24" />
+            <div className="flex-1" />
+            <Skeleton className="h-8 w-8 rounded-lg" />
+          </div>
+          <div className="pb-4 pt-1">
+            <Skeleton className="h-8 w-full rounded-lg" />
+          </div>
+        </div>
+        <div className="flex-1 overflow-hidden px-0">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <QueueRowSkeleton key={i} />
+          ))}
+        </div>
+      </div>
+
+      {/* Detail workspace skeleton */}
+      <div className="flex min-w-0 flex-1 flex-col bg-white">
+        <div className="flex h-[65px] items-center gap-4 border-b border-slate-200 px-6">
+          <Skeleton className="h-5 w-36" />
+          <Skeleton className="hidden h-4 w-px sm:block" />
+          <Skeleton className="hidden h-4 w-48 sm:block" />
+          <div className="flex-1" />
+          <Skeleton className="h-8 w-28 rounded-md" />
+          <Skeleton className="h-8 w-8 rounded-md" />
+          <Skeleton className="h-8 w-8 rounded-md" />
+        </div>
+        <div className="flex-1 bg-slate-50/40 px-6 py-6">
+          <TimelineSkeleton />
+        </div>
+        <div className="border-t border-slate-200 px-5 py-4">
+          <Skeleton className="h-24 w-full rounded-lg" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Skeleton for a single queue row — avatar + 3 text lines.
+ * Used inside both the full app loading state and the queue-only reload.
+ */
+export function QueueRowSkeleton() {
+  return (
+    <div className="flex gap-3 border-b border-slate-100 px-5 py-3.5">
+      <Skeleton className="h-10 w-10 shrink-0 rounded-full" />
+      <div className="min-w-0 flex-1 space-y-2">
+        <div className="flex items-center justify-between gap-2">
+          <Skeleton className="h-3.5 w-28" />
+          <Skeleton className="h-3 w-12" />
+        </div>
+        <Skeleton className="h-3 w-full" />
+        <Skeleton className="h-2.5 w-3/4" />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Queue loading state: renders 5 skeleton rows inside the existing list
+ * column chrome (header stays real, only rows pulse).
+ */
+export function QueueLoadingSkeleton() {
+  return (
+    <div className="min-h-0 flex-1 overflow-hidden">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <QueueRowSkeleton key={i} />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Timeline loading skeleton. Mirrors the alternating left/right bubble
+ * pattern of the real timeline.
+ */
+export function TimelineSkeleton() {
+  return (
+    <div className="flex flex-col gap-3" role="status" aria-label="Loading timeline">
+      {/* Inbound bubble (left) */}
+      <div className="flex w-full flex-col items-start">
+        <Skeleton className="mb-1 h-3 w-24" />
+        <Skeleton className="h-20 w-[70%] rounded-2xl rounded-bl-md" />
+        <Skeleton className="mt-1 h-3 w-16" />
+      </div>
+
+      {/* Outbound bubble (right) */}
+      <div className="flex w-full flex-col items-end">
+        <Skeleton className="mb-1 h-3 w-20" />
+        <Skeleton className="h-16 w-[65%] rounded-2xl rounded-br-md" />
+        <Skeleton className="mt-1 h-3 w-14" />
+      </div>
+
+      {/* System event (centered-left) */}
+      <div className="flex w-full items-center justify-start">
+        <Skeleton className="h-6 w-56 rounded-full" />
+      </div>
+
+      {/* Outbound bubble (right) */}
+      <div className="flex w-full flex-col items-end">
+        <Skeleton className="mb-1 h-3 w-28" />
+        <Skeleton className="h-24 w-[75%] rounded-2xl rounded-br-md" />
+        <Skeleton className="mt-1 h-3 w-16" />
+      </div>
+
+      {/* Inbound bubble (left) */}
+      <div className="flex w-full flex-col items-start">
+        <Skeleton className="mb-1 h-3 w-20" />
+        <Skeleton className="h-14 w-[60%] rounded-2xl rounded-bl-md" />
+        <Skeleton className="mt-1 h-3 w-12" />
+      </div>
+
+      <span className="sr-only">Loading conversation...</span>
+    </div>
+  );
+}

--- a/apps/web/app/(claude-inbox)/_components/claude-inbox-row.tsx
+++ b/apps/web/app/(claude-inbox)/_components/claude-inbox-row.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import Link from "next/link";
+
+import type { ClaudeInboxListItemViewModel } from "../_lib/view-models";
+import { ClaudeInboxAvatar } from "./claude-inbox-avatar";
+import { useClaudeInboxClient } from "./claude-inbox-client-provider";
+import { MailIcon, PhoneIcon } from "./claude-icons";
+
+interface RowProps {
+  readonly item: ClaudeInboxListItemViewModel;
+  readonly isActive: boolean;
+}
+
+/**
+ * List row for a contact. Stripped of starred / unresolved / stage badges
+ * — those are no longer part of the inbox surface. The left accent bar is
+ * sky when the row is unread and rose when the operator has flagged the
+ * contact for follow-up. The channel icon (mail/phone) is always preserved
+ * in the leading slot so operators keep their at-a-glance channel cue even
+ * on the rows most likely to need triaging.
+ */
+export function ClaudeInboxRow({ item, isActive }: RowProps) {
+  const { followUp } = useClaudeInboxClient();
+  const isFollowUp = followUp.has(item.contactId);
+  const isUnread = item.unreadCount > 0;
+  const ChannelIcon = item.latestChannel === "email" ? MailIcon : PhoneIcon;
+
+  const accentClass = isFollowUp
+    ? "bg-rose-500"
+    : isUnread
+      ? "bg-sky-500"
+      : null;
+
+  return (
+    <li>
+      <Link
+        href={`/inbox/${item.contactId}`}
+        aria-current={isActive ? "page" : undefined}
+        className={`relative flex gap-3 border-b border-slate-100 px-5 py-3.5 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 motion-reduce:transition-none ${
+          isActive
+            ? "bg-sky-50/60 ring-1 ring-inset ring-sky-200"
+            : "hover:bg-slate-50/80"
+        }`}
+      >
+        {accentClass ? (
+          <span
+            aria-hidden="true"
+            className={`absolute left-0 top-0 h-full w-1 ${accentClass}`}
+          />
+        ) : null}
+
+        <ClaudeInboxAvatar
+          initials={item.initials}
+          tone={item.avatarTone}
+          size="md"
+        />
+
+        <div className="min-w-0 flex-1">
+          <div className="flex items-baseline justify-between gap-2">
+            <p
+              className={`truncate text-sm ${
+                isUnread ? "font-semibold text-slate-900" : "text-slate-800"
+              }`}
+            >
+              {item.displayName}
+            </p>
+            <span
+              className={`shrink-0 text-[11px] tabular-nums ${
+                isUnread ? "font-semibold text-sky-700" : "text-slate-500"
+              }`}
+            >
+              {item.lastActivityLabel}
+            </span>
+          </div>
+
+          <div className="mt-0.5 flex items-center gap-1.5">
+            <ChannelIcon
+              className={`h-3 w-3 shrink-0 ${
+                isUnread ? "text-sky-600" : "text-slate-400"
+              }`}
+              aria-label={
+                item.latestChannel === "email" ? "Email" : "SMS"
+              }
+            />
+            <p
+              className={`truncate text-[13px] ${
+                isUnread ? "font-medium text-slate-800" : "text-slate-600"
+              }`}
+            >
+              {item.latestSubject}
+            </p>
+          </div>
+
+          <p className="mt-0.5 line-clamp-1 text-xs text-slate-500">
+            {item.snippet}
+          </p>
+
+          {item.projectLabel || item.unreadCount > 0 ? (
+            <div className="mt-1.5 flex items-center gap-1.5">
+              {item.projectLabel ? (
+                <span className="inline-flex items-center rounded-md bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium text-slate-600">
+                  {item.projectLabel}
+                </span>
+              ) : null}
+              {item.unreadCount > 0 ? (
+                <span className="ml-auto inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-sky-600 px-1 text-[10px] font-semibold text-white tabular-nums">
+                  {item.unreadCount}
+                </span>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </Link>
+    </li>
+  );
+}

--- a/apps/web/app/(claude-inbox)/_components/claude-inbox-shell.tsx
+++ b/apps/web/app/(claude-inbox)/_components/claude-inbox-shell.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from "react";
+
+import type {
+  ClaudeInboxFilterId,
+  ClaudeInboxFilterViewModel,
+  ClaudeInboxListItemViewModel
+} from "../_lib/view-models";
+import { ClaudeInboxClientProvider } from "./claude-inbox-client-provider";
+import { ClaudeInboxIconRail } from "./claude-inbox-icon-rail";
+import { ClaudeInboxList } from "./claude-inbox-list";
+
+interface ShellProps {
+  readonly filters: readonly ClaudeInboxFilterViewModel[];
+  readonly items: readonly ClaudeInboxListItemViewModel[];
+  readonly initialFilterId: ClaudeInboxFilterId;
+  readonly children: ReactNode;
+}
+
+/**
+ * Server shell: renders the persistent chrome once for every `/inbox` route.
+ * The {@link ClaudeInboxClientProvider} is the client boundary that holds
+ * ephemeral UI state shared across the list column and the detail workspace
+ * — specifically which contacts are flagged "Needs Follow Up" and which
+ * have a reminder pending — so those two islands can stay in sync without
+ * hoisting a store into the canonical data layer.
+ */
+export function ClaudeInboxShell({
+  filters,
+  items,
+  initialFilterId,
+  children
+}: ShellProps) {
+  return (
+    <div className="flex h-screen w-screen overflow-hidden bg-slate-100 text-slate-900 antialiased">
+      <ClaudeInboxClientProvider>
+        <ClaudeInboxIconRail />
+
+        <ClaudeInboxList
+          items={items}
+          filters={filters}
+          initialFilterId={initialFilterId}
+        />
+
+        <main className="flex min-w-0 flex-1 flex-col overflow-hidden">
+          {children}
+        </main>
+      </ClaudeInboxClientProvider>
+    </div>
+  );
+}

--- a/apps/web/app/(claude-inbox)/_components/claude-inbox-timeline.tsx
+++ b/apps/web/app/(claude-inbox)/_components/claude-inbox-timeline.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+import { useState } from "react";
+
+import type {
+  ClaudeTimelineEntryKind,
+  ClaudeTimelineEntryViewModel
+} from "../_lib/view-models";
+import {
+  ChevronRightIcon,
+  MailIcon,
+  NoteIcon,
+  PhoneIcon
+} from "./claude-icons";
+
+interface TimelineProps {
+  readonly entries: readonly ClaudeTimelineEntryViewModel[];
+  readonly volunteerFirstName: string;
+}
+
+export function ClaudeInboxTimeline({
+  entries,
+  volunteerFirstName
+}: TimelineProps) {
+  const [expanded, setExpanded] = useState<ReadonlySet<string>>(
+    () => new Set<string>()
+  );
+
+  if (entries.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-slate-200 p-10 text-center text-sm text-slate-500">
+        No history yet for this person.
+      </div>
+    );
+  }
+
+  const toggle = (id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <ol className="flex flex-col gap-4">
+      {entries.map((entry) => (
+        <TimelineEntry
+          key={entry.id}
+          entry={entry}
+          volunteerFirstName={volunteerFirstName}
+          isExpanded={expanded.has(entry.id)}
+          onToggle={() => {
+            toggle(entry.id);
+          }}
+        />
+      ))}
+    </ol>
+  );
+}
+
+// ---------- Entry router ----------
+
+interface EntryProps {
+  readonly entry: ClaudeTimelineEntryViewModel;
+  readonly volunteerFirstName: string;
+  readonly isExpanded: boolean;
+  readonly onToggle: () => void;
+}
+
+function TimelineEntry({
+  entry,
+  volunteerFirstName,
+  isExpanded,
+  onToggle
+}: EntryProps) {
+  const role = roleForKind(entry.kind);
+
+  switch (role) {
+    case "inbound":
+      return <InboundBubble entry={entry} />;
+    case "outbound":
+      return <OutboundBubble entry={entry} />;
+    case "automated":
+    case "campaign":
+      return (
+        <AutomatedRow
+          entry={entry}
+          role={role}
+          isExpanded={isExpanded}
+          onToggle={onToggle}
+        />
+      );
+    case "note":
+      return <NoteEntry entry={entry} />;
+    case "system":
+      return (
+        <SystemDivider
+          entry={entry}
+          volunteerFirstName={volunteerFirstName}
+        />
+      );
+  }
+}
+
+// ---------- Inbound bubble (them, left) ----------
+
+function InboundBubble({
+  entry
+}: {
+  readonly entry: ClaudeTimelineEntryViewModel;
+}) {
+  const isEmail = entry.channel === "email";
+  const ChannelIcon = isEmail ? MailIcon : PhoneIcon;
+
+  return (
+    <li className="flex w-full flex-col items-start">
+      <div className="max-w-lg rounded-2xl rounded-bl-sm border border-slate-200 bg-white px-4 py-3 shadow-sm">
+        {isEmail && entry.subject ? (
+          <p className="mb-1.5 text-[13px] font-semibold leading-snug text-slate-900">
+            {entry.subject}
+          </p>
+        ) : null}
+        <p className="whitespace-pre-wrap text-[13px] leading-relaxed text-slate-700">
+          {entry.body}
+        </p>
+      </div>
+      <div className="mt-1.5 flex items-center gap-1.5 px-1 text-[11px] text-slate-400">
+        <ChannelIcon className="h-3 w-3" />
+        <span className="font-medium text-slate-500">
+          {entry.actorLabel}
+        </span>
+        <span>·</span>
+        <span>{entry.occurredAtLabel}</span>
+        {entry.isUnread ? (
+          <span
+            className="inline-flex h-1.5 w-1.5 rounded-full bg-sky-500"
+            aria-label="Unread"
+          />
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+// ---------- Outbound bubble (you, right) — dark ----------
+
+function OutboundBubble({
+  entry
+}: {
+  readonly entry: ClaudeTimelineEntryViewModel;
+}) {
+  const isEmail = entry.channel === "email";
+  const ChannelIcon = isEmail ? MailIcon : PhoneIcon;
+
+  return (
+    <li className="flex w-full flex-col items-end">
+      <div className="max-w-lg rounded-2xl rounded-br-sm bg-slate-800 px-4 py-3 shadow-sm">
+        {isEmail && entry.subject ? (
+          <p className="mb-1.5 text-[13px] font-semibold leading-snug text-slate-100">
+            {entry.subject}
+          </p>
+        ) : null}
+        <p className="whitespace-pre-wrap text-[13px] leading-relaxed text-slate-200">
+          {entry.body}
+        </p>
+      </div>
+      <div className="mt-1.5 flex items-center gap-1.5 px-1 text-[11px] text-slate-400">
+        <span>{entry.occurredAtLabel}</span>
+        <span>·</span>
+        <ChannelIcon className="h-3 w-3" />
+      </div>
+    </li>
+  );
+}
+
+// ---------- Automated / campaign — inline row, not a bubble ----------
+
+function AutomatedRow({
+  entry,
+  role,
+  isExpanded,
+  onToggle
+}: {
+  readonly entry: ClaudeTimelineEntryViewModel;
+  readonly role: "automated" | "campaign";
+  readonly isExpanded: boolean;
+  readonly onToggle: () => void;
+}) {
+  const isEmail = entry.channel === "email";
+  const label =
+    role === "automated"
+      ? isEmail
+        ? "Automated Email"
+        : "Automated SMS"
+      : isEmail
+        ? "Campaign Email"
+        : "Campaign SMS";
+  const headline = entry.subject ?? "(no subject)";
+
+  return (
+    <li className="flex w-full flex-col items-end">
+      <span className="mb-1 px-1 text-[11px] text-slate-400">
+        {label}
+      </span>
+      <button
+        type="button"
+        aria-expanded={isExpanded}
+        onClick={onToggle}
+        className="group flex w-full max-w-lg items-center gap-3 rounded-lg border border-dashed border-slate-300 bg-white px-4 py-2.5 text-left transition-colors hover:bg-slate-50"
+      >
+        <div className="min-w-0 flex-1">
+          <p className="text-[13px] font-medium leading-snug text-slate-700">
+            {headline}
+          </p>
+          {isExpanded ? (
+            <p className="mt-2 whitespace-pre-wrap text-[13px] leading-relaxed text-slate-600">
+              {entry.body}
+            </p>
+          ) : null}
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <span className="text-[11px] text-slate-400">
+            {entry.occurredAtLabel}
+          </span>
+          <ChevronRightIcon
+            className={`h-3.5 w-3.5 text-slate-400 transition-transform duration-150 ${
+              isExpanded ? "rotate-90" : ""
+            }`}
+          />
+        </div>
+      </button>
+    </li>
+  );
+}
+
+// ---------- Internal note — left-border accent ----------
+
+function NoteEntry({
+  entry
+}: {
+  readonly entry: ClaudeTimelineEntryViewModel;
+}) {
+  return (
+    <li className="flex w-full flex-col items-end">
+      <div className="max-w-lg rounded-lg border-l-2 border-amber-400 bg-amber-50/60 px-4 py-2.5">
+        <div className="mb-1 flex items-center gap-1.5 text-[11px] text-amber-700">
+          <NoteIcon className="h-3 w-3" />
+          <span className="font-medium">Note</span>
+          <span className="text-amber-300">·</span>
+          <span>{entry.actorLabel}</span>
+          <span className="text-amber-300">·</span>
+          <span>{entry.occurredAtLabel}</span>
+        </div>
+        <p className="whitespace-pre-wrap text-[13px] leading-relaxed text-amber-900">
+          {entry.body}
+        </p>
+      </div>
+    </li>
+  );
+}
+
+// ---------- System event — centered divider ----------
+
+function SystemDivider({
+  entry,
+  volunteerFirstName
+}: {
+  readonly entry: ClaudeTimelineEntryViewModel;
+  readonly volunteerFirstName: string;
+}) {
+  return (
+    <li className="flex w-full items-center gap-3 py-1">
+      <div className="h-px flex-1 bg-slate-200" />
+      <span className="shrink-0 text-[11px] text-slate-400">
+        {personalizeSystemBody(entry.body, volunteerFirstName)}
+      </span>
+      <div className="h-px flex-1 bg-slate-200" />
+    </li>
+  );
+}
+
+// ---------- Helpers ----------
+
+function personalizeSystemBody(body: string, firstName: string): string {
+  if (body.length === 0) return firstName;
+  const head = body.charAt(0).toLowerCase();
+  const tail = body.slice(1);
+  return `${firstName} ${head}${tail}`;
+}
+
+type EntryRole =
+  | "inbound"
+  | "outbound"
+  | "automated"
+  | "campaign"
+  | "note"
+  | "system";
+
+function roleForKind(kind: ClaudeTimelineEntryKind): EntryRole {
+  switch (kind) {
+    case "inbound-email":
+    case "inbound-sms":
+      return "inbound";
+    case "outbound-email":
+    case "outbound-sms":
+      return "outbound";
+    case "outbound-auto-email":
+      return "automated";
+    case "outbound-campaign-email":
+    case "outbound-campaign-sms":
+      return "campaign";
+    case "internal-note":
+      return "note";
+    case "system-event":
+      return "system";
+  }
+}

--- a/apps/web/app/(claude-inbox)/_lib/filters.ts
+++ b/apps/web/app/(claude-inbox)/_lib/filters.ts
@@ -1,0 +1,20 @@
+import type { ClaudeInboxFilterId } from "./view-models";
+
+interface FilterDefinition {
+  readonly id: ClaudeInboxFilterId;
+  readonly label: string;
+  readonly hint: string | null;
+}
+
+/**
+ * Filter surface for the list column. The prototype limits this to three
+ * buckets — everything, unread-only, and contacts the operator has flagged
+ * for follow-up. Follow-up is client-side ephemeral state owned by
+ * {@link ClaudeInboxClientProvider}; the server-side list doesn't know who
+ * is flagged, so its count starts at 0 and the client recomputes it.
+ */
+export const CLAUDE_INBOX_FILTERS: readonly FilterDefinition[] = [
+  { id: "all", label: "All", hint: null },
+  { id: "unread", label: "Unread", hint: "At least one unread message" },
+  { id: "follow-up", label: "Needs Follow-Up", hint: "Flagged by you" }
+];

--- a/apps/web/app/(claude-inbox)/_lib/mock-data.ts
+++ b/apps/web/app/(claude-inbox)/_lib/mock-data.ts
@@ -1,0 +1,956 @@
+/**
+ * Claude Inbox prototype — server-only mock fixtures.
+ *
+ * This module is the single source of truth for the prototype's rendered
+ * content. It is imported only by Server Components so that the client never
+ * receives the raw fixture map — the client only sees the minimized view
+ * models returned by the selectors.
+ *
+ * Active projects match the canonical product list (Beech and Butternut,
+ * PNW Biodiversity, Monitoring Coral Reefs, Tracking Whitebark Pine,
+ * Searching for Killer Whales). Past projects are deliberately fake — the
+ * prototype only needs them to look plausible next to each volunteer.
+ *
+ * Phase 2 will swap these factories for real repository reads against the
+ * canonical inbox/timeline projections without changing view-model shapes.
+ */
+
+import type {
+  ClaudeAvatarTone,
+  ClaudeInboxBucket,
+  ClaudeInboxChannel,
+  ClaudeProjectMembershipViewModel,
+  ClaudeProjectStatus,
+  ClaudeTimelineEntryKind,
+  ClaudeTimelineEntryViewModel,
+  ClaudeVolunteerStage
+} from "./view-models";
+
+export type VolunteerMilestoneKind =
+  | "signed-up"
+  | "training-received"
+  | "training-completed"
+  | "trip-plan-submitted"
+  | "first-record-submitted";
+
+interface MockMilestone {
+  readonly id: string;
+  readonly kind: VolunteerMilestoneKind;
+  readonly projectName: string;
+  readonly daysAgo: number;
+}
+
+interface MockContactRecord {
+  readonly contactId: string;
+  readonly volunteerId: string;
+  readonly displayName: string;
+  readonly initials: string;
+  readonly avatarTone: ClaudeAvatarTone;
+  readonly volunteerStage: ClaudeVolunteerStage;
+  readonly primaryEmail: string | null;
+  readonly primaryPhone: string | null;
+  readonly cityState: string | null;
+  readonly joinedAtLabel: string;
+  readonly activeProjects: readonly ClaudeProjectMembershipViewModel[];
+  readonly pastProjects: readonly ClaudeProjectMembershipViewModel[];
+  readonly milestones: readonly MockMilestone[];
+  readonly bucket: ClaudeInboxBucket;
+  readonly isStarred: boolean;
+  readonly hasUnresolved: boolean;
+  readonly unreadCount: number;
+  readonly latestSubject: string;
+  readonly snippet: string;
+  readonly latestChannel: ClaudeInboxChannel;
+  readonly projectLabel: string | null;
+  readonly lastActivityAt: string;
+  readonly lastActivityLabel: string;
+  readonly timeline: readonly ClaudeTimelineEntryViewModel[];
+}
+
+function membership(
+  projectId: string,
+  projectName: string,
+  year: number,
+  status: ClaudeProjectStatus
+): ClaudeProjectMembershipViewModel {
+  return {
+    membershipId: `m_${projectId}_${year.toString()}`,
+    projectId,
+    projectName,
+    year,
+    status,
+    crmUrl: `https://crm.example.org/participations/${projectId}-${year.toString()}`
+  };
+}
+
+const CONTACTS: readonly MockContactRecord[] = [
+  {
+    contactId: "c_maya_patel",
+    volunteerId: "10428",
+    displayName: "Maya Patel",
+    initials: "MP",
+    avatarTone: "indigo",
+    volunteerStage: "active",
+    primaryEmail: "maya.patel@example.org",
+    primaryPhone: "+1 303 555 0142",
+    cityState: "Boulder, CO",
+    joinedAtLabel: "Joined Mar 2024",
+    activeProjects: [
+      membership(
+        "whitebark-pine",
+        "Tracking Whitebark Pine",
+        2026,
+        "in-training"
+      )
+    ],
+    pastProjects: [
+      membership("alpine-wildflower", "Alpine Wildflower Phenology", 2024, "successful"),
+      membership("front-range-owl", "Front Range Owl Survey", 2023, "successful")
+    ],
+    milestones: [
+      {
+        id: "ms_maya_1",
+        kind: "signed-up",
+        projectName: "Tracking Whitebark Pine",
+        daysAgo: 18
+      },
+      {
+        id: "ms_maya_2",
+        kind: "training-received",
+        projectName: "Tracking Whitebark Pine",
+        daysAgo: 6
+      },
+      {
+        id: "ms_maya_3",
+        kind: "first-record-submitted",
+        projectName: "Alpine Wildflower Phenology",
+        daysAgo: 210
+      }
+    ],
+    bucket: "new",
+    isStarred: true,
+    hasUnresolved: false,
+    unreadCount: 2,
+    latestSubject: "Re: Whitebark Pine — training confirmation",
+    snippet:
+      "Hi team — just confirming I can make the April 22 training. Is there a kit list I should…",
+    latestChannel: "email",
+    projectLabel: "Tracking Whitebark Pine 2026",
+    lastActivityAt: "2026-04-14T14:22:00Z",
+    lastActivityLabel: "9:22 AM",
+    timeline: buildTimeline("c_maya_patel", [
+      {
+        kind: "outbound-campaign-email",
+        actor: "Campaigns",
+        subject: "Spring 2026 field season kickoff",
+        body:
+          "Spring field work is starting soon! This season we're launching Tracking Whitebark Pine across the northern Rockies. If you've volunteered with us before and want to get back in the field this year, reply to this email and we'll get you set up for our April training weekend.",
+        daysAgo: 42,
+        isUnread: false
+      },
+      {
+        kind: "inbound-email",
+        actor: "Maya Patel",
+        subject: "Re: Spring 2026 field season kickoff",
+        body:
+          "Hi team — I'd love to help out this year. Alpine Wildflower Phenology was one of the best things I did in 2024 and the whitebark work looks like a good fit. Happy to take on a transect this season.",
+        daysAgo: 40,
+        isUnread: false
+      },
+      {
+        kind: "outbound-email",
+        actor: "Jordan (you)",
+        subject: "Re: Spring 2026 field season kickoff",
+        body:
+          "Maya — so glad you're back for another season. Tracking Whitebark Pine would be a great fit for you given your phenology experience. The April 22 training in Boulder is the next step. Can I put you down for that?",
+        daysAgo: 39,
+        isUnread: false
+      },
+      {
+        kind: "inbound-email",
+        actor: "Maya Patel",
+        subject: "Re: Spring 2026 field season kickoff",
+        body: "Yes please! Put me down for April 22.",
+        daysAgo: 38,
+        isUnread: false
+      },
+      {
+        kind: "outbound-auto-email",
+        actor: "System",
+        subject: "You're signed up: Tracking Whitebark Pine training",
+        body:
+          "This is a confirmation that Maya Patel has been added to the Tracking Whitebark Pine training roster for April 22. Training location, parking, and a recommended kit list will be sent one week before the session. If you need to cancel or reschedule, reply to this email or call (303) 555-0100.",
+        daysAgo: 38,
+        isUnread: false
+      },
+      {
+        kind: "system-event",
+        actor: "System",
+        body: "Signed up for Tracking Whitebark Pine 2026",
+        daysAgo: 38,
+        isUnread: false
+      },
+      {
+        kind: "outbound-auto-email",
+        actor: "System",
+        subject: "Reminder: your whitebark pine training is in 1 week",
+        body:
+          "Just a reminder that the Tracking Whitebark Pine volunteer training is next Wednesday, April 22 at 9am at the Boulder field office. Please bring the kit listed below and plan for an all-day session. Carpools from Denver and Fort Collins are being coordinated in the volunteer Slack.",
+        daysAgo: 8,
+        isUnread: false
+      },
+      {
+        kind: "system-event",
+        actor: "System",
+        body: "Received training materials for Tracking Whitebark Pine 2026",
+        daysAgo: 6,
+        isUnread: false
+      },
+      {
+        kind: "outbound-email",
+        actor: "Jordan (you)",
+        subject: "Whitebark Pine — training confirmation",
+        body:
+          "Hi Maya, attaching the April 22 agenda and the recommended kit list. Let us know if you need a carpool from Boulder — Elena in Santa Fe is coordinating a pickup on I-70.",
+        daysAgo: 4,
+        isUnread: false
+      },
+      {
+        kind: "inbound-email",
+        actor: "Maya Patel",
+        subject: "Re: Whitebark Pine — training confirmation",
+        body:
+          "Hi team — just confirming I can make the April 22 training. Is there a kit list I should review beforehand? Also, is there a carpool from Boulder? I can drive but I'd rather not if someone's already heading out.",
+        daysAgo: 0,
+        isUnread: true
+      },
+      {
+        kind: "internal-note",
+        actor: "Jordan",
+        body:
+          "Maya is a strong candidate for the extended Wind River route. Wants carpool — check with Elena.",
+        daysAgo: 0,
+        isUnread: false
+      }
+    ])
+  },
+  {
+    contactId: "c_daniel_rivers",
+    volunteerId: "10651",
+    displayName: "Daniel Rivers",
+    initials: "DR",
+    avatarTone: "emerald",
+    volunteerStage: "applicant",
+    primaryEmail: "d.rivers@example.com",
+    primaryPhone: null,
+    cityState: "Bellingham, WA",
+    joinedAtLabel: "Joined Apr 2026",
+    activeProjects: [
+      membership(
+        "killer-whales",
+        "Searching for Killer Whales",
+        2026,
+        "applied"
+      )
+    ],
+    pastProjects: [],
+    milestones: [
+      {
+        id: "ms_daniel_1",
+        kind: "signed-up",
+        projectName: "Searching for Killer Whales",
+        daysAgo: 7
+      }
+    ],
+    bucket: "new",
+    isStarred: false,
+    hasUnresolved: false,
+    unreadCount: 1,
+    latestSubject: "Killer Whales application",
+    snippet:
+      "Hi — I submitted the application last week and wanted to check if there's anything else you need from me.",
+    latestChannel: "email",
+    projectLabel: "Searching for Killer Whales",
+    lastActivityAt: "2026-04-14T12:05:00Z",
+    lastActivityLabel: "7:05 AM",
+    timeline: buildTimeline("c_daniel_rivers", [
+      {
+        kind: "outbound-campaign-email",
+        actor: "Campaigns",
+        subject: "Volunteers needed — Searching for Killer Whales 2026",
+        body:
+          "We're recruiting shore-based observers for the 2026 Salish Sea season of Searching for Killer Whales. No prior experience required; we provide training in mid-May before the first field window opens. If you're interested, click through to apply.",
+        daysAgo: 14,
+        isUnread: false
+      },
+      {
+        kind: "inbound-email",
+        actor: "Daniel Rivers",
+        subject: "Killer Whales project — interested",
+        body:
+          "Hi, I saw your email about the orca project and I'm very interested. I've done seabird transects with the Puget Sound Seabird Survey so I'm comfortable with data sheets and binoculars, but this would be my first project with Adventure Scientists. Where do I start?",
+        daysAgo: 12,
+        isUnread: false
+      },
+      {
+        kind: "outbound-email",
+        actor: "Jordan (you)",
+        subject: "Re: Killer Whales project — interested",
+        body:
+          "Hi Daniel, welcome! The next step is filling out the full application (takes about 15 minutes) — link below. Once that's in we'll confirm fit and schedule you for training.",
+        daysAgo: 12,
+        isUnread: false
+      },
+      {
+        kind: "system-event",
+        actor: "System",
+        body: "Signed up for Searching for Killer Whales 2026",
+        daysAgo: 7,
+        isUnread: false
+      },
+      {
+        kind: "outbound-auto-email",
+        actor: "System",
+        subject: "Application received: Searching for Killer Whales",
+        body:
+          "Thanks for applying to Searching for Killer Whales. A project coordinator will review your application within 5 business days and reach out with next steps. You'll hear from us by April 19.",
+        daysAgo: 7,
+        isUnread: false
+      },
+      {
+        kind: "inbound-email",
+        actor: "Daniel Rivers",
+        subject: "Killer Whales application",
+        body:
+          "Hi — I submitted the application last week and wanted to check if there's anything else you need from me. Happy to provide references if that helps.",
+        daysAgo: 0,
+        isUnread: true
+      }
+    ])
+  },
+  {
+    contactId: "c_priya_chen",
+    volunteerId: "9842",
+    displayName: "Priya Chen",
+    initials: "PC",
+    avatarTone: "violet",
+    volunteerStage: "active",
+    primaryEmail: "priya.chen@example.org",
+    primaryPhone: "+1 415 555 0119",
+    cityState: "San Francisco, CA",
+    joinedAtLabel: "Joined Aug 2023",
+    activeProjects: [
+      membership("coral-reefs", "Monitoring Coral Reefs", 2026, "in-field")
+    ],
+    pastProjects: [
+      membership("tide-pool-watch", "Tide Pool Watch", 2025, "successful"),
+      membership("tide-pool-watch", "Tide Pool Watch", 2024, "successful"),
+      membership("bay-estuary", "Bay Estuary Baseline", 2023, "successful")
+    ],
+    milestones: [
+      {
+        id: "ms_priya_1",
+        kind: "signed-up",
+        projectName: "Monitoring Coral Reefs",
+        daysAgo: 90
+      },
+      {
+        id: "ms_priya_2",
+        kind: "training-completed",
+        projectName: "Monitoring Coral Reefs",
+        daysAgo: 60
+      },
+      {
+        id: "ms_priya_3",
+        kind: "trip-plan-submitted",
+        projectName: "Monitoring Coral Reefs",
+        daysAgo: 12
+      },
+      {
+        id: "ms_priya_4",
+        kind: "first-record-submitted",
+        projectName: "Monitoring Coral Reefs",
+        daysAgo: 4
+      }
+    ],
+    bucket: "new",
+    isStarred: false,
+    hasUnresolved: true,
+    unreadCount: 1,
+    latestSubject: "Site access permit — urgent",
+    snippet:
+      "Got word the Molokini permit isn't in the system. Can someone confirm by Wednesday?",
+    latestChannel: "email",
+    projectLabel: "Monitoring Coral Reefs",
+    lastActivityAt: "2026-04-14T09:48:00Z",
+    lastActivityLabel: "4:48 AM",
+    timeline: buildTimeline("c_priya_chen", [
+      {
+        kind: "outbound-auto-email",
+        actor: "System",
+        subject: "Trip plan approved: Molokini Crater, Apr 15–17",
+        body:
+          "Your trip plan for Molokini Crater has been approved. Please remember to check in at the start and end of each field day via the volunteer app. Tides and access notes are attached.",
+        daysAgo: 12,
+        isUnread: false
+      },
+      {
+        kind: "outbound-campaign-sms",
+        actor: "Campaigns",
+        subject: "April field readiness SMS",
+        body:
+          "Monitoring Coral Reefs volunteers: reminder that your April field window opens Monday. Check the project app for your assigned transects and reply STOP to opt out of project texts.",
+        daysAgo: 6,
+        isUnread: false
+      },
+      {
+        kind: "outbound-email",
+        actor: "Jordan (you)",
+        subject: "Welcome back for the 2026 reef season",
+        body:
+          "Priya — so glad to have you back on Monitoring Coral Reefs as field lead. You're set for the Molokini transects. Let me know if anything on the gear list is missing from last year's kit.",
+        daysAgo: 5,
+        isUnread: false
+      },
+      {
+        kind: "inbound-email",
+        actor: "Priya Chen",
+        subject: "Re: Welcome back for the 2026 reef season",
+        body:
+          "Thanks Jordan! Kit is in good shape. I submitted the first transect record this morning — looks healthy out there compared to last year. Will send the rest by Friday.",
+        daysAgo: 4,
+        isUnread: false
+      },
+      {
+        kind: "system-event",
+        actor: "System",
+        body: "Submitted first record for Monitoring Coral Reefs",
+        daysAgo: 4,
+        isUnread: false
+      },
+      {
+        kind: "inbound-sms",
+        actor: "Priya Chen",
+        subject: null,
+        body:
+          "Heads up — ranger just told me Molokini permit isn't showing in their system. We good?",
+        daysAgo: 1,
+        isUnread: false
+      },
+      {
+        kind: "outbound-sms",
+        actor: "Jordan (you)",
+        subject: null,
+        body:
+          "Checking with the permits team now — I'll have an answer for you by EOD.",
+        daysAgo: 1,
+        isUnread: false
+      },
+      {
+        kind: "inbound-email",
+        actor: "Priya Chen",
+        subject: "Site access permit — urgent",
+        body:
+          "Hi — got word from the ranger that the Molokini Crater permit isn't in the system yet. Can someone on the AS side confirm by Wednesday? We're holding gear in Maui and I'd hate to reschedule the crew.",
+        daysAgo: 0,
+        isUnread: true
+      },
+      {
+        kind: "internal-note",
+        actor: "Jordan",
+        body:
+          "Routing: permit was approved in March but never synced to DLNR system. Looping in Mel from ops.",
+        daysAgo: 0,
+        isUnread: false
+      },
+      {
+        kind: "system-event",
+        actor: "System",
+        body:
+          "Routing review opened: permit ownership unclear between Coral Reefs and Bay Estuary projects.",
+        daysAgo: 0,
+        isUnread: false
+      }
+    ])
+  },
+  {
+    contactId: "c_sam_whitehorse",
+    volunteerId: "8127",
+    displayName: "Sam Whitehorse",
+    initials: "SW",
+    avatarTone: "amber",
+    volunteerStage: "active",
+    primaryEmail: "sam.w@example.net",
+    primaryPhone: "+1 406 555 0193",
+    cityState: "Missoula, MT",
+    joinedAtLabel: "Joined Jun 2022",
+    activeProjects: [
+      membership("beech-butternut", "Beech and Butternut", 2026, "in-field")
+    ],
+    pastProjects: [
+      membership("cutthroat-watch", "Cutthroat Trout Watch", 2025, "successful"),
+      membership("cutthroat-watch", "Cutthroat Trout Watch", 2024, "successful"),
+      membership("bitterroot-bloom", "Bitterroot Bloom Survey", 2023, "successful"),
+      membership("bitterroot-bloom", "Bitterroot Bloom Survey", 2022, "successful")
+    ],
+    milestones: [
+      {
+        id: "ms_sam_1",
+        kind: "signed-up",
+        projectName: "Beech and Butternut",
+        daysAgo: 95
+      },
+      {
+        id: "ms_sam_2",
+        kind: "training-completed",
+        projectName: "Beech and Butternut",
+        daysAgo: 70
+      },
+      {
+        id: "ms_sam_3",
+        kind: "trip-plan-submitted",
+        projectName: "Beech and Butternut",
+        daysAgo: 28
+      },
+      {
+        id: "ms_sam_4",
+        kind: "first-record-submitted",
+        projectName: "Beech and Butternut",
+        daysAgo: 10
+      }
+    ],
+    bucket: "opened",
+    isStarred: true,
+    hasUnresolved: false,
+    unreadCount: 0,
+    latestSubject: "Data upload questions",
+    snippet:
+      "Thanks — the sync worked after I switched networks. Closing this one out unless you need more.",
+    latestChannel: "email",
+    projectLabel: "Beech and Butternut",
+    lastActivityAt: "2026-04-13T19:30:00Z",
+    lastActivityLabel: "Yesterday",
+    timeline: buildTimeline("c_sam_whitehorse", [
+      {
+        kind: "outbound-email",
+        actor: "Jordan (you)",
+        subject: "2026 Beech and Butternut field window is open",
+        body:
+          "Sam — the April field window for Beech and Butternut is officially open. Your assigned stands are the same as last year. Let us know if anything has changed on your end.",
+        daysAgo: 14,
+        isUnread: false
+      },
+      {
+        kind: "inbound-email",
+        actor: "Sam Whitehorse",
+        subject: "Re: 2026 Beech and Butternut field window is open",
+        body:
+          "Perfect, same stands work. Already got the kit out of storage. Will file the trip plan this week.",
+        daysAgo: 13,
+        isUnread: false
+      },
+      {
+        kind: "system-event",
+        actor: "System",
+        body: "Submitted trip plan for Beech and Butternut",
+        daysAgo: 12,
+        isUnread: false
+      },
+      {
+        kind: "outbound-auto-email",
+        actor: "System",
+        subject: "Trip plan approved: Beech and Butternut, Apr 4–6",
+        body:
+          "Your trip plan has been reviewed and approved. Remember to carry the emergency contact card and check in at start and end of each field day.",
+        daysAgo: 11,
+        isUnread: false
+      },
+      {
+        kind: "system-event",
+        actor: "System",
+        body: "Submitted first record for Beech and Butternut",
+        daysAgo: 10,
+        isUnread: false
+      },
+      {
+        kind: "inbound-sms",
+        actor: "Sam Whitehorse",
+        subject: null,
+        body:
+          "Upload keeps failing at the last step — 'network error'. Trying from the truck hotspot.",
+        daysAgo: 2,
+        isUnread: false
+      },
+      {
+        kind: "outbound-sms",
+        actor: "Jordan (you)",
+        subject: null,
+        body:
+          "The hotspot usually does it — also try airplane-mode toggle once. Let me know if it still fails.",
+        daysAgo: 2,
+        isUnread: false
+      },
+      {
+        kind: "inbound-email",
+        actor: "Sam Whitehorse",
+        subject: "Data upload questions",
+        body:
+          "Thanks — the sync worked after I switched networks. Closing this one out unless you need more from me.",
+        daysAgo: 1,
+        isUnread: false
+      },
+      {
+        kind: "outbound-email",
+        actor: "Jordan (you)",
+        subject: "Re: Data upload questions",
+        body:
+          "Glad that worked. I'll mark the last two sessions as received. Let us know when May upload window opens.",
+        daysAgo: 1,
+        isUnread: false
+      }
+    ])
+  },
+  {
+    contactId: "c_anita_ross",
+    volunteerId: "10892",
+    displayName: "Anita Ross",
+    initials: "AR",
+    avatarTone: "rose",
+    volunteerStage: "prospect",
+    primaryEmail: "anita.ross@example.edu",
+    primaryPhone: "+1 802 555 0178",
+    cityState: "Burlington, VT",
+    joinedAtLabel: "Joined Apr 2026",
+    activeProjects: [],
+    pastProjects: [],
+    milestones: [],
+    bucket: "new",
+    isStarred: false,
+    hasUnresolved: true,
+    unreadCount: 1,
+    latestSubject: "Question from Middlebury bio dept",
+    snippet:
+      "I teach field ecology at Middlebury and would love to connect volunteers to our capstone…",
+    latestChannel: "email",
+    projectLabel: null,
+    lastActivityAt: "2026-04-14T02:14:00Z",
+    lastActivityLabel: "Yesterday",
+    timeline: buildTimeline("c_anita_ross", [
+      {
+        kind: "inbound-email",
+        actor: "Anita Ross",
+        subject: "Question from Middlebury bio dept",
+        body:
+          "Hi — I teach field ecology at Middlebury and would love to connect volunteers to our spring capstone. Do you have a partnership contact, or should I just send students to the general volunteer form? Happy to jump on a call if that's easier.",
+        daysAgo: 1,
+        isUnread: true
+      }
+    ])
+  },
+  {
+    contactId: "c_ben_okafor",
+    volunteerId: "7214",
+    displayName: "Ben Okafor",
+    initials: "BO",
+    avatarTone: "sky",
+    volunteerStage: "alumni",
+    primaryEmail: "ben.okafor@example.com",
+    primaryPhone: "+1 720 555 0111",
+    cityState: "Denver, CO",
+    joinedAtLabel: "Joined Mar 2021",
+    activeProjects: [],
+    pastProjects: [
+      membership("front-range-owl", "Front Range Owl Survey", 2023, "successful"),
+      membership("front-range-owl", "Front Range Owl Survey", 2022, "successful"),
+      membership("front-range-owl", "Front Range Owl Survey", 2021, "successful")
+    ],
+    milestones: [
+      {
+        id: "ms_ben_1",
+        kind: "first-record-submitted",
+        projectName: "Front Range Owl Survey",
+        daysAgo: 900
+      },
+      {
+        id: "ms_ben_2",
+        kind: "trip-plan-submitted",
+        projectName: "Front Range Owl Survey",
+        daysAgo: 920
+      }
+    ],
+    bucket: "opened",
+    isStarred: false,
+    hasUnresolved: false,
+    unreadCount: 0,
+    latestSubject: "Photo permissions for annual report",
+    snippet:
+      "Of course — use any of the 2023 owl photos. Credit line is fine, no logo needed.",
+    latestChannel: "email",
+    projectLabel: "Front Range Owl Survey 2023",
+    lastActivityAt: "2026-04-12T16:10:00Z",
+    lastActivityLabel: "2 days ago",
+    timeline: buildTimeline("c_ben_okafor", [
+      {
+        kind: "outbound-campaign-email",
+        actor: "Campaigns",
+        subject: "2025 Annual Report — a look back at your field work",
+        body:
+          "This year's annual report features volunteer photographers and the stories behind the data. If you have field photos from past seasons that we can feature, reply to let us know. Your contribution makes this report possible.",
+        daysAgo: 10,
+        isUnread: false
+      },
+      {
+        kind: "outbound-email",
+        actor: "Jordan (you)",
+        subject: "Photo permissions for annual report",
+        body:
+          "Hi Ben — can we use a few of your 2023 owl photos in the annual report? Full credit, of course. The drafts we want to feature are the four silhouettes from Lookout Mountain and the spread at Dinosaur Ridge.",
+        daysAgo: 3,
+        isUnread: false
+      },
+      {
+        kind: "inbound-email",
+        actor: "Ben Okafor",
+        subject: "Re: Photo permissions for annual report",
+        body:
+          "Of course — use any of the 2023 owl photos. Credit line is fine, no logo needed. Glad they'll get another life.",
+        daysAgo: 2,
+        isUnread: false
+      }
+    ])
+  },
+  {
+    contactId: "c_elena_marquez",
+    volunteerId: "9507",
+    displayName: "Elena Marquez",
+    initials: "EM",
+    avatarTone: "teal",
+    volunteerStage: "active",
+    primaryEmail: "elena.m@example.org",
+    primaryPhone: "+1 505 555 0157",
+    cityState: "Santa Fe, NM",
+    joinedAtLabel: "Joined Feb 2025",
+    activeProjects: [
+      membership("pnw-biodiversity", "PNW Biodiversity", 2026, "trip-planning")
+    ],
+    pastProjects: [
+      membership("pnw-biodiversity", "PNW Biodiversity", 2025, "successful")
+    ],
+    milestones: [
+      {
+        id: "ms_elena_1",
+        kind: "signed-up",
+        projectName: "PNW Biodiversity",
+        daysAgo: 45
+      },
+      {
+        id: "ms_elena_2",
+        kind: "training-completed",
+        projectName: "PNW Biodiversity",
+        daysAgo: 20
+      },
+      {
+        id: "ms_elena_3",
+        kind: "trip-plan-submitted",
+        projectName: "PNW Biodiversity",
+        daysAgo: 5
+      }
+    ],
+    bucket: "opened",
+    isStarred: true,
+    hasUnresolved: false,
+    unreadCount: 0,
+    latestSubject: "Carpool list for April training",
+    snippet:
+      "I can pick up two from Boulder on the 22nd — just need names by Friday.",
+    latestChannel: "sms",
+    projectLabel: "PNW Biodiversity 2026",
+    lastActivityAt: "2026-04-12T11:02:00Z",
+    lastActivityLabel: "2 days ago",
+    timeline: buildTimeline("c_elena_marquez", [
+      {
+        kind: "outbound-campaign-email",
+        actor: "Campaigns",
+        subject: "PNW Biodiversity 2026 kickoff",
+        body:
+          "Returning PNW Biodiversity volunteers: this year's project expands into the Olympic Peninsula. If you're on the 2025 roster, you're already approved for 2026 — just reply to confirm your availability.",
+        daysAgo: 50,
+        isUnread: false
+      },
+      {
+        kind: "inbound-email",
+        actor: "Elena Marquez",
+        subject: "Re: PNW Biodiversity 2026 kickoff",
+        body:
+          "I'm in for another year. Can I take a regional coordinator role for the Santa Fe / Colorado routes? I know it's a larger commitment but I've got the flexibility this year.",
+        daysAgo: 48,
+        isUnread: false
+      },
+      {
+        kind: "outbound-email",
+        actor: "Jordan (you)",
+        subject: "Re: PNW Biodiversity 2026 kickoff",
+        body:
+          "Yes — thrilled to have you as regional coord. I'll loop you into the coordinator Slack and put you on the training review list.",
+        daysAgo: 47,
+        isUnread: false
+      },
+      {
+        kind: "system-event",
+        actor: "System",
+        body: "Signed up for PNW Biodiversity 2026",
+        daysAgo: 45,
+        isUnread: false
+      },
+      {
+        kind: "system-event",
+        actor: "System",
+        body: "Completed training for PNW Biodiversity 2026",
+        daysAgo: 20,
+        isUnread: false
+      },
+      {
+        kind: "system-event",
+        actor: "System",
+        body: "Submitted trip plan for PNW Biodiversity 2026",
+        daysAgo: 5,
+        isUnread: false
+      },
+      {
+        kind: "inbound-sms",
+        actor: "Elena Marquez",
+        subject: null,
+        body: "I can pick up two from Boulder on the 22nd — just need names by Friday.",
+        daysAgo: 2,
+        isUnread: false
+      },
+      {
+        kind: "outbound-sms",
+        actor: "Jordan (you)",
+        subject: null,
+        body: "Perfect. I'll circle back with the list Thursday evening.",
+        daysAgo: 2,
+        isUnread: false
+      }
+    ])
+  },
+  {
+    contactId: "c_unknown_5551",
+    volunteerId: "—",
+    displayName: "+1 720 555 0199",
+    initials: "??",
+    avatarTone: "slate",
+    volunteerStage: "non-volunteer",
+    primaryEmail: null,
+    primaryPhone: "+1 720 555 0199",
+    cityState: null,
+    joinedAtLabel: "First seen Apr 2026",
+    activeProjects: [],
+    pastProjects: [],
+    milestones: [],
+    bucket: "new",
+    isStarred: false,
+    hasUnresolved: true,
+    unreadCount: 1,
+    latestSubject: "Inbound SMS",
+    snippet:
+      "hey is this the whitebark pine signup line? my wife saw the flyer in laramie",
+    latestChannel: "sms",
+    projectLabel: null,
+    lastActivityAt: "2026-04-13T22:45:00Z",
+    lastActivityLabel: "Yesterday",
+    timeline: buildTimeline("c_unknown_5551", [
+      {
+        kind: "inbound-sms",
+        actor: "+1 720 555 0199",
+        subject: null,
+        body:
+          "hey is this the whitebark pine signup line? my wife saw the flyer in laramie",
+        daysAgo: 1,
+        isUnread: true
+      },
+      {
+        kind: "system-event",
+        actor: "System",
+        body:
+          "Identity resolution queue: no contact match for +1 720 555 0199. Awaiting manual link.",
+        daysAgo: 1,
+        isUnread: false
+      }
+    ])
+  }
+];
+
+interface MockTimelineSeed {
+  readonly kind: ClaudeTimelineEntryKind;
+  readonly actor: string;
+  readonly subject?: string | null;
+  readonly body: string;
+  readonly daysAgo: number;
+  readonly isUnread: boolean;
+}
+
+function buildTimeline(
+  contactId: string,
+  seeds: readonly MockTimelineSeed[]
+): readonly ClaudeTimelineEntryViewModel[] {
+  return seeds.map((seed, index) => {
+    const occurredAt = iso(seed.daysAgo);
+    return {
+      id: `${contactId}_t${index.toString()}`,
+      kind: seed.kind,
+      occurredAt,
+      occurredAtLabel: relativeLabel(seed.daysAgo),
+      actorLabel: seed.actor,
+      subject: seed.subject ?? null,
+      body: seed.body,
+      channel: channelForKind(seed.kind),
+      isUnread: seed.isUnread
+    };
+  });
+}
+
+function channelForKind(kind: ClaudeTimelineEntryKind): ClaudeInboxChannel | null {
+  switch (kind) {
+    case "inbound-email":
+    case "outbound-email":
+    case "outbound-auto-email":
+    case "outbound-campaign-email":
+      return "email";
+    case "inbound-sms":
+    case "outbound-sms":
+    case "outbound-campaign-sms":
+      return "sms";
+    case "internal-note":
+    case "system-event":
+      return null;
+  }
+}
+
+function iso(daysAgo: number): string {
+  const base = Date.UTC(2026, 3, 14, 14, 0, 0);
+  const offsetMs = daysAgo * 24 * 60 * 60 * 1000;
+  return new Date(base - offsetMs).toISOString();
+}
+
+function relativeLabel(daysAgo: number): string {
+  if (daysAgo === 0) return "today";
+  if (daysAgo === 1) return "yesterday";
+  if (daysAgo < 7) return `${daysAgo.toString()} days ago`;
+  if (daysAgo < 14) return "last week";
+  if (daysAgo < 60) return `${Math.floor(daysAgo / 7).toString()} weeks ago`;
+  if (daysAgo < 365) return `${Math.floor(daysAgo / 30).toString()} months ago`;
+  return `${Math.floor(daysAgo / 365).toString()} years ago`;
+}
+
+export function getMockContacts(): readonly MockContactRecord[] {
+  return CONTACTS;
+}
+
+export function getMockContactById(
+  contactId: string
+): MockContactRecord | null {
+  return CONTACTS.find((c) => c.contactId === contactId) ?? null;
+}
+
+export type { MockContactRecord, MockMilestone };

--- a/apps/web/app/(claude-inbox)/_lib/selectors.ts
+++ b/apps/web/app/(claude-inbox)/_lib/selectors.ts
@@ -1,0 +1,153 @@
+/**
+ * Claude Inbox prototype — server-side selectors.
+ *
+ * These functions are the only place the mock records touch the view-model
+ * contract. The Server Components consume these and pass the narrow view
+ * models to client islands. In Phase 2 this module is the natural place to
+ * substitute real projection reads — the view-model shapes stay stable.
+ */
+
+import { CLAUDE_INBOX_FILTERS } from "./filters";
+import {
+  getMockContactById,
+  getMockContacts,
+  type MockMilestone
+} from "./mock-data";
+import type {
+  ClaudeContactSummaryViewModel,
+  ClaudeInboxDetailViewModel,
+  ClaudeInboxFilterId,
+  ClaudeInboxFilterViewModel,
+  ClaudeInboxListItemViewModel,
+  ClaudeInboxListViewModel,
+  ClaudeRecentActivityViewModel
+} from "./view-models";
+
+const LIST_SORT = (
+  a: ClaudeInboxListItemViewModel,
+  b: ClaudeInboxListItemViewModel
+): number => (a.lastActivityAt < b.lastActivityAt ? 1 : -1);
+
+export function getClaudeInboxList(
+  filterId: ClaudeInboxFilterId = "all"
+): ClaudeInboxListViewModel {
+  const contacts = getMockContacts();
+
+  const items: ClaudeInboxListItemViewModel[] = contacts.map((c) => ({
+    contactId: c.contactId,
+    displayName: c.displayName,
+    initials: c.initials,
+    avatarTone: c.avatarTone,
+    latestSubject: c.latestSubject,
+    snippet: c.snippet,
+    latestChannel: c.latestChannel,
+    projectLabel: c.projectLabel,
+    volunteerStage: c.volunteerStage,
+    bucket: c.bucket,
+    isStarred: c.isStarred,
+    hasUnresolved: c.hasUnresolved,
+    unreadCount: c.unreadCount,
+    lastActivityAt: c.lastActivityAt,
+    lastActivityLabel: c.lastActivityLabel
+  }));
+
+  const totals = {
+    all: items.length,
+    unread: items.filter((i) => i.unreadCount > 0).length
+  };
+
+  const filters: ClaudeInboxFilterViewModel[] = CLAUDE_INBOX_FILTERS.map((f) => ({
+    id: f.id,
+    label: f.label,
+    hint: f.hint,
+    count: f.id === "follow-up" ? 0 : totals[f.id]
+  }));
+
+  const filtered = items
+    .filter((item) => matchesServerFilter(item, filterId))
+    .sort(LIST_SORT);
+
+  return { items: filtered, filters, totals };
+}
+
+function matchesServerFilter(
+  item: ClaudeInboxListItemViewModel,
+  filterId: ClaudeInboxFilterId
+): boolean {
+  switch (filterId) {
+    case "all":
+      return true;
+    case "unread":
+      return item.unreadCount > 0;
+    case "follow-up":
+      // Follow-up is client-owned state; server returns everything and the
+      // client narrows it. Keeping this branch exhaustive satisfies the
+      // discriminated-union check.
+      return true;
+  }
+}
+
+export function getClaudeInboxDetail(
+  contactId: string
+): ClaudeInboxDetailViewModel | null {
+  const record = getMockContactById(contactId);
+  if (!record) return null;
+
+  const recentActivity: ClaudeRecentActivityViewModel[] = record.milestones
+    .slice()
+    .sort((a, b) => a.daysAgo - b.daysAgo)
+    .slice(0, 5)
+    .map((milestone) => ({
+      id: milestone.id,
+      label: milestoneLabel(milestone),
+      occurredAtLabel: relativeLabel(milestone.daysAgo)
+    }));
+
+  const contact: ClaudeContactSummaryViewModel = {
+    contactId: record.contactId,
+    displayName: record.displayName,
+    volunteerId: record.volunteerId,
+    primaryEmail: record.primaryEmail,
+    primaryPhone: record.primaryPhone,
+    cityState: record.cityState,
+    joinedAtLabel: record.joinedAtLabel,
+    hasUnresolved: record.hasUnresolved,
+    activeProjects: record.activeProjects,
+    pastProjects: record.pastProjects,
+    recentActivity
+  };
+
+  return {
+    contact,
+    timeline: record.timeline,
+    bucket: record.bucket,
+    isStarred: record.isStarred,
+    smsEligible: record.primaryPhone !== null
+  };
+}
+
+function milestoneLabel(milestone: MockMilestone): string {
+  const name = milestone.projectName;
+  switch (milestone.kind) {
+    case "signed-up":
+      return `Signed up to ${name}`;
+    case "training-received":
+      return `Received training for ${name}`;
+    case "training-completed":
+      return `Completed training for ${name}`;
+    case "trip-plan-submitted":
+      return `Submitted trip plan for ${name}`;
+    case "first-record-submitted":
+      return `Submitted first record for ${name}`;
+  }
+}
+
+function relativeLabel(daysAgo: number): string {
+  if (daysAgo === 0) return "today";
+  if (daysAgo === 1) return "yesterday";
+  if (daysAgo < 7) return `${daysAgo.toString()} days ago`;
+  if (daysAgo < 14) return "last week";
+  if (daysAgo < 60) return `${Math.floor(daysAgo / 7).toString()} weeks ago`;
+  if (daysAgo < 365) return `${Math.floor(daysAgo / 30).toString()} months ago`;
+  return `${Math.floor(daysAgo / 365).toString()} years ago`;
+}

--- a/apps/web/app/(claude-inbox)/_lib/view-models.ts
+++ b/apps/web/app/(claude-inbox)/_lib/view-models.ts
@@ -1,0 +1,153 @@
+/**
+ * Claude Inbox prototype — UI-facing view models.
+ *
+ * These types shape the minimum payload the client UI needs. They deliberately
+ * mirror the canonical Inbox / Timeline projection concepts from
+ * docs/01-core/data-core.md and docs/01-core/interfaces-core.md rather than
+ * echoing any provider payload shape.
+ *
+ * Locked rules reflected here:
+ *   - one row per person, not per thread (P-02 / INBX-01)
+ *   - primary buckets are "new" and "opened" (INBX-02)
+ *   - "starred" is a flag, not a bucket (INBX-03)
+ *   - "unresolved" is an overlay on top of the queue model (INBX-04)
+ *   - campaign and automated sends are surfaced in the timeline as collapsed
+ *     entries so 1:1 history stays readable (INBX-05)
+ */
+
+export type ClaudeInboxBucket = "new" | "opened";
+
+export type ClaudeInboxFilterId = "all" | "unread" | "follow-up";
+
+export type ClaudeInboxChannel = "email" | "sms";
+
+export type ClaudeVolunteerStage =
+  | "lead"
+  | "prospect"
+  | "applicant"
+  | "active"
+  | "alumni"
+  | "non-volunteer";
+
+export type ClaudeAvatarTone =
+  | "indigo"
+  | "emerald"
+  | "amber"
+  | "rose"
+  | "sky"
+  | "violet"
+  | "teal"
+  | "slate";
+
+export interface ClaudeInboxListItemViewModel {
+  readonly contactId: string;
+  readonly displayName: string;
+  readonly initials: string;
+  readonly avatarTone: ClaudeAvatarTone;
+  readonly latestSubject: string;
+  readonly snippet: string;
+  readonly latestChannel: ClaudeInboxChannel;
+  readonly projectLabel: string | null;
+  readonly volunteerStage: ClaudeVolunteerStage;
+  readonly bucket: ClaudeInboxBucket;
+  readonly isStarred: boolean;
+  readonly hasUnresolved: boolean;
+  readonly unreadCount: number;
+  readonly lastActivityAt: string;
+  readonly lastActivityLabel: string;
+}
+
+/**
+ * Canonical project participation status, per product brief.
+ * `lead` → `applied` → `in-training` → `trip-planning` → `in-field` →
+ * `successful`. Statuses are per-(volunteer, project) membership and do not
+ * flow through the inbox bucket model.
+ */
+export type ClaudeProjectStatus =
+  | "lead"
+  | "applied"
+  | "in-training"
+  | "trip-planning"
+  | "in-field"
+  | "successful";
+
+export interface ClaudeProjectMembershipViewModel {
+  readonly membershipId: string;
+  readonly projectId: string;
+  readonly projectName: string;
+  readonly year: number;
+  readonly status: ClaudeProjectStatus;
+  readonly crmUrl: string;
+}
+
+export interface ClaudeRecentActivityViewModel {
+  readonly id: string;
+  readonly label: string;
+  readonly occurredAtLabel: string;
+}
+
+export interface ClaudeContactSummaryViewModel {
+  readonly contactId: string;
+  readonly displayName: string;
+  readonly volunteerId: string;
+  readonly primaryEmail: string | null;
+  readonly primaryPhone: string | null;
+  readonly cityState: string | null;
+  readonly joinedAtLabel: string;
+  readonly hasUnresolved: boolean;
+  readonly activeProjects: readonly ClaudeProjectMembershipViewModel[];
+  readonly pastProjects: readonly ClaudeProjectMembershipViewModel[];
+  readonly recentActivity: readonly ClaudeRecentActivityViewModel[];
+}
+
+/**
+ * Timeline entry kinds. 1:1 kinds render as full chat bubbles; campaign and
+ * automated kinds render as collapsed single-line entries that expand on
+ * click; internal notes and system events are visually distinct.
+ */
+export type ClaudeTimelineEntryKind =
+  | "inbound-email"
+  | "outbound-email"
+  | "outbound-auto-email"
+  | "outbound-campaign-email"
+  | "inbound-sms"
+  | "outbound-sms"
+  | "outbound-campaign-sms"
+  | "internal-note"
+  | "system-event";
+
+export interface ClaudeTimelineEntryViewModel {
+  readonly id: string;
+  readonly kind: ClaudeTimelineEntryKind;
+  readonly occurredAt: string;
+  readonly occurredAtLabel: string;
+  readonly actorLabel: string;
+  readonly subject: string | null;
+  readonly body: string;
+  readonly channel: ClaudeInboxChannel | null;
+  readonly isUnread: boolean;
+}
+
+export interface ClaudeInboxDetailViewModel {
+  readonly contact: ClaudeContactSummaryViewModel;
+  readonly timeline: readonly ClaudeTimelineEntryViewModel[];
+  readonly bucket: ClaudeInboxBucket;
+  readonly isStarred: boolean;
+  readonly smsEligible: boolean;
+}
+
+export interface ClaudeInboxFilterViewModel {
+  readonly id: ClaudeInboxFilterId;
+  readonly label: string;
+  readonly count: number;
+  readonly hint: string | null;
+}
+
+export interface ClaudeInboxListViewModel {
+  readonly items: readonly ClaudeInboxListItemViewModel[];
+  readonly filters: readonly ClaudeInboxFilterViewModel[];
+  readonly totals: {
+    readonly all: number;
+    readonly unread: number;
+  };
+}

--- a/apps/web/app/(claude-inbox)/inbox/[contactId]/page.tsx
+++ b/apps/web/app/(claude-inbox)/inbox/[contactId]/page.tsx
@@ -1,0 +1,17 @@
+import { notFound } from "next/navigation";
+
+import { ClaudeInboxDetail } from "../../_components/claude-inbox-detail";
+import { getClaudeInboxDetail } from "../../_lib/selectors";
+
+interface PageProps {
+  readonly params: Promise<{ readonly contactId: string }>;
+}
+
+export default async function ClaudeInboxContactPage({ params }: PageProps) {
+  const { contactId } = await params;
+  const detail = getClaudeInboxDetail(contactId);
+  if (!detail) {
+    notFound();
+  }
+  return <ClaudeInboxDetail detail={detail} />;
+}

--- a/apps/web/app/(claude-inbox)/inbox/layout.tsx
+++ b/apps/web/app/(claude-inbox)/inbox/layout.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+
+import { ClaudeInboxShell } from "../_components/claude-inbox-shell";
+import { getClaudeInboxList } from "../_lib/selectors";
+
+export const metadata = {
+  title: "Inbox · Claude prototype"
+};
+
+/**
+ * Server Component: composes the persistent shell (icon rail + list column)
+ * once for both `/inbox` and `/inbox/[contactId]`. The page slot underneath
+ * renders either the empty state or the selected-contact detail workspace.
+ *
+ * Following FP-01/FP-02: the full list is assembled here from a server-side
+ * selector and only minimized view models flow into the client list island.
+ * The client applies the active filter locally against those view models, so
+ * the sidebar collapse has no effect on where canonical state lives.
+ */
+export default function ClaudeInboxLayout({
+  children
+}: {
+  readonly children: ReactNode;
+}) {
+  const list = getClaudeInboxList("all");
+
+  return (
+    <ClaudeInboxShell
+      filters={list.filters}
+      items={list.items}
+      initialFilterId="all"
+    >
+      {children}
+    </ClaudeInboxShell>
+  );
+}

--- a/apps/web/app/(claude-inbox)/inbox/loading.tsx
+++ b/apps/web/app/(claude-inbox)/inbox/loading.tsx
@@ -1,0 +1,5 @@
+import { ClaudeInboxAppLoading } from "../_components/claude-inbox-loading";
+
+export default function InboxLoading() {
+  return <ClaudeInboxAppLoading />;
+}

--- a/apps/web/app/(claude-inbox)/inbox/page.tsx
+++ b/apps/web/app/(claude-inbox)/inbox/page.tsx
@@ -1,0 +1,5 @@
+import { ClaudeInboxEmptyState } from "../_components/claude-inbox-empty-state";
+
+export default function ClaudeInboxListPage() {
+  return <ClaudeInboxEmptyState />;
+}

--- a/apps/web/app/(claude-inbox)/inbox/states/page.tsx
+++ b/apps/web/app/(claude-inbox)/inbox/states/page.tsx
@@ -1,0 +1,1098 @@
+"use client";
+
+/**
+ * `/inbox/states` — Interactive showcase of every Inbox UI state.
+ *
+ * This page is for design review and QA. Each section renders a real
+ * component in a specific state so reviewers can see every permutation
+ * without clicking through the prototype. Controls at the top let you
+ * drive the shared client context (loading flags, composer status, AI
+ * draft lifecycle) so the live inbox layout also updates.
+ *
+ * States covered:
+ *
+ *  APP CHROME
+ *    1. App loading (full-screen skeleton)
+ *
+ *  LIST COLUMN
+ *    2. Queue loading skeleton
+ *    3. Empty queue (all / new / opened)
+ *    4. Search active with results
+ *    5. Search active with no results
+ *    6. New bucket tab
+ *    7. Opened bucket tab
+ *
+ *  DETAIL WORKSPACE
+ *    8. No contact selected
+ *    9. Contact selected (happy path)
+ *   10. Unresolved banner / expandable panel
+ *   11. Timeline loading skeleton
+ *   12. Needs Follow Up off
+ *   13. Needs Follow Up on
+ *
+ *  COMPOSER
+ *   14. Idle (default)
+ *   15. Saving draft
+ *   16. Draft saved
+ *   17. Validation error
+ *   18. Sending
+ *   19. Sent success
+ *   20. Send failure
+ *
+ *  AI DRAFTING
+ *   21. AI idle (button ready)
+ *   22. AI generating
+ *   23. AI draft inserted into composer
+ *   24. Reprompt action
+ *   25. AI unavailable fallback
+ *   26. AI error state
+ *   27. Edited-after-generation
+ *   28. Discarded AI draft
+ */
+
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+import type { ComposerStatus, AiDraftStatus } from "../../_components/claude-inbox-client-provider";
+import { useClaudeInboxClient } from "../../_components/claude-inbox-client-provider";
+import { ClaudeInboxAppLoading, QueueLoadingSkeleton, QueueRowSkeleton, TimelineSkeleton } from "../../_components/claude-inbox-loading";
+import { ClaudeInboxEmptyState } from "../../_components/claude-inbox-empty-state";
+import {
+  AlertCircleIcon,
+  AlertTriangleIcon,
+  BotIcon,
+  CheckCircleIcon,
+  InboxIcon,
+  LoaderIcon,
+  PencilIcon,
+  RefreshCwIcon,
+  RotateCcwIcon,
+  SearchXIcon,
+  SendIcon,
+  SparkleIcon,
+  TrashIcon,
+  WandIcon,
+  WifiOffIcon,
+  XCircleIcon,
+  XIcon
+} from "../../_components/claude-icons";
+
+// ---------- Section wrapper ----------
+
+function Section({
+  id,
+  number,
+  title,
+  children
+}: {
+  readonly id: string;
+  readonly number: number;
+  readonly title: string;
+  readonly children: React.ReactNode;
+}) {
+  return (
+    <section id={id} className="scroll-mt-20">
+      <div className="mb-3 flex items-center gap-3">
+        <span className="flex h-7 w-7 items-center justify-center rounded-full bg-slate-900 text-xs font-bold text-white tabular-nums">
+          {number}
+        </span>
+        <h2 className="text-sm font-semibold text-slate-900">{title}</h2>
+      </div>
+      <div className="rounded-xl border border-slate-200 bg-white shadow-sm overflow-hidden">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+// ---------- Live controls ----------
+
+function LiveControls() {
+  const {
+    setQueueLoading,
+    isQueueLoading,
+    setTimelineLoading,
+    isTimelineLoading,
+    composerStatus,
+    setComposerStatus,
+    setComposerErrors,
+    aiDraft,
+    startAiGeneration,
+    insertAiDraft,
+    markAiDraftEdited,
+    discardAiDraft,
+    repromptAi,
+    setAiUnavailable,
+    setAiError,
+    resetAiDraft,
+    search,
+    setSearchQuery,
+    clearSearch,
+    activeBucket,
+    setActiveBucket
+  } = useClaudeInboxClient();
+
+  const composerStates: ComposerStatus[] = [
+    "idle",
+    "saving-draft",
+    "draft-saved",
+    "validation-error",
+    "sending",
+    "sent-success",
+    "send-failure"
+  ];
+
+  const aiStates: { label: string; action: () => void }[] = [
+    { label: "Idle", action: resetAiDraft },
+    {
+      label: "Generating",
+      action: () => {
+        startAiGeneration("Draft a helpful reply");
+      }
+    },
+    {
+      label: "Inserted",
+      action: () => {
+        startAiGeneration("Draft a helpful reply");
+        setTimeout(() => {
+          insertAiDraft(
+            "Hi Maya,\n\nThanks for confirming. The kit list is attached — see you on the 22nd.\n\nBest,\nJordan"
+          );
+        }, 100);
+      }
+    },
+    {
+      label: "Reprompting",
+      action: () => {
+        repromptAi("Make it shorter");
+      }
+    },
+    { label: "Unavailable", action: setAiUnavailable },
+    {
+      label: "Error",
+      action: () => {
+        setAiError("AI service timed out. Please try again.");
+      }
+    },
+    { label: "Edited", action: markAiDraftEdited },
+    { label: "Discarded", action: discardAiDraft }
+  ];
+
+  return (
+    <div className="sticky top-0 z-50 rounded-xl border border-slate-200 bg-white p-5 shadow-lg">
+      <h2 className="text-sm font-bold text-slate-900">
+        Live Controls — drives the real inbox layout
+      </h2>
+      <p className="mt-1 text-xs text-slate-500">
+        Toggle these to see the inbox (behind this page) update in real-time.
+      </p>
+
+      <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {/* Loading toggles */}
+        <div>
+          <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+            Loading
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            <ToggleChip
+              active={isQueueLoading}
+              onClick={() => {
+                setQueueLoading(!isQueueLoading);
+              }}
+            >
+              Queue
+            </ToggleChip>
+            <ToggleChip
+              active={isTimelineLoading}
+              onClick={() => {
+                setTimelineLoading(!isTimelineLoading);
+              }}
+            >
+              Timeline
+            </ToggleChip>
+          </div>
+        </div>
+
+        {/* Bucket tabs */}
+        <div>
+          <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+            Bucket
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            {(["all", "new", "opened"] as const).map((b) => (
+              <ToggleChip
+                key={b}
+                active={activeBucket === b}
+                onClick={() => {
+                  setActiveBucket(b);
+                }}
+              >
+                {b}
+              </ToggleChip>
+            ))}
+          </div>
+        </div>
+
+        {/* Composer status */}
+        <div>
+          <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+            Composer
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            {composerStates.map((s) => (
+              <ToggleChip
+                key={s}
+                active={composerStatus === s}
+                onClick={() => {
+                  if (s === "validation-error") {
+                    setComposerErrors([
+                      { field: "subject", message: "Subject is required" }
+                    ]);
+                  }
+                  setComposerStatus(s);
+                }}
+              >
+                {s}
+              </ToggleChip>
+            ))}
+          </div>
+        </div>
+
+        {/* AI status */}
+        <div>
+          <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+            AI Draft
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            {aiStates.map((s) => (
+              <ToggleChip
+                key={s.label}
+                active={
+                  aiDraft.status ===
+                  s.label.toLowerCase().replace(/ /g, "-")
+                }
+                onClick={s.action}
+              >
+                {s.label}
+              </ToggleChip>
+            ))}
+          </div>
+        </div>
+
+        {/* Search */}
+        <div>
+          <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+            Search
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            <ToggleChip
+              active={search.isActive && search.query === "Maya"}
+              onClick={() => {
+                setSearchQuery("Maya");
+              }}
+            >
+              &ldquo;Maya&rdquo;
+            </ToggleChip>
+            <ToggleChip
+              active={
+                search.isActive && search.query === "zzz_no_match"
+              }
+              onClick={() => {
+                setSearchQuery("zzz_no_match");
+              }}
+            >
+              No results
+            </ToggleChip>
+            <ToggleChip
+              active={!search.isActive}
+              onClick={clearSearch}
+            >
+              Clear
+            </ToggleChip>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ToggleChip({
+  active,
+  onClick,
+  children
+}: {
+  readonly active: boolean;
+  readonly onClick: () => void;
+  readonly children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "rounded-md px-2 py-0.5 text-[11px] font-medium transition-colors",
+        active
+          ? "bg-slate-900 text-white"
+          : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+// ---------- Isolated state previews ----------
+
+function AppLoadingPreview() {
+  return (
+    <div className="h-80 overflow-hidden">
+      <ClaudeInboxAppLoading />
+    </div>
+  );
+}
+
+function QueueLoadingPreview() {
+  return (
+    <div className="w-[22rem] border-r border-slate-200">
+      <QueueLoadingSkeleton />
+    </div>
+  );
+}
+
+function EmptyQueuePreview({ variant }: { readonly variant: "all" | "new" | "opened" }) {
+  const messages: Record<string, { title: string; description: string }> = {
+    all: {
+      title: "All caught up",
+      description: "No conversations in your inbox right now."
+    },
+    new: {
+      title: "No new conversations",
+      description: "New messages from contacts will appear here."
+    },
+    opened: {
+      title: "No opened conversations",
+      description: "Conversations you've viewed and are working on will appear here."
+    }
+  };
+  const msg = messages[variant]!;
+
+  return (
+    <div className="w-[22rem] px-5 py-16 text-center">
+      <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-slate-100">
+        <InboxIcon className="h-6 w-6 text-slate-400" />
+      </div>
+      <p className="mt-4 text-sm font-medium text-slate-700">{msg.title}</p>
+      <p className="mt-1 text-xs text-slate-500">{msg.description}</p>
+    </div>
+  );
+}
+
+function SearchNoResultsPreview() {
+  return (
+    <div className="w-[22rem] px-5 py-16 text-center">
+      <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-slate-100">
+        <SearchXIcon className="h-6 w-6 text-slate-400" />
+      </div>
+      <p className="mt-4 text-sm font-medium text-slate-700">No results</p>
+      <p className="mt-1 text-xs text-slate-500">
+        Nothing matches &ldquo;zzz_no_match&rdquo;. Try a different search.
+      </p>
+    </div>
+  );
+}
+
+function SearchWithResultsPreview() {
+  return (
+    <div className="w-[22rem]">
+      <div className="border-b border-slate-100 px-5 py-2">
+        <p className="text-xs text-slate-500">
+          <span className="font-medium text-slate-700">2</span> results for
+          &ldquo;Maya&rdquo;
+        </p>
+      </div>
+      <div className="flex gap-3 border-b border-slate-100 bg-sky-50/60 px-5 py-3.5 ring-1 ring-inset ring-sky-200">
+        <div className="h-10 w-10 shrink-0 rounded-full bg-indigo-100 flex items-center justify-center text-sm font-semibold text-indigo-800">
+          MP
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-baseline justify-between gap-2">
+            <p className="truncate text-sm font-semibold text-slate-900">
+              <mark className="rounded bg-yellow-200/60 px-0.5">Maya</mark> Patel
+            </p>
+            <span className="shrink-0 text-[11px] font-semibold tabular-nums text-sky-700">
+              9:22 AM
+            </span>
+          </div>
+          <p className="mt-0.5 truncate text-[13px] font-medium text-slate-800">
+            Re: Whitebark Pine — training confirmation
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function NoContactSelectedPreview() {
+  return (
+    <div className="h-64">
+      <ClaudeInboxEmptyState />
+    </div>
+  );
+}
+
+function TimelineLoadingPreview() {
+  return (
+    <div className="bg-slate-50/40 p-6">
+      <TimelineSkeleton />
+    </div>
+  );
+}
+
+function UnresolvedBannerPreview() {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className="border-b border-amber-200 bg-amber-50/80">
+      <button
+        type="button"
+        onClick={() => {
+          setExpanded((e) => !e);
+        }}
+        className="flex w-full items-center gap-2 px-6 py-2.5 text-left transition-colors hover:bg-amber-100/60"
+      >
+        <AlertTriangleIcon className="h-4 w-4 shrink-0 text-amber-600" />
+        <span className="flex-1 text-sm font-medium text-amber-900">
+          Unresolved items need attention
+        </span>
+        <span className="text-xs text-amber-600">
+          {expanded ? "Hide" : "Details"}
+        </span>
+      </button>
+      {expanded ? (
+        <div className="border-t border-amber-200 px-6 py-3">
+          <p className="text-xs leading-5 text-amber-800">
+            This contact has open items that require action before the
+            conversation can be considered resolved.
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function FollowUpPreview({ isOn }: { readonly isOn: boolean }) {
+  return (
+    <div className="flex items-center gap-3 px-6 py-4">
+      <Button
+        variant="outline"
+        size="sm"
+        aria-pressed={isOn}
+        className={cn(
+          "gap-1.5",
+          isOn &&
+            "border-rose-300 bg-rose-50 text-rose-800 hover:bg-rose-100 hover:text-rose-800"
+        )}
+      >
+        <span className="inline-flex h-3.5 w-3.5 items-center justify-center">
+          ↩
+        </span>
+        Needs Follow Up
+      </Button>
+      <span className="text-xs text-slate-500">
+        {isOn ? "Active — rose accent on list row" : "Inactive — default style"}
+      </span>
+    </div>
+  );
+}
+
+function ComposerStatusPreview({
+  status,
+  label
+}: {
+  readonly status: ComposerStatus;
+  readonly label: string;
+}) {
+  const StatusMap: Record<
+    ComposerStatus,
+    { icon: React.ReactNode; text: string; className: string }
+  > = {
+    idle: {
+      icon: null,
+      text: "Ready to compose",
+      className: "text-slate-500"
+    },
+    "saving-draft": {
+      icon: <LoaderIcon className="h-3 w-3 animate-spin" />,
+      text: "Saving draft…",
+      className: "text-slate-500"
+    },
+    "draft-saved": {
+      icon: <CheckCircleIcon className="h-3 w-3" />,
+      text: "Draft saved",
+      className: "text-emerald-700"
+    },
+    "validation-error": {
+      icon: <AlertCircleIcon className="h-3 w-3" />,
+      text: "Fix errors above",
+      className: "text-red-600"
+    },
+    sending: {
+      icon: <LoaderIcon className="h-3 w-3 animate-spin" />,
+      text: "Sending…",
+      className: "text-slate-500"
+    },
+    "sent-success": {
+      icon: <CheckCircleIcon className="h-3 w-3" />,
+      text: "Message sent",
+      className: "text-emerald-700"
+    },
+    "send-failure": {
+      icon: <XCircleIcon className="h-3 w-3" />,
+      text: "Failed to send",
+      className: "text-red-600"
+    }
+  };
+
+  const s = StatusMap[status];
+
+  return (
+    <div className="flex items-center justify-between border-t border-slate-100 px-5 py-3">
+      <span className={cn("flex items-center gap-1.5 text-xs", s.className)}>
+        {s.icon}
+        {s.text}
+      </span>
+      <div className="flex items-center gap-2">
+        {status === "saving-draft" ? (
+          <Button variant="ghost" size="sm" disabled>
+            <LoaderIcon className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+            Saving…
+          </Button>
+        ) : status === "draft-saved" ? (
+          <Button variant="ghost" size="sm">
+            <CheckCircleIcon className="mr-1.5 h-3.5 w-3.5 text-emerald-600" />
+            Saved
+          </Button>
+        ) : (
+          <Button variant="ghost" size="sm">
+            Save draft
+          </Button>
+        )}
+        <Button
+          size="sm"
+          className="gap-1.5"
+          disabled={status === "sending" || status === "sent-success"}
+        >
+          {status === "sending" ? (
+            <>
+              <LoaderIcon className="h-3.5 w-3.5 animate-spin" />
+              Sending…
+            </>
+          ) : status === "sent-success" ? (
+            <>
+              <CheckCircleIcon className="h-3.5 w-3.5" />
+              Sent
+            </>
+          ) : (
+            <>
+              <SendIcon className="h-3.5 w-3.5" />
+              Send
+            </>
+          )}
+        </Button>
+        {status === "send-failure" ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-2 text-xs text-red-700"
+          >
+            <RefreshCwIcon className="mr-1 h-3 w-3" />
+            Retry
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function ValidationErrorPreview() {
+  return (
+    <div>
+      <div className="flex items-center gap-2 border-b border-slate-100 px-5 py-2 text-xs">
+        <label className="font-medium text-slate-700">Subject:</label>
+        <input
+          type="text"
+          placeholder="Add a subject"
+          className="flex-1 bg-transparent text-sm text-red-700 placeholder:text-red-400 focus:outline-none"
+          readOnly
+        />
+      </div>
+      <div className="border-t border-red-100 bg-red-50/50 px-5 py-2">
+        <p className="flex items-center gap-1.5 text-xs text-red-700">
+          <AlertCircleIcon className="h-3 w-3 shrink-0" />
+          Subject is required
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function AiStatePreview({
+  status,
+  children
+}: {
+  readonly status: string;
+  readonly children: React.ReactNode;
+}) {
+  return (
+    <div className="border-b border-violet-200 bg-violet-50/50">
+      {children}
+    </div>
+  );
+}
+
+// ---------- Page component ----------
+
+export default function InboxStatesPage() {
+  return (
+    <div className="min-h-screen bg-slate-100 p-6">
+      <div className="mx-auto max-w-5xl space-y-6">
+        {/* Page header */}
+        <div>
+          <h1 className="text-xl font-bold text-slate-900">
+            Inbox UI States
+          </h1>
+          <p className="mt-1 text-sm text-slate-600">
+            Every product state rendered in isolation. Use the live controls
+            to also drive the inbox layout visible in the background.
+          </p>
+        </div>
+
+        {/* Live controls */}
+        <LiveControls />
+
+        {/* Table of contents */}
+        <nav className="rounded-xl border border-slate-200 bg-white p-5">
+          <h2 className="text-xs font-bold uppercase tracking-wider text-slate-500">
+            States
+          </h2>
+          <div className="mt-3 grid gap-x-6 gap-y-1 text-xs sm:grid-cols-2 lg:grid-cols-3">
+            {TOC.map((item) => (
+              <a
+                key={item.id}
+                href={`#${item.id}`}
+                className="flex items-center gap-2 rounded px-1.5 py-1 text-slate-700 transition-colors hover:bg-slate-50 hover:text-slate-900"
+              >
+                <span className="flex h-5 w-5 items-center justify-center rounded-full bg-slate-100 text-[10px] font-bold tabular-nums text-slate-600">
+                  {item.number}
+                </span>
+                {item.title}
+              </a>
+            ))}
+          </div>
+        </nav>
+
+        {/* ===== APP CHROME ===== */}
+        <div className="pt-4">
+          <h2 className="text-xs font-bold uppercase tracking-wider text-slate-500">
+            App Chrome
+          </h2>
+        </div>
+
+        <Section id="app-loading" number={1} title="App Loading">
+          <AppLoadingPreview />
+        </Section>
+
+        {/* ===== LIST COLUMN ===== */}
+        <div className="pt-4">
+          <h2 className="text-xs font-bold uppercase tracking-wider text-slate-500">
+            List Column
+          </h2>
+        </div>
+
+        <Section id="queue-loading" number={2} title="Queue Loading">
+          <QueueLoadingPreview />
+        </Section>
+
+        <Section id="empty-queue-all" number={3} title="Empty Queue — All">
+          <EmptyQueuePreview variant="all" />
+        </Section>
+
+        <Section id="empty-queue-new" number={4} title="Empty Queue — New">
+          <EmptyQueuePreview variant="new" />
+        </Section>
+
+        <Section id="empty-queue-opened" number={5} title="Empty Queue — Opened">
+          <EmptyQueuePreview variant="opened" />
+        </Section>
+
+        <Section
+          id="search-with-results"
+          number={6}
+          title="Search Active — With Results"
+        >
+          <SearchWithResultsPreview />
+        </Section>
+
+        <Section
+          id="search-no-results"
+          number={7}
+          title="Search Active — No Results"
+        >
+          <SearchNoResultsPreview />
+        </Section>
+
+        {/* ===== DETAIL WORKSPACE ===== */}
+        <div className="pt-4">
+          <h2 className="text-xs font-bold uppercase tracking-wider text-slate-500">
+            Detail Workspace
+          </h2>
+        </div>
+
+        <Section
+          id="no-contact-selected"
+          number={8}
+          title="No Contact Selected"
+        >
+          <NoContactSelectedPreview />
+        </Section>
+
+        <Section
+          id="unresolved-banner"
+          number={9}
+          title="Unresolved Detail Banner / Panel"
+        >
+          <UnresolvedBannerPreview />
+        </Section>
+
+        <Section
+          id="timeline-loading"
+          number={10}
+          title="Timeline Loading"
+        >
+          <TimelineLoadingPreview />
+        </Section>
+
+        <Section
+          id="follow-up-off"
+          number={11}
+          title="Needs Follow Up — Off"
+        >
+          <FollowUpPreview isOn={false} />
+        </Section>
+
+        <Section
+          id="follow-up-on"
+          number={12}
+          title="Needs Follow Up — On"
+        >
+          <FollowUpPreview isOn={true} />
+        </Section>
+
+        {/* ===== COMPOSER ===== */}
+        <div className="pt-4">
+          <h2 className="text-xs font-bold uppercase tracking-wider text-slate-500">
+            Composer
+          </h2>
+        </div>
+
+        <Section id="composer-idle" number={13} title="Composer — Idle">
+          <ComposerStatusPreview status="idle" label="Idle" />
+        </Section>
+
+        <Section
+          id="composer-saving"
+          number={14}
+          title="Composer — Saving Draft"
+        >
+          <ComposerStatusPreview status="saving-draft" label="Saving" />
+        </Section>
+
+        <Section
+          id="composer-saved"
+          number={15}
+          title="Composer — Draft Saved"
+        >
+          <ComposerStatusPreview status="draft-saved" label="Saved" />
+        </Section>
+
+        <Section
+          id="composer-validation"
+          number={16}
+          title="Composer — Validation Error"
+        >
+          <ValidationErrorPreview />
+          <ComposerStatusPreview
+            status="validation-error"
+            label="Validation Error"
+          />
+        </Section>
+
+        <Section
+          id="composer-sending"
+          number={17}
+          title="Composer — Sending"
+        >
+          <ComposerStatusPreview status="sending" label="Sending" />
+        </Section>
+
+        <Section
+          id="composer-sent"
+          number={18}
+          title="Composer — Sent Success"
+        >
+          <ComposerStatusPreview status="sent-success" label="Sent" />
+        </Section>
+
+        <Section
+          id="composer-failure"
+          number={19}
+          title="Composer — Send Failure"
+        >
+          <ComposerStatusPreview status="send-failure" label="Failure" />
+        </Section>
+
+        {/* ===== AI DRAFTING ===== */}
+        <div className="pt-4">
+          <h2 className="text-xs font-bold uppercase tracking-wider text-slate-500">
+            AI Drafting
+          </h2>
+        </div>
+
+        <Section id="ai-idle" number={20} title="AI — Idle (Button Ready)">
+          <div className="flex items-center justify-end px-5 py-3">
+            <Button variant="outline" size="sm" className="gap-1.5">
+              <SparkleIcon className="h-3.5 w-3.5 text-violet-600" />
+              Draft with AI
+            </Button>
+          </div>
+        </Section>
+
+        <Section
+          id="ai-generating"
+          number={21}
+          title="AI — Generating"
+        >
+          <AiStatePreview status="generating">
+            <div className="flex items-center gap-3 px-5 py-4">
+              <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-violet-100">
+                <BotIcon className="h-4 w-4 text-violet-600" />
+              </div>
+              <div className="flex-1">
+                <p className="text-sm font-medium text-violet-900">
+                  Drafting a reply…
+                </p>
+                <div className="mt-1.5 flex gap-1">
+                  <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-violet-400 [animation-delay:0ms]" />
+                  <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-violet-400 [animation-delay:150ms]" />
+                  <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-violet-400 [animation-delay:300ms]" />
+                </div>
+              </div>
+            </div>
+          </AiStatePreview>
+        </Section>
+
+        <Section
+          id="ai-inserted"
+          number={22}
+          title="AI Draft — Inserted into Composer"
+        >
+          <AiStatePreview status="inserted">
+            <div className="px-5 py-4">
+              <div className="flex items-start gap-3">
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-violet-100">
+                  <WandIcon className="h-4 w-4 text-violet-600" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="text-xs font-semibold text-violet-800">
+                    AI Draft Ready
+                  </p>
+                  <div className="mt-2 rounded-lg border border-violet-200 bg-white p-3">
+                    <p className="whitespace-pre-wrap text-[13px] leading-6 text-slate-700">
+                      Hi Maya,{"\n\n"}Thanks for confirming. The kit list is
+                      attached — see you on the 22nd.{"\n\n"}Best,{"\n"}Jordan
+                    </p>
+                  </div>
+                  <div className="mt-3 flex items-center gap-2">
+                    <Button
+                      size="sm"
+                      className="gap-1.5 bg-violet-600 hover:bg-violet-700"
+                    >
+                      <CheckCircleIcon className="h-3.5 w-3.5" />
+                      Insert into composer
+                    </Button>
+                    <Button variant="outline" size="sm" className="gap-1.5">
+                      <TrashIcon className="h-3.5 w-3.5" />
+                      Discard
+                    </Button>
+                  </div>
+                </div>
+              </div>
+              <div className="mt-3 flex items-center gap-2 pl-11">
+                <input
+                  type="text"
+                  placeholder="Adjust: 'Make it shorter', 'More formal'…"
+                  className="flex-1 rounded-md border border-violet-200 bg-white px-3 py-1.5 text-xs text-slate-900 placeholder:text-slate-400"
+                  readOnly
+                />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 gap-1 px-2 text-xs"
+                >
+                  <RotateCcwIcon className="h-3 w-3" />
+                  Reprompt
+                </Button>
+              </div>
+            </div>
+          </AiStatePreview>
+        </Section>
+
+        <Section
+          id="ai-reprompting"
+          number={23}
+          title="AI — Reprompt Action"
+        >
+          <AiStatePreview status="reprompting">
+            <div className="flex items-center gap-3 px-5 py-4">
+              <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-violet-100">
+                <BotIcon className="h-4 w-4 text-violet-600" />
+              </div>
+              <div className="flex-1">
+                <p className="text-sm font-medium text-violet-900">
+                  Regenerating draft…
+                </p>
+                <div className="mt-1.5 flex gap-1">
+                  <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-violet-400 [animation-delay:0ms]" />
+                  <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-violet-400 [animation-delay:150ms]" />
+                  <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-violet-400 [animation-delay:300ms]" />
+                </div>
+              </div>
+            </div>
+          </AiStatePreview>
+        </Section>
+
+        <Section
+          id="ai-unavailable"
+          number={24}
+          title="AI — Unavailable Fallback"
+        >
+          <div className="p-4">
+            <div className="flex items-center gap-3 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
+              <WifiOffIcon className="h-4 w-4 shrink-0 text-slate-500" />
+              <p className="text-xs text-slate-600">
+                AI drafting is currently unavailable. You can compose your
+                reply manually, or try again later.
+              </p>
+            </div>
+            <div className="mt-3 flex items-center justify-end">
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-1.5 text-slate-400"
+                disabled
+              >
+                <WifiOffIcon className="h-3.5 w-3.5" />
+                AI unavailable
+              </Button>
+            </div>
+          </div>
+        </Section>
+
+        <Section id="ai-error" number={25} title="AI — Error State">
+          <div className="p-4">
+            <div className="flex items-center gap-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3">
+              <AlertCircleIcon className="h-4 w-4 shrink-0 text-red-600" />
+              <p className="flex-1 text-xs text-red-700">
+                AI service timed out. Please try again.
+              </p>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 px-2 text-xs text-red-700 hover:text-red-900"
+              >
+                <RefreshCwIcon className="mr-1 h-3 w-3" />
+                Try again
+              </Button>
+            </div>
+          </div>
+        </Section>
+
+        <Section
+          id="ai-edited"
+          number={26}
+          title="AI — Edited After Generation"
+        >
+          <div className="flex items-center gap-3 border-t border-slate-100 px-5 py-3">
+            <span className="flex items-center gap-1 text-[11px] text-slate-500">
+              <PencilIcon className="h-3 w-3" />
+              Edited
+            </span>
+            <span className="text-[11px] text-slate-400">
+              Draft was generated by AI, then manually edited by the operator
+            </span>
+          </div>
+        </Section>
+
+        <Section
+          id="ai-discarded"
+          number={27}
+          title="AI — Discarded Draft"
+        >
+          <div className="border-b border-violet-200 bg-violet-50/50">
+            <div className="flex items-center justify-between px-5 py-3">
+              <span className="flex items-center gap-1.5 text-xs text-slate-500">
+                <TrashIcon className="h-3 w-3" />
+                AI draft discarded
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 px-2 text-xs"
+              >
+                <XIcon className="h-3 w-3" />
+              </Button>
+            </div>
+          </div>
+        </Section>
+
+        {/* Footer */}
+        <div className="pb-10 pt-4 text-center text-xs text-slate-400">
+          27 states — end of showcase
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------- Table of contents data ----------
+
+const TOC = [
+  { id: "app-loading", number: 1, title: "App Loading" },
+  { id: "queue-loading", number: 2, title: "Queue Loading" },
+  { id: "empty-queue-all", number: 3, title: "Empty Queue — All" },
+  { id: "empty-queue-new", number: 4, title: "Empty Queue — New" },
+  { id: "empty-queue-opened", number: 5, title: "Empty Queue — Opened" },
+  { id: "search-with-results", number: 6, title: "Search — Results" },
+  { id: "search-no-results", number: 7, title: "Search — No Results" },
+  { id: "no-contact-selected", number: 8, title: "No Contact Selected" },
+  { id: "unresolved-banner", number: 9, title: "Unresolved Banner" },
+  { id: "timeline-loading", number: 10, title: "Timeline Loading" },
+  { id: "follow-up-off", number: 11, title: "Follow Up — Off" },
+  { id: "follow-up-on", number: 12, title: "Follow Up — On" },
+  { id: "composer-idle", number: 13, title: "Composer — Idle" },
+  { id: "composer-saving", number: 14, title: "Composer — Saving" },
+  { id: "composer-saved", number: 15, title: "Composer — Saved" },
+  { id: "composer-validation", number: 16, title: "Composer — Validation" },
+  { id: "composer-sending", number: 17, title: "Composer — Sending" },
+  { id: "composer-sent", number: 18, title: "Composer — Sent" },
+  { id: "composer-failure", number: 19, title: "Composer — Failure" },
+  { id: "ai-idle", number: 20, title: "AI — Idle" },
+  { id: "ai-generating", number: 21, title: "AI — Generating" },
+  { id: "ai-inserted", number: 22, title: "AI — Inserted" },
+  { id: "ai-reprompting", number: 23, title: "AI — Reprompt" },
+  { id: "ai-unavailable", number: 24, title: "AI — Unavailable" },
+  { id: "ai-error", number: 25, title: "AI — Error" },
+  { id: "ai-edited", number: 26, title: "AI — Edited" },
+  { id: "ai-discarded", number: 27, title: "AI — Discarded" }
+];

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -2,8 +2,30 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  color-scheme: light;
+@layer base {
+  :root {
+    color-scheme: light;
+    --background: 0 0% 100%;
+    --foreground: 222.2 47.4% 11.2%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 47.4% 11.2%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 47.4% 11.2%;
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --primary: 222.2 47.4% 11.2%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 100% 50%;
+    --destructive-foreground: 210 40% 98%;
+    --ring: 215 20.2% 65.1%;
+    --radius: 0.5rem;
+  }
 }
 
 body {

--- a/apps/web/components.json
+++ b/apps/web/components.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.ts",
+    "css": "app/globals.css",
+    "baseColor": "slate",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  }
+}

--- a/apps/web/components/ui/alert.tsx
+++ b/apps/web/components/ui/alert.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive:
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+))
+Alert.displayName = "Alert"
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+AlertTitle.displayName = "AlertTitle"
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    {...props}
+  />
+))
+AlertDescription.displayName = "AlertDescription"
+
+export { Alert, AlertTitle, AlertDescription }

--- a/apps/web/components/ui/avatar.tsx
+++ b/apps/web/components/ui/avatar.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import * as React from "react"
+import * as AvatarPrimitive from "@radix-ui/react-avatar"
+
+import { cn } from "@/lib/utils"
+
+const Avatar = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
+      className
+    )}
+    {...props}
+  />
+))
+Avatar.displayName = AvatarPrimitive.Root.displayName
+
+const AvatarImage = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn("aspect-square h-full w-full", className)}
+    {...props}
+  />
+))
+AvatarImage.displayName = AvatarPrimitive.Image.displayName
+
+const AvatarFallback = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn(
+      "flex h-full w-full items-center justify-center rounded-full bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName
+
+export { Avatar, AvatarImage, AvatarFallback }

--- a/apps/web/components/ui/badge.tsx
+++ b/apps/web/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -1,0 +1,57 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-10 rounded-md px-8",
+        icon: "h-9 w-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/apps/web/components/ui/collapsible.tsx
+++ b/apps/web/components/ui/collapsible.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
+
+const Collapsible = CollapsiblePrimitive.Root
+
+const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger
+
+const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/apps/web/components/ui/dropdown-menu.tsx
+++ b/apps/web/components/ui/dropdown-menu.tsx
@@ -1,0 +1,201 @@
+"use client"
+
+import * as React from "react"
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
+import { Check, ChevronRight, Circle } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const DropdownMenu = DropdownMenuPrimitive.Root
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+
+const DropdownMenuGroup = DropdownMenuPrimitive.Group
+
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal
+
+const DropdownMenuSub = DropdownMenuPrimitive.Sub
+
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto" />
+  </DropdownMenuPrimitive.SubTrigger>
+))
+DropdownMenuSubTrigger.displayName =
+  DropdownMenuPrimitive.SubTrigger.displayName
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuSubContent.displayName =
+  DropdownMenuPrimitive.SubContent.displayName
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+))
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
+
+const DropdownMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, checked = false, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+))
+DropdownMenuCheckboxItem.displayName =
+  DropdownMenuPrimitive.CheckboxItem.displayName
+
+const DropdownMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+))
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      "px-2 py-1.5 text-sm font-semibold",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+))
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
+
+const DropdownMenuShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
+      {...props}
+    />
+  )
+}
+DropdownMenuShortcut.displayName = "DropdownMenuShortcut"
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuRadioGroup,
+}

--- a/apps/web/components/ui/input.tsx
+++ b/apps/web/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/apps/web/components/ui/popover.tsx
+++ b/apps/web/components/ui/popover.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import * as React from "react"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
+
+import { cn } from "@/lib/utils"
+
+const Popover = PopoverPrimitive.Root
+
+const PopoverTrigger = PopoverPrimitive.Trigger
+
+const PopoverAnchor = PopoverPrimitive.Anchor
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]",
+        className
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+))
+PopoverContent.displayName = PopoverPrimitive.Content.displayName
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }

--- a/apps/web/components/ui/progress.tsx
+++ b/apps/web/components/ui/progress.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import * as ProgressPrimitive from "@radix-ui/react-progress"
+
+import { cn } from "@/lib/utils"
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
+      className
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className="h-full w-full flex-1 bg-primary transition-all"
+      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+))
+Progress.displayName = ProgressPrimitive.Root.displayName
+
+export { Progress }

--- a/apps/web/components/ui/separator.tsx
+++ b/apps/web/components/ui/separator.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+
+import { cn } from "@/lib/utils"
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(
+  (
+    { className, orientation = "horizontal", decorative = true, ...props },
+    ref
+  ) => (
+    <SeparatorPrimitive.Root
+      ref={ref}
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+Separator.displayName = SeparatorPrimitive.Root.displayName
+
+export { Separator }

--- a/apps/web/components/ui/skeleton.tsx
+++ b/apps/web/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-primary/10", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/apps/web/components/ui/toggle-group.tsx
+++ b/apps/web/components/ui/toggle-group.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import * as React from "react"
+import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group"
+import { type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { toggleVariants } from "@/components/ui/toggle"
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants>
+>({
+  size: "default",
+  variant: "default",
+})
+
+const ToggleGroup = React.forwardRef<
+  React.ElementRef<typeof ToggleGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root> &
+    VariantProps<typeof toggleVariants>
+>(({ className, variant, size, children, ...props }, ref) => (
+  <ToggleGroupPrimitive.Root
+    ref={ref}
+    className={cn("flex items-center justify-center gap-1", className)}
+    {...props}
+  >
+    <ToggleGroupContext.Provider value={{ variant, size }}>
+      {children}
+    </ToggleGroupContext.Provider>
+  </ToggleGroupPrimitive.Root>
+))
+
+ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName
+
+const ToggleGroupItem = React.forwardRef<
+  React.ElementRef<typeof ToggleGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item> &
+    VariantProps<typeof toggleVariants>
+>(({ className, children, variant, size, ...props }, ref) => {
+  const context = React.useContext(ToggleGroupContext)
+
+  return (
+    <ToggleGroupPrimitive.Item
+      ref={ref}
+      className={cn(
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  )
+})
+
+ToggleGroupItem.displayName = ToggleGroupPrimitive.Item.displayName
+
+export { ToggleGroup, ToggleGroupItem }

--- a/apps/web/components/ui/toggle.tsx
+++ b/apps/web/components/ui/toggle.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import * as React from "react"
+import * as TogglePrimitive from "@radix-ui/react-toggle"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const toggleVariants = cva(
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline:
+          "border border-input bg-transparent shadow-sm hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-9 px-2 min-w-9",
+        sm: "h-8 px-1.5 min-w-8",
+        lg: "h-10 px-2.5 min-w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+const Toggle = React.forwardRef<
+  React.ElementRef<typeof TogglePrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> &
+    VariantProps<typeof toggleVariants>
+>(({ className, variant, size, ...props }, ref) => (
+  <TogglePrimitive.Root
+    ref={ref}
+    className={cn(toggleVariants({ variant, size, className }))}
+    {...props}
+  />
+))
+
+Toggle.displayName = TogglePrimitive.Root.displayName
+
+export { Toggle, toggleVariants }

--- a/apps/web/components/ui/tooltip.tsx
+++ b/apps/web/components/ui/tooltip.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "@/lib/utils"
+
+const TooltipProvider = TooltipPrimitive.Provider
+
+const Tooltip = TooltipPrimitive.Root
+
+const TooltipTrigger = TooltipPrimitive.Trigger
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
+        className
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,8 +15,23 @@
     "@as-comms/contracts": "workspace:*",
     "@as-comms/domain": "workspace:*",
     "@as-comms/ui": "workspace:*",
+    "@radix-ui/react-avatar": "^1.1.11",
+    "@radix-ui/react-collapsible": "^1.1.12",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-progress": "^1.1.8",
+    "@radix-ui/react-separator": "^1.1.8",
+    "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-toggle": "^1.1.10",
+    "@radix-ui/react-toggle-group": "^1.1.11",
+    "@radix-ui/react-tooltip": "^1.2.8",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^1.8.0",
     "next": "^15.2.2",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "tailwind-merge": "^3.5.0",
+    "tailwindcss-animate": "^1.0.7"
   }
 }

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,9 +1,11 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
   content: [
     "./app/**/*.{ts,tsx}",
     "./src/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
     "../../packages/ui/src/**/*.{ts,tsx}"
   ],
   theme: {
@@ -11,9 +13,46 @@ export default {
       colors: {
         canvas: "#f5f7fb",
         ink: "#0f172a",
-        accent: "#0f766e"
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))"
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))"
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))"
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))"
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))"
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))"
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))"
+        }
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)"
       }
     }
   },
-  plugins: []
+  plugins: [tailwindcssAnimate]
 } satisfies Config;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -7,6 +7,10 @@
     "allowJs": false,
     "noEmit": true,
     "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    },
     "plugins": [
       {
         "name": "next"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,45 @@ importers:
       '@as-comms/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@radix-ui/react-avatar':
+        specifier: ^1.1.11
+        version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-collapsible':
+        specifier: ^1.1.12
+        version: 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.16
+        version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popover':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-progress':
+        specifier: ^1.1.8
+        version: 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-separator':
+        specifier: ^1.1.8
+        version: 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot':
+        specifier: ^1.2.4
+        version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-toggle':
+        specifier: ^1.1.10
+        version: 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle-group':
+        specifier: ^1.1.11
+        version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.8
+        version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: ^1.8.0
+        version: 1.8.0(react@19.2.4)
       next:
         specifier: ^15.2.2
         version: 15.5.14(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -104,6 +143,12 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
+      tailwind-merge:
+        specifier: ^3.5.0
+        version: 3.5.0
+      tailwindcss-animate:
+        specifier: ^1.0.7
+        version: 1.0.7(tailwindcss@3.4.19(tsx@4.21.0))
 
   apps/worker:
     dependencies:
@@ -691,6 +736,21 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
   '@graphile/logger@0.2.0':
     resolution: {integrity: sha512-jjcWBokl9eb1gVJ85QmoaQ73CQ52xAaOCF29ukRbYNl6lY+ts0ErTaDYOBlejcbUs2OpaiqYLO5uDhyLFzWw4w==}
 
@@ -930,6 +990,429 @@ packages:
     resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-arrow@1.1.7':
+    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-avatar@1.1.11':
+    resolution: {integrity: sha512-0Qk603AHGV28BOBO34p7IgD5m+V5Sg/YovfayABkoDDBM5d3NCx0Mp4gGrjzLGes1jV5eNOE1r3itqOR33VC6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collapsible@1.1.12':
+    resolution: {integrity: sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.1.7':
+    resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.3':
+    resolution: {integrity: sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.1':
+    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dropdown-menu@2.1.16':
+    resolution: {integrity: sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.16':
+    resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.15':
+    resolution: {integrity: sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popper@1.2.8':
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.4':
+    resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-progress@1.1.8':
+    resolution: {integrity: sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.11':
+    resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-separator@1.1.8':
+    resolution: {integrity: sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.4':
+    resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-toggle-group@1.1.11':
+    resolution: {integrity: sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.10':
+    resolution: {integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.8':
+    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.0':
+    resolution: {integrity: sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.1':
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.1':
+    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.3':
+    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/rect@1.1.1':
+    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
   '@rollup/rollup-android-arm-eabi@4.60.0':
     resolution: {integrity: sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==}
@@ -1252,6 +1735,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1329,12 +1816,19 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1390,6 +1884,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -1652,6 +2149,10 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
+
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
@@ -1788,6 +2289,11 @@ packages:
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lucide-react@1.8.0:
+    resolution: {integrity: sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2054,6 +2560,36 @@ packages:
     peerDependencies:
       react: ^19.2.4
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
@@ -2178,6 +2714,14 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
+
+  tailwindcss-animate@1.0.7:
+    resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders'
+
   tailwindcss@3.4.19:
     resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
     engines: {node: '>=14.0.0'}
@@ -2267,6 +2811,31 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -2684,6 +3253,23 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@floating-ui/utils@0.2.11': {}
+
   '@graphile/logger@0.2.0': {}
 
   '@humanfs/core@0.19.1': {}
@@ -2853,6 +3439,401 @@ snapshots:
   '@playwright/test@1.58.2':
     dependencies:
       playwright: 1.58.2
+
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-avatar@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-collapsible@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-direction@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-progress@1.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-separator@1.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-is-hydrated@0.1.0(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/rect@1.1.1': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.0':
     optional: true
@@ -3159,6 +4140,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   assertion-error@2.0.1: {}
 
   autoprefixer@10.4.27(postcss@8.5.8):
@@ -3236,6 +4221,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
   client-only@0.0.1: {}
 
   cliui@8.0.1:
@@ -3243,6 +4232,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  clsx@2.1.1: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -3283,6 +4274,8 @@ snapshots:
 
   detect-libc@2.1.2:
     optional: true
+
+  detect-node-es@1.1.0: {}
 
   didyoumean@1.2.2: {}
 
@@ -3541,6 +4534,8 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-nonce@1.0.1: {}
+
   get-tsconfig@4.13.7:
     dependencies:
       resolve-pkg-maps: 1.0.0
@@ -3666,6 +4661,10 @@ snapshots:
   lodash.merge@4.6.2: {}
 
   loupe@3.2.1: {}
+
+  lucide-react@1.8.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   magic-string@0.30.21:
     dependencies:
@@ -3892,6 +4891,33 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.4)
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.4)
+      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   react@19.2.4: {}
 
   read-cache@1.0.0:
@@ -4047,6 +5073,12 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  tailwind-merge@3.5.0: {}
+
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.19(tsx@4.21.0)):
+    dependencies:
+      tailwindcss: 3.4.19(tsx@4.21.0)
+
   tailwindcss@3.4.19(tsx@4.21.0):
     dependencies:
       '@alloc/quick-lru': 5.2.0
@@ -4156,6 +5188,25 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sync-external-store@1.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
## Summary

- Implements every major product state for the inbox UI: loading skeletons, empty states, search, timeline, composer lifecycle, and AI draft lifecycle
- Redesigns the timeline with dark outbound bubbles, narrower widths for readability, distinct visual treatments per message type (1:1, automated, campaign, notes, system events)
- Builds a collapsible composer with From/To/Subject fields, formatting toolbar (bold, italic, lists, link, image embed, file attach), and "Reply to..." collapsed bar
- Full AI drafting flow: text lands directly in textarea, compact toolbar with redo/discard, reprompt expands into inline input
- Animated contact rail with collapse button positioned for consistent click-target
- Interactive `/inbox/states` demo page with live controls for design review

## What changed

| Area | Changes |
|---|---|
| **Loading states** | App skeleton, queue skeleton, timeline skeleton, Next.js loading boundary |
| **List column** | Live search with result count/empty state, filter dropdown |
| **Detail view** | Unresolved banner (collapsible), timeline loading integration, animated contact rail |
| **Timeline** | Dark outbound bubbles, dashed-border automated/campaign rows, centered system dividers, left-border notes, vertical dot timeline in rail |
| **Composer** | Collapsible reply bar, From alias selector, formatting toolbar with link popover/image embed/file attach (all with full state machines), auto-save notice, send with retry |
| **AI drafting** | Generating indicator in textarea area, AI toolbar (redo → inline reprompt input, discard), edited-after-generation tracking, error/unavailable banners |
| **Components** | Added shadcn skeleton, alert, progress; 14 new Lucide icon re-exports |
| **Demo** | `/inbox/states` page with 27 isolated state previews and live context controls |

## New files
- `claude-inbox-loading.tsx` — All skeleton components
- `inbox/loading.tsx` — Next.js loading boundary
- `inbox/states/page.tsx` — Interactive states demo
- `components/ui/{skeleton,alert,progress}.tsx` — shadcn additions

## Test plan
- [ ] Navigate to `/inbox` — verify list renders with contacts, search works, filter dropdown works
- [ ] Click a contact — verify timeline renders with distinct bubble styles per message type
- [ ] Click "Reply to..." bar — verify composer expands with From/To/Subject, formatting toolbar
- [ ] Test formatting toolbar: bold/italic toggles, link popover, image embed, file attach
- [ ] Click "Draft with AI" — verify generating state, text insertion, redo/discard toolbar
- [ ] Toggle volunteer details rail — verify animated expand/collapse, collapse button in rail header
- [ ] Visit `/inbox/states` — verify all 27 state previews render, live controls work

🤖 Generated with [Claude Code](https://claude.com/claude-code)