### PR TITLE
[codex] Align inbox canon and follow-up semantics

### DIFF
--- a/apps/web/app/inbox/_components/inbox-client-provider.tsx
+++ b/apps/web/app/inbox/_components/inbox-client-provider.tsx
@@ -9,6 +9,11 @@ import {
   type ReactNode
 } from "react";
 
+import {
+  toggleNeedsFollowUp,
+  type FollowUpOverrides
+} from "../_lib/follow-up-state";
+
 /**
  * Prototype-local client state shared across the Inbox list column and
  * Detail workspace. In a real build these would round-trip through server
@@ -91,9 +96,12 @@ const INITIAL_SEARCH: SearchState = {
 
 interface InboxClientState {
   // Follow-up & reminders
-  readonly followUp: ReadonlySet<string>;
+  readonly followUp: FollowUpOverrides;
   readonly reminders: ReadonlyMap<string, Reminder>;
-  readonly toggleFollowUp: (contactId: string) => void;
+  readonly toggleFollowUp: (
+    contactId: string,
+    seededNeedsFollowUp: boolean
+  ) => void;
   readonly setReminder: (contactId: string, reminder: Reminder) => void;
   readonly clearReminder: (contactId: string) => void;
 
@@ -137,23 +145,20 @@ export function InboxClientProvider({
   readonly children: ReactNode;
 }) {
   // Follow-up & reminders
-  const [followUp, setFollowUp] = useState<ReadonlySet<string>>(
-    () => new Set<string>()
+  const [followUp, setFollowUp] = useState<FollowUpOverrides>(
+    () => new Map<string, boolean>()
   );
   const [reminders, setReminders] = useState<ReadonlyMap<string, Reminder>>(
     () => new Map<string, Reminder>()
   );
 
-  const toggleFollowUp = useCallback((contactId: string) => {
-    setFollowUp((prev) => {
-      const next = new Set(prev);
-      if (next.has(contactId)) {
-        next.delete(contactId);
-      } else {
-        next.add(contactId);
-      }
-      return next;
-    });
+  const toggleFollowUp = useCallback((
+    contactId: string,
+    seededNeedsFollowUp: boolean
+  ) => {
+    setFollowUp((prev) =>
+      toggleNeedsFollowUp(contactId, seededNeedsFollowUp, prev)
+    );
   }, []);
 
   const setReminder = useCallback((contactId: string, reminder: Reminder) => {
@@ -174,7 +179,7 @@ export function InboxClientProvider({
   }, []);
 
   // Search
-  const [search, setSearch] = useState<SearchState>(INITIAL_SEARCH);
+  const [search, setSearch] = useState(INITIAL_SEARCH);
 
   const setSearchQuery = useCallback((query: string) => {
     setSearch((prev) => ({
@@ -206,7 +211,7 @@ export function InboxClientProvider({
   >([]);
 
   // AI draft lifecycle
-  const [aiDraft, setAiDraft] = useState<AiDraftState>(INITIAL_AI_DRAFT);
+  const [aiDraft, setAiDraft] = useState(INITIAL_AI_DRAFT);
 
   const startAiGeneration = useCallback((prompt: string) => {
     setAiDraft({

--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -11,6 +11,7 @@ import {
 import { cn } from "@/lib/utils";
 
 import type { InboxDetailViewModel } from "../_lib/view-models";
+import { resolveNeedsFollowUp } from "../_lib/follow-up-state";
 import {
   useInboxClient,
   type Reminder
@@ -60,7 +61,11 @@ export function InboxDetail({ detail }: DetailProps) {
   const activeProject = contact.activeProjects[0] ?? null;
   const firstName = contact.displayName.split(" ")[0] ?? contact.displayName;
 
-  const isFollowUp = followUp.has(contact.contactId) || detail.needsFollowUp;
+  const isFollowUp = resolveNeedsFollowUp(
+    contact.contactId,
+    detail.needsFollowUp,
+    followUp
+  );
   const existingReminder = reminders.get(contact.contactId) ?? null;
 
   const handleSetReminder = () => {
@@ -127,7 +132,7 @@ export function InboxDetail({ detail }: DetailProps) {
               size="sm"
               aria-pressed={isFollowUp}
               onClick={() => {
-                toggleFollowUp(contact.contactId);
+                toggleFollowUp(contact.contactId, detail.needsFollowUp);
               }}
               className={cn(
                 "gap-1.5",
@@ -136,7 +141,7 @@ export function InboxDetail({ detail }: DetailProps) {
               )}
             >
               <CornerUpLeftIcon className="h-3.5 w-3.5" />
-              Needs Follow Up
+              Needs Follow-Up
             </Button>
 
             {/* Reminder popover */}

--- a/apps/web/app/inbox/_components/inbox-list.tsx
+++ b/apps/web/app/inbox/_components/inbox-list.tsx
@@ -8,6 +8,7 @@ import type {
   InboxFilterViewModel,
   InboxListItemViewModel
 } from "../_lib/view-models";
+import { resolveNeedsFollowUp } from "../_lib/follow-up-state";
 import { EmptyState } from "@/components/ui/empty-state";
 
 import { useInboxClient } from "./inbox-client-provider";
@@ -27,13 +28,6 @@ interface ListColumnProps {
   readonly initialFilterId?: InboxFilterId;
 }
 
-const FILTER_LABELS: Record<InboxFilterId, string> = {
-  all: "All",
-  unread: "Unread",
-  "follow-up": "Follow-up",
-  unresolved: "Unresolved"
-};
-
 export function InboxList({
   items,
   filters,
@@ -50,15 +44,22 @@ export function InboxList({
   } = useInboxClient();
 
   const [activeFilter, setActiveFilter] = useState<InboxFilterId>(initialFilterId);
+  const filterLabels = useMemo(
+    () =>
+      new Map(filters.map((filter) => [filter.id, filter.label] as const)),
+    [filters]
+  );
 
-  // Compute filter counts from items + followUp set
+  // Compute filter counts from base projection state + local overrides.
   const filterCounts = useMemo(() => {
     let unread = 0;
     let followUpCount = 0;
     let unresolved = 0;
     for (const item of items) {
       if (item.bucket === "new") unread++;
-      if (followUp.has(item.contactId)) followUpCount++;
+      if (resolveNeedsFollowUp(item.contactId, item.needsFollowUp, followUp)) {
+        followUpCount++;
+      }
       if (item.hasUnresolved) unresolved++;
     }
     return {
@@ -149,14 +150,16 @@ export function InboxList({
                 key={id}
                 type="button"
                 aria-pressed={isActive}
-                onClick={() => setActiveFilter(id)}
+                onClick={() => {
+                  setActiveFilter(id);
+                }}
                 className={`rounded-full px-2.5 py-1 text-xs font-medium ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion} ${
                   isActive
                     ? "bg-slate-900 text-white"
                     : "bg-slate-100 text-slate-600 hover:bg-slate-200"
                 }`}
               >
-                {FILTER_LABELS[id]}{" "}
+                {filterLabels.get(id) ?? id}{" "}
                 <span className={isActive ? "text-slate-300" : "text-slate-400"}>
                   {filterCounts[id]}
                 </span>
@@ -200,7 +203,14 @@ export function InboxList({
             {displayItems.map((item) => (
               <InboxRow
                 key={item.contactId}
-                item={item}
+                item={{
+                  ...item,
+                  needsFollowUp: resolveNeedsFollowUp(
+                    item.contactId,
+                    item.needsFollowUp,
+                    followUp
+                  )
+                }}
                 isActive={item.contactId === activeContactId}
               />
             ))}
@@ -244,7 +254,7 @@ function extractContactId(pathname: string | null): string | null {
 function matchesActiveFilter(
   item: InboxListItemViewModel,
   activeFilter: InboxFilterId,
-  followUp: ReadonlySet<string>
+  followUp: ReadonlyMap<string, boolean>
 ): boolean {
   switch (activeFilter) {
     case "all":
@@ -252,7 +262,7 @@ function matchesActiveFilter(
     case "unread":
       return item.bucket === "new";
     case "follow-up":
-      return followUp.has(item.contactId);
+      return resolveNeedsFollowUp(item.contactId, item.needsFollowUp, followUp);
     case "unresolved":
       return item.hasUnresolved;
   }

--- a/apps/web/app/inbox/_components/inbox-row.tsx
+++ b/apps/web/app/inbox/_components/inbox-row.tsx
@@ -19,7 +19,7 @@ interface RowProps {
  * (rose) and review/unresolved (amber) state at a glance.
  */
 export function InboxRow({ item, isActive }: RowProps) {
-  const isUnread = item.unreadCount > 0;
+  const isUnread = item.bucket === "new";
   const ChannelIcon = item.latestChannel === "email" ? MailIcon : PhoneIcon;
 
   const accentClass =
@@ -30,7 +30,7 @@ export function InboxRow({ item, isActive }: RowProps) {
         : null;
 
   const showBadges =
-    item.projectLabel ||
+    Boolean(item.projectLabel) ||
     item.needsFollowUp ||
     item.hasUnresolved ||
     item.unreadCount > 0;

--- a/apps/web/app/inbox/_lib/filters.ts
+++ b/apps/web/app/inbox/_lib/filters.ts
@@ -11,9 +11,9 @@ interface FilterDefinition {
  * contacts sorted by last inbound message. These filters narrow the list
  * to contacts matching a specific row state.
  *
- * Follow-up is client-side ephemeral state owned by
- * {@link InboxClientProvider}; the server-side list doesn't know who
- * is flagged, so its count starts at 0 and the client recomputes it.
+ * The base follow-up state comes from the projection-backed
+ * `needsFollowUp` field. The client may layer temporary overrides on top
+ * while the shell is still mock-wired.
  */
 export const INBOX_FILTERS: readonly FilterDefinition[] = [
   { id: "all", label: "All", hint: null },

--- a/apps/web/app/inbox/_lib/follow-up-state.ts
+++ b/apps/web/app/inbox/_lib/follow-up-state.ts
@@ -1,0 +1,31 @@
+export type FollowUpOverrides = ReadonlyMap<string, boolean>;
+
+export function resolveNeedsFollowUp(
+  contactId: string,
+  seededNeedsFollowUp: boolean,
+  overrides: FollowUpOverrides
+): boolean {
+  return overrides.get(contactId) ?? seededNeedsFollowUp;
+}
+
+export function toggleNeedsFollowUp(
+  contactId: string,
+  seededNeedsFollowUp: boolean,
+  overrides: FollowUpOverrides
+): FollowUpOverrides {
+  const next = new Map(overrides);
+  const effectiveNeedsFollowUp = resolveNeedsFollowUp(
+    contactId,
+    seededNeedsFollowUp,
+    overrides
+  );
+  const nextNeedsFollowUp = !effectiveNeedsFollowUp;
+
+  if (nextNeedsFollowUp === seededNeedsFollowUp) {
+    next.delete(contactId);
+  } else {
+    next.set(contactId, nextNeedsFollowUp);
+  }
+
+  return next;
+}

--- a/apps/web/app/inbox/_lib/mock-data.ts
+++ b/apps/web/app/inbox/_lib/mock-data.ts
@@ -15,6 +15,8 @@
  * canonical inbox/timeline projections without changing view-model shapes.
  */
 
+import type { InboxDrivingEventType } from "@as-comms/contracts";
+
 import type {
   InboxAvatarTone,
   InboxBucket,
@@ -62,8 +64,9 @@ interface MockContactRecord {
   readonly snippet: string;
   readonly latestChannel: InboxChannel;
   readonly projectLabel: string | null;
-  readonly lastInboundAt: string;
+  readonly lastInboundAt: string | null;
   readonly lastActivityAt: string;
+  readonly lastEventType: InboxDrivingEventType;
   readonly lastActivityLabel: string;
   readonly timeline: readonly InboxTimelineEntryViewModel[];
 }
@@ -139,6 +142,7 @@ const CONTACTS: readonly MockContactRecord[] = [
     projectLabel: "Tracking Whitebark Pine 2026",
     lastInboundAt: iso(0),
     lastActivityAt: "2026-04-14T14:22:00Z",
+    lastEventType: "communication.email.inbound",
     lastActivityLabel: "9:22 AM",
     timeline: buildTimeline("c_maya_patel", [
       {
@@ -275,6 +279,7 @@ const CONTACTS: readonly MockContactRecord[] = [
     projectLabel: "Searching for Killer Whales",
     lastInboundAt: iso(0),
     lastActivityAt: "2026-04-14T12:05:00Z",
+    lastEventType: "communication.email.inbound",
     lastActivityLabel: "7:05 AM",
     timeline: buildTimeline("c_daniel_rivers", [
       {
@@ -387,6 +392,7 @@ const CONTACTS: readonly MockContactRecord[] = [
     projectLabel: "Monitoring Coral Reefs",
     lastInboundAt: iso(0),
     lastActivityAt: "2026-04-14T09:48:00Z",
+    lastEventType: "communication.email.inbound",
     lastActivityLabel: "4:48 AM",
     timeline: buildTimeline("c_priya_chen", [
       {
@@ -534,6 +540,7 @@ const CONTACTS: readonly MockContactRecord[] = [
     projectLabel: "Beech and Butternut",
     lastInboundAt: iso(2),
     lastActivityAt: "2026-04-13T19:30:00Z",
+    lastEventType: "communication.email.outbound",
     lastActivityLabel: "Yesterday",
     timeline: buildTimeline("c_sam_whitehorse", [
       {
@@ -640,6 +647,7 @@ const CONTACTS: readonly MockContactRecord[] = [
     projectLabel: null,
     lastInboundAt: iso(1),
     lastActivityAt: "2026-04-14T02:14:00Z",
+    lastEventType: "communication.email.inbound",
     lastActivityLabel: "Yesterday",
     timeline: buildTimeline("c_anita_ross", [
       {
@@ -695,6 +703,7 @@ const CONTACTS: readonly MockContactRecord[] = [
     projectLabel: "Front Range Owl Survey 2023",
     lastInboundAt: iso(2),
     lastActivityAt: "2026-04-12T16:10:00Z",
+    lastEventType: "communication.email.inbound",
     lastActivityLabel: "2 days ago",
     timeline: buildTimeline("c_ben_okafor", [
       {
@@ -774,6 +783,7 @@ const CONTACTS: readonly MockContactRecord[] = [
     projectLabel: "PNW Biodiversity 2026",
     lastInboundAt: iso(2),
     lastActivityAt: "2026-04-12T11:02:00Z",
+    lastEventType: "communication.sms.outbound",
     lastActivityLabel: "2 days ago",
     timeline: buildTimeline("c_elena_marquez", [
       {
@@ -867,6 +877,7 @@ const CONTACTS: readonly MockContactRecord[] = [
     projectLabel: null,
     lastInboundAt: iso(1),
     lastActivityAt: "2026-04-13T22:45:00Z",
+    lastEventType: "communication.sms.inbound",
     lastActivityLabel: "Yesterday",
     timeline: buildTimeline("c_unknown_5551", [
       {

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -27,10 +27,23 @@ import type {
  * Default list sort: last inbound message first.
  * Toggling follow-up does NOT change row ordering.
  */
-const LIST_SORT = (
+export const compareInboxRecency = (
   a: InboxListItemViewModel,
   b: InboxListItemViewModel
-): number => (a.lastInboundAt < b.lastInboundAt ? 1 : -1);
+): number => {
+  const aSortAt = a.lastInboundAt ?? a.lastActivityAt;
+  const bSortAt = b.lastInboundAt ?? b.lastActivityAt;
+
+  if (aSortAt !== bSortAt) {
+    return aSortAt < bSortAt ? 1 : -1;
+  }
+
+  if (a.lastActivityAt !== b.lastActivityAt) {
+    return a.lastActivityAt < b.lastActivityAt ? 1 : -1;
+  }
+
+  return a.contactId.localeCompare(b.contactId);
+};
 
 export function getInboxList(
   filterId: InboxFilterId = "all"
@@ -53,12 +66,14 @@ export function getInboxList(
     unreadCount: c.unreadCount,
     lastInboundAt: c.lastInboundAt,
     lastActivityAt: c.lastActivityAt,
+    lastEventType: c.lastEventType,
     lastActivityLabel: c.lastActivityLabel
   }));
 
   const totals = {
     all: items.length,
     unread: items.filter((i) => i.bucket === "new").length,
+    followUp: items.filter((i) => i.needsFollowUp).length,
     unresolved: items.filter((i) => i.hasUnresolved).length
   };
 
@@ -67,16 +82,16 @@ export function getInboxList(
     label: f.label,
     hint: f.hint,
     count:
-      f.id === "follow-up"
-        ? 0 // follow-up count is client-side; server returns 0
-        : f.id === "unresolved"
-          ? totals.unresolved
+      f.id === "unresolved"
+        ? totals.unresolved
+        : f.id === "follow-up"
+          ? totals.followUp
           : totals[f.id]
   }));
 
   const filtered = items
     .filter((item) => matchesServerFilter(item, filterId))
-    .sort(LIST_SORT);
+    .sort(compareInboxRecency);
 
   return { items: filtered, filters, totals };
 }
@@ -91,10 +106,7 @@ function matchesServerFilter(
     case "unread":
       return item.bucket === "new";
     case "follow-up":
-      // Follow-up is client-owned state; server returns everything and the
-      // client narrows it. Keeping this branch exhaustive satisfies the
-      // discriminated-union check.
-      return true;
+      return item.needsFollowUp;
     case "unresolved":
       return item.hasUnresolved;
   }

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -1,3 +1,5 @@
+import type { InboxDrivingEventType } from "@as-comms/contracts";
+
 /**
  * Inbox — UI-facing view models.
  *
@@ -8,12 +10,12 @@
  *
  * Locked rules reflected here:
  *   - one row per person, not per thread (P-02 / INBX-01)
- *   - primary buckets are "new" and "opened" (INBX-02)
+ *   - "new" and "opened" remain row-state bucket values, not primary tabs
  *   - "needsFollowUp" is a separate operator flag, not derived from bucket
  *   - "unresolved" is an overlay on top of the queue model (INBX-04)
  *   - campaign and automated sends are surfaced in the timeline as collapsed
  *     entries so 1:1 history stays readable (INBX-05)
- *   - default list order: lastInboundAt desc
+ *   - default list order: lastInboundAt desc, fallback lastActivityAt desc
  *   - toggling follow-up does NOT change row ordering
  */
 
@@ -59,8 +61,9 @@ export interface InboxListItemViewModel {
   readonly unreadCount: number;
 
   // ── Sort / display ──
-  readonly lastInboundAt: string;
+  readonly lastInboundAt: string | null;
   readonly lastActivityAt: string;
+  readonly lastEventType: InboxDrivingEventType;
   readonly lastActivityLabel: string;
 }
 

--- a/apps/web/tests/smoke/inbox.spec.ts
+++ b/apps/web/tests/smoke/inbox.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "@playwright/test";
+
+test("inbox renders as a mixed list with row-state filters", async ({ page }) => {
+  await page.goto("/inbox");
+
+  await expect(
+    page.getByRole("heading", { name: "Inbox", exact: true })
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /Unread 5/i })
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /Needs Follow-Up 3/i })
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /Unresolved 3/i })
+  ).toBeVisible();
+
+  await expect(
+    page.getByRole("button", { name: /^Opened$/i })
+  ).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: /^Pending$/i })
+  ).toHaveCount(0);
+
+  const rows = page.locator("ul.divide-y > li");
+  await expect(rows).toHaveCount(8);
+  await expect(rows.nth(0)).toContainText("Maya Patel");
+  await expect(rows.nth(1)).toContainText("Daniel Rivers");
+  await expect(rows.nth(2)).toContainText("Priya Chen");
+
+  await page.getByRole("button", { name: /Unread 5/i }).click();
+  await expect(rows).toHaveCount(5);
+  await expect(page.getByText("Sam Whitehorse")).toHaveCount(0);
+
+  await page.getByRole("button", { name: /Needs Follow-Up 3/i }).click();
+  await expect(rows).toHaveCount(3);
+  await expect(page.getByText("Maya Patel").first()).toBeVisible();
+  await expect(page.getByText("Sam Whitehorse").first()).toBeVisible();
+  await expect(page.getByText("Elena Marquez").first()).toBeVisible();
+
+  await page.getByRole("button", { name: /Unresolved 3/i }).click();
+  await expect(rows).toHaveCount(3);
+  await expect(page.getByText("Priya Chen").first()).toBeVisible();
+  await expect(page.getByText("Anita Ross").first()).toBeVisible();
+  await expect(page.getByText("+1 720 555 0199").first()).toBeVisible();
+});
+
+test("follow-up toggle only changes follow-up state", async ({ page }) => {
+  await page.goto("/inbox/c_maya_patel");
+  const detailHeader = page.locator("main header").first();
+  const followUpButton = page.getByRole("button", {
+    name: "Needs Follow-Up",
+    exact: true
+  });
+
+  await expect(followUpButton).toHaveAttribute("aria-pressed", "true");
+  await expect(detailHeader.getByText("Unread", { exact: true })).toBeVisible();
+
+  await followUpButton.click();
+  await expect(followUpButton).toHaveAttribute("aria-pressed", "false");
+  await expect(detailHeader.getByText("Unread", { exact: true })).toBeVisible();
+
+  await page.getByRole("button", { name: /Needs Follow-Up 2/i }).click();
+  const rows = page.locator("ul.divide-y > li");
+  await expect(rows).toHaveCount(2);
+  await expect(page.getByText("Sam Whitehorse").first()).toBeVisible();
+  await expect(page.getByText("Elena Marquez").first()).toBeVisible();
+
+  await followUpButton.click();
+  await expect(followUpButton).toHaveAttribute("aria-pressed", "true");
+  await expect(detailHeader.getByText("Unread", { exact: true })).toBeVisible();
+});

--- a/apps/web/tests/unit/inbox-follow-up-state.test.ts
+++ b/apps/web/tests/unit/inbox-follow-up-state.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveNeedsFollowUp,
+  toggleNeedsFollowUp
+} from "../../app/inbox/_lib/follow-up-state";
+
+describe("follow-up state helpers", () => {
+  it("allows a seeded follow-up row to be cleared and restored", () => {
+    const contactId = "contact_seeded";
+    const seededNeedsFollowUp = true;
+
+    const cleared = toggleNeedsFollowUp(
+      contactId,
+      seededNeedsFollowUp,
+      new Map<string, boolean>()
+    );
+
+    expect(
+      resolveNeedsFollowUp(contactId, seededNeedsFollowUp, cleared)
+    ).toBe(false);
+
+    const restored = toggleNeedsFollowUp(
+      contactId,
+      seededNeedsFollowUp,
+      cleared
+    );
+
+    expect(
+      resolveNeedsFollowUp(contactId, seededNeedsFollowUp, restored)
+    ).toBe(true);
+    expect(restored.size).toBe(0);
+  });
+
+  it("allows an unflagged row to be flagged without changing seeded state", () => {
+    const contactId = "contact_unseeded";
+    const seededNeedsFollowUp = false;
+
+    const flagged = toggleNeedsFollowUp(
+      contactId,
+      seededNeedsFollowUp,
+      new Map<string, boolean>()
+    );
+
+    expect(
+      resolveNeedsFollowUp(contactId, seededNeedsFollowUp, flagged)
+    ).toBe(true);
+    expect(flagged.get(contactId)).toBe(true);
+  });
+});

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  compareInboxRecency,
+  getInboxList
+} from "../../app/inbox/_lib/selectors";
+import type { InboxListItemViewModel } from "../../app/inbox/_lib/view-models";
+
+function buildItem(
+  overrides: Partial<InboxListItemViewModel>
+): InboxListItemViewModel {
+  return {
+    contactId: overrides.contactId ?? "contact_1",
+    displayName: overrides.displayName ?? "Contact One",
+    initials: overrides.initials ?? "CO",
+    avatarTone: overrides.avatarTone ?? "indigo",
+    latestSubject: overrides.latestSubject ?? "Subject",
+    snippet: overrides.snippet ?? "Snippet",
+    latestChannel: overrides.latestChannel ?? "email",
+    projectLabel: overrides.projectLabel ?? null,
+    volunteerStage: overrides.volunteerStage ?? "active",
+    bucket: overrides.bucket ?? "opened",
+    needsFollowUp: overrides.needsFollowUp ?? false,
+    hasUnresolved: overrides.hasUnresolved ?? false,
+    unreadCount: overrides.unreadCount ?? 0,
+    lastInboundAt: overrides.lastInboundAt ?? null,
+    lastActivityAt:
+      overrides.lastActivityAt ?? "2026-04-14T14:00:00.000Z",
+    lastEventType:
+      overrides.lastEventType ?? "communication.email.outbound",
+    lastActivityLabel: overrides.lastActivityLabel ?? "today"
+  };
+}
+
+describe("compareInboxRecency", () => {
+  it("falls back to lastActivityAt when lastInboundAt is missing", () => {
+    const outboundOnly = buildItem({
+      contactId: "contact_outbound",
+      lastInboundAt: null,
+      lastActivityAt: "2026-04-14T15:00:00.000Z"
+    });
+    const olderInbound = buildItem({
+      contactId: "contact_inbound",
+      lastInboundAt: "2026-04-14T13:00:00.000Z",
+      lastActivityAt: "2026-04-14T13:15:00.000Z"
+    });
+
+    expect(compareInboxRecency(outboundOnly, olderInbound)).toBeLessThan(0);
+  });
+});
+
+describe("getInboxList", () => {
+  it("uses bucket=new for unread filtering", () => {
+    const unreadContacts = getInboxList("unread").items.map(
+      (item) => item.displayName
+    );
+
+    expect(unreadContacts).toEqual([
+      "Maya Patel",
+      "Daniel Rivers",
+      "Priya Chen",
+      "Anita Ross",
+      "+1 720 555 0199"
+    ]);
+  });
+
+  it("uses needsFollowUp for follow-up filtering", () => {
+    const followUpContacts = getInboxList("follow-up").items.map(
+      (item) => item.displayName
+    );
+
+    expect(followUpContacts).toEqual([
+      "Maya Patel",
+      "Sam Whitehorse",
+      "Elena Marquez"
+    ]);
+  });
+
+  it("uses hasUnresolved for unresolved filtering", () => {
+    const unresolvedContacts = getInboxList("unresolved").items.map(
+      (item) => item.displayName
+    );
+
+    expect(unresolvedContacts).toEqual([
+      "Priya Chen",
+      "Anita Ross",
+      "+1 720 555 0199"
+    ]);
+  });
+});

--- a/docs/01-core/data-core.md
+++ b/docs/01-core/data-core.md
@@ -53,10 +53,13 @@
 ## Projection Rules
 
 - Inbox is one row per person, not one row per thread.
+- Inbox is one mixed contact list sorted by most recent inbound message.
 - Timeline is one chronological history per person.
-- Primary Inbox queue buckets are `New` and `Opened`.
-- `Starred` is a separate follow-up flag, not a replacement for the queue buckets.
-- Unresolved review is layered on top of the queue model, not its own bucket.
+- `New` and `Opened` remain projection-driven bucket states, but they are row states and filters rather than the primary Inbox partition.
+- Unread is derived from bucket state.
+- `needsFollowUp` is a separate explicit follow-up flag, not a replacement for bucket state.
+- Unresolved review is layered on top of the row state model, not its own bucket.
+- Default Inbox ordering is `lastInboundAt desc`, falling back to `lastActivityAt desc` when `lastInboundAt` is missing.
 - Campaign events appear in the timeline but do not drive Inbox bucket changes.
 
 ## Manual Resolution Model

--- a/docs/01-core/decision-core.md
+++ b/docs/01-core/decision-core.md
@@ -28,7 +28,7 @@
 | `D-009` | AI never sends automatically. | Human review is mandatory. |
 | `D-010` | Internal notes are in the first restart Inbox release. | Lightweight collaboration is core. |
 | `D-011` | Owners and tags are out of the first restart Inbox release. | Avoids unnecessary first-release complexity. |
-| `D-012` | Inbox uses `New` and `Opened`, with `Starred` as a separate follow-up flag and unresolved layered on top. | Simpler Gmail-familiar operator model. |
+| `D-012` | Inbox is one mixed contact list sorted by recency; unread comes from bucket state, `needsFollowUp` stays separate, and unresolved remains an overlay. | Keeps the operator model simple without collapsing row states together. |
 | `D-013` | Gmail remains the one-to-one email transport after cutover. | Locked operational topology. |
 | `D-014` | Email Campaigns ship before SMS Campaigns. | Trust milestone order is fixed. |
 | `D-015` | Campaign content and review state stay product-owned. | Provider is delivery, not authoring truth. |

--- a/docs/01-core/interfaces-core.md
+++ b/docs/01-core/interfaces-core.md
@@ -31,7 +31,7 @@
 | contact memberships | `ContactMembershipRecord` | `contactMembershipSchema` | `contactMemberships` | `id`, `contactId`, `projectId`, `expeditionId`, `role`, `status`, `source` |
 | identity resolution queue | `IdentityResolutionCase` | `identityResolutionSchema` | `identityResolutionQueue` | `id`, `sourceEvidenceId`, `candidateContactIds`, `reasonCode`, `status`, `openedAt`, `resolvedAt` |
 | routing review queue | `RoutingReviewCase` | `routingReviewSchema` | `routingReviewQueue` | `id`, `contactId`, `sourceEvidenceId`, `reasonCode`, `status`, `openedAt`, `resolvedAt` |
-| contact inbox projection | `InboxProjectionRow` | `inboxProjectionSchema` | `contactInboxProjection` | `contactId`, `bucket`, `isStarred`, `hasUnresolved`, `lastInboundAt`, `lastOutboundAt`, `lastActivityAt`, `snippet` |
+| contact inbox projection | `InboxProjectionRow` | `inboxProjectionSchema` | `contactInboxProjection` | `contactId`, `bucket`, `needsFollowUp`, `hasUnresolved`, `lastInboundAt`, `lastOutboundAt`, `lastActivityAt`, `snippet`, `lastEventType` |
 | contact timeline projection | `TimelineProjectionRow` | `timelineProjectionSchema` | `contactTimelineProjection` | `id`, `contactId`, `canonicalEventId`, `occurredAt`, `sortKey`, `eventType`, `summary`, `channel` |
 | sync/parity/backfill state | `SyncStateRecord` | `syncStateSchema` | `syncState` | `id`, `provider`, `jobType`, `cursor`, `windowStart`, `windowEnd`, `status`, `parityPercent`, `lastSuccessfulAt`, `deadLetterCount` |
 | audit/policy evidence | `AuditEvidenceRecord` | `auditEvidenceSchema` | `auditPolicyEvidence` | `id`, `actorType`, `actorId`, `action`, `entityType`, `entityId`, `occurredAt`, `result`, `policyCode`, `metadataJson` |
@@ -62,7 +62,7 @@
 | compact starting schemas with the required fields above | inventing new product concepts or queue semantics |
 | splitting provider-close raw payload storage from normalized payload schemas | using raw provider payloads as cross-package contracts |
 | additional nullable fields added later when justified by canon | deleting required fields that encode identity, provenance, or replay behavior |
-| implementation-specific table naming adjustments if semantics stay the same | changing the meaning of `New`, `Opened`, `Starred`, unresolved, or manual review here |
+| implementation-specific table naming adjustments if semantics stay the same | changing the meaning of bucket-derived unread, `needsFollowUp`, unresolved, or manual review here |
 
 ## Read Next
 

--- a/docs/01-core/product-core.md
+++ b/docs/01-core/product-core.md
@@ -47,11 +47,14 @@
 | ID | Locked truth |
 | --- | --- |
 | `INBX-01` | Inbox shows one row per person, not one row per thread. |
-| `INBX-02` | Primary queue buckets are `New` and `Opened`. |
-| `INBX-03` | `Starred` is a follow-up flag surfaced separately, not a replacement for queue buckets. |
-| `INBX-04` | Unresolved review layers on top; it is not its own bucket. |
-| `INBX-05` | New inbound on an `Opened` conversation resets it to `New`. |
-| `INBX-06` | First restart Inbox does not depend on close / reopen lifecycle actions. |
+| `INBX-02` | Inbox is a single mixed contact list sorted by most recent inbound message, not primarily partitioned into queue tabs. |
+| `INBX-03` | `New` and `Opened` remain projection-driven bucket states, but they are row states and filter inputs rather than the primary Inbox partition. |
+| `INBX-04` | Unread is derived from bucket state. |
+| `INBX-05` | `needsFollowUp` is an explicit operator-controlled follow-up flag that stays separate from bucket state. |
+| `INBX-06` | Unresolved review layers on top; it is not its own bucket. |
+| `INBX-07` | New inbound on an `Opened` conversation resets it to `New`. |
+| `INBX-08` | Toggling follow-up does not change list ordering by itself. |
+| `INBX-09` | First restart Inbox does not depend on close / reopen lifecycle actions. |
 
 ## Locked Scope Highlights
 

--- a/docs/02-bundles/inbox-bundle.md
+++ b/docs/02-bundles/inbox-bundle.md
@@ -24,9 +24,11 @@ Build the one-to-one operator workspace on top of canonical projections.
 ## Locked
 
 - one row per person, not one row per thread
-- primary queue buckets are `New` and `Opened`
-- `Starred` is a follow-up flag, not a queue bucket replacement
-- unresolved review layers on top of the queue model
+- one mixed contact list sorted by most recent inbound message
+- `New` and `Opened` remain projection-driven bucket states, but they are row states and filters rather than the primary Inbox partition
+- unread comes from bucket state
+- `needsFollowUp` is an explicit operator-controlled follow-up flag, not a bucket synonym
+- unresolved review layers on top of the row state model
 - internal notes are included
 - owners and tags are not in the first Inbox release
 - send behavior defaults to send and remain opened
@@ -45,23 +47,26 @@ Build the one-to-one operator workspace on top of canonical projections.
 
 | Allowed | Not allowed |
 | --- | --- |
-| projection-driven queue buckets | UI-owned queue state |
-| Gmail-familiar `New` / `Opened` / `Starred` semantics | resurrecting `Closed` / reopen lifecycle logic in first release |
+| projection-driven bucket state plus explicit follow-up flags | UI-owned queue state |
+| one mixed contact list with secondary row-state filters | resurrecting queue-tab-first or `Closed` / reopen lifecycle logic in first release |
 | unresolved overlays and review queues | treating unresolved as its own queue bucket |
 | timeline + notes in one workspace | thread-first Inbox behavior |
 
 ## Acceptance
 
 - queue bucket changes are projection-driven
+- default Inbox ordering is `lastInboundAt desc`, with `lastActivityAt desc` fallback when `lastInboundAt` is missing
+- unread filter keys off bucket state, follow-up filter keys off `needsFollowUp`, and unresolved filter keys off `hasUnresolved`
 - timeline remains correct for volunteers and non-volunteer contacts
 - unresolved/manual-link flows refresh context without duplicate history
-- opening, replying, new inbound resets, and star/unstar behavior stay consistent
+- opening, replying, new inbound resets, and follow-up toggles stay consistent without collapsing bucket and follow-up semantics
 - campaign events do not mutate Inbox bucket state
 
 ## Common Failure Modes
 
 - modeling Inbox around transport threads instead of people
-- making `Starred` a substitute for queue state
+- treating Needs Follow-Up as a substitute for queue state
+- reintroducing queue tabs as the primary Inbox model
 - leaking raw provider models into the workspace
 - reintroducing close / reopen complexity because donor code had it
 

--- a/docs/03-handoff/inbox-shell-handoff.md
+++ b/docs/03-handoff/inbox-shell-handoff.md
@@ -32,8 +32,9 @@ interface InboxListItemViewModel {
   unreadCount: number;
 
   // Sort / display
-  lastInboundAt: string;              // ISO 8601 — default sort field
+  lastInboundAt: string | null;       // ISO 8601 — primary sort field when present
   lastActivityAt: string;             // ISO 8601
+  lastEventType: InboxDrivingEventType;
   lastActivityLabel: string;          // relative time label
 }
 ```
@@ -98,9 +99,9 @@ projection repository calls. The view-model shapes stay stable.
 function getInboxList(filterId?: InboxFilterId): InboxListViewModel
 ```
 
-- Returns the full contact list sorted by `lastInboundAt` descending
-- Computes filter counts: all, unread (bucket = "new"), unresolved
-- Follow-up count is 0 server-side (client-owned state for now)
+- Returns the full contact list sorted by `lastInboundAt` descending, falling back to `lastActivityAt`
+- Computes base filter counts from projection state: all, unread (`bucket = "new"`), follow-up (`needsFollowUp = true`), unresolved (`hasUnresolved = true`)
+- Client-side follow-up overrides may adjust the visible follow-up filter without changing bucket semantics
 - **Swap target:** Replace `getMockContacts()` with a projection query that
   reads from `contactInboxProjection` and joins to get display fields
 
@@ -119,10 +120,10 @@ function getInboxDetail(contactId: string): InboxDetailViewModel | null
 
 ## Sort Contract
 
-- Default list order: `lastInboundAt` descending (most recent inbound first)
+- Default list order: `lastInboundAt` descending (most recent inbound first), falling back to `lastActivityAt` when `lastInboundAt` is missing
 - Toggling follow-up does NOT change row ordering
 - `lastInboundAt` tracks the most recent inbound email or SMS from the contact
-- `lastActivityAt` is kept for display but not used for sort
+- `lastActivityAt` is the fallback sort field when a row has no inbound history
 
 ---
 

--- a/docs/03-handoff/inbox-shell-status.md
+++ b/docs/03-handoff/inbox-shell-status.md
@@ -10,10 +10,10 @@ Status of every functional area in the inbox shell as of this build.
 |------|--------------|-------------------|
 | **Contact list data** | `_lib/mock-data.ts` | 8 hardcoded contacts with realistic timelines |
 | **Contact detail data** | `_lib/mock-data.ts` | Full timeline, project memberships, milestones |
-| **List selectors** | `_lib/selectors.ts` | Maps mock records to view models, sorts by `lastInboundAt` |
+| **List selectors** | `_lib/selectors.ts` | Maps mock records to view models, sorts by `lastInboundAt` with `lastActivityAt` fallback |
 | **Composer send** | `inbox-composer.tsx` | `setTimeout` simulating 1.2s send with 80% success rate |
 | **AI drafting** | `inbox-composer.tsx` | `setTimeout` inserting a canned draft after 2s |
-| **Follow-up toggle** | `inbox-client-provider.tsx` | Client-side `Set<string>` — no persistence |
+| **Follow-up toggle** | `inbox-client-provider.tsx` | Client-side follow-up override map layered on top of projection-backed `needsFollowUp` |
 | **Reminders** | `inbox-client-provider.tsx` | Client-side `Map<string, Reminder>` — no persistence |
 | **Search** | `inbox-list.tsx` | Client-side string match on name, subject, snippet, project |
 
@@ -51,9 +51,10 @@ Status of every functional area in the inbox shell as of this build.
 
 - One row per person, not one row per thread
 - Queue state is projection-driven, not UI-owned
-- Single recency-sorted list (lastInboundAt desc)
+- Single recency-sorted list (`lastInboundAt desc`, `lastActivityAt desc` fallback)
 - Unread / Needs Follow-Up / Unresolved Review are row-level states, not list partitions
 - `bucket` and `needsFollowUp` are separate fields (never collapsed)
+- Unread filter uses bucket state, follow-up filter uses `needsFollowUp`, unresolved filter uses `hasUnresolved`
 - Toggling follow-up does not change row ordering
 - Unresolved review overlays on top of queue state
 - Internal notes included in timeline and composer

--- a/docs/03-reference/reference-donor-reuse.md
+++ b/docs/03-reference/reference-donor-reuse.md
@@ -21,7 +21,7 @@
 ## Always Check First
 
 - does this donor logic fit the locked repo contract?
-- does it preserve the current Inbox `New / Opened / Starred` model?
+- does it preserve the current mixed-list Inbox model with bucket-derived unread, explicit `needsFollowUp`, and unresolved overlay?
 - does it preserve the one-normalization-path rule?
 - does it reintroduce approval-heavy, UI-owned, or benchmark-era assumptions?
 

--- a/docs/03-reference/reference-legacy-conflicts.md
+++ b/docs/03-reference/reference-legacy-conflicts.md
@@ -12,7 +12,7 @@
 | manual Notion sync/review/confirm workflow | background sync/cache with no approval gate |
 | donor repo as implementation baseline | fresh rebuild in a new repo |
 | benchmark-era UI decisions as product truth | only re-locked decisions in the current canon matter |
-| older Inbox `New / Open / Closed` or close/reopen workflows | `New` + `Opened` primary queue model, `Starred` follow-up flag, no first-release close/reopen dependency |
+| older Inbox `New / Open / Closed` or queue-tab-first workflows | one mixed contact list, bucket-derived unread, explicit `needsFollowUp`, unresolved overlay, no first-release close/reopen dependency |
 | flexible framework/stack choice during implementation | locked Next.js / React / TS / Postgres / worker stack and repo shape |
 
 ## When You Hit A Conflict

--- a/docs/04-implementation-specs/stage-1-projection-rules.md
+++ b/docs/04-implementation-specs/stage-1-projection-rules.md
@@ -59,12 +59,14 @@ Each timeline row should preserve enough information to explain:
 - `lastOutboundAt` tracks the newest outbound one-to-one event
 - `lastActivityAt` is the newest of `lastInboundAt` and `lastOutboundAt`
 - `snippet` comes from the newest one-to-one communication event that refreshed the row
+- default Inbox list order is `lastInboundAt desc`, falling back to `lastActivityAt desc` when `lastInboundAt` is missing
 
 ### Bucket semantics
 
 #### `New`
 
 - means the row has inbound one-to-one activity that has not been cleared by a later explicit open action
+- the UI projects this row state as unread
 - first inbound one-to-one contact activity initializes the row to `New`
 - new inbound on an existing `Opened` row resets the row to `New`
 
@@ -74,12 +76,12 @@ Each timeline row should preserve enough information to explain:
 - first outbound-only one-to-one history initializes the row to `Opened`
 - outbound events alone must not clear `New` automatically; that later operator action belongs to Inbox-stage behavior, not provider-driven projection rules
 
-#### `Starred`
+#### `Needs Follow-Up`
 
-- `Starred` is a separate follow-up flag
+- `needsFollowUp` is a separate explicit follow-up flag
 - it must not replace or mutate the bucket meaning
-- provider data must not infer `Starred`
-- until explicit Inbox-stage actions exist, Stage 1 should treat `isStarred` as explicit projection state, not an event-derived inference
+- provider data must not infer follow-up state
+- until explicit Inbox-stage actions exist, Stage 1 should treat `needsFollowUp` as explicit projection state, not an event-derived inference
 
 ### Unresolved overlays
 
@@ -93,14 +95,14 @@ Each timeline row should preserve enough information to explain:
 - `campaign.email.*` events appear in timeline history only
 - they must not set or reset `New`
 - they must not set or clear `Opened`
-- they must not imply `Starred`
+- they must not imply `needsFollowUp`
 
 ## Rebuild And Replay Expectations
 
 - both timeline and Inbox projections must rebuild from canonical truth
 - rebuild must be deterministic for the same canonical inputs
 - replay of source evidence must not duplicate projection rows
-- later product-layer state changes, such as explicit open or star actions, should remain separate projection inputs when those stages arrive; Stage 1 should not fake them from provider traffic
+- later product-layer state changes, such as explicit open or follow-up actions, should remain separate projection inputs when those stages arrive; Stage 1 should not fake them from provider traffic
 
 ## Explainability Requirement
 

--- a/packages/contracts/src/stage1-records.ts
+++ b/packages/contracts/src/stage1-records.ts
@@ -210,7 +210,7 @@ export const inboxProjectionSchema = z
   .object({
     contactId: idSchema,
     bucket: inboxBucketSchema,
-    isStarred: z.boolean(),
+    needsFollowUp: z.boolean(),
     hasUnresolved: z.boolean(),
     lastInboundAt: optionalTimestampSchema,
     lastOutboundAt: optionalTimestampSchema,

--- a/packages/db/src/mappers.ts
+++ b/packages/db/src/mappers.ts
@@ -405,7 +405,7 @@ export function mapInboxProjectionRow(
   return inboxProjectionSchema.parse({
     contactId: row.contactId,
     bucket: row.bucket,
-    isStarred: row.isStarred,
+    needsFollowUp: row.isStarred,
     hasUnresolved: row.hasUnresolved,
     lastInboundAt: fromDate(row.lastInboundAt),
     lastOutboundAt: fromDate(row.lastOutboundAt),
@@ -424,7 +424,7 @@ export function mapInboxProjectionToInsert(
   return {
     contactId: parsed.contactId,
     bucket: parsed.bucket,
-    isStarred: parsed.isStarred,
+    isStarred: parsed.needsFollowUp,
     hasUnresolved: parsed.hasUnresolved,
     lastInboundAt:
       parsed.lastInboundAt === null ? null : toDate(parsed.lastInboundAt),

--- a/packages/db/test/stage1-persistence.test.ts
+++ b/packages/db/test/stage1-persistence.test.ts
@@ -298,7 +298,7 @@ describe("Stage 1 persistence service", () => {
     const inbox = await persistence.saveInboxProjection({
       contactId: "contact_1",
       bucket: "Opened",
-      isStarred: false,
+      needsFollowUp: false,
       hasUnresolved: false,
       lastInboundAt: null,
       lastOutboundAt: "2026-01-01T00:00:00.000Z",

--- a/packages/db/test/stage1-repositories.test.ts
+++ b/packages/db/test/stage1-repositories.test.ts
@@ -198,7 +198,7 @@ describe("Stage 1 DB repositories", () => {
     const inboxProjection = await repositories.inboxProjection.upsert({
       contactId: "contact_1",
       bucket: "New",
-      isStarred: false,
+      needsFollowUp: false,
       hasUnresolved: true,
       lastInboundAt: "2026-01-01T00:00:00.000Z",
       lastOutboundAt: null,

--- a/packages/domain/src/normalization.ts
+++ b/packages/domain/src/normalization.ts
@@ -1116,7 +1116,7 @@ export function createStage1NormalizationService(
       return persistence.saveInboxProjection({
         contactId: parsed.canonicalEvent.contactId,
         bucket: lastInboundAt === null ? "Opened" : "New",
-        isStarred: existing?.isStarred ?? false,
+        needsFollowUp: existing?.needsFollowUp ?? false,
         hasUnresolved,
         lastInboundAt,
         lastOutboundAt,


### PR DESCRIPTION
## What changed
- aligned the inbox canon and handoff docs around the merged shell behavior: one mixed contact list, one row per person, unread from bucket, explicit `needsFollowUp`, unresolved overlay, and default sort by `lastInboundAt` with `lastActivityAt` fallback
- updated the shared logical inbox contract and persistence boundary so the consumed model uses `needsFollowUp` while physical DB names remain unchanged
- fixed the merged inbox shell selectors and client follow-up behavior so follow-up stays separate from bucket state, follow-up filtering uses `needsFollowUp`, and seeded follow-up rows can be cleared without changing list order
- added targeted unit and smoke coverage for sort/filter semantics and follow-up toggling

## Why
The merged inbox shell was directionally correct, but the core canon and logical inbox contract still reflected older `New / Opened / Starred` framing. The shell also still had two semantic gaps: follow-up filtering/counting did not fully honor seeded `needsFollowUp` state, and the selector sort did not implement the `lastActivityAt` fallback when `lastInboundAt` is missing.

## Impact
- the docs, contracts, and inbox shell now agree on the same product behavior
- unread uses bucket state only
- needs follow-up is an explicit operator state and not a synonym for bucket state
- unresolved stays an overlay
- the inbox remains a single mixed list instead of a primary queue-tab model

## Validation
- `pnpm --filter @as-comms/web typecheck`
- `pnpm --filter @as-comms/web test:unit -- tests/unit/inbox-selectors.test.ts tests/unit/inbox-follow-up-state.test.ts`
- `pnpm --filter @as-comms/db test:unit -- test/stage1-persistence.test.ts test/stage1-repositories.test.ts`
- smoke: `pnpm --dir apps/web exec next build --no-lint`, `pnpm --dir apps/web exec next start --hostname 127.0.0.1 --port 3000`, `pnpm exec playwright test apps/web/tests/smoke/inbox.spec.ts --workers=1 --retries=0 --reporter=line`

## Notes
- physical DB names remain unchanged in this pass (`is_starred`, `New|Opened`)
- the smoke run uses `next build --no-lint` because unrelated upstream ESLint failures currently block the default Playwright `webServer` build path
