### PR TITLE
Add resumable Mailchimp campaign checkpoints

### DIFF
--- a/apps/worker/src/ops/mailchimp-artifacts.ts
+++ b/apps/worker/src/ops/mailchimp-artifacts.ts
@@ -1,0 +1,748 @@
+import { access, readdir } from "node:fs/promises";
+import { basename, resolve } from "node:path";
+
+import { ZodError, z } from "zod";
+
+import {
+  importMailchimpCampaignArtifactRecordsFromPath,
+  mapMailchimpRecord,
+  type MailchimpCampaignActivityRecord
+} from "@as-comms/integrations";
+import type { Stage1PersistenceService } from "@as-comms/domain";
+import type { SyncStateRecord } from "@as-comms/contracts";
+
+import type { Stage1IngestService } from "../ingest/index.js";
+import type { Stage1IngestResult } from "../ingest/types.js";
+import {
+  buildMailchimpUnmatchedReport,
+  hasKnownMailchimpIdentity,
+  type MailchimpKnownIdentityIndex,
+  type MailchimpUnmatchedRecipientRow,
+  writeMailchimpUnmatchedReport
+} from "./mailchimp-unmatched.js";
+import {
+  Stage1NonRetryableJobError,
+  Stage1RetryableJobError,
+  type Stage1JobFailure
+} from "../orchestration/index.js";
+import { recordProjectionSeedOnce } from "../orchestration/projection-seed.js";
+import { recordSyncFailureAudit } from "../orchestration/sync-failure-audit.js";
+import type { Stage1SyncStateService } from "../orchestration/sync-state.js";
+
+const mailchimpArtifactImportInputSchema = z.object({
+  artifactPath: z.string().min(1),
+  syncStateId: z.string().min(1),
+  correlationId: z.string().min(1),
+  traceId: z.string().min(1).nullable().default(null),
+  receivedAt: z.string().datetime().nullable().default(null),
+  limitCampaigns: z.number().int().positive().nullable().default(null),
+  startAtCampaignId: z.string().min(1).nullable().default(null),
+  unmatchedReportOutputRoot: z.string().min(1).nullable().default(null)
+});
+
+export type MailchimpArtifactImportInput = z.input<
+  typeof mailchimpArtifactImportInputSchema
+>;
+
+export interface Stage1MailchimpArtifactImportResult {
+  readonly outcome: "succeeded" | "failed";
+  readonly artifactPath: string;
+  readonly importedCampaignIds: readonly string[];
+  readonly parsedCampaigns: number;
+  readonly parsedRecords: number;
+  readonly syncStateId: string;
+  readonly correlationId: string;
+  readonly summary: {
+    readonly processed: number;
+    readonly normalized: number;
+    readonly duplicate: number;
+    readonly reviewOpened: number;
+    readonly quarantined: number;
+    readonly deferred: number;
+    readonly deadLetterCountIncrement: number;
+    readonly skippedUnmatched: number;
+    readonly skippedUnmatchedRecipients: number;
+  };
+  readonly checkpoint: string | null;
+  readonly syncStatus: SyncStateRecord["status"];
+  readonly message?: string;
+  readonly unmatchedReportJsonPath?: string;
+  readonly unmatchedReportCsvPath?: string;
+}
+
+interface Stage1MailchimpArtifactImportDependencies {
+  readonly ingest: Pick<Stage1IngestService, "ingestMailchimpHistoricalRecord">;
+  readonly persistence: Stage1PersistenceService;
+  readonly syncState: Stage1SyncStateService;
+  readonly mailchimpIdentityIndex?: MailchimpKnownIdentityIndex;
+  readonly now?: () => Date;
+}
+
+const MAILCHIMP_RECORD_PROGRESS_INTERVAL = 25;
+
+function summarizeIngestResults(
+  results: readonly Stage1IngestResult[],
+  input?: {
+    readonly skippedUnmatched: number;
+    readonly skippedUnmatchedRecipients: number;
+  }
+) {
+  return {
+    processed: results.length,
+    normalized: results.filter((result) => result.outcome === "normalized").length,
+    duplicate: results.filter((result) => result.outcome === "duplicate").length,
+    reviewOpened: results.filter((result) => result.outcome === "review_opened")
+      .length,
+    quarantined: results.filter((result) => result.outcome === "quarantined")
+      .length,
+    deferred: results.filter((result) => result.outcome === "deferred").length,
+    deadLetterCountIncrement: results.filter(
+      (result) => result.outcome === "quarantined"
+    ).length,
+    skippedUnmatched: input?.skippedUnmatched ?? 0,
+    skippedUnmatchedRecipients: input?.skippedUnmatchedRecipients ?? 0
+  };
+}
+
+function isOccurredAtRecord(
+  record: unknown
+): record is { readonly occurredAt: string } {
+  return (
+    typeof record === "object" &&
+    record !== null &&
+    "occurredAt" in record &&
+    typeof record.occurredAt === "string"
+  );
+}
+
+function calculateHistoricalWindow(
+  records: readonly unknown[]
+): {
+  readonly windowStart: string | null;
+  readonly windowEnd: string | null;
+  readonly checkpoint: string | null;
+} {
+  const occurredAtValues = records
+    .filter(isOccurredAtRecord)
+    .map((record) => record.occurredAt)
+    .sort((left, right) => left.localeCompare(right));
+  const windowStart = occurredAtValues[0] ?? null;
+  const checkpoint = occurredAtValues.at(-1) ?? null;
+
+  return {
+    windowStart,
+    windowEnd: checkpoint,
+    checkpoint
+  };
+}
+
+function buildImportFailure(error: unknown): Stage1JobFailure {
+  const message = error instanceof Error ? error.message : String(error);
+
+  if (error instanceof Stage1NonRetryableJobError || error instanceof ZodError) {
+    return {
+      disposition: "non_retryable",
+      retryable: false,
+      message
+    };
+  }
+
+  return {
+    disposition:
+      error instanceof Stage1RetryableJobError ? "retryable" : "retryable",
+    retryable: true,
+    message
+  };
+}
+
+function buildMailchimpRecordCursor(
+  campaignId: string,
+  nextRecordIndex: number
+): string {
+  return `${campaignId}:record:${nextRecordIndex}`;
+}
+
+function parseMailchimpRecordCursor(
+  cursor: string | null
+): {
+  readonly campaignId: string;
+  readonly nextRecordIndex: number;
+} | null {
+  if (cursor === null) {
+    return null;
+  }
+
+  const marker = ":record:";
+  const markerIndex = cursor.lastIndexOf(marker);
+
+  if (markerIndex === -1) {
+    return null;
+  }
+
+  const campaignId = cursor.slice(0, markerIndex).trim();
+  const nextRecordIndexValue = cursor.slice(markerIndex + marker.length).trim();
+  const nextRecordIndex = Number.parseInt(nextRecordIndexValue, 10);
+
+  if (campaignId.length === 0 || Number.isNaN(nextRecordIndex) || nextRecordIndex < 0) {
+    return null;
+  }
+
+  return {
+    campaignId,
+    nextRecordIndex
+  };
+}
+
+function resolveMailchimpResumePlan(
+  cursor: string | null,
+  campaignIds: readonly string[]
+): {
+  readonly completedCampaignIds: ReadonlySet<string>;
+  readonly resumeCampaignId: string | null;
+  readonly resumeNextRecordIndex: number;
+} {
+  const recordCursor = parseMailchimpRecordCursor(cursor);
+
+  if (recordCursor !== null) {
+    const resumeCampaignIndex = campaignIds.indexOf(recordCursor.campaignId);
+
+    if (resumeCampaignIndex !== -1) {
+      return {
+        completedCampaignIds: new Set(campaignIds.slice(0, resumeCampaignIndex)),
+        resumeCampaignId: recordCursor.campaignId,
+        resumeNextRecordIndex: recordCursor.nextRecordIndex
+      };
+    }
+  }
+
+  if (cursor !== null) {
+    const completedCampaignIndex = campaignIds.indexOf(cursor);
+
+    if (completedCampaignIndex !== -1) {
+      return {
+        completedCampaignIds: new Set(campaignIds.slice(0, completedCampaignIndex + 1)),
+        resumeCampaignId: campaignIds[completedCampaignIndex + 1] ?? null,
+        resumeNextRecordIndex: 0
+      };
+    }
+  }
+
+  return {
+    completedCampaignIds: new Set<string>(),
+    resumeCampaignId: campaignIds[0] ?? null,
+    resumeNextRecordIndex: 0
+  };
+}
+
+function shouldCheckpointMailchimpCampaignRecord(
+  nextRecordIndex: number,
+  recordCount: number
+): boolean {
+  return (
+    nextRecordIndex === recordCount ||
+    nextRecordIndex % MAILCHIMP_RECORD_PROGRESS_INTERVAL === 0
+  );
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveCampaignArtifactPaths(input: {
+  readonly artifactPath: string;
+  readonly limitCampaigns: number | null;
+  readonly startAtCampaignId: string | null;
+}): Promise<string[]> {
+  const resolvedArtifactPath = resolve(input.artifactPath);
+  const summaryPath = resolve(resolvedArtifactPath, "summary.json");
+
+  if (await pathExists(summaryPath)) {
+    return [resolvedArtifactPath];
+  }
+
+  const entries = await readdir(resolvedArtifactPath, {
+    withFileTypes: true
+  });
+  const campaignPaths: string[] = [];
+
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) {
+      continue;
+    }
+
+    const campaignPath = resolve(resolvedArtifactPath, entry.name);
+
+    if (await pathExists(resolve(campaignPath, "summary.json"))) {
+      campaignPaths.push(campaignPath);
+    }
+  }
+
+  const startIndex =
+    input.startAtCampaignId === null
+      ? 0
+      : campaignPaths.findIndex(
+          (campaignPath) => basename(campaignPath) === input.startAtCampaignId
+        );
+
+  if (input.startAtCampaignId !== null && startIndex === -1) {
+    throw new Error(
+      `Could not find Mailchimp campaign artifact ${input.startAtCampaignId} under ${input.artifactPath}.`
+    );
+  }
+
+  const resumedCampaignPaths = campaignPaths.slice(startIndex === -1 ? 0 : startIndex);
+
+  return input.limitCampaigns === null
+    ? resumedCampaignPaths
+    : resumedCampaignPaths.slice(0, input.limitCampaigns);
+}
+
+async function findExistingDuplicateResult(
+  persistence: Stage1PersistenceService,
+  mapped: ReturnType<typeof mapMailchimpRecord>
+): Promise<Stage1IngestResult | null> {
+  if (mapped.outcome !== "command" || mapped.command.kind !== "canonical_event") {
+    return null;
+  }
+
+  const existingSourceEvidence = await persistence.findSourceEvidenceByIdempotencyKey(
+    mapped.command.input.sourceEvidence.idempotencyKey
+  );
+
+  if (existingSourceEvidence === null) {
+    return null;
+  }
+
+  const existingCanonicalEvent =
+    await persistence.findCanonicalEventByIdempotencyKey(
+      mapped.command.input.canonicalEvent.idempotencyKey
+    );
+
+  if (existingCanonicalEvent === null) {
+    return null;
+  }
+
+  return {
+    outcome: "duplicate",
+    ingestMode: "historical",
+    provider: "mailchimp",
+    sourceRecordType: mapped.sourceRecordType,
+    sourceRecordId: mapped.sourceRecordId,
+    commandKind: "canonical_event",
+    sourceEvidenceId: existingSourceEvidence.id,
+    canonicalEventId: existingCanonicalEvent.id,
+    contactId: existingCanonicalEvent.contactId
+  };
+}
+
+function createMailchimpIdentityPresenceResolver(
+  dependencies: Stage1MailchimpArtifactImportDependencies
+) {
+  const emailCache = new Map<string, Promise<boolean>>();
+  const volunteerIdCache = new Map<string, Promise<boolean>>();
+
+  const hasKnownEmail = (normalizedEmail: string): Promise<boolean> => {
+    const cached = emailCache.get(normalizedEmail);
+
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const lookup =
+      dependencies.mailchimpIdentityIndex !== undefined
+        ? Promise.resolve(
+            dependencies.mailchimpIdentityIndex.knownEmails.has(normalizedEmail)
+          )
+        : dependencies.persistence.repositories.contactIdentities
+            .listByNormalizedValue({
+              kind: "email",
+              normalizedValue: normalizedEmail
+            })
+            .then((rows) => rows.length > 0);
+    emailCache.set(normalizedEmail, lookup);
+
+    return lookup;
+  };
+
+  const hasKnownVolunteerId = (volunteerId: string): Promise<boolean> => {
+    const cached = volunteerIdCache.get(volunteerId);
+
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const lookup =
+      dependencies.mailchimpIdentityIndex !== undefined
+        ? Promise.resolve(
+            dependencies.mailchimpIdentityIndex.knownVolunteerIds.has(
+              volunteerId
+            )
+          )
+        : dependencies.persistence.repositories.contactIdentities
+            .listByNormalizedValue({
+              kind: "volunteer_id_plain",
+              normalizedValue: volunteerId
+            })
+            .then((rows) => rows.length > 0);
+    volunteerIdCache.set(volunteerId, lookup);
+
+    return lookup;
+  };
+
+  return {
+    async hasKnownIdentity(record: MailchimpCampaignActivityRecord) {
+      if (record.salesforceContactId !== null) {
+        return true;
+      }
+
+      if (await hasKnownEmail(record.normalizedEmail)) {
+        return true;
+      }
+
+      for (const volunteerId of record.volunteerIdPlainValues) {
+        if (await hasKnownVolunteerId(volunteerId)) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+  };
+}
+
+export function createStage1MailchimpArtifactImportService(
+  dependencies: Stage1MailchimpArtifactImportDependencies
+) {
+  const now = dependencies.now ?? (() => new Date());
+
+  return {
+    async importArtifacts(
+      input: MailchimpArtifactImportInput
+    ): Promise<Stage1MailchimpArtifactImportResult> {
+      const parsedInput = mailchimpArtifactImportInputSchema.parse(input);
+      const receivedAt = parsedInput.receivedAt ?? now().toISOString();
+      const campaignPaths = await resolveCampaignArtifactPaths({
+        artifactPath: parsedInput.artifactPath,
+        limitCampaigns: parsedInput.limitCampaigns,
+        startAtCampaignId: parsedInput.startAtCampaignId
+      });
+      const importedCampaignIds = campaignPaths.map((campaignPath) =>
+        basename(campaignPath)
+      );
+
+      if (campaignPaths.length === 0) {
+        throw new Error(
+          `No Mailchimp campaign artifacts were found under ${parsedInput.artifactPath}.`
+        );
+      }
+
+      const startedSyncState = await dependencies.syncState.startWindow({
+        syncStateId: parsedInput.syncStateId,
+        scope: "provider",
+        provider: "mailchimp",
+        jobType: "historical_backfill",
+        cursor: null,
+        checkpoint: null,
+        windowStart: null,
+        windowEnd: null
+      });
+      const resumePlan = resolveMailchimpResumePlan(
+        startedSyncState.cursor,
+        importedCampaignIds
+      );
+
+      let parsedRecords = 0;
+      const ingestResults: Stage1IngestResult[] = [];
+      let windowStart: string | null = startedSyncState.windowStart;
+      let checkpoint: string | null = startedSyncState.windowEnd;
+      let unmatchedReportPaths:
+        | {
+            readonly jsonPath: string;
+            readonly csvPath: string;
+          }
+        | null = null;
+      let skippedUnmatched = 0;
+      const skippedRecipients = new Map<
+        string,
+        {
+          campaignId: string;
+          campaignName: string | null;
+          audienceId: string | null;
+          memberId: string;
+          email: string | null;
+          platformId: string | null;
+          activityTypes: Set<string>;
+        }
+      >();
+      const identityPresenceResolver =
+        createMailchimpIdentityPresenceResolver(dependencies);
+      let pendingDeadLetterCountIncrement = 0;
+      let latestCursor = startedSyncState.cursor;
+
+      try {
+        for (const campaignPath of campaignPaths) {
+          const campaignId = basename(campaignPath);
+
+          if (resumePlan.completedCampaignIds.has(campaignId)) {
+            continue;
+          }
+
+          const records = await importMailchimpCampaignArtifactRecordsFromPath({
+            campaignPath,
+            receivedAt
+          });
+          parsedRecords += records.length;
+          const campaignWindow = calculateHistoricalWindow(records);
+
+          if (
+            campaignWindow.windowStart !== null &&
+            (windowStart === null || campaignWindow.windowStart < windowStart)
+          ) {
+            windowStart = campaignWindow.windowStart;
+          }
+
+          if (
+            campaignWindow.checkpoint !== null &&
+            (checkpoint === null || campaignWindow.checkpoint > checkpoint)
+          ) {
+            checkpoint = campaignWindow.checkpoint;
+          }
+
+          const resumeNextRecordIndex =
+            resumePlan.resumeCampaignId === campaignId
+              ? Math.min(resumePlan.resumeNextRecordIndex, records.length)
+              : 0;
+
+          for (let recordIndex = 0; recordIndex < records.length; recordIndex += 1) {
+            const record = records[recordIndex];
+
+            if (record === undefined) {
+              continue;
+            }
+
+            const hasKnownIdentity =
+              await identityPresenceResolver.hasKnownIdentity(record);
+            const nextRecordIndex = recordIndex + 1;
+
+            if (!hasKnownIdentity) {
+              skippedUnmatched += 1;
+              const skippedKey = `${record.campaignId}:${record.memberId}`;
+              const existingSkippedRecipient = skippedRecipients.get(skippedKey);
+
+              if (existingSkippedRecipient === undefined) {
+                skippedRecipients.set(skippedKey, {
+                  campaignId: record.campaignId,
+                  campaignName: record.campaignName,
+                  audienceId:
+                    record.audienceId.trim().length === 0
+                      ? null
+                      : record.audienceId,
+                  memberId: record.memberId,
+                  email: record.normalizedEmail,
+                  platformId: record.volunteerIdPlainValues[0] ?? null,
+                  activityTypes: new Set([record.activityType])
+                });
+              } else {
+                existingSkippedRecipient.activityTypes.add(record.activityType);
+              }
+            } else if (recordIndex >= resumeNextRecordIndex) {
+              const mapped = mapMailchimpRecord(record);
+              const duplicateResult = await findExistingDuplicateResult(
+                dependencies.persistence,
+                mapped
+              );
+              const ingestResult =
+                duplicateResult ??
+                (await dependencies.ingest.ingestMailchimpHistoricalRecord(record));
+              ingestResults.push(ingestResult);
+              if (ingestResult.outcome === "quarantined") {
+                pendingDeadLetterCountIncrement += 1;
+              }
+
+              if (
+                ingestResult.outcome === "deferred" ||
+                ingestResult.outcome === "quarantined" ||
+                ingestResult.canonicalEventId === null
+              ) {
+              } else if (
+                duplicateResult === null &&
+                mapped.outcome === "command" &&
+                mapped.command.kind === "canonical_event"
+              ) {
+                await recordProjectionSeedOnce(dependencies.persistence, {
+                  canonicalEventId: mapped.command.input.canonicalEvent.id,
+                  summary: mapped.command.input.canonicalEvent.summary,
+                  snippet: mapped.command.input.canonicalEvent.snippet ?? "",
+                  occurredAt: mapped.command.input.sourceEvidence.receivedAt
+                });
+              }
+            }
+
+            if (
+              recordIndex >= resumeNextRecordIndex &&
+              shouldCheckpointMailchimpCampaignRecord(nextRecordIndex, records.length)
+            ) {
+              latestCursor =
+                nextRecordIndex === records.length
+                  ? campaignId
+                  : buildMailchimpRecordCursor(campaignId, nextRecordIndex);
+              await dependencies.syncState.recordBatchProgress({
+                syncStateId: parsedInput.syncStateId,
+                scope: "provider",
+                provider: "mailchimp",
+                jobType: "historical_backfill",
+                cursor: latestCursor,
+                checkpoint,
+                windowStart,
+                windowEnd: checkpoint,
+                deadLetterCountIncrement: pendingDeadLetterCountIncrement
+              });
+              pendingDeadLetterCountIncrement = 0;
+            }
+          }
+
+          if (records.length === 0) {
+            latestCursor = campaignId;
+            await dependencies.syncState.recordBatchProgress({
+              syncStateId: parsedInput.syncStateId,
+              scope: "provider",
+              provider: "mailchimp",
+              jobType: "historical_backfill",
+              cursor: latestCursor,
+              checkpoint,
+              windowStart,
+              windowEnd: checkpoint,
+              deadLetterCountIncrement: pendingDeadLetterCountIncrement
+            });
+            pendingDeadLetterCountIncrement = 0;
+          }
+        }
+
+        if (skippedRecipients.size > 0) {
+          const unmatchedRecipients: MailchimpUnmatchedRecipientRow[] = Array.from(
+            skippedRecipients.values()
+          ).map((recipient) => ({
+            campaignId: recipient.campaignId,
+            campaignName: recipient.campaignName,
+            audienceId: recipient.audienceId,
+            memberId: recipient.memberId,
+            email: recipient.email,
+            platformId: recipient.platformId,
+            activityTypes: Array.from(recipient.activityTypes).sort()
+          }));
+          const report = buildMailchimpUnmatchedReport({
+            generatedAt: now().toISOString(),
+            recipients: unmatchedRecipients,
+            knownIdentityIndex:
+              dependencies.mailchimpIdentityIndex ?? {
+                knownEmails: new Set<string>(),
+                knownVolunteerIds: new Set<string>()
+              }
+          });
+
+          unmatchedReportPaths = await writeMailchimpUnmatchedReport({
+            outputRoot:
+              parsedInput.unmatchedReportOutputRoot ??
+              resolve(parsedInput.artifactPath, "..", "unmatched-reports"),
+            reportId: parsedInput.syncStateId,
+            report
+          });
+        }
+
+        const summary = summarizeIngestResults(ingestResults, {
+          skippedUnmatched,
+          skippedUnmatchedRecipients: skippedRecipients.size
+        });
+        const completedSyncState = await dependencies.syncState.completeWindow({
+          syncStateId: parsedInput.syncStateId,
+          scope: "provider",
+          provider: "mailchimp",
+          jobType: "historical_backfill",
+          cursor: importedCampaignIds.at(-1) ?? null,
+          checkpoint,
+          windowStart,
+          windowEnd: checkpoint,
+          parityPercent: null,
+          freshnessP95Seconds: null,
+          freshnessP99Seconds: null,
+          completedAt: now().toISOString()
+        });
+
+        return {
+          outcome: "succeeded",
+          artifactPath: parsedInput.artifactPath,
+          importedCampaignIds,
+          parsedCampaigns: campaignPaths.length,
+          parsedRecords,
+          syncStateId: parsedInput.syncStateId,
+          correlationId: parsedInput.correlationId,
+          summary,
+          checkpoint,
+          syncStatus: completedSyncState.status,
+          ...(unmatchedReportPaths === null
+            ? {}
+            : {
+                unmatchedReportJsonPath: unmatchedReportPaths.jsonPath,
+                unmatchedReportCsvPath: unmatchedReportPaths.csvPath
+              })
+        };
+      } catch (error) {
+        const failure = buildImportFailure(error);
+        const failedSyncState = await dependencies.syncState.failWindow({
+          syncStateId: parsedInput.syncStateId,
+          scope: "provider",
+          provider: "mailchimp",
+          jobType: "historical_backfill",
+          cursor: latestCursor,
+          checkpoint,
+          windowStart,
+          windowEnd: checkpoint,
+          deadLetterCountIncrement: pendingDeadLetterCountIncrement,
+          deadLettered: false
+        });
+        await recordSyncFailureAudit(dependencies.persistence, {
+          syncStateId: parsedInput.syncStateId,
+          scope: "provider",
+          provider: "mailchimp",
+          jobType: "historical_backfill",
+          checkpoint,
+          windowStart,
+          windowEnd: checkpoint,
+          failure,
+          occurredAt: now().toISOString(),
+          actorId: "stage1-mailchimp-artifact-import"
+        });
+
+        return {
+          outcome: "failed",
+          artifactPath: parsedInput.artifactPath,
+          importedCampaignIds,
+          parsedCampaigns: campaignPaths.length,
+          parsedRecords,
+          syncStateId: parsedInput.syncStateId,
+          correlationId: parsedInput.correlationId,
+          summary: {
+            ...summarizeIngestResults(ingestResults, {
+              skippedUnmatched,
+              skippedUnmatchedRecipients: skippedRecipients.size
+            })
+          },
+          checkpoint,
+          syncStatus: failedSyncState.status,
+          message: failure.message,
+          ...(unmatchedReportPaths === null
+            ? {}
+            : {
+                unmatchedReportJsonPath: unmatchedReportPaths.jsonPath,
+                unmatchedReportCsvPath: unmatchedReportPaths.csvPath
+              })
+        };
+      }
+    }
+  };
+}

--- a/apps/worker/test/stage1-mailchimp-artifact-import.test.ts
+++ b/apps/worker/test/stage1-mailchimp-artifact-import.test.ts
@@ -1,0 +1,614 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { createStage1MailchimpArtifactImportService } from "../src/ops/mailchimp-artifacts.js";
+import { Stage1RetryableJobError } from "../src/orchestration/index.js";
+import { createTestWorkerContext, type TestWorkerContext } from "./helpers.js";
+
+const contactId = "contact:salesforce:003-stage1";
+const salesforceContactId = "003-stage1";
+
+async function seedContact(context: TestWorkerContext) {
+  await context.normalization.upsertNormalizedContactGraph({
+    contact: {
+      id: contactId,
+      salesforceContactId,
+      displayName: "Stage One Volunteer",
+      primaryEmail: "volunteer@example.org",
+      primaryPhone: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z"
+    },
+    identities: [
+      {
+        id: `identity:${contactId}:salesforce`,
+        contactId,
+        kind: "salesforce_contact_id",
+        normalizedValue: salesforceContactId,
+        isPrimary: true,
+        source: "salesforce",
+        verifiedAt: "2026-01-01T00:00:00.000Z"
+      },
+      {
+        id: `identity:${contactId}:email`,
+        contactId,
+        kind: "email",
+        normalizedValue: "volunteer@example.org",
+        isPrimary: true,
+        source: "salesforce",
+        verifiedAt: "2026-01-01T00:00:00.000Z"
+      }
+    ],
+    memberships: []
+  });
+}
+
+async function writeArtifactCampaign(): Promise<string> {
+  const artifactRoot = await mkdtemp(resolve(tmpdir(), "mailchimp-artifact-root-"));
+  const campaignPath = resolve(artifactRoot, "campaign-1");
+  await mkdir(campaignPath, {
+    recursive: true
+  });
+
+  const writes = [
+    [
+      "summary.json",
+      {
+        id: "campaign-1",
+        campaign_title: "Volunteer Update",
+        subject_line: "Hello volunteers",
+        preview_text: "Project updates for this week",
+        list_id: "audience-1",
+        send_time: "2026-02-01T15:00:00.000Z"
+      }
+    ],
+    [
+      "sent-to.json",
+      [
+        {
+          email_id: "member-1",
+          email_address: "volunteer@example.org",
+          merge_fields: {
+            PLATFORMID: "VOL-123"
+          },
+          status: "sent",
+          last_open: "2026-02-01T15:10:00.000Z",
+          campaign_id: "campaign-1",
+          list_id: "audience-1"
+        }
+      ]
+    ],
+    [
+      "open-details.json",
+      [
+        {
+          campaign_id: "campaign-1",
+          list_id: "audience-1",
+          email_id: "member-1",
+          email_address: "volunteer@example.org",
+          merge_fields: {
+            PLATFORMID: "VOL-123"
+          },
+          opens: [
+            {
+              timestamp: "2026-02-01T15:10:00.000Z"
+            }
+          ]
+        }
+      ]
+    ],
+    [
+      "click-details.json",
+      [
+        {
+          id: "link-1",
+          url: "https://example.org/project",
+          last_click: "2026-02-01T15:12:00.000Z",
+          campaign_id: "campaign-1"
+        }
+      ]
+    ],
+    [
+      "click-members.json",
+      [
+        {
+          linkId: "link-1",
+          url: "https://example.org/project",
+          members: [
+            {
+              email_id: "member-1",
+              email_address: "volunteer@example.org",
+              merge_fields: {
+                PLATFORMID: "VOL-123"
+              },
+              campaign_id: "campaign-1",
+              list_id: "audience-1",
+              clicks: 1
+            }
+          ]
+        }
+      ]
+    ],
+    [
+      "unsubscribed.json",
+      [
+        {
+          email_id: "member-1",
+          email_address: "volunteer@example.org",
+          merge_fields: {
+            PLATFORMID: "VOL-123"
+          },
+          timestamp: "2026-02-02T10:00:00.000Z",
+          reason: "No thanks",
+          campaign_id: "campaign-1",
+          list_id: "audience-1"
+        }
+      ]
+    ]
+  ] as const;
+
+  await Promise.all(
+    writes.map(([fileName, payload]) =>
+      writeFile(
+        resolve(campaignPath, fileName),
+        `${JSON.stringify(payload, null, 2)}\n`
+      )
+    )
+  );
+
+  return artifactRoot;
+}
+
+async function writeArtifactCampaignWithUnmatchedRecipient(): Promise<string> {
+  const artifactRoot = await mkdtemp(
+    resolve(tmpdir(), "mailchimp-artifact-unmatched-root-")
+  );
+  const campaignPath = resolve(artifactRoot, "campaign-2");
+  await mkdir(campaignPath, {
+    recursive: true
+  });
+
+  const writes = [
+    [
+      "summary.json",
+      {
+        id: "campaign-2",
+        campaign_title: "Broad Audience Outreach",
+        subject_line: "Join us",
+        preview_text: "Volunteer and supporter updates",
+        list_id: "audience-2",
+        send_time: "2026-03-01T15:00:00.000Z"
+      }
+    ],
+    [
+      "sent-to.json",
+      [
+        {
+          email_id: "member-known",
+          email_address: "volunteer@example.org",
+          merge_fields: {
+            PLATFORMID: "VOL-123"
+          },
+          status: "sent",
+          last_open: "2026-03-01T15:10:00.000Z",
+          campaign_id: "campaign-2",
+          list_id: "audience-2"
+        },
+        {
+          email_id: "member-unknown",
+          email_address: "supporter@example.net",
+          merge_fields: {},
+          status: "sent",
+          last_open: "2026-03-01T15:20:00.000Z",
+          campaign_id: "campaign-2",
+          list_id: "audience-2"
+        }
+      ]
+    ],
+    [
+      "open-details.json",
+      [
+        {
+          campaign_id: "campaign-2",
+          list_id: "audience-2",
+          email_id: "member-known",
+          email_address: "volunteer@example.org",
+          merge_fields: {
+            PLATFORMID: "VOL-123"
+          },
+          opens: [
+            {
+              timestamp: "2026-03-01T15:10:00.000Z"
+            }
+          ]
+        },
+        {
+          campaign_id: "campaign-2",
+          list_id: "audience-2",
+          email_id: "member-unknown",
+          email_address: "supporter@example.net",
+          merge_fields: {},
+          opens: [
+            {
+              timestamp: "2026-03-01T15:20:00.000Z"
+            }
+          ]
+        }
+      ]
+    ],
+    [
+      "click-details.json",
+      [
+        {
+          id: "link-1",
+          url: "https://example.org/project",
+          last_click: "2026-03-01T15:12:00.000Z",
+          campaign_id: "campaign-2"
+        }
+      ]
+    ],
+    [
+      "click-members.json",
+      [
+        {
+          linkId: "link-1",
+          url: "https://example.org/project",
+          members: [
+            {
+              email_id: "member-known",
+              email_address: "volunteer@example.org",
+              merge_fields: {
+                PLATFORMID: "VOL-123"
+              },
+              campaign_id: "campaign-2",
+              list_id: "audience-2",
+              clicks: 1
+            },
+            {
+              email_id: "member-unknown",
+              email_address: "supporter@example.net",
+              merge_fields: {},
+              campaign_id: "campaign-2",
+              list_id: "audience-2",
+              clicks: 1
+            }
+          ]
+        }
+      ]
+    ],
+    [
+      "unsubscribed.json",
+      [
+        {
+          email_id: "member-known",
+          email_address: "volunteer@example.org",
+          merge_fields: {
+            PLATFORMID: "VOL-123"
+          },
+          timestamp: "2026-03-02T10:00:00.000Z",
+          reason: "No thanks",
+          campaign_id: "campaign-2",
+          list_id: "audience-2"
+        },
+        {
+          email_id: "member-unknown",
+          email_address: "supporter@example.net",
+          merge_fields: {},
+          timestamp: "2026-03-02T10:05:00.000Z",
+          reason: "No thanks",
+          campaign_id: "campaign-2",
+          list_id: "audience-2"
+        }
+      ]
+    ]
+  ] as const;
+
+  await Promise.all(
+    writes.map(([fileName, payload]) =>
+      writeFile(
+        resolve(campaignPath, fileName),
+        `${JSON.stringify(payload, null, 2)}\n`
+      )
+    )
+  );
+
+  return artifactRoot;
+}
+
+async function writeArtifactCampaignWithRecipientCount(input: {
+  readonly campaignId: string;
+  readonly recipientCount: number;
+}): Promise<string> {
+  const artifactRoot = await mkdtemp(
+    resolve(tmpdir(), `mailchimp-artifact-${input.campaignId}-`)
+  );
+  const campaignPath = resolve(artifactRoot, input.campaignId);
+  await mkdir(campaignPath, {
+    recursive: true
+  });
+
+  const sentTo = Array.from({ length: input.recipientCount }, (_, index) => ({
+    email_id: `member-${index + 1}`,
+    email_address: "volunteer@example.org",
+    merge_fields: {
+      PLATFORMID: "VOL-123"
+    },
+    status: "sent",
+    campaign_id: input.campaignId,
+    list_id: "audience-resume"
+  }));
+  const writes: ReadonlyArray<readonly [string, unknown]> = [
+    [
+      "summary.json",
+      {
+        id: input.campaignId,
+        campaign_title: "Resume Mailchimp Campaign",
+        subject_line: "Resume proof",
+        preview_text: "Importer should resume from the last batch checkpoint",
+        list_id: "audience-resume",
+        send_time: "2026-04-01T15:00:00.000Z"
+      }
+    ],
+    ["sent-to.json", sentTo],
+    ["open-details.json", []],
+    ["click-details.json", []],
+    ["click-members.json", []],
+    ["unsubscribed.json", []]
+  ];
+
+  await Promise.all(
+    writes.map(([fileName, payload]) =>
+      writeFile(
+        resolve(campaignPath, fileName),
+        `${JSON.stringify(payload, null, 2)}\n`
+      )
+    )
+  );
+
+  return artifactRoot;
+}
+
+describe("Stage 1 Mailchimp artifact importer", () => {
+  it("imports Mailchimp campaign artifacts through the historical normalization path and stays replay-safe", async () => {
+    const context = await createTestWorkerContext();
+    const artifactRoot = await writeArtifactCampaign();
+
+    try {
+      await seedContact(context);
+      const importer = createStage1MailchimpArtifactImportService({
+        ingest: context.ingest,
+        persistence: context.persistence,
+        syncState: context.syncState,
+        now: () => new Date("2026-02-03T00:00:00.000Z")
+      });
+
+      const firstRun = await importer.importArtifacts({
+        artifactPath: artifactRoot,
+        syncStateId: "sync:mailchimp:artifacts:first",
+        correlationId: "corr:mailchimp:artifacts:first",
+        traceId: null,
+        receivedAt: "2026-02-03T00:00:00.000Z"
+      });
+      const secondRun = await importer.importArtifacts({
+        artifactPath: artifactRoot,
+        syncStateId: "sync:mailchimp:artifacts:second",
+        correlationId: "corr:mailchimp:artifacts:second",
+        traceId: null,
+        receivedAt: "2026-02-03T00:05:00.000Z"
+      });
+
+      expect(firstRun).toMatchObject({
+        outcome: "succeeded",
+        parsedCampaigns: 1,
+        parsedRecords: 4,
+        syncStatus: "succeeded",
+        summary: {
+          processed: 4,
+          normalized: 4
+        }
+      });
+      expect(secondRun).toMatchObject({
+        outcome: "succeeded",
+        parsedCampaigns: 1,
+        parsedRecords: 4,
+        syncStatus: "succeeded",
+        summary: {
+          processed: 4,
+          duplicate: 4
+        }
+      });
+
+      await expect(context.repositories.canonicalEvents.countAll()).resolves.toBe(4);
+      const canonicalEvents =
+        await context.repositories.canonicalEvents.listByContactId(contactId);
+      expect(canonicalEvents).toHaveLength(4);
+
+      await expect(
+        context.repositories.inboxProjection.findByContactId(contactId)
+      ).resolves.toBeNull();
+
+      const sourceEvidenceIds = canonicalEvents.map((event) => event.sourceEvidenceId);
+      await expect(
+        context.repositories.mailchimpCampaignActivityDetails.listBySourceEvidenceIds(
+          sourceEvidenceIds
+        )
+      ).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            activityType: "sent",
+            campaignId: "campaign-1",
+            audienceId: "audience-1",
+            campaignName: "Volunteer Update"
+          }),
+          expect.objectContaining({
+            activityType: "clicked",
+            snippet: "https://example.org/project"
+          })
+        ])
+      );
+      await expect(
+        context.repositories.syncState.findById("sync:mailchimp:artifacts:first")
+      ).resolves.toMatchObject({
+        provider: "mailchimp",
+        jobType: "historical_backfill",
+        status: "succeeded"
+      });
+    } finally {
+      await rm(artifactRoot, {
+        recursive: true,
+        force: true
+      });
+      await context.dispose();
+    }
+  });
+
+  it("skips unmatched Mailchimp recipients and writes an aggregate report instead of opening identity review", async () => {
+    const context = await createTestWorkerContext();
+    const artifactRoot = await writeArtifactCampaignWithUnmatchedRecipient();
+
+    try {
+      await seedContact(context);
+      const importer = createStage1MailchimpArtifactImportService({
+        ingest: context.ingest,
+        persistence: context.persistence,
+        syncState: context.syncState,
+        now: () => new Date("2026-03-03T00:00:00.000Z")
+      });
+
+      const result = await importer.importArtifacts({
+        artifactPath: artifactRoot,
+        syncStateId: "sync:mailchimp:artifacts:skip-unmatched",
+        correlationId: "corr:mailchimp:artifacts:skip-unmatched",
+        traceId: null,
+        receivedAt: "2026-03-03T00:00:00.000Z"
+      });
+
+      expect(result).toMatchObject({
+        outcome: "succeeded",
+        parsedCampaigns: 1,
+        parsedRecords: 8,
+        syncStatus: "succeeded",
+        summary: {
+          processed: 4,
+          normalized: 4,
+          reviewOpened: 0,
+          skippedUnmatched: 4,
+          skippedUnmatchedRecipients: 1
+        }
+      });
+      expect(result.unmatchedReportJsonPath).toBeTruthy();
+      expect(result.unmatchedReportCsvPath).toBeTruthy();
+
+      await expect(context.repositories.canonicalEvents.countAll()).resolves.toBe(4);
+      await expect(
+        context.repositories.identityResolutionQueue.listOpenByReasonCode(
+          "identity_missing_anchor"
+        )
+      ).resolves.toEqual([]);
+    } finally {
+      await rm(artifactRoot, {
+        recursive: true,
+        force: true
+      });
+      await context.dispose();
+    }
+  });
+
+  it("resumes within a Mailchimp campaign after a retryable failure instead of replaying the whole artifact", async () => {
+    const context = await createTestWorkerContext();
+    const artifactRoot = await writeArtifactCampaignWithRecipientCount({
+      campaignId: "campaign-resume",
+      recipientCount: 30
+    });
+
+    try {
+      await seedContact(context);
+      let shouldFailOnce = true;
+      let ingestCalls = 0;
+      const flakyIngest = {
+        async ingestMailchimpHistoricalRecord(
+          record: Parameters<
+            TestWorkerContext["ingest"]["ingestMailchimpHistoricalRecord"]
+          >[0]
+        ) {
+          ingestCalls += 1;
+
+          if (shouldFailOnce && ingestCalls === 28) {
+            shouldFailOnce = false;
+            throw new Stage1RetryableJobError("read ECONNRESET");
+          }
+
+          return context.ingest.ingestMailchimpHistoricalRecord(record);
+        }
+      };
+      const importer = createStage1MailchimpArtifactImportService({
+        ingest: flakyIngest,
+        persistence: context.persistence,
+        syncState: context.syncState,
+        now: () => new Date("2026-04-02T00:00:00.000Z")
+      });
+
+      const firstRun = await importer.importArtifacts({
+        artifactPath: artifactRoot,
+        syncStateId: "sync:mailchimp:artifacts:resume",
+        correlationId: "corr:mailchimp:artifacts:resume:first",
+        traceId: null,
+        receivedAt: "2026-04-02T00:00:00.000Z"
+      });
+
+      expect(firstRun).toMatchObject({
+        outcome: "failed",
+        parsedCampaigns: 1,
+        parsedRecords: 30,
+        syncStatus: "failed",
+        summary: {
+          processed: 27,
+          normalized: 27
+        }
+      });
+      await expect(
+        context.repositories.syncState.findById("sync:mailchimp:artifacts:resume")
+      ).resolves.toMatchObject({
+        status: "failed",
+        cursor: "campaign-resume:record:25"
+      });
+
+      const secondRun = await importer.importArtifacts({
+        artifactPath: artifactRoot,
+        syncStateId: "sync:mailchimp:artifacts:resume",
+        correlationId: "corr:mailchimp:artifacts:resume:second",
+        traceId: null,
+        receivedAt: "2026-04-02T00:05:00.000Z"
+      });
+
+      expect(secondRun).toMatchObject({
+        outcome: "succeeded",
+        parsedCampaigns: 1,
+        parsedRecords: 30,
+        syncStatus: "succeeded",
+        summary: {
+          processed: 5,
+          normalized: 3,
+          duplicate: 2
+        }
+      });
+
+      await expect(context.repositories.canonicalEvents.countAll()).resolves.toBe(30);
+      await expect(
+        context.repositories.syncState.findById("sync:mailchimp:artifacts:resume")
+      ).resolves.toMatchObject({
+        status: "succeeded",
+        cursor: "campaign-resume"
+      });
+    } finally {
+      await rm(artifactRoot, {
+        recursive: true,
+        force: true
+      });
+      await context.dispose();
+    }
+  });
+});

--- a/scripts/mailchimp-campaign-queue.mjs
+++ b/scripts/mailchimp-campaign-queue.mjs
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+
+import { mkdir, appendFile } from "node:fs/promises";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const TSX_PATH = resolve(ROOT, "node_modules/.bin/tsx");
+const WORKER_CLI_PATH = resolve(ROOT, "apps/worker/src/ops/cli.ts");
+const DEFAULT_ARTIFACT_ROOT = resolve(
+  ROOT,
+  "tmp/provider-exports/mailchimp-api-backfill/campaigns"
+);
+const LOG_DIR = resolve(ROOT, "tmp/overnight-backfill");
+const DEFAULT_TIMEOUT_MS = 2 * 60 * 60 * 1000;
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_CONCURRENCY = 1;
+
+function buildOperationId(prefix) {
+  return `${prefix}:${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function delay(ms) {
+  return new Promise((resolveDelay) => {
+    setTimeout(resolveDelay, ms);
+  });
+}
+
+function timestamp() {
+  return new Date().toISOString();
+}
+
+async function appendLog(logPath, message) {
+  await appendFile(logPath, `[${timestamp()}] ${message}\n`, "utf8");
+}
+
+function extractJson(stdout) {
+  const trimmed = stdout.trim();
+
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  return JSON.parse(trimmed);
+}
+
+function buildResultSummary(result, parsedPayload) {
+  return {
+    exitCode: result.exitCode,
+    timedOut: result.timedOut,
+    parsedPayload
+  };
+}
+
+function shouldRetry(result, parsedPayload) {
+  const combinedText = `${result.stdout}\n${result.stderr}`;
+  const retryableNetworkPattern =
+    /EADDRNOTAVAIL|ECONNRESET|ECONNREFUSED|ENOTFOUND|EAI_AGAIN|ETIMEDOUT|socket hang up|read EADDRNOTAVAIL|read ECONNRESET/iu;
+
+  if (result.timedOut) {
+    return true;
+  }
+
+  if (retryableNetworkPattern.test(combinedText)) {
+    return true;
+  }
+
+  if (
+    parsedPayload !== null &&
+    typeof parsedPayload === "object" &&
+    "outcome" in parsedPayload &&
+    parsedPayload.outcome === "failed" &&
+    "message" in parsedPayload &&
+    typeof parsedPayload.message === "string" &&
+    retryableNetworkPattern.test(parsedPayload.message)
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+async function runCliCommand({
+  args,
+  logPath,
+  timeoutMs
+}) {
+  const child = spawn(TSX_PATH, [WORKER_CLI_PATH, ...args], {
+    cwd: ROOT,
+    env: process.env,
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  let stdout = "";
+  let stderr = "";
+  let timedOut = false;
+  let timeoutHandle = null;
+
+  if (timeoutMs > 0) {
+    timeoutHandle = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      setTimeout(() => {
+        if (!child.killed) {
+          child.kill("SIGKILL");
+        }
+      }, 5000).unref();
+    }, timeoutMs);
+    timeoutHandle.unref();
+  }
+
+  child.stdout.on("data", (chunk) => {
+    const text = chunk.toString();
+    stdout += text;
+  });
+  child.stderr.on("data", (chunk) => {
+    const text = chunk.toString();
+    stderr += text;
+  });
+
+  const exitCode = await new Promise((resolveExit, rejectExit) => {
+    child.on("error", rejectExit);
+    child.on("exit", (code) => resolveExit(code ?? 1));
+  });
+
+  if (timeoutHandle !== null) {
+    clearTimeout(timeoutHandle);
+  }
+
+  if (stdout.trim().length > 0) {
+    await appendLog(logPath, `stdout:\n${stdout.trim()}`);
+  }
+
+  if (stderr.trim().length > 0) {
+    await appendLog(logPath, `stderr:\n${stderr.trim()}`);
+  }
+
+  return {
+    exitCode,
+    stdout,
+    stderr,
+    timedOut
+  };
+}
+
+async function processCampaign({
+  campaignId,
+  artifactRoot,
+  logPath,
+  timeoutMs,
+  maxAttempts,
+  workerLabel
+}) {
+  let attempt = 0;
+  const syncStateId = `stage1:mailchimp:artifacts:sync-state:overnight:${campaignId}`;
+
+  while (attempt < maxAttempts) {
+    attempt += 1;
+    const correlationId = buildOperationId(
+      `stage1:mailchimp:artifacts:correlation:overnight:${campaignId}`
+    );
+
+    await appendLog(
+      logPath,
+      `${workerLabel} starting campaign ${campaignId} attempt ${attempt}/${maxAttempts}`
+    );
+
+    const result = await runCliCommand({
+      args: [
+        "import-mailchimp-artifacts",
+        "--artifact-path",
+        artifactRoot,
+        "--start-at-campaign-id",
+        campaignId,
+        "--limit-campaigns",
+        "1",
+        "--sync-state-id",
+        syncStateId,
+        "--correlation-id",
+        correlationId
+      ],
+      logPath,
+      timeoutMs
+    });
+
+    let parsedPayload = null;
+
+    try {
+      parsedPayload = extractJson(result.stdout);
+      await appendLog(
+        logPath,
+        `${workerLabel} campaign ${campaignId} result: ${JSON.stringify(parsedPayload)}`
+      );
+    } catch (error) {
+      await appendLog(
+        logPath,
+        `${workerLabel} campaign ${campaignId} produced non-JSON stdout: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+
+    await appendLog(
+      logPath,
+      `${workerLabel} campaign ${campaignId} attempt ${attempt} summary: ${JSON.stringify(
+        buildResultSummary(result, parsedPayload)
+      )}`
+    );
+
+    if (!shouldRetry(result, parsedPayload)) {
+      return;
+    }
+
+    await appendLog(
+      logPath,
+      `${workerLabel} campaign ${campaignId} hit a retryable failure; sleeping before retry`
+    );
+    await delay(5000);
+  }
+}
+
+async function main() {
+  const campaignIds = process.argv.slice(2);
+
+  if (campaignIds.length === 0) {
+    console.error(
+      "Usage: node scripts/mailchimp-campaign-queue.mjs <campaign-id> [campaign-id...]"
+    );
+    process.exit(1);
+  }
+
+  await mkdir(LOG_DIR, {
+    recursive: true
+  });
+
+  const logPath = resolve(
+    LOG_DIR,
+    `mailchimp-campaign-queue-${Date.now().toString(36)}.log`
+  );
+  const artifactRoot =
+    process.env.MAILCHIMP_ARTIFACT_ROOT ?? DEFAULT_ARTIFACT_ROOT;
+  const timeoutMs = Number.parseInt(
+    process.env.MAILCHIMP_CAMPAIGN_TIMEOUT_MS ?? `${DEFAULT_TIMEOUT_MS}`,
+    10
+  );
+  const maxAttempts = Number.parseInt(
+    process.env.MAILCHIMP_CAMPAIGN_MAX_ATTEMPTS ?? `${DEFAULT_MAX_ATTEMPTS}`,
+    10
+  );
+  const concurrency = Math.max(
+    1,
+    Number.parseInt(
+      process.env.MAILCHIMP_CAMPAIGN_CONCURRENCY ?? `${DEFAULT_CONCURRENCY}`,
+      10
+    )
+  );
+
+  await appendLog(
+    logPath,
+    `starting Mailchimp queue with ${campaignIds.length} campaign(s); artifactRoot=${artifactRoot}; timeoutMs=${timeoutMs}; maxAttempts=${maxAttempts}; concurrency=${concurrency}`
+  );
+
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.min(concurrency, campaignIds.length) },
+    (_, index) =>
+      (async () => {
+        const workerLabel = `[worker ${index + 1}]`;
+
+        while (nextIndex < campaignIds.length) {
+          const campaignId = campaignIds[nextIndex];
+          nextIndex += 1;
+          await processCampaign({
+            campaignId,
+            artifactRoot,
+            logPath,
+            timeoutMs,
+            maxAttempts,
+            workerLabel
+          });
+          await delay(2000);
+        }
+      })()
+  );
+
+  await Promise.all(workers);
+
+  await appendLog(logPath, "mailchimp queue finished");
+}
+
+main().catch(async (error) => {
+  await mkdir(LOG_DIR, {
+    recursive: true
+  });
+  const logPath = resolve(LOG_DIR, "mailchimp-campaign-queue-error.log");
+  await appendLog(
+    logPath,
+    `fatal error: ${error instanceof Error ? error.stack ?? error.message : String(error)}`
+  );
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
Summary
- add record-level Mailchimp sync cursors so retries can resume within a campaign
- reuse stable sync-state IDs across retry attempts
- checkpoint progress inside a campaign instead of only after full campaign completion
- add a regression test proving a mid-campaign failure resumes only the unfinished tail

Why
- the last stubborn Mailchimp campaigns were making partial progress, then restarting too much after connection resets
- this change lets retries resume from the last checkpoint instead of replaying the whole campaign