### PR TITLE
Wire Inbox Shell to Real Stage 1 Data

### DIFF
--- a/apps/web/app/inbox/[contactId]/page.tsx
+++ b/apps/web/app/inbox/[contactId]/page.tsx
@@ -9,7 +9,7 @@ interface PageProps {
 
 export default async function InboxContactPage({ params }: PageProps) {
   const { contactId } = await params;
-  const detail = getInboxDetail(contactId);
+  const detail = await getInboxDetail(decodeURIComponent(contactId));
   if (!detail) {
     notFound();
   }

--- a/apps/web/app/inbox/_components/inbox-client-provider.tsx
+++ b/apps/web/app/inbox/_components/inbox-client-provider.tsx
@@ -9,19 +9,12 @@ import {
   type ReactNode
 } from "react";
 
-import {
-  toggleNeedsFollowUp,
-  type FollowUpOverrides
-} from "../_lib/follow-up-state";
-
 /**
  * Prototype-local client state shared across the Inbox list column and
- * Detail workspace. In a real build these would round-trip through server
- * actions; for the prototype we keep them in React context so toggling a
- * button in one panel immediately reflects in the other.
+ * Detail workspace. These are intentionally ephemeral UI concerns only.
  *
  * Extended to cover every interactive state the UI needs:
- *   - follow-up flags and reminders (original)
+ *   - reminders
  *   - search query + results
  *   - composer status (idle → saving → saved / error → sending → sent / failed)
  *   - AI draft lifecycle (idle → generating → inserted → edited / discarded)
@@ -95,13 +88,8 @@ const INITIAL_SEARCH: SearchState = {
 // ---------- Context shape ----------
 
 interface InboxClientState {
-  // Follow-up & reminders
-  readonly followUp: FollowUpOverrides;
+  // Reminders
   readonly reminders: ReadonlyMap<string, Reminder>;
-  readonly toggleFollowUp: (
-    contactId: string,
-    seededNeedsFollowUp: boolean
-  ) => void;
   readonly setReminder: (contactId: string, reminder: Reminder) => void;
   readonly clearReminder: (contactId: string) => void;
 
@@ -144,22 +132,10 @@ export function InboxClientProvider({
 }: {
   readonly children: ReactNode;
 }) {
-  // Follow-up & reminders
-  const [followUp, setFollowUp] = useState<FollowUpOverrides>(
-    () => new Map<string, boolean>()
-  );
+  // Reminders
   const [reminders, setReminders] = useState<ReadonlyMap<string, Reminder>>(
     () => new Map<string, Reminder>()
   );
-
-  const toggleFollowUp = useCallback((
-    contactId: string,
-    seededNeedsFollowUp: boolean
-  ) => {
-    setFollowUp((prev) =>
-      toggleNeedsFollowUp(contactId, seededNeedsFollowUp, prev)
-    );
-  }, []);
 
   const setReminder = useCallback((contactId: string, reminder: Reminder) => {
     setReminders((prev) => {
@@ -276,9 +252,7 @@ export function InboxClientProvider({
 
   const value = useMemo<InboxClientState>(
     () => ({
-      followUp,
       reminders,
-      toggleFollowUp,
       setReminder,
       clearReminder,
       search,
@@ -304,9 +278,7 @@ export function InboxClientProvider({
       resetAiDraft
     }),
     [
-      followUp,
       reminders,
-      toggleFollowUp,
       setReminder,
       clearReminder,
       search,

--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
+import { useFormStatus } from "react-dom";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -10,8 +11,11 @@ import {
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 
+import {
+  clearInboxNeedsFollowUpAction,
+  markInboxNeedsFollowUpAction
+} from "../actions";
 import type { InboxDetailViewModel } from "../_lib/view-models";
-import { resolveNeedsFollowUp } from "../_lib/follow-up-state";
 import {
   useInboxClient,
   type Reminder
@@ -44,14 +48,8 @@ type ReminderUnit = "hours" | "days" | "weeks";
 export function InboxDetail({ detail }: DetailProps) {
   const { contact, timeline, smsEligible } = detail;
   const timelineRef = useRef<HTMLDivElement>(null);
-  const {
-    followUp,
-    toggleFollowUp,
-    reminders,
-    setReminder,
-    clearReminder,
-    isTimelineLoading
-  } = useInboxClient();
+  const { reminders, setReminder, clearReminder, isTimelineLoading } =
+    useInboxClient();
 
   const [railOpen, setRailOpen] = useState(false);
   const [reminderOpen, setReminderOpen] = useState(false);
@@ -61,11 +59,7 @@ export function InboxDetail({ detail }: DetailProps) {
   const activeProject = contact.activeProjects[0] ?? null;
   const firstName = contact.displayName.split(" ")[0] ?? contact.displayName;
 
-  const isFollowUp = resolveNeedsFollowUp(
-    contact.contactId,
-    detail.needsFollowUp,
-    followUp
-  );
+  const isFollowUp = detail.needsFollowUp;
   const existingReminder = reminders.get(contact.contactId) ?? null;
 
   const handleSetReminder = () => {
@@ -127,22 +121,10 @@ export function InboxDetail({ detail }: DetailProps) {
 
           <div className="flex shrink-0 items-center gap-2">
             {/* Needs Follow Up toggle — off / on */}
-            <Button
-              variant="outline"
-              size="sm"
-              aria-pressed={isFollowUp}
-              onClick={() => {
-                toggleFollowUp(contact.contactId, detail.needsFollowUp);
-              }}
-              className={cn(
-                "gap-1.5",
-                isFollowUp &&
-                  "border-rose-300 bg-rose-50 text-rose-800 hover:bg-rose-100 hover:text-rose-800"
-              )}
-            >
-              <CornerUpLeftIcon className="h-3.5 w-3.5" />
-              Needs Follow-Up
-            </Button>
+            <FollowUpToggleForm
+              contactId={contact.contactId}
+              needsFollowUp={isFollowUp}
+            />
 
             {/* Reminder popover */}
             <Popover open={reminderOpen} onOpenChange={setReminderOpen}>
@@ -258,6 +240,56 @@ export function InboxDetail({ detail }: DetailProps) {
         </div>
       </div>
     </div>
+  );
+}
+
+function FollowUpToggleForm({
+  contactId,
+  needsFollowUp
+}: {
+  readonly contactId: string;
+  readonly needsFollowUp: boolean;
+}) {
+  const action = async (formData: FormData) => {
+    if (needsFollowUp) {
+      await clearInboxNeedsFollowUpAction(formData);
+      return;
+    }
+
+    await markInboxNeedsFollowUpAction(formData);
+  };
+
+  return (
+    <form action={action}>
+      <input type="hidden" name="contactId" value={contactId} />
+      <FollowUpToggleButton needsFollowUp={needsFollowUp} />
+    </form>
+  );
+}
+
+function FollowUpToggleButton({
+  needsFollowUp
+}: {
+  readonly needsFollowUp: boolean;
+}) {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button
+      type="submit"
+      variant="outline"
+      size="sm"
+      disabled={pending}
+      aria-pressed={needsFollowUp}
+      className={cn(
+        "gap-1.5",
+        needsFollowUp &&
+          "border-rose-300 bg-rose-50 text-rose-800 hover:bg-rose-100 hover:text-rose-800"
+      )}
+    >
+      <CornerUpLeftIcon className="h-3.5 w-3.5" />
+      Needs Follow-Up
+    </Button>
   );
 }
 

--- a/apps/web/app/inbox/_components/inbox-list.tsx
+++ b/apps/web/app/inbox/_components/inbox-list.tsx
@@ -8,7 +8,6 @@ import type {
   InboxFilterViewModel,
   InboxListItemViewModel
 } from "../_lib/view-models";
-import { resolveNeedsFollowUp } from "../_lib/follow-up-state";
 import { EmptyState } from "@/components/ui/empty-state";
 
 import { useInboxClient } from "./inbox-client-provider";
@@ -35,13 +34,7 @@ export function InboxList({
 }: ListColumnProps) {
   const pathname = usePathname();
   const activeContactId = extractContactId(pathname);
-  const {
-    followUp,
-    search,
-    setSearchQuery,
-    clearSearch,
-    isQueueLoading
-  } = useInboxClient();
+  const { search, setSearchQuery, clearSearch, isQueueLoading } = useInboxClient();
 
   const [activeFilter, setActiveFilter] = useState<InboxFilterId>(initialFilterId);
   const filterLabels = useMemo(
@@ -50,14 +43,14 @@ export function InboxList({
     [filters]
   );
 
-  // Compute filter counts from base projection state + local overrides.
+  // Compute filter counts from the server-backed projection state.
   const filterCounts = useMemo(() => {
     let unread = 0;
     let followUpCount = 0;
     let unresolved = 0;
     for (const item of items) {
       if (item.bucket === "new") unread++;
-      if (resolveNeedsFollowUp(item.contactId, item.needsFollowUp, followUp)) {
+      if (item.needsFollowUp) {
         followUpCount++;
       }
       if (item.hasUnresolved) unresolved++;
@@ -68,13 +61,11 @@ export function InboxList({
       "follow-up": followUpCount,
       unresolved
     };
-  }, [items, followUp]);
+  }, [items]);
 
   // Apply filters: active filter -> search
   const filteredItems = useMemo(() => {
-    let result = items.filter((item) =>
-      matchesActiveFilter(item, activeFilter, followUp)
-    );
+    let result = items.filter((item) => matchesActiveFilter(item, activeFilter));
 
     // Search filter
     if (search.isActive && search.resultContactIds.length > 0) {
@@ -83,7 +74,7 @@ export function InboxList({
     }
 
     return result;
-  }, [items, activeFilter, followUp, search]);
+  }, [items, activeFilter, search]);
 
   // For local search simulation: filter by query string matching
   const searchFilteredItems = useMemo(() => {
@@ -203,14 +194,7 @@ export function InboxList({
             {displayItems.map((item) => (
               <InboxRow
                 key={item.contactId}
-                item={{
-                  ...item,
-                  needsFollowUp: resolveNeedsFollowUp(
-                    item.contactId,
-                    item.needsFollowUp,
-                    followUp
-                  )
-                }}
+                item={item}
                 isActive={item.contactId === activeContactId}
               />
             ))}
@@ -248,13 +232,18 @@ function SearchEmptyState({ query }: { readonly query: string }) {
 function extractContactId(pathname: string | null): string | null {
   if (!pathname) return null;
   const match = /^\/inbox\/([^/]+)/.exec(pathname);
-  return match ? (match[1] ?? null) : null;
+  if (!match) return null;
+
+  try {
+    return decodeURIComponent(match[1] ?? "");
+  } catch {
+    return match[1] ?? null;
+  }
 }
 
 function matchesActiveFilter(
   item: InboxListItemViewModel,
-  activeFilter: InboxFilterId,
-  followUp: ReadonlyMap<string, boolean>
+  activeFilter: InboxFilterId
 ): boolean {
   switch (activeFilter) {
     case "all":
@@ -262,7 +251,7 @@ function matchesActiveFilter(
     case "unread":
       return item.bucket === "new";
     case "follow-up":
-      return resolveNeedsFollowUp(item.contactId, item.needsFollowUp, followUp);
+      return item.needsFollowUp;
     case "unresolved":
       return item.hasUnresolved;
   }

--- a/apps/web/app/inbox/_components/inbox-row.tsx
+++ b/apps/web/app/inbox/_components/inbox-row.tsx
@@ -38,7 +38,7 @@ export function InboxRow({ item, isActive }: RowProps) {
   return (
     <li>
       <Link
-        href={`/inbox/${item.contactId}`}
+        href={`/inbox/${encodeURIComponent(item.contactId)}`}
         aria-current={isActive ? "page" : undefined}
         className={`relative flex gap-3 border-b border-slate-100 ${SPACING.listItem} ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion} ${
           isActive

--- a/apps/web/app/inbox/_components/inbox-shell.tsx
+++ b/apps/web/app/inbox/_components/inbox-shell.tsx
@@ -19,10 +19,11 @@ interface ShellProps {
 /**
  * Server shell: renders the persistent chrome once for every `/inbox` route.
  * The {@link InboxClientProvider} is the client boundary that holds
- * ephemeral UI state shared across the list column and the detail workspace
- * — specifically which contacts are flagged "Needs Follow Up" and which
- * have a reminder pending — so those two islands can stay in sync without
- * hoisting a store into the canonical data layer.
+ * ephemeral UI state shared across the list column and the detail workspace:
+ * reminders, search state, loading indicators, and composer draft status.
+ *
+ * Canonical inbox row state remains server-owned and flows through the
+ * server selectors for both the list shell and the selected-contact detail.
  */
 export function InboxShell({
   filters,

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -1,27 +1,68 @@
-/**
- * Inbox — server-side selectors.
- *
- * These functions are the only place the mock records touch the view-model
- * contract. The Server Components consume these and pass the narrow view
- * models to client islands. This module is the natural place to substitute
- * real projection reads — the view-model shapes stay stable.
- */
+import { unstable_cache } from "next/cache";
+
+import type {
+  CanonicalEventRecord,
+  ContactMembershipRecord,
+  ContactRecord,
+  GmailMessageDetailRecord,
+  InboxDrivingEventType,
+  InboxProjectionRow,
+  TimelineProjectionRow
+} from "@as-comms/contracts";
+
+import { getStage1WebRuntime } from "../../../src/server/stage1-runtime";
 
 import { INBOX_FILTERS } from "./filters";
-import {
-  getMockContactById,
-  getMockContacts,
-  type MockMilestone
-} from "./mock-data";
 import type {
+  InboxAvatarTone,
+  InboxBucket,
+  InboxChannel,
   InboxContactSummaryViewModel,
   InboxDetailViewModel,
   InboxFilterId,
   InboxFilterViewModel,
   InboxListItemViewModel,
   InboxListViewModel,
-  InboxRecentActivityViewModel
+  InboxProjectMembershipViewModel,
+  InboxProjectStatus,
+  InboxRecentActivityViewModel,
+  InboxTimelineEntryKind,
+  InboxTimelineEntryViewModel,
+  InboxVolunteerStage
 } from "./view-models";
+
+interface InboxListCacheRow {
+  readonly contact: ContactRecord;
+  readonly inboxProjection: InboxProjectionRow;
+  readonly memberships: readonly ContactMembershipRecord[];
+  readonly latestSubject: string | null;
+}
+
+interface InboxListCacheData {
+  readonly rows: readonly InboxListCacheRow[];
+  readonly projectNameById: Readonly<Record<string, string>>;
+}
+
+interface InboxDetailCacheData {
+  readonly contact: ContactRecord;
+  readonly inboxProjection: InboxProjectionRow;
+  readonly memberships: readonly ContactMembershipRecord[];
+  readonly timelineRows: readonly TimelineProjectionRow[];
+  readonly canonicalEvents: readonly CanonicalEventRecord[];
+  readonly gmailDetails: readonly GmailMessageDetailRecord[];
+  readonly projectNameById: Readonly<Record<string, string>>;
+}
+
+const AVATAR_TONES: readonly InboxAvatarTone[] = [
+  "indigo",
+  "emerald",
+  "amber",
+  "rose",
+  "sky",
+  "violet",
+  "teal",
+  "slate"
+];
 
 /**
  * Default list sort: last inbound message first.
@@ -45,55 +86,577 @@ export const compareInboxRecency = (
   return a.contactId.localeCompare(b.contactId);
 };
 
-export function getInboxList(
-  filterId: InboxFilterId = "all"
-): InboxListViewModel {
-  const contacts = getMockContacts();
+function uniqueStrings(values: readonly (string | null | undefined)[]): string[] {
+  return Array.from(
+    new Set(
+      values.filter((value): value is string => typeof value === "string")
+    )
+  );
+}
 
-  const items: InboxListItemViewModel[] = contacts.map((c) => ({
-    contactId: c.contactId,
-    displayName: c.displayName,
-    initials: c.initials,
-    avatarTone: c.avatarTone,
-    latestSubject: c.latestSubject,
-    snippet: c.snippet,
-    latestChannel: c.latestChannel,
-    projectLabel: c.projectLabel,
-    volunteerStage: c.volunteerStage,
-    bucket: c.bucket,
-    needsFollowUp: c.needsFollowUp,
-    hasUnresolved: c.hasUnresolved,
-    unreadCount: c.unreadCount,
-    lastInboundAt: c.lastInboundAt,
-    lastActivityAt: c.lastActivityAt,
-    lastEventType: c.lastEventType,
-    lastActivityLabel: c.lastActivityLabel
-  }));
+function toInitials(displayName: string): string {
+  const parts = displayName
+    .trim()
+    .split(/\s+/)
+    .filter((part) => part.length > 0)
+    .slice(0, 2);
 
-  const totals = {
-    all: items.length,
-    unread: items.filter((i) => i.bucket === "new").length,
-    followUp: items.filter((i) => i.needsFollowUp).length,
-    unresolved: items.filter((i) => i.hasUnresolved).length
+  if (parts.length === 0) {
+    return "??";
+  }
+
+  return parts
+    .map((part) => part.charAt(0).toUpperCase())
+    .join("");
+}
+
+function hashString(value: string): number {
+  let hash = 0;
+
+  for (const character of value) {
+    hash = (hash * 31 + character.charCodeAt(0)) >>> 0;
+  }
+
+  return hash;
+}
+
+function avatarToneForContact(contactId: string): InboxAvatarTone {
+  return AVATAR_TONES[hashString(contactId) % AVATAR_TONES.length] ?? "slate";
+}
+
+function mapBucket(bucket: InboxProjectionRow["bucket"]): InboxBucket {
+  return bucket === "New" ? "new" : "opened";
+}
+
+function mapChannel(eventType: InboxDrivingEventType): InboxChannel {
+  return eventType.includes(".sms.") ? "sms" : "email";
+}
+
+function normalizeMembershipStatus(status: string | null): string | null {
+  if (status === null) {
+    return null;
+  }
+
+  const normalized = status.trim().toLowerCase().replace(/[_\s]+/g, "-");
+  return normalized.length > 0 ? normalized : null;
+}
+
+function membershipSortRank(membership: ContactMembershipRecord): number {
+  switch (normalizeMembershipStatus(membership.status)) {
+    case "lead":
+      return 0;
+    case "applied":
+    case "applicant":
+      return 1;
+    case "in-training":
+    case "training":
+      return 2;
+    case "trip-planning":
+      return 3;
+    case "in-field":
+    case "active":
+      return 4;
+    case "successful":
+    case "completed":
+      return 5;
+    default:
+      return 6;
+  }
+}
+
+function sortMemberships(
+  memberships: readonly ContactMembershipRecord[]
+): readonly ContactMembershipRecord[] {
+  return [...memberships].sort((left, right) => {
+    const rankDifference = membershipSortRank(left) - membershipSortRank(right);
+
+    if (rankDifference !== 0) {
+      return rankDifference;
+    }
+
+    if (left.projectId !== right.projectId) {
+      return (left.projectId ?? "").localeCompare(right.projectId ?? "");
+    }
+
+    return left.id.localeCompare(right.id);
+  });
+}
+
+function mapVolunteerStage(
+  memberships: readonly ContactMembershipRecord[]
+): InboxVolunteerStage {
+  const primaryMembership = sortMemberships(memberships)[0] ?? null;
+  const normalizedStatus = normalizeMembershipStatus(primaryMembership?.status ?? null);
+
+  switch (normalizedStatus) {
+    case "lead":
+      return "lead";
+    case "applied":
+    case "applicant":
+      return "applicant";
+    case "in-training":
+    case "training":
+    case "trip-planning":
+    case "in-field":
+    case "active":
+      return "active";
+    case "successful":
+    case "completed":
+      return "alumni";
+    default:
+      return "non-volunteer";
+  }
+}
+
+function mapProjectStatus(status: string | null): InboxProjectStatus {
+  switch (normalizeMembershipStatus(status)) {
+    case "lead":
+      return "lead";
+    case "applied":
+    case "applicant":
+      return "applied";
+    case "in-training":
+    case "training":
+      return "in-training";
+    case "trip-planning":
+      return "trip-planning";
+    case "in-field":
+    case "active":
+      return "in-field";
+    case "successful":
+    case "completed":
+      return "successful";
+    default:
+      return "applied";
+  }
+}
+
+function resolveProjectName(
+  membership: ContactMembershipRecord,
+  projectNameById: Readonly<Record<string, string>>
+): string | null {
+  if (membership.projectId === null) {
+    return null;
+  }
+
+  return projectNameById[membership.projectId] ?? membership.projectId;
+}
+
+function buildProjectMembershipViewModel(
+  membership: ContactMembershipRecord,
+  projectNameById: Readonly<Record<string, string>>
+): InboxProjectMembershipViewModel | null {
+  const projectName = resolveProjectName(membership, projectNameById);
+
+  if (projectName === null || membership.projectId === null) {
+    return null;
+  }
+
+  return {
+    membershipId: membership.id,
+    projectId: membership.projectId,
+    projectName,
+    // Gap: the canonical membership season/year is not persisted yet, so the
+    // shell keeps its existing contract with a selector-derived current year.
+    year: new Date().getUTCFullYear(),
+    status: mapProjectStatus(membership.status),
+    // Gap: the canonical project URL is not stored yet, so the shell uses a
+    // stable best-effort CRM path derived from the project identifier.
+    crmUrl: `https://adventurescientists.lightning.force.com/lightning/r/Project__c/${encodeURIComponent(
+      membership.projectId
+    )}/view`
   };
+}
 
-  const filters: InboxFilterViewModel[] = INBOX_FILTERS.map((f) => ({
-    id: f.id,
-    label: f.label,
-    hint: f.hint,
-    count:
-      f.id === "unresolved"
-        ? totals.unresolved
-        : f.id === "follow-up"
-          ? totals.followUp
-          : totals[f.id]
-  }));
+function isPastProject(status: InboxProjectStatus): boolean {
+  return status === "successful";
+}
 
-  const filtered = items
-    .filter((item) => matchesServerFilter(item, filterId))
-    .sort(compareInboxRecency);
+function formatJoinedAtLabel(createdAt: string): string {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC"
+  });
 
-  return { items: filtered, filters, totals };
+  return `Joined ${formatter.format(new Date(createdAt))}`;
+}
+
+function formatRelativeTimestamp(timestamp: string, referenceNowIso: string): string {
+  const target = new Date(timestamp).getTime();
+  const now = new Date(referenceNowIso).getTime();
+  const deltaMs = Math.max(0, now - target);
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+
+  if (deltaMs < hour) {
+    const minutes = Math.max(1, Math.floor(deltaMs / minute));
+    return `${minutes.toString()}m ago`;
+  }
+
+  if (deltaMs < day) {
+    const hours = Math.floor(deltaMs / hour);
+    return `${hours.toString()}h ago`;
+  }
+
+  const days = Math.floor(deltaMs / day);
+
+  if (days === 1) {
+    return "yesterday";
+  }
+
+  if (days < 7) {
+    return `${days.toString()}d ago`;
+  }
+
+  if (days < 30) {
+    return `${Math.floor(days / 7).toString()}w ago`;
+  }
+
+  if (days < 365) {
+    return `${Math.floor(days / 30).toString()}mo ago`;
+  }
+
+  return `${Math.floor(days / 365).toString()}y ago`;
+}
+
+function defaultLatestSubject(
+  eventType: InboxDrivingEventType,
+  fallback: string | null
+): string {
+  if (fallback !== null && fallback.trim().length > 0) {
+    return fallback;
+  }
+
+  return mapChannel(eventType) === "sms" ? "SMS conversation" : "Email conversation";
+}
+
+function mapTimelineKind(
+  row: TimelineProjectionRow
+): InboxTimelineEntryKind {
+  switch (row.eventType) {
+    case "communication.email.inbound":
+      return "inbound-email";
+    case "communication.email.outbound":
+      return "outbound-email";
+    case "communication.sms.inbound":
+      return "inbound-sms";
+    case "communication.sms.outbound":
+      return "outbound-sms";
+    default:
+      return "system-event";
+  }
+}
+
+function buildRecentActivity(
+  timelineRows: readonly TimelineProjectionRow[],
+  referenceNowIso: string
+): readonly InboxRecentActivityViewModel[] {
+  return [...timelineRows]
+    .sort((left, right) => right.occurredAt.localeCompare(left.occurredAt))
+    .slice(0, 5)
+    .map((row) => ({
+      id: row.id,
+      label: row.summary,
+      occurredAtLabel: formatRelativeTimestamp(row.occurredAt, referenceNowIso)
+    }));
+}
+
+function groupMembershipsByContactId(
+  memberships: readonly ContactMembershipRecord[]
+): ReadonlyMap<string, readonly ContactMembershipRecord[]> {
+  const grouped = new Map<string, ContactMembershipRecord[]>();
+
+  for (const membership of memberships) {
+    const existing = grouped.get(membership.contactId);
+
+    if (existing === undefined) {
+      grouped.set(membership.contactId, [membership]);
+      continue;
+    }
+
+    existing.push(membership);
+  }
+
+  return grouped;
+}
+
+async function loadProjectNameById(
+  memberships: readonly ContactMembershipRecord[]
+): Promise<Readonly<Record<string, string>>> {
+  const projectIds = uniqueStrings(
+    memberships.map((membership) => membership.projectId)
+  );
+
+  if (projectIds.length === 0) {
+    return {};
+  }
+
+  const runtime = await getStage1WebRuntime();
+  const dimensions = await runtime.repositories.projectDimensions.listByIds(projectIds);
+
+  return Object.fromEntries(
+    dimensions.map((dimension) => [dimension.projectId, dimension.projectName])
+  );
+}
+
+async function loadLatestSubjectByCanonicalEventId(
+  projections: readonly InboxProjectionRow[]
+): Promise<Readonly<Record<string, string | null>>> {
+  const eventIds = uniqueStrings(
+    projections.map((projection) => projection.lastCanonicalEventId)
+  );
+
+  if (eventIds.length === 0) {
+    return {};
+  }
+
+  const runtime = await getStage1WebRuntime();
+  const [canonicalEvents, timelineRows] = await Promise.all([
+    runtime.repositories.canonicalEvents.listByIds(eventIds),
+    Promise.all(
+      eventIds.map((eventId) =>
+        runtime.repositories.timelineProjection.findByCanonicalEventId(eventId)
+      )
+    )
+  ]);
+  const sourceEvidenceIds = uniqueStrings(
+    canonicalEvents.map((event) => event.sourceEvidenceId)
+  );
+  const gmailDetails = await runtime.repositories.gmailMessageDetails.listBySourceEvidenceIds(
+    sourceEvidenceIds
+  );
+  const canonicalEventById = new Map(
+    canonicalEvents.map((event) => [event.id, event])
+  );
+  const timelineByCanonicalEventId = new Map(
+    timelineRows
+      .filter((row): row is TimelineProjectionRow => row !== null)
+      .map((row) => [row.canonicalEventId, row])
+  );
+  const gmailDetailBySourceEvidenceId = new Map(
+    gmailDetails.map((detail) => [detail.sourceEvidenceId, detail])
+  );
+
+  return Object.fromEntries(
+    eventIds.map((eventId) => {
+      const event = canonicalEventById.get(eventId);
+
+      if (event === undefined) {
+        return [eventId, null] as const;
+      }
+
+      return [
+        eventId,
+        gmailDetailBySourceEvidenceId.get(event.sourceEvidenceId)?.subject ??
+          timelineByCanonicalEventId.get(eventId)?.summary ??
+          null
+      ] as const;
+    })
+  );
+}
+
+async function readInboxListCacheData(): Promise<InboxListCacheData> {
+  const runtime = await getStage1WebRuntime();
+  const projections = await runtime.repositories.inboxProjection.listAllOrderedByRecency();
+  const contactIds = projections.map((projection) => projection.contactId);
+  const [contacts, memberships, latestSubjectByCanonicalEventId] = await Promise.all([
+    runtime.repositories.contacts.listByIds(contactIds),
+    runtime.repositories.contactMemberships.listByContactIds(contactIds),
+    loadLatestSubjectByCanonicalEventId(projections)
+  ]);
+  const contactById = new Map(contacts.map((contact) => [contact.id, contact]));
+  const membershipsByContactId = groupMembershipsByContactId(memberships);
+
+  return {
+    rows: projections.flatMap((inboxProjection) => {
+      const contact = contactById.get(inboxProjection.contactId);
+
+      if (contact === undefined) {
+        return [];
+      }
+
+      return [
+        {
+          contact,
+          inboxProjection,
+          memberships: membershipsByContactId.get(inboxProjection.contactId) ?? [],
+          latestSubject:
+            latestSubjectByCanonicalEventId[inboxProjection.lastCanonicalEventId] ?? null
+        } satisfies InboxListCacheRow
+      ];
+    }),
+    projectNameById: await loadProjectNameById(memberships)
+  };
+}
+
+async function readInboxDetailCacheData(
+  contactId: string
+): Promise<InboxDetailCacheData | null> {
+  const runtime = await getStage1WebRuntime();
+  const [contact, inboxProjection, memberships, timelineRows, canonicalEvents] =
+    await Promise.all([
+      runtime.repositories.contacts.findById(contactId),
+      runtime.repositories.inboxProjection.findByContactId(contactId),
+      runtime.repositories.contactMemberships.listByContactId(contactId),
+      runtime.repositories.timelineProjection.listByContactId(contactId),
+      runtime.repositories.canonicalEvents.listByContactId(contactId)
+    ]);
+
+  if (contact === null || inboxProjection === null) {
+    return null;
+  }
+
+  const gmailDetails = await runtime.repositories.gmailMessageDetails.listBySourceEvidenceIds(
+    uniqueStrings(canonicalEvents.map((event) => event.sourceEvidenceId))
+  );
+
+  return {
+    contact,
+    inboxProjection,
+    memberships,
+    timelineRows,
+    canonicalEvents,
+    gmailDetails,
+    projectNameById: await loadProjectNameById(memberships)
+  };
+}
+
+const loadInboxListCacheData = unstable_cache(
+  readInboxListCacheData,
+  ["inbox:list:data"],
+  {
+    tags: ["inbox"]
+  }
+);
+
+function loadInboxDetailCacheData(contactId: string) {
+  return unstable_cache(
+    () => readInboxDetailCacheData(contactId),
+    [`inbox:detail:data:${contactId}`],
+    {
+      tags: ["inbox", `inbox:contact:${contactId}`, `timeline:contact:${contactId}`]
+    }
+  )();
+}
+
+function toListItemViewModel(
+  row: InboxListCacheRow,
+  projectNameById: Readonly<Record<string, string>>,
+  referenceNowIso: string
+): InboxListItemViewModel {
+  const sortedMemberships = sortMemberships(row.memberships);
+  const primaryMembership = sortedMemberships[0] ?? null;
+
+  return {
+    contactId: row.contact.id,
+    displayName: row.contact.displayName,
+    initials: toInitials(row.contact.displayName),
+    avatarTone: avatarToneForContact(row.contact.id),
+    latestSubject: defaultLatestSubject(
+      row.inboxProjection.lastEventType,
+      row.latestSubject
+    ),
+    snippet: row.inboxProjection.snippet,
+    latestChannel: mapChannel(row.inboxProjection.lastEventType),
+    projectLabel:
+      primaryMembership === null
+        ? null
+        : resolveProjectName(primaryMembership, projectNameById),
+    volunteerStage: mapVolunteerStage(sortedMemberships),
+    bucket: mapBucket(row.inboxProjection.bucket),
+    needsFollowUp: row.inboxProjection.needsFollowUp,
+    hasUnresolved: row.inboxProjection.hasUnresolved,
+    unreadCount: row.inboxProjection.bucket === "New" ? 1 : 0,
+    lastInboundAt: row.inboxProjection.lastInboundAt,
+    lastActivityAt: row.inboxProjection.lastActivityAt,
+    lastEventType: row.inboxProjection.lastEventType,
+    lastActivityLabel: formatRelativeTimestamp(
+      row.inboxProjection.lastActivityAt,
+      referenceNowIso
+    )
+  };
+}
+
+function buildContactSummary(
+  input: {
+    readonly contact: ContactRecord;
+    readonly inboxProjection: InboxProjectionRow;
+    readonly memberships: readonly ContactMembershipRecord[];
+    readonly timelineRows: readonly TimelineProjectionRow[];
+    readonly projectNameById: Readonly<Record<string, string>>;
+    readonly referenceNowIso: string;
+  }
+): InboxContactSummaryViewModel {
+  const memberships = sortMemberships(input.memberships);
+  const projectMemberships = memberships
+    .map((membership) =>
+      buildProjectMembershipViewModel(membership, input.projectNameById)
+    )
+    .filter((membership): membership is InboxProjectMembershipViewModel => membership !== null);
+
+  return {
+    contactId: input.contact.id,
+    displayName: input.contact.displayName,
+    volunteerId: input.contact.salesforceContactId ?? input.contact.id,
+    primaryEmail: input.contact.primaryEmail,
+    primaryPhone: input.contact.primaryPhone,
+    cityState: null,
+    joinedAtLabel: formatJoinedAtLabel(input.contact.createdAt),
+    hasUnresolved: input.inboxProjection.hasUnresolved,
+    activeProjects: projectMemberships.filter(
+      (membership) => !isPastProject(membership.status)
+    ),
+    pastProjects: projectMemberships.filter((membership) =>
+      isPastProject(membership.status)
+    ),
+    recentActivity: buildRecentActivity(
+      input.timelineRows,
+      input.referenceNowIso
+    )
+  };
+}
+
+function buildTimelineEntry(
+  input: {
+    readonly contactDisplayName: string;
+    readonly inboxProjection: InboxProjectionRow;
+    readonly row: TimelineProjectionRow;
+    readonly canonicalEvent: CanonicalEventRecord | null;
+    readonly gmailDetail: GmailMessageDetailRecord | null;
+    readonly referenceNowIso: string;
+  }
+): InboxTimelineEntryViewModel {
+  const kind = mapTimelineKind(input.row);
+  const subject =
+    input.row.channel === "email"
+      ? input.gmailDetail?.subject ?? input.row.summary
+      : null;
+  const body =
+    input.gmailDetail?.bodyTextPreview ??
+    input.gmailDetail?.snippetClean ??
+    input.row.summary;
+  const isInbound =
+    kind === "inbound-email" || kind === "inbound-sms";
+
+  return {
+    id: input.row.id,
+    kind,
+    occurredAt: input.row.occurredAt,
+    occurredAtLabel: formatRelativeTimestamp(
+      input.row.occurredAt,
+      input.referenceNowIso
+    ),
+    actorLabel: isInbound ? input.contactDisplayName : "You",
+    subject,
+    body,
+    channel: input.row.channel === "sms" ? "sms" : "email",
+    isUnread:
+      input.inboxProjection.bucket === "New" &&
+      isInbound &&
+      input.canonicalEvent?.id === input.inboxProjection.lastCanonicalEventId
+  };
 }
 
 function matchesServerFilter(
@@ -112,67 +675,82 @@ function matchesServerFilter(
   }
 }
 
-export function getInboxDetail(
-  contactId: string
-): InboxDetailViewModel | null {
-  const record = getMockContactById(contactId);
-  if (!record) return null;
-
-  const recentActivity: InboxRecentActivityViewModel[] = record.milestones
-    .slice()
-    .sort((a, b) => a.daysAgo - b.daysAgo)
-    .slice(0, 5)
-    .map((milestone) => ({
-      id: milestone.id,
-      label: milestoneLabel(milestone),
-      occurredAtLabel: relativeLabel(milestone.daysAgo)
-    }));
-
-  const contact: InboxContactSummaryViewModel = {
-    contactId: record.contactId,
-    displayName: record.displayName,
-    volunteerId: record.volunteerId,
-    primaryEmail: record.primaryEmail,
-    primaryPhone: record.primaryPhone,
-    cityState: record.cityState,
-    joinedAtLabel: record.joinedAtLabel,
-    hasUnresolved: record.hasUnresolved,
-    activeProjects: record.activeProjects,
-    pastProjects: record.pastProjects,
-    recentActivity
+export async function getInboxList(
+  filterId: InboxFilterId = "all"
+): Promise<InboxListViewModel> {
+  const cachedData = await loadInboxListCacheData();
+  const referenceNowIso = new Date().toISOString();
+  const items = cachedData.rows.map((row) =>
+    toListItemViewModel(row, cachedData.projectNameById, referenceNowIso)
+  );
+  const totals = {
+    all: items.length,
+    unread: items.filter((item) => item.bucket === "new").length,
+    followUp: items.filter((item) => item.needsFollowUp).length,
+    unresolved: items.filter((item) => item.hasUnresolved).length
   };
+  const filters: InboxFilterViewModel[] = INBOX_FILTERS.map((filter) => ({
+    id: filter.id,
+    label: filter.label,
+    hint: filter.hint,
+    count:
+      filter.id === "follow-up"
+        ? totals.followUp
+        : filter.id === "unresolved"
+          ? totals.unresolved
+          : totals[filter.id]
+  }));
 
   return {
-    contact,
-    timeline: record.timeline,
-    bucket: record.bucket,
-    needsFollowUp: record.needsFollowUp,
-    smsEligible: record.primaryPhone !== null
+    items: items.filter((item) => matchesServerFilter(item, filterId)),
+    filters,
+    totals
   };
 }
 
-function milestoneLabel(milestone: MockMilestone): string {
-  const name = milestone.projectName;
-  switch (milestone.kind) {
-    case "signed-up":
-      return `Signed up to ${name}`;
-    case "training-received":
-      return `Received training for ${name}`;
-    case "training-completed":
-      return `Completed training for ${name}`;
-    case "trip-plan-submitted":
-      return `Submitted trip plan for ${name}`;
-    case "first-record-submitted":
-      return `Submitted first record for ${name}`;
-  }
-}
+export async function getInboxDetail(
+  contactId: string
+): Promise<InboxDetailViewModel | null> {
+  const cachedData = await loadInboxDetailCacheData(contactId);
 
-function relativeLabel(daysAgo: number): string {
-  if (daysAgo === 0) return "today";
-  if (daysAgo === 1) return "yesterday";
-  if (daysAgo < 7) return `${daysAgo.toString()} days ago`;
-  if (daysAgo < 14) return "last week";
-  if (daysAgo < 60) return `${Math.floor(daysAgo / 7).toString()} weeks ago`;
-  if (daysAgo < 365) return `${Math.floor(daysAgo / 30).toString()} months ago`;
-  return `${Math.floor(daysAgo / 365).toString()} years ago`;
+  if (cachedData === null) {
+    return null;
+  }
+
+  const referenceNowIso = new Date().toISOString();
+  const canonicalEventById = new Map(
+    cachedData.canonicalEvents.map((event) => [event.id, event])
+  );
+  const gmailDetailBySourceEvidenceId = new Map(
+    cachedData.gmailDetails.map((detail) => [detail.sourceEvidenceId, detail])
+  );
+
+  return {
+    contact: buildContactSummary({
+      contact: cachedData.contact,
+      inboxProjection: cachedData.inboxProjection,
+      memberships: cachedData.memberships,
+      timelineRows: cachedData.timelineRows,
+      projectNameById: cachedData.projectNameById,
+      referenceNowIso
+    }),
+    timeline: cachedData.timelineRows.map((row) => {
+      const canonicalEvent = canonicalEventById.get(row.canonicalEventId) ?? null;
+
+      return buildTimelineEntry({
+        contactDisplayName: cachedData.contact.displayName,
+        inboxProjection: cachedData.inboxProjection,
+        row,
+        canonicalEvent,
+        gmailDetail:
+          canonicalEvent === null
+            ? null
+            : gmailDetailBySourceEvidenceId.get(canonicalEvent.sourceEvidenceId) ?? null,
+        referenceNowIso
+      });
+    }),
+    bucket: mapBucket(cachedData.inboxProjection.bucket),
+    needsFollowUp: cachedData.inboxProjection.needsFollowUp,
+    smsEligible: cachedData.contact.primaryPhone !== null
+  };
 }

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -7,6 +7,7 @@ import type {
   GmailMessageDetailRecord,
   InboxDrivingEventType,
   InboxProjectionRow,
+  TimelineItem,
   TimelineProjectionRow
 } from "@as-comms/contracts";
 
@@ -47,9 +48,7 @@ interface InboxDetailCacheData {
   readonly contact: ContactRecord;
   readonly inboxProjection: InboxProjectionRow;
   readonly memberships: readonly ContactMembershipRecord[];
-  readonly timelineRows: readonly TimelineProjectionRow[];
-  readonly canonicalEvents: readonly CanonicalEventRecord[];
-  readonly gmailDetails: readonly GmailMessageDetailRecord[];
+  readonly timelineItems: readonly TimelineItem[];
   readonly projectNameById: Readonly<Record<string, string>>;
 }
 
@@ -333,34 +332,172 @@ function defaultLatestSubject(
 }
 
 function mapTimelineKind(
-  row: TimelineProjectionRow
+  item: TimelineItem
 ): InboxTimelineEntryKind {
-  switch (row.eventType) {
-    case "communication.email.inbound":
-      return "inbound-email";
-    case "communication.email.outbound":
-      return "outbound-email";
-    case "communication.sms.inbound":
-      return "inbound-sms";
-    case "communication.sms.outbound":
-      return "outbound-sms";
-    default:
+  switch (item.family) {
+    case "one_to_one_email":
+      return item.direction === "inbound" ? "inbound-email" : "outbound-email";
+    case "one_to_one_sms":
+      return item.direction === "inbound" ? "inbound-sms" : "outbound-sms";
+    case "auto_email":
+      return "outbound-auto-email";
+    case "campaign_email":
+      return "outbound-campaign-email";
+    case "campaign_sms":
+      return "outbound-campaign-sms";
+    case "internal_note":
+      return "internal-note";
+    case "salesforce_event":
       return "system-event";
   }
 }
 
+function recentActivityLabel(item: TimelineItem): string {
+  switch (item.family) {
+    case "one_to_one_email":
+    case "auto_email":
+      return item.subject ?? item.summary;
+    case "one_to_one_sms":
+    case "campaign_sms":
+      return item.messageTextPreview || item.summary;
+    case "campaign_email":
+      return item.campaignName ?? item.summary;
+    case "internal_note":
+      return item.body;
+    case "salesforce_event":
+      return item.summary;
+  }
+}
+
 function buildRecentActivity(
-  timelineRows: readonly TimelineProjectionRow[],
+  timelineItems: readonly TimelineItem[],
   referenceNowIso: string
 ): readonly InboxRecentActivityViewModel[] {
-  return [...timelineRows]
+  return [...timelineItems]
     .sort((left, right) => right.occurredAt.localeCompare(left.occurredAt))
     .slice(0, 5)
-    .map((row) => ({
-      id: row.id,
-      label: row.summary,
-      occurredAtLabel: formatRelativeTimestamp(row.occurredAt, referenceNowIso)
+    .map((item) => ({
+      id: item.id,
+      label: recentActivityLabel(item),
+      occurredAtLabel: formatRelativeTimestamp(item.occurredAt, referenceNowIso)
     }));
+}
+
+function timelineChannel(item: TimelineItem): InboxChannel | null {
+  switch (item.family) {
+    case "one_to_one_email":
+    case "auto_email":
+    case "campaign_email":
+      return "email";
+    case "one_to_one_sms":
+    case "campaign_sms":
+      return "sms";
+    case "internal_note":
+    case "salesforce_event":
+      return null;
+  }
+}
+
+function timelineActorLabel(
+  item: TimelineItem,
+  contactDisplayName: string
+): string {
+  switch (item.family) {
+    case "one_to_one_email":
+    case "one_to_one_sms":
+      return item.direction === "inbound" ? contactDisplayName : "You";
+    case "auto_email":
+      return item.sourceLabel;
+    case "campaign_email":
+    case "campaign_sms":
+      return "Campaigns";
+    case "internal_note":
+      return item.authorDisplayName ?? "Internal note";
+    case "salesforce_event":
+      return "System";
+  }
+}
+
+function timelineSubject(item: TimelineItem): string | null {
+  switch (item.family) {
+    case "one_to_one_email":
+    case "auto_email":
+      return item.subject;
+    case "campaign_email":
+    case "campaign_sms":
+      return item.campaignName ?? item.summary;
+    case "one_to_one_sms":
+    case "internal_note":
+    case "salesforce_event":
+      return null;
+  }
+}
+
+function timelineBody(item: TimelineItem): string {
+  switch (item.family) {
+    case "one_to_one_email":
+      return item.bodyPreview ?? item.snippet;
+    case "one_to_one_sms":
+      return item.messageTextPreview;
+    case "auto_email":
+      return item.snippet;
+    case "campaign_email":
+      return item.snippet;
+    case "campaign_sms":
+      return item.messageTextPreview;
+    case "internal_note":
+      return item.body;
+    case "salesforce_event":
+      return item.summary;
+  }
+}
+
+function isUnreadTimelineItem(
+  item: TimelineItem,
+  inboxProjection: InboxProjectionRow
+): boolean {
+  if (inboxProjection.bucket !== "New") {
+    return false;
+  }
+
+  switch (item.family) {
+    case "one_to_one_email":
+    case "one_to_one_sms":
+      return (
+        item.direction === "inbound" &&
+        item.canonicalEventId === inboxProjection.lastCanonicalEventId
+      );
+    case "auto_email":
+    case "campaign_email":
+    case "campaign_sms":
+    case "internal_note":
+    case "salesforce_event":
+      return false;
+  }
+}
+
+function buildTimelineEntry(
+  input: {
+    readonly contactDisplayName: string;
+    readonly inboxProjection: InboxProjectionRow;
+    readonly item: TimelineItem;
+    readonly referenceNowIso: string;
+  }
+): InboxTimelineEntryViewModel {
+  return {
+    id: input.item.id,
+    kind: mapTimelineKind(input.item),
+    occurredAt: input.item.occurredAt,
+    occurredAtLabel: formatRelativeTimestamp(
+      input.item.occurredAt,
+      input.referenceNowIso
+    ),
+    actorLabel: timelineActorLabel(input.item, input.contactDisplayName),
+    subject: timelineSubject(input.item),
+    body: timelineBody(input.item),
+    channel: timelineChannel(input.item),
+    isUnread: isUnreadTimelineItem(input.item, input.inboxProjection)
+  };
 }
 
 function groupMembershipsByContactId(
@@ -495,30 +632,22 @@ async function readInboxDetailCacheData(
   contactId: string
 ): Promise<InboxDetailCacheData | null> {
   const runtime = await getStage1WebRuntime();
-  const [contact, inboxProjection, memberships, timelineRows, canonicalEvents] =
-    await Promise.all([
-      runtime.repositories.contacts.findById(contactId),
-      runtime.repositories.inboxProjection.findByContactId(contactId),
-      runtime.repositories.contactMemberships.listByContactId(contactId),
-      runtime.repositories.timelineProjection.listByContactId(contactId),
-      runtime.repositories.canonicalEvents.listByContactId(contactId)
-    ]);
+  const [contact, inboxProjection, memberships, timelineItems] = await Promise.all([
+    runtime.repositories.contacts.findById(contactId),
+    runtime.repositories.inboxProjection.findByContactId(contactId),
+    runtime.repositories.contactMemberships.listByContactId(contactId),
+    runtime.timelinePresentation.listTimelineItemsByContactId(contactId)
+  ]);
 
   if (contact === null || inboxProjection === null) {
     return null;
   }
 
-  const gmailDetails = await runtime.repositories.gmailMessageDetails.listBySourceEvidenceIds(
-    uniqueStrings(canonicalEvents.map((event) => event.sourceEvidenceId))
-  );
-
   return {
     contact,
     inboxProjection,
     memberships,
-    timelineRows,
-    canonicalEvents,
-    gmailDetails,
+    timelineItems,
     projectNameById: await loadProjectNameById(memberships)
   };
 }
@@ -584,7 +713,7 @@ function buildContactSummary(
     readonly contact: ContactRecord;
     readonly inboxProjection: InboxProjectionRow;
     readonly memberships: readonly ContactMembershipRecord[];
-    readonly timelineRows: readonly TimelineProjectionRow[];
+    readonly timelineItems: readonly TimelineItem[];
     readonly projectNameById: Readonly<Record<string, string>>;
     readonly referenceNowIso: string;
   }
@@ -612,50 +741,9 @@ function buildContactSummary(
       isPastProject(membership.status)
     ),
     recentActivity: buildRecentActivity(
-      input.timelineRows,
+      input.timelineItems,
       input.referenceNowIso
     )
-  };
-}
-
-function buildTimelineEntry(
-  input: {
-    readonly contactDisplayName: string;
-    readonly inboxProjection: InboxProjectionRow;
-    readonly row: TimelineProjectionRow;
-    readonly canonicalEvent: CanonicalEventRecord | null;
-    readonly gmailDetail: GmailMessageDetailRecord | null;
-    readonly referenceNowIso: string;
-  }
-): InboxTimelineEntryViewModel {
-  const kind = mapTimelineKind(input.row);
-  const subject =
-    input.row.channel === "email"
-      ? input.gmailDetail?.subject ?? input.row.summary
-      : null;
-  const body =
-    input.gmailDetail?.bodyTextPreview ??
-    input.gmailDetail?.snippetClean ??
-    input.row.summary;
-  const isInbound =
-    kind === "inbound-email" || kind === "inbound-sms";
-
-  return {
-    id: input.row.id,
-    kind,
-    occurredAt: input.row.occurredAt,
-    occurredAtLabel: formatRelativeTimestamp(
-      input.row.occurredAt,
-      input.referenceNowIso
-    ),
-    actorLabel: isInbound ? input.contactDisplayName : "You",
-    subject,
-    body,
-    channel: input.row.channel === "sms" ? "sms" : "email",
-    isUnread:
-      input.inboxProjection.bucket === "New" &&
-      isInbound &&
-      input.canonicalEvent?.id === input.inboxProjection.lastCanonicalEventId
   };
 }
 
@@ -718,37 +806,24 @@ export async function getInboxDetail(
   }
 
   const referenceNowIso = new Date().toISOString();
-  const canonicalEventById = new Map(
-    cachedData.canonicalEvents.map((event) => [event.id, event])
-  );
-  const gmailDetailBySourceEvidenceId = new Map(
-    cachedData.gmailDetails.map((detail) => [detail.sourceEvidenceId, detail])
-  );
 
   return {
     contact: buildContactSummary({
       contact: cachedData.contact,
       inboxProjection: cachedData.inboxProjection,
       memberships: cachedData.memberships,
-      timelineRows: cachedData.timelineRows,
+      timelineItems: cachedData.timelineItems,
       projectNameById: cachedData.projectNameById,
       referenceNowIso
     }),
-    timeline: cachedData.timelineRows.map((row) => {
-      const canonicalEvent = canonicalEventById.get(row.canonicalEventId) ?? null;
-
-      return buildTimelineEntry({
+    timeline: cachedData.timelineItems.map((item) =>
+      buildTimelineEntry({
         contactDisplayName: cachedData.contact.displayName,
         inboxProjection: cachedData.inboxProjection,
-        row,
-        canonicalEvent,
-        gmailDetail:
-          canonicalEvent === null
-            ? null
-            : gmailDetailBySourceEvidenceId.get(canonicalEvent.sourceEvidenceId) ?? null,
+        item,
         referenceNowIso
-      });
-    }),
+      })
+    ),
     bucket: mapBucket(cachedData.inboxProjection.bucket),
     needsFollowUp: cachedData.inboxProjection.needsFollowUp,
     smsEligible: cachedData.contact.primaryPhone !== null

--- a/apps/web/app/inbox/actions.ts
+++ b/apps/web/app/inbox/actions.ts
@@ -1,0 +1,70 @@
+"use server";
+
+import { revalidateTag } from "next/cache";
+
+import { setInboxNeedsFollowUp } from "../../src/server/inbox/follow-up";
+
+export type FollowUpActionResult =
+  | {
+      readonly ok: true;
+      readonly contactId: string;
+      readonly needsFollowUp: boolean;
+    }
+  | {
+      readonly ok: false;
+      readonly code: "validation_error" | "inbox_contact_not_found";
+    };
+
+function readContactId(formData: FormData): string | null {
+  const value = formData.get("contactId");
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function revalidateInboxContact(contactId: string): void {
+  revalidateTag("inbox");
+  revalidateTag(`inbox:contact:${contactId}`);
+  revalidateTag(`timeline:contact:${contactId}`);
+}
+
+async function updateNeedsFollowUp(
+  formData: FormData,
+  needsFollowUp: boolean
+): Promise<FollowUpActionResult> {
+  const contactId = readContactId(formData);
+
+  if (contactId === null) {
+    return {
+      ok: false,
+      code: "validation_error"
+    };
+  }
+
+  const result = await setInboxNeedsFollowUp({
+    contactId,
+    needsFollowUp
+  });
+
+  if (!result.ok) {
+    return result;
+  }
+
+  revalidateInboxContact(contactId);
+
+  return {
+    ok: true,
+    contactId,
+    needsFollowUp
+  };
+}
+
+export async function markInboxNeedsFollowUpAction(
+  formData: FormData
+): Promise<FollowUpActionResult> {
+  return updateNeedsFollowUp(formData, true);
+}
+
+export async function clearInboxNeedsFollowUpAction(
+  formData: FormData
+): Promise<FollowUpActionResult> {
+  return updateNeedsFollowUp(formData, false);
+}

--- a/apps/web/app/inbox/layout.tsx
+++ b/apps/web/app/inbox/layout.tsx
@@ -17,12 +17,12 @@ export const metadata = {
  * The client applies the active filter locally against those view models, so
  * the sidebar collapse has no effect on where canonical state lives.
  */
-export default function InboxLayout({
+export default async function InboxLayout({
   children
 }: {
   readonly children: ReactNode;
 }) {
-  const list = getInboxList("all");
+  const list = await getInboxList("all");
 
   return (
     <InboxShell

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -2,7 +2,12 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
-  transpilePackages: ["@as-comms/contracts", "@as-comms/domain", "@as-comms/ui"]
+  transpilePackages: [
+    "@as-comms/contracts",
+    "@as-comms/db",
+    "@as-comms/domain",
+    "@as-comms/ui"
+  ]
 };
 
 export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@as-comms/contracts": "workspace:*",
+    "@as-comms/db": "workspace:*",
     "@as-comms/domain": "workspace:*",
     "@as-comms/ui": "workspace:*",
     "@radix-ui/react-avatar": "^1.1.11",

--- a/apps/web/src/server/inbox/follow-up.ts
+++ b/apps/web/src/server/inbox/follow-up.ts
@@ -16,21 +16,17 @@ export async function setInboxNeedsFollowUp(input: {
   readonly needsFollowUp: boolean;
 }): Promise<InboxNeedsFollowUpUpdateResult | InboxNeedsFollowUpUpdateNotFound> {
   const runtime = await getStage1WebRuntime();
-  const existing = await runtime.repositories.inboxProjection.findByContactId(
-    input.contactId
-  );
+  const updated = await runtime.repositories.inboxProjection.setNeedsFollowUp({
+    contactId: input.contactId,
+    needsFollowUp: input.needsFollowUp
+  });
 
-  if (existing === null) {
+  if (updated === null) {
     return {
       ok: false,
       code: "inbox_contact_not_found"
     };
   }
-
-  await runtime.repositories.inboxProjection.upsert({
-    ...existing,
-    needsFollowUp: input.needsFollowUp
-  });
 
   return {
     ok: true,

--- a/apps/web/src/server/inbox/follow-up.ts
+++ b/apps/web/src/server/inbox/follow-up.ts
@@ -1,0 +1,40 @@
+import { getStage1WebRuntime } from "../stage1-runtime";
+
+export interface InboxNeedsFollowUpUpdateResult {
+  readonly ok: true;
+  readonly contactId: string;
+  readonly needsFollowUp: boolean;
+}
+
+export interface InboxNeedsFollowUpUpdateNotFound {
+  readonly ok: false;
+  readonly code: "inbox_contact_not_found";
+}
+
+export async function setInboxNeedsFollowUp(input: {
+  readonly contactId: string;
+  readonly needsFollowUp: boolean;
+}): Promise<InboxNeedsFollowUpUpdateResult | InboxNeedsFollowUpUpdateNotFound> {
+  const runtime = await getStage1WebRuntime();
+  const existing = await runtime.repositories.inboxProjection.findByContactId(
+    input.contactId
+  );
+
+  if (existing === null) {
+    return {
+      ok: false,
+      code: "inbox_contact_not_found"
+    };
+  }
+
+  await runtime.repositories.inboxProjection.upsert({
+    ...existing,
+    needsFollowUp: input.needsFollowUp
+  });
+
+  return {
+    ok: true,
+    contactId: input.contactId,
+    needsFollowUp: input.needsFollowUp
+  };
+}

--- a/apps/web/src/server/stage1-runtime.ts
+++ b/apps/web/src/server/stage1-runtime.ts
@@ -4,10 +4,15 @@ import {
   type DatabaseConnection
 } from "@as-comms/db";
 import type { Stage1RepositoryBundle } from "@as-comms/domain";
+import {
+  createStage1TimelinePresentationService,
+  type Stage1TimelinePresentationService
+} from "../../../../packages/domain/src/timeline";
 
 export interface Stage1WebRuntime {
   readonly connection: Pick<DatabaseConnection, "db" | "sql"> | null;
   readonly repositories: Stage1RepositoryBundle;
+  readonly timelinePresentation: Stage1TimelinePresentationService;
 }
 
 let runtimeOverride: Stage1WebRuntime | null = null;
@@ -23,10 +28,12 @@ function createRuntime(): Stage1WebRuntime {
   const connection = createDatabaseConnection({
     connectionString
   });
+  const repositories = createStage1RepositoryBundleFromConnection(connection);
 
   return {
     connection,
-    repositories: createStage1RepositoryBundleFromConnection(connection)
+    repositories,
+    timelinePresentation: createStage1TimelinePresentationService(repositories)
   };
 }
 

--- a/apps/web/src/server/stage1-runtime.ts
+++ b/apps/web/src/server/stage1-runtime.ts
@@ -1,0 +1,47 @@
+import {
+  createDatabaseConnection,
+  createStage1RepositoryBundleFromConnection,
+  type DatabaseConnection
+} from "@as-comms/db";
+import type { Stage1RepositoryBundle } from "@as-comms/domain";
+
+export interface Stage1WebRuntime {
+  readonly connection: Pick<DatabaseConnection, "db" | "sql"> | null;
+  readonly repositories: Stage1RepositoryBundle;
+}
+
+let runtimeOverride: Stage1WebRuntime | null = null;
+let runtimePromise: Promise<Stage1WebRuntime> | null = null;
+
+function createRuntime(): Stage1WebRuntime {
+  const connectionString = process.env.DATABASE_URL;
+
+  if (!connectionString) {
+    throw new Error("DATABASE_URL must be set before using the Stage 1 inbox runtime.");
+  }
+
+  const connection = createDatabaseConnection({
+    connectionString
+  });
+
+  return {
+    connection,
+    repositories: createStage1RepositoryBundleFromConnection(connection)
+  };
+}
+
+export async function getStage1WebRuntime(): Promise<Stage1WebRuntime> {
+  if (runtimeOverride !== null) {
+    return runtimeOverride;
+  }
+
+  runtimePromise ??= Promise.resolve(createRuntime());
+  return runtimePromise;
+}
+
+export function setStage1WebRuntimeForTests(
+  runtime: Stage1WebRuntime | null
+): void {
+  runtimeOverride = runtime;
+  runtimePromise = null;
+}

--- a/apps/web/tests/smoke/inbox.spec.ts
+++ b/apps/web/tests/smoke/inbox.spec.ts
@@ -1,19 +1,17 @@
 import { expect, test } from "@playwright/test";
 
-test("inbox renders as a mixed list with row-state filters", async ({ page }) => {
+test("inbox renders as a single mixed list backed by real data", async ({ page }) => {
   await page.goto("/inbox");
 
   await expect(
     page.getByRole("heading", { name: "Inbox", exact: true })
   ).toBeVisible();
+  await expect(page.getByRole("button", { name: /Unread/i })).toBeVisible();
   await expect(
-    page.getByRole("button", { name: /Unread 5/i })
+    page.getByRole("button", { name: /Needs Follow-Up/i })
   ).toBeVisible();
   await expect(
-    page.getByRole("button", { name: /Needs Follow-Up 3/i })
-  ).toBeVisible();
-  await expect(
-    page.getByRole("button", { name: /Unresolved 3/i })
+    page.getByRole("button", { name: /Unresolved/i })
   ).toBeVisible();
 
   await expect(
@@ -23,51 +21,13 @@ test("inbox renders as a mixed list with row-state filters", async ({ page }) =>
     page.getByRole("button", { name: /^Pending$/i })
   ).toHaveCount(0);
 
-  const rows = page.locator("ul.divide-y > li");
-  await expect(rows).toHaveCount(8);
-  await expect(rows.nth(0)).toContainText("Maya Patel");
-  await expect(rows.nth(1)).toContainText("Daniel Rivers");
-  await expect(rows.nth(2)).toContainText("Priya Chen");
+  const firstRowLink = page.locator("ul.divide-y > li a").first();
+  await expect(firstRowLink).toBeVisible();
+  await firstRowLink.click();
 
-  await page.getByRole("button", { name: /Unread 5/i }).click();
-  await expect(rows).toHaveCount(5);
-  await expect(page.getByText("Sam Whitehorse")).toHaveCount(0);
-
-  await page.getByRole("button", { name: /Needs Follow-Up 3/i }).click();
-  await expect(rows).toHaveCount(3);
-  await expect(page.getByText("Maya Patel").first()).toBeVisible();
-  await expect(page.getByText("Sam Whitehorse").first()).toBeVisible();
-  await expect(page.getByText("Elena Marquez").first()).toBeVisible();
-
-  await page.getByRole("button", { name: /Unresolved 3/i }).click();
-  await expect(rows).toHaveCount(3);
-  await expect(page.getByText("Priya Chen").first()).toBeVisible();
-  await expect(page.getByText("Anita Ross").first()).toBeVisible();
-  await expect(page.getByText("+1 720 555 0199").first()).toBeVisible();
-});
-
-test("follow-up toggle only changes follow-up state", async ({ page }) => {
-  await page.goto("/inbox/c_maya_patel");
-  const detailHeader = page.locator("main header").first();
-  const followUpButton = page.getByRole("button", {
-    name: "Needs Follow-Up",
-    exact: true
-  });
-
-  await expect(followUpButton).toHaveAttribute("aria-pressed", "true");
-  await expect(detailHeader.getByText("Unread", { exact: true })).toBeVisible();
-
-  await followUpButton.click();
-  await expect(followUpButton).toHaveAttribute("aria-pressed", "false");
-  await expect(detailHeader.getByText("Unread", { exact: true })).toBeVisible();
-
-  await page.getByRole("button", { name: /Needs Follow-Up 2/i }).click();
-  const rows = page.locator("ul.divide-y > li");
-  await expect(rows).toHaveCount(2);
-  await expect(page.getByText("Sam Whitehorse").first()).toBeVisible();
-  await expect(page.getByText("Elena Marquez").first()).toBeVisible();
-
-  await followUpButton.click();
-  await expect(followUpButton).toHaveAttribute("aria-pressed", "true");
-  await expect(detailHeader.getByText("Unread", { exact: true })).toBeVisible();
+  await expect(page).toHaveURL(/\/inbox\/.+/);
+  await expect(
+    page.getByRole("button", { name: "Needs Follow-Up", exact: true })
+  ).toBeVisible();
+  await expect(page.locator("main header").first()).toBeVisible();
 });

--- a/apps/web/tests/unit/inbox-actions.test.ts
+++ b/apps/web/tests/unit/inbox-actions.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const revalidateTag = vi.hoisted(() => vi.fn());
+
+vi.mock("next/cache", () => ({
+  unstable_cache: (loader: () => unknown) => loader,
+  revalidateTag
+}));
+
+import {
+  clearInboxNeedsFollowUpAction,
+  markInboxNeedsFollowUpAction
+} from "../../app/inbox/actions";
+import { getInboxDetail, getInboxList } from "../../app/inbox/_lib/selectors";
+import {
+  createInboxTestRuntime,
+  seedInboxContact,
+  seedInboxEmailEvent,
+  seedInboxProjection,
+  type InboxTestRuntime
+} from "./inbox-stage1-helpers";
+
+async function seedActionFixture(runtime: InboxTestRuntime): Promise<void> {
+  await seedInboxContact(runtime.context, {
+    contactId: "contact:sarah-martinez",
+    salesforceContactId: "003-sarah",
+    displayName: "Sarah Martinez",
+    primaryEmail: "sarah@example.org",
+    primaryPhone: "+15550000001",
+    projectId: "project:amazon-basin",
+    projectName: "Amazon Basin Research",
+    membershipId: "membership:sarah",
+    membershipStatus: "in_training"
+  });
+  const sarahLatest = await seedInboxEmailEvent(runtime.context, {
+    id: "sarah-inbound-1",
+    contactId: "contact:sarah-martinez",
+    occurredAt: "2026-04-14T13:00:00.000Z",
+    direction: "inbound",
+    subject: "Re: Amazon Basin equipment list",
+    snippet: "Following up on the field study logistics for the Amazon basin project."
+  });
+  await seedInboxProjection(runtime.context, {
+    contactId: "contact:sarah-martinez",
+    bucket: "New",
+    needsFollowUp: false,
+    hasUnresolved: false,
+    lastInboundAt: "2026-04-14T13:00:00.000Z",
+    lastOutboundAt: null,
+    lastActivityAt: "2026-04-14T13:00:00.000Z",
+    snippet:
+      "Following up on the field study logistics for the Amazon basin project.",
+    lastCanonicalEventId: sarahLatest.canonicalEventId,
+    lastEventType: "communication.email.inbound"
+  });
+
+  await seedInboxContact(runtime.context, {
+    contactId: "contact:michael-chen",
+    salesforceContactId: "003-michael",
+    displayName: "Michael Chen",
+    primaryEmail: "michael@example.org",
+    primaryPhone: null,
+    projectId: "project:coral-reefs",
+    projectName: "Monitoring Coral Reefs",
+    membershipId: "membership:michael",
+    membershipStatus: "in_training"
+  });
+  const michaelLatest = await seedInboxEmailEvent(runtime.context, {
+    id: "michael-inbound-1",
+    contactId: "contact:michael-chen",
+    occurredAt: "2026-04-14T12:00:00.000Z",
+    direction: "inbound",
+    subject: "Questions about data collection protocols",
+    snippet:
+      "Thanks for the training materials. I have a few questions about the data collection protocols."
+  });
+  await seedInboxProjection(runtime.context, {
+    contactId: "contact:michael-chen",
+    bucket: "New",
+    needsFollowUp: false,
+    hasUnresolved: false,
+    lastInboundAt: "2026-04-14T12:00:00.000Z",
+    lastOutboundAt: null,
+    lastActivityAt: "2026-04-14T12:00:00.000Z",
+    snippet:
+      "Thanks for the training materials. I have a few questions about the data collection protocols.",
+    lastCanonicalEventId: michaelLatest.canonicalEventId,
+    lastEventType: "communication.email.inbound"
+  });
+}
+
+describe("server-backed follow-up actions", () => {
+  let runtime: InboxTestRuntime | null = null;
+
+  beforeEach(async () => {
+    revalidateTag.mockReset();
+    runtime = await createInboxTestRuntime();
+    await seedActionFixture(runtime);
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    runtime = null;
+  });
+
+  it("marks needsFollowUp without changing bucket semantics or row ordering", async () => {
+    const before = await getInboxList();
+    const formData = new FormData();
+    formData.set("contactId", "contact:michael-chen");
+
+    const result = await markInboxNeedsFollowUpAction(formData);
+    const projection = await runtime?.context.repositories.inboxProjection.findByContactId(
+      "contact:michael-chen"
+    );
+    const after = await getInboxList();
+    const detail = await getInboxDetail("contact:michael-chen");
+
+    expect(result).toEqual({
+      ok: true,
+      contactId: "contact:michael-chen",
+      needsFollowUp: true
+    });
+    expect(before.items.map((item) => item.contactId)).toEqual([
+      "contact:sarah-martinez",
+      "contact:michael-chen"
+    ]);
+    expect(after.items.map((item) => item.contactId)).toEqual([
+      "contact:sarah-martinez",
+      "contact:michael-chen"
+    ]);
+    expect(projection).toMatchObject({
+      contactId: "contact:michael-chen",
+      needsFollowUp: true,
+      bucket: "New"
+    });
+    expect(after.items.find((item) => item.contactId === "contact:michael-chen")).toMatchObject({
+      needsFollowUp: true,
+      bucket: "new"
+    });
+    expect(detail).toMatchObject({
+      needsFollowUp: true,
+      bucket: "new"
+    });
+    expect(revalidateTag).toHaveBeenCalledTimes(3);
+    expect(revalidateTag).toHaveBeenNthCalledWith(1, "inbox");
+    expect(revalidateTag).toHaveBeenNthCalledWith(
+      2,
+      "inbox:contact:contact:michael-chen"
+    );
+    expect(revalidateTag).toHaveBeenNthCalledWith(
+      3,
+      "timeline:contact:contact:michael-chen"
+    );
+  });
+
+  it("clears needsFollowUp without mutating unread state", async () => {
+    const formData = new FormData();
+    formData.set("contactId", "contact:michael-chen");
+    await markInboxNeedsFollowUpAction(formData);
+    revalidateTag.mockReset();
+
+    const result = await clearInboxNeedsFollowUpAction(formData);
+    const projection = await runtime?.context.repositories.inboxProjection.findByContactId(
+      "contact:michael-chen"
+    );
+    const followUpList = await getInboxList("follow-up");
+
+    expect(result).toEqual({
+      ok: true,
+      contactId: "contact:michael-chen",
+      needsFollowUp: false
+    });
+    expect(projection).toMatchObject({
+      contactId: "contact:michael-chen",
+      needsFollowUp: false,
+      bucket: "New"
+    });
+    expect(followUpList.items).toHaveLength(0);
+    expect(revalidateTag).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/web/tests/unit/inbox-actions.test.ts
+++ b/apps/web/tests/unit/inbox-actions.test.ts
@@ -178,4 +178,68 @@ describe("server-backed follow-up actions", () => {
     expect(followUpList.items).toHaveLength(0);
     expect(revalidateTag).toHaveBeenCalledTimes(3);
   });
+
+  it("does not clobber fresher projection state when follow-up is toggled", async () => {
+    const staleProjection =
+      await runtime?.context.repositories.inboxProjection.findByContactId(
+        "contact:michael-chen"
+      );
+    const fresherEvent = await seedInboxEmailEvent(runtime!.context, {
+      id: "michael-inbound-2",
+      contactId: "contact:michael-chen",
+      occurredAt: "2026-04-14T14:30:00.000Z",
+      direction: "inbound",
+      subject: "Latest logistics update",
+      snippet: "Fresh inbound message that arrived after the stale snapshot."
+    });
+
+    await runtime?.context.repositories.inboxProjection.upsert({
+      contactId: "contact:michael-chen",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: true,
+      lastInboundAt: "2026-04-14T14:30:00.000Z",
+      lastOutboundAt: "2026-04-14T12:00:00.000Z",
+      lastActivityAt: "2026-04-14T14:30:00.000Z",
+      snippet: "Fresh inbound message that arrived after the stale snapshot.",
+      lastCanonicalEventId: fresherEvent.canonicalEventId,
+      lastEventType: "communication.email.inbound"
+    });
+
+    const findByContactIdSpy = vi
+      .spyOn(runtime!.context.repositories.inboxProjection, "findByContactId")
+      .mockResolvedValue(staleProjection ?? null);
+    const upsertSpy = vi.spyOn(
+      runtime!.context.repositories.inboxProjection,
+      "upsert"
+    );
+    const formData = new FormData();
+    formData.set("contactId", "contact:michael-chen");
+
+    const result = await markInboxNeedsFollowUpAction(formData);
+    expect(findByContactIdSpy).not.toHaveBeenCalled();
+    expect(upsertSpy).not.toHaveBeenCalled();
+    findByContactIdSpy.mockRestore();
+    upsertSpy.mockRestore();
+    const projection = await runtime?.context.repositories.inboxProjection.findByContactId(
+      "contact:michael-chen"
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      contactId: "contact:michael-chen",
+      needsFollowUp: true
+    });
+    expect(projection).toMatchObject({
+      contactId: "contact:michael-chen",
+      bucket: "New",
+      needsFollowUp: true,
+      hasUnresolved: true,
+      lastInboundAt: "2026-04-14T14:30:00.000Z",
+      lastActivityAt: "2026-04-14T14:30:00.000Z",
+      snippet: "Fresh inbound message that arrived after the stale snapshot.",
+      lastCanonicalEventId: fresherEvent.canonicalEventId,
+      lastEventType: "communication.email.inbound"
+    });
+  });
 });

--- a/apps/web/tests/unit/inbox-follow-up-state.test.ts
+++ b/apps/web/tests/unit/inbox-follow-up-state.test.ts
@@ -1,50 +1,19 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import {
-  resolveNeedsFollowUp,
-  toggleNeedsFollowUp
-} from "../../app/inbox/_lib/follow-up-state";
+vi.mock("next/cache", () => ({
+  unstable_cache: (loader: () => unknown) => loader,
+  revalidateTag: vi.fn()
+}));
 
-describe("follow-up state helpers", () => {
-  it("allows a seeded follow-up row to be cleared and restored", () => {
-    const contactId = "contact_seeded";
-    const seededNeedsFollowUp = true;
+import { markInboxNeedsFollowUpAction } from "../../app/inbox/actions";
 
-    const cleared = toggleNeedsFollowUp(
-      contactId,
-      seededNeedsFollowUp,
-      new Map<string, boolean>()
-    );
+describe("follow-up action validation", () => {
+  it("returns a validation error when contactId is missing", async () => {
+    const formData = new FormData();
 
-    expect(
-      resolveNeedsFollowUp(contactId, seededNeedsFollowUp, cleared)
-    ).toBe(false);
-
-    const restored = toggleNeedsFollowUp(
-      contactId,
-      seededNeedsFollowUp,
-      cleared
-    );
-
-    expect(
-      resolveNeedsFollowUp(contactId, seededNeedsFollowUp, restored)
-    ).toBe(true);
-    expect(restored.size).toBe(0);
-  });
-
-  it("allows an unflagged row to be flagged without changing seeded state", () => {
-    const contactId = "contact_unseeded";
-    const seededNeedsFollowUp = false;
-
-    const flagged = toggleNeedsFollowUp(
-      contactId,
-      seededNeedsFollowUp,
-      new Map<string, boolean>()
-    );
-
-    expect(
-      resolveNeedsFollowUp(contactId, seededNeedsFollowUp, flagged)
-    ).toBe(true);
-    expect(flagged.get(contactId)).toBe(true);
+    await expect(markInboxNeedsFollowUpAction(formData)).resolves.toEqual({
+      ok: false,
+      code: "validation_error"
+    });
   });
 });

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -13,8 +13,13 @@ import {
 import type { InboxListItemViewModel } from "../../app/inbox/_lib/view-models";
 import {
   createInboxTestRuntime,
+  seedInboxAutoEmailEvent,
+  seedInboxCampaignEmailEvent,
+  seedInboxCampaignSmsEvent,
   seedInboxContact,
   seedInboxEmailEvent,
+  seedInboxInternalNoteEvent,
+  seedInboxLifecycleEvent,
   seedInboxProjection,
   seedInboxSmsEvent,
   type InboxTestRuntime
@@ -251,6 +256,78 @@ describe("real inbox selectors", () => {
     expect(detail?.timeline.at(-1)).toMatchObject({
       subject: "Re: Amazon Basin equipment list",
       isUnread: true
+    });
+  });
+
+  it("preserves Stage 1 timeline families instead of flattening them into generic system events", async () => {
+    await seedInboxCampaignEmailEvent(runtime!.context, {
+      id: "sarah-campaign-email-1",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-10T09:00:00.000Z",
+      activityType: "sent",
+      campaignName: "Spring Kickoff",
+      snippet: "Welcome to the new field season."
+    });
+    await seedInboxAutoEmailEvent(runtime!.context, {
+      id: "sarah-auto-email-1",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-11T09:00:00.000Z",
+      subject: "Training confirmation",
+      snippet: "You are confirmed for training."
+    });
+    await seedInboxCampaignSmsEvent(runtime!.context, {
+      id: "sarah-campaign-sms-1",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-12T09:00:00.000Z",
+      campaignName: "Field Reminder",
+      messageTextPreview: "Field reminder text"
+    });
+    await seedInboxInternalNoteEvent(runtime!.context, {
+      id: "sarah-note-1",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-12T12:00:00.000Z",
+      body: "Prefers SMS check-ins before training.",
+      authorDisplayName: "Jordan"
+    });
+    await seedInboxLifecycleEvent(runtime!.context, {
+      id: "sarah-lifecycle-1",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-09T09:00:00.000Z",
+      eventType: "lifecycle.received_training",
+      summary: "Received training materials"
+    });
+
+    const detail = await getInboxDetail("contact:sarah-martinez");
+
+    expect(detail).not.toBeNull();
+    expect(detail?.timeline.map((entry) => entry.kind)).toEqual([
+      "system-event",
+      "outbound-campaign-email",
+      "outbound-auto-email",
+      "outbound-campaign-sms",
+      "internal-note",
+      "outbound-email",
+      "inbound-email"
+    ]);
+    expect(detail?.timeline[1]).toMatchObject({
+      kind: "outbound-campaign-email",
+      subject: "Spring Kickoff",
+      body: "Welcome to the new field season."
+    });
+    expect(detail?.timeline[2]).toMatchObject({
+      kind: "outbound-auto-email",
+      subject: "Training confirmation",
+      body: "You are confirmed for training."
+    });
+    expect(detail?.timeline[3]).toMatchObject({
+      kind: "outbound-campaign-sms",
+      subject: "Field Reminder",
+      body: "Field reminder text"
+    });
+    expect(detail?.timeline[4]).toMatchObject({
+      kind: "internal-note",
+      actorLabel: "Jordan",
+      body: "Prefers SMS check-ins before training."
     });
   });
 });

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -1,10 +1,24 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/cache", () => ({
+  unstable_cache: (loader: () => unknown) => loader,
+  revalidateTag: vi.fn()
+}));
 
 import {
   compareInboxRecency,
+  getInboxDetail,
   getInboxList
 } from "../../app/inbox/_lib/selectors";
 import type { InboxListItemViewModel } from "../../app/inbox/_lib/view-models";
+import {
+  createInboxTestRuntime,
+  seedInboxContact,
+  seedInboxEmailEvent,
+  seedInboxProjection,
+  seedInboxSmsEvent,
+  type InboxTestRuntime
+} from "./inbox-stage1-helpers";
 
 function buildItem(
   overrides: Partial<InboxListItemViewModel>
@@ -32,6 +46,119 @@ function buildItem(
   };
 }
 
+async function seedInboxFixture(runtime: InboxTestRuntime): Promise<void> {
+  await seedInboxContact(runtime.context, {
+    contactId: "contact:lisa-zhang",
+    salesforceContactId: "003-lisa",
+    displayName: "Lisa Zhang",
+    primaryEmail: "lisa@example.org",
+    primaryPhone: null,
+    projectId: "project:killer-whales",
+    projectName: "Searching for Killer Whales",
+    membershipId: "membership:lisa",
+    membershipStatus: "successful"
+  });
+  const lisaLatest = await seedInboxEmailEvent(runtime.context, {
+    id: "lisa-outbound-1",
+    contactId: "contact:lisa-zhang",
+    occurredAt: "2026-04-14T15:00:00.000Z",
+    direction: "outbound",
+    subject: "Safety protocols",
+    snippet: "Sending the final safety protocol packet for review."
+  });
+  await seedInboxProjection(runtime.context, {
+    contactId: "contact:lisa-zhang",
+    bucket: "Opened",
+    needsFollowUp: false,
+    hasUnresolved: false,
+    lastInboundAt: null,
+    lastOutboundAt: "2026-04-14T15:00:00.000Z",
+    lastActivityAt: "2026-04-14T15:00:00.000Z",
+    snippet: "Sending the final safety protocol packet for review.",
+    lastCanonicalEventId: lisaLatest.canonicalEventId,
+    lastEventType: "communication.email.outbound"
+  });
+
+  await seedInboxContact(runtime.context, {
+    contactId: "contact:sarah-martinez",
+    salesforceContactId: "003-sarah",
+    displayName: "Sarah Martinez",
+    primaryEmail: "sarah@example.org",
+    primaryPhone: "+15550000001",
+    projectId: "project:amazon-basin",
+    projectName: "Amazon Basin Research",
+    membershipId: "membership:sarah",
+    membershipStatus: "in_training"
+  });
+  await seedInboxEmailEvent(runtime.context, {
+    id: "sarah-outbound-1",
+    contactId: "contact:sarah-martinez",
+    occurredAt: "2026-04-13T12:00:00.000Z",
+    direction: "outbound",
+    subject: "Amazon Basin equipment list",
+    snippet: "Sharing the equipment list for the next field session."
+  });
+  const sarahLatest = await seedInboxEmailEvent(runtime.context, {
+    id: "sarah-inbound-1",
+    contactId: "contact:sarah-martinez",
+    occurredAt: "2026-04-14T13:00:00.000Z",
+    direction: "inbound",
+    subject: "Re: Amazon Basin equipment list",
+    snippet: "Following up on the field study logistics for the Amazon basin project."
+  });
+  await seedInboxProjection(runtime.context, {
+    contactId: "contact:sarah-martinez",
+    bucket: "New",
+    needsFollowUp: true,
+    hasUnresolved: false,
+    lastInboundAt: "2026-04-14T13:00:00.000Z",
+    lastOutboundAt: "2026-04-13T12:00:00.000Z",
+    lastActivityAt: "2026-04-14T13:00:00.000Z",
+    snippet:
+      "Following up on the field study logistics for the Amazon basin project.",
+    lastCanonicalEventId: sarahLatest.canonicalEventId,
+    lastEventType: "communication.email.inbound"
+  });
+
+  await seedInboxContact(runtime.context, {
+    contactId: "contact:alex-thompson",
+    salesforceContactId: "003-alex",
+    displayName: "Alex Thompson",
+    primaryEmail: null,
+    primaryPhone: "+15550000002",
+    projectId: "project:whitebark-pine",
+    projectName: "Tracking Whitebark Pine",
+    membershipId: "membership:alex",
+    membershipStatus: "trip_planning"
+  });
+  await seedInboxSmsEvent(runtime.context, {
+    id: "alex-outbound-1",
+    contactId: "contact:alex-thompson",
+    occurredAt: "2026-04-12T18:00:00.000Z",
+    direction: "outbound",
+    summary: "We can shift the mountain research dates if weather stays rough."
+  });
+  const alexLatest = await seedInboxSmsEvent(runtime.context, {
+    id: "alex-inbound-1",
+    contactId: "contact:alex-thompson",
+    occurredAt: "2026-04-12T19:00:00.000Z",
+    direction: "inbound",
+    summary: "Had to postpone due to weather. Proposing new dates."
+  });
+  await seedInboxProjection(runtime.context, {
+    contactId: "contact:alex-thompson",
+    bucket: "Opened",
+    needsFollowUp: false,
+    hasUnresolved: true,
+    lastInboundAt: "2026-04-12T19:00:00.000Z",
+    lastOutboundAt: "2026-04-12T18:00:00.000Z",
+    lastActivityAt: "2026-04-12T19:00:00.000Z",
+    snippet: "Had to postpone due to weather. Proposing new dates.",
+    lastCanonicalEventId: alexLatest.canonicalEventId,
+    lastEventType: "communication.sms.inbound"
+  });
+}
+
 describe("compareInboxRecency", () => {
   it("falls back to lastActivityAt when lastInboundAt is missing", () => {
     const outboundOnly = buildItem({
@@ -49,42 +176,81 @@ describe("compareInboxRecency", () => {
   });
 });
 
-describe("getInboxList", () => {
-  it("uses bucket=new for unread filtering", () => {
-    const unreadContacts = getInboxList("unread").items.map(
-      (item) => item.displayName
-    );
+describe("real inbox selectors", () => {
+  let runtime: InboxTestRuntime | null = null;
 
-    expect(unreadContacts).toEqual([
-      "Maya Patel",
-      "Daniel Rivers",
-      "Priya Chen",
-      "Anita Ross",
-      "+1 720 555 0199"
+  beforeEach(async () => {
+    runtime = await createInboxTestRuntime();
+    await seedInboxFixture(runtime);
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    runtime = null;
+  });
+
+  it("reads one row per contact from real projections with inbound-first sorting and activity fallback", async () => {
+    const list = await getInboxList();
+
+    expect(list.items.map((item) => item.contactId)).toEqual([
+      "contact:lisa-zhang",
+      "contact:sarah-martinez",
+      "contact:alex-thompson"
+    ]);
+    expect(list.items[0]).toMatchObject({
+      contactId: "contact:lisa-zhang",
+      latestSubject: "Safety protocols",
+      bucket: "opened"
+    });
+    expect(list.items[1]).toMatchObject({
+      contactId: "contact:sarah-martinez",
+      latestSubject: "Re: Amazon Basin equipment list",
+      needsFollowUp: true,
+      bucket: "new"
+    });
+  });
+
+  it("uses bucket, needsFollowUp, and hasUnresolved for the secondary filters", async () => {
+    const unread = await getInboxList("unread");
+    const followUp = await getInboxList("follow-up");
+    const unresolved = await getInboxList("unresolved");
+
+    expect(unread.items.map((item) => item.contactId)).toEqual([
+      "contact:sarah-martinez"
+    ]);
+    expect(followUp.items.map((item) => item.contactId)).toEqual([
+      "contact:sarah-martinez"
+    ]);
+    expect(unresolved.items.map((item) => item.contactId)).toEqual([
+      "contact:alex-thompson"
     ]);
   });
 
-  it("uses needsFollowUp for follow-up filtering", () => {
-    const followUpContacts = getInboxList("follow-up").items.map(
-      (item) => item.displayName
-    );
+  it("assembles selected-contact detail from real contact, membership, timeline, and projection data", async () => {
+    const detail = await getInboxDetail("contact:sarah-martinez");
 
-    expect(followUpContacts).toEqual([
-      "Maya Patel",
-      "Sam Whitehorse",
-      "Elena Marquez"
+    expect(detail).not.toBeNull();
+    expect(detail).toMatchObject({
+      bucket: "new",
+      needsFollowUp: true,
+      smsEligible: true
+    });
+    expect(detail?.contact).toMatchObject({
+      contactId: "contact:sarah-martinez",
+      displayName: "Sarah Martinez",
+      volunteerId: "003-sarah"
+    });
+    expect(detail?.contact.activeProjects[0]).toMatchObject({
+      projectName: "Amazon Basin Research",
+      status: "in-training"
+    });
+    expect(detail?.timeline.map((entry) => entry.kind)).toEqual([
+      "outbound-email",
+      "inbound-email"
     ]);
-  });
-
-  it("uses hasUnresolved for unresolved filtering", () => {
-    const unresolvedContacts = getInboxList("unresolved").items.map(
-      (item) => item.displayName
-    );
-
-    expect(unresolvedContacts).toEqual([
-      "Priya Chen",
-      "Anita Ross",
-      "+1 720 555 0199"
-    ]);
+    expect(detail?.timeline.at(-1)).toMatchObject({
+      subject: "Re: Amazon Basin equipment list",
+      isUnread: true
+    });
   });
 });

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -21,6 +21,7 @@ import {
   seedInboxInternalNoteEvent,
   seedInboxLifecycleEvent,
   seedInboxProjection,
+  seedInboxSalesforceOutboundEmailEvent,
   seedInboxSmsEvent,
   type InboxTestRuntime
 } from "./inbox-stage1-helpers";
@@ -329,5 +330,55 @@ describe("real inbox selectors", () => {
       actorLabel: "Jordan",
       body: "Prefers SMS check-ins before training."
     });
+  });
+
+  it("keeps Salesforce outbound email in the 1:1 contract unless canon explicitly marks it auto", async () => {
+    await seedInboxSalesforceOutboundEmailEvent(runtime!.context, {
+      id: "sarah-salesforce-null-1",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-10T06:00:00.000Z",
+      subject: "Logged Salesforce follow-up",
+      snippet: "Logged Salesforce follow-up body.",
+      messageKind: null
+    });
+    await seedInboxSalesforceOutboundEmailEvent(runtime!.context, {
+      id: "sarah-salesforce-one-to-one-1",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-10T07:00:00.000Z",
+      subject: "Explicit Salesforce one-to-one",
+      snippet: "Explicit Salesforce one-to-one body.",
+      messageKind: "one_to_one"
+    });
+
+    const detail = await getInboxDetail("contact:sarah-martinez");
+    const nullClassifiedEntry = detail?.timeline.find(
+      (entry) => entry.subject === "Logged Salesforce follow-up"
+    );
+    const explicitOneToOneEntry = detail?.timeline.find(
+      (entry) => entry.subject === "Explicit Salesforce one-to-one"
+    );
+
+    expect(nullClassifiedEntry).toMatchObject({
+      kind: "outbound-email",
+      actorLabel: "You",
+      channel: "email",
+      body: "Logged Salesforce follow-up body."
+    });
+    expect(explicitOneToOneEntry).toMatchObject({
+      kind: "outbound-email",
+      actorLabel: "You",
+      channel: "email",
+      body: "Explicit Salesforce one-to-one body."
+    });
+    expect(
+      detail?.timeline
+        .filter((entry) => entry.kind === "outbound-auto-email")
+        .map((entry) => entry.subject)
+    ).not.toEqual(
+      expect.arrayContaining([
+        "Logged Salesforce follow-up",
+        "Explicit Salesforce one-to-one"
+      ])
+    );
   });
 });

--- a/apps/web/tests/unit/inbox-stage1-helpers.ts
+++ b/apps/web/tests/unit/inbox-stage1-helpers.ts
@@ -1,0 +1,241 @@
+import type { InboxProjectionRow } from "@as-comms/contracts";
+
+import {
+  createTestStage1Context,
+  type TestStage1Context
+} from "../../../../packages/db/test/helpers.js";
+import { setStage1WebRuntimeForTests } from "../../src/server/stage1-runtime";
+
+export interface InboxTestRuntime {
+  readonly context: TestStage1Context;
+  dispose(): Promise<void>;
+}
+
+export async function createInboxTestRuntime(): Promise<InboxTestRuntime> {
+  const context = await createTestStage1Context();
+
+  setStage1WebRuntimeForTests({
+    connection: null,
+    repositories: context.repositories
+  });
+
+  return {
+    context,
+    async dispose() {
+      setStage1WebRuntimeForTests(null);
+      await context.client.close();
+    }
+  };
+}
+
+export async function seedInboxContact(
+  context: TestStage1Context,
+  input: {
+    readonly contactId: string;
+    readonly salesforceContactId: string | null;
+    readonly displayName: string;
+    readonly primaryEmail: string | null;
+    readonly primaryPhone: string | null;
+    readonly projectId?: string;
+    readonly projectName?: string;
+    readonly membershipId?: string;
+    readonly membershipStatus?: string | null;
+  }
+): Promise<void> {
+  await context.repositories.contacts.upsert({
+    id: input.contactId,
+    salesforceContactId: input.salesforceContactId,
+    displayName: input.displayName,
+    primaryEmail: input.primaryEmail,
+    primaryPhone: input.primaryPhone,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z"
+  });
+
+  if (input.projectId !== undefined) {
+    await context.repositories.projectDimensions.upsert({
+      projectId: input.projectId,
+      projectName: input.projectName ?? input.projectId,
+      source: "salesforce"
+    });
+  }
+
+  if (input.membershipId !== undefined) {
+    await context.repositories.contactMemberships.upsert({
+      id: input.membershipId,
+      contactId: input.contactId,
+      projectId: input.projectId ?? null,
+      expeditionId: null,
+      role: "volunteer",
+      status: input.membershipStatus ?? null,
+      source: "salesforce"
+    });
+  }
+}
+
+export async function seedInboxEmailEvent(
+  context: TestStage1Context,
+  input: {
+    readonly id: string;
+    readonly contactId: string;
+    readonly occurredAt: string;
+    readonly direction: "inbound" | "outbound";
+    readonly subject: string;
+    readonly snippet: string;
+  }
+): Promise<{ readonly canonicalEventId: string }> {
+  const sourceEvidenceId = `source:${input.id}`;
+  const canonicalEventId = `event:${input.id}`;
+
+  await context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "gmail",
+    providerRecordType: "message",
+    providerRecordId: input.id,
+    receivedAt: input.occurredAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `payloads/gmail/${input.id}.json`,
+    idempotencyKey: `gmail:${input.id}`,
+    checksum: `checksum:${input.id}`
+  });
+
+  await context.repositories.canonicalEvents.upsert({
+    id: canonicalEventId,
+    contactId: input.contactId,
+    eventType:
+      input.direction === "inbound"
+        ? "communication.email.inbound"
+        : "communication.email.outbound",
+    channel: "email",
+    occurredAt: input.occurredAt,
+    sourceEvidenceId,
+    idempotencyKey: `canonical:${input.id}`,
+    provenance: {
+      primaryProvider: "gmail",
+      primarySourceEvidenceId: sourceEvidenceId,
+      supportingSourceEvidenceIds: [],
+      winnerReason: "single_source",
+      sourceRecordType: "message",
+      sourceRecordId: input.id,
+      messageKind: "one_to_one",
+      campaignRef: null,
+      threadRef: null,
+      direction: input.direction,
+      notes: null
+    },
+    reviewState: "clear"
+  });
+
+  await context.repositories.gmailMessageDetails.upsert({
+    sourceEvidenceId,
+    providerRecordId: input.id,
+    gmailThreadId: `thread:${input.contactId}`,
+    rfc822MessageId: `<${input.id}@example.org>`,
+    direction: input.direction,
+    subject: input.subject,
+    snippetClean: input.snippet,
+    bodyTextPreview: input.snippet,
+    capturedMailbox: "volunteers@example.org",
+    projectInboxAlias: "volunteers@example.org"
+  });
+
+  await context.repositories.timelineProjection.upsert({
+    id: `timeline:${input.id}`,
+    contactId: input.contactId,
+    canonicalEventId,
+    occurredAt: input.occurredAt,
+    sortKey: `${input.occurredAt}::${canonicalEventId}`,
+    eventType:
+      input.direction === "inbound"
+        ? "communication.email.inbound"
+        : "communication.email.outbound",
+    summary: input.subject,
+    channel: "email",
+    primaryProvider: "gmail",
+    reviewState: "clear"
+  });
+
+  return {
+    canonicalEventId
+  };
+}
+
+export async function seedInboxSmsEvent(
+  context: TestStage1Context,
+  input: {
+    readonly id: string;
+    readonly contactId: string;
+    readonly occurredAt: string;
+    readonly direction: "inbound" | "outbound";
+    readonly summary: string;
+  }
+): Promise<{ readonly canonicalEventId: string }> {
+  const sourceEvidenceId = `source:${input.id}`;
+  const canonicalEventId = `event:${input.id}`;
+
+  await context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "salesforce",
+    providerRecordType: "communication",
+    providerRecordId: input.id,
+    receivedAt: input.occurredAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `payloads/salesforce/${input.id}.json`,
+    idempotencyKey: `salesforce:${input.id}`,
+    checksum: `checksum:${input.id}`
+  });
+
+  await context.repositories.canonicalEvents.upsert({
+    id: canonicalEventId,
+    contactId: input.contactId,
+    eventType:
+      input.direction === "inbound"
+        ? "communication.sms.inbound"
+        : "communication.sms.outbound",
+    channel: "sms",
+    occurredAt: input.occurredAt,
+    sourceEvidenceId,
+    idempotencyKey: `canonical:${input.id}`,
+    provenance: {
+      primaryProvider: "salesforce",
+      primarySourceEvidenceId: sourceEvidenceId,
+      supportingSourceEvidenceIds: [],
+      winnerReason: "single_source",
+      sourceRecordType: "communication",
+      sourceRecordId: input.id,
+      messageKind: "one_to_one",
+      campaignRef: null,
+      threadRef: null,
+      direction: input.direction,
+      notes: null
+    },
+    reviewState: "clear"
+  });
+
+  await context.repositories.timelineProjection.upsert({
+    id: `timeline:${input.id}`,
+    contactId: input.contactId,
+    canonicalEventId,
+    occurredAt: input.occurredAt,
+    sortKey: `${input.occurredAt}::${canonicalEventId}`,
+    eventType:
+      input.direction === "inbound"
+        ? "communication.sms.inbound"
+        : "communication.sms.outbound",
+    summary: input.summary,
+    channel: "sms",
+    primaryProvider: "salesforce",
+    reviewState: "clear"
+  });
+
+  return {
+    canonicalEventId
+  };
+}
+
+export async function seedInboxProjection(
+  context: TestStage1Context,
+  row: InboxProjectionRow
+): Promise<void> {
+  await context.repositories.inboxProjection.upsert(row);
+}

--- a/apps/web/tests/unit/inbox-stage1-helpers.ts
+++ b/apps/web/tests/unit/inbox-stage1-helpers.ts
@@ -315,6 +315,89 @@ export async function seedInboxAutoEmailEvent(
   };
 }
 
+export async function seedInboxSalesforceOutboundEmailEvent(
+  context: TestStage1Context,
+  input: {
+    readonly id: string;
+    readonly contactId: string;
+    readonly occurredAt: string;
+    readonly subject: string;
+    readonly snippet: string;
+    readonly messageKind: "one_to_one" | null;
+    readonly sourceRecordType?: string;
+    readonly sourceLabel?: string;
+  }
+): Promise<{ readonly canonicalEventId: string }> {
+  const sourceEvidenceId = `source:${input.id}`;
+  const canonicalEventId = `event:${input.id}`;
+  const sourceRecordType = input.sourceRecordType ?? "task_communication";
+
+  await context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "salesforce",
+    providerRecordType: sourceRecordType,
+    providerRecordId: input.id,
+    receivedAt: input.occurredAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `payloads/salesforce/${input.id}.json`,
+    idempotencyKey: `salesforce:${input.id}`,
+    checksum: `checksum:${input.id}`
+  });
+
+  await context.repositories.canonicalEvents.upsert({
+    id: canonicalEventId,
+    contactId: input.contactId,
+    eventType: "communication.email.outbound",
+    channel: "email",
+    occurredAt: input.occurredAt,
+    sourceEvidenceId,
+    idempotencyKey: `canonical:${input.id}`,
+    provenance: {
+      primaryProvider: "salesforce",
+      primarySourceEvidenceId: sourceEvidenceId,
+      supportingSourceEvidenceIds: [],
+      winnerReason: "single_source",
+      sourceRecordType,
+      sourceRecordId: input.id,
+      messageKind: input.messageKind,
+      campaignRef: null,
+      threadRef: null,
+      direction: "outbound",
+      notes: null
+    },
+    reviewState: "clear"
+  });
+
+  await context.repositories.salesforceCommunicationDetails.upsert({
+    sourceEvidenceId,
+    providerRecordId: input.id,
+    channel: "email",
+    // The detail row stores a concrete message kind even when canonical
+    // provenance remains null for the logged-email regression case.
+    messageKind: input.messageKind ?? "one_to_one",
+    subject: input.subject,
+    snippet: input.snippet,
+    sourceLabel: input.sourceLabel ?? "Salesforce Logged Email"
+  });
+
+  await context.repositories.timelineProjection.upsert({
+    id: `timeline:${input.id}`,
+    contactId: input.contactId,
+    canonicalEventId,
+    occurredAt: input.occurredAt,
+    sortKey: `${input.occurredAt}::${canonicalEventId}`,
+    eventType: "communication.email.outbound",
+    summary: input.subject,
+    channel: "email",
+    primaryProvider: "salesforce",
+    reviewState: "clear"
+  });
+
+  return {
+    canonicalEventId
+  };
+}
+
 export async function seedInboxCampaignEmailEvent(
   context: TestStage1Context,
   input: {

--- a/apps/web/tests/unit/inbox-stage1-helpers.ts
+++ b/apps/web/tests/unit/inbox-stage1-helpers.ts
@@ -1,4 +1,5 @@
 import type { InboxProjectionRow } from "@as-comms/contracts";
+import { createStage1TimelinePresentationService } from "../../../../packages/domain/src/timeline.js";
 
 import {
   createTestStage1Context,
@@ -16,7 +17,10 @@ export async function createInboxTestRuntime(): Promise<InboxTestRuntime> {
 
   setStage1WebRuntimeForTests({
     connection: null,
-    repositories: context.repositories
+    repositories: context.repositories,
+    timelinePresentation: createStage1TimelinePresentationService(
+      context.repositories
+    )
   });
 
   return {
@@ -224,6 +228,407 @@ export async function seedInboxSmsEvent(
         : "communication.sms.outbound",
     summary: input.summary,
     channel: "sms",
+    primaryProvider: "salesforce",
+    reviewState: "clear"
+  });
+
+  return {
+    canonicalEventId
+  };
+}
+
+export async function seedInboxAutoEmailEvent(
+  context: TestStage1Context,
+  input: {
+    readonly id: string;
+    readonly contactId: string;
+    readonly occurredAt: string;
+    readonly subject: string;
+    readonly snippet: string;
+    readonly sourceLabel?: string;
+  }
+): Promise<{ readonly canonicalEventId: string }> {
+  const sourceEvidenceId = `source:${input.id}`;
+  const canonicalEventId = `event:${input.id}`;
+
+  await context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "salesforce",
+    providerRecordType: "task",
+    providerRecordId: input.id,
+    receivedAt: input.occurredAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `payloads/salesforce/${input.id}.json`,
+    idempotencyKey: `salesforce:${input.id}`,
+    checksum: `checksum:${input.id}`
+  });
+
+  await context.repositories.canonicalEvents.upsert({
+    id: canonicalEventId,
+    contactId: input.contactId,
+    eventType: "communication.email.outbound",
+    channel: "email",
+    occurredAt: input.occurredAt,
+    sourceEvidenceId,
+    idempotencyKey: `canonical:${input.id}`,
+    provenance: {
+      primaryProvider: "salesforce",
+      primarySourceEvidenceId: sourceEvidenceId,
+      supportingSourceEvidenceIds: [],
+      winnerReason: "single_source",
+      sourceRecordType: "task",
+      sourceRecordId: input.id,
+      messageKind: "auto",
+      campaignRef: null,
+      threadRef: null,
+      direction: "outbound",
+      notes: null
+    },
+    reviewState: "clear"
+  });
+
+  await context.repositories.salesforceCommunicationDetails.upsert({
+    sourceEvidenceId,
+    providerRecordId: input.id,
+    channel: "email",
+    messageKind: "auto",
+    subject: input.subject,
+    snippet: input.snippet,
+    sourceLabel: input.sourceLabel ?? "Salesforce Flow"
+  });
+
+  await context.repositories.timelineProjection.upsert({
+    id: `timeline:${input.id}`,
+    contactId: input.contactId,
+    canonicalEventId,
+    occurredAt: input.occurredAt,
+    sortKey: `${input.occurredAt}::${canonicalEventId}`,
+    eventType: "communication.email.outbound",
+    summary: input.subject,
+    channel: "email",
+    primaryProvider: "salesforce",
+    reviewState: "clear"
+  });
+
+  return {
+    canonicalEventId
+  };
+}
+
+export async function seedInboxCampaignEmailEvent(
+  context: TestStage1Context,
+  input: {
+    readonly id: string;
+    readonly contactId: string;
+    readonly occurredAt: string;
+    readonly activityType: "sent" | "opened" | "clicked" | "unsubscribed";
+    readonly campaignName: string;
+    readonly snippet: string;
+  }
+): Promise<{ readonly canonicalEventId: string }> {
+  const sourceEvidenceId = `source:${input.id}`;
+  const canonicalEventId = `event:${input.id}`;
+  const eventType = `campaign.email.${input.activityType}` as const;
+
+  await context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "mailchimp",
+    providerRecordType: "campaign_activity",
+    providerRecordId: input.id,
+    receivedAt: input.occurredAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `payloads/mailchimp/${input.id}.json`,
+    idempotencyKey: `mailchimp:${input.id}`,
+    checksum: `checksum:${input.id}`
+  });
+
+  await context.repositories.canonicalEvents.upsert({
+    id: canonicalEventId,
+    contactId: input.contactId,
+    eventType,
+    channel: "campaign_email",
+    occurredAt: input.occurredAt,
+    sourceEvidenceId,
+    idempotencyKey: `canonical:${input.id}`,
+    provenance: {
+      primaryProvider: "mailchimp",
+      primarySourceEvidenceId: sourceEvidenceId,
+      supportingSourceEvidenceIds: [],
+      winnerReason: "single_source",
+      sourceRecordType: "campaign_activity",
+      sourceRecordId: input.id,
+      messageKind: "campaign",
+      campaignRef: {
+        providerCampaignId: "campaign_email_1",
+        providerAudienceId: "audience_1",
+        providerMessageName: input.campaignName
+      },
+      threadRef: null,
+      direction: "outbound",
+      notes: null
+    },
+    reviewState: "clear"
+  });
+
+  await context.repositories.mailchimpCampaignActivityDetails.upsert({
+    sourceEvidenceId,
+    providerRecordId: input.id,
+    activityType: input.activityType,
+    campaignId: "campaign_email_1",
+    audienceId: "audience_1",
+    memberId: "member_1",
+    campaignName: input.campaignName,
+    snippet: input.snippet
+  });
+
+  await context.repositories.timelineProjection.upsert({
+    id: `timeline:${input.id}`,
+    contactId: input.contactId,
+    canonicalEventId,
+    occurredAt: input.occurredAt,
+    sortKey: `${input.occurredAt}::${canonicalEventId}`,
+    eventType,
+    summary: input.campaignName,
+    channel: "campaign_email",
+    primaryProvider: "mailchimp",
+    reviewState: "clear"
+  });
+
+  return {
+    canonicalEventId
+  };
+}
+
+export async function seedInboxCampaignSmsEvent(
+  context: TestStage1Context,
+  input: {
+    readonly id: string;
+    readonly contactId: string;
+    readonly occurredAt: string;
+    readonly campaignName: string;
+    readonly messageTextPreview: string;
+  }
+): Promise<{ readonly canonicalEventId: string }> {
+  const sourceEvidenceId = `source:${input.id}`;
+  const canonicalEventId = `event:${input.id}`;
+
+  await context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "simpletexting",
+    providerRecordType: "message",
+    providerRecordId: input.id,
+    receivedAt: input.occurredAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `payloads/simpletexting/${input.id}.json`,
+    idempotencyKey: `simpletexting:${input.id}`,
+    checksum: `checksum:${input.id}`
+  });
+
+  await context.repositories.canonicalEvents.upsert({
+    id: canonicalEventId,
+    contactId: input.contactId,
+    eventType: "communication.sms.outbound",
+    channel: "sms",
+    occurredAt: input.occurredAt,
+    sourceEvidenceId,
+    idempotencyKey: `canonical:${input.id}`,
+    provenance: {
+      primaryProvider: "simpletexting",
+      primarySourceEvidenceId: sourceEvidenceId,
+      supportingSourceEvidenceIds: [],
+      winnerReason: "single_source",
+      sourceRecordType: "message",
+      sourceRecordId: input.id,
+      messageKind: "campaign",
+      campaignRef: {
+        providerCampaignId: "campaign_sms_1",
+        providerAudienceId: null,
+        providerMessageName: input.campaignName
+      },
+      threadRef: null,
+      direction: "outbound",
+      notes: null
+    },
+    reviewState: "clear"
+  });
+
+  await context.repositories.simpleTextingMessageDetails.upsert({
+    sourceEvidenceId,
+    providerRecordId: input.id,
+    direction: "outbound",
+    messageKind: "campaign",
+    messageTextPreview: input.messageTextPreview,
+    normalizedPhone: "+15550000001",
+    campaignId: "campaign_sms_1",
+    campaignName: input.campaignName,
+    providerThreadId: `thread:${input.contactId}`,
+    threadKey: `thread:${input.contactId}`
+  });
+
+  await context.repositories.timelineProjection.upsert({
+    id: `timeline:${input.id}`,
+    contactId: input.contactId,
+    canonicalEventId,
+    occurredAt: input.occurredAt,
+    sortKey: `${input.occurredAt}::${canonicalEventId}`,
+    eventType: "communication.sms.outbound",
+    summary: input.campaignName,
+    channel: "sms",
+    primaryProvider: "simpletexting",
+    reviewState: "clear"
+  });
+
+  return {
+    canonicalEventId
+  };
+}
+
+export async function seedInboxInternalNoteEvent(
+  context: TestStage1Context,
+  input: {
+    readonly id: string;
+    readonly contactId: string;
+    readonly occurredAt: string;
+    readonly body: string;
+    readonly authorDisplayName: string;
+  }
+): Promise<{ readonly canonicalEventId: string }> {
+  const sourceEvidenceId = `source:${input.id}`;
+  const canonicalEventId = `event:${input.id}`;
+
+  await context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "manual",
+    providerRecordType: "note",
+    providerRecordId: input.id,
+    receivedAt: input.occurredAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `payloads/manual/${input.id}.json`,
+    idempotencyKey: `manual:${input.id}`,
+    checksum: `checksum:${input.id}`
+  });
+
+  await context.repositories.canonicalEvents.upsert({
+    id: canonicalEventId,
+    contactId: input.contactId,
+    eventType: "note.internal.created",
+    channel: "note",
+    occurredAt: input.occurredAt,
+    sourceEvidenceId,
+    idempotencyKey: `canonical:${input.id}`,
+    provenance: {
+      primaryProvider: "manual",
+      primarySourceEvidenceId: sourceEvidenceId,
+      supportingSourceEvidenceIds: [],
+      winnerReason: "single_source",
+      sourceRecordType: "note",
+      sourceRecordId: input.id,
+      messageKind: null,
+      campaignRef: null,
+      threadRef: null,
+      direction: null,
+      notes: null
+    },
+    reviewState: "clear"
+  });
+
+  await context.repositories.manualNoteDetails.upsert({
+    sourceEvidenceId,
+    providerRecordId: input.id,
+    body: input.body,
+    authorDisplayName: input.authorDisplayName
+  });
+
+  await context.repositories.timelineProjection.upsert({
+    id: `timeline:${input.id}`,
+    contactId: input.contactId,
+    canonicalEventId,
+    occurredAt: input.occurredAt,
+    sortKey: `${input.occurredAt}::${canonicalEventId}`,
+    eventType: "note.internal.created",
+    summary: "Internal note added",
+    channel: "note",
+    primaryProvider: "manual",
+    reviewState: "clear"
+  });
+
+  return {
+    canonicalEventId
+  };
+}
+
+export async function seedInboxLifecycleEvent(
+  context: TestStage1Context,
+  input: {
+    readonly id: string;
+    readonly contactId: string;
+    readonly occurredAt: string;
+    readonly eventType:
+      | "lifecycle.signed_up"
+      | "lifecycle.received_training"
+      | "lifecycle.completed_training"
+      | "lifecycle.submitted_first_data";
+    readonly summary: string;
+    readonly projectId?: string | null;
+    readonly expeditionId?: string | null;
+  }
+): Promise<{ readonly canonicalEventId: string }> {
+  const sourceEvidenceId = `source:${input.id}`;
+  const canonicalEventId = `event:${input.id}`;
+
+  await context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "salesforce",
+    providerRecordType: "lifecycle",
+    providerRecordId: input.id,
+    receivedAt: input.occurredAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `payloads/salesforce/${input.id}.json`,
+    idempotencyKey: `salesforce:${input.id}`,
+    checksum: `checksum:${input.id}`
+  });
+
+  await context.repositories.canonicalEvents.upsert({
+    id: canonicalEventId,
+    contactId: input.contactId,
+    eventType: input.eventType,
+    channel: "lifecycle",
+    occurredAt: input.occurredAt,
+    sourceEvidenceId,
+    idempotencyKey: `canonical:${input.id}`,
+    provenance: {
+      primaryProvider: "salesforce",
+      primarySourceEvidenceId: sourceEvidenceId,
+      supportingSourceEvidenceIds: [],
+      winnerReason: "single_source",
+      sourceRecordType: "lifecycle",
+      sourceRecordId: input.id,
+      messageKind: null,
+      campaignRef: null,
+      threadRef: null,
+      direction: null,
+      notes: null
+    },
+    reviewState: "clear"
+  });
+
+  await context.repositories.salesforceEventContext.upsert({
+    sourceEvidenceId,
+    salesforceContactId: null,
+    projectId: input.projectId ?? null,
+    expeditionId: input.expeditionId ?? null,
+    sourceField: "Lifecycle"
+  });
+
+  await context.repositories.timelineProjection.upsert({
+    id: `timeline:${input.id}`,
+    contactId: input.contactId,
+    canonicalEventId,
+    occurredAt: input.occurredAt,
+    sortKey: `${input.occurredAt}::${canonicalEventId}`,
+    eventType: input.eventType,
+    summary: input.summary,
+    channel: "lifecycle",
     primaryProvider: "salesforce",
     reviewState: "clear"
   });

--- a/docs/03-handoff/inbox-shell-handoff.md
+++ b/docs/03-handoff/inbox-shell-handoff.md
@@ -1,167 +1,64 @@
-# Inbox Shell — Codex Data Contracts
+# Inbox Shell — Real Wiring Handoff
 
-This document describes the data contracts the inbox frontend shell expects.
-The shell is fully implemented with mock data and can be wired to real
-projection reads by swapping the two selector functions in
-`apps/web/app/inbox/_lib/selectors.ts`.
+This handoff reflects the current mainline Inbox shell under
+`apps/web/app/inbox/`. The shell architecture is unchanged: the persistent list
+chrome still lives in `layout.tsx`, `/inbox` still renders the empty-state page
+inside that shell, and `/inbox/[contactId]` still renders the selected-contact
+detail page.
 
----
+## What Is Real Now
 
-## View Model Interfaces
+- `apps/web/app/inbox/_lib/selectors.ts`
+  - `getInboxList(filterId?)` now reads real Stage 1 data from
+    `contact_inbox_projection`, `contacts`, `contact_memberships`,
+    `project_dimensions`, `canonical_event_ledger`, `gmail_message_details`,
+    and `contact_timeline_projection`.
+  - `getInboxDetail(contactId)` now reads real Stage 1 data from
+    `contacts`, `contact_inbox_projection`, `contact_memberships`,
+    `project_dimensions`, `canonical_event_ledger`,
+    `gmail_message_details`, and `contact_timeline_projection`.
+- `apps/web/app/inbox/actions.ts`
+  - `markInboxNeedsFollowUpAction` and `clearInboxNeedsFollowUpAction` now
+    persist through the server by updating the inbox projection row for the
+    selected contact.
+- `apps/web/src/server/stage1-runtime.ts`
+  - Small server-only runtime for `DATABASE_URL`, Stage 1 repositories, and
+    test overrides.
+- `apps/web/src/server/inbox/follow-up.ts`
+  - Narrow server helper that updates only `needsFollowUp` and leaves bucket,
+    unresolved state, timestamps, snippet, and last-event fields untouched.
 
-All types are defined in `apps/web/app/inbox/_lib/view-models.ts`.
+## Preserved Contract
 
-### InboxListItemViewModel (one row per person)
+- One row per person, not one row per thread.
+- Single mixed contact list.
+- Default ordering remains `lastInboundAt desc`, with `lastActivityAt desc`
+  fallback when `lastInboundAt` is missing.
+- Unread remains bucket-driven.
+- `needsFollowUp` remains a separate explicit flag.
+- `hasUnresolved` remains an overlay.
+- Follow-up toggling does not reorder rows.
+- Route structure remains `/inbox` and `/inbox/[contactId]`.
 
-```typescript
-interface InboxListItemViewModel {
-  contactId: string;
-  displayName: string;
-  initials: string;
-  avatarTone: InboxAvatarTone;
-  latestSubject: string;
-  snippet: string;
-  latestChannel: InboxChannel;        // "email" | "sms"
-  projectLabel: string | null;
-  volunteerStage: InboxVolunteerStage;
+## Current Bridging Logic
 
-  // Row states (all separate, not collapsed)
-  bucket: InboxBucket;                // "new" | "opened"
-  needsFollowUp: boolean;             // explicit operator flag
-  hasUnresolved: boolean;              // review overlay
-  unreadCount: number;
+- `unreadCount` is still a selector-derived `1/0` badge keyed from bucket state,
+  because the current projection model does not store a per-contact unread
+  message count.
+- Membership `year` is still selector-derived from the current UTC year,
+  because the canonical membership season/year is not persisted on the current
+  Stage 1 read model.
+- `crmUrl` in the contact rail is still synthesized from `projectId`, because a
+  canonical persisted CRM URL is not available on the membership dimension yet.
+- Timeline bodies and subjects are exact for Gmail-backed email events. When a
+  richer provider-specific communication detail is not available, the selector
+  falls back to timeline summaries so the shell contract stays stable.
 
-  // Sort / display
-  lastInboundAt: string | null;       // ISO 8601 — primary sort field when present
-  lastActivityAt: string;             // ISO 8601
-  lastEventType: InboxDrivingEventType;
-  lastActivityLabel: string;          // relative time label
-}
-```
+## Revalidation
 
-### InboxDetailViewModel (selected contact workspace)
+- `inbox`
+- `inbox:contact:{contactId}`
+- `timeline:contact:{contactId}`
 
-```typescript
-interface InboxDetailViewModel {
-  contact: InboxContactSummaryViewModel;
-  timeline: readonly InboxTimelineEntryViewModel[];
-  bucket: InboxBucket;
-  needsFollowUp: boolean;
-  smsEligible: boolean;
-}
-```
-
-### InboxTimelineEntryViewModel
-
-```typescript
-interface InboxTimelineEntryViewModel {
-  id: string;
-  kind: InboxTimelineEntryKind;       // 9 variants (see view-models.ts)
-  occurredAt: string;
-  occurredAtLabel: string;
-  actorLabel: string;
-  subject: string | null;
-  body: string;
-  channel: InboxChannel | null;
-  isUnread: boolean;
-}
-```
-
-### InboxContactSummaryViewModel
-
-```typescript
-interface InboxContactSummaryViewModel {
-  contactId: string;
-  displayName: string;
-  volunteerId: string;
-  primaryEmail: string | null;
-  primaryPhone: string | null;
-  cityState: string | null;
-  joinedAtLabel: string;
-  hasUnresolved: boolean;
-  activeProjects: readonly InboxProjectMembershipViewModel[];
-  pastProjects: readonly InboxProjectMembershipViewModel[];
-  recentActivity: readonly InboxRecentActivityViewModel[];
-}
-```
-
----
-
-## Selector Swap Points
-
-Both selectors live in `apps/web/app/inbox/_lib/selectors.ts`. They currently
-import from `mock-data.ts`. To wire to real data, replace the mock reads with
-projection repository calls. The view-model shapes stay stable.
-
-### getInboxList(filterId?)
-
-```typescript
-function getInboxList(filterId?: InboxFilterId): InboxListViewModel
-```
-
-- Returns the full contact list sorted by `lastInboundAt` descending, falling back to `lastActivityAt`
-- Computes base filter counts from projection state: all, unread (`bucket = "new"`), follow-up (`needsFollowUp = true`), unresolved (`hasUnresolved = true`)
-- Client-side follow-up overrides may adjust the visible follow-up filter without changing bucket semantics
-- **Swap target:** Replace `getMockContacts()` with a projection query that
-  reads from `contactInboxProjection` and joins to get display fields
-
-### getInboxDetail(contactId)
-
-```typescript
-function getInboxDetail(contactId: string): InboxDetailViewModel | null
-```
-
-- Returns the full contact detail including timeline, project context, and
-  recent activity milestones
-- **Swap target:** Replace `getMockContactById()` with projection reads from
-  `contactTimelineProjection` + `contacts` + `contactMemberships`
-
----
-
-## Sort Contract
-
-- Default list order: `lastInboundAt` descending (most recent inbound first), falling back to `lastActivityAt` when `lastInboundAt` is missing
-- Toggling follow-up does NOT change row ordering
-- `lastInboundAt` tracks the most recent inbound email or SMS from the contact
-- `lastActivityAt` is the fallback sort field when a row has no inbound history
-
----
-
-## Cache Tag Expectations (FP-05)
-
-| Tag | Invalidation scope |
-|-----|--------------------|
-| `inbox` | Top-level inbox list shell |
-| `inbox:contact:{contactId}` | Row-level contact inbox refresh |
-| `timeline:contact:{contactId}` | Per-contact timeline refresh |
-
-Server actions should call `revalidateTag()` for the narrowest affected tags
-before returning. Webhook/worker-triggered changes should hit a protected
-internal revalidation endpoint that calls `revalidateTag()`.
-
----
-
-## Server Action Stubs Needed
-
-| Action | Description |
-|--------|-------------|
-| `sendReply` | Send email or SMS reply to a contact |
-| `saveNote` | Save an internal note to the contact timeline |
-| `toggleFollowUp` | Set or clear `needsFollowUp` on the inbox projection |
-| `markAsRead` | Transition bucket from "new" to "opened" |
-
-All actions should return the safe error envelope:
-```typescript
-type UiSuccess<T> = { ok: true; data: T; requestId: string };
-type UiError = { ok: false; code: string; message: string; requestId: string };
-```
-
----
-
-## Polling / Freshness Contract (FP-06)
-
-- Inbox-like views should poll a lightweight freshness endpoint while visible
-- Default interval: 30-60 seconds
-- Pause when tab is hidden (use `document.visibilityState`)
-- Polling is a resilience fallback, not the primary consistency mechanism
-- Primary consistency comes from `revalidateTag` after mutations
+The follow-up actions revalidate those tags after a successful update so the
+mainline shell refreshes from server state instead of client-side overrides.

--- a/docs/03-handoff/inbox-shell-handoff.md
+++ b/docs/03-handoff/inbox-shell-handoff.md
@@ -15,8 +15,8 @@ detail page.
     and `contact_timeline_projection`.
   - `getInboxDetail(contactId)` now reads real Stage 1 data from
     `contacts`, `contact_inbox_projection`, `contact_memberships`,
-    `project_dimensions`, `canonical_event_ledger`,
-    `gmail_message_details`, and `contact_timeline_projection`.
+    `project_dimensions`, and the typed Stage 1 timeline presentation service
+    backed by canonical events plus provider-specific detail tables.
 - `apps/web/app/inbox/actions.ts`
   - `markInboxNeedsFollowUpAction` and `clearInboxNeedsFollowUpAction` now
     persist through the server by updating the inbox projection row for the
@@ -53,6 +53,9 @@ detail page.
 - Timeline bodies and subjects are exact for Gmail-backed email events. When a
   richer provider-specific communication detail is not available, the selector
   falls back to timeline summaries so the shell contract stays stable.
+- Unresolved review detail is not yet hydrated into dedicated detail-panel
+  context; the shell currently uses the persisted `hasUnresolved` overlay and
+  banner only.
 
 ## Revalidation
 

--- a/docs/03-handoff/inbox-shell-status.md
+++ b/docs/03-handoff/inbox-shell-status.md
@@ -24,6 +24,9 @@
 
 - The list and detail selectors now run against real Stage 1 repository reads
   and use `unstable_cache` with inbox/timeline tags.
+- Detail timeline rendering now preserves the existing inbox timeline kinds by
+  adapting typed Stage 1 timeline families instead of flattening non-1:1
+  events into generic system rows.
 - Follow-up persistence writes back to the existing inbox projection field
   mapped from the persistence boundary field `is_starred`.
 - The physical DB naming is unchanged.
@@ -31,8 +34,9 @@
 ## Known Follow-Ups
 
 - Large real inbox payloads can still trigger `unstable_cache` size warnings.
-- Identity review detail still relies on selector-side contact matching where a
-  case is anchored by contact ID or references the contact in candidate IDs.
+- Unresolved review detail is still banner-only in the shell; this pass does
+  not yet surface routing or identity case summaries in the selected-contact
+  panel.
 - The current data model still does not provide:
   - a canonical persisted CRM URL for project memberships
   - a dedicated unread-count field for the list badge

--- a/docs/03-handoff/inbox-shell-status.md
+++ b/docs/03-handoff/inbox-shell-status.md
@@ -1,62 +1,39 @@
-# Inbox Shell — Mocked vs Wired Inventory
+# Inbox Shell — Status
 
-Status of every functional area in the inbox shell as of this build.
+## Wired in this pass
 
----
+- Real Stage 1-backed inbox list reads.
+- Real Stage 1-backed selected-contact detail reads.
+- Real server-backed `needsFollowUp` persistence.
+- Mainline route shape preserved:
+  - `/inbox`
+  - `/inbox/[contactId]`
+- Mainline shell architecture preserved:
+  - `app/inbox/layout.tsx`
+  - `app/inbox/_components/*`
+  - `app/inbox/_lib/*`
 
-## Fully Mocked (needs backend wiring)
+## Still Mocked or Prototype
 
-| Area | Mock location | What the mock does |
-|------|--------------|-------------------|
-| **Contact list data** | `_lib/mock-data.ts` | 8 hardcoded contacts with realistic timelines |
-| **Contact detail data** | `_lib/mock-data.ts` | Full timeline, project memberships, milestones |
-| **List selectors** | `_lib/selectors.ts` | Maps mock records to view models, sorts by `lastInboundAt` with `lastActivityAt` fallback |
-| **Composer send** | `inbox-composer.tsx` | `setTimeout` simulating 1.2s send with 80% success rate |
-| **AI drafting** | `inbox-composer.tsx` | `setTimeout` inserting a canned draft after 2s |
-| **Follow-up toggle** | `inbox-client-provider.tsx` | Client-side follow-up override map layered on top of projection-backed `needsFollowUp` |
-| **Reminders** | `inbox-client-provider.tsx` | Client-side `Map<string, Reminder>` — no persistence |
-| **Search** | `inbox-list.tsx` | Client-side string match on name, subject, snippet, project |
+- Composer send remains prototype/local.
+- Internal note creation remains prototype/local.
+- Reminder state remains client-only.
+- Search remains client-side string matching over the rendered list items.
 
----
+## Backend Notes
 
-## Ready for Backend Wiring (no UI changes needed)
+- The list and detail selectors now run against real Stage 1 repository reads
+  and use `unstable_cache` with inbox/timeline tags.
+- Follow-up persistence writes back to the existing inbox projection field
+  mapped from the persistence boundary field `is_starred`.
+- The physical DB naming is unchanged.
 
-| Area | File | Wiring notes |
-|------|------|-------------|
-| **View model shapes** | `_lib/view-models.ts` | Stable interfaces — backend must produce these shapes |
-| **Selector interfaces** | `_lib/selectors.ts` | Swap `getMockContacts()` → projection query |
-| **Filter definitions** | `_lib/filters.ts` | 4 filters (all, unread, follow-up, unresolved) — counts from server |
-| **Error boundary** | `error.tsx` | Safe FP-07 boundary — logs digest, shows retry |
-| **Loading skeletons** | `inbox-loading.tsx` | Full-app and queue-only skeletons ready |
-| **Empty states** | `inbox-empty-state.tsx` | "Select a person" and "All caught up" states |
-| **Timeline rendering** | `inbox-timeline.tsx` | 9 entry kinds with correct visual treatment |
-| **Contact rail** | `inbox-contact-rail.tsx` | Projects, milestones, contact info — driven by view model |
+## Known Follow-Ups
 
----
-
-## Needs Backend (new code required)
-
-| Area | What's needed |
-|------|--------------|
-| **Server actions** | `sendReply`, `saveNote`, `toggleFollowUp`, `markAsRead` returning safe error envelope |
-| **Projection queries** | Read from `contactInboxProjection` + `contactTimelineProjection` |
-| **Revalidation endpoint** | Protected internal route that calls `revalidateTag()` for webhook/worker triggers |
-| **Polling endpoint** | Lightweight freshness check (returns last-modified timestamp or version) |
-| **Real search** | Server-side search across contacts, replacing client-side string matching |
-| **Auth guard** | Route-level auth check (not built per task scope — no sign-in page) |
-
----
-
-## Product Behavior Preserved
-
-- One row per person, not one row per thread
-- Queue state is projection-driven, not UI-owned
-- Single recency-sorted list (`lastInboundAt desc`, `lastActivityAt desc` fallback)
-- Unread / Needs Follow-Up / Unresolved Review are row-level states, not list partitions
-- `bucket` and `needsFollowUp` are separate fields (never collapsed)
-- Unread filter uses bucket state, follow-up filter uses `needsFollowUp`, unresolved filter uses `hasUnresolved`
-- Toggling follow-up does not change row ordering
-- Unresolved review overlays on top of queue state
-- Internal notes included in timeline and composer
-- Campaign/automated sends rendered as collapsed entries
-- Safe error envelope — no raw errors in UI
+- Large real inbox payloads can still trigger `unstable_cache` size warnings.
+- Identity review detail still relies on selector-side contact matching where a
+  case is anchored by contact ID or references the contact in candidate IDs.
+- The current data model still does not provide:
+  - a canonical persisted CRM URL for project memberships
+  - a dedicated unread-count field for the list badge
+  - a canonical persisted membership season/year for the contact rail

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2,5 +2,6 @@ export * from "./health.js";
 export * from "./jobs.js";
 export * from "./stage1-normalization.js";
 export * from "./stage1-records.js";
+export * from "./stage1-timeline.js";
 export * from "./stage1-taxonomy.js";
 export * from "./stage1-worker-jobs.js";

--- a/packages/contracts/src/stage1-timeline.ts
+++ b/packages/contracts/src/stage1-timeline.ts
@@ -1,0 +1,119 @@
+import { z } from "zod";
+
+import {
+  campaignEmailActivityTypeSchema,
+  providerSchema,
+  reviewStateSchema,
+  timelineFamilySchema
+} from "./stage1-taxonomy.js";
+
+const idSchema = z.string().min(1);
+const timestampSchema = z.string().datetime();
+const nullableStringSchema = z.string().min(1).nullable();
+
+const timelineItemBaseSchema = z.object({
+  id: idSchema,
+  contactId: idSchema,
+  canonicalEventId: idSchema,
+  family: timelineFamilySchema,
+  occurredAt: timestampSchema,
+  sortKey: z.string().min(1),
+  reviewState: reviewStateSchema,
+  primaryProvider: providerSchema,
+  summary: z.string().min(1)
+});
+
+export const salesforceTimelineItemSchema = timelineItemBaseSchema.extend({
+  family: z.literal("salesforce_event"),
+  milestone: z.enum([
+    "signed_up",
+    "received_training",
+    "completed_training",
+    "submitted_first_data"
+  ]),
+  projectName: nullableStringSchema,
+  expeditionName: nullableStringSchema,
+  sourceField: nullableStringSchema
+});
+export type SalesforceTimelineItem = z.infer<
+  typeof salesforceTimelineItemSchema
+>;
+
+export const autoEmailTimelineItemSchema = timelineItemBaseSchema.extend({
+  family: z.literal("auto_email"),
+  direction: z.literal("outbound"),
+  subject: nullableStringSchema,
+  snippet: z.string(),
+  sourceLabel: z.string().min(1)
+});
+export type AutoEmailTimelineItem = z.infer<typeof autoEmailTimelineItemSchema>;
+
+export const campaignEmailTimelineItemSchema = timelineItemBaseSchema.extend({
+  family: z.literal("campaign_email"),
+  activityType: campaignEmailActivityTypeSchema,
+  campaignName: nullableStringSchema,
+  campaignId: nullableStringSchema,
+  audienceId: nullableStringSchema,
+  snippet: z.string()
+});
+export type CampaignEmailTimelineItem = z.infer<
+  typeof campaignEmailTimelineItemSchema
+>;
+
+export const campaignSmsTimelineItemSchema = timelineItemBaseSchema.extend({
+  family: z.literal("campaign_sms"),
+  direction: z.literal("outbound"),
+  messageTextPreview: z.string(),
+  campaignName: nullableStringSchema,
+  campaignId: nullableStringSchema
+});
+export type CampaignSmsTimelineItem = z.infer<
+  typeof campaignSmsTimelineItemSchema
+>;
+
+export const oneToOneEmailTimelineItemSchema = timelineItemBaseSchema.extend({
+  family: z.literal("one_to_one_email"),
+  direction: z.enum(["inbound", "outbound"]),
+  subject: nullableStringSchema,
+  snippet: z.string(),
+  bodyPreview: nullableStringSchema,
+  mailbox: nullableStringSchema,
+  threadId: nullableStringSchema
+});
+export type OneToOneEmailTimelineItem = z.infer<
+  typeof oneToOneEmailTimelineItemSchema
+>;
+
+export const oneToOneSmsTimelineItemSchema = timelineItemBaseSchema.extend({
+  family: z.literal("one_to_one_sms"),
+  direction: z.enum(["inbound", "outbound"]),
+  messageTextPreview: z.string(),
+  phone: nullableStringSchema,
+  threadKey: nullableStringSchema
+});
+export type OneToOneSmsTimelineItem = z.infer<
+  typeof oneToOneSmsTimelineItemSchema
+>;
+
+export const internalNoteTimelineItemSchema = timelineItemBaseSchema.extend({
+  family: z.literal("internal_note"),
+  body: z.string().min(1),
+  authorDisplayName: nullableStringSchema
+});
+export type InternalNoteTimelineItem = z.infer<
+  typeof internalNoteTimelineItemSchema
+>;
+
+export const timelineItemSchema = z.discriminatedUnion("family", [
+  salesforceTimelineItemSchema,
+  autoEmailTimelineItemSchema,
+  campaignEmailTimelineItemSchema,
+  campaignSmsTimelineItemSchema,
+  oneToOneEmailTimelineItemSchema,
+  oneToOneSmsTimelineItemSchema,
+  internalNoteTimelineItemSchema
+]);
+export type TimelineItem = z.infer<typeof timelineItemSchema>;
+
+export const timelineItemListSchema = z.array(timelineItemSchema);
+export type TimelineItemList = z.infer<typeof timelineItemListSchema>;

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -35,12 +35,20 @@ import {
   mapIdentityResolutionToInsert,
   mapInboxProjectionRow,
   mapInboxProjectionToInsert,
+  mapMailchimpCampaignActivityDetailRow,
+  mapMailchimpCampaignActivityDetailToInsert,
+  mapManualNoteDetailRow,
+  mapManualNoteDetailToInsert,
   mapProjectDimensionRow,
   mapProjectDimensionToInsert,
   mapRoutingReviewRow,
   mapRoutingReviewToInsert,
+  mapSalesforceCommunicationDetailRow,
+  mapSalesforceCommunicationDetailToInsert,
   mapSalesforceEventContextRow,
   mapSalesforceEventContextToInsert,
+  mapSimpleTextingMessageDetailRow,
+  mapSimpleTextingMessageDetailToInsert,
   mapSourceEvidenceRow,
   mapSourceEvidenceToInsert,
   mapSyncStateRow,
@@ -60,9 +68,13 @@ import {
   expeditionDimensions,
   gmailMessageDetails,
   identityResolutionQueue,
+  mailchimpCampaignActivityDetails,
+  manualNoteDetails,
   projectDimensions,
   routingReviewQueue,
+  salesforceCommunicationDetails,
   salesforceEventContext,
+  simpleTextingMessageDetails,
   sourceEvidenceLog,
   syncState
 } from "./schema/index.js";
@@ -621,6 +633,188 @@ function createStage1RepositoriesInternal(
       }
     },
 
+    salesforceCommunicationDetails: {
+      async listBySourceEvidenceIds(sourceEvidenceIds) {
+        if (sourceEvidenceIds.length === 0) {
+          return [];
+        }
+
+        const rows = await db
+          .select()
+          .from(salesforceCommunicationDetails)
+          .where(
+            inArray(salesforceCommunicationDetails.sourceEvidenceId, [
+              ...sourceEvidenceIds
+            ])
+          )
+          .orderBy(asc(salesforceCommunicationDetails.sourceEvidenceId));
+
+        return rows.map(mapSalesforceCommunicationDetailRow);
+      },
+
+      async upsert(record) {
+        const values = mapSalesforceCommunicationDetailToInsert(record);
+        const [row] = await db
+          .insert(salesforceCommunicationDetails)
+          .values(values)
+          .onConflictDoUpdate({
+            target: salesforceCommunicationDetails.sourceEvidenceId,
+            set: {
+              providerRecordId: values.providerRecordId,
+              channel: values.channel,
+              messageKind: values.messageKind,
+              subject: values.subject,
+              snippet: values.snippet,
+              sourceLabel: values.sourceLabel,
+              updatedAt: new Date()
+            }
+          })
+          .returning();
+
+        return mapSalesforceCommunicationDetailRow(
+          requireRow(
+            row,
+            "Expected Salesforce communication detail row to be returned."
+          )
+        );
+      }
+    },
+
+    simpleTextingMessageDetails: {
+      async listBySourceEvidenceIds(sourceEvidenceIds) {
+        if (sourceEvidenceIds.length === 0) {
+          return [];
+        }
+
+        const rows = await db
+          .select()
+          .from(simpleTextingMessageDetails)
+          .where(
+            inArray(simpleTextingMessageDetails.sourceEvidenceId, [
+              ...sourceEvidenceIds
+            ])
+          )
+          .orderBy(asc(simpleTextingMessageDetails.sourceEvidenceId));
+
+        return rows.map(mapSimpleTextingMessageDetailRow);
+      },
+
+      async upsert(record) {
+        const values = mapSimpleTextingMessageDetailToInsert(record);
+        const [row] = await db
+          .insert(simpleTextingMessageDetails)
+          .values(values)
+          .onConflictDoUpdate({
+            target: simpleTextingMessageDetails.sourceEvidenceId,
+            set: {
+              providerRecordId: values.providerRecordId,
+              direction: values.direction,
+              messageKind: values.messageKind,
+              messageTextPreview: values.messageTextPreview,
+              normalizedPhone: values.normalizedPhone,
+              campaignId: values.campaignId,
+              campaignName: values.campaignName,
+              providerThreadId: values.providerThreadId,
+              threadKey: values.threadKey,
+              updatedAt: new Date()
+            }
+          })
+          .returning();
+
+        return mapSimpleTextingMessageDetailRow(
+          requireRow(
+            row,
+            "Expected SimpleTexting message detail row to be returned."
+          )
+        );
+      }
+    },
+
+    mailchimpCampaignActivityDetails: {
+      async listBySourceEvidenceIds(sourceEvidenceIds) {
+        if (sourceEvidenceIds.length === 0) {
+          return [];
+        }
+
+        const rows = await db
+          .select()
+          .from(mailchimpCampaignActivityDetails)
+          .where(
+            inArray(mailchimpCampaignActivityDetails.sourceEvidenceId, [
+              ...sourceEvidenceIds
+            ])
+          )
+          .orderBy(asc(mailchimpCampaignActivityDetails.sourceEvidenceId));
+
+        return rows.map(mapMailchimpCampaignActivityDetailRow);
+      },
+
+      async upsert(record) {
+        const values = mapMailchimpCampaignActivityDetailToInsert(record);
+        const [row] = await db
+          .insert(mailchimpCampaignActivityDetails)
+          .values(values)
+          .onConflictDoUpdate({
+            target: mailchimpCampaignActivityDetails.sourceEvidenceId,
+            set: {
+              providerRecordId: values.providerRecordId,
+              activityType: values.activityType,
+              campaignId: values.campaignId,
+              audienceId: values.audienceId,
+              memberId: values.memberId,
+              campaignName: values.campaignName,
+              snippet: values.snippet,
+              updatedAt: new Date()
+            }
+          })
+          .returning();
+
+        return mapMailchimpCampaignActivityDetailRow(
+          requireRow(
+            row,
+            "Expected Mailchimp campaign activity detail row to be returned."
+          )
+        );
+      }
+    },
+
+    manualNoteDetails: {
+      async listBySourceEvidenceIds(sourceEvidenceIds) {
+        if (sourceEvidenceIds.length === 0) {
+          return [];
+        }
+
+        const rows = await db
+          .select()
+          .from(manualNoteDetails)
+          .where(inArray(manualNoteDetails.sourceEvidenceId, [...sourceEvidenceIds]))
+          .orderBy(asc(manualNoteDetails.sourceEvidenceId));
+
+        return rows.map(mapManualNoteDetailRow);
+      },
+
+      async upsert(record) {
+        const values = mapManualNoteDetailToInsert(record);
+        const [row] = await db
+          .insert(manualNoteDetails)
+          .values(values)
+          .onConflictDoUpdate({
+            target: manualNoteDetails.sourceEvidenceId,
+            set: {
+              providerRecordId: values.providerRecordId,
+              body: values.body,
+              authorDisplayName: values.authorDisplayName,
+              updatedAt: new Date()
+            }
+          })
+          .returning();
+
+        return mapManualNoteDetailRow(
+          requireRow(row, "Expected manual note detail row to be returned.")
+        );
+      }
+    },
+
     identityResolutionQueue: {
       async findById(id) {
         const [row] = await db
@@ -795,6 +989,19 @@ function createStage1RepositoriesInternal(
           );
 
         return rows.map(mapInboxProjectionRow);
+      },
+
+      async setNeedsFollowUp(input) {
+        const [row] = await db
+          .update(contactInboxProjection)
+          .set({
+            isStarred: input.needsFollowUp,
+            updatedAt: new Date()
+          })
+          .where(eq(contactInboxProjection.contactId, input.contactId))
+          .returning();
+
+        return row === undefined ? null : mapInboxProjectionRow(row);
       },
 
       async upsert(record) {

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -6,7 +6,9 @@ import {
   desc,
   eq,
   inArray,
-  isNull
+  isNull,
+  or,
+  sql
 } from "drizzle-orm";
 import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
 
@@ -234,6 +236,20 @@ function createStage1RepositoriesInternal(
         return row?.value ?? 0;
       },
 
+      async listByIds(ids) {
+        if (ids.length === 0) {
+          return [];
+        }
+
+        const rows = await db
+          .select()
+          .from(canonicalEventLedger)
+          .where(inArray(canonicalEventLedger.id, [...ids]))
+          .orderBy(asc(canonicalEventLedger.id));
+
+        return rows.map(mapCanonicalEventRow);
+      },
+
       async listByContactId(contactId) {
         const rows = await db
           .select()
@@ -297,6 +313,20 @@ function createStage1RepositoriesInternal(
 
       async listAll() {
         const rows = await db.select().from(contacts).orderBy(asc(contacts.id));
+
+        return rows.map(mapContactRow);
+      },
+
+      async listByIds(ids) {
+        if (ids.length === 0) {
+          return [];
+        }
+
+        const rows = await db
+          .select()
+          .from(contacts)
+          .where(inArray(contacts.id, [...ids]))
+          .orderBy(asc(contacts.id));
 
         return rows.map(mapContactRow);
       },
@@ -385,6 +415,24 @@ function createStage1RepositoriesInternal(
           .from(contactMemberships)
           .where(eq(contactMemberships.contactId, contactId))
           .orderBy(asc(contactMemberships.projectId), asc(contactMemberships.id));
+
+        return rows.map(mapContactMembershipRow);
+      },
+
+      async listByContactIds(contactIds) {
+        if (contactIds.length === 0) {
+          return [];
+        }
+
+        const rows = await db
+          .select()
+          .from(contactMemberships)
+          .where(inArray(contactMemberships.contactId, [...contactIds]))
+          .orderBy(
+            asc(contactMemberships.contactId),
+            asc(contactMemberships.projectId),
+            asc(contactMemberships.id)
+          );
 
         return rows.map(mapContactMembershipRow);
       },
@@ -599,6 +647,24 @@ function createStage1RepositoriesInternal(
         return rows.map(mapIdentityResolutionRow);
       },
 
+      async listOpenByContactId(contactId) {
+        const rows = await db
+          .select()
+          .from(identityResolutionQueue)
+          .where(
+            and(
+              eq(identityResolutionQueue.status, "open"),
+              or(
+                eq(identityResolutionQueue.anchoredContactId, contactId),
+                sql`${contactId} = any(${identityResolutionQueue.candidateContactIds})`
+              )
+            )
+          )
+          .orderBy(desc(identityResolutionQueue.openedAt), asc(identityResolutionQueue.id));
+
+        return rows.map(mapIdentityResolutionRow);
+      },
+
       async upsert(record) {
         const values = mapIdentityResolutionToInsert(record);
         const [row] = await db
@@ -653,6 +719,21 @@ function createStage1RepositoriesInternal(
         return rows.map(mapRoutingReviewRow);
       },
 
+      async listOpenByContactId(contactId) {
+        const rows = await db
+          .select()
+          .from(routingReviewQueue)
+          .where(
+            and(
+              eq(routingReviewQueue.contactId, contactId),
+              eq(routingReviewQueue.status, "open")
+            )
+          )
+          .orderBy(desc(routingReviewQueue.openedAt), asc(routingReviewQueue.id));
+
+        return rows.map(mapRoutingReviewRow);
+      },
+
       async upsert(record) {
         const values = mapRoutingReviewToInsert(record);
         const [row] = await db
@@ -699,6 +780,21 @@ function createStage1RepositoriesInternal(
           .limit(1);
 
         return row === undefined ? null : mapInboxProjectionRow(row);
+      },
+
+      async listAllOrderedByRecency() {
+        const rows = await db
+          .select()
+          .from(contactInboxProjection)
+          .orderBy(
+            desc(
+              sql`coalesce(${contactInboxProjection.lastInboundAt}, ${contactInboxProjection.lastActivityAt})`
+            ),
+            desc(contactInboxProjection.lastActivityAt),
+            asc(contactInboxProjection.contactId)
+          );
+
+        return rows.map(mapInboxProjectionRow);
       },
 
       async upsert(record) {

--- a/packages/db/test/stage1-repositories.test.ts
+++ b/packages/db/test/stage1-repositories.test.ts
@@ -48,6 +48,9 @@ describe("Stage 1 DB repositories", () => {
     await expect(
       repositories.contacts.findBySalesforceContactId("003-stage1")
     ).resolves.toEqual(contact);
+    await expect(repositories.contacts.listByIds([contact.id])).resolves.toEqual([
+      contact
+    ]);
 
     const identity = await repositories.contactIdentities.upsert({
       id: "identity_1",
@@ -80,6 +83,9 @@ describe("Stage 1 DB repositories", () => {
     ).resolves.toEqual([identity]);
     await expect(
       repositories.contactMemberships.listByContactId(contact.id)
+    ).resolves.toEqual([membership]);
+    await expect(
+      repositories.contactMemberships.listByContactIds([contact.id])
     ).resolves.toEqual([membership]);
 
     const projectDimension = await repositories.projectDimensions.upsert({
@@ -165,7 +171,14 @@ describe("Stage 1 DB repositories", () => {
         primaryProvider: "gmail",
         primarySourceEvidenceId: "sev_1",
         supportingSourceEvidenceIds: [],
-        winnerReason: "single_source"
+        winnerReason: "single_source",
+        sourceRecordType: "message",
+        sourceRecordId: "gmail-message-1",
+        messageKind: "one_to_one",
+        campaignRef: null,
+        threadRef: null,
+        direction: "inbound",
+        notes: null
       },
       reviewState: "clear"
     });
@@ -220,6 +233,61 @@ describe("Stage 1 DB repositories", () => {
       primaryProvider: "gmail",
       reviewState: "clear"
     });
+    await repositories.contacts.upsert({
+      id: "contact_2",
+      salesforceContactId: "003-stage1-secondary",
+      displayName: "Another Volunteer",
+      primaryEmail: "another@example.org",
+      primaryPhone: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z"
+    });
+    await repositories.sourceEvidence.append({
+      id: "sev_2",
+      provider: "gmail",
+      providerRecordType: "message",
+      providerRecordId: "gmail-message-2",
+      receivedAt: "2026-01-01T00:11:00.000Z",
+      occurredAt: "2026-01-01T00:10:00.000Z",
+      payloadRef: "payloads/gmail/gmail-message-2.json",
+      idempotencyKey: "gmail:message:gmail-message-2",
+      checksum: "checksum-2"
+    });
+    const secondCanonicalEvent = await repositories.canonicalEvents.upsert({
+      id: "evt_2",
+      contactId: "contact_2",
+      eventType: "communication.email.outbound",
+      channel: "email",
+      occurredAt: "2026-01-01T00:10:00.000Z",
+      sourceEvidenceId: "sev_2",
+      idempotencyKey: "canonical:gmail-message-2",
+      provenance: {
+        primaryProvider: "gmail",
+        primarySourceEvidenceId: "sev_2",
+        supportingSourceEvidenceIds: [],
+        winnerReason: "single_source",
+        sourceRecordType: "message",
+        sourceRecordId: "gmail-message-2",
+        messageKind: "one_to_one",
+        campaignRef: null,
+        threadRef: null,
+        direction: "outbound",
+        notes: null
+      },
+      reviewState: "clear"
+    });
+    const secondInboxProjection = await repositories.inboxProjection.upsert({
+      contactId: "contact_2",
+      bucket: "Opened",
+      needsFollowUp: true,
+      hasUnresolved: false,
+      lastInboundAt: null,
+      lastOutboundAt: "2026-01-01T00:10:00.000Z",
+      lastActivityAt: "2026-01-01T00:10:00.000Z",
+      snippet: "Outbound only follow-up",
+      lastCanonicalEventId: secondCanonicalEvent.id,
+      lastEventType: "communication.email.outbound"
+    });
 
     await expect(
       repositories.canonicalEvents.findByIdempotencyKey(
@@ -230,10 +298,19 @@ describe("Stage 1 DB repositories", () => {
       repositories.canonicalEvents.listByContactId("contact_1")
     ).resolves.toEqual([canonicalEvent]);
     await expect(
+      repositories.canonicalEvents.listByIds([canonicalEvent.id])
+    ).resolves.toEqual([canonicalEvent]);
+    await expect(
+      repositories.identityResolutionQueue.listOpenByContactId("contact_1")
+    ).resolves.toEqual([identityCase]);
+    await expect(
       repositories.identityResolutionQueue.listOpenByReasonCode(
         "identity_missing_anchor"
       )
     ).resolves.toEqual([identityCase]);
+    await expect(
+      repositories.routingReviewQueue.listOpenByContactId("contact_1")
+    ).resolves.toEqual([routingCase]);
     await expect(
       repositories.routingReviewQueue.listOpenByReasonCode(
         "routing_missing_membership"
@@ -242,6 +319,9 @@ describe("Stage 1 DB repositories", () => {
     await expect(
       repositories.inboxProjection.findByContactId("contact_1")
     ).resolves.toEqual(inboxProjection);
+    await expect(
+      repositories.inboxProjection.listAllOrderedByRecency()
+    ).resolves.toEqual([secondInboxProjection, inboxProjection]);
     await expect(
       repositories.timelineProjection.findByCanonicalEventId(canonicalEvent.id)
     ).resolves.toEqual(timelineProjection);

--- a/packages/db/test/stage1-repositories.test.ts
+++ b/packages/db/test/stage1-repositories.test.ts
@@ -117,6 +117,46 @@ describe("Stage 1 DB repositories", () => {
       projectId: "project_1",
       expeditionId: "expedition_1"
     });
+    const salesforceCommunicationDetail =
+      await repositories.salesforceCommunicationDetails.upsert({
+        sourceEvidenceId: sourceEvidence.id,
+        providerRecordId: sourceEvidence.providerRecordId,
+        channel: "email",
+        messageKind: "auto",
+        subject: "Automation complete",
+        snippet: "Your workflow completed successfully.",
+        sourceLabel: "Salesforce Flow"
+      });
+    const simpleTextingMessageDetail =
+      await repositories.simpleTextingMessageDetails.upsert({
+        sourceEvidenceId: sourceEvidence.id,
+        providerRecordId: sourceEvidence.providerRecordId,
+        direction: "outbound",
+        messageKind: "campaign",
+        messageTextPreview: "Campaign kickoff reminder",
+        normalizedPhone: "+15555550123",
+        campaignId: "campaign_sms_1",
+        campaignName: "Volunteer Reminders",
+        providerThreadId: "thread_1",
+        threadKey: "thread-key-1"
+      });
+    const mailchimpCampaignActivityDetail =
+      await repositories.mailchimpCampaignActivityDetails.upsert({
+        sourceEvidenceId: sourceEvidence.id,
+        providerRecordId: sourceEvidence.providerRecordId,
+        activityType: "sent",
+        campaignId: "campaign_email_1",
+        audienceId: "audience_1",
+        memberId: "member_1",
+        campaignName: "Spring Launch",
+        snippet: "Campaign launch message"
+      });
+    const manualNoteDetail = await repositories.manualNoteDetails.upsert({
+      sourceEvidenceId: sourceEvidence.id,
+      providerRecordId: sourceEvidence.providerRecordId,
+      body: "Follow up after the kickoff call.",
+      authorDisplayName: "Stage One Operator"
+    });
 
     await expect(
       repositories.projectDimensions.listByIds(["project_1"])
@@ -132,6 +172,24 @@ describe("Stage 1 DB repositories", () => {
         sourceEvidence.id
       ])
     ).resolves.toEqual([salesforceContext]);
+    await expect(
+      repositories.salesforceCommunicationDetails.listBySourceEvidenceIds([
+        sourceEvidence.id
+      ])
+    ).resolves.toEqual([salesforceCommunicationDetail]);
+    await expect(
+      repositories.simpleTextingMessageDetails.listBySourceEvidenceIds([
+        sourceEvidence.id
+      ])
+    ).resolves.toEqual([simpleTextingMessageDetail]);
+    await expect(
+      repositories.mailchimpCampaignActivityDetails.listBySourceEvidenceIds([
+        sourceEvidence.id
+      ])
+    ).resolves.toEqual([mailchimpCampaignActivityDetail]);
+    await expect(
+      repositories.manualNoteDetails.listBySourceEvidenceIds([sourceEvidence.id])
+    ).resolves.toEqual([manualNoteDetail]);
   });
 
   it("persists canonical events, review queues, and projections", async () => {
@@ -322,6 +380,21 @@ describe("Stage 1 DB repositories", () => {
     await expect(
       repositories.inboxProjection.listAllOrderedByRecency()
     ).resolves.toEqual([secondInboxProjection, inboxProjection]);
+    await expect(
+      repositories.inboxProjection.setNeedsFollowUp({
+        contactId: "contact_1",
+        needsFollowUp: true
+      })
+    ).resolves.toEqual({
+      ...inboxProjection,
+      needsFollowUp: true
+    });
+    await expect(
+      repositories.inboxProjection.findByContactId("contact_1")
+    ).resolves.toEqual({
+      ...inboxProjection,
+      needsFollowUp: true
+    });
     await expect(
       repositories.timelineProjection.findByCanonicalEventId(canonicalEvent.id)
     ).resolves.toEqual(timelineProjection);

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -10,11 +10,15 @@ import type {
   IdentityResolutionCase,
   IdentityResolutionReasonCode,
   InboxProjectionRow,
+  MailchimpCampaignActivityDetailRecord,
+  ManualNoteDetailRecord,
   ProjectDimensionRecord,
   Provider,
   RoutingReviewCase,
   RoutingReviewReasonCode,
+  SalesforceCommunicationDetailRecord,
   SalesforceEventContextRecord,
+  SimpleTextingMessageDetailRecord,
   SourceEvidenceRecord,
   SyncScope,
   SyncJobType,
@@ -102,6 +106,40 @@ export interface SalesforceEventContextRepository {
   ): Promise<SalesforceEventContextRecord>;
 }
 
+export interface SalesforceCommunicationDetailRepository {
+  listBySourceEvidenceIds(
+    sourceEvidenceIds: readonly string[]
+  ): Promise<readonly SalesforceCommunicationDetailRecord[]>;
+  upsert(
+    record: SalesforceCommunicationDetailRecord
+  ): Promise<SalesforceCommunicationDetailRecord>;
+}
+
+export interface SimpleTextingMessageDetailRepository {
+  listBySourceEvidenceIds(
+    sourceEvidenceIds: readonly string[]
+  ): Promise<readonly SimpleTextingMessageDetailRecord[]>;
+  upsert(
+    record: SimpleTextingMessageDetailRecord
+  ): Promise<SimpleTextingMessageDetailRecord>;
+}
+
+export interface MailchimpCampaignActivityDetailRepository {
+  listBySourceEvidenceIds(
+    sourceEvidenceIds: readonly string[]
+  ): Promise<readonly MailchimpCampaignActivityDetailRecord[]>;
+  upsert(
+    record: MailchimpCampaignActivityDetailRecord
+  ): Promise<MailchimpCampaignActivityDetailRecord>;
+}
+
+export interface ManualNoteDetailRepository {
+  listBySourceEvidenceIds(
+    sourceEvidenceIds: readonly string[]
+  ): Promise<readonly ManualNoteDetailRecord[]>;
+  upsert(record: ManualNoteDetailRecord): Promise<ManualNoteDetailRecord>;
+}
+
 export interface IdentityResolutionRepository {
   findById(id: string): Promise<IdentityResolutionCase | null>;
   listOpenByContactId(contactId: string): Promise<readonly IdentityResolutionCase[]>;
@@ -124,6 +162,10 @@ export interface InboxProjectionRepository {
   countAll(): Promise<number>;
   findByContactId(contactId: string): Promise<InboxProjectionRow | null>;
   listAllOrderedByRecency(): Promise<readonly InboxProjectionRow[]>;
+  setNeedsFollowUp(input: {
+    readonly contactId: string;
+    readonly needsFollowUp: boolean;
+  }): Promise<InboxProjectionRow | null>;
   upsert(record: InboxProjectionRow): Promise<InboxProjectionRow>;
 }
 
@@ -162,6 +204,10 @@ export interface Stage1RepositoryBundle {
   readonly expeditionDimensions: ExpeditionDimensionRepository;
   readonly gmailMessageDetails: GmailMessageDetailRepository;
   readonly salesforceEventContext: SalesforceEventContextRepository;
+  readonly salesforceCommunicationDetails: SalesforceCommunicationDetailRepository;
+  readonly simpleTextingMessageDetails: SimpleTextingMessageDetailRepository;
+  readonly mailchimpCampaignActivityDetails: MailchimpCampaignActivityDetailRepository;
+  readonly manualNoteDetails: ManualNoteDetailRepository;
   readonly identityResolutionQueue: IdentityResolutionRepository;
   readonly routingReviewQueue: RoutingReviewRepository;
   readonly inboxProjection: InboxProjectionRepository;

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -40,6 +40,7 @@ export interface CanonicalEventRepository {
   countAll(): Promise<number>;
   countByPrimaryProvider(provider: Provider): Promise<number>;
   countDistinctInboxContacts(): Promise<number>;
+  listByIds(ids: readonly string[]): Promise<readonly CanonicalEventRecord[]>;
   listByContactId(contactId: string): Promise<readonly CanonicalEventRecord[]>;
   upsert(record: CanonicalEventRecord): Promise<CanonicalEventRecord>;
 }
@@ -50,6 +51,7 @@ export interface ContactRepository {
     salesforceContactId: string
   ): Promise<ContactRecord | null>;
   listAll(): Promise<readonly ContactRecord[]>;
+  listByIds(ids: readonly string[]): Promise<readonly ContactRecord[]>;
   upsert(record: ContactRecord): Promise<ContactRecord>;
 }
 
@@ -65,6 +67,9 @@ export interface ContactIdentityRepository {
 export interface ContactMembershipRepository {
   listByContactId(
     contactId: string
+  ): Promise<readonly ContactMembershipRecord[]>;
+  listByContactIds(
+    contactIds: readonly string[]
   ): Promise<readonly ContactMembershipRecord[]>;
   upsert(record: ContactMembershipRecord): Promise<ContactMembershipRecord>;
 }
@@ -99,6 +104,7 @@ export interface SalesforceEventContextRepository {
 
 export interface IdentityResolutionRepository {
   findById(id: string): Promise<IdentityResolutionCase | null>;
+  listOpenByContactId(contactId: string): Promise<readonly IdentityResolutionCase[]>;
   listOpenByReasonCode(
     reasonCode: IdentityResolutionReasonCode
   ): Promise<readonly IdentityResolutionCase[]>;
@@ -107,6 +113,7 @@ export interface IdentityResolutionRepository {
 
 export interface RoutingReviewRepository {
   findById(id: string): Promise<RoutingReviewCase | null>;
+  listOpenByContactId(contactId: string): Promise<readonly RoutingReviewCase[]>;
   listOpenByReasonCode(
     reasonCode: RoutingReviewReasonCode
   ): Promise<readonly RoutingReviewCase[]>;
@@ -116,6 +123,7 @@ export interface RoutingReviewRepository {
 export interface InboxProjectionRepository {
   countAll(): Promise<number>;
   findByContactId(contactId: string): Promise<InboxProjectionRow | null>;
+  listAllOrderedByRecency(): Promise<readonly InboxProjectionRow[]>;
   upsert(record: InboxProjectionRow): Promise<InboxProjectionRow>;
 }
 

--- a/packages/domain/src/timeline.ts
+++ b/packages/domain/src/timeline.ts
@@ -41,9 +41,7 @@ function resolveFamily(event: CanonicalEventRecord): TimelineItem["family"] {
 
   if (
     event.eventType === "communication.email.outbound" &&
-    (event.provenance.messageKind === "auto" ||
-      (event.provenance.messageKind === null &&
-        event.provenance.primaryProvider === "salesforce"))
+    event.provenance.messageKind === "auto"
   ) {
     return "auto_email";
   }

--- a/packages/domain/src/timeline.ts
+++ b/packages/domain/src/timeline.ts
@@ -1,0 +1,344 @@
+import {
+  timelineItemListSchema,
+  type CampaignEmailTimelineItem,
+  type CanonicalEventRecord,
+  type SourceEvidenceRecord,
+  type TimelineItem,
+  type TimelineProjectionRow
+} from "@as-comms/contracts";
+
+import type { Stage1RepositoryBundle } from "./repositories.js";
+
+function getLifecycleMilestone(
+  eventType: CanonicalEventRecord["eventType"]
+): "signed_up" | "received_training" | "completed_training" | "submitted_first_data" {
+  switch (eventType) {
+    case "lifecycle.signed_up":
+      return "signed_up";
+    case "lifecycle.received_training":
+      return "received_training";
+    case "lifecycle.completed_training":
+      return "completed_training";
+    case "lifecycle.submitted_first_data":
+      return "submitted_first_data";
+    default:
+      throw new Error(`Unsupported lifecycle event type ${eventType}.`);
+  }
+}
+
+function resolveFamily(event: CanonicalEventRecord): TimelineItem["family"] {
+  if (event.eventType.startsWith("lifecycle.")) {
+    return "salesforce_event";
+  }
+
+  if (event.eventType === "note.internal.created") {
+    return "internal_note";
+  }
+
+  if (event.eventType.startsWith("campaign.email.")) {
+    return "campaign_email";
+  }
+
+  if (
+    event.eventType === "communication.email.outbound" &&
+    (event.provenance.messageKind === "auto" ||
+      (event.provenance.messageKind === null &&
+        event.provenance.primaryProvider === "salesforce"))
+  ) {
+    return "auto_email";
+  }
+
+  if (
+    event.eventType === "communication.sms.outbound" &&
+    event.provenance.messageKind === "campaign"
+  ) {
+    return "campaign_sms";
+  }
+
+  if (
+    (event.eventType === "communication.email.inbound" ||
+      event.eventType === "communication.email.outbound") &&
+    (event.provenance.messageKind === "one_to_one" ||
+      (event.provenance.messageKind === null &&
+        (event.provenance.primaryProvider === "gmail" ||
+          event.provenance.primaryProvider === "salesforce")))
+  ) {
+    return "one_to_one_email";
+  }
+
+  if (
+    (event.eventType === "communication.sms.inbound" ||
+      event.eventType === "communication.sms.outbound") &&
+    (event.provenance.messageKind === "one_to_one" ||
+      (event.provenance.messageKind === null &&
+        (event.provenance.primaryProvider === "simpletexting" ||
+          event.provenance.primaryProvider === "salesforce")))
+  ) {
+    return "one_to_one_sms";
+  }
+
+  throw new Error(
+    `Canonical event ${event.id} (${event.eventType}) could not be resolved to a timeline family.`
+  );
+}
+
+function commonFields(
+  row: TimelineProjectionRow
+): Omit<TimelineItem, "family"> & { family?: never } {
+  return {
+    id: row.id,
+    contactId: row.contactId,
+    canonicalEventId: row.canonicalEventId,
+    occurredAt: row.occurredAt,
+    sortKey: row.sortKey,
+    reviewState: row.reviewState,
+    primaryProvider: row.primaryProvider,
+    summary: row.summary
+  } as Omit<TimelineItem, "family"> & { family?: never };
+}
+
+export interface Stage1TimelinePresentationService {
+  listTimelineItemsByContactId(contactId: string): Promise<readonly TimelineItem[]>;
+}
+
+export function createStage1TimelinePresentationService(
+  repositories: Stage1RepositoryBundle
+): Stage1TimelinePresentationService {
+  return {
+    async listTimelineItemsByContactId(contactId) {
+      const [canonicalEvents, timelineRows] = await Promise.all([
+        repositories.canonicalEvents.listByContactId(contactId),
+        repositories.timelineProjection.listByContactId(contactId)
+      ]);
+      const canonicalEventById = new Map(
+        canonicalEvents.map((event) => [event.id, event])
+      );
+      const sourceEvidence = (
+        await Promise.all(
+          canonicalEvents.map((event) =>
+            repositories.sourceEvidence.findById(event.sourceEvidenceId)
+          )
+        )
+      ).filter((record): record is SourceEvidenceRecord => record !== null);
+      const sourceEvidenceById = new Map(
+        sourceEvidence.map((record) => [record.id, record])
+      );
+      const sourceEvidenceIds = sourceEvidence.map((record) => record.id);
+      const [
+        gmailDetails,
+        salesforceContexts,
+        salesforceCommunicationDetails,
+        simpleTextingMessageDetails,
+        mailchimpCampaignActivityDetails,
+        manualNoteDetails
+      ] = await Promise.all([
+        repositories.gmailMessageDetails.listBySourceEvidenceIds(sourceEvidenceIds),
+        repositories.salesforceEventContext.listBySourceEvidenceIds(sourceEvidenceIds),
+        repositories.salesforceCommunicationDetails.listBySourceEvidenceIds(
+          sourceEvidenceIds
+        ),
+        repositories.simpleTextingMessageDetails.listBySourceEvidenceIds(
+          sourceEvidenceIds
+        ),
+        repositories.mailchimpCampaignActivityDetails.listBySourceEvidenceIds(
+          sourceEvidenceIds
+        ),
+        repositories.manualNoteDetails.listBySourceEvidenceIds(sourceEvidenceIds)
+      ]);
+
+      const salesforceContextBySourceEvidenceId = new Map(
+        salesforceContexts.map((detail) => [detail.sourceEvidenceId, detail])
+      );
+      const gmailDetailBySourceEvidenceId = new Map(
+        gmailDetails.map((detail) => [detail.sourceEvidenceId, detail])
+      );
+      const salesforceCommunicationBySourceEvidenceId = new Map(
+        salesforceCommunicationDetails.map((detail) => [
+          detail.sourceEvidenceId,
+          detail
+        ])
+      );
+      const simpleTextingDetailBySourceEvidenceId = new Map(
+        simpleTextingMessageDetails.map((detail) => [detail.sourceEvidenceId, detail])
+      );
+      const mailchimpDetailBySourceEvidenceId = new Map(
+        mailchimpCampaignActivityDetails.map((detail) => [
+          detail.sourceEvidenceId,
+          detail
+        ])
+      );
+      const manualNoteDetailBySourceEvidenceId = new Map(
+        manualNoteDetails.map((detail) => [detail.sourceEvidenceId, detail])
+      );
+      const [projectDimensions, expeditionDimensions] = await Promise.all([
+        repositories.projectDimensions.listByIds(
+          Array.from(
+            new Set(
+              salesforceContexts
+                .map((context) => context.projectId)
+                .filter((value): value is string => value !== null)
+            )
+          )
+        ),
+        repositories.expeditionDimensions.listByIds(
+          Array.from(
+            new Set(
+              salesforceContexts
+                .map((context) => context.expeditionId)
+                .filter((value): value is string => value !== null)
+            )
+          )
+        )
+      ]);
+      const projectNameById = new Map(
+        projectDimensions.map((dimension) => [
+          dimension.projectId,
+          dimension.projectName
+        ])
+      );
+      const expeditionNameById = new Map(
+        expeditionDimensions.map((dimension) => [
+          dimension.expeditionId,
+          dimension.expeditionName
+        ])
+      );
+
+      const items: TimelineItem[] = [];
+
+      for (const row of timelineRows) {
+        const event = canonicalEventById.get(row.canonicalEventId);
+
+        if (event === undefined) {
+          continue;
+        }
+
+        const evidence = sourceEvidenceById.get(event.sourceEvidenceId);
+
+        if (evidence === undefined) {
+          continue;
+        }
+
+        const family = resolveFamily(event);
+        const base = commonFields(row);
+        const salesforceContext = salesforceContextBySourceEvidenceId.get(evidence.id);
+        const gmailDetail = gmailDetailBySourceEvidenceId.get(evidence.id);
+        const salesforceCommunicationDetail =
+          salesforceCommunicationBySourceEvidenceId.get(evidence.id);
+        const simpleTextingDetail = simpleTextingDetailBySourceEvidenceId.get(
+          evidence.id
+        );
+        const mailchimpDetail = mailchimpDetailBySourceEvidenceId.get(evidence.id);
+        const manualNoteDetail = manualNoteDetailBySourceEvidenceId.get(evidence.id);
+
+        switch (family) {
+          case "salesforce_event":
+            items.push({
+              ...base,
+              family,
+              milestone: getLifecycleMilestone(event.eventType),
+              projectName:
+                salesforceContext?.projectId === null ||
+                salesforceContext?.projectId === undefined
+                  ? null
+                  : (projectNameById.get(salesforceContext.projectId) ?? null),
+              expeditionName:
+                salesforceContext?.expeditionId === null ||
+                salesforceContext?.expeditionId === undefined
+                  ? null
+                  : (expeditionNameById.get(salesforceContext.expeditionId) ?? null),
+              sourceField: salesforceContext?.sourceField ?? null
+            });
+            break;
+          case "auto_email":
+            items.push({
+              ...base,
+              family,
+              direction: "outbound",
+              subject: salesforceCommunicationDetail?.subject ?? null,
+              snippet: salesforceCommunicationDetail?.snippet ?? "",
+              sourceLabel:
+                salesforceCommunicationDetail?.sourceLabel ?? "Salesforce Flow"
+            });
+            break;
+          case "campaign_email":
+            items.push({
+              ...base,
+              family,
+              activityType:
+                mailchimpDetail?.activityType ??
+                (event.eventType.replace("campaign.email.", "") as CampaignEmailTimelineItem["activityType"]),
+              campaignName: mailchimpDetail?.campaignName ?? null,
+              campaignId: mailchimpDetail?.campaignId ?? null,
+              audienceId: mailchimpDetail?.audienceId ?? null,
+              snippet: mailchimpDetail?.snippet ?? ""
+            });
+            break;
+          case "campaign_sms":
+            items.push({
+              ...base,
+              family,
+              direction: "outbound",
+              messageTextPreview: simpleTextingDetail?.messageTextPreview ?? "",
+              campaignName:
+                simpleTextingDetail?.campaignName ??
+                event.provenance.campaignRef?.providerMessageName ??
+                null,
+              campaignId:
+                simpleTextingDetail?.campaignId ??
+                event.provenance.campaignRef?.providerCampaignId ??
+                null
+            });
+            break;
+          case "one_to_one_email":
+            items.push({
+              ...base,
+              family,
+              direction:
+                gmailDetail?.direction ?? event.provenance.direction ?? "outbound",
+              subject:
+                gmailDetail?.subject ?? salesforceCommunicationDetail?.subject ?? null,
+              snippet:
+                gmailDetail?.snippetClean ?? salesforceCommunicationDetail?.snippet ?? "",
+              bodyPreview: gmailDetail?.bodyTextPreview ?? null,
+              mailbox:
+                gmailDetail?.projectInboxAlias ?? gmailDetail?.capturedMailbox ?? null,
+              threadId:
+                gmailDetail?.gmailThreadId ??
+                event.provenance.threadRef?.providerThreadId ??
+                null
+            });
+            break;
+          case "one_to_one_sms":
+            items.push({
+              ...base,
+              family,
+              direction:
+                simpleTextingDetail?.direction ??
+                event.provenance.direction ??
+                "outbound",
+              messageTextPreview:
+                simpleTextingDetail?.messageTextPreview ??
+                salesforceCommunicationDetail?.snippet ??
+                "",
+              phone: simpleTextingDetail?.normalizedPhone ?? null,
+              threadKey:
+                simpleTextingDetail?.threadKey ??
+                event.provenance.threadRef?.crossProviderCollapseKey ??
+                null
+            });
+            break;
+          case "internal_note":
+            items.push({
+              ...base,
+              family,
+              body: manualNoteDetail?.body ?? "",
+              authorDisplayName: manualNoteDetail?.authorDisplayName ?? null
+            });
+            break;
+        }
+      }
+
+      return timelineItemListSchema.parse(items);
+    }
+  };
+}

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -70,6 +70,22 @@ describe("defineStage1RepositoryBundle", () => {
         listBySourceEvidenceIds: () => Promise.resolve([]),
         upsert: (record) => Promise.resolve(record)
       },
+      salesforceCommunicationDetails: {
+        listBySourceEvidenceIds: () => Promise.resolve([]),
+        upsert: (record) => Promise.resolve(record)
+      },
+      simpleTextingMessageDetails: {
+        listBySourceEvidenceIds: () => Promise.resolve([]),
+        upsert: (record) => Promise.resolve(record)
+      },
+      mailchimpCampaignActivityDetails: {
+        listBySourceEvidenceIds: () => Promise.resolve([]),
+        upsert: (record) => Promise.resolve(record)
+      },
+      manualNoteDetails: {
+        listBySourceEvidenceIds: () => Promise.resolve([]),
+        upsert: (record) => Promise.resolve(record)
+      },
       identityResolutionQueue: {
         findById: () => Promise.resolve(null),
         listOpenByContactId: () => Promise.resolve([]),
@@ -86,6 +102,7 @@ describe("defineStage1RepositoryBundle", () => {
         countAll: () => Promise.resolve(0),
         findByContactId: () => Promise.resolve(null),
         listAllOrderedByRecency: () => Promise.resolve([]),
+        setNeedsFollowUp: () => Promise.resolve(null),
         upsert: (record) => Promise.resolve(record)
       },
       timelineProjection: {

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -33,6 +33,7 @@ describe("defineStage1RepositoryBundle", () => {
         countAll: () => Promise.resolve(0),
         countByPrimaryProvider: () => Promise.resolve(0),
         countDistinctInboxContacts: () => Promise.resolve(0),
+        listByIds: () => Promise.resolve([]),
         listByContactId: () => Promise.resolve([]),
         upsert: (record) => Promise.resolve(record)
       },
@@ -40,6 +41,7 @@ describe("defineStage1RepositoryBundle", () => {
         findById: () => Promise.resolve(contact),
         findBySalesforceContactId: () => Promise.resolve(contact),
         listAll: () => Promise.resolve([contact]),
+        listByIds: () => Promise.resolve([contact]),
         upsert: (record) => Promise.resolve(record)
       },
       contactIdentities: {
@@ -49,6 +51,7 @@ describe("defineStage1RepositoryBundle", () => {
       },
       contactMemberships: {
         listByContactId: () => Promise.resolve([]),
+        listByContactIds: () => Promise.resolve([]),
         upsert: (record) => Promise.resolve(record)
       },
       projectDimensions: {
@@ -69,17 +72,20 @@ describe("defineStage1RepositoryBundle", () => {
       },
       identityResolutionQueue: {
         findById: () => Promise.resolve(null),
+        listOpenByContactId: () => Promise.resolve([]),
         listOpenByReasonCode: () => Promise.resolve([]),
         upsert: (record) => Promise.resolve(record)
       },
       routingReviewQueue: {
         findById: () => Promise.resolve(null),
+        listOpenByContactId: () => Promise.resolve([]),
         listOpenByReasonCode: () => Promise.resolve([]),
         upsert: (record) => Promise.resolve(record)
       },
       inboxProjection: {
         countAll: () => Promise.resolve(0),
         findByContactId: () => Promise.resolve(null),
+        listAllOrderedByRecency: () => Promise.resolve([]),
         upsert: (record) => Promise.resolve(record)
       },
       timelineProjection: {

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  AuditEvidenceRecord,
+  CanonicalEventRecord,
+  ContactRecord,
+  InboxProjectionRow,
+  SalesforceCommunicationDetailRecord,
+  SourceEvidenceRecord,
+  TimelineProjectionRow
+} from "@as-comms/contracts";
+
+import {
+  createStage1TimelinePresentationService,
+  defineStage1RepositoryBundle,
+  type Stage1RepositoryBundle
+} from "../src/index.js";
+
+function createRepositoryBundle(input: {
+  readonly canonicalEvents: readonly CanonicalEventRecord[];
+  readonly sourceEvidence: readonly SourceEvidenceRecord[];
+  readonly salesforceCommunicationDetails: readonly SalesforceCommunicationDetailRecord[];
+  readonly timelineRows: readonly TimelineProjectionRow[];
+}): Stage1RepositoryBundle {
+  const canonicalEventsById = new Map(
+    input.canonicalEvents.map((event) => [event.id, event])
+  );
+  const sourceEvidenceById = new Map(
+    input.sourceEvidence.map((evidence) => [evidence.id, evidence])
+  );
+  const salesforceCommunicationDetailsBySourceEvidenceId = new Map(
+    input.salesforceCommunicationDetails.map((detail) => [
+      detail.sourceEvidenceId,
+      detail
+    ])
+  );
+  const timelineRowsByCanonicalEventId = new Map(
+    input.timelineRows.map((row) => [row.canonicalEventId, row])
+  );
+
+  const contact: ContactRecord = {
+    id: "contact_1",
+    salesforceContactId: "003-stage1",
+    displayName: "Stage One Volunteer",
+    primaryEmail: "volunteer@example.org",
+    primaryPhone: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z"
+  };
+
+  return defineStage1RepositoryBundle({
+    sourceEvidence: {
+      append: (record) => Promise.resolve(record),
+      findById: (id) => Promise.resolve(sourceEvidenceById.get(id) ?? null),
+      findByIdempotencyKey: () => Promise.resolve(null),
+      countByProvider: () => Promise.resolve(0),
+      listByProviderRecord: () => Promise.resolve([])
+    },
+    canonicalEvents: {
+      findById: (id) => Promise.resolve(canonicalEventsById.get(id) ?? null),
+      findByIdempotencyKey: () => Promise.resolve(null),
+      countAll: () => Promise.resolve(input.canonicalEvents.length),
+      countByPrimaryProvider: () => Promise.resolve(0),
+      countDistinctInboxContacts: () => Promise.resolve(1),
+      listByIds: (ids) =>
+        Promise.resolve(
+          ids.flatMap((id) => {
+            const event = canonicalEventsById.get(id);
+            return event === undefined ? [] : [event];
+          })
+        ),
+      listByContactId: (contactId) =>
+        Promise.resolve(
+          input.canonicalEvents.filter((event) => event.contactId === contactId)
+        ),
+      upsert: (record) => Promise.resolve(record)
+    },
+    contacts: {
+      findById: () => Promise.resolve(contact),
+      findBySalesforceContactId: () => Promise.resolve(contact),
+      listAll: () => Promise.resolve([contact]),
+      listByIds: () => Promise.resolve([contact]),
+      upsert: (record) => Promise.resolve(record)
+    },
+    contactIdentities: {
+      listByContactId: () => Promise.resolve([]),
+      listByNormalizedValue: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record)
+    },
+    contactMemberships: {
+      listByContactId: () => Promise.resolve([]),
+      listByContactIds: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record)
+    },
+    projectDimensions: {
+      listByIds: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record)
+    },
+    expeditionDimensions: {
+      listByIds: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record)
+    },
+    gmailMessageDetails: {
+      listBySourceEvidenceIds: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record)
+    },
+    salesforceEventContext: {
+      listBySourceEvidenceIds: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record)
+    },
+    salesforceCommunicationDetails: {
+      listBySourceEvidenceIds: (sourceEvidenceIds) =>
+        Promise.resolve(
+          sourceEvidenceIds.flatMap((sourceEvidenceId) => {
+            const detail =
+              salesforceCommunicationDetailsBySourceEvidenceId.get(sourceEvidenceId);
+            return detail === undefined ? [] : [detail];
+          })
+        ),
+      upsert: (record) => Promise.resolve(record)
+    },
+    simpleTextingMessageDetails: {
+      listBySourceEvidenceIds: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record)
+    },
+    mailchimpCampaignActivityDetails: {
+      listBySourceEvidenceIds: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record)
+    },
+    manualNoteDetails: {
+      listBySourceEvidenceIds: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record)
+    },
+    identityResolutionQueue: {
+      findById: () => Promise.resolve(null),
+      listOpenByContactId: () => Promise.resolve([]),
+      listOpenByReasonCode: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record)
+    },
+    routingReviewQueue: {
+      findById: () => Promise.resolve(null),
+      listOpenByContactId: () => Promise.resolve([]),
+      listOpenByReasonCode: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record)
+    },
+    inboxProjection: {
+      countAll: () => Promise.resolve(0),
+      findByContactId: () => Promise.resolve(null),
+      listAllOrderedByRecency: () => Promise.resolve([]),
+      setNeedsFollowUp: () => Promise.resolve(null),
+      upsert: (record: InboxProjectionRow) => Promise.resolve(record)
+    },
+    timelineProjection: {
+      countAll: () => Promise.resolve(input.timelineRows.length),
+      findByCanonicalEventId: (canonicalEventId) =>
+        Promise.resolve(timelineRowsByCanonicalEventId.get(canonicalEventId) ?? null),
+      listByContactId: (contactId) =>
+        Promise.resolve(
+          input.timelineRows.filter((row) => row.contactId === contactId)
+        ),
+      upsert: (record) => Promise.resolve(record)
+    },
+    syncState: {
+      findById: () => Promise.resolve(null),
+      findLatest: () => Promise.resolve(null),
+      upsert: (record) => Promise.resolve(record)
+    },
+    auditEvidence: {
+      append: (record: AuditEvidenceRecord) => Promise.resolve(record),
+      listByEntity: () => Promise.resolve([])
+    }
+  });
+}
+
+function buildSourceEvidence(
+  id: string,
+  providerRecordId: string
+): SourceEvidenceRecord {
+  return {
+    id,
+    provider: "salesforce",
+    providerRecordType: "task_communication",
+    providerRecordId,
+    receivedAt: "2026-01-01T00:00:00.000Z",
+    occurredAt: "2026-01-01T00:00:00.000Z",
+    payloadRef: `payloads/salesforce/${providerRecordId}.json`,
+    idempotencyKey: `salesforce:${providerRecordId}`,
+    checksum: `checksum:${providerRecordId}`
+  };
+}
+
+function buildSalesforceOutboundEmailEvent(input: {
+  readonly id: string;
+  readonly sourceEvidenceId: string;
+  readonly occurredAt: string;
+  readonly messageKind: "one_to_one" | "auto" | null;
+  readonly subject: string;
+  readonly snippet: string;
+}): {
+  readonly canonicalEvent: CanonicalEventRecord;
+  readonly detail: SalesforceCommunicationDetailRecord;
+  readonly timelineRow: TimelineProjectionRow;
+} {
+  return {
+    canonicalEvent: {
+      id: input.id,
+      contactId: "contact_1",
+      eventType: "communication.email.outbound",
+      channel: "email",
+      occurredAt: input.occurredAt,
+      sourceEvidenceId: input.sourceEvidenceId,
+      idempotencyKey: `canonical:${input.id}`,
+      provenance: {
+        primaryProvider: "salesforce",
+        primarySourceEvidenceId: input.sourceEvidenceId,
+        supportingSourceEvidenceIds: [],
+        winnerReason: "single_source",
+        sourceRecordType: "task_communication",
+        sourceRecordId: input.id,
+        messageKind: input.messageKind,
+        campaignRef: null,
+        threadRef: null,
+        direction: "outbound",
+        notes: null
+      },
+      reviewState: "clear"
+    },
+    detail: {
+      sourceEvidenceId: input.sourceEvidenceId,
+      providerRecordId: input.id,
+      channel: "email",
+      // The detail table stores a concrete message kind even when canonical
+      // provenance remains null for the classification regression case.
+      messageKind: input.messageKind ?? "one_to_one",
+      subject: input.subject,
+      snippet: input.snippet,
+      sourceLabel: "Salesforce Logged Email"
+    },
+    timelineRow: {
+      id: `timeline:${input.id}`,
+      contactId: "contact_1",
+      canonicalEventId: input.id,
+      occurredAt: input.occurredAt,
+      sortKey: `${input.occurredAt}::${input.id}`,
+      eventType: "communication.email.outbound",
+      summary: input.subject,
+      channel: "email",
+      primaryProvider: "salesforce",
+      reviewState: "clear"
+    }
+  };
+}
+
+describe("Stage 1 timeline presenter", () => {
+  it("keeps Salesforce outbound email in the 1:1 family unless canon explicitly marks it auto", async () => {
+    const nullClassified = buildSalesforceOutboundEmailEvent({
+      id: "evt_salesforce_null",
+      sourceEvidenceId: "sev_salesforce_null",
+      occurredAt: "2026-01-01T00:00:00.000Z",
+      messageKind: null,
+      subject: "Logged follow-up",
+      snippet: "Logged follow-up body"
+    });
+    const explicitOneToOne = buildSalesforceOutboundEmailEvent({
+      id: "evt_salesforce_one_to_one",
+      sourceEvidenceId: "sev_salesforce_one_to_one",
+      occurredAt: "2026-01-01T00:01:00.000Z",
+      messageKind: "one_to_one",
+      subject: "Explicit one-to-one follow-up",
+      snippet: "Explicit one-to-one body"
+    });
+    const explicitAuto = buildSalesforceOutboundEmailEvent({
+      id: "evt_salesforce_auto",
+      sourceEvidenceId: "sev_salesforce_auto",
+      occurredAt: "2026-01-01T00:02:00.000Z",
+      messageKind: "auto",
+      subject: "Automation sent",
+      snippet: "Automation body"
+    });
+
+    const repositories = createRepositoryBundle({
+      canonicalEvents: [
+        nullClassified.canonicalEvent,
+        explicitOneToOne.canonicalEvent,
+        explicitAuto.canonicalEvent
+      ],
+      sourceEvidence: [
+        buildSourceEvidence("sev_salesforce_null", "salesforce-null"),
+        buildSourceEvidence("sev_salesforce_one_to_one", "salesforce-one-to-one"),
+        buildSourceEvidence("sev_salesforce_auto", "salesforce-auto")
+      ],
+      salesforceCommunicationDetails: [
+        nullClassified.detail,
+        explicitOneToOne.detail,
+        explicitAuto.detail
+      ],
+      timelineRows: [
+        nullClassified.timelineRow,
+        explicitOneToOne.timelineRow,
+        explicitAuto.timelineRow
+      ]
+    });
+    const presenter = createStage1TimelinePresentationService(repositories);
+
+    const items = await presenter.listTimelineItemsByContactId("contact_1");
+
+    expect(
+      items.map((item) => ({
+        canonicalEventId: item.canonicalEventId,
+        family: item.family
+      }))
+    ).toEqual([
+      {
+        canonicalEventId: "evt_salesforce_null",
+        family: "one_to_one_email"
+      },
+      {
+        canonicalEventId: "evt_salesforce_one_to_one",
+        family: "one_to_one_email"
+      },
+      {
+        canonicalEventId: "evt_salesforce_auto",
+        family: "auto_email"
+      }
+    ]);
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     trace: "on-first-retry"
   },
   webServer: {
-    command: `pnpm --dir apps/web exec next build && pnpm --dir apps/web exec next start --hostname 127.0.0.1 --port ${port}`,
+    command: `bash -lc 'set -a && source .env.local && set +a && pnpm --dir apps/web exec next build && pnpm --dir apps/web exec next start --hostname 127.0.0.1 --port ${port}'`,
     url: `http://127.0.0.1:${port}`,
     reuseExistingServer: !process.env.CI,
     timeout: 120000


### PR DESCRIPTION
Summary
- Wire the existing inbox shell to real Stage 1-backed list/detail reads
- Persist needsFollowUp server-side without changing bucket semantics
- Preserve locked inbox behavior:
  - one mixed contact list
  - unread from bucket
  - needsFollowUp separate from bucket
  - unresolved as overlay
  - default sort by lastInboundAt desc with lastActivityAt fallback

Included
- real selector/query wiring
- server-backed follow-up persistence
- minimal Stage 1 runtime/repository support
- inbox runtime/test updates
- handoff doc updates

Known follow-ups
- unstable_cache warnings on large inbox list payloads
- identity review detail still relies on selector-side matching
- reply sending and internal note creation remain staged for later
