### PR TITLE
Fix Gmail capture test typecheck narrowing

### DIFF
--- a/packages/integrations/test/stage1-gmail-capture-service.test.ts
+++ b/packages/integrations/test/stage1-gmail-capture-service.test.ts
@@ -280,12 +280,17 @@ describe("Gmail capture service", () => {
       maxRecords: 25
     });
 
+    const [firstRecord] = result.records;
+
     expect(result.records).toHaveLength(1);
-    expect(result.records[0]).toMatchObject({
+    expect(firstRecord).toMatchObject({
       recordType: "message",
       subject: "Checking in"
     });
-    expect(result.records[0]?.checksum).toBe(
+    if (!firstRecord || !("checksum" in firstRecord)) {
+      throw new Error("Expected a Gmail message record");
+    }
+    expect(firstRecord.checksum).toBe(
       sha256Json({
         id: "gmail-live-1",
         threadId: "thread-live-1",


### PR DESCRIPTION
Summary
- narrow the Gmail capture test record before asserting on `checksum`
- keep the change test-only and scoped to the surfaced integrations typecheck failure

Verification
- `pnpm --filter @as-comms/integrations typecheck`

Why
- unblocks the current repo-wide `verify` failure surfacing through PR #13 without touching inbox behavior