### PR TITLE
Add resumable Mailchimp campaign checkpoints

### DIFF
--- a/apps/web/app/inbox/[contactId]/page.tsx
+++ b/apps/web/app/inbox/[contactId]/page.tsx
@@ -1,0 +1,17 @@
+import { notFound } from "next/navigation";
+
+import { InboxDetail } from "../_components/inbox-detail";
+import { getInboxDetail } from "../_lib/selectors";
+
+interface PageProps {
+  readonly params: Promise<{ readonly contactId: string }>;
+}
+
+export default async function InboxContactPage({ params }: PageProps) {
+  const { contactId } = await params;
+  const detail = await getInboxDetail(decodeURIComponent(contactId));
+  if (!detail) {
+    notFound();
+  }
+  return <InboxDetail detail={detail} />;
+}

--- a/apps/web/app/inbox/_components/inbox-client-provider.tsx
+++ b/apps/web/app/inbox/_components/inbox-client-provider.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode
+} from "react";
+
+/**
+ * Prototype-local client state shared across the Inbox list column and
+ * Detail workspace. These are intentionally ephemeral UI concerns only.
+ *
+ * Extended to cover every interactive state the UI needs:
+ *   - reminders
+ *   - search query + results
+ *   - composer status (idle → saving → saved / error → sending → sent / failed)
+ *   - AI draft lifecycle (idle → generating → inserted → edited / discarded)
+ *   - queue & timeline loading flags
+ */
+
+// ---------- Reminder ----------
+
+export interface Reminder {
+  readonly value: number;
+  readonly unit: "hours" | "days" | "weeks";
+  readonly firesAt: string;
+}
+
+// ---------- Composer status ----------
+
+export type ComposerStatus =
+  | "idle"
+  | "saving-draft"
+  | "draft-saved"
+  | "validation-error"
+  | "sending"
+  | "sent-success"
+  | "send-failure";
+
+export interface ComposerValidationError {
+  readonly field: "subject" | "body" | "recipient";
+  readonly message: string;
+}
+
+// ---------- AI draft lifecycle ----------
+
+export type AiDraftStatus =
+  | "idle"
+  | "generating"
+  | "inserted"
+  | "reprompting"
+  | "edited-after-generation"
+  | "discarded"
+  | "unavailable"
+  | "error";
+
+export interface AiDraftState {
+  readonly status: AiDraftStatus;
+  readonly prompt: string;
+  readonly generatedText: string;
+  readonly errorMessage: string | null;
+}
+
+const INITIAL_AI_DRAFT: AiDraftState = {
+  status: "idle",
+  prompt: "",
+  generatedText: "",
+  errorMessage: null
+};
+
+// ---------- Search ----------
+
+export interface SearchState {
+  readonly query: string;
+  readonly isActive: boolean;
+  readonly resultContactIds: readonly string[];
+}
+
+const INITIAL_SEARCH: SearchState = {
+  query: "",
+  isActive: false,
+  resultContactIds: []
+};
+
+// ---------- Context shape ----------
+
+interface InboxClientState {
+  // Reminders
+  readonly reminders: ReadonlyMap<string, Reminder>;
+  readonly setReminder: (contactId: string, reminder: Reminder) => void;
+  readonly clearReminder: (contactId: string) => void;
+
+  // Search
+  readonly search: SearchState;
+  readonly setSearchQuery: (query: string) => void;
+  readonly setSearchResults: (contactIds: readonly string[]) => void;
+  readonly clearSearch: () => void;
+
+  // Loading flags
+  readonly isQueueLoading: boolean;
+  readonly setQueueLoading: (loading: boolean) => void;
+  readonly isTimelineLoading: boolean;
+  readonly setTimelineLoading: (loading: boolean) => void;
+
+  // Composer status
+  readonly composerStatus: ComposerStatus;
+  readonly composerErrors: readonly ComposerValidationError[];
+  readonly setComposerStatus: (status: ComposerStatus) => void;
+  readonly setComposerErrors: (errors: readonly ComposerValidationError[]) => void;
+
+  // AI drafting
+  readonly aiDraft: AiDraftState;
+  readonly startAiGeneration: (prompt: string) => void;
+  readonly insertAiDraft: (text: string) => void;
+  readonly markAiDraftEdited: () => void;
+  readonly discardAiDraft: () => void;
+  readonly repromptAi: (prompt: string) => void;
+  readonly setAiUnavailable: () => void;
+  readonly setAiError: (message: string) => void;
+  readonly resetAiDraft: () => void;
+}
+
+const InboxClientContext = createContext<InboxClientState | null>(
+  null
+);
+
+export function InboxClientProvider({
+  children
+}: {
+  readonly children: ReactNode;
+}) {
+  // Reminders
+  const [reminders, setReminders] = useState<ReadonlyMap<string, Reminder>>(
+    () => new Map<string, Reminder>()
+  );
+
+  const setReminder = useCallback((contactId: string, reminder: Reminder) => {
+    setReminders((prev) => {
+      const next = new Map(prev);
+      next.set(contactId, reminder);
+      return next;
+    });
+  }, []);
+
+  const clearReminder = useCallback((contactId: string) => {
+    setReminders((prev) => {
+      if (!prev.has(contactId)) return prev;
+      const next = new Map(prev);
+      next.delete(contactId);
+      return next;
+    });
+  }, []);
+
+  // Search
+  const [search, setSearch] = useState(INITIAL_SEARCH);
+
+  const setSearchQuery = useCallback((query: string) => {
+    setSearch((prev) => ({
+      ...prev,
+      query,
+      isActive: query.length > 0
+    }));
+  }, []);
+
+  const setSearchResults = useCallback((contactIds: readonly string[]) => {
+    setSearch((prev) => ({
+      ...prev,
+      resultContactIds: contactIds
+    }));
+  }, []);
+
+  const clearSearch = useCallback(() => {
+    setSearch(INITIAL_SEARCH);
+  }, []);
+
+  // Loading flags
+  const [isQueueLoading, setQueueLoading] = useState(false);
+  const [isTimelineLoading, setTimelineLoading] = useState(false);
+
+  // Composer status
+  const [composerStatus, setComposerStatus] = useState<ComposerStatus>("idle");
+  const [composerErrors, setComposerErrors] = useState<
+    readonly ComposerValidationError[]
+  >([]);
+
+  // AI draft lifecycle
+  const [aiDraft, setAiDraft] = useState(INITIAL_AI_DRAFT);
+
+  const startAiGeneration = useCallback((prompt: string) => {
+    setAiDraft({
+      status: "generating",
+      prompt,
+      generatedText: "",
+      errorMessage: null
+    });
+  }, []);
+
+  const insertAiDraft = useCallback((text: string) => {
+    setAiDraft((prev) => ({
+      ...prev,
+      status: "inserted",
+      generatedText: text
+    }));
+  }, []);
+
+  const markAiDraftEdited = useCallback(() => {
+    setAiDraft((prev) => ({
+      ...prev,
+      status: "edited-after-generation"
+    }));
+  }, []);
+
+  const discardAiDraft = useCallback(() => {
+    setAiDraft((prev) => ({
+      ...prev,
+      status: "discarded",
+      generatedText: ""
+    }));
+  }, []);
+
+  const repromptAi = useCallback((prompt: string) => {
+    setAiDraft({
+      status: "reprompting",
+      prompt,
+      generatedText: "",
+      errorMessage: null
+    });
+  }, []);
+
+  const setAiUnavailable = useCallback(() => {
+    setAiDraft((prev) => ({
+      ...prev,
+      status: "unavailable",
+      errorMessage: "AI drafting is currently unavailable."
+    }));
+  }, []);
+
+  const setAiError = useCallback((message: string) => {
+    setAiDraft((prev) => ({
+      ...prev,
+      status: "error",
+      errorMessage: message
+    }));
+  }, []);
+
+  const resetAiDraft = useCallback(() => {
+    setAiDraft(INITIAL_AI_DRAFT);
+  }, []);
+
+  const value = useMemo<InboxClientState>(
+    () => ({
+      reminders,
+      setReminder,
+      clearReminder,
+      search,
+      setSearchQuery,
+      setSearchResults,
+      clearSearch,
+      isQueueLoading,
+      setQueueLoading,
+      isTimelineLoading,
+      setTimelineLoading,
+      composerStatus,
+      composerErrors,
+      setComposerStatus,
+      setComposerErrors,
+      aiDraft,
+      startAiGeneration,
+      insertAiDraft,
+      markAiDraftEdited,
+      discardAiDraft,
+      repromptAi,
+      setAiUnavailable,
+      setAiError,
+      resetAiDraft
+    }),
+    [
+      reminders,
+      setReminder,
+      clearReminder,
+      search,
+      setSearchQuery,
+      setSearchResults,
+      clearSearch,
+      isQueueLoading,
+      isTimelineLoading,
+      composerStatus,
+      composerErrors,
+      aiDraft,
+      startAiGeneration,
+      insertAiDraft,
+      markAiDraftEdited,
+      discardAiDraft,
+      repromptAi,
+      setAiUnavailable,
+      setAiError,
+      resetAiDraft
+    ]
+  );
+
+  return (
+    <InboxClientContext.Provider value={value}>
+      {children}
+    </InboxClientContext.Provider>
+  );
+}
+
+export function useInboxClient(): InboxClientState {
+  const value = useContext(InboxClientContext);
+  if (!value) {
+    throw new Error(
+      "useInboxClient must be used inside InboxClientProvider"
+    );
+  }
+  return value;
+}

--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -1,0 +1,571 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { useFormStatus } from "react-dom";
+
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+import {
+  clearInboxNeedsFollowUpAction,
+  markInboxNeedsFollowUpAction
+} from "../actions";
+import type { InboxDetailViewModel } from "../_lib/view-models";
+import {
+  useInboxClient,
+  type Reminder
+} from "./inbox-client-provider";
+import { SectionLabel } from "@/components/ui/section-label";
+import { LAYOUT, TEXT, TONE, TRANSITION, SPACING } from "@/app/_lib/design-tokens";
+import { InboxComposer } from "./inbox-composer";
+import {
+  InboxContactRail,
+  InboxProjectStatusBadge
+} from "./inbox-contact-rail";
+import { TimelineSkeleton } from "./inbox-loading";
+import { InboxTimeline } from "./inbox-timeline";
+import {
+  AlertTriangleIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+  ClockIcon,
+  CornerUpLeftIcon,
+  PanelRightOpenIcon,
+  XIcon
+} from "./icons";
+
+interface DetailProps {
+  readonly detail: InboxDetailViewModel;
+}
+
+type ReminderUnit = "hours" | "days" | "weeks";
+
+export function InboxDetail({ detail }: DetailProps) {
+  const { contact, timeline, smsEligible } = detail;
+  const timelineRef = useRef<HTMLDivElement>(null);
+  const { reminders, setReminder, clearReminder, isTimelineLoading } =
+    useInboxClient();
+
+  const [railOpen, setRailOpen] = useState(false);
+  const [reminderOpen, setReminderOpen] = useState(false);
+  const [reminderValue, setReminderValue] = useState("");
+  const [reminderUnit, setReminderUnit] = useState<ReminderUnit>("hours");
+
+  const activeProject = contact.activeProjects[0] ?? null;
+  const firstName = contact.displayName.split(" ")[0] ?? contact.displayName;
+
+  const isFollowUp = detail.needsFollowUp;
+  const existingReminder = reminders.get(contact.contactId) ?? null;
+
+  const handleSetReminder = () => {
+    const numeric = Number(reminderValue);
+    if (!Number.isFinite(numeric) || numeric <= 0) return;
+    setReminder(contact.contactId, buildReminder(numeric, reminderUnit));
+    setReminderValue("");
+    setReminderOpen(false);
+  };
+
+  const handleClearReminder = () => {
+    clearReminder(contact.contactId);
+    setReminderOpen(false);
+  };
+
+  return (
+    <div className="flex min-h-0 flex-1">
+      <section className="flex min-w-0 flex-1 flex-col border-r border-slate-200 bg-white">
+        {/* Detail header */}
+        <header className={`flex ${LAYOUT.headerHeight} items-center justify-between gap-4 border-b border-slate-200 px-6`}>
+          <div className="flex min-w-0 items-center gap-4">
+            <h1 className={`truncate ${TEXT.headingLg}`}>
+              {contact.displayName}
+            </h1>
+            <div className="hidden h-5 w-px bg-slate-200 sm:block" />
+            <div className="hidden min-w-0 flex-1 sm:block">
+              {activeProject ? (
+                <div className="flex min-w-0 items-center gap-2 text-xs">
+                  <span className="min-w-0 truncate font-medium text-slate-700">
+                    {activeProject.projectName}{" "}
+                    {activeProject.year.toString()}
+                  </span>
+                  <InboxProjectStatusBadge status={activeProject.status} />
+                </div>
+              ) : (
+                <span className="text-xs text-slate-400">
+                  No active project
+                </span>
+              )}
+            </div>
+            <div className="hidden items-center gap-1.5 sm:flex">
+              {detail.bucket === "new" && (
+                <span className="inline-flex items-center rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-[11px] font-medium text-sky-800">
+                  Unread
+                </span>
+              )}
+              {isFollowUp && (
+                <span className="inline-flex items-center rounded-full border border-rose-200 bg-rose-50 px-2 py-0.5 text-[11px] font-medium text-rose-800">
+                  Needs Follow-Up
+                </span>
+              )}
+              {contact.hasUnresolved && (
+                <span className="inline-flex items-center rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-800">
+                  Unresolved
+                </span>
+              )}
+            </div>
+          </div>
+
+          <div className="flex shrink-0 items-center gap-2">
+            {/* Needs Follow Up toggle — off / on */}
+            <FollowUpToggleForm
+              contactId={contact.contactId}
+              needsFollowUp={isFollowUp}
+            />
+
+            {/* Reminder popover */}
+            <Popover open={reminderOpen} onOpenChange={setReminderOpen}>
+              <PopoverTrigger asChild>
+                {existingReminder ? (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="gap-1.5 border-sky-300 bg-sky-50 text-sky-800 hover:bg-sky-100 hover:text-sky-800"
+                  >
+                    <ClockIcon className="h-3.5 w-3.5" />
+                    Reminder · {formatShortReminder(existingReminder)}
+                  </Button>
+                ) : (
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    className="h-8 w-8"
+                    aria-label="Set a reminder"
+                  >
+                    <ClockIcon className="h-4 w-4" />
+                  </Button>
+                )}
+              </PopoverTrigger>
+              <PopoverContent align="end" className="w-72">
+                <ReminderPopoverBody
+                  existing={existingReminder}
+                  value={reminderValue}
+                  unit={reminderUnit}
+                  onChangeValue={setReminderValue}
+                  onChangeUnit={setReminderUnit}
+                  onClose={() => {
+                    setReminderOpen(false);
+                  }}
+                  onSet={handleSetReminder}
+                  onClear={handleClearReminder}
+                />
+              </PopoverContent>
+            </Popover>
+
+            {!railOpen ? (
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-8 w-8"
+                aria-label="Expand volunteer details"
+                aria-expanded={false}
+                aria-controls="inbox-contact-rail"
+                onClick={() => {
+                  setRailOpen(true);
+                }}
+              >
+                <PanelRightOpenIcon className="h-4 w-4" />
+              </Button>
+            ) : null}
+          </div>
+        </header>
+
+        {/* Unresolved banner */}
+        {contact.hasUnresolved ? <UnresolvedBanner /> : null}
+
+        {/* Timeline area */}
+        <div
+          ref={timelineRef}
+          className={`min-h-0 flex-1 overflow-y-auto ${TONE.slate.subtle} ${SPACING.container}`}
+        >
+          {isTimelineLoading ? (
+            <TimelineSkeleton />
+          ) : (
+            <InboxTimeline
+              entries={timeline}
+              volunteerFirstName={firstName}
+            />
+          )}
+        </div>
+
+        <div className="shrink-0">
+          <InboxComposer
+            contactDisplayName={contact.displayName}
+            smsEligible={smsEligible}
+            onOpenChange={(open) => {
+              if (open && timelineRef.current) {
+                // Scroll timeline to bottom when composer opens
+                // so the latest messages stay visible
+                setTimeout(() => {
+                  const el = timelineRef.current as unknown as
+                    | { scrollTop: number; scrollHeight: number }
+                    | null;
+                  if (el) el.scrollTop = el.scrollHeight;
+                }, 50);
+              }
+            }}
+          />
+        </div>
+      </section>
+
+      {/* Animated contact rail — width transitions from 0 → 20rem */}
+      <div
+        className={cn(
+          `overflow-hidden border-l ${TRANSITION.layout} ${TRANSITION.reduceMotion}`,
+          railOpen
+            ? `${LAYOUT.railWidth} border-slate-200 opacity-100`
+            : "w-0 border-transparent opacity-0"
+        )}
+      >
+        <div className={LAYOUT.railWidth}>
+          <InboxContactRail
+            contact={contact}
+            onClose={() => {
+              setRailOpen(false);
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function FollowUpToggleForm({
+  contactId,
+  needsFollowUp
+}: {
+  readonly contactId: string;
+  readonly needsFollowUp: boolean;
+}) {
+  const action = async (formData: FormData) => {
+    if (needsFollowUp) {
+      await clearInboxNeedsFollowUpAction(formData);
+      return;
+    }
+
+    await markInboxNeedsFollowUpAction(formData);
+  };
+
+  return (
+    <form action={action}>
+      <input type="hidden" name="contactId" value={contactId} />
+      <FollowUpToggleButton needsFollowUp={needsFollowUp} />
+    </form>
+  );
+}
+
+function FollowUpToggleButton({
+  needsFollowUp
+}: {
+  readonly needsFollowUp: boolean;
+}) {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button
+      type="submit"
+      variant="outline"
+      size="sm"
+      disabled={pending}
+      aria-pressed={needsFollowUp}
+      className={cn(
+        "gap-1.5",
+        needsFollowUp &&
+          "border-rose-300 bg-rose-50 text-rose-800 hover:bg-rose-100 hover:text-rose-800"
+      )}
+    >
+      <CornerUpLeftIcon className="h-3.5 w-3.5" />
+      Needs Follow-Up
+    </Button>
+  );
+}
+
+// ---------- Unresolved banner ----------
+
+function UnresolvedBanner() {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className={`border-b border-amber-200 ${TONE.amber.subtle}`}>
+      <button
+        type="button"
+        onClick={() => {
+          setExpanded((e) => !e);
+        }}
+        className={`flex w-full items-center gap-2 px-6 py-2.5 text-left ${TRANSITION.fast} hover:bg-amber-100/60`}
+        aria-expanded={expanded}
+      >
+        <AlertTriangleIcon className="h-4 w-4 shrink-0 text-amber-600" />
+        <span className="flex-1 text-sm font-medium text-amber-900">
+          Unresolved items need attention
+        </span>
+        <span className="text-xs text-amber-600">
+          {expanded ? "Hide" : "Details"}
+        </span>
+      </button>
+
+      {expanded ? (
+        <div className="border-t border-amber-200 px-6 py-3">
+          <p className="text-xs leading-5 text-amber-800">
+            This contact has open items that require action before the
+            conversation can be considered resolved. Review the timeline
+            for pending requests and routing notices.
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// ---------- Reminder popover body ----------
+
+interface ReminderPopoverBodyProps {
+  readonly existing: Reminder | null;
+  readonly value: string;
+  readonly unit: ReminderUnit;
+  readonly onChangeValue: (value: string) => void;
+  readonly onChangeUnit: (unit: ReminderUnit) => void;
+  readonly onClose: () => void;
+  readonly onSet: () => void;
+  readonly onClear: () => void;
+}
+
+const REMINDER_UNITS: readonly ReminderUnit[] = ["hours", "days", "weeks"];
+
+function ReminderPopoverBody({
+  existing,
+  value,
+  unit,
+  onChangeValue,
+  onChangeUnit,
+  onClose,
+  onSet,
+  onClear
+}: ReminderPopoverBodyProps) {
+  const numeric = Number(value);
+  const canSet = value.length > 0 && Number.isFinite(numeric) && numeric > 0;
+  const preview = canSet ? previewForDelta(numeric, unit) : null;
+
+  if (existing) {
+    return (
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <SectionLabel as="p">
+            Reminder set
+          </SectionLabel>
+          <p className="mt-1 text-sm font-medium text-slate-900">
+            {formatLongReminder(existing)}
+          </p>
+          <p className="mt-0.5 text-[11px] text-slate-500">
+            In {formatShortReminder(existing)}
+          </p>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 shrink-0 text-slate-400 hover:text-slate-700"
+          aria-label="Cancel reminder"
+          onClick={onClear}
+        >
+          <XIcon className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <SectionLabel as="p">
+        Remind me in
+      </SectionLabel>
+      <div className="mt-2 flex items-center gap-2">
+        {/* Number stepper */}
+        <div className="flex h-9 w-16 items-center overflow-hidden rounded-md border border-slate-200 shadow-sm">
+          <span
+            className="flex-1 select-none text-center text-sm font-semibold tabular-nums text-slate-900"
+            aria-live="polite"
+          >
+            {value || "0"}
+          </span>
+          <div className="flex flex-col border-l border-slate-200">
+            <button
+              type="button"
+              aria-label="Increase"
+              onClick={() => {
+                const n = Math.min(99, (Number(value) || 0) + 1);
+                onChangeValue(n.toString());
+              }}
+              className="flex h-[18px] w-6 items-center justify-center text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900"
+            >
+              <ChevronUpIcon className="h-3.5 w-3.5" />
+            </button>
+            <button
+              type="button"
+              aria-label="Decrease"
+              onClick={() => {
+                const n = Math.max(0, (Number(value) || 0) - 1);
+                onChangeValue(n.toString());
+              }}
+              className="flex h-[18px] w-6 items-center justify-center border-t border-slate-200 text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900"
+            >
+              <ChevronDownIcon className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+        <div className="flex flex-1 items-center gap-1 rounded-lg bg-slate-100 p-0.5 text-[11px] font-medium">
+          {REMINDER_UNITS.map((option) => {
+            const isActive = option === unit;
+            return (
+              <button
+                key={option}
+                type="button"
+                aria-pressed={isActive}
+                onClick={() => {
+                  onChangeUnit(option);
+                }}
+                className={cn(
+                  "flex-1 rounded-md px-1.5 py-1 capitalize transition-colors duration-150",
+                  isActive
+                    ? "bg-white text-slate-900 shadow-sm"
+                    : "text-slate-500 hover:text-slate-900"
+                )}
+              >
+                {option}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      <p
+        className={cn(
+          "mt-2 min-h-4 text-[11px]",
+          preview ? "text-slate-500" : "text-transparent"
+        )}
+        aria-live="polite"
+      >
+        {preview ?? "—"}
+      </p>
+      <div className="mt-3 flex items-center justify-end gap-2">
+        <Button variant="ghost" size="sm" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button size="sm" disabled={!canSet} onClick={onSet}>
+          Set reminder
+        </Button>
+      </div>
+    </>
+  );
+}
+
+// ---------- Reminder helpers ----------
+
+function buildReminder(value: number, unit: ReminderUnit): Reminder {
+  const ms = value * millisPerUnit(unit);
+  const firesAt = new Date(Date.now() + ms).toISOString();
+  return { value, unit, firesAt };
+}
+
+function millisPerUnit(unit: ReminderUnit): number {
+  switch (unit) {
+    case "hours":
+      return 60 * 60 * 1000;
+    case "days":
+      return 24 * 60 * 60 * 1000;
+    case "weeks":
+      return 7 * 24 * 60 * 60 * 1000;
+  }
+}
+
+function previewForDelta(value: number, unit: ReminderUnit): string {
+  const ms = value * millisPerUnit(unit);
+  const target = new Date(Date.now() + ms);
+  return formatAbsolute(target);
+}
+
+function formatShortReminder(reminder: Reminder): string {
+  const unitLabel =
+    reminder.value === 1 ? reminder.unit.slice(0, -1) : reminder.unit;
+  return `${reminder.value.toString()} ${unitLabel}`;
+}
+
+function formatLongReminder(reminder: Reminder): string {
+  return formatAbsolute(new Date(reminder.firesAt));
+}
+
+function formatAbsolute(target: Date): string {
+  const now = new Date();
+  const startOfToday = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate()
+  ).getTime();
+  const startOfTarget = new Date(
+    target.getFullYear(),
+    target.getMonth(),
+    target.getDate()
+  ).getTime();
+  const dayDelta = Math.round(
+    (startOfTarget - startOfToday) / (24 * 60 * 60 * 1000)
+  );
+
+  const time = formatTime(target);
+
+  if (dayDelta === 0) return `Today at ${time}`;
+  if (dayDelta === 1) return `Tomorrow at ${time}`;
+  if (dayDelta > 1 && dayDelta < 7) {
+    return `${weekdayName(target.getDay())} at ${time}`;
+  }
+  return `${monthName(target.getMonth())} ${target.getDate().toString()} at ${time}`;
+}
+
+function formatTime(target: Date): string {
+  const hours24 = target.getHours();
+  const minutes = target.getMinutes();
+  const ampm = hours24 >= 12 ? "pm" : "am";
+  const hours12 = hours24 % 12 === 0 ? 12 : hours24 % 12;
+  if (minutes === 0) return `${hours12.toString()} ${ampm}`;
+  const padded = minutes < 10 ? `0${minutes.toString()}` : minutes.toString();
+  return `${hours12.toString()}:${padded} ${ampm}`;
+}
+
+function weekdayName(day: number): string {
+  return [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday"
+  ][day] ?? "";
+}
+
+function monthName(month: number): string {
+  return [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec"
+  ][month] ?? "";
+}

--- a/apps/web/app/inbox/_components/inbox-list.tsx
+++ b/apps/web/app/inbox/_components/inbox-list.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useMemo, useState } from "react";
+
+import type {
+  InboxFilterId,
+  InboxFilterViewModel,
+  InboxListItemViewModel
+} from "../_lib/view-models";
+import { EmptyState } from "@/components/ui/empty-state";
+
+import { useInboxClient } from "./inbox-client-provider";
+import { FOCUS_RING, LAYOUT, RADIUS, SHADOW, TEXT, TRANSITION } from "@/app/_lib/design-tokens";
+import {
+  InboxIcon,
+  SearchIcon,
+  SearchXIcon,
+  XIcon
+} from "./icons";
+import { QueueLoadingSkeleton } from "./inbox-loading";
+import { InboxRow } from "./inbox-row";
+
+interface ListColumnProps {
+  readonly items: readonly InboxListItemViewModel[];
+  readonly filters: readonly InboxFilterViewModel[];
+  readonly initialFilterId?: InboxFilterId;
+}
+
+export function InboxList({
+  items,
+  filters,
+  initialFilterId = "all"
+}: ListColumnProps) {
+  const pathname = usePathname();
+  const activeContactId = extractContactId(pathname);
+  const { search, setSearchQuery, clearSearch, isQueueLoading } = useInboxClient();
+
+  const [activeFilter, setActiveFilter] = useState<InboxFilterId>(initialFilterId);
+  const filterLabels = useMemo(
+    () =>
+      new Map(filters.map((filter) => [filter.id, filter.label] as const)),
+    [filters]
+  );
+
+  // Compute filter counts from the server-backed projection state.
+  const filterCounts = useMemo(() => {
+    let unread = 0;
+    let followUpCount = 0;
+    let unresolved = 0;
+    for (const item of items) {
+      if (item.bucket === "new") unread++;
+      if (item.needsFollowUp) {
+        followUpCount++;
+      }
+      if (item.hasUnresolved) unresolved++;
+    }
+    return {
+      all: items.length,
+      unread,
+      "follow-up": followUpCount,
+      unresolved
+    };
+  }, [items]);
+
+  // Apply filters: active filter -> search
+  const filteredItems = useMemo(() => {
+    let result = items.filter((item) => matchesActiveFilter(item, activeFilter));
+
+    // Search filter
+    if (search.isActive && search.resultContactIds.length > 0) {
+      const ids = new Set(search.resultContactIds);
+      result = result.filter((item) => ids.has(item.contactId));
+    }
+
+    return result;
+  }, [items, activeFilter, search]);
+
+  // For local search simulation: filter by query string matching
+  const searchFilteredItems = useMemo(() => {
+    if (!search.isActive || search.query.length === 0) return filteredItems;
+    const q = search.query.toLowerCase();
+    return filteredItems.filter(
+      (item) =>
+        item.displayName.toLowerCase().includes(q) ||
+        item.latestSubject.toLowerCase().includes(q) ||
+        item.snippet.toLowerCase().includes(q) ||
+        (item.projectLabel?.toLowerCase().includes(q) ?? false)
+    );
+  }, [filteredItems, search]);
+
+  const displayItems = search.isActive ? searchFilteredItems : filteredItems;
+
+  const filterIds: readonly InboxFilterId[] = ["all", "unread", "follow-up", "unresolved"];
+
+  return (
+    <section className={`relative flex ${LAYOUT.listWidth} shrink-0 flex-col overflow-hidden border-r border-slate-200 bg-white`}>
+      <div className="sticky top-0 z-10 bg-white/95 backdrop-blur">
+        {/* Header */}
+        <div className={`flex ${LAYOUT.headerHeight} items-center gap-2 border-b border-slate-200 px-5`}>
+          <h1 className={`min-w-0 flex-1 truncate ${TEXT.headingLg}`}>
+            Inbox
+          </h1>
+        </div>
+
+        {/* Search bar */}
+        <div className="px-5 pb-3 pt-3">
+          <label className={`flex items-center gap-2 ${RADIUS.md} border border-slate-200 bg-white px-3 py-1.5 text-sm ${SHADOW.sm} ${TRANSITION.fast} focus-within:border-slate-400 focus-within:ring-1 focus-within:ring-slate-300`}>
+            <SearchIcon className="h-4 w-4 text-slate-400" />
+            <input
+              type="text"
+              placeholder="Search people, subjects, projects"
+              value={search.query}
+              onChange={(e) => {
+                const target = e.currentTarget as unknown as {
+                  readonly value: string;
+                };
+                setSearchQuery(target.value);
+              }}
+              className="flex-1 bg-transparent text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none"
+            />
+            {search.isActive ? (
+              <button
+                type="button"
+                aria-label="Clear search"
+                onClick={clearSearch}
+                className="rounded p-0.5 text-slate-400 hover:text-slate-700"
+              >
+                <XIcon className="h-3.5 w-3.5" />
+              </button>
+            ) : null}
+          </label>
+        </div>
+
+        {/* Inline filter chips */}
+        <div className="flex flex-wrap gap-1.5 px-5 pb-3">
+          {filterIds.map((id) => {
+            const isActive = activeFilter === id;
+            return (
+              <button
+                key={id}
+                type="button"
+                aria-pressed={isActive}
+                onClick={() => {
+                  setActiveFilter(id);
+                }}
+                className={`rounded-full px-2.5 py-1 text-xs font-medium ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion} ${
+                  isActive
+                    ? "bg-slate-900 text-white"
+                    : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                }`}
+              >
+                {filterLabels.get(id) ?? id}{" "}
+                <span className={isActive ? "text-slate-300" : "text-slate-400"}>
+                  {filterCounts[id]}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Search active indicator */}
+        {search.isActive ? (
+          <div className="border-t border-slate-100 px-5 py-2">
+            <p className="text-xs text-slate-500">
+              {searchFilteredItems.length === 0 ? (
+                <span className="text-slate-400">
+                  No results for &ldquo;{search.query}&rdquo;
+                </span>
+              ) : (
+                <>
+                  <span className="font-medium text-slate-700">
+                    {searchFilteredItems.length}
+                  </span>{" "}
+                  {searchFilteredItems.length === 1 ? "result" : "results"} for
+                  &ldquo;{search.query}&rdquo;
+                </>
+              )}
+            </p>
+          </div>
+        ) : null}
+      </div>
+
+      {/* List body */}
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {isQueueLoading ? (
+          <QueueLoadingSkeleton />
+        ) : search.isActive && searchFilteredItems.length === 0 ? (
+          <SearchEmptyState query={search.query} />
+        ) : displayItems.length === 0 ? (
+          <QueueEmptyState />
+        ) : (
+          <ul className="divide-y divide-slate-100">
+            {displayItems.map((item) => (
+              <InboxRow
+                key={item.contactId}
+                item={item}
+                isActive={item.contactId === activeContactId}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}
+
+// ---------- Empty states ----------
+
+function QueueEmptyState() {
+  return (
+    <EmptyState
+      icon={<InboxIcon className="h-6 w-6" />}
+      title="All caught up"
+      description="No conversations match the current filter."
+    />
+  );
+}
+
+function SearchEmptyState({ query }: { readonly query: string }) {
+  return (
+    <EmptyState
+      icon={<SearchXIcon className="h-6 w-6" />}
+      title="No results"
+      description={<>Nothing matches &ldquo;{query}&rdquo;. Try a different search.</>}
+    />
+  );
+}
+
+// ---------- Helpers ----------
+
+function extractContactId(pathname: string | null): string | null {
+  if (!pathname) return null;
+  const match = /^\/inbox\/([^/]+)/.exec(pathname);
+  if (!match) return null;
+
+  try {
+    return decodeURIComponent(match[1] ?? "");
+  } catch {
+    return match[1] ?? null;
+  }
+}
+
+function matchesActiveFilter(
+  item: InboxListItemViewModel,
+  activeFilter: InboxFilterId
+): boolean {
+  switch (activeFilter) {
+    case "all":
+      return true;
+    case "unread":
+      return item.bucket === "new";
+    case "follow-up":
+      return item.needsFollowUp;
+    case "unresolved":
+      return item.hasUnresolved;
+  }
+}

--- a/apps/web/app/inbox/_components/inbox-row.tsx
+++ b/apps/web/app/inbox/_components/inbox-row.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import Link from "next/link";
+
+import type { InboxListItemViewModel } from "../_lib/view-models";
+import { InboxAvatar } from "./inbox-avatar";
+import { MailIcon, PhoneIcon } from "./icons";
+import { FOCUS_RING, SPACING, TEXT, TRANSITION } from "@/app/_lib/design-tokens";
+
+interface RowProps {
+  readonly item: InboxListItemViewModel;
+  readonly isActive: boolean;
+}
+
+/**
+ * List row for a contact. The left accent bar is sky when the row has
+ * bucket === "new" and rose when needsFollowUp is set. If both apply,
+ * sky wins. Stacking badges after the project label show follow-up
+ * (rose) and review/unresolved (amber) state at a glance.
+ */
+export function InboxRow({ item, isActive }: RowProps) {
+  const isUnread = item.bucket === "new";
+  const ChannelIcon = item.latestChannel === "email" ? MailIcon : PhoneIcon;
+
+  const accentClass =
+    item.bucket === "new"
+      ? "bg-sky-500"
+      : item.needsFollowUp
+        ? "bg-rose-500"
+        : null;
+
+  const showBadges =
+    Boolean(item.projectLabel) ||
+    item.needsFollowUp ||
+    item.hasUnresolved ||
+    item.unreadCount > 0;
+
+  return (
+    <li>
+      <Link
+        href={`/inbox/${encodeURIComponent(item.contactId)}`}
+        aria-current={isActive ? "page" : undefined}
+        className={`relative flex gap-3 border-b border-slate-100 ${SPACING.listItem} ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion} ${
+          isActive
+            ? "bg-sky-50/60 ring-1 ring-inset ring-sky-200"
+            : "hover:bg-slate-50/80"
+        }`}
+      >
+        {accentClass ? (
+          <span
+            aria-hidden="true"
+            className={`absolute left-0 top-0 h-full w-1 ${accentClass}`}
+          />
+        ) : null}
+
+        <InboxAvatar
+          initials={item.initials}
+          tone={item.avatarTone}
+          size="md"
+        />
+
+        <div className="min-w-0 flex-1">
+          <div className="flex items-baseline justify-between gap-2">
+            <p
+              className={`truncate text-sm ${
+                isUnread ? "font-semibold text-slate-900" : "text-slate-800"
+              }`}
+            >
+              {item.displayName}
+            </p>
+            <span
+              className={`shrink-0 text-[11px] tabular-nums ${
+                isUnread ? "font-semibold text-sky-700" : "text-slate-500"
+              }`}
+            >
+              {item.lastActivityLabel}
+            </span>
+          </div>
+
+          <div className="mt-0.5 flex items-center gap-1.5">
+            <ChannelIcon
+              className={`h-3 w-3 shrink-0 ${
+                isUnread ? "text-sky-600" : "text-slate-400"
+              }`}
+              aria-label={
+                item.latestChannel === "email" ? "Email" : "SMS"
+              }
+            />
+            <p
+              className={`truncate text-[13px] ${
+                isUnread ? "font-medium text-slate-800" : "text-slate-600"
+              }`}
+            >
+              {item.latestSubject}
+            </p>
+          </div>
+
+          <p className={`mt-0.5 line-clamp-1 ${TEXT.caption}`}>
+            {item.snippet}
+          </p>
+
+          {showBadges ? (
+            <div className="mt-1.5 flex items-center gap-1.5">
+              {item.projectLabel ? (
+                <span className="inline-flex items-center rounded-md bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium text-slate-600">
+                  {item.projectLabel}
+                </span>
+              ) : null}
+              {item.needsFollowUp ? (
+                <span className="inline-flex items-center rounded-md bg-rose-100 px-1.5 py-0.5 text-[10px] font-medium text-rose-700">
+                  Follow-up
+                </span>
+              ) : null}
+              {item.hasUnresolved ? (
+                <span className="inline-flex items-center rounded-md bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700">
+                  Review
+                </span>
+              ) : null}
+              {item.unreadCount > 0 ? (
+                <span className="ml-auto inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-sky-600 px-1 text-[10px] font-semibold text-white tabular-nums">
+                  {item.unreadCount}
+                </span>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </Link>
+    </li>
+  );
+}

--- a/apps/web/app/inbox/_components/inbox-shell.tsx
+++ b/apps/web/app/inbox/_components/inbox-shell.tsx
@@ -1,0 +1,51 @@
+import type { ReactNode } from "react";
+
+import type {
+  InboxFilterId,
+  InboxFilterViewModel,
+  InboxListItemViewModel
+} from "../_lib/view-models";
+import { InboxClientProvider } from "./inbox-client-provider";
+import { InboxIconRail } from "./inbox-icon-rail";
+import { InboxList } from "./inbox-list";
+
+interface ShellProps {
+  readonly filters: readonly InboxFilterViewModel[];
+  readonly items: readonly InboxListItemViewModel[];
+  readonly initialFilterId: InboxFilterId;
+  readonly children: ReactNode;
+}
+
+/**
+ * Server shell: renders the persistent chrome once for every `/inbox` route.
+ * The {@link InboxClientProvider} is the client boundary that holds
+ * ephemeral UI state shared across the list column and the detail workspace:
+ * reminders, search state, loading indicators, and composer draft status.
+ *
+ * Canonical inbox row state remains server-owned and flows through the
+ * server selectors for both the list shell and the selected-contact detail.
+ */
+export function InboxShell({
+  filters,
+  items,
+  initialFilterId,
+  children
+}: ShellProps) {
+  return (
+    <div className="flex h-screen w-screen overflow-hidden bg-slate-100 text-slate-900 antialiased">
+      <InboxClientProvider>
+        <InboxIconRail />
+
+        <InboxList
+          items={items}
+          filters={filters}
+          initialFilterId={initialFilterId}
+        />
+
+        <main className="flex min-w-0 flex-1 flex-col overflow-hidden">
+          {children}
+        </main>
+      </InboxClientProvider>
+    </div>
+  );
+}

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -1,0 +1,756 @@
+import { unstable_cache } from "next/cache";
+
+import type {
+  CanonicalEventRecord,
+  ContactMembershipRecord,
+  ContactRecord,
+  GmailMessageDetailRecord,
+  InboxDrivingEventType,
+  InboxProjectionRow,
+  TimelineProjectionRow
+} from "@as-comms/contracts";
+
+import { getStage1WebRuntime } from "../../../src/server/stage1-runtime";
+
+import { INBOX_FILTERS } from "./filters";
+import type {
+  InboxAvatarTone,
+  InboxBucket,
+  InboxChannel,
+  InboxContactSummaryViewModel,
+  InboxDetailViewModel,
+  InboxFilterId,
+  InboxFilterViewModel,
+  InboxListItemViewModel,
+  InboxListViewModel,
+  InboxProjectMembershipViewModel,
+  InboxProjectStatus,
+  InboxRecentActivityViewModel,
+  InboxTimelineEntryKind,
+  InboxTimelineEntryViewModel,
+  InboxVolunteerStage
+} from "./view-models";
+
+interface InboxListCacheRow {
+  readonly contact: ContactRecord;
+  readonly inboxProjection: InboxProjectionRow;
+  readonly memberships: readonly ContactMembershipRecord[];
+  readonly latestSubject: string | null;
+}
+
+interface InboxListCacheData {
+  readonly rows: readonly InboxListCacheRow[];
+  readonly projectNameById: Readonly<Record<string, string>>;
+}
+
+interface InboxDetailCacheData {
+  readonly contact: ContactRecord;
+  readonly inboxProjection: InboxProjectionRow;
+  readonly memberships: readonly ContactMembershipRecord[];
+  readonly timelineRows: readonly TimelineProjectionRow[];
+  readonly canonicalEvents: readonly CanonicalEventRecord[];
+  readonly gmailDetails: readonly GmailMessageDetailRecord[];
+  readonly projectNameById: Readonly<Record<string, string>>;
+}
+
+const AVATAR_TONES: readonly InboxAvatarTone[] = [
+  "indigo",
+  "emerald",
+  "amber",
+  "rose",
+  "sky",
+  "violet",
+  "teal",
+  "slate"
+];
+
+/**
+ * Default list sort: last inbound message first.
+ * Toggling follow-up does NOT change row ordering.
+ */
+export const compareInboxRecency = (
+  a: InboxListItemViewModel,
+  b: InboxListItemViewModel
+): number => {
+  const aSortAt = a.lastInboundAt ?? a.lastActivityAt;
+  const bSortAt = b.lastInboundAt ?? b.lastActivityAt;
+
+  if (aSortAt !== bSortAt) {
+    return aSortAt < bSortAt ? 1 : -1;
+  }
+
+  if (a.lastActivityAt !== b.lastActivityAt) {
+    return a.lastActivityAt < b.lastActivityAt ? 1 : -1;
+  }
+
+  return a.contactId.localeCompare(b.contactId);
+};
+
+function uniqueStrings(values: readonly (string | null | undefined)[]): string[] {
+  return Array.from(
+    new Set(
+      values.filter((value): value is string => typeof value === "string")
+    )
+  );
+}
+
+function toInitials(displayName: string): string {
+  const parts = displayName
+    .trim()
+    .split(/\s+/)
+    .filter((part) => part.length > 0)
+    .slice(0, 2);
+
+  if (parts.length === 0) {
+    return "??";
+  }
+
+  return parts
+    .map((part) => part.charAt(0).toUpperCase())
+    .join("");
+}
+
+function hashString(value: string): number {
+  let hash = 0;
+
+  for (const character of value) {
+    hash = (hash * 31 + character.charCodeAt(0)) >>> 0;
+  }
+
+  return hash;
+}
+
+function avatarToneForContact(contactId: string): InboxAvatarTone {
+  return AVATAR_TONES[hashString(contactId) % AVATAR_TONES.length] ?? "slate";
+}
+
+function mapBucket(bucket: InboxProjectionRow["bucket"]): InboxBucket {
+  return bucket === "New" ? "new" : "opened";
+}
+
+function mapChannel(eventType: InboxDrivingEventType): InboxChannel {
+  return eventType.includes(".sms.") ? "sms" : "email";
+}
+
+function normalizeMembershipStatus(status: string | null): string | null {
+  if (status === null) {
+    return null;
+  }
+
+  const normalized = status.trim().toLowerCase().replace(/[_\s]+/g, "-");
+  return normalized.length > 0 ? normalized : null;
+}
+
+function membershipSortRank(membership: ContactMembershipRecord): number {
+  switch (normalizeMembershipStatus(membership.status)) {
+    case "lead":
+      return 0;
+    case "applied":
+    case "applicant":
+      return 1;
+    case "in-training":
+    case "training":
+      return 2;
+    case "trip-planning":
+      return 3;
+    case "in-field":
+    case "active":
+      return 4;
+    case "successful":
+    case "completed":
+      return 5;
+    default:
+      return 6;
+  }
+}
+
+function sortMemberships(
+  memberships: readonly ContactMembershipRecord[]
+): readonly ContactMembershipRecord[] {
+  return [...memberships].sort((left, right) => {
+    const rankDifference = membershipSortRank(left) - membershipSortRank(right);
+
+    if (rankDifference !== 0) {
+      return rankDifference;
+    }
+
+    if (left.projectId !== right.projectId) {
+      return (left.projectId ?? "").localeCompare(right.projectId ?? "");
+    }
+
+    return left.id.localeCompare(right.id);
+  });
+}
+
+function mapVolunteerStage(
+  memberships: readonly ContactMembershipRecord[]
+): InboxVolunteerStage {
+  const primaryMembership = sortMemberships(memberships)[0] ?? null;
+  const normalizedStatus = normalizeMembershipStatus(primaryMembership?.status ?? null);
+
+  switch (normalizedStatus) {
+    case "lead":
+      return "lead";
+    case "applied":
+    case "applicant":
+      return "applicant";
+    case "in-training":
+    case "training":
+    case "trip-planning":
+    case "in-field":
+    case "active":
+      return "active";
+    case "successful":
+    case "completed":
+      return "alumni";
+    default:
+      return "non-volunteer";
+  }
+}
+
+function mapProjectStatus(status: string | null): InboxProjectStatus {
+  switch (normalizeMembershipStatus(status)) {
+    case "lead":
+      return "lead";
+    case "applied":
+    case "applicant":
+      return "applied";
+    case "in-training":
+    case "training":
+      return "in-training";
+    case "trip-planning":
+      return "trip-planning";
+    case "in-field":
+    case "active":
+      return "in-field";
+    case "successful":
+    case "completed":
+      return "successful";
+    default:
+      return "applied";
+  }
+}
+
+function resolveProjectName(
+  membership: ContactMembershipRecord,
+  projectNameById: Readonly<Record<string, string>>
+): string | null {
+  if (membership.projectId === null) {
+    return null;
+  }
+
+  return projectNameById[membership.projectId] ?? membership.projectId;
+}
+
+function buildProjectMembershipViewModel(
+  membership: ContactMembershipRecord,
+  projectNameById: Readonly<Record<string, string>>
+): InboxProjectMembershipViewModel | null {
+  const projectName = resolveProjectName(membership, projectNameById);
+
+  if (projectName === null || membership.projectId === null) {
+    return null;
+  }
+
+  return {
+    membershipId: membership.id,
+    projectId: membership.projectId,
+    projectName,
+    // Gap: the canonical membership season/year is not persisted yet, so the
+    // shell keeps its existing contract with a selector-derived current year.
+    year: new Date().getUTCFullYear(),
+    status: mapProjectStatus(membership.status),
+    // Gap: the canonical project URL is not stored yet, so the shell uses a
+    // stable best-effort CRM path derived from the project identifier.
+    crmUrl: `https://adventurescientists.lightning.force.com/lightning/r/Project__c/${encodeURIComponent(
+      membership.projectId
+    )}/view`
+  };
+}
+
+function isPastProject(status: InboxProjectStatus): boolean {
+  return status === "successful";
+}
+
+function formatJoinedAtLabel(createdAt: string): string {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC"
+  });
+
+  return `Joined ${formatter.format(new Date(createdAt))}`;
+}
+
+function formatRelativeTimestamp(timestamp: string, referenceNowIso: string): string {
+  const target = new Date(timestamp).getTime();
+  const now = new Date(referenceNowIso).getTime();
+  const deltaMs = Math.max(0, now - target);
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+
+  if (deltaMs < hour) {
+    const minutes = Math.max(1, Math.floor(deltaMs / minute));
+    return `${minutes.toString()}m ago`;
+  }
+
+  if (deltaMs < day) {
+    const hours = Math.floor(deltaMs / hour);
+    return `${hours.toString()}h ago`;
+  }
+
+  const days = Math.floor(deltaMs / day);
+
+  if (days === 1) {
+    return "yesterday";
+  }
+
+  if (days < 7) {
+    return `${days.toString()}d ago`;
+  }
+
+  if (days < 30) {
+    return `${Math.floor(days / 7).toString()}w ago`;
+  }
+
+  if (days < 365) {
+    return `${Math.floor(days / 30).toString()}mo ago`;
+  }
+
+  return `${Math.floor(days / 365).toString()}y ago`;
+}
+
+function defaultLatestSubject(
+  eventType: InboxDrivingEventType,
+  fallback: string | null
+): string {
+  if (fallback !== null && fallback.trim().length > 0) {
+    return fallback;
+  }
+
+  return mapChannel(eventType) === "sms" ? "SMS conversation" : "Email conversation";
+}
+
+function mapTimelineKind(
+  row: TimelineProjectionRow
+): InboxTimelineEntryKind {
+  switch (row.eventType) {
+    case "communication.email.inbound":
+      return "inbound-email";
+    case "communication.email.outbound":
+      return "outbound-email";
+    case "communication.sms.inbound":
+      return "inbound-sms";
+    case "communication.sms.outbound":
+      return "outbound-sms";
+    default:
+      return "system-event";
+  }
+}
+
+function buildRecentActivity(
+  timelineRows: readonly TimelineProjectionRow[],
+  referenceNowIso: string
+): readonly InboxRecentActivityViewModel[] {
+  return [...timelineRows]
+    .sort((left, right) => right.occurredAt.localeCompare(left.occurredAt))
+    .slice(0, 5)
+    .map((row) => ({
+      id: row.id,
+      label: row.summary,
+      occurredAtLabel: formatRelativeTimestamp(row.occurredAt, referenceNowIso)
+    }));
+}
+
+function groupMembershipsByContactId(
+  memberships: readonly ContactMembershipRecord[]
+): ReadonlyMap<string, readonly ContactMembershipRecord[]> {
+  const grouped = new Map<string, ContactMembershipRecord[]>();
+
+  for (const membership of memberships) {
+    const existing = grouped.get(membership.contactId);
+
+    if (existing === undefined) {
+      grouped.set(membership.contactId, [membership]);
+      continue;
+    }
+
+    existing.push(membership);
+  }
+
+  return grouped;
+}
+
+async function loadProjectNameById(
+  memberships: readonly ContactMembershipRecord[]
+): Promise<Readonly<Record<string, string>>> {
+  const projectIds = uniqueStrings(
+    memberships.map((membership) => membership.projectId)
+  );
+
+  if (projectIds.length === 0) {
+    return {};
+  }
+
+  const runtime = await getStage1WebRuntime();
+  const dimensions = await runtime.repositories.projectDimensions.listByIds(projectIds);
+
+  return Object.fromEntries(
+    dimensions.map((dimension) => [dimension.projectId, dimension.projectName])
+  );
+}
+
+async function loadLatestSubjectByCanonicalEventId(
+  projections: readonly InboxProjectionRow[]
+): Promise<Readonly<Record<string, string | null>>> {
+  const eventIds = uniqueStrings(
+    projections.map((projection) => projection.lastCanonicalEventId)
+  );
+
+  if (eventIds.length === 0) {
+    return {};
+  }
+
+  const runtime = await getStage1WebRuntime();
+  const [canonicalEvents, timelineRows] = await Promise.all([
+    runtime.repositories.canonicalEvents.listByIds(eventIds),
+    Promise.all(
+      eventIds.map((eventId) =>
+        runtime.repositories.timelineProjection.findByCanonicalEventId(eventId)
+      )
+    )
+  ]);
+  const sourceEvidenceIds = uniqueStrings(
+    canonicalEvents.map((event) => event.sourceEvidenceId)
+  );
+  const gmailDetails = await runtime.repositories.gmailMessageDetails.listBySourceEvidenceIds(
+    sourceEvidenceIds
+  );
+  const canonicalEventById = new Map(
+    canonicalEvents.map((event) => [event.id, event])
+  );
+  const timelineByCanonicalEventId = new Map(
+    timelineRows
+      .filter((row): row is TimelineProjectionRow => row !== null)
+      .map((row) => [row.canonicalEventId, row])
+  );
+  const gmailDetailBySourceEvidenceId = new Map(
+    gmailDetails.map((detail) => [detail.sourceEvidenceId, detail])
+  );
+
+  return Object.fromEntries(
+    eventIds.map((eventId) => {
+      const event = canonicalEventById.get(eventId);
+
+      if (event === undefined) {
+        return [eventId, null] as const;
+      }
+
+      return [
+        eventId,
+        gmailDetailBySourceEvidenceId.get(event.sourceEvidenceId)?.subject ??
+          timelineByCanonicalEventId.get(eventId)?.summary ??
+          null
+      ] as const;
+    })
+  );
+}
+
+async function readInboxListCacheData(): Promise<InboxListCacheData> {
+  const runtime = await getStage1WebRuntime();
+  const projections = await runtime.repositories.inboxProjection.listAllOrderedByRecency();
+  const contactIds = projections.map((projection) => projection.contactId);
+  const [contacts, memberships, latestSubjectByCanonicalEventId] = await Promise.all([
+    runtime.repositories.contacts.listByIds(contactIds),
+    runtime.repositories.contactMemberships.listByContactIds(contactIds),
+    loadLatestSubjectByCanonicalEventId(projections)
+  ]);
+  const contactById = new Map(contacts.map((contact) => [contact.id, contact]));
+  const membershipsByContactId = groupMembershipsByContactId(memberships);
+
+  return {
+    rows: projections.flatMap((inboxProjection) => {
+      const contact = contactById.get(inboxProjection.contactId);
+
+      if (contact === undefined) {
+        return [];
+      }
+
+      return [
+        {
+          contact,
+          inboxProjection,
+          memberships: membershipsByContactId.get(inboxProjection.contactId) ?? [],
+          latestSubject:
+            latestSubjectByCanonicalEventId[inboxProjection.lastCanonicalEventId] ?? null
+        } satisfies InboxListCacheRow
+      ];
+    }),
+    projectNameById: await loadProjectNameById(memberships)
+  };
+}
+
+async function readInboxDetailCacheData(
+  contactId: string
+): Promise<InboxDetailCacheData | null> {
+  const runtime = await getStage1WebRuntime();
+  const [contact, inboxProjection, memberships, timelineRows, canonicalEvents] =
+    await Promise.all([
+      runtime.repositories.contacts.findById(contactId),
+      runtime.repositories.inboxProjection.findByContactId(contactId),
+      runtime.repositories.contactMemberships.listByContactId(contactId),
+      runtime.repositories.timelineProjection.listByContactId(contactId),
+      runtime.repositories.canonicalEvents.listByContactId(contactId)
+    ]);
+
+  if (contact === null || inboxProjection === null) {
+    return null;
+  }
+
+  const gmailDetails = await runtime.repositories.gmailMessageDetails.listBySourceEvidenceIds(
+    uniqueStrings(canonicalEvents.map((event) => event.sourceEvidenceId))
+  );
+
+  return {
+    contact,
+    inboxProjection,
+    memberships,
+    timelineRows,
+    canonicalEvents,
+    gmailDetails,
+    projectNameById: await loadProjectNameById(memberships)
+  };
+}
+
+const loadInboxListCacheData = unstable_cache(
+  readInboxListCacheData,
+  ["inbox:list:data"],
+  {
+    tags: ["inbox"]
+  }
+);
+
+function loadInboxDetailCacheData(contactId: string) {
+  return unstable_cache(
+    () => readInboxDetailCacheData(contactId),
+    [`inbox:detail:data:${contactId}`],
+    {
+      tags: ["inbox", `inbox:contact:${contactId}`, `timeline:contact:${contactId}`]
+    }
+  )();
+}
+
+function toListItemViewModel(
+  row: InboxListCacheRow,
+  projectNameById: Readonly<Record<string, string>>,
+  referenceNowIso: string
+): InboxListItemViewModel {
+  const sortedMemberships = sortMemberships(row.memberships);
+  const primaryMembership = sortedMemberships[0] ?? null;
+
+  return {
+    contactId: row.contact.id,
+    displayName: row.contact.displayName,
+    initials: toInitials(row.contact.displayName),
+    avatarTone: avatarToneForContact(row.contact.id),
+    latestSubject: defaultLatestSubject(
+      row.inboxProjection.lastEventType,
+      row.latestSubject
+    ),
+    snippet: row.inboxProjection.snippet,
+    latestChannel: mapChannel(row.inboxProjection.lastEventType),
+    projectLabel:
+      primaryMembership === null
+        ? null
+        : resolveProjectName(primaryMembership, projectNameById),
+    volunteerStage: mapVolunteerStage(sortedMemberships),
+    bucket: mapBucket(row.inboxProjection.bucket),
+    needsFollowUp: row.inboxProjection.needsFollowUp,
+    hasUnresolved: row.inboxProjection.hasUnresolved,
+    unreadCount: row.inboxProjection.bucket === "New" ? 1 : 0,
+    lastInboundAt: row.inboxProjection.lastInboundAt,
+    lastActivityAt: row.inboxProjection.lastActivityAt,
+    lastEventType: row.inboxProjection.lastEventType,
+    lastActivityLabel: formatRelativeTimestamp(
+      row.inboxProjection.lastActivityAt,
+      referenceNowIso
+    )
+  };
+}
+
+function buildContactSummary(
+  input: {
+    readonly contact: ContactRecord;
+    readonly inboxProjection: InboxProjectionRow;
+    readonly memberships: readonly ContactMembershipRecord[];
+    readonly timelineRows: readonly TimelineProjectionRow[];
+    readonly projectNameById: Readonly<Record<string, string>>;
+    readonly referenceNowIso: string;
+  }
+): InboxContactSummaryViewModel {
+  const memberships = sortMemberships(input.memberships);
+  const projectMemberships = memberships
+    .map((membership) =>
+      buildProjectMembershipViewModel(membership, input.projectNameById)
+    )
+    .filter((membership): membership is InboxProjectMembershipViewModel => membership !== null);
+
+  return {
+    contactId: input.contact.id,
+    displayName: input.contact.displayName,
+    volunteerId: input.contact.salesforceContactId ?? input.contact.id,
+    primaryEmail: input.contact.primaryEmail,
+    primaryPhone: input.contact.primaryPhone,
+    cityState: null,
+    joinedAtLabel: formatJoinedAtLabel(input.contact.createdAt),
+    hasUnresolved: input.inboxProjection.hasUnresolved,
+    activeProjects: projectMemberships.filter(
+      (membership) => !isPastProject(membership.status)
+    ),
+    pastProjects: projectMemberships.filter((membership) =>
+      isPastProject(membership.status)
+    ),
+    recentActivity: buildRecentActivity(
+      input.timelineRows,
+      input.referenceNowIso
+    )
+  };
+}
+
+function buildTimelineEntry(
+  input: {
+    readonly contactDisplayName: string;
+    readonly inboxProjection: InboxProjectionRow;
+    readonly row: TimelineProjectionRow;
+    readonly canonicalEvent: CanonicalEventRecord | null;
+    readonly gmailDetail: GmailMessageDetailRecord | null;
+    readonly referenceNowIso: string;
+  }
+): InboxTimelineEntryViewModel {
+  const kind = mapTimelineKind(input.row);
+  const subject =
+    input.row.channel === "email"
+      ? input.gmailDetail?.subject ?? input.row.summary
+      : null;
+  const body =
+    input.gmailDetail?.bodyTextPreview ??
+    input.gmailDetail?.snippetClean ??
+    input.row.summary;
+  const isInbound =
+    kind === "inbound-email" || kind === "inbound-sms";
+
+  return {
+    id: input.row.id,
+    kind,
+    occurredAt: input.row.occurredAt,
+    occurredAtLabel: formatRelativeTimestamp(
+      input.row.occurredAt,
+      input.referenceNowIso
+    ),
+    actorLabel: isInbound ? input.contactDisplayName : "You",
+    subject,
+    body,
+    channel: input.row.channel === "sms" ? "sms" : "email",
+    isUnread:
+      input.inboxProjection.bucket === "New" &&
+      isInbound &&
+      input.canonicalEvent?.id === input.inboxProjection.lastCanonicalEventId
+  };
+}
+
+function matchesServerFilter(
+  item: InboxListItemViewModel,
+  filterId: InboxFilterId
+): boolean {
+  switch (filterId) {
+    case "all":
+      return true;
+    case "unread":
+      return item.bucket === "new";
+    case "follow-up":
+      return item.needsFollowUp;
+    case "unresolved":
+      return item.hasUnresolved;
+  }
+}
+
+export async function getInboxList(
+  filterId: InboxFilterId = "all"
+): Promise<InboxListViewModel> {
+  const cachedData = await loadInboxListCacheData();
+  const referenceNowIso = new Date().toISOString();
+  const items = cachedData.rows.map((row) =>
+    toListItemViewModel(row, cachedData.projectNameById, referenceNowIso)
+  );
+  const totals = {
+    all: items.length,
+    unread: items.filter((item) => item.bucket === "new").length,
+    followUp: items.filter((item) => item.needsFollowUp).length,
+    unresolved: items.filter((item) => item.hasUnresolved).length
+  };
+  const filters: InboxFilterViewModel[] = INBOX_FILTERS.map((filter) => ({
+    id: filter.id,
+    label: filter.label,
+    hint: filter.hint,
+    count:
+      filter.id === "follow-up"
+        ? totals.followUp
+        : filter.id === "unresolved"
+          ? totals.unresolved
+          : totals[filter.id]
+  }));
+
+  return {
+    items: items.filter((item) => matchesServerFilter(item, filterId)),
+    filters,
+    totals
+  };
+}
+
+export async function getInboxDetail(
+  contactId: string
+): Promise<InboxDetailViewModel | null> {
+  const cachedData = await loadInboxDetailCacheData(contactId);
+
+  if (cachedData === null) {
+    return null;
+  }
+
+  const referenceNowIso = new Date().toISOString();
+  const canonicalEventById = new Map(
+    cachedData.canonicalEvents.map((event) => [event.id, event])
+  );
+  const gmailDetailBySourceEvidenceId = new Map(
+    cachedData.gmailDetails.map((detail) => [detail.sourceEvidenceId, detail])
+  );
+
+  return {
+    contact: buildContactSummary({
+      contact: cachedData.contact,
+      inboxProjection: cachedData.inboxProjection,
+      memberships: cachedData.memberships,
+      timelineRows: cachedData.timelineRows,
+      projectNameById: cachedData.projectNameById,
+      referenceNowIso
+    }),
+    timeline: cachedData.timelineRows.map((row) => {
+      const canonicalEvent = canonicalEventById.get(row.canonicalEventId) ?? null;
+
+      return buildTimelineEntry({
+        contactDisplayName: cachedData.contact.displayName,
+        inboxProjection: cachedData.inboxProjection,
+        row,
+        canonicalEvent,
+        gmailDetail:
+          canonicalEvent === null
+            ? null
+            : gmailDetailBySourceEvidenceId.get(canonicalEvent.sourceEvidenceId) ?? null,
+        referenceNowIso
+      });
+    }),
+    bucket: mapBucket(cachedData.inboxProjection.bucket),
+    needsFollowUp: cachedData.inboxProjection.needsFollowUp,
+    smsEligible: cachedData.contact.primaryPhone !== null
+  };
+}

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -7,6 +7,7 @@ import type {
   GmailMessageDetailRecord,
   InboxDrivingEventType,
   InboxProjectionRow,
+  TimelineItem,
   TimelineProjectionRow
 } from "@as-comms/contracts";
 
@@ -47,9 +48,7 @@ interface InboxDetailCacheData {
   readonly contact: ContactRecord;
   readonly inboxProjection: InboxProjectionRow;
   readonly memberships: readonly ContactMembershipRecord[];
-  readonly timelineRows: readonly TimelineProjectionRow[];
-  readonly canonicalEvents: readonly CanonicalEventRecord[];
-  readonly gmailDetails: readonly GmailMessageDetailRecord[];
+  readonly timelineItems: readonly TimelineItem[];
   readonly projectNameById: Readonly<Record<string, string>>;
 }
 
@@ -333,34 +332,172 @@ function defaultLatestSubject(
 }
 
 function mapTimelineKind(
-  row: TimelineProjectionRow
+  item: TimelineItem
 ): InboxTimelineEntryKind {
-  switch (row.eventType) {
-    case "communication.email.inbound":
-      return "inbound-email";
-    case "communication.email.outbound":
-      return "outbound-email";
-    case "communication.sms.inbound":
-      return "inbound-sms";
-    case "communication.sms.outbound":
-      return "outbound-sms";
-    default:
+  switch (item.family) {
+    case "one_to_one_email":
+      return item.direction === "inbound" ? "inbound-email" : "outbound-email";
+    case "one_to_one_sms":
+      return item.direction === "inbound" ? "inbound-sms" : "outbound-sms";
+    case "auto_email":
+      return "outbound-auto-email";
+    case "campaign_email":
+      return "outbound-campaign-email";
+    case "campaign_sms":
+      return "outbound-campaign-sms";
+    case "internal_note":
+      return "internal-note";
+    case "salesforce_event":
       return "system-event";
   }
 }
 
+function recentActivityLabel(item: TimelineItem): string {
+  switch (item.family) {
+    case "one_to_one_email":
+    case "auto_email":
+      return item.subject ?? item.summary;
+    case "one_to_one_sms":
+    case "campaign_sms":
+      return item.messageTextPreview || item.summary;
+    case "campaign_email":
+      return item.campaignName ?? item.summary;
+    case "internal_note":
+      return item.body;
+    case "salesforce_event":
+      return item.summary;
+  }
+}
+
 function buildRecentActivity(
-  timelineRows: readonly TimelineProjectionRow[],
+  timelineItems: readonly TimelineItem[],
   referenceNowIso: string
 ): readonly InboxRecentActivityViewModel[] {
-  return [...timelineRows]
+  return [...timelineItems]
     .sort((left, right) => right.occurredAt.localeCompare(left.occurredAt))
     .slice(0, 5)
-    .map((row) => ({
-      id: row.id,
-      label: row.summary,
-      occurredAtLabel: formatRelativeTimestamp(row.occurredAt, referenceNowIso)
+    .map((item) => ({
+      id: item.id,
+      label: recentActivityLabel(item),
+      occurredAtLabel: formatRelativeTimestamp(item.occurredAt, referenceNowIso)
     }));
+}
+
+function timelineChannel(item: TimelineItem): InboxChannel | null {
+  switch (item.family) {
+    case "one_to_one_email":
+    case "auto_email":
+    case "campaign_email":
+      return "email";
+    case "one_to_one_sms":
+    case "campaign_sms":
+      return "sms";
+    case "internal_note":
+    case "salesforce_event":
+      return null;
+  }
+}
+
+function timelineActorLabel(
+  item: TimelineItem,
+  contactDisplayName: string
+): string {
+  switch (item.family) {
+    case "one_to_one_email":
+    case "one_to_one_sms":
+      return item.direction === "inbound" ? contactDisplayName : "You";
+    case "auto_email":
+      return item.sourceLabel;
+    case "campaign_email":
+    case "campaign_sms":
+      return "Campaigns";
+    case "internal_note":
+      return item.authorDisplayName ?? "Internal note";
+    case "salesforce_event":
+      return "System";
+  }
+}
+
+function timelineSubject(item: TimelineItem): string | null {
+  switch (item.family) {
+    case "one_to_one_email":
+    case "auto_email":
+      return item.subject;
+    case "campaign_email":
+    case "campaign_sms":
+      return item.campaignName ?? item.summary;
+    case "one_to_one_sms":
+    case "internal_note":
+    case "salesforce_event":
+      return null;
+  }
+}
+
+function timelineBody(item: TimelineItem): string {
+  switch (item.family) {
+    case "one_to_one_email":
+      return item.bodyPreview ?? item.snippet;
+    case "one_to_one_sms":
+      return item.messageTextPreview;
+    case "auto_email":
+      return item.snippet;
+    case "campaign_email":
+      return item.snippet;
+    case "campaign_sms":
+      return item.messageTextPreview;
+    case "internal_note":
+      return item.body;
+    case "salesforce_event":
+      return item.summary;
+  }
+}
+
+function isUnreadTimelineItem(
+  item: TimelineItem,
+  inboxProjection: InboxProjectionRow
+): boolean {
+  if (inboxProjection.bucket !== "New") {
+    return false;
+  }
+
+  switch (item.family) {
+    case "one_to_one_email":
+    case "one_to_one_sms":
+      return (
+        item.direction === "inbound" &&
+        item.canonicalEventId === inboxProjection.lastCanonicalEventId
+      );
+    case "auto_email":
+    case "campaign_email":
+    case "campaign_sms":
+    case "internal_note":
+    case "salesforce_event":
+      return false;
+  }
+}
+
+function buildTimelineEntry(
+  input: {
+    readonly contactDisplayName: string;
+    readonly inboxProjection: InboxProjectionRow;
+    readonly item: TimelineItem;
+    readonly referenceNowIso: string;
+  }
+): InboxTimelineEntryViewModel {
+  return {
+    id: input.item.id,
+    kind: mapTimelineKind(input.item),
+    occurredAt: input.item.occurredAt,
+    occurredAtLabel: formatRelativeTimestamp(
+      input.item.occurredAt,
+      input.referenceNowIso
+    ),
+    actorLabel: timelineActorLabel(input.item, input.contactDisplayName),
+    subject: timelineSubject(input.item),
+    body: timelineBody(input.item),
+    channel: timelineChannel(input.item),
+    isUnread: isUnreadTimelineItem(input.item, input.inboxProjection)
+  };
 }
 
 function groupMembershipsByContactId(
@@ -495,30 +632,22 @@ async function readInboxDetailCacheData(
   contactId: string
 ): Promise<InboxDetailCacheData | null> {
   const runtime = await getStage1WebRuntime();
-  const [contact, inboxProjection, memberships, timelineRows, canonicalEvents] =
-    await Promise.all([
-      runtime.repositories.contacts.findById(contactId),
-      runtime.repositories.inboxProjection.findByContactId(contactId),
-      runtime.repositories.contactMemberships.listByContactId(contactId),
-      runtime.repositories.timelineProjection.listByContactId(contactId),
-      runtime.repositories.canonicalEvents.listByContactId(contactId)
-    ]);
+  const [contact, inboxProjection, memberships, timelineItems] = await Promise.all([
+    runtime.repositories.contacts.findById(contactId),
+    runtime.repositories.inboxProjection.findByContactId(contactId),
+    runtime.repositories.contactMemberships.listByContactId(contactId),
+    runtime.timelinePresentation.listTimelineItemsByContactId(contactId)
+  ]);
 
   if (contact === null || inboxProjection === null) {
     return null;
   }
 
-  const gmailDetails = await runtime.repositories.gmailMessageDetails.listBySourceEvidenceIds(
-    uniqueStrings(canonicalEvents.map((event) => event.sourceEvidenceId))
-  );
-
   return {
     contact,
     inboxProjection,
     memberships,
-    timelineRows,
-    canonicalEvents,
-    gmailDetails,
+    timelineItems,
     projectNameById: await loadProjectNameById(memberships)
   };
 }
@@ -584,7 +713,7 @@ function buildContactSummary(
     readonly contact: ContactRecord;
     readonly inboxProjection: InboxProjectionRow;
     readonly memberships: readonly ContactMembershipRecord[];
-    readonly timelineRows: readonly TimelineProjectionRow[];
+    readonly timelineItems: readonly TimelineItem[];
     readonly projectNameById: Readonly<Record<string, string>>;
     readonly referenceNowIso: string;
   }
@@ -612,50 +741,9 @@ function buildContactSummary(
       isPastProject(membership.status)
     ),
     recentActivity: buildRecentActivity(
-      input.timelineRows,
+      input.timelineItems,
       input.referenceNowIso
     )
-  };
-}
-
-function buildTimelineEntry(
-  input: {
-    readonly contactDisplayName: string;
-    readonly inboxProjection: InboxProjectionRow;
-    readonly row: TimelineProjectionRow;
-    readonly canonicalEvent: CanonicalEventRecord | null;
-    readonly gmailDetail: GmailMessageDetailRecord | null;
-    readonly referenceNowIso: string;
-  }
-): InboxTimelineEntryViewModel {
-  const kind = mapTimelineKind(input.row);
-  const subject =
-    input.row.channel === "email"
-      ? input.gmailDetail?.subject ?? input.row.summary
-      : null;
-  const body =
-    input.gmailDetail?.bodyTextPreview ??
-    input.gmailDetail?.snippetClean ??
-    input.row.summary;
-  const isInbound =
-    kind === "inbound-email" || kind === "inbound-sms";
-
-  return {
-    id: input.row.id,
-    kind,
-    occurredAt: input.row.occurredAt,
-    occurredAtLabel: formatRelativeTimestamp(
-      input.row.occurredAt,
-      input.referenceNowIso
-    ),
-    actorLabel: isInbound ? input.contactDisplayName : "You",
-    subject,
-    body,
-    channel: input.row.channel === "sms" ? "sms" : "email",
-    isUnread:
-      input.inboxProjection.bucket === "New" &&
-      isInbound &&
-      input.canonicalEvent?.id === input.inboxProjection.lastCanonicalEventId
   };
 }
 
@@ -718,37 +806,24 @@ export async function getInboxDetail(
   }
 
   const referenceNowIso = new Date().toISOString();
-  const canonicalEventById = new Map(
-    cachedData.canonicalEvents.map((event) => [event.id, event])
-  );
-  const gmailDetailBySourceEvidenceId = new Map(
-    cachedData.gmailDetails.map((detail) => [detail.sourceEvidenceId, detail])
-  );
 
   return {
     contact: buildContactSummary({
       contact: cachedData.contact,
       inboxProjection: cachedData.inboxProjection,
       memberships: cachedData.memberships,
-      timelineRows: cachedData.timelineRows,
+      timelineItems: cachedData.timelineItems,
       projectNameById: cachedData.projectNameById,
       referenceNowIso
     }),
-    timeline: cachedData.timelineRows.map((row) => {
-      const canonicalEvent = canonicalEventById.get(row.canonicalEventId) ?? null;
-
-      return buildTimelineEntry({
+    timeline: cachedData.timelineItems.map((item) =>
+      buildTimelineEntry({
         contactDisplayName: cachedData.contact.displayName,
         inboxProjection: cachedData.inboxProjection,
-        row,
-        canonicalEvent,
-        gmailDetail:
-          canonicalEvent === null
-            ? null
-            : gmailDetailBySourceEvidenceId.get(canonicalEvent.sourceEvidenceId) ?? null,
+        item,
         referenceNowIso
-      });
-    }),
+      })
+    ),
     bucket: mapBucket(cachedData.inboxProjection.bucket),
     needsFollowUp: cachedData.inboxProjection.needsFollowUp,
     smsEligible: cachedData.contact.primaryPhone !== null

--- a/apps/web/app/inbox/actions.ts
+++ b/apps/web/app/inbox/actions.ts
@@ -1,0 +1,70 @@
+"use server";
+
+import { revalidateTag } from "next/cache";
+
+import { setInboxNeedsFollowUp } from "../../src/server/inbox/follow-up";
+
+export type FollowUpActionResult =
+  | {
+      readonly ok: true;
+      readonly contactId: string;
+      readonly needsFollowUp: boolean;
+    }
+  | {
+      readonly ok: false;
+      readonly code: "validation_error" | "inbox_contact_not_found";
+    };
+
+function readContactId(formData: FormData): string | null {
+  const value = formData.get("contactId");
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function revalidateInboxContact(contactId: string): void {
+  revalidateTag("inbox");
+  revalidateTag(`inbox:contact:${contactId}`);
+  revalidateTag(`timeline:contact:${contactId}`);
+}
+
+async function updateNeedsFollowUp(
+  formData: FormData,
+  needsFollowUp: boolean
+): Promise<FollowUpActionResult> {
+  const contactId = readContactId(formData);
+
+  if (contactId === null) {
+    return {
+      ok: false,
+      code: "validation_error"
+    };
+  }
+
+  const result = await setInboxNeedsFollowUp({
+    contactId,
+    needsFollowUp
+  });
+
+  if (!result.ok) {
+    return result;
+  }
+
+  revalidateInboxContact(contactId);
+
+  return {
+    ok: true,
+    contactId,
+    needsFollowUp
+  };
+}
+
+export async function markInboxNeedsFollowUpAction(
+  formData: FormData
+): Promise<FollowUpActionResult> {
+  return updateNeedsFollowUp(formData, true);
+}
+
+export async function clearInboxNeedsFollowUpAction(
+  formData: FormData
+): Promise<FollowUpActionResult> {
+  return updateNeedsFollowUp(formData, false);
+}

--- a/apps/web/app/inbox/layout.tsx
+++ b/apps/web/app/inbox/layout.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+
+import { InboxShell } from "./_components/inbox-shell";
+import { getInboxList } from "./_lib/selectors";
+
+export const metadata = {
+  title: "Inbox"
+};
+
+/**
+ * Server Component: composes the persistent shell (icon rail + list column)
+ * once for both `/inbox` and `/inbox/[contactId]`. The page slot underneath
+ * renders either the empty state or the selected-contact detail workspace.
+ *
+ * Following FP-01/FP-02: the full list is assembled here from a server-side
+ * selector and only minimized view models flow into the client list island.
+ * The client applies the active filter locally against those view models, so
+ * the sidebar collapse has no effect on where canonical state lives.
+ */
+export default async function InboxLayout({
+  children
+}: {
+  readonly children: ReactNode;
+}) {
+  const list = await getInboxList("all");
+
+  return (
+    <InboxShell
+      filters={list.filters}
+      items={list.items}
+      initialFilterId="all"
+    >
+      {children}
+    </InboxShell>
+  );
+}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -2,7 +2,12 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
-  transpilePackages: ["@as-comms/contracts", "@as-comms/domain", "@as-comms/ui"]
+  transpilePackages: [
+    "@as-comms/contracts",
+    "@as-comms/db",
+    "@as-comms/domain",
+    "@as-comms/ui"
+  ]
 };
 
 export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,10 +13,26 @@
   },
   "dependencies": {
     "@as-comms/contracts": "workspace:*",
+    "@as-comms/db": "workspace:*",
     "@as-comms/domain": "workspace:*",
     "@as-comms/ui": "workspace:*",
+    "@radix-ui/react-avatar": "^1.1.11",
+    "@radix-ui/react-collapsible": "^1.1.12",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-progress": "^1.1.8",
+    "@radix-ui/react-separator": "^1.1.8",
+    "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-toggle": "^1.1.10",
+    "@radix-ui/react-toggle-group": "^1.1.11",
+    "@radix-ui/react-tooltip": "^1.2.8",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^1.8.0",
     "next": "^15.2.2",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "tailwind-merge": "^3.5.0",
+    "tailwindcss-animate": "^1.0.7"
   }
 }

--- a/apps/web/src/server/inbox/follow-up.ts
+++ b/apps/web/src/server/inbox/follow-up.ts
@@ -16,21 +16,17 @@ export async function setInboxNeedsFollowUp(input: {
   readonly needsFollowUp: boolean;
 }): Promise<InboxNeedsFollowUpUpdateResult | InboxNeedsFollowUpUpdateNotFound> {
   const runtime = await getStage1WebRuntime();
-  const existing = await runtime.repositories.inboxProjection.findByContactId(
-    input.contactId
-  );
+  const updated = await runtime.repositories.inboxProjection.setNeedsFollowUp({
+    contactId: input.contactId,
+    needsFollowUp: input.needsFollowUp
+  });
 
-  if (existing === null) {
+  if (updated === null) {
     return {
       ok: false,
       code: "inbox_contact_not_found"
     };
   }
-
-  await runtime.repositories.inboxProjection.upsert({
-    ...existing,
-    needsFollowUp: input.needsFollowUp
-  });
 
   return {
     ok: true,

--- a/apps/web/src/server/inbox/follow-up.ts
+++ b/apps/web/src/server/inbox/follow-up.ts
@@ -1,0 +1,40 @@
+import { getStage1WebRuntime } from "../stage1-runtime";
+
+export interface InboxNeedsFollowUpUpdateResult {
+  readonly ok: true;
+  readonly contactId: string;
+  readonly needsFollowUp: boolean;
+}
+
+export interface InboxNeedsFollowUpUpdateNotFound {
+  readonly ok: false;
+  readonly code: "inbox_contact_not_found";
+}
+
+export async function setInboxNeedsFollowUp(input: {
+  readonly contactId: string;
+  readonly needsFollowUp: boolean;
+}): Promise<InboxNeedsFollowUpUpdateResult | InboxNeedsFollowUpUpdateNotFound> {
+  const runtime = await getStage1WebRuntime();
+  const existing = await runtime.repositories.inboxProjection.findByContactId(
+    input.contactId
+  );
+
+  if (existing === null) {
+    return {
+      ok: false,
+      code: "inbox_contact_not_found"
+    };
+  }
+
+  await runtime.repositories.inboxProjection.upsert({
+    ...existing,
+    needsFollowUp: input.needsFollowUp
+  });
+
+  return {
+    ok: true,
+    contactId: input.contactId,
+    needsFollowUp: input.needsFollowUp
+  };
+}

--- a/apps/web/src/server/stage1-runtime.ts
+++ b/apps/web/src/server/stage1-runtime.ts
@@ -4,10 +4,15 @@ import {
   type DatabaseConnection
 } from "@as-comms/db";
 import type { Stage1RepositoryBundle } from "@as-comms/domain";
+import {
+  createStage1TimelinePresentationService,
+  type Stage1TimelinePresentationService
+} from "../../../../packages/domain/src/timeline";
 
 export interface Stage1WebRuntime {
   readonly connection: Pick<DatabaseConnection, "db" | "sql"> | null;
   readonly repositories: Stage1RepositoryBundle;
+  readonly timelinePresentation: Stage1TimelinePresentationService;
 }
 
 let runtimeOverride: Stage1WebRuntime | null = null;
@@ -23,10 +28,12 @@ function createRuntime(): Stage1WebRuntime {
   const connection = createDatabaseConnection({
     connectionString
   });
+  const repositories = createStage1RepositoryBundleFromConnection(connection);
 
   return {
     connection,
-    repositories: createStage1RepositoryBundleFromConnection(connection)
+    repositories,
+    timelinePresentation: createStage1TimelinePresentationService(repositories)
   };
 }
 

--- a/apps/web/src/server/stage1-runtime.ts
+++ b/apps/web/src/server/stage1-runtime.ts
@@ -1,0 +1,47 @@
+import {
+  createDatabaseConnection,
+  createStage1RepositoryBundleFromConnection,
+  type DatabaseConnection
+} from "@as-comms/db";
+import type { Stage1RepositoryBundle } from "@as-comms/domain";
+
+export interface Stage1WebRuntime {
+  readonly connection: Pick<DatabaseConnection, "db" | "sql"> | null;
+  readonly repositories: Stage1RepositoryBundle;
+}
+
+let runtimeOverride: Stage1WebRuntime | null = null;
+let runtimePromise: Promise<Stage1WebRuntime> | null = null;
+
+function createRuntime(): Stage1WebRuntime {
+  const connectionString = process.env.DATABASE_URL;
+
+  if (!connectionString) {
+    throw new Error("DATABASE_URL must be set before using the Stage 1 inbox runtime.");
+  }
+
+  const connection = createDatabaseConnection({
+    connectionString
+  });
+
+  return {
+    connection,
+    repositories: createStage1RepositoryBundleFromConnection(connection)
+  };
+}
+
+export async function getStage1WebRuntime(): Promise<Stage1WebRuntime> {
+  if (runtimeOverride !== null) {
+    return runtimeOverride;
+  }
+
+  runtimePromise ??= Promise.resolve(createRuntime());
+  return runtimePromise;
+}
+
+export function setStage1WebRuntimeForTests(
+  runtime: Stage1WebRuntime | null
+): void {
+  runtimeOverride = runtime;
+  runtimePromise = null;
+}

--- a/apps/web/tests/smoke/inbox.spec.ts
+++ b/apps/web/tests/smoke/inbox.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/test";
+
+test("inbox renders as a single mixed list backed by real data", async ({ page }) => {
+  await page.goto("/inbox");
+
+  await expect(
+    page.getByRole("heading", { name: "Inbox", exact: true })
+  ).toBeVisible();
+  await expect(page.getByRole("button", { name: /Unread/i })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /Needs Follow-Up/i })
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /Unresolved/i })
+  ).toBeVisible();
+
+  await expect(
+    page.getByRole("button", { name: /^Opened$/i })
+  ).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: /^Pending$/i })
+  ).toHaveCount(0);
+
+  const firstRowLink = page.locator("ul.divide-y > li a").first();
+  await expect(firstRowLink).toBeVisible();
+  await firstRowLink.click();
+
+  await expect(page).toHaveURL(/\/inbox\/.+/);
+  await expect(
+    page.getByRole("button", { name: "Needs Follow-Up", exact: true })
+  ).toBeVisible();
+  await expect(page.locator("main header").first()).toBeVisible();
+});

--- a/apps/web/tests/unit/inbox-actions.test.ts
+++ b/apps/web/tests/unit/inbox-actions.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const revalidateTag = vi.hoisted(() => vi.fn());
+
+vi.mock("next/cache", () => ({
+  unstable_cache: (loader: () => unknown) => loader,
+  revalidateTag
+}));
+
+import {
+  clearInboxNeedsFollowUpAction,
+  markInboxNeedsFollowUpAction
+} from "../../app/inbox/actions";
+import { getInboxDetail, getInboxList } from "../../app/inbox/_lib/selectors";
+import {
+  createInboxTestRuntime,
+  seedInboxContact,
+  seedInboxEmailEvent,
+  seedInboxProjection,
+  type InboxTestRuntime
+} from "./inbox-stage1-helpers";
+
+async function seedActionFixture(runtime: InboxTestRuntime): Promise<void> {
+  await seedInboxContact(runtime.context, {
+    contactId: "contact:sarah-martinez",
+    salesforceContactId: "003-sarah",
+    displayName: "Sarah Martinez",
+    primaryEmail: "sarah@example.org",
+    primaryPhone: "+15550000001",
+    projectId: "project:amazon-basin",
+    projectName: "Amazon Basin Research",
+    membershipId: "membership:sarah",
+    membershipStatus: "in_training"
+  });
+  const sarahLatest = await seedInboxEmailEvent(runtime.context, {
+    id: "sarah-inbound-1",
+    contactId: "contact:sarah-martinez",
+    occurredAt: "2026-04-14T13:00:00.000Z",
+    direction: "inbound",
+    subject: "Re: Amazon Basin equipment list",
+    snippet: "Following up on the field study logistics for the Amazon basin project."
+  });
+  await seedInboxProjection(runtime.context, {
+    contactId: "contact:sarah-martinez",
+    bucket: "New",
+    needsFollowUp: false,
+    hasUnresolved: false,
+    lastInboundAt: "2026-04-14T13:00:00.000Z",
+    lastOutboundAt: null,
+    lastActivityAt: "2026-04-14T13:00:00.000Z",
+    snippet:
+      "Following up on the field study logistics for the Amazon basin project.",
+    lastCanonicalEventId: sarahLatest.canonicalEventId,
+    lastEventType: "communication.email.inbound"
+  });
+
+  await seedInboxContact(runtime.context, {
+    contactId: "contact:michael-chen",
+    salesforceContactId: "003-michael",
+    displayName: "Michael Chen",
+    primaryEmail: "michael@example.org",
+    primaryPhone: null,
+    projectId: "project:coral-reefs",
+    projectName: "Monitoring Coral Reefs",
+    membershipId: "membership:michael",
+    membershipStatus: "in_training"
+  });
+  const michaelLatest = await seedInboxEmailEvent(runtime.context, {
+    id: "michael-inbound-1",
+    contactId: "contact:michael-chen",
+    occurredAt: "2026-04-14T12:00:00.000Z",
+    direction: "inbound",
+    subject: "Questions about data collection protocols",
+    snippet:
+      "Thanks for the training materials. I have a few questions about the data collection protocols."
+  });
+  await seedInboxProjection(runtime.context, {
+    contactId: "contact:michael-chen",
+    bucket: "New",
+    needsFollowUp: false,
+    hasUnresolved: false,
+    lastInboundAt: "2026-04-14T12:00:00.000Z",
+    lastOutboundAt: null,
+    lastActivityAt: "2026-04-14T12:00:00.000Z",
+    snippet:
+      "Thanks for the training materials. I have a few questions about the data collection protocols.",
+    lastCanonicalEventId: michaelLatest.canonicalEventId,
+    lastEventType: "communication.email.inbound"
+  });
+}
+
+describe("server-backed follow-up actions", () => {
+  let runtime: InboxTestRuntime | null = null;
+
+  beforeEach(async () => {
+    revalidateTag.mockReset();
+    runtime = await createInboxTestRuntime();
+    await seedActionFixture(runtime);
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    runtime = null;
+  });
+
+  it("marks needsFollowUp without changing bucket semantics or row ordering", async () => {
+    const before = await getInboxList();
+    const formData = new FormData();
+    formData.set("contactId", "contact:michael-chen");
+
+    const result = await markInboxNeedsFollowUpAction(formData);
+    const projection = await runtime?.context.repositories.inboxProjection.findByContactId(
+      "contact:michael-chen"
+    );
+    const after = await getInboxList();
+    const detail = await getInboxDetail("contact:michael-chen");
+
+    expect(result).toEqual({
+      ok: true,
+      contactId: "contact:michael-chen",
+      needsFollowUp: true
+    });
+    expect(before.items.map((item) => item.contactId)).toEqual([
+      "contact:sarah-martinez",
+      "contact:michael-chen"
+    ]);
+    expect(after.items.map((item) => item.contactId)).toEqual([
+      "contact:sarah-martinez",
+      "contact:michael-chen"
+    ]);
+    expect(projection).toMatchObject({
+      contactId: "contact:michael-chen",
+      needsFollowUp: true,
+      bucket: "New"
+    });
+    expect(after.items.find((item) => item.contactId === "contact:michael-chen")).toMatchObject({
+      needsFollowUp: true,
+      bucket: "new"
+    });
+    expect(detail).toMatchObject({
+      needsFollowUp: true,
+      bucket: "new"
+    });
+    expect(revalidateTag).toHaveBeenCalledTimes(3);
+    expect(revalidateTag).toHaveBeenNthCalledWith(1, "inbox");
+    expect(revalidateTag).toHaveBeenNthCalledWith(
+      2,
+      "inbox:contact:contact:michael-chen"
+    );
+    expect(revalidateTag).toHaveBeenNthCalledWith(
+      3,
+      "timeline:contact:contact:michael-chen"
+    );
+  });
+
+  it("clears needsFollowUp without mutating unread state", async () => {
+    const formData = new FormData();
+    formData.set("contactId", "contact:michael-chen");
+    await markInboxNeedsFollowUpAction(formData);
+    revalidateTag.mockReset();
+
+    const result = await clearInboxNeedsFollowUpAction(formData);
+    const projection = await runtime?.context.repositories.inboxProjection.findByContactId(
+      "contact:michael-chen"
+    );
+    const followUpList = await getInboxList("follow-up");
+
+    expect(result).toEqual({
+      ok: true,
+      contactId: "contact:michael-chen",
+      needsFollowUp: false
+    });
+    expect(projection).toMatchObject({
+      contactId: "contact:michael-chen",
+      needsFollowUp: false,
+      bucket: "New"
+    });
+    expect(followUpList.items).toHaveLength(0);
+    expect(revalidateTag).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/web/tests/unit/inbox-actions.test.ts
+++ b/apps/web/tests/unit/inbox-actions.test.ts
@@ -178,4 +178,68 @@ describe("server-backed follow-up actions", () => {
     expect(followUpList.items).toHaveLength(0);
     expect(revalidateTag).toHaveBeenCalledTimes(3);
   });
+
+  it("does not clobber fresher projection state when follow-up is toggled", async () => {
+    const staleProjection =
+      await runtime?.context.repositories.inboxProjection.findByContactId(
+        "contact:michael-chen"
+      );
+    const fresherEvent = await seedInboxEmailEvent(runtime!.context, {
+      id: "michael-inbound-2",
+      contactId: "contact:michael-chen",
+      occurredAt: "2026-04-14T14:30:00.000Z",
+      direction: "inbound",
+      subject: "Latest logistics update",
+      snippet: "Fresh inbound message that arrived after the stale snapshot."
+    });
+
+    await runtime?.context.repositories.inboxProjection.upsert({
+      contactId: "contact:michael-chen",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: true,
+      lastInboundAt: "2026-04-14T14:30:00.000Z",
+      lastOutboundAt: "2026-04-14T12:00:00.000Z",
+      lastActivityAt: "2026-04-14T14:30:00.000Z",
+      snippet: "Fresh inbound message that arrived after the stale snapshot.",
+      lastCanonicalEventId: fresherEvent.canonicalEventId,
+      lastEventType: "communication.email.inbound"
+    });
+
+    const findByContactIdSpy = vi
+      .spyOn(runtime!.context.repositories.inboxProjection, "findByContactId")
+      .mockResolvedValue(staleProjection ?? null);
+    const upsertSpy = vi.spyOn(
+      runtime!.context.repositories.inboxProjection,
+      "upsert"
+    );
+    const formData = new FormData();
+    formData.set("contactId", "contact:michael-chen");
+
+    const result = await markInboxNeedsFollowUpAction(formData);
+    expect(findByContactIdSpy).not.toHaveBeenCalled();
+    expect(upsertSpy).not.toHaveBeenCalled();
+    findByContactIdSpy.mockRestore();
+    upsertSpy.mockRestore();
+    const projection = await runtime?.context.repositories.inboxProjection.findByContactId(
+      "contact:michael-chen"
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      contactId: "contact:michael-chen",
+      needsFollowUp: true
+    });
+    expect(projection).toMatchObject({
+      contactId: "contact:michael-chen",
+      bucket: "New",
+      needsFollowUp: true,
+      hasUnresolved: true,
+      lastInboundAt: "2026-04-14T14:30:00.000Z",
+      lastActivityAt: "2026-04-14T14:30:00.000Z",
+      snippet: "Fresh inbound message that arrived after the stale snapshot.",
+      lastCanonicalEventId: fresherEvent.canonicalEventId,
+      lastEventType: "communication.email.inbound"
+    });
+  });
 });

--- a/apps/web/tests/unit/inbox-follow-up-state.test.ts
+++ b/apps/web/tests/unit/inbox-follow-up-state.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/cache", () => ({
+  unstable_cache: (loader: () => unknown) => loader,
+  revalidateTag: vi.fn()
+}));
+
+import { markInboxNeedsFollowUpAction } from "../../app/inbox/actions";
+
+describe("follow-up action validation", () => {
+  it("returns a validation error when contactId is missing", async () => {
+    const formData = new FormData();
+
+    await expect(markInboxNeedsFollowUpAction(formData)).resolves.toEqual({
+      ok: false,
+      code: "validation_error"
+    });
+  });
+});

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -13,8 +13,13 @@ import {
 import type { InboxListItemViewModel } from "../../app/inbox/_lib/view-models";
 import {
   createInboxTestRuntime,
+  seedInboxAutoEmailEvent,
+  seedInboxCampaignEmailEvent,
+  seedInboxCampaignSmsEvent,
   seedInboxContact,
   seedInboxEmailEvent,
+  seedInboxInternalNoteEvent,
+  seedInboxLifecycleEvent,
   seedInboxProjection,
   seedInboxSmsEvent,
   type InboxTestRuntime
@@ -251,6 +256,78 @@ describe("real inbox selectors", () => {
     expect(detail?.timeline.at(-1)).toMatchObject({
       subject: "Re: Amazon Basin equipment list",
       isUnread: true
+    });
+  });
+
+  it("preserves Stage 1 timeline families instead of flattening them into generic system events", async () => {
+    await seedInboxCampaignEmailEvent(runtime!.context, {
+      id: "sarah-campaign-email-1",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-10T09:00:00.000Z",
+      activityType: "sent",
+      campaignName: "Spring Kickoff",
+      snippet: "Welcome to the new field season."
+    });
+    await seedInboxAutoEmailEvent(runtime!.context, {
+      id: "sarah-auto-email-1",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-11T09:00:00.000Z",
+      subject: "Training confirmation",
+      snippet: "You are confirmed for training."
+    });
+    await seedInboxCampaignSmsEvent(runtime!.context, {
+      id: "sarah-campaign-sms-1",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-12T09:00:00.000Z",
+      campaignName: "Field Reminder",
+      messageTextPreview: "Field reminder text"
+    });
+    await seedInboxInternalNoteEvent(runtime!.context, {
+      id: "sarah-note-1",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-12T12:00:00.000Z",
+      body: "Prefers SMS check-ins before training.",
+      authorDisplayName: "Jordan"
+    });
+    await seedInboxLifecycleEvent(runtime!.context, {
+      id: "sarah-lifecycle-1",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-09T09:00:00.000Z",
+      eventType: "lifecycle.received_training",
+      summary: "Received training materials"
+    });
+
+    const detail = await getInboxDetail("contact:sarah-martinez");
+
+    expect(detail).not.toBeNull();
+    expect(detail?.timeline.map((entry) => entry.kind)).toEqual([
+      "system-event",
+      "outbound-campaign-email",
+      "outbound-auto-email",
+      "outbound-campaign-sms",
+      "internal-note",
+      "outbound-email",
+      "inbound-email"
+    ]);
+    expect(detail?.timeline[1]).toMatchObject({
+      kind: "outbound-campaign-email",
+      subject: "Spring Kickoff",
+      body: "Welcome to the new field season."
+    });
+    expect(detail?.timeline[2]).toMatchObject({
+      kind: "outbound-auto-email",
+      subject: "Training confirmation",
+      body: "You are confirmed for training."
+    });
+    expect(detail?.timeline[3]).toMatchObject({
+      kind: "outbound-campaign-sms",
+      subject: "Field Reminder",
+      body: "Field reminder text"
+    });
+    expect(detail?.timeline[4]).toMatchObject({
+      kind: "internal-note",
+      actorLabel: "Jordan",
+      body: "Prefers SMS check-ins before training."
     });
   });
 });

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -1,0 +1,256 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/cache", () => ({
+  unstable_cache: (loader: () => unknown) => loader,
+  revalidateTag: vi.fn()
+}));
+
+import {
+  compareInboxRecency,
+  getInboxDetail,
+  getInboxList
+} from "../../app/inbox/_lib/selectors";
+import type { InboxListItemViewModel } from "../../app/inbox/_lib/view-models";
+import {
+  createInboxTestRuntime,
+  seedInboxContact,
+  seedInboxEmailEvent,
+  seedInboxProjection,
+  seedInboxSmsEvent,
+  type InboxTestRuntime
+} from "./inbox-stage1-helpers";
+
+function buildItem(
+  overrides: Partial<InboxListItemViewModel>
+): InboxListItemViewModel {
+  return {
+    contactId: overrides.contactId ?? "contact_1",
+    displayName: overrides.displayName ?? "Contact One",
+    initials: overrides.initials ?? "CO",
+    avatarTone: overrides.avatarTone ?? "indigo",
+    latestSubject: overrides.latestSubject ?? "Subject",
+    snippet: overrides.snippet ?? "Snippet",
+    latestChannel: overrides.latestChannel ?? "email",
+    projectLabel: overrides.projectLabel ?? null,
+    volunteerStage: overrides.volunteerStage ?? "active",
+    bucket: overrides.bucket ?? "opened",
+    needsFollowUp: overrides.needsFollowUp ?? false,
+    hasUnresolved: overrides.hasUnresolved ?? false,
+    unreadCount: overrides.unreadCount ?? 0,
+    lastInboundAt: overrides.lastInboundAt ?? null,
+    lastActivityAt:
+      overrides.lastActivityAt ?? "2026-04-14T14:00:00.000Z",
+    lastEventType:
+      overrides.lastEventType ?? "communication.email.outbound",
+    lastActivityLabel: overrides.lastActivityLabel ?? "today"
+  };
+}
+
+async function seedInboxFixture(runtime: InboxTestRuntime): Promise<void> {
+  await seedInboxContact(runtime.context, {
+    contactId: "contact:lisa-zhang",
+    salesforceContactId: "003-lisa",
+    displayName: "Lisa Zhang",
+    primaryEmail: "lisa@example.org",
+    primaryPhone: null,
+    projectId: "project:killer-whales",
+    projectName: "Searching for Killer Whales",
+    membershipId: "membership:lisa",
+    membershipStatus: "successful"
+  });
+  const lisaLatest = await seedInboxEmailEvent(runtime.context, {
+    id: "lisa-outbound-1",
+    contactId: "contact:lisa-zhang",
+    occurredAt: "2026-04-14T15:00:00.000Z",
+    direction: "outbound",
+    subject: "Safety protocols",
+    snippet: "Sending the final safety protocol packet for review."
+  });
+  await seedInboxProjection(runtime.context, {
+    contactId: "contact:lisa-zhang",
+    bucket: "Opened",
+    needsFollowUp: false,
+    hasUnresolved: false,
+    lastInboundAt: null,
+    lastOutboundAt: "2026-04-14T15:00:00.000Z",
+    lastActivityAt: "2026-04-14T15:00:00.000Z",
+    snippet: "Sending the final safety protocol packet for review.",
+    lastCanonicalEventId: lisaLatest.canonicalEventId,
+    lastEventType: "communication.email.outbound"
+  });
+
+  await seedInboxContact(runtime.context, {
+    contactId: "contact:sarah-martinez",
+    salesforceContactId: "003-sarah",
+    displayName: "Sarah Martinez",
+    primaryEmail: "sarah@example.org",
+    primaryPhone: "+15550000001",
+    projectId: "project:amazon-basin",
+    projectName: "Amazon Basin Research",
+    membershipId: "membership:sarah",
+    membershipStatus: "in_training"
+  });
+  await seedInboxEmailEvent(runtime.context, {
+    id: "sarah-outbound-1",
+    contactId: "contact:sarah-martinez",
+    occurredAt: "2026-04-13T12:00:00.000Z",
+    direction: "outbound",
+    subject: "Amazon Basin equipment list",
+    snippet: "Sharing the equipment list for the next field session."
+  });
+  const sarahLatest = await seedInboxEmailEvent(runtime.context, {
+    id: "sarah-inbound-1",
+    contactId: "contact:sarah-martinez",
+    occurredAt: "2026-04-14T13:00:00.000Z",
+    direction: "inbound",
+    subject: "Re: Amazon Basin equipment list",
+    snippet: "Following up on the field study logistics for the Amazon basin project."
+  });
+  await seedInboxProjection(runtime.context, {
+    contactId: "contact:sarah-martinez",
+    bucket: "New",
+    needsFollowUp: true,
+    hasUnresolved: false,
+    lastInboundAt: "2026-04-14T13:00:00.000Z",
+    lastOutboundAt: "2026-04-13T12:00:00.000Z",
+    lastActivityAt: "2026-04-14T13:00:00.000Z",
+    snippet:
+      "Following up on the field study logistics for the Amazon basin project.",
+    lastCanonicalEventId: sarahLatest.canonicalEventId,
+    lastEventType: "communication.email.inbound"
+  });
+
+  await seedInboxContact(runtime.context, {
+    contactId: "contact:alex-thompson",
+    salesforceContactId: "003-alex",
+    displayName: "Alex Thompson",
+    primaryEmail: null,
+    primaryPhone: "+15550000002",
+    projectId: "project:whitebark-pine",
+    projectName: "Tracking Whitebark Pine",
+    membershipId: "membership:alex",
+    membershipStatus: "trip_planning"
+  });
+  await seedInboxSmsEvent(runtime.context, {
+    id: "alex-outbound-1",
+    contactId: "contact:alex-thompson",
+    occurredAt: "2026-04-12T18:00:00.000Z",
+    direction: "outbound",
+    summary: "We can shift the mountain research dates if weather stays rough."
+  });
+  const alexLatest = await seedInboxSmsEvent(runtime.context, {
+    id: "alex-inbound-1",
+    contactId: "contact:alex-thompson",
+    occurredAt: "2026-04-12T19:00:00.000Z",
+    direction: "inbound",
+    summary: "Had to postpone due to weather. Proposing new dates."
+  });
+  await seedInboxProjection(runtime.context, {
+    contactId: "contact:alex-thompson",
+    bucket: "Opened",
+    needsFollowUp: false,
+    hasUnresolved: true,
+    lastInboundAt: "2026-04-12T19:00:00.000Z",
+    lastOutboundAt: "2026-04-12T18:00:00.000Z",
+    lastActivityAt: "2026-04-12T19:00:00.000Z",
+    snippet: "Had to postpone due to weather. Proposing new dates.",
+    lastCanonicalEventId: alexLatest.canonicalEventId,
+    lastEventType: "communication.sms.inbound"
+  });
+}
+
+describe("compareInboxRecency", () => {
+  it("falls back to lastActivityAt when lastInboundAt is missing", () => {
+    const outboundOnly = buildItem({
+      contactId: "contact_outbound",
+      lastInboundAt: null,
+      lastActivityAt: "2026-04-14T15:00:00.000Z"
+    });
+    const olderInbound = buildItem({
+      contactId: "contact_inbound",
+      lastInboundAt: "2026-04-14T13:00:00.000Z",
+      lastActivityAt: "2026-04-14T13:15:00.000Z"
+    });
+
+    expect(compareInboxRecency(outboundOnly, olderInbound)).toBeLessThan(0);
+  });
+});
+
+describe("real inbox selectors", () => {
+  let runtime: InboxTestRuntime | null = null;
+
+  beforeEach(async () => {
+    runtime = await createInboxTestRuntime();
+    await seedInboxFixture(runtime);
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    runtime = null;
+  });
+
+  it("reads one row per contact from real projections with inbound-first sorting and activity fallback", async () => {
+    const list = await getInboxList();
+
+    expect(list.items.map((item) => item.contactId)).toEqual([
+      "contact:lisa-zhang",
+      "contact:sarah-martinez",
+      "contact:alex-thompson"
+    ]);
+    expect(list.items[0]).toMatchObject({
+      contactId: "contact:lisa-zhang",
+      latestSubject: "Safety protocols",
+      bucket: "opened"
+    });
+    expect(list.items[1]).toMatchObject({
+      contactId: "contact:sarah-martinez",
+      latestSubject: "Re: Amazon Basin equipment list",
+      needsFollowUp: true,
+      bucket: "new"
+    });
+  });
+
+  it("uses bucket, needsFollowUp, and hasUnresolved for the secondary filters", async () => {
+    const unread = await getInboxList("unread");
+    const followUp = await getInboxList("follow-up");
+    const unresolved = await getInboxList("unresolved");
+
+    expect(unread.items.map((item) => item.contactId)).toEqual([
+      "contact:sarah-martinez"
+    ]);
+    expect(followUp.items.map((item) => item.contactId)).toEqual([
+      "contact:sarah-martinez"
+    ]);
+    expect(unresolved.items.map((item) => item.contactId)).toEqual([
+      "contact:alex-thompson"
+    ]);
+  });
+
+  it("assembles selected-contact detail from real contact, membership, timeline, and projection data", async () => {
+    const detail = await getInboxDetail("contact:sarah-martinez");
+
+    expect(detail).not.toBeNull();
+    expect(detail).toMatchObject({
+      bucket: "new",
+      needsFollowUp: true,
+      smsEligible: true
+    });
+    expect(detail?.contact).toMatchObject({
+      contactId: "contact:sarah-martinez",
+      displayName: "Sarah Martinez",
+      volunteerId: "003-sarah"
+    });
+    expect(detail?.contact.activeProjects[0]).toMatchObject({
+      projectName: "Amazon Basin Research",
+      status: "in-training"
+    });
+    expect(detail?.timeline.map((entry) => entry.kind)).toEqual([
+      "outbound-email",
+      "inbound-email"
+    ]);
+    expect(detail?.timeline.at(-1)).toMatchObject({
+      subject: "Re: Amazon Basin equipment list",
+      isUnread: true
+    });
+  });
+});

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -21,6 +21,7 @@ import {
   seedInboxInternalNoteEvent,
   seedInboxLifecycleEvent,
   seedInboxProjection,
+  seedInboxSalesforceOutboundEmailEvent,
   seedInboxSmsEvent,
   type InboxTestRuntime
 } from "./inbox-stage1-helpers";
@@ -329,5 +330,55 @@ describe("real inbox selectors", () => {
       actorLabel: "Jordan",
       body: "Prefers SMS check-ins before training."
     });
+  });
+
+  it("keeps Salesforce outbound email in the 1:1 contract unless canon explicitly marks it auto", async () => {
+    await seedInboxSalesforceOutboundEmailEvent(runtime!.context, {
+      id: "sarah-salesforce-null-1",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-10T06:00:00.000Z",
+      subject: "Logged Salesforce follow-up",
+      snippet: "Logged Salesforce follow-up body.",
+      messageKind: null
+    });
+    await seedInboxSalesforceOutboundEmailEvent(runtime!.context, {
+      id: "sarah-salesforce-one-to-one-1",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-10T07:00:00.000Z",
+      subject: "Explicit Salesforce one-to-one",
+      snippet: "Explicit Salesforce one-to-one body.",
+      messageKind: "one_to_one"
+    });
+
+    const detail = await getInboxDetail("contact:sarah-martinez");
+    const nullClassifiedEntry = detail?.timeline.find(
+      (entry) => entry.subject === "Logged Salesforce follow-up"
+    );
+    const explicitOneToOneEntry = detail?.timeline.find(
+      (entry) => entry.subject === "Explicit Salesforce one-to-one"
+    );
+
+    expect(nullClassifiedEntry).toMatchObject({
+      kind: "outbound-email",
+      actorLabel: "You",
+      channel: "email",
+      body: "Logged Salesforce follow-up body."
+    });
+    expect(explicitOneToOneEntry).toMatchObject({
+      kind: "outbound-email",
+      actorLabel: "You",
+      channel: "email",
+      body: "Explicit Salesforce one-to-one body."
+    });
+    expect(
+      detail?.timeline
+        .filter((entry) => entry.kind === "outbound-auto-email")
+        .map((entry) => entry.subject)
+    ).not.toEqual(
+      expect.arrayContaining([
+        "Logged Salesforce follow-up",
+        "Explicit Salesforce one-to-one"
+      ])
+    );
   });
 });

--- a/apps/web/tests/unit/inbox-stage1-helpers.ts
+++ b/apps/web/tests/unit/inbox-stage1-helpers.ts
@@ -1,0 +1,241 @@
+import type { InboxProjectionRow } from "@as-comms/contracts";
+
+import {
+  createTestStage1Context,
+  type TestStage1Context
+} from "../../../../packages/db/test/helpers.js";
+import { setStage1WebRuntimeForTests } from "../../src/server/stage1-runtime";
+
+export interface InboxTestRuntime {
+  readonly context: TestStage1Context;
+  dispose(): Promise<void>;
+}
+
+export async function createInboxTestRuntime(): Promise<InboxTestRuntime> {
+  const context = await createTestStage1Context();
+
+  setStage1WebRuntimeForTests({
+    connection: null,
+    repositories: context.repositories
+  });
+
+  return {
+    context,
+    async dispose() {
+      setStage1WebRuntimeForTests(null);
+      await context.client.close();
+    }
+  };
+}
+
+export async function seedInboxContact(
+  context: TestStage1Context,
+  input: {
+    readonly contactId: string;
+    readonly salesforceContactId: string | null;
+    readonly displayName: string;
+    readonly primaryEmail: string | null;
+    readonly primaryPhone: string | null;
+    readonly projectId?: string;
+    readonly projectName?: string;
+    readonly membershipId?: string;
+    readonly membershipStatus?: string | null;
+  }
+): Promise<void> {
+  await context.repositories.contacts.upsert({
+    id: input.contactId,
+    salesforceContactId: input.salesforceContactId,
+    displayName: input.displayName,
+    primaryEmail: input.primaryEmail,
+    primaryPhone: input.primaryPhone,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z"
+  });
+
+  if (input.projectId !== undefined) {
+    await context.repositories.projectDimensions.upsert({
+      projectId: input.projectId,
+      projectName: input.projectName ?? input.projectId,
+      source: "salesforce"
+    });
+  }
+
+  if (input.membershipId !== undefined) {
+    await context.repositories.contactMemberships.upsert({
+      id: input.membershipId,
+      contactId: input.contactId,
+      projectId: input.projectId ?? null,
+      expeditionId: null,
+      role: "volunteer",
+      status: input.membershipStatus ?? null,
+      source: "salesforce"
+    });
+  }
+}
+
+export async function seedInboxEmailEvent(
+  context: TestStage1Context,
+  input: {
+    readonly id: string;
+    readonly contactId: string;
+    readonly occurredAt: string;
+    readonly direction: "inbound" | "outbound";
+    readonly subject: string;
+    readonly snippet: string;
+  }
+): Promise<{ readonly canonicalEventId: string }> {
+  const sourceEvidenceId = `source:${input.id}`;
+  const canonicalEventId = `event:${input.id}`;
+
+  await context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "gmail",
+    providerRecordType: "message",
+    providerRecordId: input.id,
+    receivedAt: input.occurredAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `payloads/gmail/${input.id}.json`,
+    idempotencyKey: `gmail:${input.id}`,
+    checksum: `checksum:${input.id}`
+  });
+
+  await context.repositories.canonicalEvents.upsert({
+    id: canonicalEventId,
+    contactId: input.contactId,
+    eventType:
+      input.direction === "inbound"
+        ? "communication.email.inbound"
+        : "communication.email.outbound",
+    channel: "email",
+    occurredAt: input.occurredAt,
+    sourceEvidenceId,
+    idempotencyKey: `canonical:${input.id}`,
+    provenance: {
+      primaryProvider: "gmail",
+      primarySourceEvidenceId: sourceEvidenceId,
+      supportingSourceEvidenceIds: [],
+      winnerReason: "single_source",
+      sourceRecordType: "message",
+      sourceRecordId: input.id,
+      messageKind: "one_to_one",
+      campaignRef: null,
+      threadRef: null,
+      direction: input.direction,
+      notes: null
+    },
+    reviewState: "clear"
+  });
+
+  await context.repositories.gmailMessageDetails.upsert({
+    sourceEvidenceId,
+    providerRecordId: input.id,
+    gmailThreadId: `thread:${input.contactId}`,
+    rfc822MessageId: `<${input.id}@example.org>`,
+    direction: input.direction,
+    subject: input.subject,
+    snippetClean: input.snippet,
+    bodyTextPreview: input.snippet,
+    capturedMailbox: "volunteers@example.org",
+    projectInboxAlias: "volunteers@example.org"
+  });
+
+  await context.repositories.timelineProjection.upsert({
+    id: `timeline:${input.id}`,
+    contactId: input.contactId,
+    canonicalEventId,
+    occurredAt: input.occurredAt,
+    sortKey: `${input.occurredAt}::${canonicalEventId}`,
+    eventType:
+      input.direction === "inbound"
+        ? "communication.email.inbound"
+        : "communication.email.outbound",
+    summary: input.subject,
+    channel: "email",
+    primaryProvider: "gmail",
+    reviewState: "clear"
+  });
+
+  return {
+    canonicalEventId
+  };
+}
+
+export async function seedInboxSmsEvent(
+  context: TestStage1Context,
+  input: {
+    readonly id: string;
+    readonly contactId: string;
+    readonly occurredAt: string;
+    readonly direction: "inbound" | "outbound";
+    readonly summary: string;
+  }
+): Promise<{ readonly canonicalEventId: string }> {
+  const sourceEvidenceId = `source:${input.id}`;
+  const canonicalEventId = `event:${input.id}`;
+
+  await context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "salesforce",
+    providerRecordType: "communication",
+    providerRecordId: input.id,
+    receivedAt: input.occurredAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `payloads/salesforce/${input.id}.json`,
+    idempotencyKey: `salesforce:${input.id}`,
+    checksum: `checksum:${input.id}`
+  });
+
+  await context.repositories.canonicalEvents.upsert({
+    id: canonicalEventId,
+    contactId: input.contactId,
+    eventType:
+      input.direction === "inbound"
+        ? "communication.sms.inbound"
+        : "communication.sms.outbound",
+    channel: "sms",
+    occurredAt: input.occurredAt,
+    sourceEvidenceId,
+    idempotencyKey: `canonical:${input.id}`,
+    provenance: {
+      primaryProvider: "salesforce",
+      primarySourceEvidenceId: sourceEvidenceId,
+      supportingSourceEvidenceIds: [],
+      winnerReason: "single_source",
+      sourceRecordType: "communication",
+      sourceRecordId: input.id,
+      messageKind: "one_to_one",
+      campaignRef: null,
+      threadRef: null,
+      direction: input.direction,
+      notes: null
+    },
+    reviewState: "clear"
+  });
+
+  await context.repositories.timelineProjection.upsert({
+    id: `timeline:${input.id}`,
+    contactId: input.contactId,
+    canonicalEventId,
+    occurredAt: input.occurredAt,
+    sortKey: `${input.occurredAt}::${canonicalEventId}`,
+    eventType:
+      input.direction === "inbound"
+        ? "communication.sms.inbound"
+        : "communication.sms.outbound",
+    summary: input.summary,
+    channel: "sms",
+    primaryProvider: "salesforce",
+    reviewState: "clear"
+  });
+
+  return {
+    canonicalEventId
+  };
+}
+
+export async function seedInboxProjection(
+  context: TestStage1Context,
+  row: InboxProjectionRow
+): Promise<void> {
+  await context.repositories.inboxProjection.upsert(row);
+}

--- a/apps/web/tests/unit/inbox-stage1-helpers.ts
+++ b/apps/web/tests/unit/inbox-stage1-helpers.ts
@@ -315,6 +315,89 @@ export async function seedInboxAutoEmailEvent(
   };
 }
 
+export async function seedInboxSalesforceOutboundEmailEvent(
+  context: TestStage1Context,
+  input: {
+    readonly id: string;
+    readonly contactId: string;
+    readonly occurredAt: string;
+    readonly subject: string;
+    readonly snippet: string;
+    readonly messageKind: "one_to_one" | null;
+    readonly sourceRecordType?: string;
+    readonly sourceLabel?: string;
+  }
+): Promise<{ readonly canonicalEventId: string }> {
+  const sourceEvidenceId = `source:${input.id}`;
+  const canonicalEventId = `event:${input.id}`;
+  const sourceRecordType = input.sourceRecordType ?? "task_communication";
+
+  await context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "salesforce",
+    providerRecordType: sourceRecordType,
+    providerRecordId: input.id,
+    receivedAt: input.occurredAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `payloads/salesforce/${input.id}.json`,
+    idempotencyKey: `salesforce:${input.id}`,
+    checksum: `checksum:${input.id}`
+  });
+
+  await context.repositories.canonicalEvents.upsert({
+    id: canonicalEventId,
+    contactId: input.contactId,
+    eventType: "communication.email.outbound",
+    channel: "email",
+    occurredAt: input.occurredAt,
+    sourceEvidenceId,
+    idempotencyKey: `canonical:${input.id}`,
+    provenance: {
+      primaryProvider: "salesforce",
+      primarySourceEvidenceId: sourceEvidenceId,
+      supportingSourceEvidenceIds: [],
+      winnerReason: "single_source",
+      sourceRecordType,
+      sourceRecordId: input.id,
+      messageKind: input.messageKind,
+      campaignRef: null,
+      threadRef: null,
+      direction: "outbound",
+      notes: null
+    },
+    reviewState: "clear"
+  });
+
+  await context.repositories.salesforceCommunicationDetails.upsert({
+    sourceEvidenceId,
+    providerRecordId: input.id,
+    channel: "email",
+    // The detail row stores a concrete message kind even when canonical
+    // provenance remains null for the logged-email regression case.
+    messageKind: input.messageKind ?? "one_to_one",
+    subject: input.subject,
+    snippet: input.snippet,
+    sourceLabel: input.sourceLabel ?? "Salesforce Logged Email"
+  });
+
+  await context.repositories.timelineProjection.upsert({
+    id: `timeline:${input.id}`,
+    contactId: input.contactId,
+    canonicalEventId,
+    occurredAt: input.occurredAt,
+    sortKey: `${input.occurredAt}::${canonicalEventId}`,
+    eventType: "communication.email.outbound",
+    summary: input.subject,
+    channel: "email",
+    primaryProvider: "salesforce",
+    reviewState: "clear"
+  });
+
+  return {
+    canonicalEventId
+  };
+}
+
 export async function seedInboxCampaignEmailEvent(
   context: TestStage1Context,
   input: {

--- a/apps/web/tests/unit/inbox-stage1-helpers.ts
+++ b/apps/web/tests/unit/inbox-stage1-helpers.ts
@@ -1,4 +1,5 @@
 import type { InboxProjectionRow } from "@as-comms/contracts";
+import { createStage1TimelinePresentationService } from "../../../../packages/domain/src/timeline.js";
 
 import {
   createTestStage1Context,
@@ -16,7 +17,10 @@ export async function createInboxTestRuntime(): Promise<InboxTestRuntime> {
 
   setStage1WebRuntimeForTests({
     connection: null,
-    repositories: context.repositories
+    repositories: context.repositories,
+    timelinePresentation: createStage1TimelinePresentationService(
+      context.repositories
+    )
   });
 
   return {
@@ -224,6 +228,407 @@ export async function seedInboxSmsEvent(
         : "communication.sms.outbound",
     summary: input.summary,
     channel: "sms",
+    primaryProvider: "salesforce",
+    reviewState: "clear"
+  });
+
+  return {
+    canonicalEventId
+  };
+}
+
+export async function seedInboxAutoEmailEvent(
+  context: TestStage1Context,
+  input: {
+    readonly id: string;
+    readonly contactId: string;
+    readonly occurredAt: string;
+    readonly subject: string;
+    readonly snippet: string;
+    readonly sourceLabel?: string;
+  }
+): Promise<{ readonly canonicalEventId: string }> {
+  const sourceEvidenceId = `source:${input.id}`;
+  const canonicalEventId = `event:${input.id}`;
+
+  await context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "salesforce",
+    providerRecordType: "task",
+    providerRecordId: input.id,
+    receivedAt: input.occurredAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `payloads/salesforce/${input.id}.json`,
+    idempotencyKey: `salesforce:${input.id}`,
+    checksum: `checksum:${input.id}`
+  });
+
+  await context.repositories.canonicalEvents.upsert({
+    id: canonicalEventId,
+    contactId: input.contactId,
+    eventType: "communication.email.outbound",
+    channel: "email",
+    occurredAt: input.occurredAt,
+    sourceEvidenceId,
+    idempotencyKey: `canonical:${input.id}`,
+    provenance: {
+      primaryProvider: "salesforce",
+      primarySourceEvidenceId: sourceEvidenceId,
+      supportingSourceEvidenceIds: [],
+      winnerReason: "single_source",
+      sourceRecordType: "task",
+      sourceRecordId: input.id,
+      messageKind: "auto",
+      campaignRef: null,
+      threadRef: null,
+      direction: "outbound",
+      notes: null
+    },
+    reviewState: "clear"
+  });
+
+  await context.repositories.salesforceCommunicationDetails.upsert({
+    sourceEvidenceId,
+    providerRecordId: input.id,
+    channel: "email",
+    messageKind: "auto",
+    subject: input.subject,
+    snippet: input.snippet,
+    sourceLabel: input.sourceLabel ?? "Salesforce Flow"
+  });
+
+  await context.repositories.timelineProjection.upsert({
+    id: `timeline:${input.id}`,
+    contactId: input.contactId,
+    canonicalEventId,
+    occurredAt: input.occurredAt,
+    sortKey: `${input.occurredAt}::${canonicalEventId}`,
+    eventType: "communication.email.outbound",
+    summary: input.subject,
+    channel: "email",
+    primaryProvider: "salesforce",
+    reviewState: "clear"
+  });
+
+  return {
+    canonicalEventId
+  };
+}
+
+export async function seedInboxCampaignEmailEvent(
+  context: TestStage1Context,
+  input: {
+    readonly id: string;
+    readonly contactId: string;
+    readonly occurredAt: string;
+    readonly activityType: "sent" | "opened" | "clicked" | "unsubscribed";
+    readonly campaignName: string;
+    readonly snippet: string;
+  }
+): Promise<{ readonly canonicalEventId: string }> {
+  const sourceEvidenceId = `source:${input.id}`;
+  const canonicalEventId = `event:${input.id}`;
+  const eventType = `campaign.email.${input.activityType}` as const;
+
+  await context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "mailchimp",
+    providerRecordType: "campaign_activity",
+    providerRecordId: input.id,
+    receivedAt: input.occurredAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `payloads/mailchimp/${input.id}.json`,
+    idempotencyKey: `mailchimp:${input.id}`,
+    checksum: `checksum:${input.id}`
+  });
+
+  await context.repositories.canonicalEvents.upsert({
+    id: canonicalEventId,
+    contactId: input.contactId,
+    eventType,
+    channel: "campaign_email",
+    occurredAt: input.occurredAt,
+    sourceEvidenceId,
+    idempotencyKey: `canonical:${input.id}`,
+    provenance: {
+      primaryProvider: "mailchimp",
+      primarySourceEvidenceId: sourceEvidenceId,
+      supportingSourceEvidenceIds: [],
+      winnerReason: "single_source",
+      sourceRecordType: "campaign_activity",
+      sourceRecordId: input.id,
+      messageKind: "campaign",
+      campaignRef: {
+        providerCampaignId: "campaign_email_1",
+        providerAudienceId: "audience_1",
+        providerMessageName: input.campaignName
+      },
+      threadRef: null,
+      direction: "outbound",
+      notes: null
+    },
+    reviewState: "clear"
+  });
+
+  await context.repositories.mailchimpCampaignActivityDetails.upsert({
+    sourceEvidenceId,
+    providerRecordId: input.id,
+    activityType: input.activityType,
+    campaignId: "campaign_email_1",
+    audienceId: "audience_1",
+    memberId: "member_1",
+    campaignName: input.campaignName,
+    snippet: input.snippet
+  });
+
+  await context.repositories.timelineProjection.upsert({
+    id: `timeline:${input.id}`,
+    contactId: input.contactId,
+    canonicalEventId,
+    occurredAt: input.occurredAt,
+    sortKey: `${input.occurredAt}::${canonicalEventId}`,
+    eventType,
+    summary: input.campaignName,
+    channel: "campaign_email",
+    primaryProvider: "mailchimp",
+    reviewState: "clear"
+  });
+
+  return {
+    canonicalEventId
+  };
+}
+
+export async function seedInboxCampaignSmsEvent(
+  context: TestStage1Context,
+  input: {
+    readonly id: string;
+    readonly contactId: string;
+    readonly occurredAt: string;
+    readonly campaignName: string;
+    readonly messageTextPreview: string;
+  }
+): Promise<{ readonly canonicalEventId: string }> {
+  const sourceEvidenceId = `source:${input.id}`;
+  const canonicalEventId = `event:${input.id}`;
+
+  await context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "simpletexting",
+    providerRecordType: "message",
+    providerRecordId: input.id,
+    receivedAt: input.occurredAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `payloads/simpletexting/${input.id}.json`,
+    idempotencyKey: `simpletexting:${input.id}`,
+    checksum: `checksum:${input.id}`
+  });
+
+  await context.repositories.canonicalEvents.upsert({
+    id: canonicalEventId,
+    contactId: input.contactId,
+    eventType: "communication.sms.outbound",
+    channel: "sms",
+    occurredAt: input.occurredAt,
+    sourceEvidenceId,
+    idempotencyKey: `canonical:${input.id}`,
+    provenance: {
+      primaryProvider: "simpletexting",
+      primarySourceEvidenceId: sourceEvidenceId,
+      supportingSourceEvidenceIds: [],
+      winnerReason: "single_source",
+      sourceRecordType: "message",
+      sourceRecordId: input.id,
+      messageKind: "campaign",
+      campaignRef: {
+        providerCampaignId: "campaign_sms_1",
+        providerAudienceId: null,
+        providerMessageName: input.campaignName
+      },
+      threadRef: null,
+      direction: "outbound",
+      notes: null
+    },
+    reviewState: "clear"
+  });
+
+  await context.repositories.simpleTextingMessageDetails.upsert({
+    sourceEvidenceId,
+    providerRecordId: input.id,
+    direction: "outbound",
+    messageKind: "campaign",
+    messageTextPreview: input.messageTextPreview,
+    normalizedPhone: "+15550000001",
+    campaignId: "campaign_sms_1",
+    campaignName: input.campaignName,
+    providerThreadId: `thread:${input.contactId}`,
+    threadKey: `thread:${input.contactId}`
+  });
+
+  await context.repositories.timelineProjection.upsert({
+    id: `timeline:${input.id}`,
+    contactId: input.contactId,
+    canonicalEventId,
+    occurredAt: input.occurredAt,
+    sortKey: `${input.occurredAt}::${canonicalEventId}`,
+    eventType: "communication.sms.outbound",
+    summary: input.campaignName,
+    channel: "sms",
+    primaryProvider: "simpletexting",
+    reviewState: "clear"
+  });
+
+  return {
+    canonicalEventId
+  };
+}
+
+export async function seedInboxInternalNoteEvent(
+  context: TestStage1Context,
+  input: {
+    readonly id: string;
+    readonly contactId: string;
+    readonly occurredAt: string;
+    readonly body: string;
+    readonly authorDisplayName: string;
+  }
+): Promise<{ readonly canonicalEventId: string }> {
+  const sourceEvidenceId = `source:${input.id}`;
+  const canonicalEventId = `event:${input.id}`;
+
+  await context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "manual",
+    providerRecordType: "note",
+    providerRecordId: input.id,
+    receivedAt: input.occurredAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `payloads/manual/${input.id}.json`,
+    idempotencyKey: `manual:${input.id}`,
+    checksum: `checksum:${input.id}`
+  });
+
+  await context.repositories.canonicalEvents.upsert({
+    id: canonicalEventId,
+    contactId: input.contactId,
+    eventType: "note.internal.created",
+    channel: "note",
+    occurredAt: input.occurredAt,
+    sourceEvidenceId,
+    idempotencyKey: `canonical:${input.id}`,
+    provenance: {
+      primaryProvider: "manual",
+      primarySourceEvidenceId: sourceEvidenceId,
+      supportingSourceEvidenceIds: [],
+      winnerReason: "single_source",
+      sourceRecordType: "note",
+      sourceRecordId: input.id,
+      messageKind: null,
+      campaignRef: null,
+      threadRef: null,
+      direction: null,
+      notes: null
+    },
+    reviewState: "clear"
+  });
+
+  await context.repositories.manualNoteDetails.upsert({
+    sourceEvidenceId,
+    providerRecordId: input.id,
+    body: input.body,
+    authorDisplayName: input.authorDisplayName
+  });
+
+  await context.repositories.timelineProjection.upsert({
+    id: `timeline:${input.id}`,
+    contactId: input.contactId,
+    canonicalEventId,
+    occurredAt: input.occurredAt,
+    sortKey: `${input.occurredAt}::${canonicalEventId}`,
+    eventType: "note.internal.created",
+    summary: "Internal note added",
+    channel: "note",
+    primaryProvider: "manual",
+    reviewState: "clear"
+  });
+
+  return {
+    canonicalEventId
+  };
+}
+
+export async function seedInboxLifecycleEvent(
+  context: TestStage1Context,
+  input: {
+    readonly id: string;
+    readonly contactId: string;
+    readonly occurredAt: string;
+    readonly eventType:
+      | "lifecycle.signed_up"
+      | "lifecycle.received_training"
+      | "lifecycle.completed_training"
+      | "lifecycle.submitted_first_data";
+    readonly summary: string;
+    readonly projectId?: string | null;
+    readonly expeditionId?: string | null;
+  }
+): Promise<{ readonly canonicalEventId: string }> {
+  const sourceEvidenceId = `source:${input.id}`;
+  const canonicalEventId = `event:${input.id}`;
+
+  await context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "salesforce",
+    providerRecordType: "lifecycle",
+    providerRecordId: input.id,
+    receivedAt: input.occurredAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `payloads/salesforce/${input.id}.json`,
+    idempotencyKey: `salesforce:${input.id}`,
+    checksum: `checksum:${input.id}`
+  });
+
+  await context.repositories.canonicalEvents.upsert({
+    id: canonicalEventId,
+    contactId: input.contactId,
+    eventType: input.eventType,
+    channel: "lifecycle",
+    occurredAt: input.occurredAt,
+    sourceEvidenceId,
+    idempotencyKey: `canonical:${input.id}`,
+    provenance: {
+      primaryProvider: "salesforce",
+      primarySourceEvidenceId: sourceEvidenceId,
+      supportingSourceEvidenceIds: [],
+      winnerReason: "single_source",
+      sourceRecordType: "lifecycle",
+      sourceRecordId: input.id,
+      messageKind: null,
+      campaignRef: null,
+      threadRef: null,
+      direction: null,
+      notes: null
+    },
+    reviewState: "clear"
+  });
+
+  await context.repositories.salesforceEventContext.upsert({
+    sourceEvidenceId,
+    salesforceContactId: null,
+    projectId: input.projectId ?? null,
+    expeditionId: input.expeditionId ?? null,
+    sourceField: "Lifecycle"
+  });
+
+  await context.repositories.timelineProjection.upsert({
+    id: `timeline:${input.id}`,
+    contactId: input.contactId,
+    canonicalEventId,
+    occurredAt: input.occurredAt,
+    sortKey: `${input.occurredAt}::${canonicalEventId}`,
+    eventType: input.eventType,
+    summary: input.summary,
+    channel: "lifecycle",
     primaryProvider: "salesforce",
     reviewState: "clear"
   });

--- a/apps/worker/src/ops/mailchimp-artifacts.ts
+++ b/apps/worker/src/ops/mailchimp-artifacts.ts
@@ -1,0 +1,748 @@
+import { access, readdir } from "node:fs/promises";
+import { basename, resolve } from "node:path";
+
+import { ZodError, z } from "zod";
+
+import {
+  importMailchimpCampaignArtifactRecordsFromPath,
+  mapMailchimpRecord,
+  type MailchimpCampaignActivityRecord
+} from "@as-comms/integrations";
+import type { Stage1PersistenceService } from "@as-comms/domain";
+import type { SyncStateRecord } from "@as-comms/contracts";
+
+import type { Stage1IngestService } from "../ingest/index.js";
+import type { Stage1IngestResult } from "../ingest/types.js";
+import {
+  buildMailchimpUnmatchedReport,
+  hasKnownMailchimpIdentity,
+  type MailchimpKnownIdentityIndex,
+  type MailchimpUnmatchedRecipientRow,
+  writeMailchimpUnmatchedReport
+} from "./mailchimp-unmatched.js";
+import {
+  Stage1NonRetryableJobError,
+  Stage1RetryableJobError,
+  type Stage1JobFailure
+} from "../orchestration/index.js";
+import { recordProjectionSeedOnce } from "../orchestration/projection-seed.js";
+import { recordSyncFailureAudit } from "../orchestration/sync-failure-audit.js";
+import type { Stage1SyncStateService } from "../orchestration/sync-state.js";
+
+const mailchimpArtifactImportInputSchema = z.object({
+  artifactPath: z.string().min(1),
+  syncStateId: z.string().min(1),
+  correlationId: z.string().min(1),
+  traceId: z.string().min(1).nullable().default(null),
+  receivedAt: z.string().datetime().nullable().default(null),
+  limitCampaigns: z.number().int().positive().nullable().default(null),
+  startAtCampaignId: z.string().min(1).nullable().default(null),
+  unmatchedReportOutputRoot: z.string().min(1).nullable().default(null)
+});
+
+export type MailchimpArtifactImportInput = z.input<
+  typeof mailchimpArtifactImportInputSchema
+>;
+
+export interface Stage1MailchimpArtifactImportResult {
+  readonly outcome: "succeeded" | "failed";
+  readonly artifactPath: string;
+  readonly importedCampaignIds: readonly string[];
+  readonly parsedCampaigns: number;
+  readonly parsedRecords: number;
+  readonly syncStateId: string;
+  readonly correlationId: string;
+  readonly summary: {
+    readonly processed: number;
+    readonly normalized: number;
+    readonly duplicate: number;
+    readonly reviewOpened: number;
+    readonly quarantined: number;
+    readonly deferred: number;
+    readonly deadLetterCountIncrement: number;
+    readonly skippedUnmatched: number;
+    readonly skippedUnmatchedRecipients: number;
+  };
+  readonly checkpoint: string | null;
+  readonly syncStatus: SyncStateRecord["status"];
+  readonly message?: string;
+  readonly unmatchedReportJsonPath?: string;
+  readonly unmatchedReportCsvPath?: string;
+}
+
+interface Stage1MailchimpArtifactImportDependencies {
+  readonly ingest: Pick<Stage1IngestService, "ingestMailchimpHistoricalRecord">;
+  readonly persistence: Stage1PersistenceService;
+  readonly syncState: Stage1SyncStateService;
+  readonly mailchimpIdentityIndex?: MailchimpKnownIdentityIndex;
+  readonly now?: () => Date;
+}
+
+const MAILCHIMP_RECORD_PROGRESS_INTERVAL = 25;
+
+function summarizeIngestResults(
+  results: readonly Stage1IngestResult[],
+  input?: {
+    readonly skippedUnmatched: number;
+    readonly skippedUnmatchedRecipients: number;
+  }
+) {
+  return {
+    processed: results.length,
+    normalized: results.filter((result) => result.outcome === "normalized").length,
+    duplicate: results.filter((result) => result.outcome === "duplicate").length,
+    reviewOpened: results.filter((result) => result.outcome === "review_opened")
+      .length,
+    quarantined: results.filter((result) => result.outcome === "quarantined")
+      .length,
+    deferred: results.filter((result) => result.outcome === "deferred").length,
+    deadLetterCountIncrement: results.filter(
+      (result) => result.outcome === "quarantined"
+    ).length,
+    skippedUnmatched: input?.skippedUnmatched ?? 0,
+    skippedUnmatchedRecipients: input?.skippedUnmatchedRecipients ?? 0
+  };
+}
+
+function isOccurredAtRecord(
+  record: unknown
+): record is { readonly occurredAt: string } {
+  return (
+    typeof record === "object" &&
+    record !== null &&
+    "occurredAt" in record &&
+    typeof record.occurredAt === "string"
+  );
+}
+
+function calculateHistoricalWindow(
+  records: readonly unknown[]
+): {
+  readonly windowStart: string | null;
+  readonly windowEnd: string | null;
+  readonly checkpoint: string | null;
+} {
+  const occurredAtValues = records
+    .filter(isOccurredAtRecord)
+    .map((record) => record.occurredAt)
+    .sort((left, right) => left.localeCompare(right));
+  const windowStart = occurredAtValues[0] ?? null;
+  const checkpoint = occurredAtValues.at(-1) ?? null;
+
+  return {
+    windowStart,
+    windowEnd: checkpoint,
+    checkpoint
+  };
+}
+
+function buildImportFailure(error: unknown): Stage1JobFailure {
+  const message = error instanceof Error ? error.message : String(error);
+
+  if (error instanceof Stage1NonRetryableJobError || error instanceof ZodError) {
+    return {
+      disposition: "non_retryable",
+      retryable: false,
+      message
+    };
+  }
+
+  return {
+    disposition:
+      error instanceof Stage1RetryableJobError ? "retryable" : "retryable",
+    retryable: true,
+    message
+  };
+}
+
+function buildMailchimpRecordCursor(
+  campaignId: string,
+  nextRecordIndex: number
+): string {
+  return `${campaignId}:record:${nextRecordIndex}`;
+}
+
+function parseMailchimpRecordCursor(
+  cursor: string | null
+): {
+  readonly campaignId: string;
+  readonly nextRecordIndex: number;
+} | null {
+  if (cursor === null) {
+    return null;
+  }
+
+  const marker = ":record:";
+  const markerIndex = cursor.lastIndexOf(marker);
+
+  if (markerIndex === -1) {
+    return null;
+  }
+
+  const campaignId = cursor.slice(0, markerIndex).trim();
+  const nextRecordIndexValue = cursor.slice(markerIndex + marker.length).trim();
+  const nextRecordIndex = Number.parseInt(nextRecordIndexValue, 10);
+
+  if (campaignId.length === 0 || Number.isNaN(nextRecordIndex) || nextRecordIndex < 0) {
+    return null;
+  }
+
+  return {
+    campaignId,
+    nextRecordIndex
+  };
+}
+
+function resolveMailchimpResumePlan(
+  cursor: string | null,
+  campaignIds: readonly string[]
+): {
+  readonly completedCampaignIds: ReadonlySet<string>;
+  readonly resumeCampaignId: string | null;
+  readonly resumeNextRecordIndex: number;
+} {
+  const recordCursor = parseMailchimpRecordCursor(cursor);
+
+  if (recordCursor !== null) {
+    const resumeCampaignIndex = campaignIds.indexOf(recordCursor.campaignId);
+
+    if (resumeCampaignIndex !== -1) {
+      return {
+        completedCampaignIds: new Set(campaignIds.slice(0, resumeCampaignIndex)),
+        resumeCampaignId: recordCursor.campaignId,
+        resumeNextRecordIndex: recordCursor.nextRecordIndex
+      };
+    }
+  }
+
+  if (cursor !== null) {
+    const completedCampaignIndex = campaignIds.indexOf(cursor);
+
+    if (completedCampaignIndex !== -1) {
+      return {
+        completedCampaignIds: new Set(campaignIds.slice(0, completedCampaignIndex + 1)),
+        resumeCampaignId: campaignIds[completedCampaignIndex + 1] ?? null,
+        resumeNextRecordIndex: 0
+      };
+    }
+  }
+
+  return {
+    completedCampaignIds: new Set<string>(),
+    resumeCampaignId: campaignIds[0] ?? null,
+    resumeNextRecordIndex: 0
+  };
+}
+
+function shouldCheckpointMailchimpCampaignRecord(
+  nextRecordIndex: number,
+  recordCount: number
+): boolean {
+  return (
+    nextRecordIndex === recordCount ||
+    nextRecordIndex % MAILCHIMP_RECORD_PROGRESS_INTERVAL === 0
+  );
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveCampaignArtifactPaths(input: {
+  readonly artifactPath: string;
+  readonly limitCampaigns: number | null;
+  readonly startAtCampaignId: string | null;
+}): Promise<string[]> {
+  const resolvedArtifactPath = resolve(input.artifactPath);
+  const summaryPath = resolve(resolvedArtifactPath, "summary.json");
+
+  if (await pathExists(summaryPath)) {
+    return [resolvedArtifactPath];
+  }
+
+  const entries = await readdir(resolvedArtifactPath, {
+    withFileTypes: true
+  });
+  const campaignPaths: string[] = [];
+
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) {
+      continue;
+    }
+
+    const campaignPath = resolve(resolvedArtifactPath, entry.name);
+
+    if (await pathExists(resolve(campaignPath, "summary.json"))) {
+      campaignPaths.push(campaignPath);
+    }
+  }
+
+  const startIndex =
+    input.startAtCampaignId === null
+      ? 0
+      : campaignPaths.findIndex(
+          (campaignPath) => basename(campaignPath) === input.startAtCampaignId
+        );
+
+  if (input.startAtCampaignId !== null && startIndex === -1) {
+    throw new Error(
+      `Could not find Mailchimp campaign artifact ${input.startAtCampaignId} under ${input.artifactPath}.`
+    );
+  }
+
+  const resumedCampaignPaths = campaignPaths.slice(startIndex === -1 ? 0 : startIndex);
+
+  return input.limitCampaigns === null
+    ? resumedCampaignPaths
+    : resumedCampaignPaths.slice(0, input.limitCampaigns);
+}
+
+async function findExistingDuplicateResult(
+  persistence: Stage1PersistenceService,
+  mapped: ReturnType<typeof mapMailchimpRecord>
+): Promise<Stage1IngestResult | null> {
+  if (mapped.outcome !== "command" || mapped.command.kind !== "canonical_event") {
+    return null;
+  }
+
+  const existingSourceEvidence = await persistence.findSourceEvidenceByIdempotencyKey(
+    mapped.command.input.sourceEvidence.idempotencyKey
+  );
+
+  if (existingSourceEvidence === null) {
+    return null;
+  }
+
+  const existingCanonicalEvent =
+    await persistence.findCanonicalEventByIdempotencyKey(
+      mapped.command.input.canonicalEvent.idempotencyKey
+    );
+
+  if (existingCanonicalEvent === null) {
+    return null;
+  }
+
+  return {
+    outcome: "duplicate",
+    ingestMode: "historical",
+    provider: "mailchimp",
+    sourceRecordType: mapped.sourceRecordType,
+    sourceRecordId: mapped.sourceRecordId,
+    commandKind: "canonical_event",
+    sourceEvidenceId: existingSourceEvidence.id,
+    canonicalEventId: existingCanonicalEvent.id,
+    contactId: existingCanonicalEvent.contactId
+  };
+}
+
+function createMailchimpIdentityPresenceResolver(
+  dependencies: Stage1MailchimpArtifactImportDependencies
+) {
+  const emailCache = new Map<string, Promise<boolean>>();
+  const volunteerIdCache = new Map<string, Promise<boolean>>();
+
+  const hasKnownEmail = (normalizedEmail: string): Promise<boolean> => {
+    const cached = emailCache.get(normalizedEmail);
+
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const lookup =
+      dependencies.mailchimpIdentityIndex !== undefined
+        ? Promise.resolve(
+            dependencies.mailchimpIdentityIndex.knownEmails.has(normalizedEmail)
+          )
+        : dependencies.persistence.repositories.contactIdentities
+            .listByNormalizedValue({
+              kind: "email",
+              normalizedValue: normalizedEmail
+            })
+            .then((rows) => rows.length > 0);
+    emailCache.set(normalizedEmail, lookup);
+
+    return lookup;
+  };
+
+  const hasKnownVolunteerId = (volunteerId: string): Promise<boolean> => {
+    const cached = volunteerIdCache.get(volunteerId);
+
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const lookup =
+      dependencies.mailchimpIdentityIndex !== undefined
+        ? Promise.resolve(
+            dependencies.mailchimpIdentityIndex.knownVolunteerIds.has(
+              volunteerId
+            )
+          )
+        : dependencies.persistence.repositories.contactIdentities
+            .listByNormalizedValue({
+              kind: "volunteer_id_plain",
+              normalizedValue: volunteerId
+            })
+            .then((rows) => rows.length > 0);
+    volunteerIdCache.set(volunteerId, lookup);
+
+    return lookup;
+  };
+
+  return {
+    async hasKnownIdentity(record: MailchimpCampaignActivityRecord) {
+      if (record.salesforceContactId !== null) {
+        return true;
+      }
+
+      if (await hasKnownEmail(record.normalizedEmail)) {
+        return true;
+      }
+
+      for (const volunteerId of record.volunteerIdPlainValues) {
+        if (await hasKnownVolunteerId(volunteerId)) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+  };
+}
+
+export function createStage1MailchimpArtifactImportService(
+  dependencies: Stage1MailchimpArtifactImportDependencies
+) {
+  const now = dependencies.now ?? (() => new Date());
+
+  return {
+    async importArtifacts(
+      input: MailchimpArtifactImportInput
+    ): Promise<Stage1MailchimpArtifactImportResult> {
+      const parsedInput = mailchimpArtifactImportInputSchema.parse(input);
+      const receivedAt = parsedInput.receivedAt ?? now().toISOString();
+      const campaignPaths = await resolveCampaignArtifactPaths({
+        artifactPath: parsedInput.artifactPath,
+        limitCampaigns: parsedInput.limitCampaigns,
+        startAtCampaignId: parsedInput.startAtCampaignId
+      });
+      const importedCampaignIds = campaignPaths.map((campaignPath) =>
+        basename(campaignPath)
+      );
+
+      if (campaignPaths.length === 0) {
+        throw new Error(
+          `No Mailchimp campaign artifacts were found under ${parsedInput.artifactPath}.`
+        );
+      }
+
+      const startedSyncState = await dependencies.syncState.startWindow({
+        syncStateId: parsedInput.syncStateId,
+        scope: "provider",
+        provider: "mailchimp",
+        jobType: "historical_backfill",
+        cursor: null,
+        checkpoint: null,
+        windowStart: null,
+        windowEnd: null
+      });
+      const resumePlan = resolveMailchimpResumePlan(
+        startedSyncState.cursor,
+        importedCampaignIds
+      );
+
+      let parsedRecords = 0;
+      const ingestResults: Stage1IngestResult[] = [];
+      let windowStart: string | null = startedSyncState.windowStart;
+      let checkpoint: string | null = startedSyncState.windowEnd;
+      let unmatchedReportPaths:
+        | {
+            readonly jsonPath: string;
+            readonly csvPath: string;
+          }
+        | null = null;
+      let skippedUnmatched = 0;
+      const skippedRecipients = new Map<
+        string,
+        {
+          campaignId: string;
+          campaignName: string | null;
+          audienceId: string | null;
+          memberId: string;
+          email: string | null;
+          platformId: string | null;
+          activityTypes: Set<string>;
+        }
+      >();
+      const identityPresenceResolver =
+        createMailchimpIdentityPresenceResolver(dependencies);
+      let pendingDeadLetterCountIncrement = 0;
+      let latestCursor = startedSyncState.cursor;
+
+      try {
+        for (const campaignPath of campaignPaths) {
+          const campaignId = basename(campaignPath);
+
+          if (resumePlan.completedCampaignIds.has(campaignId)) {
+            continue;
+          }
+
+          const records = await importMailchimpCampaignArtifactRecordsFromPath({
+            campaignPath,
+            receivedAt
+          });
+          parsedRecords += records.length;
+          const campaignWindow = calculateHistoricalWindow(records);
+
+          if (
+            campaignWindow.windowStart !== null &&
+            (windowStart === null || campaignWindow.windowStart < windowStart)
+          ) {
+            windowStart = campaignWindow.windowStart;
+          }
+
+          if (
+            campaignWindow.checkpoint !== null &&
+            (checkpoint === null || campaignWindow.checkpoint > checkpoint)
+          ) {
+            checkpoint = campaignWindow.checkpoint;
+          }
+
+          const resumeNextRecordIndex =
+            resumePlan.resumeCampaignId === campaignId
+              ? Math.min(resumePlan.resumeNextRecordIndex, records.length)
+              : 0;
+
+          for (let recordIndex = 0; recordIndex < records.length; recordIndex += 1) {
+            const record = records[recordIndex];
+
+            if (record === undefined) {
+              continue;
+            }
+
+            const hasKnownIdentity =
+              await identityPresenceResolver.hasKnownIdentity(record);
+            const nextRecordIndex = recordIndex + 1;
+
+            if (!hasKnownIdentity) {
+              skippedUnmatched += 1;
+              const skippedKey = `${record.campaignId}:${record.memberId}`;
+              const existingSkippedRecipient = skippedRecipients.get(skippedKey);
+
+              if (existingSkippedRecipient === undefined) {
+                skippedRecipients.set(skippedKey, {
+                  campaignId: record.campaignId,
+                  campaignName: record.campaignName,
+                  audienceId:
+                    record.audienceId.trim().length === 0
+                      ? null
+                      : record.audienceId,
+                  memberId: record.memberId,
+                  email: record.normalizedEmail,
+                  platformId: record.volunteerIdPlainValues[0] ?? null,
+                  activityTypes: new Set([record.activityType])
+                });
+              } else {
+                existingSkippedRecipient.activityTypes.add(record.activityType);
+              }
+            } else if (recordIndex >= resumeNextRecordIndex) {
+              const mapped = mapMailchimpRecord(record);
+              const duplicateResult = await findExistingDuplicateResult(
+                dependencies.persistence,
+                mapped
+              );
+              const ingestResult =
+                duplicateResult ??
+                (await dependencies.ingest.ingestMailchimpHistoricalRecord(record));
+              ingestResults.push(ingestResult);
+              if (ingestResult.outcome === "quarantined") {
+                pendingDeadLetterCountIncrement += 1;
+              }
+
+              if (
+                ingestResult.outcome === "deferred" ||
+                ingestResult.outcome === "quarantined" ||
+                ingestResult.canonicalEventId === null
+              ) {
+              } else if (
+                duplicateResult === null &&
+                mapped.outcome === "command" &&
+                mapped.command.kind === "canonical_event"
+              ) {
+                await recordProjectionSeedOnce(dependencies.persistence, {
+                  canonicalEventId: mapped.command.input.canonicalEvent.id,
+                  summary: mapped.command.input.canonicalEvent.summary,
+                  snippet: mapped.command.input.canonicalEvent.snippet ?? "",
+                  occurredAt: mapped.command.input.sourceEvidence.receivedAt
+                });
+              }
+            }
+
+            if (
+              recordIndex >= resumeNextRecordIndex &&
+              shouldCheckpointMailchimpCampaignRecord(nextRecordIndex, records.length)
+            ) {
+              latestCursor =
+                nextRecordIndex === records.length
+                  ? campaignId
+                  : buildMailchimpRecordCursor(campaignId, nextRecordIndex);
+              await dependencies.syncState.recordBatchProgress({
+                syncStateId: parsedInput.syncStateId,
+                scope: "provider",
+                provider: "mailchimp",
+                jobType: "historical_backfill",
+                cursor: latestCursor,
+                checkpoint,
+                windowStart,
+                windowEnd: checkpoint,
+                deadLetterCountIncrement: pendingDeadLetterCountIncrement
+              });
+              pendingDeadLetterCountIncrement = 0;
+            }
+          }
+
+          if (records.length === 0) {
+            latestCursor = campaignId;
+            await dependencies.syncState.recordBatchProgress({
+              syncStateId: parsedInput.syncStateId,
+              scope: "provider",
+              provider: "mailchimp",
+              jobType: "historical_backfill",
+              cursor: latestCursor,
+              checkpoint,
+              windowStart,
+              windowEnd: checkpoint,
+              deadLetterCountIncrement: pendingDeadLetterCountIncrement
+            });
+            pendingDeadLetterCountIncrement = 0;
+          }
+        }
+
+        if (skippedRecipients.size > 0) {
+          const unmatchedRecipients: MailchimpUnmatchedRecipientRow[] = Array.from(
+            skippedRecipients.values()
+          ).map((recipient) => ({
+            campaignId: recipient.campaignId,
+            campaignName: recipient.campaignName,
+            audienceId: recipient.audienceId,
+            memberId: recipient.memberId,
+            email: recipient.email,
+            platformId: recipient.platformId,
+            activityTypes: Array.from(recipient.activityTypes).sort()
+          }));
+          const report = buildMailchimpUnmatchedReport({
+            generatedAt: now().toISOString(),
+            recipients: unmatchedRecipients,
+            knownIdentityIndex:
+              dependencies.mailchimpIdentityIndex ?? {
+                knownEmails: new Set<string>(),
+                knownVolunteerIds: new Set<string>()
+              }
+          });
+
+          unmatchedReportPaths = await writeMailchimpUnmatchedReport({
+            outputRoot:
+              parsedInput.unmatchedReportOutputRoot ??
+              resolve(parsedInput.artifactPath, "..", "unmatched-reports"),
+            reportId: parsedInput.syncStateId,
+            report
+          });
+        }
+
+        const summary = summarizeIngestResults(ingestResults, {
+          skippedUnmatched,
+          skippedUnmatchedRecipients: skippedRecipients.size
+        });
+        const completedSyncState = await dependencies.syncState.completeWindow({
+          syncStateId: parsedInput.syncStateId,
+          scope: "provider",
+          provider: "mailchimp",
+          jobType: "historical_backfill",
+          cursor: importedCampaignIds.at(-1) ?? null,
+          checkpoint,
+          windowStart,
+          windowEnd: checkpoint,
+          parityPercent: null,
+          freshnessP95Seconds: null,
+          freshnessP99Seconds: null,
+          completedAt: now().toISOString()
+        });
+
+        return {
+          outcome: "succeeded",
+          artifactPath: parsedInput.artifactPath,
+          importedCampaignIds,
+          parsedCampaigns: campaignPaths.length,
+          parsedRecords,
+          syncStateId: parsedInput.syncStateId,
+          correlationId: parsedInput.correlationId,
+          summary,
+          checkpoint,
+          syncStatus: completedSyncState.status,
+          ...(unmatchedReportPaths === null
+            ? {}
+            : {
+                unmatchedReportJsonPath: unmatchedReportPaths.jsonPath,
+                unmatchedReportCsvPath: unmatchedReportPaths.csvPath
+              })
+        };
+      } catch (error) {
+        const failure = buildImportFailure(error);
+        const failedSyncState = await dependencies.syncState.failWindow({
+          syncStateId: parsedInput.syncStateId,
+          scope: "provider",
+          provider: "mailchimp",
+          jobType: "historical_backfill",
+          cursor: latestCursor,
+          checkpoint,
+          windowStart,
+          windowEnd: checkpoint,
+          deadLetterCountIncrement: pendingDeadLetterCountIncrement,
+          deadLettered: false
+        });
+        await recordSyncFailureAudit(dependencies.persistence, {
+          syncStateId: parsedInput.syncStateId,
+          scope: "provider",
+          provider: "mailchimp",
+          jobType: "historical_backfill",
+          checkpoint,
+          windowStart,
+          windowEnd: checkpoint,
+          failure,
+          occurredAt: now().toISOString(),
+          actorId: "stage1-mailchimp-artifact-import"
+        });
+
+        return {
+          outcome: "failed",
+          artifactPath: parsedInput.artifactPath,
+          importedCampaignIds,
+          parsedCampaigns: campaignPaths.length,
+          parsedRecords,
+          syncStateId: parsedInput.syncStateId,
+          correlationId: parsedInput.correlationId,
+          summary: {
+            ...summarizeIngestResults(ingestResults, {
+              skippedUnmatched,
+              skippedUnmatchedRecipients: skippedRecipients.size
+            })
+          },
+          checkpoint,
+          syncStatus: failedSyncState.status,
+          message: failure.message,
+          ...(unmatchedReportPaths === null
+            ? {}
+            : {
+                unmatchedReportJsonPath: unmatchedReportPaths.jsonPath,
+                unmatchedReportCsvPath: unmatchedReportPaths.csvPath
+              })
+        };
+      }
+    }
+  };
+}

--- a/apps/worker/test/stage1-mailchimp-artifact-import.test.ts
+++ b/apps/worker/test/stage1-mailchimp-artifact-import.test.ts
@@ -1,0 +1,614 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { createStage1MailchimpArtifactImportService } from "../src/ops/mailchimp-artifacts.js";
+import { Stage1RetryableJobError } from "../src/orchestration/index.js";
+import { createTestWorkerContext, type TestWorkerContext } from "./helpers.js";
+
+const contactId = "contact:salesforce:003-stage1";
+const salesforceContactId = "003-stage1";
+
+async function seedContact(context: TestWorkerContext) {
+  await context.normalization.upsertNormalizedContactGraph({
+    contact: {
+      id: contactId,
+      salesforceContactId,
+      displayName: "Stage One Volunteer",
+      primaryEmail: "volunteer@example.org",
+      primaryPhone: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z"
+    },
+    identities: [
+      {
+        id: `identity:${contactId}:salesforce`,
+        contactId,
+        kind: "salesforce_contact_id",
+        normalizedValue: salesforceContactId,
+        isPrimary: true,
+        source: "salesforce",
+        verifiedAt: "2026-01-01T00:00:00.000Z"
+      },
+      {
+        id: `identity:${contactId}:email`,
+        contactId,
+        kind: "email",
+        normalizedValue: "volunteer@example.org",
+        isPrimary: true,
+        source: "salesforce",
+        verifiedAt: "2026-01-01T00:00:00.000Z"
+      }
+    ],
+    memberships: []
+  });
+}
+
+async function writeArtifactCampaign(): Promise<string> {
+  const artifactRoot = await mkdtemp(resolve(tmpdir(), "mailchimp-artifact-root-"));
+  const campaignPath = resolve(artifactRoot, "campaign-1");
+  await mkdir(campaignPath, {
+    recursive: true
+  });
+
+  const writes = [
+    [
+      "summary.json",
+      {
+        id: "campaign-1",
+        campaign_title: "Volunteer Update",
+        subject_line: "Hello volunteers",
+        preview_text: "Project updates for this week",
+        list_id: "audience-1",
+        send_time: "2026-02-01T15:00:00.000Z"
+      }
+    ],
+    [
+      "sent-to.json",
+      [
+        {
+          email_id: "member-1",
+          email_address: "volunteer@example.org",
+          merge_fields: {
+            PLATFORMID: "VOL-123"
+          },
+          status: "sent",
+          last_open: "2026-02-01T15:10:00.000Z",
+          campaign_id: "campaign-1",
+          list_id: "audience-1"
+        }
+      ]
+    ],
+    [
+      "open-details.json",
+      [
+        {
+          campaign_id: "campaign-1",
+          list_id: "audience-1",
+          email_id: "member-1",
+          email_address: "volunteer@example.org",
+          merge_fields: {
+            PLATFORMID: "VOL-123"
+          },
+          opens: [
+            {
+              timestamp: "2026-02-01T15:10:00.000Z"
+            }
+          ]
+        }
+      ]
+    ],
+    [
+      "click-details.json",
+      [
+        {
+          id: "link-1",
+          url: "https://example.org/project",
+          last_click: "2026-02-01T15:12:00.000Z",
+          campaign_id: "campaign-1"
+        }
+      ]
+    ],
+    [
+      "click-members.json",
+      [
+        {
+          linkId: "link-1",
+          url: "https://example.org/project",
+          members: [
+            {
+              email_id: "member-1",
+              email_address: "volunteer@example.org",
+              merge_fields: {
+                PLATFORMID: "VOL-123"
+              },
+              campaign_id: "campaign-1",
+              list_id: "audience-1",
+              clicks: 1
+            }
+          ]
+        }
+      ]
+    ],
+    [
+      "unsubscribed.json",
+      [
+        {
+          email_id: "member-1",
+          email_address: "volunteer@example.org",
+          merge_fields: {
+            PLATFORMID: "VOL-123"
+          },
+          timestamp: "2026-02-02T10:00:00.000Z",
+          reason: "No thanks",
+          campaign_id: "campaign-1",
+          list_id: "audience-1"
+        }
+      ]
+    ]
+  ] as const;
+
+  await Promise.all(
+    writes.map(([fileName, payload]) =>
+      writeFile(
+        resolve(campaignPath, fileName),
+        `${JSON.stringify(payload, null, 2)}\n`
+      )
+    )
+  );
+
+  return artifactRoot;
+}
+
+async function writeArtifactCampaignWithUnmatchedRecipient(): Promise<string> {
+  const artifactRoot = await mkdtemp(
+    resolve(tmpdir(), "mailchimp-artifact-unmatched-root-")
+  );
+  const campaignPath = resolve(artifactRoot, "campaign-2");
+  await mkdir(campaignPath, {
+    recursive: true
+  });
+
+  const writes = [
+    [
+      "summary.json",
+      {
+        id: "campaign-2",
+        campaign_title: "Broad Audience Outreach",
+        subject_line: "Join us",
+        preview_text: "Volunteer and supporter updates",
+        list_id: "audience-2",
+        send_time: "2026-03-01T15:00:00.000Z"
+      }
+    ],
+    [
+      "sent-to.json",
+      [
+        {
+          email_id: "member-known",
+          email_address: "volunteer@example.org",
+          merge_fields: {
+            PLATFORMID: "VOL-123"
+          },
+          status: "sent",
+          last_open: "2026-03-01T15:10:00.000Z",
+          campaign_id: "campaign-2",
+          list_id: "audience-2"
+        },
+        {
+          email_id: "member-unknown",
+          email_address: "supporter@example.net",
+          merge_fields: {},
+          status: "sent",
+          last_open: "2026-03-01T15:20:00.000Z",
+          campaign_id: "campaign-2",
+          list_id: "audience-2"
+        }
+      ]
+    ],
+    [
+      "open-details.json",
+      [
+        {
+          campaign_id: "campaign-2",
+          list_id: "audience-2",
+          email_id: "member-known",
+          email_address: "volunteer@example.org",
+          merge_fields: {
+            PLATFORMID: "VOL-123"
+          },
+          opens: [
+            {
+              timestamp: "2026-03-01T15:10:00.000Z"
+            }
+          ]
+        },
+        {
+          campaign_id: "campaign-2",
+          list_id: "audience-2",
+          email_id: "member-unknown",
+          email_address: "supporter@example.net",
+          merge_fields: {},
+          opens: [
+            {
+              timestamp: "2026-03-01T15:20:00.000Z"
+            }
+          ]
+        }
+      ]
+    ],
+    [
+      "click-details.json",
+      [
+        {
+          id: "link-1",
+          url: "https://example.org/project",
+          last_click: "2026-03-01T15:12:00.000Z",
+          campaign_id: "campaign-2"
+        }
+      ]
+    ],
+    [
+      "click-members.json",
+      [
+        {
+          linkId: "link-1",
+          url: "https://example.org/project",
+          members: [
+            {
+              email_id: "member-known",
+              email_address: "volunteer@example.org",
+              merge_fields: {
+                PLATFORMID: "VOL-123"
+              },
+              campaign_id: "campaign-2",
+              list_id: "audience-2",
+              clicks: 1
+            },
+            {
+              email_id: "member-unknown",
+              email_address: "supporter@example.net",
+              merge_fields: {},
+              campaign_id: "campaign-2",
+              list_id: "audience-2",
+              clicks: 1
+            }
+          ]
+        }
+      ]
+    ],
+    [
+      "unsubscribed.json",
+      [
+        {
+          email_id: "member-known",
+          email_address: "volunteer@example.org",
+          merge_fields: {
+            PLATFORMID: "VOL-123"
+          },
+          timestamp: "2026-03-02T10:00:00.000Z",
+          reason: "No thanks",
+          campaign_id: "campaign-2",
+          list_id: "audience-2"
+        },
+        {
+          email_id: "member-unknown",
+          email_address: "supporter@example.net",
+          merge_fields: {},
+          timestamp: "2026-03-02T10:05:00.000Z",
+          reason: "No thanks",
+          campaign_id: "campaign-2",
+          list_id: "audience-2"
+        }
+      ]
+    ]
+  ] as const;
+
+  await Promise.all(
+    writes.map(([fileName, payload]) =>
+      writeFile(
+        resolve(campaignPath, fileName),
+        `${JSON.stringify(payload, null, 2)}\n`
+      )
+    )
+  );
+
+  return artifactRoot;
+}
+
+async function writeArtifactCampaignWithRecipientCount(input: {
+  readonly campaignId: string;
+  readonly recipientCount: number;
+}): Promise<string> {
+  const artifactRoot = await mkdtemp(
+    resolve(tmpdir(), `mailchimp-artifact-${input.campaignId}-`)
+  );
+  const campaignPath = resolve(artifactRoot, input.campaignId);
+  await mkdir(campaignPath, {
+    recursive: true
+  });
+
+  const sentTo = Array.from({ length: input.recipientCount }, (_, index) => ({
+    email_id: `member-${index + 1}`,
+    email_address: "volunteer@example.org",
+    merge_fields: {
+      PLATFORMID: "VOL-123"
+    },
+    status: "sent",
+    campaign_id: input.campaignId,
+    list_id: "audience-resume"
+  }));
+  const writes: ReadonlyArray<readonly [string, unknown]> = [
+    [
+      "summary.json",
+      {
+        id: input.campaignId,
+        campaign_title: "Resume Mailchimp Campaign",
+        subject_line: "Resume proof",
+        preview_text: "Importer should resume from the last batch checkpoint",
+        list_id: "audience-resume",
+        send_time: "2026-04-01T15:00:00.000Z"
+      }
+    ],
+    ["sent-to.json", sentTo],
+    ["open-details.json", []],
+    ["click-details.json", []],
+    ["click-members.json", []],
+    ["unsubscribed.json", []]
+  ];
+
+  await Promise.all(
+    writes.map(([fileName, payload]) =>
+      writeFile(
+        resolve(campaignPath, fileName),
+        `${JSON.stringify(payload, null, 2)}\n`
+      )
+    )
+  );
+
+  return artifactRoot;
+}
+
+describe("Stage 1 Mailchimp artifact importer", () => {
+  it("imports Mailchimp campaign artifacts through the historical normalization path and stays replay-safe", async () => {
+    const context = await createTestWorkerContext();
+    const artifactRoot = await writeArtifactCampaign();
+
+    try {
+      await seedContact(context);
+      const importer = createStage1MailchimpArtifactImportService({
+        ingest: context.ingest,
+        persistence: context.persistence,
+        syncState: context.syncState,
+        now: () => new Date("2026-02-03T00:00:00.000Z")
+      });
+
+      const firstRun = await importer.importArtifacts({
+        artifactPath: artifactRoot,
+        syncStateId: "sync:mailchimp:artifacts:first",
+        correlationId: "corr:mailchimp:artifacts:first",
+        traceId: null,
+        receivedAt: "2026-02-03T00:00:00.000Z"
+      });
+      const secondRun = await importer.importArtifacts({
+        artifactPath: artifactRoot,
+        syncStateId: "sync:mailchimp:artifacts:second",
+        correlationId: "corr:mailchimp:artifacts:second",
+        traceId: null,
+        receivedAt: "2026-02-03T00:05:00.000Z"
+      });
+
+      expect(firstRun).toMatchObject({
+        outcome: "succeeded",
+        parsedCampaigns: 1,
+        parsedRecords: 4,
+        syncStatus: "succeeded",
+        summary: {
+          processed: 4,
+          normalized: 4
+        }
+      });
+      expect(secondRun).toMatchObject({
+        outcome: "succeeded",
+        parsedCampaigns: 1,
+        parsedRecords: 4,
+        syncStatus: "succeeded",
+        summary: {
+          processed: 4,
+          duplicate: 4
+        }
+      });
+
+      await expect(context.repositories.canonicalEvents.countAll()).resolves.toBe(4);
+      const canonicalEvents =
+        await context.repositories.canonicalEvents.listByContactId(contactId);
+      expect(canonicalEvents).toHaveLength(4);
+
+      await expect(
+        context.repositories.inboxProjection.findByContactId(contactId)
+      ).resolves.toBeNull();
+
+      const sourceEvidenceIds = canonicalEvents.map((event) => event.sourceEvidenceId);
+      await expect(
+        context.repositories.mailchimpCampaignActivityDetails.listBySourceEvidenceIds(
+          sourceEvidenceIds
+        )
+      ).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            activityType: "sent",
+            campaignId: "campaign-1",
+            audienceId: "audience-1",
+            campaignName: "Volunteer Update"
+          }),
+          expect.objectContaining({
+            activityType: "clicked",
+            snippet: "https://example.org/project"
+          })
+        ])
+      );
+      await expect(
+        context.repositories.syncState.findById("sync:mailchimp:artifacts:first")
+      ).resolves.toMatchObject({
+        provider: "mailchimp",
+        jobType: "historical_backfill",
+        status: "succeeded"
+      });
+    } finally {
+      await rm(artifactRoot, {
+        recursive: true,
+        force: true
+      });
+      await context.dispose();
+    }
+  });
+
+  it("skips unmatched Mailchimp recipients and writes an aggregate report instead of opening identity review", async () => {
+    const context = await createTestWorkerContext();
+    const artifactRoot = await writeArtifactCampaignWithUnmatchedRecipient();
+
+    try {
+      await seedContact(context);
+      const importer = createStage1MailchimpArtifactImportService({
+        ingest: context.ingest,
+        persistence: context.persistence,
+        syncState: context.syncState,
+        now: () => new Date("2026-03-03T00:00:00.000Z")
+      });
+
+      const result = await importer.importArtifacts({
+        artifactPath: artifactRoot,
+        syncStateId: "sync:mailchimp:artifacts:skip-unmatched",
+        correlationId: "corr:mailchimp:artifacts:skip-unmatched",
+        traceId: null,
+        receivedAt: "2026-03-03T00:00:00.000Z"
+      });
+
+      expect(result).toMatchObject({
+        outcome: "succeeded",
+        parsedCampaigns: 1,
+        parsedRecords: 8,
+        syncStatus: "succeeded",
+        summary: {
+          processed: 4,
+          normalized: 4,
+          reviewOpened: 0,
+          skippedUnmatched: 4,
+          skippedUnmatchedRecipients: 1
+        }
+      });
+      expect(result.unmatchedReportJsonPath).toBeTruthy();
+      expect(result.unmatchedReportCsvPath).toBeTruthy();
+
+      await expect(context.repositories.canonicalEvents.countAll()).resolves.toBe(4);
+      await expect(
+        context.repositories.identityResolutionQueue.listOpenByReasonCode(
+          "identity_missing_anchor"
+        )
+      ).resolves.toEqual([]);
+    } finally {
+      await rm(artifactRoot, {
+        recursive: true,
+        force: true
+      });
+      await context.dispose();
+    }
+  });
+
+  it("resumes within a Mailchimp campaign after a retryable failure instead of replaying the whole artifact", async () => {
+    const context = await createTestWorkerContext();
+    const artifactRoot = await writeArtifactCampaignWithRecipientCount({
+      campaignId: "campaign-resume",
+      recipientCount: 30
+    });
+
+    try {
+      await seedContact(context);
+      let shouldFailOnce = true;
+      let ingestCalls = 0;
+      const flakyIngest = {
+        async ingestMailchimpHistoricalRecord(
+          record: Parameters<
+            TestWorkerContext["ingest"]["ingestMailchimpHistoricalRecord"]
+          >[0]
+        ) {
+          ingestCalls += 1;
+
+          if (shouldFailOnce && ingestCalls === 28) {
+            shouldFailOnce = false;
+            throw new Stage1RetryableJobError("read ECONNRESET");
+          }
+
+          return context.ingest.ingestMailchimpHistoricalRecord(record);
+        }
+      };
+      const importer = createStage1MailchimpArtifactImportService({
+        ingest: flakyIngest,
+        persistence: context.persistence,
+        syncState: context.syncState,
+        now: () => new Date("2026-04-02T00:00:00.000Z")
+      });
+
+      const firstRun = await importer.importArtifacts({
+        artifactPath: artifactRoot,
+        syncStateId: "sync:mailchimp:artifacts:resume",
+        correlationId: "corr:mailchimp:artifacts:resume:first",
+        traceId: null,
+        receivedAt: "2026-04-02T00:00:00.000Z"
+      });
+
+      expect(firstRun).toMatchObject({
+        outcome: "failed",
+        parsedCampaigns: 1,
+        parsedRecords: 30,
+        syncStatus: "failed",
+        summary: {
+          processed: 27,
+          normalized: 27
+        }
+      });
+      await expect(
+        context.repositories.syncState.findById("sync:mailchimp:artifacts:resume")
+      ).resolves.toMatchObject({
+        status: "failed",
+        cursor: "campaign-resume:record:25"
+      });
+
+      const secondRun = await importer.importArtifacts({
+        artifactPath: artifactRoot,
+        syncStateId: "sync:mailchimp:artifacts:resume",
+        correlationId: "corr:mailchimp:artifacts:resume:second",
+        traceId: null,
+        receivedAt: "2026-04-02T00:05:00.000Z"
+      });
+
+      expect(secondRun).toMatchObject({
+        outcome: "succeeded",
+        parsedCampaigns: 1,
+        parsedRecords: 30,
+        syncStatus: "succeeded",
+        summary: {
+          processed: 5,
+          normalized: 3,
+          duplicate: 2
+        }
+      });
+
+      await expect(context.repositories.canonicalEvents.countAll()).resolves.toBe(30);
+      await expect(
+        context.repositories.syncState.findById("sync:mailchimp:artifacts:resume")
+      ).resolves.toMatchObject({
+        status: "succeeded",
+        cursor: "campaign-resume"
+      });
+    } finally {
+      await rm(artifactRoot, {
+        recursive: true,
+        force: true
+      });
+      await context.dispose();
+    }
+  });
+});

--- a/docs/03-handoff/inbox-shell-handoff.md
+++ b/docs/03-handoff/inbox-shell-handoff.md
@@ -1,0 +1,64 @@
+# Inbox Shell — Real Wiring Handoff
+
+This handoff reflects the current mainline Inbox shell under
+`apps/web/app/inbox/`. The shell architecture is unchanged: the persistent list
+chrome still lives in `layout.tsx`, `/inbox` still renders the empty-state page
+inside that shell, and `/inbox/[contactId]` still renders the selected-contact
+detail page.
+
+## What Is Real Now
+
+- `apps/web/app/inbox/_lib/selectors.ts`
+  - `getInboxList(filterId?)` now reads real Stage 1 data from
+    `contact_inbox_projection`, `contacts`, `contact_memberships`,
+    `project_dimensions`, `canonical_event_ledger`, `gmail_message_details`,
+    and `contact_timeline_projection`.
+  - `getInboxDetail(contactId)` now reads real Stage 1 data from
+    `contacts`, `contact_inbox_projection`, `contact_memberships`,
+    `project_dimensions`, `canonical_event_ledger`,
+    `gmail_message_details`, and `contact_timeline_projection`.
+- `apps/web/app/inbox/actions.ts`
+  - `markInboxNeedsFollowUpAction` and `clearInboxNeedsFollowUpAction` now
+    persist through the server by updating the inbox projection row for the
+    selected contact.
+- `apps/web/src/server/stage1-runtime.ts`
+  - Small server-only runtime for `DATABASE_URL`, Stage 1 repositories, and
+    test overrides.
+- `apps/web/src/server/inbox/follow-up.ts`
+  - Narrow server helper that updates only `needsFollowUp` and leaves bucket,
+    unresolved state, timestamps, snippet, and last-event fields untouched.
+
+## Preserved Contract
+
+- One row per person, not one row per thread.
+- Single mixed contact list.
+- Default ordering remains `lastInboundAt desc`, with `lastActivityAt desc`
+  fallback when `lastInboundAt` is missing.
+- Unread remains bucket-driven.
+- `needsFollowUp` remains a separate explicit flag.
+- `hasUnresolved` remains an overlay.
+- Follow-up toggling does not reorder rows.
+- Route structure remains `/inbox` and `/inbox/[contactId]`.
+
+## Current Bridging Logic
+
+- `unreadCount` is still a selector-derived `1/0` badge keyed from bucket state,
+  because the current projection model does not store a per-contact unread
+  message count.
+- Membership `year` is still selector-derived from the current UTC year,
+  because the canonical membership season/year is not persisted on the current
+  Stage 1 read model.
+- `crmUrl` in the contact rail is still synthesized from `projectId`, because a
+  canonical persisted CRM URL is not available on the membership dimension yet.
+- Timeline bodies and subjects are exact for Gmail-backed email events. When a
+  richer provider-specific communication detail is not available, the selector
+  falls back to timeline summaries so the shell contract stays stable.
+
+## Revalidation
+
+- `inbox`
+- `inbox:contact:{contactId}`
+- `timeline:contact:{contactId}`
+
+The follow-up actions revalidate those tags after a successful update so the
+mainline shell refreshes from server state instead of client-side overrides.

--- a/docs/03-handoff/inbox-shell-handoff.md
+++ b/docs/03-handoff/inbox-shell-handoff.md
@@ -15,8 +15,8 @@ detail page.
     and `contact_timeline_projection`.
   - `getInboxDetail(contactId)` now reads real Stage 1 data from
     `contacts`, `contact_inbox_projection`, `contact_memberships`,
-    `project_dimensions`, `canonical_event_ledger`,
-    `gmail_message_details`, and `contact_timeline_projection`.
+    `project_dimensions`, and the typed Stage 1 timeline presentation service
+    backed by canonical events plus provider-specific detail tables.
 - `apps/web/app/inbox/actions.ts`
   - `markInboxNeedsFollowUpAction` and `clearInboxNeedsFollowUpAction` now
     persist through the server by updating the inbox projection row for the
@@ -53,6 +53,9 @@ detail page.
 - Timeline bodies and subjects are exact for Gmail-backed email events. When a
   richer provider-specific communication detail is not available, the selector
   falls back to timeline summaries so the shell contract stays stable.
+- Unresolved review detail is not yet hydrated into dedicated detail-panel
+  context; the shell currently uses the persisted `hasUnresolved` overlay and
+  banner only.
 
 ## Revalidation
 

--- a/docs/03-handoff/inbox-shell-status.md
+++ b/docs/03-handoff/inbox-shell-status.md
@@ -24,6 +24,9 @@
 
 - The list and detail selectors now run against real Stage 1 repository reads
   and use `unstable_cache` with inbox/timeline tags.
+- Detail timeline rendering now preserves the existing inbox timeline kinds by
+  adapting typed Stage 1 timeline families instead of flattening non-1:1
+  events into generic system rows.
 - Follow-up persistence writes back to the existing inbox projection field
   mapped from the persistence boundary field `is_starred`.
 - The physical DB naming is unchanged.
@@ -31,8 +34,9 @@
 ## Known Follow-Ups
 
 - Large real inbox payloads can still trigger `unstable_cache` size warnings.
-- Identity review detail still relies on selector-side contact matching where a
-  case is anchored by contact ID or references the contact in candidate IDs.
+- Unresolved review detail is still banner-only in the shell; this pass does
+  not yet surface routing or identity case summaries in the selected-contact
+  panel.
 - The current data model still does not provide:
   - a canonical persisted CRM URL for project memberships
   - a dedicated unread-count field for the list badge

--- a/docs/03-handoff/inbox-shell-status.md
+++ b/docs/03-handoff/inbox-shell-status.md
@@ -1,0 +1,39 @@
+# Inbox Shell — Status
+
+## Wired in this pass
+
+- Real Stage 1-backed inbox list reads.
+- Real Stage 1-backed selected-contact detail reads.
+- Real server-backed `needsFollowUp` persistence.
+- Mainline route shape preserved:
+  - `/inbox`
+  - `/inbox/[contactId]`
+- Mainline shell architecture preserved:
+  - `app/inbox/layout.tsx`
+  - `app/inbox/_components/*`
+  - `app/inbox/_lib/*`
+
+## Still Mocked or Prototype
+
+- Composer send remains prototype/local.
+- Internal note creation remains prototype/local.
+- Reminder state remains client-only.
+- Search remains client-side string matching over the rendered list items.
+
+## Backend Notes
+
+- The list and detail selectors now run against real Stage 1 repository reads
+  and use `unstable_cache` with inbox/timeline tags.
+- Follow-up persistence writes back to the existing inbox projection field
+  mapped from the persistence boundary field `is_starred`.
+- The physical DB naming is unchanged.
+
+## Known Follow-Ups
+
+- Large real inbox payloads can still trigger `unstable_cache` size warnings.
+- Identity review detail still relies on selector-side contact matching where a
+  case is anchored by contact ID or references the contact in candidate IDs.
+- The current data model still does not provide:
+  - a canonical persisted CRM URL for project memberships
+  - a dedicated unread-count field for the list badge
+  - a canonical persisted membership season/year for the contact rail

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2,5 +2,6 @@ export * from "./health.js";
 export * from "./jobs.js";
 export * from "./stage1-normalization.js";
 export * from "./stage1-records.js";
+export * from "./stage1-timeline.js";
 export * from "./stage1-taxonomy.js";
 export * from "./stage1-worker-jobs.js";

--- a/packages/contracts/src/stage1-timeline.ts
+++ b/packages/contracts/src/stage1-timeline.ts
@@ -1,0 +1,119 @@
+import { z } from "zod";
+
+import {
+  campaignEmailActivityTypeSchema,
+  providerSchema,
+  reviewStateSchema,
+  timelineFamilySchema
+} from "./stage1-taxonomy.js";
+
+const idSchema = z.string().min(1);
+const timestampSchema = z.string().datetime();
+const nullableStringSchema = z.string().min(1).nullable();
+
+const timelineItemBaseSchema = z.object({
+  id: idSchema,
+  contactId: idSchema,
+  canonicalEventId: idSchema,
+  family: timelineFamilySchema,
+  occurredAt: timestampSchema,
+  sortKey: z.string().min(1),
+  reviewState: reviewStateSchema,
+  primaryProvider: providerSchema,
+  summary: z.string().min(1)
+});
+
+export const salesforceTimelineItemSchema = timelineItemBaseSchema.extend({
+  family: z.literal("salesforce_event"),
+  milestone: z.enum([
+    "signed_up",
+    "received_training",
+    "completed_training",
+    "submitted_first_data"
+  ]),
+  projectName: nullableStringSchema,
+  expeditionName: nullableStringSchema,
+  sourceField: nullableStringSchema
+});
+export type SalesforceTimelineItem = z.infer<
+  typeof salesforceTimelineItemSchema
+>;
+
+export const autoEmailTimelineItemSchema = timelineItemBaseSchema.extend({
+  family: z.literal("auto_email"),
+  direction: z.literal("outbound"),
+  subject: nullableStringSchema,
+  snippet: z.string(),
+  sourceLabel: z.string().min(1)
+});
+export type AutoEmailTimelineItem = z.infer<typeof autoEmailTimelineItemSchema>;
+
+export const campaignEmailTimelineItemSchema = timelineItemBaseSchema.extend({
+  family: z.literal("campaign_email"),
+  activityType: campaignEmailActivityTypeSchema,
+  campaignName: nullableStringSchema,
+  campaignId: nullableStringSchema,
+  audienceId: nullableStringSchema,
+  snippet: z.string()
+});
+export type CampaignEmailTimelineItem = z.infer<
+  typeof campaignEmailTimelineItemSchema
+>;
+
+export const campaignSmsTimelineItemSchema = timelineItemBaseSchema.extend({
+  family: z.literal("campaign_sms"),
+  direction: z.literal("outbound"),
+  messageTextPreview: z.string(),
+  campaignName: nullableStringSchema,
+  campaignId: nullableStringSchema
+});
+export type CampaignSmsTimelineItem = z.infer<
+  typeof campaignSmsTimelineItemSchema
+>;
+
+export const oneToOneEmailTimelineItemSchema = timelineItemBaseSchema.extend({
+  family: z.literal("one_to_one_email"),
+  direction: z.enum(["inbound", "outbound"]),
+  subject: nullableStringSchema,
+  snippet: z.string(),
+  bodyPreview: nullableStringSchema,
+  mailbox: nullableStringSchema,
+  threadId: nullableStringSchema
+});
+export type OneToOneEmailTimelineItem = z.infer<
+  typeof oneToOneEmailTimelineItemSchema
+>;
+
+export const oneToOneSmsTimelineItemSchema = timelineItemBaseSchema.extend({
+  family: z.literal("one_to_one_sms"),
+  direction: z.enum(["inbound", "outbound"]),
+  messageTextPreview: z.string(),
+  phone: nullableStringSchema,
+  threadKey: nullableStringSchema
+});
+export type OneToOneSmsTimelineItem = z.infer<
+  typeof oneToOneSmsTimelineItemSchema
+>;
+
+export const internalNoteTimelineItemSchema = timelineItemBaseSchema.extend({
+  family: z.literal("internal_note"),
+  body: z.string().min(1),
+  authorDisplayName: nullableStringSchema
+});
+export type InternalNoteTimelineItem = z.infer<
+  typeof internalNoteTimelineItemSchema
+>;
+
+export const timelineItemSchema = z.discriminatedUnion("family", [
+  salesforceTimelineItemSchema,
+  autoEmailTimelineItemSchema,
+  campaignEmailTimelineItemSchema,
+  campaignSmsTimelineItemSchema,
+  oneToOneEmailTimelineItemSchema,
+  oneToOneSmsTimelineItemSchema,
+  internalNoteTimelineItemSchema
+]);
+export type TimelineItem = z.infer<typeof timelineItemSchema>;
+
+export const timelineItemListSchema = z.array(timelineItemSchema);
+export type TimelineItemList = z.infer<typeof timelineItemListSchema>;

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -35,12 +35,20 @@ import {
   mapIdentityResolutionToInsert,
   mapInboxProjectionRow,
   mapInboxProjectionToInsert,
+  mapMailchimpCampaignActivityDetailRow,
+  mapMailchimpCampaignActivityDetailToInsert,
+  mapManualNoteDetailRow,
+  mapManualNoteDetailToInsert,
   mapProjectDimensionRow,
   mapProjectDimensionToInsert,
   mapRoutingReviewRow,
   mapRoutingReviewToInsert,
+  mapSalesforceCommunicationDetailRow,
+  mapSalesforceCommunicationDetailToInsert,
   mapSalesforceEventContextRow,
   mapSalesforceEventContextToInsert,
+  mapSimpleTextingMessageDetailRow,
+  mapSimpleTextingMessageDetailToInsert,
   mapSourceEvidenceRow,
   mapSourceEvidenceToInsert,
   mapSyncStateRow,
@@ -60,9 +68,13 @@ import {
   expeditionDimensions,
   gmailMessageDetails,
   identityResolutionQueue,
+  mailchimpCampaignActivityDetails,
+  manualNoteDetails,
   projectDimensions,
   routingReviewQueue,
+  salesforceCommunicationDetails,
   salesforceEventContext,
+  simpleTextingMessageDetails,
   sourceEvidenceLog,
   syncState
 } from "./schema/index.js";
@@ -621,6 +633,188 @@ function createStage1RepositoriesInternal(
       }
     },
 
+    salesforceCommunicationDetails: {
+      async listBySourceEvidenceIds(sourceEvidenceIds) {
+        if (sourceEvidenceIds.length === 0) {
+          return [];
+        }
+
+        const rows = await db
+          .select()
+          .from(salesforceCommunicationDetails)
+          .where(
+            inArray(salesforceCommunicationDetails.sourceEvidenceId, [
+              ...sourceEvidenceIds
+            ])
+          )
+          .orderBy(asc(salesforceCommunicationDetails.sourceEvidenceId));
+
+        return rows.map(mapSalesforceCommunicationDetailRow);
+      },
+
+      async upsert(record) {
+        const values = mapSalesforceCommunicationDetailToInsert(record);
+        const [row] = await db
+          .insert(salesforceCommunicationDetails)
+          .values(values)
+          .onConflictDoUpdate({
+            target: salesforceCommunicationDetails.sourceEvidenceId,
+            set: {
+              providerRecordId: values.providerRecordId,
+              channel: values.channel,
+              messageKind: values.messageKind,
+              subject: values.subject,
+              snippet: values.snippet,
+              sourceLabel: values.sourceLabel,
+              updatedAt: new Date()
+            }
+          })
+          .returning();
+
+        return mapSalesforceCommunicationDetailRow(
+          requireRow(
+            row,
+            "Expected Salesforce communication detail row to be returned."
+          )
+        );
+      }
+    },
+
+    simpleTextingMessageDetails: {
+      async listBySourceEvidenceIds(sourceEvidenceIds) {
+        if (sourceEvidenceIds.length === 0) {
+          return [];
+        }
+
+        const rows = await db
+          .select()
+          .from(simpleTextingMessageDetails)
+          .where(
+            inArray(simpleTextingMessageDetails.sourceEvidenceId, [
+              ...sourceEvidenceIds
+            ])
+          )
+          .orderBy(asc(simpleTextingMessageDetails.sourceEvidenceId));
+
+        return rows.map(mapSimpleTextingMessageDetailRow);
+      },
+
+      async upsert(record) {
+        const values = mapSimpleTextingMessageDetailToInsert(record);
+        const [row] = await db
+          .insert(simpleTextingMessageDetails)
+          .values(values)
+          .onConflictDoUpdate({
+            target: simpleTextingMessageDetails.sourceEvidenceId,
+            set: {
+              providerRecordId: values.providerRecordId,
+              direction: values.direction,
+              messageKind: values.messageKind,
+              messageTextPreview: values.messageTextPreview,
+              normalizedPhone: values.normalizedPhone,
+              campaignId: values.campaignId,
+              campaignName: values.campaignName,
+              providerThreadId: values.providerThreadId,
+              threadKey: values.threadKey,
+              updatedAt: new Date()
+            }
+          })
+          .returning();
+
+        return mapSimpleTextingMessageDetailRow(
+          requireRow(
+            row,
+            "Expected SimpleTexting message detail row to be returned."
+          )
+        );
+      }
+    },
+
+    mailchimpCampaignActivityDetails: {
+      async listBySourceEvidenceIds(sourceEvidenceIds) {
+        if (sourceEvidenceIds.length === 0) {
+          return [];
+        }
+
+        const rows = await db
+          .select()
+          .from(mailchimpCampaignActivityDetails)
+          .where(
+            inArray(mailchimpCampaignActivityDetails.sourceEvidenceId, [
+              ...sourceEvidenceIds
+            ])
+          )
+          .orderBy(asc(mailchimpCampaignActivityDetails.sourceEvidenceId));
+
+        return rows.map(mapMailchimpCampaignActivityDetailRow);
+      },
+
+      async upsert(record) {
+        const values = mapMailchimpCampaignActivityDetailToInsert(record);
+        const [row] = await db
+          .insert(mailchimpCampaignActivityDetails)
+          .values(values)
+          .onConflictDoUpdate({
+            target: mailchimpCampaignActivityDetails.sourceEvidenceId,
+            set: {
+              providerRecordId: values.providerRecordId,
+              activityType: values.activityType,
+              campaignId: values.campaignId,
+              audienceId: values.audienceId,
+              memberId: values.memberId,
+              campaignName: values.campaignName,
+              snippet: values.snippet,
+              updatedAt: new Date()
+            }
+          })
+          .returning();
+
+        return mapMailchimpCampaignActivityDetailRow(
+          requireRow(
+            row,
+            "Expected Mailchimp campaign activity detail row to be returned."
+          )
+        );
+      }
+    },
+
+    manualNoteDetails: {
+      async listBySourceEvidenceIds(sourceEvidenceIds) {
+        if (sourceEvidenceIds.length === 0) {
+          return [];
+        }
+
+        const rows = await db
+          .select()
+          .from(manualNoteDetails)
+          .where(inArray(manualNoteDetails.sourceEvidenceId, [...sourceEvidenceIds]))
+          .orderBy(asc(manualNoteDetails.sourceEvidenceId));
+
+        return rows.map(mapManualNoteDetailRow);
+      },
+
+      async upsert(record) {
+        const values = mapManualNoteDetailToInsert(record);
+        const [row] = await db
+          .insert(manualNoteDetails)
+          .values(values)
+          .onConflictDoUpdate({
+            target: manualNoteDetails.sourceEvidenceId,
+            set: {
+              providerRecordId: values.providerRecordId,
+              body: values.body,
+              authorDisplayName: values.authorDisplayName,
+              updatedAt: new Date()
+            }
+          })
+          .returning();
+
+        return mapManualNoteDetailRow(
+          requireRow(row, "Expected manual note detail row to be returned.")
+        );
+      }
+    },
+
     identityResolutionQueue: {
       async findById(id) {
         const [row] = await db
@@ -795,6 +989,19 @@ function createStage1RepositoriesInternal(
           );
 
         return rows.map(mapInboxProjectionRow);
+      },
+
+      async setNeedsFollowUp(input) {
+        const [row] = await db
+          .update(contactInboxProjection)
+          .set({
+            isStarred: input.needsFollowUp,
+            updatedAt: new Date()
+          })
+          .where(eq(contactInboxProjection.contactId, input.contactId))
+          .returning();
+
+        return row === undefined ? null : mapInboxProjectionRow(row);
       },
 
       async upsert(record) {

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -6,7 +6,9 @@ import {
   desc,
   eq,
   inArray,
-  isNull
+  isNull,
+  or,
+  sql
 } from "drizzle-orm";
 import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
 
@@ -234,6 +236,20 @@ function createStage1RepositoriesInternal(
         return row?.value ?? 0;
       },
 
+      async listByIds(ids) {
+        if (ids.length === 0) {
+          return [];
+        }
+
+        const rows = await db
+          .select()
+          .from(canonicalEventLedger)
+          .where(inArray(canonicalEventLedger.id, [...ids]))
+          .orderBy(asc(canonicalEventLedger.id));
+
+        return rows.map(mapCanonicalEventRow);
+      },
+
       async listByContactId(contactId) {
         const rows = await db
           .select()
@@ -297,6 +313,20 @@ function createStage1RepositoriesInternal(
 
       async listAll() {
         const rows = await db.select().from(contacts).orderBy(asc(contacts.id));
+
+        return rows.map(mapContactRow);
+      },
+
+      async listByIds(ids) {
+        if (ids.length === 0) {
+          return [];
+        }
+
+        const rows = await db
+          .select()
+          .from(contacts)
+          .where(inArray(contacts.id, [...ids]))
+          .orderBy(asc(contacts.id));
 
         return rows.map(mapContactRow);
       },
@@ -385,6 +415,24 @@ function createStage1RepositoriesInternal(
           .from(contactMemberships)
           .where(eq(contactMemberships.contactId, contactId))
           .orderBy(asc(contactMemberships.projectId), asc(contactMemberships.id));
+
+        return rows.map(mapContactMembershipRow);
+      },
+
+      async listByContactIds(contactIds) {
+        if (contactIds.length === 0) {
+          return [];
+        }
+
+        const rows = await db
+          .select()
+          .from(contactMemberships)
+          .where(inArray(contactMemberships.contactId, [...contactIds]))
+          .orderBy(
+            asc(contactMemberships.contactId),
+            asc(contactMemberships.projectId),
+            asc(contactMemberships.id)
+          );
 
         return rows.map(mapContactMembershipRow);
       },
@@ -599,6 +647,24 @@ function createStage1RepositoriesInternal(
         return rows.map(mapIdentityResolutionRow);
       },
 
+      async listOpenByContactId(contactId) {
+        const rows = await db
+          .select()
+          .from(identityResolutionQueue)
+          .where(
+            and(
+              eq(identityResolutionQueue.status, "open"),
+              or(
+                eq(identityResolutionQueue.anchoredContactId, contactId),
+                sql`${contactId} = any(${identityResolutionQueue.candidateContactIds})`
+              )
+            )
+          )
+          .orderBy(desc(identityResolutionQueue.openedAt), asc(identityResolutionQueue.id));
+
+        return rows.map(mapIdentityResolutionRow);
+      },
+
       async upsert(record) {
         const values = mapIdentityResolutionToInsert(record);
         const [row] = await db
@@ -653,6 +719,21 @@ function createStage1RepositoriesInternal(
         return rows.map(mapRoutingReviewRow);
       },
 
+      async listOpenByContactId(contactId) {
+        const rows = await db
+          .select()
+          .from(routingReviewQueue)
+          .where(
+            and(
+              eq(routingReviewQueue.contactId, contactId),
+              eq(routingReviewQueue.status, "open")
+            )
+          )
+          .orderBy(desc(routingReviewQueue.openedAt), asc(routingReviewQueue.id));
+
+        return rows.map(mapRoutingReviewRow);
+      },
+
       async upsert(record) {
         const values = mapRoutingReviewToInsert(record);
         const [row] = await db
@@ -699,6 +780,21 @@ function createStage1RepositoriesInternal(
           .limit(1);
 
         return row === undefined ? null : mapInboxProjectionRow(row);
+      },
+
+      async listAllOrderedByRecency() {
+        const rows = await db
+          .select()
+          .from(contactInboxProjection)
+          .orderBy(
+            desc(
+              sql`coalesce(${contactInboxProjection.lastInboundAt}, ${contactInboxProjection.lastActivityAt})`
+            ),
+            desc(contactInboxProjection.lastActivityAt),
+            asc(contactInboxProjection.contactId)
+          );
+
+        return rows.map(mapInboxProjectionRow);
       },
 
       async upsert(record) {

--- a/packages/db/test/stage1-repositories.test.ts
+++ b/packages/db/test/stage1-repositories.test.ts
@@ -48,6 +48,9 @@ describe("Stage 1 DB repositories", () => {
     await expect(
       repositories.contacts.findBySalesforceContactId("003-stage1")
     ).resolves.toEqual(contact);
+    await expect(repositories.contacts.listByIds([contact.id])).resolves.toEqual([
+      contact
+    ]);
 
     const identity = await repositories.contactIdentities.upsert({
       id: "identity_1",
@@ -80,6 +83,9 @@ describe("Stage 1 DB repositories", () => {
     ).resolves.toEqual([identity]);
     await expect(
       repositories.contactMemberships.listByContactId(contact.id)
+    ).resolves.toEqual([membership]);
+    await expect(
+      repositories.contactMemberships.listByContactIds([contact.id])
     ).resolves.toEqual([membership]);
 
     const projectDimension = await repositories.projectDimensions.upsert({
@@ -165,7 +171,14 @@ describe("Stage 1 DB repositories", () => {
         primaryProvider: "gmail",
         primarySourceEvidenceId: "sev_1",
         supportingSourceEvidenceIds: [],
-        winnerReason: "single_source"
+        winnerReason: "single_source",
+        sourceRecordType: "message",
+        sourceRecordId: "gmail-message-1",
+        messageKind: "one_to_one",
+        campaignRef: null,
+        threadRef: null,
+        direction: "inbound",
+        notes: null
       },
       reviewState: "clear"
     });
@@ -198,7 +211,7 @@ describe("Stage 1 DB repositories", () => {
     const inboxProjection = await repositories.inboxProjection.upsert({
       contactId: "contact_1",
       bucket: "New",
-      isStarred: false,
+      needsFollowUp: false,
       hasUnresolved: true,
       lastInboundAt: "2026-01-01T00:00:00.000Z",
       lastOutboundAt: null,
@@ -220,6 +233,61 @@ describe("Stage 1 DB repositories", () => {
       primaryProvider: "gmail",
       reviewState: "clear"
     });
+    await repositories.contacts.upsert({
+      id: "contact_2",
+      salesforceContactId: "003-stage1-secondary",
+      displayName: "Another Volunteer",
+      primaryEmail: "another@example.org",
+      primaryPhone: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z"
+    });
+    await repositories.sourceEvidence.append({
+      id: "sev_2",
+      provider: "gmail",
+      providerRecordType: "message",
+      providerRecordId: "gmail-message-2",
+      receivedAt: "2026-01-01T00:11:00.000Z",
+      occurredAt: "2026-01-01T00:10:00.000Z",
+      payloadRef: "payloads/gmail/gmail-message-2.json",
+      idempotencyKey: "gmail:message:gmail-message-2",
+      checksum: "checksum-2"
+    });
+    const secondCanonicalEvent = await repositories.canonicalEvents.upsert({
+      id: "evt_2",
+      contactId: "contact_2",
+      eventType: "communication.email.outbound",
+      channel: "email",
+      occurredAt: "2026-01-01T00:10:00.000Z",
+      sourceEvidenceId: "sev_2",
+      idempotencyKey: "canonical:gmail-message-2",
+      provenance: {
+        primaryProvider: "gmail",
+        primarySourceEvidenceId: "sev_2",
+        supportingSourceEvidenceIds: [],
+        winnerReason: "single_source",
+        sourceRecordType: "message",
+        sourceRecordId: "gmail-message-2",
+        messageKind: "one_to_one",
+        campaignRef: null,
+        threadRef: null,
+        direction: "outbound",
+        notes: null
+      },
+      reviewState: "clear"
+    });
+    const secondInboxProjection = await repositories.inboxProjection.upsert({
+      contactId: "contact_2",
+      bucket: "Opened",
+      needsFollowUp: true,
+      hasUnresolved: false,
+      lastInboundAt: null,
+      lastOutboundAt: "2026-01-01T00:10:00.000Z",
+      lastActivityAt: "2026-01-01T00:10:00.000Z",
+      snippet: "Outbound only follow-up",
+      lastCanonicalEventId: secondCanonicalEvent.id,
+      lastEventType: "communication.email.outbound"
+    });
 
     await expect(
       repositories.canonicalEvents.findByIdempotencyKey(
@@ -230,10 +298,19 @@ describe("Stage 1 DB repositories", () => {
       repositories.canonicalEvents.listByContactId("contact_1")
     ).resolves.toEqual([canonicalEvent]);
     await expect(
+      repositories.canonicalEvents.listByIds([canonicalEvent.id])
+    ).resolves.toEqual([canonicalEvent]);
+    await expect(
+      repositories.identityResolutionQueue.listOpenByContactId("contact_1")
+    ).resolves.toEqual([identityCase]);
+    await expect(
       repositories.identityResolutionQueue.listOpenByReasonCode(
         "identity_missing_anchor"
       )
     ).resolves.toEqual([identityCase]);
+    await expect(
+      repositories.routingReviewQueue.listOpenByContactId("contact_1")
+    ).resolves.toEqual([routingCase]);
     await expect(
       repositories.routingReviewQueue.listOpenByReasonCode(
         "routing_missing_membership"
@@ -242,6 +319,9 @@ describe("Stage 1 DB repositories", () => {
     await expect(
       repositories.inboxProjection.findByContactId("contact_1")
     ).resolves.toEqual(inboxProjection);
+    await expect(
+      repositories.inboxProjection.listAllOrderedByRecency()
+    ).resolves.toEqual([secondInboxProjection, inboxProjection]);
     await expect(
       repositories.timelineProjection.findByCanonicalEventId(canonicalEvent.id)
     ).resolves.toEqual(timelineProjection);

--- a/packages/db/test/stage1-repositories.test.ts
+++ b/packages/db/test/stage1-repositories.test.ts
@@ -117,6 +117,46 @@ describe("Stage 1 DB repositories", () => {
       projectId: "project_1",
       expeditionId: "expedition_1"
     });
+    const salesforceCommunicationDetail =
+      await repositories.salesforceCommunicationDetails.upsert({
+        sourceEvidenceId: sourceEvidence.id,
+        providerRecordId: sourceEvidence.providerRecordId,
+        channel: "email",
+        messageKind: "auto",
+        subject: "Automation complete",
+        snippet: "Your workflow completed successfully.",
+        sourceLabel: "Salesforce Flow"
+      });
+    const simpleTextingMessageDetail =
+      await repositories.simpleTextingMessageDetails.upsert({
+        sourceEvidenceId: sourceEvidence.id,
+        providerRecordId: sourceEvidence.providerRecordId,
+        direction: "outbound",
+        messageKind: "campaign",
+        messageTextPreview: "Campaign kickoff reminder",
+        normalizedPhone: "+15555550123",
+        campaignId: "campaign_sms_1",
+        campaignName: "Volunteer Reminders",
+        providerThreadId: "thread_1",
+        threadKey: "thread-key-1"
+      });
+    const mailchimpCampaignActivityDetail =
+      await repositories.mailchimpCampaignActivityDetails.upsert({
+        sourceEvidenceId: sourceEvidence.id,
+        providerRecordId: sourceEvidence.providerRecordId,
+        activityType: "sent",
+        campaignId: "campaign_email_1",
+        audienceId: "audience_1",
+        memberId: "member_1",
+        campaignName: "Spring Launch",
+        snippet: "Campaign launch message"
+      });
+    const manualNoteDetail = await repositories.manualNoteDetails.upsert({
+      sourceEvidenceId: sourceEvidence.id,
+      providerRecordId: sourceEvidence.providerRecordId,
+      body: "Follow up after the kickoff call.",
+      authorDisplayName: "Stage One Operator"
+    });
 
     await expect(
       repositories.projectDimensions.listByIds(["project_1"])
@@ -132,6 +172,24 @@ describe("Stage 1 DB repositories", () => {
         sourceEvidence.id
       ])
     ).resolves.toEqual([salesforceContext]);
+    await expect(
+      repositories.salesforceCommunicationDetails.listBySourceEvidenceIds([
+        sourceEvidence.id
+      ])
+    ).resolves.toEqual([salesforceCommunicationDetail]);
+    await expect(
+      repositories.simpleTextingMessageDetails.listBySourceEvidenceIds([
+        sourceEvidence.id
+      ])
+    ).resolves.toEqual([simpleTextingMessageDetail]);
+    await expect(
+      repositories.mailchimpCampaignActivityDetails.listBySourceEvidenceIds([
+        sourceEvidence.id
+      ])
+    ).resolves.toEqual([mailchimpCampaignActivityDetail]);
+    await expect(
+      repositories.manualNoteDetails.listBySourceEvidenceIds([sourceEvidence.id])
+    ).resolves.toEqual([manualNoteDetail]);
   });
 
   it("persists canonical events, review queues, and projections", async () => {
@@ -322,6 +380,21 @@ describe("Stage 1 DB repositories", () => {
     await expect(
       repositories.inboxProjection.listAllOrderedByRecency()
     ).resolves.toEqual([secondInboxProjection, inboxProjection]);
+    await expect(
+      repositories.inboxProjection.setNeedsFollowUp({
+        contactId: "contact_1",
+        needsFollowUp: true
+      })
+    ).resolves.toEqual({
+      ...inboxProjection,
+      needsFollowUp: true
+    });
+    await expect(
+      repositories.inboxProjection.findByContactId("contact_1")
+    ).resolves.toEqual({
+      ...inboxProjection,
+      needsFollowUp: true
+    });
     await expect(
       repositories.timelineProjection.findByCanonicalEventId(canonicalEvent.id)
     ).resolves.toEqual(timelineProjection);

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -10,11 +10,15 @@ import type {
   IdentityResolutionCase,
   IdentityResolutionReasonCode,
   InboxProjectionRow,
+  MailchimpCampaignActivityDetailRecord,
+  ManualNoteDetailRecord,
   ProjectDimensionRecord,
   Provider,
   RoutingReviewCase,
   RoutingReviewReasonCode,
+  SalesforceCommunicationDetailRecord,
   SalesforceEventContextRecord,
+  SimpleTextingMessageDetailRecord,
   SourceEvidenceRecord,
   SyncScope,
   SyncJobType,
@@ -102,6 +106,40 @@ export interface SalesforceEventContextRepository {
   ): Promise<SalesforceEventContextRecord>;
 }
 
+export interface SalesforceCommunicationDetailRepository {
+  listBySourceEvidenceIds(
+    sourceEvidenceIds: readonly string[]
+  ): Promise<readonly SalesforceCommunicationDetailRecord[]>;
+  upsert(
+    record: SalesforceCommunicationDetailRecord
+  ): Promise<SalesforceCommunicationDetailRecord>;
+}
+
+export interface SimpleTextingMessageDetailRepository {
+  listBySourceEvidenceIds(
+    sourceEvidenceIds: readonly string[]
+  ): Promise<readonly SimpleTextingMessageDetailRecord[]>;
+  upsert(
+    record: SimpleTextingMessageDetailRecord
+  ): Promise<SimpleTextingMessageDetailRecord>;
+}
+
+export interface MailchimpCampaignActivityDetailRepository {
+  listBySourceEvidenceIds(
+    sourceEvidenceIds: readonly string[]
+  ): Promise<readonly MailchimpCampaignActivityDetailRecord[]>;
+  upsert(
+    record: MailchimpCampaignActivityDetailRecord
+  ): Promise<MailchimpCampaignActivityDetailRecord>;
+}
+
+export interface ManualNoteDetailRepository {
+  listBySourceEvidenceIds(
+    sourceEvidenceIds: readonly string[]
+  ): Promise<readonly ManualNoteDetailRecord[]>;
+  upsert(record: ManualNoteDetailRecord): Promise<ManualNoteDetailRecord>;
+}
+
 export interface IdentityResolutionRepository {
   findById(id: string): Promise<IdentityResolutionCase | null>;
   listOpenByContactId(contactId: string): Promise<readonly IdentityResolutionCase[]>;
@@ -124,6 +162,10 @@ export interface InboxProjectionRepository {
   countAll(): Promise<number>;
   findByContactId(contactId: string): Promise<InboxProjectionRow | null>;
   listAllOrderedByRecency(): Promise<readonly InboxProjectionRow[]>;
+  setNeedsFollowUp(input: {
+    readonly contactId: string;
+    readonly needsFollowUp: boolean;
+  }): Promise<InboxProjectionRow | null>;
   upsert(record: InboxProjectionRow): Promise<InboxProjectionRow>;
 }
 
@@ -162,6 +204,10 @@ export interface Stage1RepositoryBundle {
   readonly expeditionDimensions: ExpeditionDimensionRepository;
   readonly gmailMessageDetails: GmailMessageDetailRepository;
   readonly salesforceEventContext: SalesforceEventContextRepository;
+  readonly salesforceCommunicationDetails: SalesforceCommunicationDetailRepository;
+  readonly simpleTextingMessageDetails: SimpleTextingMessageDetailRepository;
+  readonly mailchimpCampaignActivityDetails: MailchimpCampaignActivityDetailRepository;
+  readonly manualNoteDetails: ManualNoteDetailRepository;
   readonly identityResolutionQueue: IdentityResolutionRepository;
   readonly routingReviewQueue: RoutingReviewRepository;
   readonly inboxProjection: InboxProjectionRepository;

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -40,6 +40,7 @@ export interface CanonicalEventRepository {
   countAll(): Promise<number>;
   countByPrimaryProvider(provider: Provider): Promise<number>;
   countDistinctInboxContacts(): Promise<number>;
+  listByIds(ids: readonly string[]): Promise<readonly CanonicalEventRecord[]>;
   listByContactId(contactId: string): Promise<readonly CanonicalEventRecord[]>;
   upsert(record: CanonicalEventRecord): Promise<CanonicalEventRecord>;
 }
@@ -50,6 +51,7 @@ export interface ContactRepository {
     salesforceContactId: string
   ): Promise<ContactRecord | null>;
   listAll(): Promise<readonly ContactRecord[]>;
+  listByIds(ids: readonly string[]): Promise<readonly ContactRecord[]>;
   upsert(record: ContactRecord): Promise<ContactRecord>;
 }
 
@@ -65,6 +67,9 @@ export interface ContactIdentityRepository {
 export interface ContactMembershipRepository {
   listByContactId(
     contactId: string
+  ): Promise<readonly ContactMembershipRecord[]>;
+  listByContactIds(
+    contactIds: readonly string[]
   ): Promise<readonly ContactMembershipRecord[]>;
   upsert(record: ContactMembershipRecord): Promise<ContactMembershipRecord>;
 }
@@ -99,6 +104,7 @@ export interface SalesforceEventContextRepository {
 
 export interface IdentityResolutionRepository {
   findById(id: string): Promise<IdentityResolutionCase | null>;
+  listOpenByContactId(contactId: string): Promise<readonly IdentityResolutionCase[]>;
   listOpenByReasonCode(
     reasonCode: IdentityResolutionReasonCode
   ): Promise<readonly IdentityResolutionCase[]>;
@@ -107,6 +113,7 @@ export interface IdentityResolutionRepository {
 
 export interface RoutingReviewRepository {
   findById(id: string): Promise<RoutingReviewCase | null>;
+  listOpenByContactId(contactId: string): Promise<readonly RoutingReviewCase[]>;
   listOpenByReasonCode(
     reasonCode: RoutingReviewReasonCode
   ): Promise<readonly RoutingReviewCase[]>;
@@ -116,6 +123,7 @@ export interface RoutingReviewRepository {
 export interface InboxProjectionRepository {
   countAll(): Promise<number>;
   findByContactId(contactId: string): Promise<InboxProjectionRow | null>;
+  listAllOrderedByRecency(): Promise<readonly InboxProjectionRow[]>;
   upsert(record: InboxProjectionRow): Promise<InboxProjectionRow>;
 }
 

--- a/packages/domain/src/timeline.ts
+++ b/packages/domain/src/timeline.ts
@@ -41,9 +41,7 @@ function resolveFamily(event: CanonicalEventRecord): TimelineItem["family"] {
 
   if (
     event.eventType === "communication.email.outbound" &&
-    (event.provenance.messageKind === "auto" ||
-      (event.provenance.messageKind === null &&
-        event.provenance.primaryProvider === "salesforce"))
+    event.provenance.messageKind === "auto"
   ) {
     return "auto_email";
   }

--- a/packages/domain/src/timeline.ts
+++ b/packages/domain/src/timeline.ts
@@ -1,0 +1,344 @@
+import {
+  timelineItemListSchema,
+  type CampaignEmailTimelineItem,
+  type CanonicalEventRecord,
+  type SourceEvidenceRecord,
+  type TimelineItem,
+  type TimelineProjectionRow
+} from "@as-comms/contracts";
+
+import type { Stage1RepositoryBundle } from "./repositories.js";
+
+function getLifecycleMilestone(
+  eventType: CanonicalEventRecord["eventType"]
+): "signed_up" | "received_training" | "completed_training" | "submitted_first_data" {
+  switch (eventType) {
+    case "lifecycle.signed_up":
+      return "signed_up";
+    case "lifecycle.received_training":
+      return "received_training";
+    case "lifecycle.completed_training":
+      return "completed_training";
+    case "lifecycle.submitted_first_data":
+      return "submitted_first_data";
+    default:
+      throw new Error(`Unsupported lifecycle event type ${eventType}.`);
+  }
+}
+
+function resolveFamily(event: CanonicalEventRecord): TimelineItem["family"] {
+  if (event.eventType.startsWith("lifecycle.")) {
+    return "salesforce_event";
+  }
+
+  if (event.eventType === "note.internal.created") {
+    return "internal_note";
+  }
+
+  if (event.eventType.startsWith("campaign.email.")) {
+    return "campaign_email";
+  }
+
+  if (
+    event.eventType === "communication.email.outbound" &&
+    (event.provenance.messageKind === "auto" ||
+      (event.provenance.messageKind === null &&
+        event.provenance.primaryProvider === "salesforce"))
+  ) {
+    return "auto_email";
+  }
+
+  if (
+    event.eventType === "communication.sms.outbound" &&
+    event.provenance.messageKind === "campaign"
+  ) {
+    return "campaign_sms";
+  }
+
+  if (
+    (event.eventType === "communication.email.inbound" ||
+      event.eventType === "communication.email.outbound") &&
+    (event.provenance.messageKind === "one_to_one" ||
+      (event.provenance.messageKind === null &&
+        (event.provenance.primaryProvider === "gmail" ||
+          event.provenance.primaryProvider === "salesforce")))
+  ) {
+    return "one_to_one_email";
+  }
+
+  if (
+    (event.eventType === "communication.sms.inbound" ||
+      event.eventType === "communication.sms.outbound") &&
+    (event.provenance.messageKind === "one_to_one" ||
+      (event.provenance.messageKind === null &&
+        (event.provenance.primaryProvider === "simpletexting" ||
+          event.provenance.primaryProvider === "salesforce")))
+  ) {
+    return "one_to_one_sms";
+  }
+
+  throw new Error(
+    `Canonical event ${event.id} (${event.eventType}) could not be resolved to a timeline family.`
+  );
+}
+
+function commonFields(
+  row: TimelineProjectionRow
+): Omit<TimelineItem, "family"> & { family?: never } {
+  return {
+    id: row.id,
+    contactId: row.contactId,
+    canonicalEventId: row.canonicalEventId,
+    occurredAt: row.occurredAt,
+    sortKey: row.sortKey,
+    reviewState: row.reviewState,
+    primaryProvider: row.primaryProvider,
+    summary: row.summary
+  } as Omit<TimelineItem, "family"> & { family?: never };
+}
+
+export interface Stage1TimelinePresentationService {
+  listTimelineItemsByContactId(contactId: string): Promise<readonly TimelineItem[]>;
+}
+
+export function createStage1TimelinePresentationService(
+  repositories: Stage1RepositoryBundle
+): Stage1TimelinePresentationService {
+  return {
+    async listTimelineItemsByContactId(contactId) {
+      const [canonicalEvents, timelineRows] = await Promise.all([
+        repositories.canonicalEvents.listByContactId(contactId),
+        repositories.timelineProjection.listByContactId(contactId)
+      ]);
+      const canonicalEventById = new Map(
+        canonicalEvents.map((event) => [event.id, event])
+      );
+      const sourceEvidence = (
+        await Promise.all(
+          canonicalEvents.map((event) =>
+            repositories.sourceEvidence.findById(event.sourceEvidenceId)
+          )
+        )
+      ).filter((record): record is SourceEvidenceRecord => record !== null);
+      const sourceEvidenceById = new Map(
+        sourceEvidence.map((record) => [record.id, record])
+      );
+      const sourceEvidenceIds = sourceEvidence.map((record) => record.id);
+      const [
+        gmailDetails,
+        salesforceContexts,
+        salesforceCommunicationDetails,
+        simpleTextingMessageDetails,
+        mailchimpCampaignActivityDetails,
+        manualNoteDetails
+      ] = await Promise.all([
+        repositories.gmailMessageDetails.listBySourceEvidenceIds(sourceEvidenceIds),
+        repositories.salesforceEventContext.listBySourceEvidenceIds(sourceEvidenceIds),
+        repositories.salesforceCommunicationDetails.listBySourceEvidenceIds(
+          sourceEvidenceIds
+        ),
+        repositories.simpleTextingMessageDetails.listBySourceEvidenceIds(
+          sourceEvidenceIds
+        ),
+        repositories.mailchimpCampaignActivityDetails.listBySourceEvidenceIds(
+          sourceEvidenceIds
+        ),
+        repositories.manualNoteDetails.listBySourceEvidenceIds(sourceEvidenceIds)
+      ]);
+
+      const salesforceContextBySourceEvidenceId = new Map(
+        salesforceContexts.map((detail) => [detail.sourceEvidenceId, detail])
+      );
+      const gmailDetailBySourceEvidenceId = new Map(
+        gmailDetails.map((detail) => [detail.sourceEvidenceId, detail])
+      );
+      const salesforceCommunicationBySourceEvidenceId = new Map(
+        salesforceCommunicationDetails.map((detail) => [
+          detail.sourceEvidenceId,
+          detail
+        ])
+      );
+      const simpleTextingDetailBySourceEvidenceId = new Map(
+        simpleTextingMessageDetails.map((detail) => [detail.sourceEvidenceId, detail])
+      );
+      const mailchimpDetailBySourceEvidenceId = new Map(
+        mailchimpCampaignActivityDetails.map((detail) => [
+          detail.sourceEvidenceId,
+          detail
+        ])
+      );
+      const manualNoteDetailBySourceEvidenceId = new Map(
+        manualNoteDetails.map((detail) => [detail.sourceEvidenceId, detail])
+      );
+      const [projectDimensions, expeditionDimensions] = await Promise.all([
+        repositories.projectDimensions.listByIds(
+          Array.from(
+            new Set(
+              salesforceContexts
+                .map((context) => context.projectId)
+                .filter((value): value is string => value !== null)
+            )
+          )
+        ),
+        repositories.expeditionDimensions.listByIds(
+          Array.from(
+            new Set(
+              salesforceContexts
+                .map((context) => context.expeditionId)
+                .filter((value): value is string => value !== null)
+            )
+          )
+        )
+      ]);
+      const projectNameById = new Map(
+        projectDimensions.map((dimension) => [
+          dimension.projectId,
+          dimension.projectName
+        ])
+      );
+      const expeditionNameById = new Map(
+        expeditionDimensions.map((dimension) => [
+          dimension.expeditionId,
+          dimension.expeditionName
+        ])
+      );
+
+      const items: TimelineItem[] = [];
+
+      for (const row of timelineRows) {
+        const event = canonicalEventById.get(row.canonicalEventId);
+
+        if (event === undefined) {
+          continue;
+        }
+
+        const evidence = sourceEvidenceById.get(event.sourceEvidenceId);
+
+        if (evidence === undefined) {
+          continue;
+        }
+
+        const family = resolveFamily(event);
+        const base = commonFields(row);
+        const salesforceContext = salesforceContextBySourceEvidenceId.get(evidence.id);
+        const gmailDetail = gmailDetailBySourceEvidenceId.get(evidence.id);
+        const salesforceCommunicationDetail =
+          salesforceCommunicationBySourceEvidenceId.get(evidence.id);
+        const simpleTextingDetail = simpleTextingDetailBySourceEvidenceId.get(
+          evidence.id
+        );
+        const mailchimpDetail = mailchimpDetailBySourceEvidenceId.get(evidence.id);
+        const manualNoteDetail = manualNoteDetailBySourceEvidenceId.get(evidence.id);
+
+        switch (family) {
+          case "salesforce_event":
+            items.push({
+              ...base,
+              family,
+              milestone: getLifecycleMilestone(event.eventType),
+              projectName:
+                salesforceContext?.projectId === null ||
+                salesforceContext?.projectId === undefined
+                  ? null
+                  : (projectNameById.get(salesforceContext.projectId) ?? null),
+              expeditionName:
+                salesforceContext?.expeditionId === null ||
+                salesforceContext?.expeditionId === undefined
+                  ? null
+                  : (expeditionNameById.get(salesforceContext.expeditionId) ?? null),
+              sourceField: salesforceContext?.sourceField ?? null
+            });
+            break;
+          case "auto_email":
+            items.push({
+              ...base,
+              family,
+              direction: "outbound",
+              subject: salesforceCommunicationDetail?.subject ?? null,
+              snippet: salesforceCommunicationDetail?.snippet ?? "",
+              sourceLabel:
+                salesforceCommunicationDetail?.sourceLabel ?? "Salesforce Flow"
+            });
+            break;
+          case "campaign_email":
+            items.push({
+              ...base,
+              family,
+              activityType:
+                mailchimpDetail?.activityType ??
+                (event.eventType.replace("campaign.email.", "") as CampaignEmailTimelineItem["activityType"]),
+              campaignName: mailchimpDetail?.campaignName ?? null,
+              campaignId: mailchimpDetail?.campaignId ?? null,
+              audienceId: mailchimpDetail?.audienceId ?? null,
+              snippet: mailchimpDetail?.snippet ?? ""
+            });
+            break;
+          case "campaign_sms":
+            items.push({
+              ...base,
+              family,
+              direction: "outbound",
+              messageTextPreview: simpleTextingDetail?.messageTextPreview ?? "",
+              campaignName:
+                simpleTextingDetail?.campaignName ??
+                event.provenance.campaignRef?.providerMessageName ??
+                null,
+              campaignId:
+                simpleTextingDetail?.campaignId ??
+                event.provenance.campaignRef?.providerCampaignId ??
+                null
+            });
+            break;
+          case "one_to_one_email":
+            items.push({
+              ...base,
+              family,
+              direction:
+                gmailDetail?.direction ?? event.provenance.direction ?? "outbound",
+              subject:
+                gmailDetail?.subject ?? salesforceCommunicationDetail?.subject ?? null,
+              snippet:
+                gmailDetail?.snippetClean ?? salesforceCommunicationDetail?.snippet ?? "",
+              bodyPreview: gmailDetail?.bodyTextPreview ?? null,
+              mailbox:
+                gmailDetail?.projectInboxAlias ?? gmailDetail?.capturedMailbox ?? null,
+              threadId:
+                gmailDetail?.gmailThreadId ??
+                event.provenance.threadRef?.providerThreadId ??
+                null
+            });
+            break;
+          case "one_to_one_sms":
+            items.push({
+              ...base,
+              family,
+              direction:
+                simpleTextingDetail?.direction ??
+                event.provenance.direction ??
+                "outbound",
+              messageTextPreview:
+                simpleTextingDetail?.messageTextPreview ??
+                salesforceCommunicationDetail?.snippet ??
+                "",
+              phone: simpleTextingDetail?.normalizedPhone ?? null,
+              threadKey:
+                simpleTextingDetail?.threadKey ??
+                event.provenance.threadRef?.crossProviderCollapseKey ??
+                null
+            });
+            break;
+          case "internal_note":
+            items.push({
+              ...base,
+              family,
+              body: manualNoteDetail?.body ?? "",
+              authorDisplayName: manualNoteDetail?.authorDisplayName ?? null
+            });
+            break;
+        }
+      }
+
+      return timelineItemListSchema.parse(items);
+    }
+  };
+}

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -70,6 +70,22 @@ describe("defineStage1RepositoryBundle", () => {
         listBySourceEvidenceIds: () => Promise.resolve([]),
         upsert: (record) => Promise.resolve(record)
       },
+      salesforceCommunicationDetails: {
+        listBySourceEvidenceIds: () => Promise.resolve([]),
+        upsert: (record) => Promise.resolve(record)
+      },
+      simpleTextingMessageDetails: {
+        listBySourceEvidenceIds: () => Promise.resolve([]),
+        upsert: (record) => Promise.resolve(record)
+      },
+      mailchimpCampaignActivityDetails: {
+        listBySourceEvidenceIds: () => Promise.resolve([]),
+        upsert: (record) => Promise.resolve(record)
+      },
+      manualNoteDetails: {
+        listBySourceEvidenceIds: () => Promise.resolve([]),
+        upsert: (record) => Promise.resolve(record)
+      },
       identityResolutionQueue: {
         findById: () => Promise.resolve(null),
         listOpenByContactId: () => Promise.resolve([]),
@@ -86,6 +102,7 @@ describe("defineStage1RepositoryBundle", () => {
         countAll: () => Promise.resolve(0),
         findByContactId: () => Promise.resolve(null),
         listAllOrderedByRecency: () => Promise.resolve([]),
+        setNeedsFollowUp: () => Promise.resolve(null),
         upsert: (record) => Promise.resolve(record)
       },
       timelineProjection: {

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -33,6 +33,7 @@ describe("defineStage1RepositoryBundle", () => {
         countAll: () => Promise.resolve(0),
         countByPrimaryProvider: () => Promise.resolve(0),
         countDistinctInboxContacts: () => Promise.resolve(0),
+        listByIds: () => Promise.resolve([]),
         listByContactId: () => Promise.resolve([]),
         upsert: (record) => Promise.resolve(record)
       },
@@ -40,6 +41,7 @@ describe("defineStage1RepositoryBundle", () => {
         findById: () => Promise.resolve(contact),
         findBySalesforceContactId: () => Promise.resolve(contact),
         listAll: () => Promise.resolve([contact]),
+        listByIds: () => Promise.resolve([contact]),
         upsert: (record) => Promise.resolve(record)
       },
       contactIdentities: {
@@ -49,6 +51,7 @@ describe("defineStage1RepositoryBundle", () => {
       },
       contactMemberships: {
         listByContactId: () => Promise.resolve([]),
+        listByContactIds: () => Promise.resolve([]),
         upsert: (record) => Promise.resolve(record)
       },
       projectDimensions: {
@@ -69,17 +72,20 @@ describe("defineStage1RepositoryBundle", () => {
       },
       identityResolutionQueue: {
         findById: () => Promise.resolve(null),
+        listOpenByContactId: () => Promise.resolve([]),
         listOpenByReasonCode: () => Promise.resolve([]),
         upsert: (record) => Promise.resolve(record)
       },
       routingReviewQueue: {
         findById: () => Promise.resolve(null),
+        listOpenByContactId: () => Promise.resolve([]),
         listOpenByReasonCode: () => Promise.resolve([]),
         upsert: (record) => Promise.resolve(record)
       },
       inboxProjection: {
         countAll: () => Promise.resolve(0),
         findByContactId: () => Promise.resolve(null),
+        listAllOrderedByRecency: () => Promise.resolve([]),
         upsert: (record) => Promise.resolve(record)
       },
       timelineProjection: {

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  AuditEvidenceRecord,
+  CanonicalEventRecord,
+  ContactRecord,
+  InboxProjectionRow,
+  SalesforceCommunicationDetailRecord,
+  SourceEvidenceRecord,
+  TimelineProjectionRow
+} from "@as-comms/contracts";
+
+import {
+  createStage1TimelinePresentationService,
+  defineStage1RepositoryBundle,
+  type Stage1RepositoryBundle
+} from "../src/index.js";
+
+function createRepositoryBundle(input: {
+  readonly canonicalEvents: readonly CanonicalEventRecord[];
+  readonly sourceEvidence: readonly SourceEvidenceRecord[];
+  readonly salesforceCommunicationDetails: readonly SalesforceCommunicationDetailRecord[];
+  readonly timelineRows: readonly TimelineProjectionRow[];
+}): Stage1RepositoryBundle {
+  const canonicalEventsById = new Map(
+    input.canonicalEvents.map((event) => [event.id, event])
+  );
+  const sourceEvidenceById = new Map(
+    input.sourceEvidence.map((evidence) => [evidence.id, evidence])
+  );
+  const salesforceCommunicationDetailsBySourceEvidenceId = new Map(
+    input.salesforceCommunicationDetails.map((detail) => [
+      detail.sourceEvidenceId,
+      detail
+    ])
+  );
+  const timelineRowsByCanonicalEventId = new Map(
+    input.timelineRows.map((row) => [row.canonicalEventId, row])
+  );
+
+  const contact: ContactRecord = {
+    id: "contact_1",
+    salesforceContactId: "003-stage1",
+    displayName: "Stage One Volunteer",
+    primaryEmail: "volunteer@example.org",
+    primaryPhone: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z"
+  };
+
+  return defineStage1RepositoryBundle({
+    sourceEvidence: {
+      append: (record) => Promise.resolve(record),
+      findById: (id) => Promise.resolve(sourceEvidenceById.get(id) ?? null),
+      findByIdempotencyKey: () => Promise.resolve(null),
+      countByProvider: () => Promise.resolve(0),
+      listByProviderRecord: () => Promise.resolve([])
+    },
+    canonicalEvents: {
+      findById: (id) => Promise.resolve(canonicalEventsById.get(id) ?? null),
+      findByIdempotencyKey: () => Promise.resolve(null),
+      countAll: () => Promise.resolve(input.canonicalEvents.length),
+      countByPrimaryProvider: () => Promise.resolve(0),
+      countDistinctInboxContacts: () => Promise.resolve(1),
+      listByIds: (ids) =>
+        Promise.resolve(
+          ids.flatMap((id) => {
+            const event = canonicalEventsById.get(id);
+            return event === undefined ? [] : [event];
+          })
+        ),
+      listByContactId: (contactId) =>
+        Promise.resolve(
+          input.canonicalEvents.filter((event) => event.contactId === contactId)
+        ),
+      upsert: (record) => Promise.resolve(record)
+    },
+    contacts: {
+      findById: () => Promise.resolve(contact),
+      findBySalesforceContactId: () => Promise.resolve(contact),
+      listAll: () => Promise.resolve([contact]),
+      listByIds: () => Promise.resolve([contact]),
+      upsert: (record) => Promise.resolve(record)
+    },
+    contactIdentities: {
+      listByContactId: () => Promise.resolve([]),
+      listByNormalizedValue: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record)
+    },
+    contactMemberships: {
+      listByContactId: () => Promise.resolve([]),
+      listByContactIds: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record)
+    },
+    projectDimensions: {
+      listByIds: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record)
+    },
+    expeditionDimensions: {
+      listByIds: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record)
+    },
+    gmailMessageDetails: {
+      listBySourceEvidenceIds: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record)
+    },
+    salesforceEventContext: {
+      listBySourceEvidenceIds: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record)
+    },
+    salesforceCommunicationDetails: {
+      listBySourceEvidenceIds: (sourceEvidenceIds) =>
+        Promise.resolve(
+          sourceEvidenceIds.flatMap((sourceEvidenceId) => {
+            const detail =
+              salesforceCommunicationDetailsBySourceEvidenceId.get(sourceEvidenceId);
+            return detail === undefined ? [] : [detail];
+          })
+        ),
+      upsert: (record) => Promise.resolve(record)
+    },
+    simpleTextingMessageDetails: {
+      listBySourceEvidenceIds: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record)
+    },
+    mailchimpCampaignActivityDetails: {
+      listBySourceEvidenceIds: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record)
+    },
+    manualNoteDetails: {
+      listBySourceEvidenceIds: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record)
+    },
+    identityResolutionQueue: {
+      findById: () => Promise.resolve(null),
+      listOpenByContactId: () => Promise.resolve([]),
+      listOpenByReasonCode: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record)
+    },
+    routingReviewQueue: {
+      findById: () => Promise.resolve(null),
+      listOpenByContactId: () => Promise.resolve([]),
+      listOpenByReasonCode: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record)
+    },
+    inboxProjection: {
+      countAll: () => Promise.resolve(0),
+      findByContactId: () => Promise.resolve(null),
+      listAllOrderedByRecency: () => Promise.resolve([]),
+      setNeedsFollowUp: () => Promise.resolve(null),
+      upsert: (record: InboxProjectionRow) => Promise.resolve(record)
+    },
+    timelineProjection: {
+      countAll: () => Promise.resolve(input.timelineRows.length),
+      findByCanonicalEventId: (canonicalEventId) =>
+        Promise.resolve(timelineRowsByCanonicalEventId.get(canonicalEventId) ?? null),
+      listByContactId: (contactId) =>
+        Promise.resolve(
+          input.timelineRows.filter((row) => row.contactId === contactId)
+        ),
+      upsert: (record) => Promise.resolve(record)
+    },
+    syncState: {
+      findById: () => Promise.resolve(null),
+      findLatest: () => Promise.resolve(null),
+      upsert: (record) => Promise.resolve(record)
+    },
+    auditEvidence: {
+      append: (record: AuditEvidenceRecord) => Promise.resolve(record),
+      listByEntity: () => Promise.resolve([])
+    }
+  });
+}
+
+function buildSourceEvidence(
+  id: string,
+  providerRecordId: string
+): SourceEvidenceRecord {
+  return {
+    id,
+    provider: "salesforce",
+    providerRecordType: "task_communication",
+    providerRecordId,
+    receivedAt: "2026-01-01T00:00:00.000Z",
+    occurredAt: "2026-01-01T00:00:00.000Z",
+    payloadRef: `payloads/salesforce/${providerRecordId}.json`,
+    idempotencyKey: `salesforce:${providerRecordId}`,
+    checksum: `checksum:${providerRecordId}`
+  };
+}
+
+function buildSalesforceOutboundEmailEvent(input: {
+  readonly id: string;
+  readonly sourceEvidenceId: string;
+  readonly occurredAt: string;
+  readonly messageKind: "one_to_one" | "auto" | null;
+  readonly subject: string;
+  readonly snippet: string;
+}): {
+  readonly canonicalEvent: CanonicalEventRecord;
+  readonly detail: SalesforceCommunicationDetailRecord;
+  readonly timelineRow: TimelineProjectionRow;
+} {
+  return {
+    canonicalEvent: {
+      id: input.id,
+      contactId: "contact_1",
+      eventType: "communication.email.outbound",
+      channel: "email",
+      occurredAt: input.occurredAt,
+      sourceEvidenceId: input.sourceEvidenceId,
+      idempotencyKey: `canonical:${input.id}`,
+      provenance: {
+        primaryProvider: "salesforce",
+        primarySourceEvidenceId: input.sourceEvidenceId,
+        supportingSourceEvidenceIds: [],
+        winnerReason: "single_source",
+        sourceRecordType: "task_communication",
+        sourceRecordId: input.id,
+        messageKind: input.messageKind,
+        campaignRef: null,
+        threadRef: null,
+        direction: "outbound",
+        notes: null
+      },
+      reviewState: "clear"
+    },
+    detail: {
+      sourceEvidenceId: input.sourceEvidenceId,
+      providerRecordId: input.id,
+      channel: "email",
+      // The detail table stores a concrete message kind even when canonical
+      // provenance remains null for the classification regression case.
+      messageKind: input.messageKind ?? "one_to_one",
+      subject: input.subject,
+      snippet: input.snippet,
+      sourceLabel: "Salesforce Logged Email"
+    },
+    timelineRow: {
+      id: `timeline:${input.id}`,
+      contactId: "contact_1",
+      canonicalEventId: input.id,
+      occurredAt: input.occurredAt,
+      sortKey: `${input.occurredAt}::${input.id}`,
+      eventType: "communication.email.outbound",
+      summary: input.subject,
+      channel: "email",
+      primaryProvider: "salesforce",
+      reviewState: "clear"
+    }
+  };
+}
+
+describe("Stage 1 timeline presenter", () => {
+  it("keeps Salesforce outbound email in the 1:1 family unless canon explicitly marks it auto", async () => {
+    const nullClassified = buildSalesforceOutboundEmailEvent({
+      id: "evt_salesforce_null",
+      sourceEvidenceId: "sev_salesforce_null",
+      occurredAt: "2026-01-01T00:00:00.000Z",
+      messageKind: null,
+      subject: "Logged follow-up",
+      snippet: "Logged follow-up body"
+    });
+    const explicitOneToOne = buildSalesforceOutboundEmailEvent({
+      id: "evt_salesforce_one_to_one",
+      sourceEvidenceId: "sev_salesforce_one_to_one",
+      occurredAt: "2026-01-01T00:01:00.000Z",
+      messageKind: "one_to_one",
+      subject: "Explicit one-to-one follow-up",
+      snippet: "Explicit one-to-one body"
+    });
+    const explicitAuto = buildSalesforceOutboundEmailEvent({
+      id: "evt_salesforce_auto",
+      sourceEvidenceId: "sev_salesforce_auto",
+      occurredAt: "2026-01-01T00:02:00.000Z",
+      messageKind: "auto",
+      subject: "Automation sent",
+      snippet: "Automation body"
+    });
+
+    const repositories = createRepositoryBundle({
+      canonicalEvents: [
+        nullClassified.canonicalEvent,
+        explicitOneToOne.canonicalEvent,
+        explicitAuto.canonicalEvent
+      ],
+      sourceEvidence: [
+        buildSourceEvidence("sev_salesforce_null", "salesforce-null"),
+        buildSourceEvidence("sev_salesforce_one_to_one", "salesforce-one-to-one"),
+        buildSourceEvidence("sev_salesforce_auto", "salesforce-auto")
+      ],
+      salesforceCommunicationDetails: [
+        nullClassified.detail,
+        explicitOneToOne.detail,
+        explicitAuto.detail
+      ],
+      timelineRows: [
+        nullClassified.timelineRow,
+        explicitOneToOne.timelineRow,
+        explicitAuto.timelineRow
+      ]
+    });
+    const presenter = createStage1TimelinePresentationService(repositories);
+
+    const items = await presenter.listTimelineItemsByContactId("contact_1");
+
+    expect(
+      items.map((item) => ({
+        canonicalEventId: item.canonicalEventId,
+        family: item.family
+      }))
+    ).toEqual([
+      {
+        canonicalEventId: "evt_salesforce_null",
+        family: "one_to_one_email"
+      },
+      {
+        canonicalEventId: "evt_salesforce_one_to_one",
+        family: "one_to_one_email"
+      },
+      {
+        canonicalEventId: "evt_salesforce_auto",
+        family: "auto_email"
+      }
+    ]);
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     trace: "on-first-retry"
   },
   webServer: {
-    command: `pnpm --dir apps/web exec next build && pnpm --dir apps/web exec next start --hostname 127.0.0.1 --port ${port}`,
+    command: `bash -lc 'set -a && source .env.local && set +a && pnpm --dir apps/web exec next build && pnpm --dir apps/web exec next start --hostname 127.0.0.1 --port ${port}'`,
     url: `http://127.0.0.1:${port}`,
     reuseExistingServer: !process.env.CI,
     timeout: 120000

--- a/scripts/mailchimp-campaign-queue.mjs
+++ b/scripts/mailchimp-campaign-queue.mjs
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+
+import { mkdir, appendFile } from "node:fs/promises";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const TSX_PATH = resolve(ROOT, "node_modules/.bin/tsx");
+const WORKER_CLI_PATH = resolve(ROOT, "apps/worker/src/ops/cli.ts");
+const DEFAULT_ARTIFACT_ROOT = resolve(
+  ROOT,
+  "tmp/provider-exports/mailchimp-api-backfill/campaigns"
+);
+const LOG_DIR = resolve(ROOT, "tmp/overnight-backfill");
+const DEFAULT_TIMEOUT_MS = 2 * 60 * 60 * 1000;
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_CONCURRENCY = 1;
+
+function buildOperationId(prefix) {
+  return `${prefix}:${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function delay(ms) {
+  return new Promise((resolveDelay) => {
+    setTimeout(resolveDelay, ms);
+  });
+}
+
+function timestamp() {
+  return new Date().toISOString();
+}
+
+async function appendLog(logPath, message) {
+  await appendFile(logPath, `[${timestamp()}] ${message}\n`, "utf8");
+}
+
+function extractJson(stdout) {
+  const trimmed = stdout.trim();
+
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  return JSON.parse(trimmed);
+}
+
+function buildResultSummary(result, parsedPayload) {
+  return {
+    exitCode: result.exitCode,
+    timedOut: result.timedOut,
+    parsedPayload
+  };
+}
+
+function shouldRetry(result, parsedPayload) {
+  const combinedText = `${result.stdout}\n${result.stderr}`;
+  const retryableNetworkPattern =
+    /EADDRNOTAVAIL|ECONNRESET|ECONNREFUSED|ENOTFOUND|EAI_AGAIN|ETIMEDOUT|socket hang up|read EADDRNOTAVAIL|read ECONNRESET/iu;
+
+  if (result.timedOut) {
+    return true;
+  }
+
+  if (retryableNetworkPattern.test(combinedText)) {
+    return true;
+  }
+
+  if (
+    parsedPayload !== null &&
+    typeof parsedPayload === "object" &&
+    "outcome" in parsedPayload &&
+    parsedPayload.outcome === "failed" &&
+    "message" in parsedPayload &&
+    typeof parsedPayload.message === "string" &&
+    retryableNetworkPattern.test(parsedPayload.message)
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+async function runCliCommand({
+  args,
+  logPath,
+  timeoutMs
+}) {
+  const child = spawn(TSX_PATH, [WORKER_CLI_PATH, ...args], {
+    cwd: ROOT,
+    env: process.env,
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  let stdout = "";
+  let stderr = "";
+  let timedOut = false;
+  let timeoutHandle = null;
+
+  if (timeoutMs > 0) {
+    timeoutHandle = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      setTimeout(() => {
+        if (!child.killed) {
+          child.kill("SIGKILL");
+        }
+      }, 5000).unref();
+    }, timeoutMs);
+    timeoutHandle.unref();
+  }
+
+  child.stdout.on("data", (chunk) => {
+    const text = chunk.toString();
+    stdout += text;
+  });
+  child.stderr.on("data", (chunk) => {
+    const text = chunk.toString();
+    stderr += text;
+  });
+
+  const exitCode = await new Promise((resolveExit, rejectExit) => {
+    child.on("error", rejectExit);
+    child.on("exit", (code) => resolveExit(code ?? 1));
+  });
+
+  if (timeoutHandle !== null) {
+    clearTimeout(timeoutHandle);
+  }
+
+  if (stdout.trim().length > 0) {
+    await appendLog(logPath, `stdout:\n${stdout.trim()}`);
+  }
+
+  if (stderr.trim().length > 0) {
+    await appendLog(logPath, `stderr:\n${stderr.trim()}`);
+  }
+
+  return {
+    exitCode,
+    stdout,
+    stderr,
+    timedOut
+  };
+}
+
+async function processCampaign({
+  campaignId,
+  artifactRoot,
+  logPath,
+  timeoutMs,
+  maxAttempts,
+  workerLabel
+}) {
+  let attempt = 0;
+  const syncStateId = `stage1:mailchimp:artifacts:sync-state:overnight:${campaignId}`;
+
+  while (attempt < maxAttempts) {
+    attempt += 1;
+    const correlationId = buildOperationId(
+      `stage1:mailchimp:artifacts:correlation:overnight:${campaignId}`
+    );
+
+    await appendLog(
+      logPath,
+      `${workerLabel} starting campaign ${campaignId} attempt ${attempt}/${maxAttempts}`
+    );
+
+    const result = await runCliCommand({
+      args: [
+        "import-mailchimp-artifacts",
+        "--artifact-path",
+        artifactRoot,
+        "--start-at-campaign-id",
+        campaignId,
+        "--limit-campaigns",
+        "1",
+        "--sync-state-id",
+        syncStateId,
+        "--correlation-id",
+        correlationId
+      ],
+      logPath,
+      timeoutMs
+    });
+
+    let parsedPayload = null;
+
+    try {
+      parsedPayload = extractJson(result.stdout);
+      await appendLog(
+        logPath,
+        `${workerLabel} campaign ${campaignId} result: ${JSON.stringify(parsedPayload)}`
+      );
+    } catch (error) {
+      await appendLog(
+        logPath,
+        `${workerLabel} campaign ${campaignId} produced non-JSON stdout: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+
+    await appendLog(
+      logPath,
+      `${workerLabel} campaign ${campaignId} attempt ${attempt} summary: ${JSON.stringify(
+        buildResultSummary(result, parsedPayload)
+      )}`
+    );
+
+    if (!shouldRetry(result, parsedPayload)) {
+      return;
+    }
+
+    await appendLog(
+      logPath,
+      `${workerLabel} campaign ${campaignId} hit a retryable failure; sleeping before retry`
+    );
+    await delay(5000);
+  }
+}
+
+async function main() {
+  const campaignIds = process.argv.slice(2);
+
+  if (campaignIds.length === 0) {
+    console.error(
+      "Usage: node scripts/mailchimp-campaign-queue.mjs <campaign-id> [campaign-id...]"
+    );
+    process.exit(1);
+  }
+
+  await mkdir(LOG_DIR, {
+    recursive: true
+  });
+
+  const logPath = resolve(
+    LOG_DIR,
+    `mailchimp-campaign-queue-${Date.now().toString(36)}.log`
+  );
+  const artifactRoot =
+    process.env.MAILCHIMP_ARTIFACT_ROOT ?? DEFAULT_ARTIFACT_ROOT;
+  const timeoutMs = Number.parseInt(
+    process.env.MAILCHIMP_CAMPAIGN_TIMEOUT_MS ?? `${DEFAULT_TIMEOUT_MS}`,
+    10
+  );
+  const maxAttempts = Number.parseInt(
+    process.env.MAILCHIMP_CAMPAIGN_MAX_ATTEMPTS ?? `${DEFAULT_MAX_ATTEMPTS}`,
+    10
+  );
+  const concurrency = Math.max(
+    1,
+    Number.parseInt(
+      process.env.MAILCHIMP_CAMPAIGN_CONCURRENCY ?? `${DEFAULT_CONCURRENCY}`,
+      10
+    )
+  );
+
+  await appendLog(
+    logPath,
+    `starting Mailchimp queue with ${campaignIds.length} campaign(s); artifactRoot=${artifactRoot}; timeoutMs=${timeoutMs}; maxAttempts=${maxAttempts}; concurrency=${concurrency}`
+  );
+
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.min(concurrency, campaignIds.length) },
+    (_, index) =>
+      (async () => {
+        const workerLabel = `[worker ${index + 1}]`;
+
+        while (nextIndex < campaignIds.length) {
+          const campaignId = campaignIds[nextIndex];
+          nextIndex += 1;
+          await processCampaign({
+            campaignId,
+            artifactRoot,
+            logPath,
+            timeoutMs,
+            maxAttempts,
+            workerLabel
+          });
+          await delay(2000);
+        }
+      })()
+  );
+
+  await Promise.all(workers);
+
+  await appendLog(logPath, "mailchimp queue finished");
+}
+
+main().catch(async (error) => {
+  await mkdir(LOG_DIR, {
+    recursive: true
+  });
+  const logPath = resolve(LOG_DIR, "mailchimp-campaign-queue-error.log");
+  await appendLog(
+    logPath,
+    `fatal error: ${error instanceof Error ? error.stack ?? error.message : String(error)}`
+  );
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add record-level Mailchimp sync cursors so retries can resume within a campaign
- reuse stable Mailchimp queue sync state ids across retry attempts
- add a worker regression test that proves mid-campaign retries resume only the unfinished tail
