### PR TITLE
[codex] Unblock worker typecheck blockers

### DIFF
--- a/apps/worker/src/ingest/service.ts
+++ b/apps/worker/src/ingest/service.ts
@@ -3,18 +3,18 @@ import type {
   MailchimpRecord,
   ProviderMappingResult,
   SalesforceRecord,
-  SimpleTextingRecord
+  SimpleTextingRecord,
 } from "@as-comms/integrations";
 import {
   mapGmailRecord,
   mapMailchimpRecord,
   mapSalesforceRecord,
-  mapSimpleTextingRecord
+  mapSimpleTextingRecord,
 } from "@as-comms/integrations";
 import type {
   NormalizedCanonicalEventResult,
   NormalizedContactGraphResult,
-  Stage1NormalizationService
+  Stage1NormalizationService,
 } from "@as-comms/domain";
 
 import type {
@@ -25,7 +25,7 @@ import type {
   Stage1IngestReviewCaseSummary,
   Stage1NormalizedIngestResult,
   Stage1QuarantinedIngestResult,
-  Stage1ReviewOpenedIngestResult
+  Stage1ReviewOpenedIngestResult,
 } from "./types.js";
 
 export type Stage1IngestNormalizationPort = Pick<
@@ -37,27 +37,27 @@ export interface Stage1IngestService {
   ingestGmailHistoricalRecord(record: GmailRecord): Promise<Stage1IngestResult>;
   ingestGmailLiveRecord(record: GmailRecord): Promise<Stage1IngestResult>;
   ingestSalesforceHistoricalRecord(
-    record: SalesforceRecord
+    record: SalesforceRecord,
   ): Promise<Stage1IngestResult>;
   ingestSalesforceLiveRecord(
-    record: SalesforceRecord
+    record: SalesforceRecord,
   ): Promise<Stage1IngestResult>;
   ingestSimpleTextingHistoricalRecord(
-    record: SimpleTextingRecord
+    record: SimpleTextingRecord,
   ): Promise<Stage1IngestResult>;
   ingestSimpleTextingLiveRecord(
-    record: SimpleTextingRecord
+    record: SimpleTextingRecord,
   ): Promise<Stage1IngestResult>;
   ingestMailchimpHistoricalRecord(
-    record: MailchimpRecord
+    record: MailchimpRecord,
   ): Promise<Stage1IngestResult>;
   ingestMailchimpTransitionRecord(
-    record: MailchimpRecord
+    record: MailchimpRecord,
   ): Promise<Stage1IngestResult>;
 }
 
 function buildReviewCases(
-  result: NormalizedCanonicalEventResult
+  result: NormalizedCanonicalEventResult,
 ): Stage1IngestReviewCaseSummary[] {
   switch (result.outcome) {
     case "needs_identity_review":
@@ -65,8 +65,8 @@ function buildReviewCases(
         {
           queue: "identity",
           caseId: result.identityCase.id,
-          reasonCode: result.identityCase.reasonCode
-        }
+          reasonCode: result.identityCase.reasonCode,
+        },
       ];
     case "applied":
     case "duplicate": {
@@ -76,7 +76,7 @@ function buildReviewCases(
         reviewCases.push({
           queue: "identity",
           caseId: result.identityCase.id,
-          reasonCode: result.identityCase.reasonCode
+          reasonCode: result.identityCase.reasonCode,
         });
       }
 
@@ -84,7 +84,7 @@ function buildReviewCases(
         reviewCases.push({
           queue: "routing",
           caseId: result.routingCase.id,
-          reasonCode: result.routingCase.reasonCode
+          reasonCode: result.routingCase.reasonCode,
         });
       }
 
@@ -97,17 +97,33 @@ function buildReviewCases(
 
 function mapDeferredResult(
   input: ProviderMappingResult & { readonly outcome: "deferred" },
-  ingestMode: Stage1IngestMode
+  ingestMode: Stage1IngestMode,
 ): Stage1DeferredIngestResult {
   return {
     outcome: "deferred",
     ingestMode,
-    provider: input.provider,
+    provider: toStage1IngestProvider(input.provider),
     sourceRecordType: input.sourceRecordType,
     sourceRecordId: input.sourceRecordId,
     reason: input.reason,
-    detail: input.detail
+    detail: input.detail,
   };
+}
+
+function toStage1IngestProvider(
+  provider: Stage1IngestResult["provider"] | "manual",
+): Stage1IngestResult["provider"] {
+  switch (provider) {
+    case "gmail":
+    case "salesforce":
+    case "simpletexting":
+    case "mailchimp":
+      return provider;
+    case "manual":
+      throw new Error(
+        "Manual provider records are not supported by the Stage 1 ingest service.",
+      );
+  }
 }
 
 function mapContactGraphResult(input: {
@@ -118,13 +134,13 @@ function mapContactGraphResult(input: {
   return {
     outcome: "normalized",
     ingestMode: input.ingestMode,
-    provider: input.mapped.provider,
+    provider: toStage1IngestProvider(input.mapped.provider),
     sourceRecordType: input.mapped.sourceRecordType,
     sourceRecordId: input.mapped.sourceRecordId,
     commandKind: "contact_graph",
     sourceEvidenceId: null,
     canonicalEventId: null,
-    contactId: input.result.contact.id
+    contactId: input.result.contact.id,
   };
 }
 
@@ -139,10 +155,10 @@ function mapCanonicalEventResult(input: {
   | Stage1QuarantinedIngestResult {
   const base = {
     ingestMode: input.ingestMode,
-    provider: input.mapped.provider,
+    provider: toStage1IngestProvider(input.mapped.provider),
     sourceRecordType: input.mapped.sourceRecordType,
     sourceRecordId: input.mapped.sourceRecordId,
-    commandKind: "canonical_event" as const
+    commandKind: "canonical_event" as const,
   };
 
   switch (input.result.outcome) {
@@ -156,7 +172,7 @@ function mapCanonicalEventResult(input: {
           sourceEvidenceId: input.result.sourceEvidence.id,
           canonicalEventId: input.result.canonicalEvent.id,
           contactId: input.result.canonicalEvent.contactId,
-          reviewCases
+          reviewCases,
         };
       }
 
@@ -165,7 +181,7 @@ function mapCanonicalEventResult(input: {
         outcome: "normalized",
         sourceEvidenceId: input.result.sourceEvidence.id,
         canonicalEventId: input.result.canonicalEvent.id,
-        contactId: input.result.canonicalEvent.contactId
+        contactId: input.result.canonicalEvent.contactId,
       };
     }
     case "duplicate": {
@@ -178,7 +194,7 @@ function mapCanonicalEventResult(input: {
           sourceEvidenceId: input.result.sourceEvidence.id,
           canonicalEventId: input.result.canonicalEvent.id,
           contactId: input.result.canonicalEvent.contactId,
-          reviewCases
+          reviewCases,
         };
       }
 
@@ -187,7 +203,7 @@ function mapCanonicalEventResult(input: {
         outcome: "duplicate",
         sourceEvidenceId: input.result.sourceEvidence.id,
         canonicalEventId: input.result.canonicalEvent.id,
-        contactId: input.result.canonicalEvent.contactId
+        contactId: input.result.canonicalEvent.contactId,
       };
     }
     case "needs_identity_review":
@@ -197,7 +213,7 @@ function mapCanonicalEventResult(input: {
         sourceEvidenceId: input.result.sourceEvidence.id,
         canonicalEventId: null,
         contactId: input.result.identityCase.anchoredContactId,
-        reviewCases: buildReviewCases(input.result)
+        reviewCases: buildReviewCases(input.result),
       };
     case "quarantined":
       return {
@@ -208,7 +224,7 @@ function mapCanonicalEventResult(input: {
         contactId: input.result.existingCanonicalEvent?.contactId ?? null,
         reasonCode: input.result.reasonCode,
         explanation: input.result.explanation,
-        auditEvidenceId: input.result.auditEvidence.id
+        auditEvidenceId: input.result.auditEvidence.id,
       };
   }
 }
@@ -216,7 +232,7 @@ function mapCanonicalEventResult(input: {
 async function executeMappedCommand(
   normalization: Stage1IngestNormalizationPort,
   ingestMode: Stage1IngestMode,
-  mapped: ProviderMappingResult
+  mapped: ProviderMappingResult,
 ): Promise<Stage1IngestResult> {
   if (mapped.outcome === "deferred") {
     return mapDeferredResult(mapped, ingestMode);
@@ -228,14 +244,14 @@ async function executeMappedCommand(
     return mapContactGraphResult({
       ingestMode,
       mapped,
-      result: await normalization.upsertNormalizedContactGraph(command.input)
+      result: await normalization.upsertNormalizedContactGraph(command.input),
     });
   }
 
   return mapCanonicalEventResult({
     ingestMode,
     mapped,
-    result: await normalization.applyNormalizedCanonicalEvent(command.input)
+    result: await normalization.applyNormalizedCanonicalEvent(command.input),
   });
 }
 
@@ -245,24 +261,24 @@ async function ingestRecord<TRecord>(
     readonly ingestMode: Stage1IngestMode;
     readonly mapper: (record: TRecord) => ProviderMappingResult;
     readonly record: TRecord;
-  }
+  },
 ): Promise<Stage1IngestResult> {
   return executeMappedCommand(
     normalization,
     input.ingestMode,
-    input.mapper(input.record)
+    input.mapper(input.record),
   );
 }
 
 export function createStage1IngestService(
-  normalization: Stage1IngestNormalizationPort
+  normalization: Stage1IngestNormalizationPort,
 ): Stage1IngestService {
   return {
     ingestGmailHistoricalRecord(record) {
       return ingestRecord(normalization, {
         ingestMode: "historical",
         mapper: mapGmailRecord,
-        record
+        record,
       });
     },
 
@@ -270,7 +286,7 @@ export function createStage1IngestService(
       return ingestRecord(normalization, {
         ingestMode: "live",
         mapper: mapGmailRecord,
-        record
+        record,
       });
     },
 
@@ -278,7 +294,7 @@ export function createStage1IngestService(
       return ingestRecord(normalization, {
         ingestMode: "historical",
         mapper: mapSalesforceRecord,
-        record
+        record,
       });
     },
 
@@ -286,7 +302,7 @@ export function createStage1IngestService(
       return ingestRecord(normalization, {
         ingestMode: "live",
         mapper: mapSalesforceRecord,
-        record
+        record,
       });
     },
 
@@ -294,7 +310,7 @@ export function createStage1IngestService(
       return ingestRecord(normalization, {
         ingestMode: "historical",
         mapper: mapSimpleTextingRecord,
-        record
+        record,
       });
     },
 
@@ -302,7 +318,7 @@ export function createStage1IngestService(
       return ingestRecord(normalization, {
         ingestMode: "live",
         mapper: mapSimpleTextingRecord,
-        record
+        record,
       });
     },
 
@@ -310,7 +326,7 @@ export function createStage1IngestService(
       return ingestRecord(normalization, {
         ingestMode: "historical",
         mapper: mapMailchimpRecord,
-        record
+        record,
       });
     },
 
@@ -318,8 +334,8 @@ export function createStage1IngestService(
       return ingestRecord(normalization, {
         ingestMode: "transition_live",
         mapper: mapMailchimpRecord,
-        record
+        record,
       });
-    }
+    },
   };
 }

--- a/apps/worker/src/ops/mailchimp-artifacts.ts
+++ b/apps/worker/src/ops/mailchimp-artifacts.ts
@@ -1,12 +1,15 @@
-import { access, readdir } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { access, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { basename, resolve } from "node:path";
 
 import { ZodError, z } from "zod";
 
 import {
-  importMailchimpCampaignArtifactRecordsFromPath,
+  mailchimpCampaignActivityRecordSchema,
   mapMailchimpRecord,
-  type MailchimpCampaignActivityRecord
+  toSafeIsoTimestamp,
+  type MailchimpCampaignActivityRecord,
+  uniqueStrings,
 } from "@as-comms/integrations";
 import type { Stage1PersistenceService } from "@as-comms/domain";
 import type { SyncStateRecord } from "@as-comms/contracts";
@@ -14,13 +17,9 @@ import type { SyncStateRecord } from "@as-comms/contracts";
 import type { Stage1IngestService } from "../ingest/index.js";
 import type { Stage1IngestResult } from "../ingest/types.js";
 import {
-  buildMailchimpUnmatchedReport,
-  writeMailchimpUnmatchedReport
-} from "./mailchimp-unmatched.js";
-import {
   Stage1NonRetryableJobError,
   Stage1RetryableJobError,
-  type Stage1JobFailure
+  type Stage1JobFailure,
 } from "../orchestration/index.js";
 import { recordProjectionSeedOnce } from "../orchestration/projection-seed.js";
 import { recordSyncFailureAudit } from "../orchestration/sync-failure-audit.js";
@@ -34,7 +33,7 @@ const mailchimpArtifactImportInputSchema = z.object({
   receivedAt: z.string().datetime().nullable().default(null),
   limitCampaigns: z.number().int().positive().nullable().default(null),
   startAtCampaignId: z.string().min(1).nullable().default(null),
-  unmatchedReportOutputRoot: z.string().min(1).nullable().default(null)
+  unmatchedReportOutputRoot: z.string().min(1).nullable().default(null),
 });
 
 export type MailchimpArtifactImportInput = z.input<
@@ -82,9 +81,10 @@ interface MailchimpUnmatchedRecipientRow {
   readonly activityTypes: readonly string[];
 }
 
-type ImportedMailchimpCampaignActivityRecord = MailchimpCampaignActivityRecord & {
-  readonly campaignName: string | null;
-};
+type ImportedMailchimpCampaignActivityRecord =
+  MailchimpCampaignActivityRecord & {
+    readonly campaignName: string | null;
+  };
 
 interface Stage1MailchimpArtifactImportDependencies {
   readonly ingest: Pick<Stage1IngestService, "ingestMailchimpHistoricalRecord">;
@@ -97,55 +97,902 @@ interface Stage1MailchimpArtifactImportDependencies {
 const MAILCHIMP_RECORD_PROGRESS_INTERVAL = 25;
 const emptyMailchimpKnownIdentityIndex: MailchimpKnownIdentityIndex = {
   knownEmails: new Set<string>(),
-  knownVolunteerIds: new Set<string>()
+  knownVolunteerIds: new Set<string>(),
 };
-const importMailchimpCampaignArtifactRecords =
-  importMailchimpCampaignArtifactRecordsFromPath as (input: {
-    readonly campaignPath: string;
-    readonly receivedAt: string;
-  }) => Promise<ImportedMailchimpCampaignActivityRecord[]>;
-const buildTypedMailchimpUnmatchedReport =
-  buildMailchimpUnmatchedReport as (input: {
-    readonly generatedAt: string;
-    readonly recipients: readonly MailchimpUnmatchedRecipientRow[];
-    readonly knownIdentityIndex: MailchimpKnownIdentityIndex;
-  }) => unknown;
-const writeTypedMailchimpUnmatchedReport =
-  writeMailchimpUnmatchedReport as (input: {
-    readonly outputRoot: string;
-    readonly reportId: string;
-    readonly report: unknown;
-  }) => Promise<{
-    readonly jsonPath: string;
-    readonly csvPath: string;
-  }>;
+const consumerEmailDomains = new Set([
+  "gmail.com",
+  "yahoo.com",
+  "hotmail.com",
+  "outlook.com",
+  "icloud.com",
+  "me.com",
+  "aol.com",
+  "msn.com",
+]);
+const artifactTimestampSchema = z.string().transform((value, context) => {
+  const normalizedTimestamp = toSafeIsoTimestamp(value);
+
+  if (normalizedTimestamp === null) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Invalid datetime",
+    });
+    return z.NEVER;
+  }
+
+  return normalizedTimestamp;
+});
+const artifactOptionalStringSchema = z.string().optional().nullable();
+const artifactMergeFieldsSchema = z.record(z.string(), z.unknown()).default({});
+const mailchimpCampaignSummarySchema = z.object({
+  id: z.string().min(1),
+  campaign_title: artifactOptionalStringSchema,
+  subject_line: artifactOptionalStringSchema,
+  preview_text: artifactOptionalStringSchema,
+  list_id: artifactOptionalStringSchema,
+  send_time: artifactTimestampSchema,
+});
+const mailchimpSentToMemberSchema = z.object({
+  email_id: artifactOptionalStringSchema,
+  email_address: artifactOptionalStringSchema,
+  merge_fields: artifactMergeFieldsSchema,
+  status: artifactOptionalStringSchema,
+  last_open: artifactOptionalStringSchema,
+  campaign_id: artifactOptionalStringSchema,
+  list_id: artifactOptionalStringSchema,
+});
+const mailchimpOpenEventSchema = z.object({
+  timestamp: artifactTimestampSchema,
+});
+const mailchimpOpenDetailSchema = z.object({
+  campaign_id: artifactOptionalStringSchema,
+  list_id: artifactOptionalStringSchema,
+  email_id: artifactOptionalStringSchema,
+  email_address: artifactOptionalStringSchema,
+  merge_fields: artifactMergeFieldsSchema,
+  opens: z.array(mailchimpOpenEventSchema).default([]),
+});
+const mailchimpClickDetailSchema = z.object({
+  id: z.string().min(1),
+  url: artifactOptionalStringSchema,
+  last_click: artifactOptionalStringSchema,
+  campaign_id: artifactOptionalStringSchema,
+});
+const mailchimpClickMemberSchema = z.object({
+  email_id: artifactOptionalStringSchema,
+  email_address: artifactOptionalStringSchema,
+  merge_fields: artifactMergeFieldsSchema,
+  campaign_id: artifactOptionalStringSchema,
+  list_id: artifactOptionalStringSchema,
+  clicks: z.number().int().nonnegative().default(0),
+});
+const mailchimpClickMemberGroupSchema = z.object({
+  linkId: z.string().min(1),
+  url: artifactOptionalStringSchema,
+  members: z.array(mailchimpClickMemberSchema).default([]),
+});
+const mailchimpUnsubscribedMemberSchema = z.object({
+  email_id: artifactOptionalStringSchema,
+  email_address: artifactOptionalStringSchema,
+  merge_fields: artifactMergeFieldsSchema,
+  timestamp: artifactTimestampSchema,
+  reason: artifactOptionalStringSchema,
+  campaign_id: artifactOptionalStringSchema,
+  list_id: artifactOptionalStringSchema,
+});
+const mailchimpCampaignArtifactSchema = z.object({
+  summary: mailchimpCampaignSummarySchema,
+  sentTo: z.array(mailchimpSentToMemberSchema),
+  openDetails: z.array(mailchimpOpenDetailSchema),
+  clickDetails: z.array(mailchimpClickDetailSchema),
+  clickMembers: z.array(mailchimpClickMemberGroupSchema),
+  unsubscribed: z.array(mailchimpUnsubscribedMemberSchema),
+});
+const artifactFileNames = {
+  summary: "summary.json",
+  sentTo: "sent-to.json",
+  openDetails: "open-details.json",
+  clickDetails: "click-details.json",
+  clickMembers: "click-members.json",
+  unsubscribed: "unsubscribed.json",
+} as const;
+
+type MailchimpCampaignSummary = z.infer<typeof mailchimpCampaignSummarySchema>;
+type MailchimpCampaignArtifact = z.infer<
+  typeof mailchimpCampaignArtifactSchema
+>;
+type MailchimpClickDetail = z.infer<typeof mailchimpClickDetailSchema>;
+
+interface MailchimpUnmatchedRecipientSummaryRow {
+  readonly email: string | null;
+  readonly memberId: string;
+  readonly platformId: string | null;
+  readonly domain: string | null;
+  readonly audienceIds: readonly string[];
+  readonly campaignIds: readonly string[];
+  readonly campaignNames: readonly string[];
+  readonly activityTypes: readonly string[];
+  readonly sameLocalDifferentDomain: boolean;
+  readonly localPartCandidateEmails: readonly string[];
+  readonly bucket:
+    | "has_platform_id"
+    | "same_local_different_domain"
+    | "consumer_domain_unmatched"
+    | "other_unmatched";
+}
+
+interface MailchimpUnmatchedReport {
+  readonly generatedAt: string;
+  readonly summary: {
+    readonly reviewRows: number;
+    readonly distinctMembers: number;
+    readonly distinctCampaignMembers: number;
+    readonly withPlatformId: number;
+    readonly sameLocalDifferentDomain: number;
+    readonly consumerDomainMembers: number;
+  };
+  readonly topDomains: readonly {
+    readonly domain: string;
+    readonly count: number;
+  }[];
+  readonly topAudiences: readonly {
+    readonly audienceId: string;
+    readonly count: number;
+  }[];
+  readonly topCampaigns: readonly {
+    readonly campaignId: string;
+    readonly campaignName: string | null;
+    readonly audienceId: string | null;
+    readonly unmatchedMembers: number;
+  }[];
+  readonly recipients: readonly MailchimpUnmatchedRecipientSummaryRow[];
+}
+
+interface MailchimpUnmatchedReportPaths {
+  readonly jsonPath: string;
+  readonly csvPath: string;
+}
+
+function normalizeOptionalString(
+  value: string | null | undefined,
+): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeEmail(value: string | null | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim().toLowerCase();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function readMergeFieldString(
+  mergeFields: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = mergeFields[key];
+
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  return normalizeOptionalString(value);
+}
+
+function buildArtifactPayloadRef(input: {
+  readonly campaignPath: string;
+  readonly fileName: string;
+  readonly memberId: string;
+}): string {
+  return `mailchimp-artifact://${encodeURIComponent(input.campaignPath)}#file=${encodeURIComponent(input.fileName)}&member=${encodeURIComponent(input.memberId)}`;
+}
+
+function buildChecksum(value: unknown): string {
+  return createHash("sha256")
+    .update(JSON.stringify(value), "utf8")
+    .digest("hex");
+}
+
+function buildCampaignSnippet(summary: MailchimpCampaignSummary): string {
+  return (
+    normalizeOptionalString(summary.preview_text) ??
+    normalizeOptionalString(summary.subject_line) ??
+    normalizeOptionalString(summary.campaign_title) ??
+    ""
+  );
+}
+
+function resolveMemberId(input: {
+  readonly emailId: string | null | undefined;
+  readonly normalizedEmail: string;
+}): string {
+  return normalizeOptionalString(input.emailId) ?? input.normalizedEmail;
+}
+
+function sortTimestamps(values: readonly string[]): string[] {
+  return [...values].sort((left, right) => left.localeCompare(right));
+}
+
+function pickEarliestTimestamp(
+  values: readonly (string | null | undefined)[],
+): string | null {
+  const timestamps = sortTimestamps(
+    values
+      .map((value) =>
+        value === null || value === undefined
+          ? null
+          : toSafeIsoTimestamp(value),
+      )
+      .filter((value): value is string => value !== null),
+  );
+
+  return timestamps[0] ?? null;
+}
+
+function createMailchimpActivityRecord(input: {
+  readonly campaignPath: string;
+  readonly receivedAt: string;
+  readonly campaignId: string;
+  readonly audienceId: string | null;
+  readonly campaignName: string | null;
+  readonly snippet: string;
+  readonly activityType: MailchimpCampaignActivityRecord["activityType"];
+  readonly occurredAt: string;
+  readonly memberId: string;
+  readonly normalizedEmail: string;
+  readonly mergeFields: Record<string, unknown>;
+  readonly fileName: string;
+  readonly checksumData: unknown;
+}): ImportedMailchimpCampaignActivityRecord {
+  const providerRecordId = [
+    input.campaignId,
+    input.memberId,
+    input.activityType,
+  ].join(":");
+  const baseRecord = mailchimpCampaignActivityRecordSchema.parse({
+    recordType: "campaign_member_activity",
+    recordId: providerRecordId,
+    activityType: input.activityType,
+    occurredAt: input.occurredAt,
+    receivedAt: input.receivedAt,
+    payloadRef: buildArtifactPayloadRef({
+      campaignPath: input.campaignPath,
+      fileName: input.fileName,
+      memberId: input.memberId,
+    }),
+    checksum: buildChecksum(input.checksumData),
+    normalizedEmail: input.normalizedEmail,
+    salesforceContactId: null,
+    volunteerIdPlainValues: uniqueStrings(
+      [readMergeFieldString(input.mergeFields, "PLATFORMID") ?? ""].filter(
+        (value) => value.length > 0,
+      ),
+    ),
+    normalizedPhones: [],
+    campaignId: input.campaignId,
+    audienceId: input.audienceId ?? "",
+    memberId: input.memberId,
+    snippet: input.snippet,
+  });
+
+  return {
+    ...baseRecord,
+    campaignName: input.campaignName,
+  };
+}
+
+function sortMailchimpRecords(
+  records: readonly ImportedMailchimpCampaignActivityRecord[],
+): ImportedMailchimpCampaignActivityRecord[] {
+  return [...records].sort((left, right) => {
+    const occurredAtOrder = left.occurredAt.localeCompare(right.occurredAt);
+
+    if (occurredAtOrder !== 0) {
+      return occurredAtOrder;
+    }
+
+    return left.recordId.localeCompare(right.recordId);
+  });
+}
+
+async function readMailchimpCampaignArtifact(input: {
+  readonly campaignPath: string;
+}): Promise<MailchimpCampaignArtifact> {
+  const [
+    summaryText,
+    sentToText,
+    openDetailsText,
+    clickDetailsText,
+    clickMembersText,
+    unsubscribedText,
+  ] = await Promise.all([
+    readFile(resolve(input.campaignPath, artifactFileNames.summary), "utf8"),
+    readFile(resolve(input.campaignPath, artifactFileNames.sentTo), "utf8"),
+    readFile(
+      resolve(input.campaignPath, artifactFileNames.openDetails),
+      "utf8",
+    ),
+    readFile(
+      resolve(input.campaignPath, artifactFileNames.clickDetails),
+      "utf8",
+    ),
+    readFile(
+      resolve(input.campaignPath, artifactFileNames.clickMembers),
+      "utf8",
+    ),
+    readFile(
+      resolve(input.campaignPath, artifactFileNames.unsubscribed),
+      "utf8",
+    ),
+  ] as const);
+
+  return mailchimpCampaignArtifactSchema.parse({
+    summary: JSON.parse(summaryText),
+    sentTo: JSON.parse(sentToText),
+    openDetails: JSON.parse(openDetailsText),
+    clickDetails: JSON.parse(clickDetailsText),
+    clickMembers: JSON.parse(clickMembersText),
+    unsubscribed: JSON.parse(unsubscribedText),
+  });
+}
+
+async function importMailchimpCampaignArtifactRecordsFromPath(input: {
+  readonly campaignPath: string;
+  readonly receivedAt: string;
+}): Promise<ImportedMailchimpCampaignActivityRecord[]> {
+  const artifact = await readMailchimpCampaignArtifact({
+    campaignPath: input.campaignPath,
+  });
+  const campaignId = artifact.summary.id;
+  const campaignName = normalizeOptionalString(artifact.summary.campaign_title);
+  const audienceId = normalizeOptionalString(artifact.summary.list_id) ?? null;
+  const campaignSnippet = buildCampaignSnippet(artifact.summary);
+  const sendTime = artifact.summary.send_time;
+  const records: ImportedMailchimpCampaignActivityRecord[] = [];
+
+  const earliestOpenByMemberId = new Map<string, string>();
+  const lastOpenByMemberId = new Map<string, string>();
+
+  for (const row of artifact.sentTo) {
+    const normalizedEmail = normalizeEmail(row.email_address);
+
+    if (normalizedEmail === null) {
+      continue;
+    }
+
+    const memberId = resolveMemberId({
+      emailId: row.email_id,
+      normalizedEmail,
+    });
+    const earliestOpen = pickEarliestTimestamp([row.last_open]);
+
+    if (earliestOpen !== null) {
+      lastOpenByMemberId.set(memberId, earliestOpen);
+    }
+
+    records.push(
+      createMailchimpActivityRecord({
+        campaignPath: input.campaignPath,
+        receivedAt: input.receivedAt,
+        campaignId,
+        audienceId: normalizeOptionalString(row.list_id) ?? audienceId,
+        campaignName,
+        snippet: campaignSnippet,
+        activityType: "sent",
+        occurredAt: sendTime,
+        memberId,
+        normalizedEmail,
+        mergeFields: row.merge_fields,
+        fileName: artifactFileNames.sentTo,
+        checksumData: {
+          campaignId,
+          activityType: "sent",
+          memberId,
+          row,
+        },
+      }),
+    );
+  }
+
+  for (const row of artifact.openDetails) {
+    const normalizedEmail = normalizeEmail(row.email_address);
+
+    if (normalizedEmail === null) {
+      continue;
+    }
+
+    const memberId = resolveMemberId({
+      emailId: row.email_id,
+      normalizedEmail,
+    });
+    const earliestOpen = pickEarliestTimestamp(
+      row.opens.map((open) => open.timestamp),
+    );
+
+    if (earliestOpen === null) {
+      continue;
+    }
+
+    earliestOpenByMemberId.set(memberId, earliestOpen);
+    records.push(
+      createMailchimpActivityRecord({
+        campaignPath: input.campaignPath,
+        receivedAt: input.receivedAt,
+        campaignId,
+        audienceId: normalizeOptionalString(row.list_id) ?? audienceId,
+        campaignName,
+        snippet: campaignSnippet,
+        activityType: "opened",
+        occurredAt: earliestOpen,
+        memberId,
+        normalizedEmail,
+        mergeFields: row.merge_fields,
+        fileName: artifactFileNames.openDetails,
+        checksumData: {
+          campaignId,
+          activityType: "opened",
+          memberId,
+          opens: row.opens,
+        },
+      }),
+    );
+  }
+
+  const clickedMembers = new Map<
+    string,
+    {
+      normalizedEmail: string;
+      mergeFields: Record<string, unknown>;
+      audienceId: string | null;
+      clickedUrls: string[];
+      linkIds: string[];
+    }
+  >();
+  const clickDetailById = new Map<string, MailchimpClickDetail>(
+    artifact.clickDetails.map((detail) => [detail.id, detail]),
+  );
+
+  for (const group of artifact.clickMembers) {
+    for (const member of group.members) {
+      const normalizedEmail = normalizeEmail(member.email_address);
+
+      if (normalizedEmail === null) {
+        continue;
+      }
+
+      const memberId = resolveMemberId({
+        emailId: member.email_id,
+        normalizedEmail,
+      });
+      const clickedUrl =
+        normalizeOptionalString(group.url) ??
+        normalizeOptionalString(clickDetailById.get(group.linkId)?.url ?? null);
+      const existing = clickedMembers.get(memberId);
+
+      if (existing === undefined) {
+        clickedMembers.set(memberId, {
+          normalizedEmail,
+          mergeFields: member.merge_fields,
+          audienceId: normalizeOptionalString(member.list_id) ?? audienceId,
+          clickedUrls: uniqueStrings([clickedUrl ?? ""].filter(Boolean)),
+          linkIds: [group.linkId],
+        });
+        continue;
+      }
+
+      existing.clickedUrls = uniqueStrings([
+        ...existing.clickedUrls,
+        clickedUrl ?? "",
+      ]);
+      existing.linkIds = uniqueStrings([...existing.linkIds, group.linkId]);
+    }
+  }
+
+  for (const [memberId, clickedMember] of clickedMembers.entries()) {
+    const occurredAt =
+      earliestOpenByMemberId.get(memberId) ??
+      lastOpenByMemberId.get(memberId) ??
+      sendTime;
+    const clickSnippet = clickedMember.clickedUrls[0] ?? campaignSnippet;
+
+    records.push(
+      createMailchimpActivityRecord({
+        campaignPath: input.campaignPath,
+        receivedAt: input.receivedAt,
+        campaignId,
+        audienceId: clickedMember.audienceId,
+        campaignName,
+        snippet: clickSnippet,
+        activityType: "clicked",
+        occurredAt,
+        memberId,
+        normalizedEmail: clickedMember.normalizedEmail,
+        mergeFields: clickedMember.mergeFields,
+        fileName: artifactFileNames.clickMembers,
+        checksumData: {
+          campaignId,
+          activityType: "clicked",
+          memberId,
+          clickedUrls: clickedMember.clickedUrls,
+          linkIds: clickedMember.linkIds,
+        },
+      }),
+    );
+  }
+
+  for (const row of artifact.unsubscribed) {
+    const normalizedEmail = normalizeEmail(row.email_address);
+
+    if (normalizedEmail === null) {
+      continue;
+    }
+
+    const memberId = resolveMemberId({
+      emailId: row.email_id,
+      normalizedEmail,
+    });
+
+    records.push(
+      createMailchimpActivityRecord({
+        campaignPath: input.campaignPath,
+        receivedAt: input.receivedAt,
+        campaignId,
+        audienceId: normalizeOptionalString(row.list_id) ?? audienceId,
+        campaignName,
+        snippet: campaignSnippet,
+        activityType: "unsubscribed",
+        occurredAt: row.timestamp,
+        memberId,
+        normalizedEmail,
+        mergeFields: row.merge_fields,
+        fileName: artifactFileNames.unsubscribed,
+        checksumData: {
+          campaignId,
+          activityType: "unsubscribed",
+          memberId,
+          timestamp: row.timestamp,
+          reason: normalizeOptionalString(row.reason),
+        },
+      }),
+    );
+  }
+
+  return sortMailchimpRecords(records);
+}
+
+function normalizeEmailLocalPart(email: string): string {
+  const [localPart = ""] = email.toLowerCase().split("@");
+  return localPart.split("+")[0] ?? localPart;
+}
+
+function resolveDomain(email: string | null): string | null {
+  if (email === null) {
+    return null;
+  }
+
+  const [, domain] = email.toLowerCase().split("@");
+  return domain?.trim().length ? domain.trim() : null;
+}
+
+function classifyRecipientBucket(input: {
+  readonly platformId: string | null;
+  readonly sameLocalDifferentDomain: boolean;
+  readonly domain: string | null;
+}): MailchimpUnmatchedRecipientSummaryRow["bucket"] {
+  if (input.platformId !== null) {
+    return "has_platform_id";
+  }
+
+  if (input.sameLocalDifferentDomain) {
+    return "same_local_different_domain";
+  }
+
+  if (input.domain !== null && consumerEmailDomains.has(input.domain)) {
+    return "consumer_domain_unmatched";
+  }
+
+  return "other_unmatched";
+}
+
+function escapeCsvValue(value: string): string {
+  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+    return `"${value.replaceAll('"', '""')}"`;
+  }
+
+  return value;
+}
+
+function slugifyReportId(value: string): string {
+  return value.replaceAll(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+function buildMailchimpUnmatchedReport(input: {
+  readonly generatedAt: string;
+  readonly recipients: readonly MailchimpUnmatchedRecipientRow[];
+  readonly knownIdentityIndex: MailchimpKnownIdentityIndex;
+}): MailchimpUnmatchedReport {
+  const localPartToKnownEmails = new Map<string, Set<string>>();
+
+  for (const email of input.knownIdentityIndex.knownEmails) {
+    const localPart = normalizeEmailLocalPart(email);
+
+    if (!localPartToKnownEmails.has(localPart)) {
+      localPartToKnownEmails.set(localPart, new Set());
+    }
+
+    localPartToKnownEmails.get(localPart)?.add(email);
+  }
+
+  const memberSummaryMap = new Map<
+    string,
+    {
+      email: string | null;
+      memberId: string;
+      platformId: string | null;
+      domain: string | null;
+      audienceIds: Set<string>;
+      campaignIds: Set<string>;
+      campaignNames: Set<string>;
+      activityTypes: Set<string>;
+      sameLocalDifferentDomain: boolean;
+      localPartCandidateEmails: Set<string>;
+    }
+  >();
+  const campaignCounts = new Map<
+    string,
+    {
+      campaignId: string;
+      campaignName: string | null;
+      audienceId: string | null;
+      memberIds: Set<string>;
+    }
+  >();
+  const domainCounts = new Map<string, number>();
+  const audienceCounts = new Map<string, number>();
+
+  for (const recipient of input.recipients) {
+    const memberSummary = memberSummaryMap.get(recipient.memberId) ?? {
+      email: recipient.email,
+      memberId: recipient.memberId,
+      platformId: recipient.platformId,
+      domain: resolveDomain(recipient.email),
+      audienceIds: new Set<string>(),
+      campaignIds: new Set<string>(),
+      campaignNames: new Set<string>(),
+      activityTypes: new Set<string>(),
+      sameLocalDifferentDomain: false,
+      localPartCandidateEmails: new Set<string>(),
+    };
+
+    if (recipient.audienceId !== null) {
+      memberSummary.audienceIds.add(recipient.audienceId);
+      audienceCounts.set(
+        recipient.audienceId,
+        (audienceCounts.get(recipient.audienceId) ?? 0) + 1,
+      );
+    }
+
+    memberSummary.campaignIds.add(recipient.campaignId);
+    if (recipient.campaignName !== null) {
+      memberSummary.campaignNames.add(recipient.campaignName);
+    }
+    for (const activityType of recipient.activityTypes) {
+      memberSummary.activityTypes.add(activityType);
+    }
+
+    if (memberSummary.email !== null) {
+      const localPart = normalizeEmailLocalPart(memberSummary.email);
+      const candidates = Array.from(
+        localPartToKnownEmails.get(localPart) ?? new Set<string>(),
+      ).filter((candidateEmail) => candidateEmail !== memberSummary.email);
+
+      if (candidates.length > 0) {
+        memberSummary.sameLocalDifferentDomain = true;
+        for (const candidateEmail of candidates) {
+          memberSummary.localPartCandidateEmails.add(candidateEmail);
+        }
+      }
+    }
+
+    memberSummaryMap.set(recipient.memberId, memberSummary);
+
+    const campaignSummary = campaignCounts.get(recipient.campaignId) ?? {
+      campaignId: recipient.campaignId,
+      campaignName: recipient.campaignName,
+      audienceId: recipient.audienceId,
+      memberIds: new Set<string>(),
+    };
+    campaignSummary.memberIds.add(recipient.memberId);
+    campaignCounts.set(recipient.campaignId, campaignSummary);
+
+    const domain = resolveDomain(recipient.email);
+    if (domain !== null) {
+      domainCounts.set(domain, (domainCounts.get(domain) ?? 0) + 1);
+    }
+  }
+
+  const recipients = Array.from(memberSummaryMap.values())
+    .map((memberSummary) => {
+      const domain = memberSummary.domain;
+      const sameLocalDifferentDomain = memberSummary.sameLocalDifferentDomain;
+
+      return {
+        email: memberSummary.email,
+        memberId: memberSummary.memberId,
+        platformId: memberSummary.platformId,
+        domain,
+        audienceIds: Array.from(memberSummary.audienceIds).sort(),
+        campaignIds: Array.from(memberSummary.campaignIds).sort(),
+        campaignNames: Array.from(memberSummary.campaignNames).sort(),
+        activityTypes: Array.from(memberSummary.activityTypes).sort(),
+        sameLocalDifferentDomain,
+        localPartCandidateEmails: Array.from(
+          memberSummary.localPartCandidateEmails,
+        ).sort(),
+        bucket: classifyRecipientBucket({
+          platformId: memberSummary.platformId,
+          sameLocalDifferentDomain,
+          domain,
+        }),
+      };
+    })
+    .sort((left, right) => {
+      if (left.email === null && right.email === null) {
+        return left.memberId.localeCompare(right.memberId);
+      }
+
+      if (left.email === null) {
+        return 1;
+      }
+
+      if (right.email === null) {
+        return -1;
+      }
+
+      return left.email.localeCompare(right.email);
+    });
+
+  return {
+    generatedAt: input.generatedAt,
+    summary: {
+      reviewRows: input.recipients.reduce(
+        (total, recipient) => total + recipient.activityTypes.length,
+        0,
+      ),
+      distinctMembers: recipients.length,
+      distinctCampaignMembers: input.recipients.length,
+      withPlatformId: recipients.filter(
+        (recipient) => recipient.platformId !== null,
+      ).length,
+      sameLocalDifferentDomain: recipients.filter(
+        (recipient) => recipient.sameLocalDifferentDomain,
+      ).length,
+      consumerDomainMembers: recipients.filter(
+        (recipient) =>
+          recipient.domain !== null &&
+          consumerEmailDomains.has(recipient.domain),
+      ).length,
+    },
+    topDomains: Array.from(domainCounts.entries())
+      .sort((left, right) => right[1] - left[1])
+      .slice(0, 20)
+      .map(([domain, count]) => ({
+        domain,
+        count,
+      })),
+    topAudiences: Array.from(audienceCounts.entries())
+      .sort((left, right) => right[1] - left[1])
+      .slice(0, 10)
+      .map(([audienceId, count]) => ({
+        audienceId,
+        count,
+      })),
+    topCampaigns: Array.from(campaignCounts.values())
+      .sort((left, right) => right.memberIds.size - left.memberIds.size)
+      .slice(0, 20)
+      .map((campaignSummary) => ({
+        campaignId: campaignSummary.campaignId,
+        campaignName: campaignSummary.campaignName,
+        audienceId: campaignSummary.audienceId,
+        unmatchedMembers: campaignSummary.memberIds.size,
+      })),
+    recipients,
+  };
+}
+
+async function writeMailchimpUnmatchedReport(input: {
+  readonly outputRoot: string;
+  readonly reportId: string;
+  readonly report: MailchimpUnmatchedReport;
+}): Promise<MailchimpUnmatchedReportPaths> {
+  await mkdir(input.outputRoot, {
+    recursive: true,
+  });
+
+  const reportId = slugifyReportId(input.reportId);
+  const jsonPath = resolve(input.outputRoot, `${reportId}.json`);
+  const csvPath = resolve(input.outputRoot, `${reportId}.csv`);
+  const csvLines = [
+    [
+      "email",
+      "member_id",
+      "platform_id",
+      "domain",
+      "bucket",
+      "audience_ids",
+      "campaign_ids",
+      "campaign_names",
+      "activity_types",
+      "same_local_different_domain",
+      "local_part_candidate_emails",
+    ].join(","),
+    ...input.report.recipients.map((recipient) =>
+      [
+        recipient.email ?? "",
+        recipient.memberId,
+        recipient.platformId ?? "",
+        recipient.domain ?? "",
+        recipient.bucket,
+        recipient.audienceIds.join("|"),
+        recipient.campaignIds.join("|"),
+        recipient.campaignNames.join("|"),
+        recipient.activityTypes.join("|"),
+        recipient.sameLocalDifferentDomain ? "true" : "false",
+        recipient.localPartCandidateEmails.join("|"),
+      ]
+        .map(escapeCsvValue)
+        .join(","),
+    ),
+  ];
+
+  await writeFile(
+    jsonPath,
+    `${JSON.stringify(input.report, null, 2)}\n`,
+    "utf8",
+  );
+  await writeFile(csvPath, `${csvLines.join("\n")}\n`, "utf8");
+
+  return {
+    jsonPath,
+    csvPath,
+  };
+}
 
 function summarizeIngestResults(
   results: readonly Stage1IngestResult[],
   input?: {
     readonly skippedUnmatched: number;
     readonly skippedUnmatchedRecipients: number;
-  }
+  },
 ) {
   return {
     processed: results.length,
-    normalized: results.filter((result) => result.outcome === "normalized").length,
-    duplicate: results.filter((result) => result.outcome === "duplicate").length,
+    normalized: results.filter((result) => result.outcome === "normalized")
+      .length,
+    duplicate: results.filter((result) => result.outcome === "duplicate")
+      .length,
     reviewOpened: results.filter((result) => result.outcome === "review_opened")
       .length,
     quarantined: results.filter((result) => result.outcome === "quarantined")
       .length,
     deferred: results.filter((result) => result.outcome === "deferred").length,
     deadLetterCountIncrement: results.filter(
-      (result) => result.outcome === "quarantined"
+      (result) => result.outcome === "quarantined",
     ).length,
     skippedUnmatched: input?.skippedUnmatched ?? 0,
-    skippedUnmatchedRecipients: input?.skippedUnmatchedRecipients ?? 0
+    skippedUnmatchedRecipients: input?.skippedUnmatchedRecipients ?? 0,
   };
 }
 
 function isOccurredAtRecord(
-  record: unknown
+  record: unknown,
 ): record is { readonly occurredAt: string } {
   return (
     typeof record === "object" &&
@@ -155,9 +1002,7 @@ function isOccurredAtRecord(
   );
 }
 
-function calculateHistoricalWindow(
-  records: readonly unknown[]
-): {
+function calculateHistoricalWindow(records: readonly unknown[]): {
   readonly windowStart: string | null;
   readonly windowEnd: string | null;
   readonly checkpoint: string | null;
@@ -172,18 +1017,21 @@ function calculateHistoricalWindow(
   return {
     windowStart,
     windowEnd: checkpoint,
-    checkpoint
+    checkpoint,
   };
 }
 
 function buildImportFailure(error: unknown): Stage1JobFailure {
   const message = error instanceof Error ? error.message : String(error);
 
-  if (error instanceof Stage1NonRetryableJobError || error instanceof ZodError) {
+  if (
+    error instanceof Stage1NonRetryableJobError ||
+    error instanceof ZodError
+  ) {
     return {
       disposition: "non_retryable",
       retryable: false,
-      message
+      message,
     };
   }
 
@@ -191,20 +1039,18 @@ function buildImportFailure(error: unknown): Stage1JobFailure {
     disposition:
       error instanceof Stage1RetryableJobError ? "retryable" : "retryable",
     retryable: true,
-    message
+    message,
   };
 }
 
 function buildMailchimpRecordCursor(
   campaignId: string,
-  nextRecordIndex: number
+  nextRecordIndex: number,
 ): string {
   return `${campaignId}:record:${String(nextRecordIndex)}`;
 }
 
-function parseMailchimpRecordCursor(
-  cursor: string | null
-): {
+function parseMailchimpRecordCursor(cursor: string | null): {
   readonly campaignId: string;
   readonly nextRecordIndex: number;
 } | null {
@@ -223,19 +1069,23 @@ function parseMailchimpRecordCursor(
   const nextRecordIndexValue = cursor.slice(markerIndex + marker.length).trim();
   const nextRecordIndex = Number.parseInt(nextRecordIndexValue, 10);
 
-  if (campaignId.length === 0 || Number.isNaN(nextRecordIndex) || nextRecordIndex < 0) {
+  if (
+    campaignId.length === 0 ||
+    Number.isNaN(nextRecordIndex) ||
+    nextRecordIndex < 0
+  ) {
     return null;
   }
 
   return {
     campaignId,
-    nextRecordIndex
+    nextRecordIndex,
   };
 }
 
 function resolveMailchimpResumePlan(
   cursor: string | null,
-  campaignIds: readonly string[]
+  campaignIds: readonly string[],
 ): {
   readonly completedCampaignIds: ReadonlySet<string>;
   readonly resumeCampaignId: string | null;
@@ -248,9 +1098,11 @@ function resolveMailchimpResumePlan(
 
     if (resumeCampaignIndex !== -1) {
       return {
-        completedCampaignIds: new Set(campaignIds.slice(0, resumeCampaignIndex)),
+        completedCampaignIds: new Set(
+          campaignIds.slice(0, resumeCampaignIndex),
+        ),
         resumeCampaignId: recordCursor.campaignId,
-        resumeNextRecordIndex: recordCursor.nextRecordIndex
+        resumeNextRecordIndex: recordCursor.nextRecordIndex,
       };
     }
   }
@@ -260,9 +1112,11 @@ function resolveMailchimpResumePlan(
 
     if (completedCampaignIndex !== -1) {
       return {
-        completedCampaignIds: new Set(campaignIds.slice(0, completedCampaignIndex + 1)),
+        completedCampaignIds: new Set(
+          campaignIds.slice(0, completedCampaignIndex + 1),
+        ),
         resumeCampaignId: campaignIds[completedCampaignIndex + 1] ?? null,
-        resumeNextRecordIndex: 0
+        resumeNextRecordIndex: 0,
       };
     }
   }
@@ -270,13 +1124,13 @@ function resolveMailchimpResumePlan(
   return {
     completedCampaignIds: new Set<string>(),
     resumeCampaignId: campaignIds[0] ?? null,
-    resumeNextRecordIndex: 0
+    resumeNextRecordIndex: 0,
   };
 }
 
 function shouldCheckpointMailchimpCampaignRecord(
   nextRecordIndex: number,
-  recordCount: number
+  recordCount: number,
 ): boolean {
   return (
     nextRecordIndex === recordCount ||
@@ -306,11 +1160,13 @@ async function resolveCampaignArtifactPaths(input: {
   }
 
   const entries = await readdir(resolvedArtifactPath, {
-    withFileTypes: true
+    withFileTypes: true,
   });
   const campaignPaths: string[] = [];
 
-  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+  for (const entry of entries.sort((left, right) =>
+    left.name.localeCompare(right.name),
+  )) {
     if (!entry.isDirectory() && !entry.isSymbolicLink()) {
       continue;
     }
@@ -326,16 +1182,18 @@ async function resolveCampaignArtifactPaths(input: {
     input.startAtCampaignId === null
       ? 0
       : campaignPaths.findIndex(
-          (campaignPath) => basename(campaignPath) === input.startAtCampaignId
+          (campaignPath) => basename(campaignPath) === input.startAtCampaignId,
         );
 
   if (input.startAtCampaignId !== null && startIndex === -1) {
     throw new Error(
-      `Could not find Mailchimp campaign artifact ${input.startAtCampaignId} under ${input.artifactPath}.`
+      `Could not find Mailchimp campaign artifact ${input.startAtCampaignId} under ${input.artifactPath}.`,
     );
   }
 
-  const resumedCampaignPaths = campaignPaths.slice(startIndex === -1 ? 0 : startIndex);
+  const resumedCampaignPaths = campaignPaths.slice(
+    startIndex === -1 ? 0 : startIndex,
+  );
 
   return input.limitCampaigns === null
     ? resumedCampaignPaths
@@ -344,15 +1202,19 @@ async function resolveCampaignArtifactPaths(input: {
 
 async function findExistingDuplicateResult(
   persistence: Stage1PersistenceService,
-  mapped: ReturnType<typeof mapMailchimpRecord>
+  mapped: ReturnType<typeof mapMailchimpRecord>,
 ): Promise<Stage1IngestResult | null> {
-  if (mapped.outcome !== "command" || mapped.command.kind !== "canonical_event") {
+  if (
+    mapped.outcome !== "command" ||
+    mapped.command.kind !== "canonical_event"
+  ) {
     return null;
   }
 
-  const existingSourceEvidence = await persistence.findSourceEvidenceByIdempotencyKey(
-    mapped.command.input.sourceEvidence.idempotencyKey
-  );
+  const existingSourceEvidence =
+    await persistence.findSourceEvidenceByIdempotencyKey(
+      mapped.command.input.sourceEvidence.idempotencyKey,
+    );
 
   if (existingSourceEvidence === null) {
     return null;
@@ -360,7 +1222,7 @@ async function findExistingDuplicateResult(
 
   const existingCanonicalEvent =
     await persistence.findCanonicalEventByIdempotencyKey(
-      mapped.command.input.canonicalEvent.idempotencyKey
+      mapped.command.input.canonicalEvent.idempotencyKey,
     );
 
   if (existingCanonicalEvent === null) {
@@ -376,12 +1238,12 @@ async function findExistingDuplicateResult(
     commandKind: "canonical_event",
     sourceEvidenceId: existingSourceEvidence.id,
     canonicalEventId: existingCanonicalEvent.id,
-    contactId: existingCanonicalEvent.contactId
+    contactId: existingCanonicalEvent.contactId,
   };
 }
 
 function createMailchimpIdentityPresenceResolver(
-  dependencies: Stage1MailchimpArtifactImportDependencies
+  dependencies: Stage1MailchimpArtifactImportDependencies,
 ) {
   const emailCache = new Map<string, Promise<boolean>>();
   const volunteerIdCache = new Map<string, Promise<boolean>>();
@@ -400,7 +1262,7 @@ function createMailchimpIdentityPresenceResolver(
         : dependencies.persistence.repositories.contactIdentities
             .listByNormalizedValue({
               kind: "email",
-              normalizedValue: normalizedEmail
+              normalizedValue: normalizedEmail,
             })
             .then((rows) => rows.length > 0);
     emailCache.set(normalizedEmail, lookup);
@@ -421,7 +1283,7 @@ function createMailchimpIdentityPresenceResolver(
         : dependencies.persistence.repositories.contactIdentities
             .listByNormalizedValue({
               kind: "volunteer_id_plain",
-              normalizedValue: volunteerId
+              normalizedValue: volunteerId,
             })
             .then((rows) => rows.length > 0);
     volunteerIdCache.set(volunteerId, lookup);
@@ -446,33 +1308,33 @@ function createMailchimpIdentityPresenceResolver(
       }
 
       return false;
-    }
+    },
   };
 }
 
 export function createStage1MailchimpArtifactImportService(
-  dependencies: Stage1MailchimpArtifactImportDependencies
+  dependencies: Stage1MailchimpArtifactImportDependencies,
 ) {
   const now = dependencies.now ?? (() => new Date());
 
   return {
     async importArtifacts(
-      input: MailchimpArtifactImportInput
+      input: MailchimpArtifactImportInput,
     ): Promise<Stage1MailchimpArtifactImportResult> {
       const parsedInput = mailchimpArtifactImportInputSchema.parse(input);
       const receivedAt = parsedInput.receivedAt ?? now().toISOString();
       const campaignPaths = await resolveCampaignArtifactPaths({
         artifactPath: parsedInput.artifactPath,
         limitCampaigns: parsedInput.limitCampaigns,
-        startAtCampaignId: parsedInput.startAtCampaignId
+        startAtCampaignId: parsedInput.startAtCampaignId,
       });
       const importedCampaignIds = campaignPaths.map((campaignPath) =>
-        basename(campaignPath)
+        basename(campaignPath),
       );
 
       if (campaignPaths.length === 0) {
         throw new Error(
-          `No Mailchimp campaign artifacts were found under ${parsedInput.artifactPath}.`
+          `No Mailchimp campaign artifacts were found under ${parsedInput.artifactPath}.`,
         );
       }
 
@@ -484,23 +1346,21 @@ export function createStage1MailchimpArtifactImportService(
         cursor: null,
         checkpoint: null,
         windowStart: null,
-        windowEnd: null
+        windowEnd: null,
       });
       const resumePlan = resolveMailchimpResumePlan(
         startedSyncState.cursor,
-        importedCampaignIds
+        importedCampaignIds,
       );
 
       let parsedRecords = 0;
       const ingestResults: Stage1IngestResult[] = [];
       let windowStart: string | null = startedSyncState.windowStart;
       let checkpoint: string | null = startedSyncState.windowEnd;
-      let unmatchedReportPaths:
-        | {
-            readonly jsonPath: string;
-            readonly csvPath: string;
-          }
-        | null = null;
+      let unmatchedReportPaths: {
+        readonly jsonPath: string;
+        readonly csvPath: string;
+      } | null = null;
       let skippedUnmatched = 0;
       const skippedRecipients = new Map<
         string,
@@ -527,9 +1387,9 @@ export function createStage1MailchimpArtifactImportService(
             continue;
           }
 
-          const records = await importMailchimpCampaignArtifactRecords({
+          const records = await importMailchimpCampaignArtifactRecordsFromPath({
             campaignPath,
-            receivedAt
+            receivedAt,
           });
           parsedRecords += records.length;
           const campaignWindow = calculateHistoricalWindow(records);
@@ -553,7 +1413,11 @@ export function createStage1MailchimpArtifactImportService(
               ? Math.min(resumePlan.resumeNextRecordIndex, records.length)
               : 0;
 
-          for (let recordIndex = 0; recordIndex < records.length; recordIndex += 1) {
+          for (
+            let recordIndex = 0;
+            recordIndex < records.length;
+            recordIndex += 1
+          ) {
             const record = records[recordIndex];
 
             if (record === undefined) {
@@ -567,7 +1431,8 @@ export function createStage1MailchimpArtifactImportService(
             if (!hasKnownIdentity) {
               skippedUnmatched += 1;
               const skippedKey = `${record.campaignId}:${record.memberId}`;
-              const existingSkippedRecipient = skippedRecipients.get(skippedKey);
+              const existingSkippedRecipient =
+                skippedRecipients.get(skippedKey);
 
               if (existingSkippedRecipient === undefined) {
                 skippedRecipients.set(skippedKey, {
@@ -580,7 +1445,7 @@ export function createStage1MailchimpArtifactImportService(
                   memberId: record.memberId,
                   email: record.normalizedEmail,
                   platformId: record.volunteerIdPlainValues[0] ?? null,
-                  activityTypes: new Set([record.activityType])
+                  activityTypes: new Set([record.activityType]),
                 });
               } else {
                 existingSkippedRecipient.activityTypes.add(record.activityType);
@@ -589,11 +1454,13 @@ export function createStage1MailchimpArtifactImportService(
               const mapped = mapMailchimpRecord(record);
               const duplicateResult = await findExistingDuplicateResult(
                 dependencies.persistence,
-                mapped
+                mapped,
               );
               const ingestResult =
                 duplicateResult ??
-                (await dependencies.ingest.ingestMailchimpHistoricalRecord(record));
+                (await dependencies.ingest.ingestMailchimpHistoricalRecord(
+                  record,
+                ));
               ingestResults.push(ingestResult);
               if (ingestResult.outcome === "quarantined") {
                 pendingDeadLetterCountIncrement += 1;
@@ -613,14 +1480,17 @@ export function createStage1MailchimpArtifactImportService(
                   canonicalEventId: mapped.command.input.canonicalEvent.id,
                   summary: mapped.command.input.canonicalEvent.summary,
                   snippet: mapped.command.input.canonicalEvent.snippet ?? "",
-                  occurredAt: mapped.command.input.sourceEvidence.receivedAt
+                  occurredAt: mapped.command.input.sourceEvidence.receivedAt,
                 });
               }
             }
 
             if (
               recordIndex >= resumeNextRecordIndex &&
-              shouldCheckpointMailchimpCampaignRecord(nextRecordIndex, records.length)
+              shouldCheckpointMailchimpCampaignRecord(
+                nextRecordIndex,
+                records.length,
+              )
             ) {
               latestCursor =
                 nextRecordIndex === records.length
@@ -635,7 +1505,7 @@ export function createStage1MailchimpArtifactImportService(
                 checkpoint,
                 windowStart,
                 windowEnd: checkpoint,
-                deadLetterCountIncrement: pendingDeadLetterCountIncrement
+                deadLetterCountIncrement: pendingDeadLetterCountIncrement,
               });
               pendingDeadLetterCountIncrement = 0;
             }
@@ -652,43 +1522,43 @@ export function createStage1MailchimpArtifactImportService(
               checkpoint,
               windowStart,
               windowEnd: checkpoint,
-              deadLetterCountIncrement: pendingDeadLetterCountIncrement
+              deadLetterCountIncrement: pendingDeadLetterCountIncrement,
             });
             pendingDeadLetterCountIncrement = 0;
           }
         }
 
         if (skippedRecipients.size > 0) {
-          const unmatchedRecipients: MailchimpUnmatchedRecipientRow[] = Array.from(
-            skippedRecipients.values()
-          ).map((recipient) => ({
-            campaignId: recipient.campaignId,
-            campaignName: recipient.campaignName,
-            audienceId: recipient.audienceId,
-            memberId: recipient.memberId,
-            email: recipient.email,
-            platformId: recipient.platformId,
-            activityTypes: Array.from(recipient.activityTypes).sort()
-          }));
-          const report = buildTypedMailchimpUnmatchedReport({
+          const unmatchedRecipients: MailchimpUnmatchedRecipientRow[] =
+            Array.from(skippedRecipients.values()).map((recipient) => ({
+              campaignId: recipient.campaignId,
+              campaignName: recipient.campaignName,
+              audienceId: recipient.audienceId,
+              memberId: recipient.memberId,
+              email: recipient.email,
+              platformId: recipient.platformId,
+              activityTypes: Array.from(recipient.activityTypes).sort(),
+            }));
+          const report = buildMailchimpUnmatchedReport({
             generatedAt: now().toISOString(),
             recipients: unmatchedRecipients,
             knownIdentityIndex:
-              dependencies.mailchimpIdentityIndex ?? emptyMailchimpKnownIdentityIndex
+              dependencies.mailchimpIdentityIndex ??
+              emptyMailchimpKnownIdentityIndex,
           });
 
-          unmatchedReportPaths = await writeTypedMailchimpUnmatchedReport({
+          unmatchedReportPaths = await writeMailchimpUnmatchedReport({
             outputRoot:
               parsedInput.unmatchedReportOutputRoot ??
               resolve(parsedInput.artifactPath, "..", "unmatched-reports"),
             reportId: parsedInput.syncStateId,
-            report
+            report,
           });
         }
 
         const summary = summarizeIngestResults(ingestResults, {
           skippedUnmatched,
-          skippedUnmatchedRecipients: skippedRecipients.size
+          skippedUnmatchedRecipients: skippedRecipients.size,
         });
         const completedSyncState = await dependencies.syncState.completeWindow({
           syncStateId: parsedInput.syncStateId,
@@ -702,7 +1572,7 @@ export function createStage1MailchimpArtifactImportService(
           parityPercent: null,
           freshnessP95Seconds: null,
           freshnessP99Seconds: null,
-          completedAt: now().toISOString()
+          completedAt: now().toISOString(),
         });
 
         return {
@@ -720,8 +1590,8 @@ export function createStage1MailchimpArtifactImportService(
             ? {}
             : {
                 unmatchedReportJsonPath: unmatchedReportPaths.jsonPath,
-                unmatchedReportCsvPath: unmatchedReportPaths.csvPath
-              })
+                unmatchedReportCsvPath: unmatchedReportPaths.csvPath,
+              }),
         };
       } catch (error) {
         const failure = buildImportFailure(error);
@@ -735,7 +1605,7 @@ export function createStage1MailchimpArtifactImportService(
           windowStart,
           windowEnd: checkpoint,
           deadLetterCountIncrement: pendingDeadLetterCountIncrement,
-          deadLettered: false
+          deadLettered: false,
         });
         await recordSyncFailureAudit(dependencies.persistence, {
           syncStateId: parsedInput.syncStateId,
@@ -747,7 +1617,7 @@ export function createStage1MailchimpArtifactImportService(
           windowEnd: checkpoint,
           failure,
           occurredAt: now().toISOString(),
-          actorId: "stage1-mailchimp-artifact-import"
+          actorId: "stage1-mailchimp-artifact-import",
         });
 
         return {
@@ -761,8 +1631,8 @@ export function createStage1MailchimpArtifactImportService(
           summary: {
             ...summarizeIngestResults(ingestResults, {
               skippedUnmatched,
-              skippedUnmatchedRecipients: skippedRecipients.size
-            })
+              skippedUnmatchedRecipients: skippedRecipients.size,
+            }),
           },
           checkpoint,
           syncStatus: failedSyncState.status,
@@ -771,10 +1641,10 @@ export function createStage1MailchimpArtifactImportService(
             ? {}
             : {
                 unmatchedReportJsonPath: unmatchedReportPaths.jsonPath,
-                unmatchedReportCsvPath: unmatchedReportPaths.csvPath
-              })
+                unmatchedReportCsvPath: unmatchedReportPaths.csvPath,
+              }),
         };
       }
-    }
+    },
   };
 }

--- a/apps/worker/src/orchestration/service.ts
+++ b/apps/worker/src/orchestration/service.ts
@@ -24,7 +24,7 @@ import {
   type ProjectionRebuildBatchPayload,
   type Provider,
   type ReplayBatchPayload,
-  type SyncJobType
+  type SyncJobType,
 } from "@as-comms/contracts";
 import {
   ProviderCaptureError,
@@ -32,27 +32,30 @@ import {
   mapGmailRecord,
   mapMailchimpRecord,
   mapSalesforceRecord,
-  mapSimpleTextingRecord
+  mapSimpleTextingRecord,
 } from "@as-comms/integrations";
 import type {
   GmailRecord,
   MailchimpRecord,
   ProviderMappingResult,
   SalesforceRecord,
-  SimpleTextingRecord
+  SimpleTextingRecord,
 } from "@as-comms/integrations";
 import type {
   Stage1NormalizationService,
-  Stage1PersistenceService
+  Stage1PersistenceService,
 } from "@as-comms/domain";
 
 import type { Stage1IngestService } from "../ingest/service.js";
 import type { Stage1IngestResult } from "../ingest/types.js";
 import {
   Stage1NonRetryableJobError,
-  Stage1RetryableJobError
+  Stage1RetryableJobError,
 } from "./errors.js";
-import { projectionSeedPolicyCode, recordProjectionSeedOnce } from "./projection-seed.js";
+import {
+  projectionSeedPolicyCode,
+  recordProjectionSeedOnce,
+} from "./projection-seed.js";
 import { recordSyncFailureAudit } from "./sync-failure-audit.js";
 import { createStage1SyncStateService } from "./sync-state.js";
 import type {
@@ -69,7 +72,7 @@ import type {
   Stage1ProjectionSeed,
   Stage1ProviderCapturePorts,
   Stage1SampledParityContact,
-  Stage1WorkerOrchestrationService
+  Stage1WorkerOrchestrationService,
 } from "./types.js";
 
 const paritySnapshotPolicyCode = "stage1.parity.snapshot";
@@ -84,6 +87,10 @@ type CapturedProviderRecord =
   | SalesforceRecord
   | SimpleTextingRecord
   | MailchimpRecord;
+type Stage1WorkerProvider = Provider | "manual";
+type Stage1ProjectionEventType =
+  | CanonicalEventRecord["eventType"]
+  | "note.internal.created";
 
 interface Stage1FreshnessMetrics {
   readonly p95Seconds: number | null;
@@ -105,7 +112,9 @@ function buildHistoricalReplayProjectInboxAliases(input: {
   readonly recordedProjectInboxAlias: string | null;
 }): string[] {
   const aliases = new Set(
-    input.configuredAliases.map((alias) => alias.trim()).filter((alias) => alias.length > 0)
+    input.configuredAliases
+      .map((alias) => alias.trim())
+      .filter((alias) => alias.length > 0),
   );
 
   if (
@@ -120,7 +129,7 @@ function buildHistoricalReplayProjectInboxAliases(input: {
 
 function compareEventOrder(
   left: CanonicalEventRecord,
-  right: CanonicalEventRecord
+  right: CanonicalEventRecord,
 ): number {
   if (left.occurredAt < right.occurredAt) {
     return -1;
@@ -134,121 +143,132 @@ function compareEventOrder(
 }
 
 function isInboxDrivingEvent(
-  eventType: CanonicalEventRecord["eventType"]
+  eventType: CanonicalEventRecord["eventType"],
 ): boolean {
   return inboxDrivingEventTypes.has(eventType);
 }
 
 function buildDefaultProjectionSeed(
-  eventType: CanonicalEventRecord["eventType"]
+  eventType: Stage1ProjectionEventType,
 ): Stage1ProjectionSeed {
   switch (eventType) {
     case "communication.email.inbound":
       return {
         summary: "Inbound email received",
         snippet: "",
-        source: "fallback"
+        source: "fallback",
       };
     case "communication.email.outbound":
       return {
         summary: "Outbound email sent",
         snippet: "",
-        source: "fallback"
+        source: "fallback",
       };
     case "communication.sms.inbound":
       return {
         summary: "Inbound SMS received",
         snippet: "",
-        source: "fallback"
+        source: "fallback",
       };
     case "communication.sms.outbound":
       return {
         summary: "Outbound SMS sent",
         snippet: "",
-        source: "fallback"
+        source: "fallback",
       };
     case "communication.sms.opt_in":
       return {
         summary: "SMS opt-in received",
         snippet: "",
-        source: "fallback"
+        source: "fallback",
       };
     case "communication.sms.opt_out":
       return {
         summary: "SMS opt-out received",
         snippet: "",
-        source: "fallback"
+        source: "fallback",
       };
     case "lifecycle.signed_up":
       return {
         summary: "Volunteer signed up",
         snippet: "",
-        source: "fallback"
+        source: "fallback",
       };
     case "lifecycle.received_training":
       return {
         summary: "Volunteer received training",
         snippet: "",
-        source: "fallback"
+        source: "fallback",
       };
     case "lifecycle.completed_training":
       return {
         summary: "Volunteer completed training",
         snippet: "",
-        source: "fallback"
+        source: "fallback",
       };
     case "lifecycle.submitted_first_data":
       return {
         summary: "Volunteer submitted first data",
         snippet: "",
-        source: "fallback"
+        source: "fallback",
       };
     case "campaign.email.sent":
       return {
         summary: "Campaign email sent",
         snippet: "",
-        source: "fallback"
+        source: "fallback",
       };
     case "campaign.email.opened":
       return {
         summary: "Campaign email opened",
         snippet: "",
-        source: "fallback"
+        source: "fallback",
       };
     case "campaign.email.clicked":
       return {
         summary: "Campaign email clicked",
         snippet: "",
-        source: "fallback"
+        source: "fallback",
       };
     case "campaign.email.unsubscribed":
       return {
         summary: "Campaign email unsubscribed",
         snippet: "",
-        source: "fallback"
+        source: "fallback",
+      };
+    case "note.internal.created":
+      return {
+        summary: "Internal note added",
+        snippet: "",
+        source: "fallback",
       };
   }
 }
 
 function summarizeIngestResults(
-  results: readonly Stage1IngestResult[]
+  results: readonly Stage1IngestResult[],
 ): Stage1IngestBatchSummary {
   return {
     processed: results.length,
-    normalized: results.filter((result) => result.outcome === "normalized").length,
-    duplicate: results.filter((result) => result.outcome === "duplicate").length,
+    normalized: results.filter((result) => result.outcome === "normalized")
+      .length,
+    duplicate: results.filter((result) => result.outcome === "duplicate")
+      .length,
     reviewOpened: results.filter((result) => result.outcome === "review_opened")
       .length,
     quarantined: results.filter((result) => result.outcome === "quarantined")
       .length,
     deferred: results.filter((result) => result.outcome === "deferred").length,
     deadLetterCountIncrement: results.filter(
-      (result) => result.outcome === "quarantined"
-    ).length
+      (result) => result.outcome === "quarantined",
+    ).length,
   };
 }
 
-function calculateParityPercent(numerator: number, denominator: number): number {
+function calculateParityPercent(
+  numerator: number,
+  denominator: number,
+): number {
   if (denominator === 0) {
     return 100;
   }
@@ -262,7 +282,7 @@ function formatPercent(value: number): string {
 
 function calculatePercentileSeconds(
   values: readonly number[],
-  percentile: number
+  percentile: number,
 ): number | null {
   if (values.length === 0) {
     return null;
@@ -271,7 +291,7 @@ function calculatePercentileSeconds(
   const sorted = [...values].sort((left, right) => left - right);
   const index = Math.min(
     sorted.length - 1,
-    Math.max(0, Math.ceil(sorted.length * percentile) - 1)
+    Math.max(0, Math.ceil(sorted.length * percentile) - 1),
   );
   const value = sorted[index];
 
@@ -284,7 +304,7 @@ function calculatePercentileSeconds(
 
 function toFreshnessSeconds(
   occurredAt: string,
-  receivedAt: string
+  receivedAt: string,
 ): number | null {
   const occurredAtMs = Date.parse(occurredAt);
   const receivedAtMs = Date.parse(receivedAt);
@@ -296,9 +316,7 @@ function toFreshnessSeconds(
   return Math.max(0, Math.round((receivedAtMs - occurredAtMs) / 1000));
 }
 
-function hasTimedTimestamps(
-  record: CapturedProviderRecord
-): record is Extract<
+function hasTimedTimestamps(record: CapturedProviderRecord): record is Extract<
   CapturedProviderRecord,
   {
     readonly occurredAt: string;
@@ -309,9 +327,9 @@ function hasTimedTimestamps(
 }
 
 function extractFreshnessSample(
-  provider: Provider,
+  provider: Stage1WorkerProvider,
   jobType: SyncJobType,
-  record: CapturedProviderRecord
+  record: CapturedProviderRecord,
 ): number | null {
   if (jobType !== "live_ingest") {
     return null;
@@ -323,9 +341,8 @@ function extractFreshnessSample(
         ? toFreshnessSeconds(record.occurredAt, record.receivedAt)
         : null;
     case "salesforce":
-      return (
-        record.recordType === "lifecycle_milestone" && hasTimedTimestamps(record)
-      )
+      return record.recordType === "lifecycle_milestone" &&
+        hasTimedTimestamps(record)
         ? toFreshnessSeconds(record.occurredAt, record.receivedAt)
         : null;
     case "simpletexting":
@@ -333,6 +350,7 @@ function extractFreshnessSample(
         ? toFreshnessSeconds(record.occurredAt, record.receivedAt)
         : null;
     case "mailchimp":
+    case "manual":
       return null;
   }
 }
@@ -340,7 +358,7 @@ function extractFreshnessSample(
 function calculateFreshnessMetrics(
   provider: Provider,
   jobType: SyncJobType,
-  records: readonly CapturedProviderRecord[]
+  records: readonly CapturedProviderRecord[],
 ): Stage1FreshnessMetrics {
   const samples = records
     .map((record) => extractFreshnessSample(provider, jobType, record))
@@ -348,22 +366,25 @@ function calculateFreshnessMetrics(
 
   return {
     p95Seconds: calculatePercentileSeconds(samples, 0.95),
-    p99Seconds: calculatePercentileSeconds(samples, 0.99)
+    p99Seconds: calculatePercentileSeconds(samples, 0.99),
   };
 }
 
 function buildJobFailure(
   error: unknown,
   attempt: number,
-  maxAttempts: number
+  maxAttempts: number,
 ): Stage1JobFailure {
   const message = error instanceof Error ? error.message : String(error);
 
-  if (error instanceof Stage1NonRetryableJobError || error instanceof ZodError) {
+  if (
+    error instanceof Stage1NonRetryableJobError ||
+    error instanceof ZodError
+  ) {
     return {
       disposition: "non_retryable",
       retryable: false,
-      message
+      message,
     };
   }
 
@@ -375,7 +396,7 @@ function buildJobFailure(
           : "retryable"
         : "non_retryable",
       retryable: error.retryable && attempt < maxAttempts,
-      message
+      message,
     };
   }
 
@@ -383,7 +404,7 @@ function buildJobFailure(
     return {
       disposition: "dead_letter",
       retryable: false,
-      message
+      message,
     };
   }
 
@@ -391,20 +412,21 @@ function buildJobFailure(
     disposition:
       error instanceof Stage1RetryableJobError ? "retryable" : "retryable",
     retryable: true,
-    message
+    message,
   };
 }
 
 async function loadProjectionSeed(
   persistence: Stage1PersistenceService,
-  event: CanonicalEventRecord
+  event: CanonicalEventRecord,
 ): Promise<Stage1ProjectionSeed> {
-  const existingRecords = await persistence.repositories.auditEvidence.listByEntity({
-    entityType: "canonical_event",
-    entityId: event.id
-  });
+  const existingRecords =
+    await persistence.repositories.auditEvidence.listByEntity({
+      entityType: "canonical_event",
+      entityId: event.id,
+    });
   const projectionSeedRecord = existingRecords.find(
-    (record) => record.policyCode === projectionSeedPolicyCode
+    (record) => record.policyCode === projectionSeedPolicyCode,
   );
 
   if (projectionSeedRecord !== undefined) {
@@ -415,7 +437,7 @@ async function loadProjectionSeed(
       return {
         summary: summaryValue,
         snippet: snippetValue,
-        source: "audit"
+        source: "audit",
       };
     }
   }
@@ -424,8 +446,12 @@ async function loadProjectionSeed(
 }
 
 function getMappedResultForRecord(
-  provider: Provider,
-  record: GmailRecord | SalesforceRecord | SimpleTextingRecord | MailchimpRecord
+  provider: Stage1WorkerProvider,
+  record:
+    | GmailRecord
+    | SalesforceRecord
+    | SimpleTextingRecord
+    | MailchimpRecord,
 ): ProviderMappingResult {
   switch (provider) {
     case "gmail":
@@ -436,12 +462,16 @@ function getMappedResultForRecord(
       return mapSimpleTextingRecord(record as SimpleTextingRecord);
     case "mailchimp":
       return mapMailchimpRecord(record as MailchimpRecord);
+    case "manual":
+      throw new Stage1NonRetryableJobError(
+        "Manual note provider records are not mapped through worker orchestration.",
+      );
   }
 }
 
 function prioritizeCapturedRecordsForIngest<TRecord>(
   records: readonly TRecord[],
-  mapRecord: (record: TRecord) => ProviderMappingResult
+  mapRecord: (record: TRecord) => ProviderMappingResult,
 ): {
   readonly record: TRecord;
   readonly mapped: ProviderMappingResult;
@@ -459,7 +489,10 @@ function prioritizeCapturedRecordsForIngest<TRecord>(
     const mapped = mapRecord(record);
     const entry = { record, mapped };
 
-    if (mapped.outcome === "command" && mapped.command.kind === "contact_graph") {
+    if (
+      mapped.outcome === "command" &&
+      mapped.command.kind === "contact_graph"
+    ) {
       contactGraphRecords.push(entry);
       continue;
     }
@@ -474,7 +507,7 @@ async function captureRecordsForReplay(
   capture: Stage1ProviderCapturePorts,
   persistence: Stage1PersistenceService,
   gmailHistoricalReplay: Stage1GmailHistoricalReplayConfig,
-  payload: ReplayBatchPayload
+  payload: ReplayBatchPayload,
 ): Promise<{
   readonly records: readonly (
     | GmailRecord
@@ -487,8 +520,9 @@ async function captureRecordsForReplay(
 }> {
   const replayMaxRecords =
     payload.provider === "salesforce" ? 1000 : payload.items.length;
+  const replayProvider = payload.provider as Stage1WorkerProvider;
 
-  switch (payload.provider) {
+  switch (replayProvider) {
     case "gmail":
       return payload.mode === "historical"
         ? captureHistoricalGmailRecordsForReplay(
@@ -504,8 +538,8 @@ async function captureRecordsForReplay(
               windowStart: null,
               windowEnd: null,
               recordIds: payload.items.map((item) => item.providerRecordId),
-              maxRecords: replayMaxRecords
-            })
+              maxRecords: replayMaxRecords,
+            }),
           )
         : capture.gmail.captureLiveBatch(
             gmailLiveCaptureBatchPayloadSchema.parse({
@@ -518,8 +552,8 @@ async function captureRecordsForReplay(
               windowStart: null,
               windowEnd: null,
               recordIds: payload.items.map((item) => item.providerRecordId),
-              maxRecords: replayMaxRecords
-            })
+              maxRecords: replayMaxRecords,
+            }),
           );
     case "salesforce":
       return payload.mode === "historical"
@@ -534,8 +568,8 @@ async function captureRecordsForReplay(
               windowStart: null,
               windowEnd: null,
               recordIds: payload.items.map((item) => item.providerRecordId),
-              maxRecords: replayMaxRecords
-            })
+              maxRecords: replayMaxRecords,
+            }),
           )
         : capture.salesforce.captureLiveBatch(
             salesforceLiveCaptureBatchPayloadSchema.parse({
@@ -548,8 +582,8 @@ async function captureRecordsForReplay(
               windowStart: null,
               windowEnd: null,
               recordIds: payload.items.map((item) => item.providerRecordId),
-              maxRecords: replayMaxRecords
-            })
+              maxRecords: replayMaxRecords,
+            }),
           );
     case "simpletexting":
       return payload.mode === "historical"
@@ -564,8 +598,8 @@ async function captureRecordsForReplay(
               windowStart: null,
               windowEnd: null,
               recordIds: payload.items.map((item) => item.providerRecordId),
-              maxRecords: replayMaxRecords
-            })
+              maxRecords: replayMaxRecords,
+            }),
           )
         : capture.simpleTexting.captureLiveBatch(
             simpleTextingLiveCaptureBatchPayloadSchema.parse({
@@ -578,8 +612,8 @@ async function captureRecordsForReplay(
               windowStart: null,
               windowEnd: null,
               recordIds: payload.items.map((item) => item.providerRecordId),
-              maxRecords: replayMaxRecords
-            })
+              maxRecords: replayMaxRecords,
+            }),
           );
     case "mailchimp":
       return payload.mode === "historical"
@@ -594,8 +628,8 @@ async function captureRecordsForReplay(
               windowStart: null,
               windowEnd: null,
               recordIds: payload.items.map((item) => item.providerRecordId),
-              maxRecords: replayMaxRecords
-            })
+              maxRecords: replayMaxRecords,
+            }),
           )
         : capture.mailchimp.captureTransitionBatch(
             mailchimpTransitionCaptureBatchPayloadSchema.parse({
@@ -608,30 +642,34 @@ async function captureRecordsForReplay(
               windowStart: null,
               windowEnd: null,
               recordIds: payload.items.map((item) => item.providerRecordId),
-              maxRecords: replayMaxRecords
-            })
+              maxRecords: replayMaxRecords,
+            }),
           );
+    case "manual":
+      throw new Stage1NonRetryableJobError(
+        "Manual note provider is not supported for replay capture batches.",
+      );
   }
 }
 
 function parseGmailHistoricalPayloadRef(
-  payloadRef: string
+  payloadRef: string,
 ): ParsedGmailHistoricalPayloadRef {
   if (!payloadRef.startsWith("mbox://")) {
     throw new Stage1NonRetryableJobError(
-      `Expected Gmail historical replay payloadRef to use the mbox:// scheme, received ${payloadRef}.`
+      `Expected Gmail historical replay payloadRef to use the mbox:// scheme, received ${payloadRef}.`,
     );
   }
 
   const hashIndex = payloadRef.indexOf("#");
   const encodedPath = payloadRef.slice(
     "mbox://".length,
-    hashIndex === -1 ? undefined : hashIndex
+    hashIndex === -1 ? undefined : hashIndex,
   );
 
   if (encodedPath.trim().length === 0) {
     throw new Stage1NonRetryableJobError(
-      `Expected Gmail historical replay payloadRef to include an mbox path, received ${payloadRef}.`
+      `Expected Gmail historical replay payloadRef to include an mbox path, received ${payloadRef}.`,
     );
   }
 
@@ -641,12 +679,12 @@ function parseGmailHistoricalPayloadRef(
     mboxPath = decodeURIComponent(encodedPath);
   } catch {
     throw new Stage1NonRetryableJobError(
-      `Expected Gmail historical replay payloadRef to contain a valid encoded mbox path, received ${payloadRef}.`
+      `Expected Gmail historical replay payloadRef to contain a valid encoded mbox path, received ${payloadRef}.`,
     );
   }
 
   const searchParams = new URLSearchParams(
-    hashIndex === -1 ? "" : payloadRef.slice(hashIndex + 1)
+    hashIndex === -1 ? "" : payloadRef.slice(hashIndex + 1),
   );
   const messageValue = searchParams.get("message");
   const messageNumber =
@@ -654,20 +692,20 @@ function parseGmailHistoricalPayloadRef(
 
   if (!Number.isInteger(messageNumber) || messageNumber < 1) {
     throw new Stage1NonRetryableJobError(
-      `Expected Gmail historical replay payloadRef to include a positive message number, received ${payloadRef}.`
+      `Expected Gmail historical replay payloadRef to include a positive message number, received ${payloadRef}.`,
     );
   }
 
   return {
     mboxPath,
-    messageNumber
+    messageNumber,
   };
 }
 
 async function captureHistoricalGmailRecordsForReplay(
   persistence: Stage1PersistenceService,
   gmailHistoricalReplay: Stage1GmailHistoricalReplayConfig,
-  payload: z.infer<typeof gmailHistoricalCaptureBatchPayloadSchema>
+  payload: z.infer<typeof gmailHistoricalCaptureBatchPayloadSchema>,
 ): Promise<{
   readonly records: readonly GmailRecord[];
   readonly nextCursor: string | null;
@@ -675,29 +713,32 @@ async function captureHistoricalGmailRecordsForReplay(
 }> {
   const sourceEvidenceRecords = await Promise.all(
     payload.recordIds.map(async (recordId: string) => {
-      const matches = await persistence.repositories.sourceEvidence.listByProviderRecord({
-        provider: "gmail",
-        providerRecordType: "message",
-        providerRecordId: recordId
-      });
+      const matches =
+        await persistence.repositories.sourceEvidence.listByProviderRecord({
+          provider: "gmail",
+          providerRecordType: "message",
+          providerRecordId: recordId,
+        });
 
       return matches.at(-1) ?? null;
-    })
+    }),
   );
-  const gmailDetails = await persistence.repositories.gmailMessageDetails.listBySourceEvidenceIds(
-    sourceEvidenceRecords
-      .filter(
-        (
-          record: (typeof sourceEvidenceRecords)[number]
-        ): record is NonNullable<(typeof sourceEvidenceRecords)[number]> =>
-          record !== null
-      )
-      .map(
-        (record: NonNullable<(typeof sourceEvidenceRecords)[number]>) => record.id
-      )
-  );
+  const gmailDetails =
+    await persistence.repositories.gmailMessageDetails.listBySourceEvidenceIds(
+      sourceEvidenceRecords
+        .filter(
+          (
+            record: (typeof sourceEvidenceRecords)[number],
+          ): record is NonNullable<(typeof sourceEvidenceRecords)[number]> =>
+            record !== null,
+        )
+        .map(
+          (record: NonNullable<(typeof sourceEvidenceRecords)[number]>) =>
+            record.id,
+        ),
+    );
   const gmailDetailBySourceEvidenceId = new Map(
-    gmailDetails.map((detail) => [detail.sourceEvidenceId, detail])
+    gmailDetails.map((detail) => [detail.sourceEvidenceId, detail]),
   );
   const mboxTextByPath = new Map<string, string>();
   const importedRecordsByCacheKey = new Map<string, readonly GmailRecord[]>();
@@ -714,11 +755,13 @@ async function captureHistoricalGmailRecordsForReplay(
 
     if (gmailDetail === undefined) {
       throw new Stage1NonRetryableJobError(
-        `Expected gmail_message_details to exist for historical replay source evidence ${sourceEvidence.id}.`
+        `Expected gmail_message_details to exist for historical replay source evidence ${sourceEvidence.id}.`,
       );
     }
 
-    const parsedPayloadRef = parseGmailHistoricalPayloadRef(sourceEvidence.payloadRef);
+    const parsedPayloadRef = parseGmailHistoricalPayloadRef(
+      sourceEvidence.payloadRef,
+    );
     let mboxText = mboxTextByPath.get(parsedPayloadRef.mboxPath);
 
     if (mboxText === undefined) {
@@ -728,7 +771,7 @@ async function captureHistoricalGmailRecordsForReplay(
         const message = error instanceof Error ? error.message : String(error);
 
         throw new Stage1NonRetryableJobError(
-          `Unable to read Gmail historical replay payload file ${parsedPayloadRef.mboxPath}: ${message}`
+          `Unable to read Gmail historical replay payload file ${parsedPayloadRef.mboxPath}: ${message}`,
         );
       }
 
@@ -739,14 +782,14 @@ async function captureHistoricalGmailRecordsForReplay(
       gmailDetail.capturedMailbox ?? gmailHistoricalReplay.liveAccount;
     const replayProjectInboxAliases = buildHistoricalReplayProjectInboxAliases({
       configuredAliases: gmailHistoricalReplay.projectInboxAliases,
-      recordedProjectInboxAlias: gmailDetail.projectInboxAlias
+      recordedProjectInboxAlias: gmailDetail.projectInboxAlias,
     });
     const importedRecordCacheKey = JSON.stringify({
       mboxPath: parsedPayloadRef.mboxPath,
       capturedMailbox,
       projectInboxAliases: replayProjectInboxAliases,
       projectInboxAliasOverride: gmailDetail.projectInboxAlias,
-      receivedAt: sourceEvidence.receivedAt
+      receivedAt: sourceEvidence.receivedAt,
     });
     let importedRecords = importedRecordsByCacheKey.get(importedRecordCacheKey);
 
@@ -758,7 +801,7 @@ async function captureHistoricalGmailRecordsForReplay(
         liveAccount: gmailHistoricalReplay.liveAccount,
         projectInboxAliases: replayProjectInboxAliases,
         projectInboxAliasOverride: gmailDetail.projectInboxAlias,
-        receivedAt: sourceEvidence.receivedAt
+        receivedAt: sourceEvidence.receivedAt,
       });
       importedRecordsByCacheKey.set(importedRecordCacheKey, importedRecords);
     }
@@ -770,7 +813,7 @@ async function captureHistoricalGmailRecordsForReplay(
       replayedRecord.recordId !== recordId
     ) {
       throw new Stage1NonRetryableJobError(
-        `Unable to reconstruct Gmail historical replay record message:${recordId} from ${parsedPayloadRef.mboxPath}#message=${String(parsedPayloadRef.messageNumber)}.`
+        `Unable to reconstruct Gmail historical replay record message:${recordId} from ${parsedPayloadRef.mboxPath}#message=${String(parsedPayloadRef.messageNumber)}.`,
       );
     }
 
@@ -780,7 +823,7 @@ async function captureHistoricalGmailRecordsForReplay(
   return {
     records,
     nextCursor: null,
-    checkpoint: payload.recordIds.at(-1) ?? null
+    checkpoint: payload.recordIds.at(-1) ?? null,
   };
 }
 
@@ -789,7 +832,9 @@ export function createStage1WorkerOrchestrationService(input: {
   readonly ingest: Stage1IngestService;
   readonly normalization: Pick<
     Stage1NormalizationService,
-    "applyInboxProjection" | "applyTimelineProjection" | "refreshInboxReviewOverlay"
+    | "applyInboxProjection"
+    | "applyTimelineProjection"
+    | "refreshInboxReviewOverlay"
   >;
   readonly persistence: Stage1PersistenceService;
   readonly gmailHistoricalReplay: Stage1GmailHistoricalReplayConfig;
@@ -809,9 +854,7 @@ export function createStage1WorkerOrchestrationService(input: {
       readonly attempt: number;
       readonly maxAttempts: number;
     };
-    readonly capture: (
-      payload: TPayload
-    ) => Promise<{
+    readonly capture: (payload: TPayload) => Promise<{
       readonly records: readonly TRecord[];
       readonly nextCursor: string | null;
       readonly checkpoint: string | null;
@@ -828,7 +871,7 @@ export function createStage1WorkerOrchestrationService(input: {
       cursor: payload.cursor,
       checkpoint: payload.checkpoint,
       windowStart: payload.windowStart,
-      windowEnd: payload.windowEnd
+      windowEnd: payload.windowEnd,
     });
 
     try {
@@ -836,7 +879,7 @@ export function createStage1WorkerOrchestrationService(input: {
       const ingestResults: Stage1IngestResult[] = [];
       const prioritizedRecords = prioritizeCapturedRecordsForIngest(
         captured.records,
-        params.mapRecord
+        params.mapRecord,
       );
 
       for (const { record, mapped } of prioritizedRecords) {
@@ -848,12 +891,15 @@ export function createStage1WorkerOrchestrationService(input: {
           ingestResult.outcome !== "quarantined" &&
           ingestResult.canonicalEventId !== null
         ) {
-          if (mapped.outcome === "command" && mapped.command.kind === "canonical_event") {
+          if (
+            mapped.outcome === "command" &&
+            mapped.command.kind === "canonical_event"
+          ) {
             await recordProjectionSeedOnce(input.persistence, {
               canonicalEventId: mapped.command.input.canonicalEvent.id,
               summary: mapped.command.input.canonicalEvent.summary,
               snippet: mapped.command.input.canonicalEvent.snippet ?? "",
-              occurredAt: mapped.command.input.sourceEvidence.receivedAt
+              occurredAt: mapped.command.input.sourceEvidence.receivedAt,
             });
           }
         }
@@ -863,7 +909,7 @@ export function createStage1WorkerOrchestrationService(input: {
       const freshnessMetrics = calculateFreshnessMetrics(
         payload.provider,
         payload.jobType,
-        captured.records as readonly CapturedProviderRecord[]
+        captured.records as readonly CapturedProviderRecord[],
       );
       await syncState.recordBatchProgress({
         syncStateId: payload.syncStateId,
@@ -874,7 +920,7 @@ export function createStage1WorkerOrchestrationService(input: {
         checkpoint: captured.checkpoint,
         windowStart: payload.windowStart,
         windowEnd: payload.windowEnd,
-        deadLetterCountIncrement: summary.deadLetterCountIncrement
+        deadLetterCountIncrement: summary.deadLetterCountIncrement,
       });
       const completedSyncState = await syncState.completeWindow({
         syncStateId: payload.syncStateId,
@@ -888,7 +934,7 @@ export function createStage1WorkerOrchestrationService(input: {
         parityPercent: null,
         freshnessP95Seconds: freshnessMetrics.p95Seconds,
         freshnessP99Seconds: freshnessMetrics.p99Seconds,
-        completedAt: payload.windowEnd ?? new Date().toISOString()
+        completedAt: payload.windowEnd ?? new Date().toISOString(),
       });
 
       return {
@@ -898,10 +944,14 @@ export function createStage1WorkerOrchestrationService(input: {
         summary,
         ingestResults,
         nextCursor: captured.nextCursor,
-        checkpoint: captured.checkpoint
+        checkpoint: captured.checkpoint,
       };
     } catch (error) {
-      const failure = buildJobFailure(error, payload.attempt, payload.maxAttempts);
+      const failure = buildJobFailure(
+        error,
+        payload.attempt,
+        payload.maxAttempts,
+      );
       const failedSyncState = await syncState.failWindow({
         syncStateId: payload.syncStateId,
         scope: "provider",
@@ -912,7 +962,7 @@ export function createStage1WorkerOrchestrationService(input: {
         windowStart: payload.windowStart,
         windowEnd: payload.windowEnd,
         deadLetterCountIncrement: failure.disposition === "dead_letter" ? 1 : 0,
-        deadLettered: failure.disposition === "dead_letter"
+        deadLettered: failure.disposition === "dead_letter",
       });
       await recordSyncFailureAudit(input.persistence, {
         syncStateId: payload.syncStateId,
@@ -924,7 +974,7 @@ export function createStage1WorkerOrchestrationService(input: {
         windowEnd: payload.windowEnd,
         failure,
         occurredAt: new Date().toISOString(),
-        actorId: "stage1-orchestration"
+        actorId: "stage1-orchestration",
       });
 
       return {
@@ -939,18 +989,18 @@ export function createStage1WorkerOrchestrationService(input: {
           quarantined: 0,
           deferred: 0,
           deadLetterCountIncrement:
-            failure.disposition === "dead_letter" ? 1 : 0
+            failure.disposition === "dead_letter" ? 1 : 0,
         },
         ingestResults: [],
         nextCursor: payload.cursor,
         checkpoint: payload.checkpoint,
-        failure
+        failure,
       };
     }
   }
 
   async function runProjectionRebuildBatch(
-    rawPayload: ProjectionRebuildBatchPayload
+    rawPayload: ProjectionRebuildBatchPayload,
   ): Promise<Stage1ProjectionRebuildJobOutcome> {
     const payload = projectionRebuildBatchPayloadSchema.parse(rawPayload);
     await syncState.startWindow({
@@ -961,7 +1011,7 @@ export function createStage1WorkerOrchestrationService(input: {
       cursor: null,
       checkpoint: payload.batchId,
       windowStart: null,
-      windowEnd: null
+      windowEnd: null,
     });
 
     try {
@@ -969,10 +1019,10 @@ export function createStage1WorkerOrchestrationService(input: {
         payload.contactIds.length > 0
           ? payload.contactIds
           : (await input.persistence.repositories.contacts.listAll()).map(
-              (contact) => contact.id
+              (contact) => contact.id,
             );
       const rebuiltContactIds = [...contacts].sort((left, right) =>
-        left.localeCompare(right)
+        left.localeCompare(right),
       );
       const missingProjectionSeeds = new Set<string>();
       const discrepancies: Stage1OperationalDiscrepancy[] = [];
@@ -980,23 +1030,29 @@ export function createStage1WorkerOrchestrationService(input: {
       let rebuiltInboxRows = 0;
 
       for (const contactId of rebuiltContactIds) {
-        const canonicalEvents = [...(
-          await input.persistence.repositories.canonicalEvents.listByContactId(
-            contactId
-          )
-        )].sort(compareEventOrder);
+        const canonicalEvents = [
+          ...(await input.persistence.repositories.canonicalEvents.listByContactId(
+            contactId,
+          )),
+        ].sort(compareEventOrder);
 
         for (const event of canonicalEvents) {
-          const projectionSeed = await loadProjectionSeed(input.persistence, event);
+          const projectionSeed = await loadProjectionSeed(
+            input.persistence,
+            event,
+          );
 
           if (projectionSeed.source === "fallback") {
             missingProjectionSeeds.add(event.id);
           }
 
-          if (payload.projection === "timeline" || payload.projection === "all") {
+          if (
+            payload.projection === "timeline" ||
+            payload.projection === "all"
+          ) {
             await input.normalization.applyTimelineProjection({
               canonicalEvent: event,
-              summary: projectionSeed.summary
+              summary: projectionSeed.summary,
             });
             rebuiltTimelineRows += 1;
           }
@@ -1007,7 +1063,7 @@ export function createStage1WorkerOrchestrationService(input: {
           ) {
             await input.normalization.applyInboxProjection({
               canonicalEvent: event,
-              snippet: projectionSeed.snippet
+              snippet: projectionSeed.snippet,
             });
             rebuiltInboxRows += 1;
           }
@@ -1018,7 +1074,7 @@ export function createStage1WorkerOrchestrationService(input: {
           (payload.projection === "inbox" || payload.projection === "all")
         ) {
           await input.normalization.refreshInboxReviewOverlay({
-            contactId
+            contactId,
           });
         }
       }
@@ -1030,8 +1086,8 @@ export function createStage1WorkerOrchestrationService(input: {
           message:
             "One or more canonical events were rebuilt with fallback summary or snippet values because no durable projection seed audit record was present.",
           entityIds: Array.from(missingProjectionSeeds).sort((left, right) =>
-            left.localeCompare(right)
-          )
+            left.localeCompare(right),
+          ),
         });
       }
 
@@ -1047,7 +1103,7 @@ export function createStage1WorkerOrchestrationService(input: {
         parityPercent: null,
         freshnessP95Seconds: null,
         freshnessP99Seconds: null,
-        completedAt: new Date().toISOString()
+        completedAt: new Date().toISOString(),
       });
 
       return {
@@ -1059,13 +1115,17 @@ export function createStage1WorkerOrchestrationService(input: {
         rebuiltTimelineRows,
         rebuiltInboxRows,
         missingProjectionSeeds: Array.from(missingProjectionSeeds).sort(
-          (left, right) => left.localeCompare(right)
+          (left, right) => left.localeCompare(right),
         ),
         discrepancies,
-        failure: null
+        failure: null,
       };
     } catch (error) {
-      const failure = buildJobFailure(error, payload.attempt, payload.maxAttempts);
+      const failure = buildJobFailure(
+        error,
+        payload.attempt,
+        payload.maxAttempts,
+      );
       const failedSyncState = await syncState.failWindow({
         syncStateId: payload.syncStateId,
         scope: "orchestration",
@@ -1076,7 +1136,7 @@ export function createStage1WorkerOrchestrationService(input: {
         windowStart: null,
         windowEnd: null,
         deadLetterCountIncrement: failure.disposition === "dead_letter" ? 1 : 0,
-        deadLettered: failure.disposition === "dead_letter"
+        deadLettered: failure.disposition === "dead_letter",
       });
       await recordSyncFailureAudit(input.persistence, {
         syncStateId: payload.syncStateId,
@@ -1088,7 +1148,7 @@ export function createStage1WorkerOrchestrationService(input: {
         windowEnd: null,
         failure,
         occurredAt: new Date().toISOString(),
-        actorId: "stage1-orchestration"
+        actorId: "stage1-orchestration",
       });
 
       return {
@@ -1101,13 +1161,13 @@ export function createStage1WorkerOrchestrationService(input: {
         rebuiltInboxRows: 0,
         missingProjectionSeeds: [],
         discrepancies: [],
-        failure
+        failure,
       };
     }
   }
 
   async function runParityCheckBatch(
-    rawPayload: ParityCheckBatchPayload
+    rawPayload: ParityCheckBatchPayload,
   ): Promise<Stage1ParityCheckJobOutcome> {
     const payload = parityCheckBatchPayloadSchema.parse(rawPayload);
     await syncState.startWindow({
@@ -1118,7 +1178,7 @@ export function createStage1WorkerOrchestrationService(input: {
       cursor: null,
       checkpoint: payload.checkpointId,
       windowStart: null,
-      windowEnd: payload.evaluatedAt
+      windowEnd: payload.evaluatedAt,
     });
 
     try {
@@ -1129,12 +1189,12 @@ export function createStage1WorkerOrchestrationService(input: {
           provider,
           sourceEvidenceCount:
             await input.persistence.repositories.sourceEvidence.countByProvider(
-              provider
+              provider,
             ),
           canonicalEventCount:
             await input.persistence.repositories.canonicalEvents.countByPrimaryProvider(
-              provider
-            )
+              provider,
+            ),
         });
       }
 
@@ -1149,29 +1209,30 @@ export function createStage1WorkerOrchestrationService(input: {
       const openIdentityCasesByReason = await Promise.all(
         identityResolutionReasonCodeValues.map((reasonCode) =>
           input.persistence.repositories.identityResolutionQueue.listOpenByReasonCode(
-            reasonCode
-          )
-        )
+            reasonCode,
+          ),
+        ),
       );
       const openRoutingCasesByReason = await Promise.all(
         routingReviewReasonCodeValues.map((reasonCode) =>
           input.persistence.repositories.routingReviewQueue.listOpenByReasonCode(
-            reasonCode
-          )
-        )
+            reasonCode,
+          ),
+        ),
       );
       const openIdentityCaseCount = openIdentityCasesByReason.flat().length;
-      const openIdentityConflictCount = openIdentityCasesByReason[
-        identityResolutionReasonCodeValues.indexOf("identity_conflict")
-      ]?.length ?? 0;
+      const openIdentityConflictCount =
+        openIdentityCasesByReason[
+          identityResolutionReasonCodeValues.indexOf("identity_conflict")
+        ]?.length ?? 0;
       const openRoutingCaseCount = openRoutingCasesByReason.flat().length;
       const queueRowParityPercent = calculateParityPercent(
         inboxProjectionCount,
-        inboxContactCount
+        inboxContactCount,
       );
       const timelineEventParityPercent = calculateParityPercent(
         timelineProjectionCount,
-        canonicalEventCount
+        canonicalEventCount,
       );
       const metrics: Stage1ParityMetrics = {
         byProvider,
@@ -1183,7 +1244,7 @@ export function createStage1WorkerOrchestrationService(input: {
         timelineEventParityPercent,
         openIdentityConflictCount,
         openIdentityCaseCount,
-        openRoutingCaseCount
+        openRoutingCaseCount,
       };
       const discrepancies: Stage1OperationalDiscrepancy[] = [];
 
@@ -1192,7 +1253,7 @@ export function createStage1WorkerOrchestrationService(input: {
           code: "queue_row_parity_below_threshold",
           severity: "blocking",
           message: `Inbox row parity ${formatPercent(queueRowParityPercent)}% is below the configured threshold of ${formatPercent(payload.queueParityThresholdPercent)}%.`,
-          entityIds: []
+          entityIds: [],
         });
       }
 
@@ -1201,7 +1262,7 @@ export function createStage1WorkerOrchestrationService(input: {
           code: "timeline_event_parity_below_threshold",
           severity: "blocking",
           message: `Timeline parity ${formatPercent(timelineEventParityPercent)}% is below the configured threshold of ${formatPercent(payload.timelineParityThresholdPercent)}%.`,
-          entityIds: []
+          entityIds: [],
         });
       }
 
@@ -1211,31 +1272,37 @@ export function createStage1WorkerOrchestrationService(input: {
           severity: "blocking",
           message:
             "One or more open identity_conflict cases remain in the manual review queue.",
-          entityIds: []
+          entityIds: [],
         });
       }
 
-      const allContacts = await input.persistence.repositories.contacts.listAll();
+      const allContacts =
+        await input.persistence.repositories.contacts.listAll();
       const sampledContactIds =
         payload.sampleContactIds.length > 0
           ? [...payload.sampleContactIds]
-          : allContacts.slice(0, payload.sampleSize).map((contact) => contact.id);
+          : allContacts
+              .slice(0, payload.sampleSize)
+              .map((contact) => contact.id);
       const sampledContacts: Stage1SampledParityContact[] = [];
       const sampledTimelineMismatchIds: string[] = [];
       const sampledInboxMismatchIds: string[] = [];
 
       for (const contactId of sampledContactIds) {
-        const canonicalEvents = await input.persistence.repositories.canonicalEvents.listByContactId(
-          contactId
-        );
-        const timelineRows = await input.persistence.repositories.timelineProjection.listByContactId(
-          contactId
-        );
-        const inboxRow = await input.persistence.repositories.inboxProjection.findByContactId(
-          contactId
-        );
+        const canonicalEvents =
+          await input.persistence.repositories.canonicalEvents.listByContactId(
+            contactId,
+          );
+        const timelineRows =
+          await input.persistence.repositories.timelineProjection.listByContactId(
+            contactId,
+          );
+        const inboxRow =
+          await input.persistence.repositories.inboxProjection.findByContactId(
+            contactId,
+          );
         const inboxDrivingEventCount = canonicalEvents.filter((event) =>
-          isInboxDrivingEvent(event.eventType)
+          isInboxDrivingEvent(event.eventType),
         ).length;
 
         sampledContacts.push({
@@ -1243,7 +1310,7 @@ export function createStage1WorkerOrchestrationService(input: {
           canonicalEventCount: canonicalEvents.length,
           timelineRowCount: timelineRows.length,
           hasInboxRow: inboxRow !== null,
-          inboxDrivingEventCount
+          inboxDrivingEventCount,
         });
 
         if (timelineRows.length !== canonicalEvents.length) {
@@ -1264,7 +1331,7 @@ export function createStage1WorkerOrchestrationService(input: {
           severity: "warning",
           message:
             "At least one sampled contact has a timeline projection row count that does not match canonical event count.",
-          entityIds: sampledTimelineMismatchIds
+          entityIds: sampledTimelineMismatchIds,
         });
       }
 
@@ -1274,7 +1341,7 @@ export function createStage1WorkerOrchestrationService(input: {
           severity: "warning",
           message:
             "At least one sampled contact has an inbox projection mismatch against inbox-driving canonical events.",
-          entityIds: sampledInboxMismatchIds
+          entityIds: sampledInboxMismatchIds,
         });
       }
 
@@ -1293,8 +1360,8 @@ export function createStage1WorkerOrchestrationService(input: {
           timelineEventParityPercent,
           canonicalEventCount,
           timelineProjectionCount,
-          inboxProjectionCount
-        }
+          inboxProjectionCount,
+        },
       });
       const completedSyncState = await syncState.completeWindow({
         syncStateId: payload.syncStateId,
@@ -1305,10 +1372,13 @@ export function createStage1WorkerOrchestrationService(input: {
         checkpoint: payload.checkpointId,
         windowStart: null,
         windowEnd: payload.evaluatedAt,
-        parityPercent: Math.min(queueRowParityPercent, timelineEventParityPercent),
+        parityPercent: Math.min(
+          queueRowParityPercent,
+          timelineEventParityPercent,
+        ),
         freshnessP95Seconds: null,
         freshnessP99Seconds: null,
-        completedAt: payload.evaluatedAt
+        completedAt: payload.evaluatedAt,
       });
 
       return {
@@ -1320,10 +1390,14 @@ export function createStage1WorkerOrchestrationService(input: {
         sampledContacts,
         discrepancies,
         auditEvidenceId: auditEvidence.id,
-        failure: null
+        failure: null,
       };
     } catch (error) {
-      const failure = buildJobFailure(error, payload.attempt, payload.maxAttempts);
+      const failure = buildJobFailure(
+        error,
+        payload.attempt,
+        payload.maxAttempts,
+      );
       const failedSyncState = await syncState.failWindow({
         syncStateId: payload.syncStateId,
         scope: "orchestration",
@@ -1334,7 +1408,7 @@ export function createStage1WorkerOrchestrationService(input: {
         windowStart: null,
         windowEnd: payload.evaluatedAt,
         deadLetterCountIncrement: failure.disposition === "dead_letter" ? 1 : 0,
-        deadLettered: failure.disposition === "dead_letter"
+        deadLettered: failure.disposition === "dead_letter",
       });
       await recordSyncFailureAudit(input.persistence, {
         syncStateId: payload.syncStateId,
@@ -1346,7 +1420,7 @@ export function createStage1WorkerOrchestrationService(input: {
         windowEnd: payload.evaluatedAt,
         failure,
         occurredAt: payload.evaluatedAt,
-        actorId: "stage1-orchestration"
+        actorId: "stage1-orchestration",
       });
 
       return {
@@ -1364,18 +1438,18 @@ export function createStage1WorkerOrchestrationService(input: {
           timelineEventParityPercent: 0,
           openIdentityConflictCount: 0,
           openIdentityCaseCount: 0,
-          openRoutingCaseCount: 0
+          openRoutingCaseCount: 0,
         },
         sampledContacts: [],
         discrepancies: [],
         auditEvidenceId: null,
-        failure
+        failure,
       };
     }
   }
 
   async function runCutoverCheckpointBatch(
-    rawPayload: CutoverCheckpointBatchPayload
+    rawPayload: CutoverCheckpointBatchPayload,
   ): Promise<Stage1CutoverCheckpointJobOutcome> {
     const payload = cutoverCheckpointBatchPayloadSchema.parse(rawPayload);
     await syncState.startWindow({
@@ -1386,7 +1460,7 @@ export function createStage1WorkerOrchestrationService(input: {
       cursor: null,
       checkpoint: payload.checkpointId,
       windowStart: null,
-      windowEnd: payload.evaluatedAt
+      windowEnd: payload.evaluatedAt,
     });
 
     try {
@@ -1407,8 +1481,8 @@ export function createStage1WorkerOrchestrationService(input: {
           sampleSize: 25,
           queueParityThresholdPercent: 99.5,
           timelineParityThresholdPercent: 99,
-          evaluatedAt: payload.evaluatedAt
-        })
+          evaluatedAt: payload.evaluatedAt,
+        }),
       );
       const syncSnapshots: Stage1CutoverSyncSnapshot[] = [];
       const discrepancies = [...parity.discrepancies];
@@ -1418,20 +1492,19 @@ export function createStage1WorkerOrchestrationService(input: {
           await input.persistence.repositories.syncState.findLatest({
             scope: "provider",
             provider,
-            jobType: "historical_backfill"
+            jobType: "historical_backfill",
           });
-        const liveIngest = await input.persistence.repositories.syncState.findLatest(
-          {
+        const liveIngest =
+          await input.persistence.repositories.syncState.findLatest({
             scope: "provider",
             provider,
-            jobType: "live_ingest"
-          }
-        );
+            jobType: "live_ingest",
+          });
 
         syncSnapshots.push({
           provider,
           historicalBackfill,
-          liveIngest
+          liveIngest,
         });
 
         if (
@@ -1442,7 +1515,8 @@ export function createStage1WorkerOrchestrationService(input: {
             code: "historical_backfill_incomplete",
             severity: "blocking",
             message: `Provider ${provider} does not yet have a succeeded historical backfill checkpoint.`,
-            entityIds: historicalBackfill === null ? [] : [historicalBackfill.id]
+            entityIds:
+              historicalBackfill === null ? [] : [historicalBackfill.id],
           });
         }
 
@@ -1451,7 +1525,7 @@ export function createStage1WorkerOrchestrationService(input: {
             code: "live_ingest_missing",
             severity: "blocking",
             message: `Provider ${provider} has no live ingest sync state yet.`,
-            entityIds: []
+            entityIds: [],
           });
         } else if (
           payload.requireLiveIngestCoverage &&
@@ -1461,7 +1535,7 @@ export function createStage1WorkerOrchestrationService(input: {
             code: "live_ingest_incomplete",
             severity: "blocking",
             message: `Provider ${provider} does not yet have a succeeded live ingest checkpoint.`,
-            entityIds: liveIngest === null ? [] : [liveIngest.id]
+            entityIds: liveIngest === null ? [] : [liveIngest.id],
           });
         }
 
@@ -1469,16 +1543,13 @@ export function createStage1WorkerOrchestrationService(input: {
           continue;
         }
 
-        if (
-          provider === "gmail" ||
-          provider === "simpletexting"
-        ) {
+        if (provider === "gmail" || provider === "simpletexting") {
           if (liveIngest.freshnessP95Seconds === null) {
             discrepancies.push({
               code: "comms_freshness_p95_unavailable",
               severity: "blocking",
               message: `Provider ${provider} has no live comms freshness p95 metric recorded yet.`,
-              entityIds: [liveIngest.id]
+              entityIds: [liveIngest.id],
             });
           } else if (
             liveIngest.freshnessP95Seconds >
@@ -1488,7 +1559,7 @@ export function createStage1WorkerOrchestrationService(input: {
               code: "comms_freshness_p95_above_threshold",
               severity: "blocking",
               message: `Provider ${provider} has live comms freshness p95 ${String(liveIngest.freshnessP95Seconds)}s above the ${String(gmailAndSimpleTextingP95ThresholdSeconds)}s cutover threshold.`,
-              entityIds: [liveIngest.id]
+              entityIds: [liveIngest.id],
             });
           }
 
@@ -1497,7 +1568,7 @@ export function createStage1WorkerOrchestrationService(input: {
               code: "comms_freshness_p99_unavailable",
               severity: "blocking",
               message: `Provider ${provider} has no live comms freshness p99 metric recorded yet.`,
-              entityIds: [liveIngest.id]
+              entityIds: [liveIngest.id],
             });
           } else if (
             liveIngest.freshnessP99Seconds >
@@ -1507,7 +1578,7 @@ export function createStage1WorkerOrchestrationService(input: {
               code: "comms_freshness_p99_above_threshold",
               severity: "blocking",
               message: `Provider ${provider} has live comms freshness p99 ${String(liveIngest.freshnessP99Seconds)}s above the ${String(gmailAndSimpleTextingP99ThresholdSeconds)}s cutover threshold.`,
-              entityIds: [liveIngest.id]
+              entityIds: [liveIngest.id],
             });
           }
         }
@@ -1519,7 +1590,7 @@ export function createStage1WorkerOrchestrationService(input: {
               severity: "blocking",
               message:
                 "Salesforce has no lifecycle freshness p95 metric recorded yet.",
-              entityIds: [liveIngest.id]
+              entityIds: [liveIngest.id],
             });
           } else if (
             liveIngest.freshnessP95Seconds >
@@ -1529,7 +1600,7 @@ export function createStage1WorkerOrchestrationService(input: {
               code: "lifecycle_freshness_p95_above_threshold",
               severity: "blocking",
               message: `Salesforce lifecycle freshness p95 ${String(liveIngest.freshnessP95Seconds)}s is above the ${String(salesforceLifecycleP95ThresholdSeconds)}s cutover threshold.`,
-              entityIds: [liveIngest.id]
+              entityIds: [liveIngest.id],
             });
           }
         }
@@ -1548,11 +1619,11 @@ export function createStage1WorkerOrchestrationService(input: {
         metadataJson: {
           providerCount: payload.providers.length,
           discrepancyCount: discrepancies.length,
-          parityCheckpointId: parity.checkpointId
-        }
+          parityCheckpointId: parity.checkpointId,
+        },
       });
       const ready = discrepancies.every(
-        (discrepancy) => discrepancy.severity !== "blocking"
+        (discrepancy) => discrepancy.severity !== "blocking",
       );
       const completedSyncState = await syncState.completeWindow({
         syncStateId: payload.syncStateId,
@@ -1566,7 +1637,7 @@ export function createStage1WorkerOrchestrationService(input: {
         parityPercent: parity.metrics.timelineEventParityPercent,
         freshnessP95Seconds: null,
         freshnessP99Seconds: null,
-        completedAt: payload.evaluatedAt
+        completedAt: payload.evaluatedAt,
       });
 
       return {
@@ -1579,10 +1650,14 @@ export function createStage1WorkerOrchestrationService(input: {
         syncSnapshots,
         discrepancies,
         auditEvidenceId: auditEvidence.id,
-        failure: null
+        failure: null,
       };
     } catch (error) {
-      const failure = buildJobFailure(error, payload.attempt, payload.maxAttempts);
+      const failure = buildJobFailure(
+        error,
+        payload.attempt,
+        payload.maxAttempts,
+      );
       const failedSyncState = await syncState.failWindow({
         syncStateId: payload.syncStateId,
         scope: "orchestration",
@@ -1593,7 +1668,7 @@ export function createStage1WorkerOrchestrationService(input: {
         windowStart: null,
         windowEnd: payload.evaluatedAt,
         deadLetterCountIncrement: failure.disposition === "dead_letter" ? 1 : 0,
-        deadLettered: failure.disposition === "dead_letter"
+        deadLettered: failure.disposition === "dead_letter",
       });
       await recordSyncFailureAudit(input.persistence, {
         syncStateId: payload.syncStateId,
@@ -1605,7 +1680,7 @@ export function createStage1WorkerOrchestrationService(input: {
         windowEnd: payload.evaluatedAt,
         failure,
         occurredAt: payload.evaluatedAt,
-        actorId: "stage1-orchestration"
+        actorId: "stage1-orchestration",
       });
 
       return {
@@ -1629,17 +1704,17 @@ export function createStage1WorkerOrchestrationService(input: {
             timelineEventParityPercent: 0,
             openIdentityConflictCount: 0,
             openIdentityCaseCount: 0,
-            openRoutingCaseCount: 0
+            openRoutingCaseCount: 0,
           },
           sampledContacts: [],
           discrepancies: [],
           auditEvidenceId: null,
-          failure
+          failure,
         },
         syncSnapshots: [],
         discrepancies: [],
         auditEvidenceId: null,
-        failure
+        failure,
       };
     }
   }
@@ -1652,18 +1727,21 @@ export function createStage1WorkerOrchestrationService(input: {
           gmailHistoricalCaptureBatchPayloadSchema.parse(rawPayload),
         capture: (batchPayload) =>
           input.capture.gmail.captureHistoricalBatch(batchPayload),
-        ingestRecord: (record) => input.ingest.ingestGmailHistoricalRecord(record),
-        mapRecord: mapGmailRecord
+        ingestRecord: (record) =>
+          input.ingest.ingestGmailHistoricalRecord(record),
+        mapRecord: mapGmailRecord,
       });
     },
 
     runGmailLiveCaptureBatch: (payload) => {
       return runCapturedBatch({
         payload,
-        parse: (rawPayload) => gmailLiveCaptureBatchPayloadSchema.parse(rawPayload),
-        capture: (batchPayload) => input.capture.gmail.captureLiveBatch(batchPayload),
+        parse: (rawPayload) =>
+          gmailLiveCaptureBatchPayloadSchema.parse(rawPayload),
+        capture: (batchPayload) =>
+          input.capture.gmail.captureLiveBatch(batchPayload),
         ingestRecord: (record) => input.ingest.ingestGmailLiveRecord(record),
-        mapRecord: mapGmailRecord
+        mapRecord: mapGmailRecord,
       });
     },
 
@@ -1676,7 +1754,7 @@ export function createStage1WorkerOrchestrationService(input: {
           input.capture.salesforce.captureHistoricalBatch(batchPayload),
         ingestRecord: (record) =>
           input.ingest.ingestSalesforceHistoricalRecord(record),
-        mapRecord: mapSalesforceRecord
+        mapRecord: mapSalesforceRecord,
       });
     },
 
@@ -1687,8 +1765,9 @@ export function createStage1WorkerOrchestrationService(input: {
           salesforceLiveCaptureBatchPayloadSchema.parse(rawPayload),
         capture: (batchPayload) =>
           input.capture.salesforce.captureLiveBatch(batchPayload),
-        ingestRecord: (record) => input.ingest.ingestSalesforceLiveRecord(record),
-        mapRecord: mapSalesforceRecord
+        ingestRecord: (record) =>
+          input.ingest.ingestSalesforceLiveRecord(record),
+        mapRecord: mapSalesforceRecord,
       });
     },
 
@@ -1701,7 +1780,7 @@ export function createStage1WorkerOrchestrationService(input: {
           input.capture.simpleTexting.captureHistoricalBatch(batchPayload),
         ingestRecord: (record) =>
           input.ingest.ingestSimpleTextingHistoricalRecord(record),
-        mapRecord: mapSimpleTextingRecord
+        mapRecord: mapSimpleTextingRecord,
       });
     },
 
@@ -1714,7 +1793,7 @@ export function createStage1WorkerOrchestrationService(input: {
           input.capture.simpleTexting.captureLiveBatch(batchPayload),
         ingestRecord: (record) =>
           input.ingest.ingestSimpleTextingLiveRecord(record),
-        mapRecord: mapSimpleTextingRecord
+        mapRecord: mapSimpleTextingRecord,
       });
     },
 
@@ -1725,8 +1804,9 @@ export function createStage1WorkerOrchestrationService(input: {
           mailchimpHistoricalCaptureBatchPayloadSchema.parse(rawPayload),
         capture: (batchPayload) =>
           input.capture.mailchimp.captureHistoricalBatch(batchPayload),
-        ingestRecord: (record) => input.ingest.ingestMailchimpHistoricalRecord(record),
-        mapRecord: mapMailchimpRecord
+        ingestRecord: (record) =>
+          input.ingest.ingestMailchimpHistoricalRecord(record),
+        mapRecord: mapMailchimpRecord,
       });
     },
 
@@ -1737,13 +1817,15 @@ export function createStage1WorkerOrchestrationService(input: {
           mailchimpTransitionCaptureBatchPayloadSchema.parse(rawPayload),
         capture: (batchPayload) =>
           input.capture.mailchimp.captureTransitionBatch(batchPayload),
-        ingestRecord: (record) => input.ingest.ingestMailchimpTransitionRecord(record),
-        mapRecord: mapMailchimpRecord
+        ingestRecord: (record) =>
+          input.ingest.ingestMailchimpTransitionRecord(record),
+        mapRecord: mapMailchimpRecord,
       });
     },
 
     runReplayBatch: (rawPayload) => {
       const payload = replayBatchPayloadSchema.parse(rawPayload);
+      const replayProvider = payload.provider as Stage1WorkerProvider;
 
       return runCapturedBatch({
         payload,
@@ -1753,46 +1835,52 @@ export function createStage1WorkerOrchestrationService(input: {
             input.capture,
             input.persistence,
             input.gmailHistoricalReplay,
-            parsedPayload
+            parsedPayload,
           ),
         ingestRecord: (record) => {
-          switch (payload.provider) {
+          switch (replayProvider) {
             case "gmail":
               return payload.mode === "historical"
-                ? input.ingest.ingestGmailHistoricalRecord(record as GmailRecord)
+                ? input.ingest.ingestGmailHistoricalRecord(
+                    record as GmailRecord,
+                  )
                 : input.ingest.ingestGmailLiveRecord(record as GmailRecord);
             case "salesforce":
               return payload.mode === "historical"
                 ? input.ingest.ingestSalesforceHistoricalRecord(
-                    record as SalesforceRecord
+                    record as SalesforceRecord,
                   )
                 : input.ingest.ingestSalesforceLiveRecord(
-                    record as SalesforceRecord
+                    record as SalesforceRecord,
                   );
             case "simpletexting":
               return payload.mode === "historical"
                 ? input.ingest.ingestSimpleTextingHistoricalRecord(
-                    record as SimpleTextingRecord
+                    record as SimpleTextingRecord,
                   )
                 : input.ingest.ingestSimpleTextingLiveRecord(
-                    record as SimpleTextingRecord
+                    record as SimpleTextingRecord,
                   );
             case "mailchimp":
               return payload.mode === "historical"
                 ? input.ingest.ingestMailchimpHistoricalRecord(
-                    record as MailchimpRecord
+                    record as MailchimpRecord,
                   )
                 : input.ingest.ingestMailchimpTransitionRecord(
-                    record as MailchimpRecord
+                    record as MailchimpRecord,
                   );
+            case "manual":
+              throw new Stage1NonRetryableJobError(
+                "Manual note provider is not supported for replay ingest batches.",
+              );
           }
         },
-        mapRecord: (record) => getMappedResultForRecord(payload.provider, record)
+        mapRecord: (record) => getMappedResultForRecord(replayProvider, record),
       });
     },
 
     runProjectionRebuildBatch,
     runParityCheckBatch,
-    runCutoverCheckpointBatch
+    runCutoverCheckpointBatch,
   };
 }

--- a/apps/worker/test/stage1-ingest.test.ts
+++ b/apps/worker/test/stage1-ingest.test.ts
@@ -1,29 +1,95 @@
 import { describe, expect, it, vi } from "vitest";
 
-import type {
-  NormalizedCanonicalEventIntake,
-  NormalizedContactGraphUpsertInput
+import {
+  resolveCanonicalChannel,
+  type NormalizedCanonicalEventIntake,
+  type NormalizedContactGraphUpsertInput,
 } from "@as-comms/contracts";
 import type {
   NormalizedCanonicalEventResult,
-  NormalizedContactGraphResult
+  NormalizedContactGraphResult,
 } from "@as-comms/domain";
 
 import { createStage1IngestService } from "../src/ingest/index.js";
 
+type CompatibilityCommunicationClassification = {
+  readonly messageKind?: "auto" | "campaign" | "one_to_one" | null;
+  readonly campaignRef?: {
+    readonly providerCampaignId?: string | null;
+    readonly providerAudienceId?: string | null;
+    readonly providerMessageName?: string | null;
+  } | null;
+  readonly threadRef?: {
+    readonly crossProviderCollapseKey?: string | null;
+    readonly providerThreadId?: string | null;
+  } | null;
+  readonly direction?: "inbound" | "outbound" | null;
+};
+
 function buildContactGraphResult(
-  input: NormalizedContactGraphUpsertInput
+  input: NormalizedContactGraphUpsertInput,
 ): NormalizedContactGraphResult {
   return {
     contact: input.contact,
     identities: input.identities ?? [],
-    memberships: input.memberships ?? []
+    memberships: input.memberships ?? [],
   };
 }
 
 function buildAppliedCanonicalEventResult(
-  input: NormalizedCanonicalEventIntake
+  input: NormalizedCanonicalEventIntake,
 ): NormalizedCanonicalEventResult {
+  const communicationClassification = (
+    input as NormalizedCanonicalEventIntake & {
+      readonly communicationClassification?: CompatibilityCommunicationClassification;
+    }
+  ).communicationClassification;
+  const provenance = {
+    primaryProvider: input.sourceEvidence.provider,
+    primarySourceEvidenceId: input.sourceEvidence.id,
+    supportingSourceEvidenceIds: (input.supportingSources ?? []).map(
+      (source) => source.sourceEvidenceId,
+    ),
+    winnerReason:
+      input.sourceEvidence.provider === "gmail" &&
+      (input.supportingSources ?? []).some(
+        (source) => source.provider === "salesforce",
+      )
+        ? "gmail_wins_duplicate_collapse"
+        : "single_source",
+    sourceRecordType: input.sourceEvidence.providerRecordType,
+    sourceRecordId: input.sourceEvidence.providerRecordId,
+    messageKind: communicationClassification?.messageKind ?? null,
+    campaignRef:
+      communicationClassification?.campaignRef === undefined
+        ? null
+        : {
+            providerCampaignId:
+              communicationClassification.campaignRef?.providerCampaignId ??
+              null,
+            providerAudienceId:
+              communicationClassification.campaignRef?.providerAudienceId ??
+              null,
+            providerMessageName:
+              communicationClassification.campaignRef?.providerMessageName ??
+              null,
+          },
+    threadRef:
+      communicationClassification?.threadRef === undefined
+        ? null
+        : {
+            crossProviderCollapseKey:
+              communicationClassification.threadRef?.crossProviderCollapseKey ??
+              null,
+            providerThreadId:
+              communicationClassification.threadRef?.providerThreadId ?? null,
+          },
+    direction: communicationClassification?.direction ?? null,
+  } as Extract<
+    NormalizedCanonicalEventResult,
+    { readonly outcome: "applied" | "duplicate" }
+  >["canonicalEvent"]["provenance"];
+
   return {
     outcome: "applied",
     sourceEvidence: input.sourceEvidence,
@@ -31,32 +97,12 @@ function buildAppliedCanonicalEventResult(
       id: input.canonicalEvent.id,
       contactId: "contact:salesforce:003-stage1",
       eventType: input.canonicalEvent.eventType,
-      channel:
-        input.canonicalEvent.eventType.includes(".sms.")
-          ? "sms"
-          : input.canonicalEvent.eventType.startsWith("lifecycle.")
-            ? "lifecycle"
-            : input.canonicalEvent.eventType.startsWith("campaign.")
-              ? "campaign_email"
-              : "email",
+      channel: resolveCanonicalChannel(input.canonicalEvent.eventType),
       occurredAt: input.canonicalEvent.occurredAt,
       sourceEvidenceId: input.sourceEvidence.id,
       idempotencyKey: input.canonicalEvent.idempotencyKey,
-      provenance: {
-        primaryProvider: input.sourceEvidence.provider,
-        primarySourceEvidenceId: input.sourceEvidence.id,
-        supportingSourceEvidenceIds: (input.supportingSources ?? []).map(
-          (source) => source.sourceEvidenceId
-        ),
-        winnerReason:
-          input.sourceEvidence.provider === "gmail" &&
-          (input.supportingSources ?? []).some(
-            (source) => source.provider === "salesforce"
-          )
-            ? "gmail_wins_duplicate_collapse"
-            : "single_source"
-      },
-      reviewState: "clear"
+      provenance,
+      reviewState: "clear",
     },
     timelineProjection: {
       id: `timeline:${input.canonicalEvent.id}`,
@@ -66,21 +112,14 @@ function buildAppliedCanonicalEventResult(
       sortKey: `${input.canonicalEvent.occurredAt}::${input.canonicalEvent.id}`,
       eventType: input.canonicalEvent.eventType,
       summary: input.canonicalEvent.summary,
-      channel:
-        input.canonicalEvent.eventType.includes(".sms.")
-          ? "sms"
-          : input.canonicalEvent.eventType.startsWith("lifecycle.")
-            ? "lifecycle"
-            : input.canonicalEvent.eventType.startsWith("campaign.")
-              ? "campaign_email"
-              : "email",
+      channel: resolveCanonicalChannel(input.canonicalEvent.eventType),
       primaryProvider: input.sourceEvidence.provider,
-      reviewState: "clear"
+      reviewState: "clear",
     },
     inboxProjection: null,
     identityCase: null,
     routingCase: null,
-    auditEvidence: null
+    auditEvidence: null,
   };
 }
 
@@ -88,15 +127,15 @@ describe("Stage 1 worker ingest service", () => {
   it("routes Gmail historical and live intake through the same normalized path", async () => {
     const applyNormalizedCanonicalEvent = vi.fn(
       (input: NormalizedCanonicalEventIntake) =>
-        Promise.resolve(buildAppliedCanonicalEventResult(input))
+        Promise.resolve(buildAppliedCanonicalEventResult(input)),
     );
     const upsertNormalizedContactGraph = vi.fn(
       (input: NormalizedContactGraphUpsertInput) =>
-        Promise.resolve(buildContactGraphResult(input))
+        Promise.resolve(buildContactGraphResult(input)),
     );
     const service = createStage1IngestService({
       applyNormalizedCanonicalEvent,
-      upsertNormalizedContactGraph
+      upsertNormalizedContactGraph,
     });
 
     const record = {
@@ -118,11 +157,13 @@ describe("Stage 1 worker ingest service", () => {
         {
           provider: "salesforce" as const,
           providerRecordType: "task_communication",
-          providerRecordId: "task-1"
-        }
+          providerRecordId: "task-1",
+        },
       ],
-      crossProviderCollapseKey: "email-thread-1"
-    };
+      crossProviderCollapseKey: "email-thread-1",
+      messageKind: "one_to_one",
+      subject: null,
+    } as Parameters<typeof service.ingestGmailHistoricalRecord>[0];
 
     const historicalResult = await service.ingestGmailHistoricalRecord(record);
     const liveResult = await service.ingestGmailLiveRecord(record);
@@ -131,35 +172,38 @@ describe("Stage 1 worker ingest service", () => {
     expect(liveResult.outcome).toBe("normalized");
     expect(applyNormalizedCanonicalEvent).toHaveBeenCalledTimes(2);
     expect(applyNormalizedCanonicalEvent.mock.calls[0]?.[0]).toEqual(
-      applyNormalizedCanonicalEvent.mock.calls[1]?.[0]
+      applyNormalizedCanonicalEvent.mock.calls[1]?.[0],
     );
     expect(
-      applyNormalizedCanonicalEvent.mock.calls[0]?.[0].supportingSources
+      applyNormalizedCanonicalEvent.mock.calls[0]?.[0].supportingSources,
     ).toEqual([
       {
         provider: "salesforce",
         sourceEvidenceId:
-          "source-evidence:salesforce:task_communication:task-1"
-      }
+          "source-evidence:salesforce:task_communication:task-1",
+      },
     ]);
     expect(
-      applyNormalizedCanonicalEvent.mock.calls[0]?.[0].canonicalEvent.idempotencyKey
-    ).toBe("canonical-event:collapse:communication.email.outbound:email-thread-1");
+      applyNormalizedCanonicalEvent.mock.calls[0]?.[0].canonicalEvent
+        .idempotencyKey,
+    ).toBe(
+      "canonical-event:collapse:communication.email.outbound:email-thread-1",
+    );
     expect(upsertNormalizedContactGraph).not.toHaveBeenCalled();
   });
 
   it("sends Salesforce contact snapshots through the contact-graph normalization path", async () => {
     const applyNormalizedCanonicalEvent = vi.fn(
       (input: NormalizedCanonicalEventIntake) =>
-        Promise.resolve(buildAppliedCanonicalEventResult(input))
+        Promise.resolve(buildAppliedCanonicalEventResult(input)),
     );
     const upsertNormalizedContactGraph = vi.fn(
       (input: NormalizedContactGraphUpsertInput) =>
-        Promise.resolve(buildContactGraphResult(input))
+        Promise.resolve(buildContactGraphResult(input)),
     );
     const service = createStage1IngestService({
       applyNormalizedCanonicalEvent,
-      upsertNormalizedContactGraph
+      upsertNormalizedContactGraph,
     });
 
     const result = await service.ingestSalesforceHistoricalRecord({
@@ -174,7 +218,7 @@ describe("Stage 1 worker ingest service", () => {
       volunteerIdPlainValues: ["VOL-123"],
       createdAt: "2026-01-01T00:00:00.000Z",
       updatedAt: "2026-01-02T00:00:00.000Z",
-      memberships: []
+      memberships: [],
     });
 
     expect(result).toEqual({
@@ -186,7 +230,7 @@ describe("Stage 1 worker ingest service", () => {
       commandKind: "contact_graph",
       sourceEvidenceId: null,
       canonicalEventId: null,
-      contactId: "contact:salesforce:003-stage1"
+      contactId: "contact:salesforce:003-stage1",
     });
     expect(upsertNormalizedContactGraph).toHaveBeenCalledTimes(1);
     expect(applyNormalizedCanonicalEvent).not.toHaveBeenCalled();
@@ -195,20 +239,20 @@ describe("Stage 1 worker ingest service", () => {
   it("returns explicit deferred outcomes for unsupported provider records without calling normalization", async () => {
     const applyNormalizedCanonicalEvent = vi.fn(
       (input: NormalizedCanonicalEventIntake) =>
-        Promise.resolve(buildAppliedCanonicalEventResult(input))
+        Promise.resolve(buildAppliedCanonicalEventResult(input)),
     );
     const upsertNormalizedContactGraph = vi.fn(
       (input: NormalizedContactGraphUpsertInput) =>
-        Promise.resolve(buildContactGraphResult(input))
+        Promise.resolve(buildContactGraphResult(input)),
     );
     const service = createStage1IngestService({
       applyNormalizedCanonicalEvent,
-      upsertNormalizedContactGraph
+      upsertNormalizedContactGraph,
     });
 
     const result = await service.ingestMailchimpHistoricalRecord({
       recordType: "audience_mutation",
-      recordId: "audience-1"
+      recordId: "audience-1",
     });
 
     expect(result).toEqual({
@@ -218,7 +262,7 @@ describe("Stage 1 worker ingest service", () => {
       sourceRecordType: "audience_mutation",
       sourceRecordId: "audience-1",
       reason: "deferred_record_family",
-      detail: "Mailchimp audience_mutation records are deferred in Stage 1."
+      detail: "Mailchimp audience_mutation records are deferred in Stage 1.",
     });
     expect(applyNormalizedCanonicalEvent).not.toHaveBeenCalled();
     expect(upsertNormalizedContactGraph).not.toHaveBeenCalled();
@@ -227,7 +271,9 @@ describe("Stage 1 worker ingest service", () => {
   it("surfaces review-opened and quarantined outcomes from the normalization boundary", async () => {
     const applyNormalizedCanonicalEvent = vi
       .fn<
-        (input: NormalizedCanonicalEventIntake) => Promise<NormalizedCanonicalEventResult>
+        (
+          input: NormalizedCanonicalEventIntake,
+        ) => Promise<NormalizedCanonicalEventResult>
       >()
       .mockResolvedValueOnce({
         outcome: "needs_identity_review",
@@ -240,7 +286,7 @@ describe("Stage 1 worker ingest service", () => {
           occurredAt: "2026-01-01T00:00:00.000Z",
           payloadRef: "payloads/gmail/gmail-message-1.json",
           idempotencyKey: "source-evidence:gmail:message:gmail-message-1",
-          checksum: "checksum-1"
+          checksum: "checksum-1",
         },
         identityCase: {
           id: "identity-review:source-evidence:gmail:message:gmail-message-1:identity_multi_candidate",
@@ -252,9 +298,9 @@ describe("Stage 1 worker ingest service", () => {
           resolvedAt: null,
           normalizedIdentityValues: ["shared@example.org"],
           anchoredContactId: null,
-          explanation: "Multiple contacts matched the same email."
+          explanation: "Multiple contacts matched the same email.",
         },
-        auditEvidence: null
+        auditEvidence: null,
       })
       .mockResolvedValueOnce({
         outcome: "quarantined",
@@ -266,11 +312,13 @@ describe("Stage 1 worker ingest service", () => {
           receivedAt: "2026-01-01T00:02:00.000Z",
           occurredAt: "2026-01-01T00:01:00.000Z",
           payloadRef: "payloads/salesforce/task-1.json",
-          idempotencyKey: "source-evidence:salesforce:task_communication:task-1",
-          checksum: "checksum-task-1"
+          idempotencyKey:
+            "source-evidence:salesforce:task_communication:task-1",
+          checksum: "checksum-task-1",
         },
         reasonCode: "duplicate_collapse_conflict",
-        explanation: "Gmail must win duplicate collapse for the same outbound email.",
+        explanation:
+          "Gmail must win duplicate collapse for the same outbound email.",
         existingCanonicalEvent: null,
         auditEvidence: {
           id: "audit:canonical_event:task-1:duplicate_collapse_conflict",
@@ -282,16 +330,16 @@ describe("Stage 1 worker ingest service", () => {
           occurredAt: "2026-01-01T00:02:00.000Z",
           result: "recorded",
           policyCode: "stage1.quarantine.duplicate_collapse_conflict",
-          metadataJson: {}
-        }
+          metadataJson: {},
+        },
       });
     const upsertNormalizedContactGraph = vi.fn(
       (input: NormalizedContactGraphUpsertInput) =>
-        Promise.resolve(buildContactGraphResult(input))
+        Promise.resolve(buildContactGraphResult(input)),
     );
     const service = createStage1IngestService({
       applyNormalizedCanonicalEvent,
-      upsertNormalizedContactGraph
+      upsertNormalizedContactGraph,
     });
 
     const reviewResult = await service.ingestGmailHistoricalRecord({
@@ -310,8 +358,10 @@ describe("Stage 1 worker ingest service", () => {
       volunteerIdPlainValues: [],
       normalizedPhones: [],
       supportingRecords: [],
-      crossProviderCollapseKey: null
-    });
+      crossProviderCollapseKey: null,
+      messageKind: "one_to_one",
+      subject: null,
+    } as Parameters<typeof service.ingestGmailHistoricalRecord>[0]);
 
     const quarantineResult = await service.ingestSalesforceLiveRecord({
       recordType: "task_communication",
@@ -330,8 +380,8 @@ describe("Stage 1 worker ingest service", () => {
         {
           provider: "gmail",
           providerRecordType: "message",
-          providerRecordId: "gmail-message-1"
-        }
+          providerRecordId: "gmail-message-1",
+        },
       ],
       crossProviderCollapseKey: "email-thread-1",
       routing: {
@@ -339,8 +389,8 @@ describe("Stage 1 worker ingest service", () => {
         projectId: null,
         expeditionId: null,
         projectName: null,
-        expeditionName: null
-      }
+        expeditionName: null,
+      },
     });
 
     expect(reviewResult).toEqual({
@@ -358,9 +408,9 @@ describe("Stage 1 worker ingest service", () => {
           queue: "identity",
           caseId:
             "identity-review:source-evidence:gmail:message:gmail-message-1:identity_multi_candidate",
-          reasonCode: "identity_multi_candidate"
-        }
-      ]
+          reasonCode: "identity_multi_candidate",
+        },
+      ],
     });
     expect(quarantineResult).toEqual({
       outcome: "quarantined",
@@ -375,7 +425,8 @@ describe("Stage 1 worker ingest service", () => {
       reasonCode: "duplicate_collapse_conflict",
       explanation:
         "Gmail must win duplicate collapse for the same outbound email.",
-      auditEvidenceId: "audit:canonical_event:task-1:duplicate_collapse_conflict"
+      auditEvidenceId:
+        "audit:canonical_event:task-1:duplicate_collapse_conflict",
     });
   });
 });

--- a/apps/worker/test/stage1-sync-failure-audit.test.ts
+++ b/apps/worker/test/stage1-sync-failure-audit.test.ts
@@ -15,14 +15,13 @@ describe("Stage 1 sync failure audit", () => {
         jobType: "parity_snapshot",
         status: "failed",
         cursor: null,
-        checkpoint: "checkpoint:parity:collision-proof",
         windowStart: null,
         windowEnd: "2026-01-05T00:00:00.000Z",
         parityPercent: null,
         lastSuccessfulAt: null,
         deadLetterCount: 0,
         freshnessP95Seconds: null,
-        freshnessP99Seconds: null
+        freshnessP99Seconds: null,
       });
 
       const failureInput = {
@@ -36,17 +35,23 @@ describe("Stage 1 sync failure audit", () => {
         failure: {
           disposition: "non_retryable" as const,
           retryable: false,
-          message: "Parity snapshot failed."
+          message: "Parity snapshot failed.",
         },
         occurredAt: "2026-01-05T00:00:00.000Z",
-        actorId: "stage1-orchestration"
+        actorId: "stage1-orchestration",
       };
 
-      const first = await recordSyncFailureAudit(context.persistence, failureInput);
-      const second = await recordSyncFailureAudit(context.persistence, failureInput);
+      const first = await recordSyncFailureAudit(
+        context.persistence,
+        failureInput,
+      );
+      const second = await recordSyncFailureAudit(
+        context.persistence,
+        failureInput,
+      );
       const audits = await context.repositories.auditEvidence.listByEntity({
         entityType: "sync_state",
-        entityId: "sync:parity:collision-proof"
+        entityId: "sync:parity:collision-proof",
       });
 
       expect(first.id).not.toBe(second.id);
@@ -56,13 +61,13 @@ describe("Stage 1 sync failure audit", () => {
         expect.arrayContaining([
           expect.objectContaining({
             id: first.id,
-            policyCode: "stage1.sync.failure"
+            policyCode: "stage1.sync.failure",
           }),
           expect.objectContaining({
             id: second.id,
-            policyCode: "stage1.sync.failure"
-          })
-        ])
+            policyCode: "stage1.sync.failure",
+          }),
+        ]),
       );
     } finally {
       await context.dispose();


### PR DESCRIPTION
## What changed
- fixes the currently surfaced `@as-comms/worker` typecheck blockers in the requested worker files only
- restores the Mailchimp artifact importer and unmatched-report helpers locally so the worker branch stays self-contained on `main`
- updates worker/test fixtures to match the newer worker type surface without changing inbox behavior

## Why
PR #13 is currently failing on worker typecheck blockers in these files:
- `apps/worker/src/ingest/service.ts`
- `apps/worker/src/ops/mailchimp-artifacts.ts`
- `apps/worker/src/orchestration/service.ts`
- `apps/worker/test/stage1-ingest.test.ts`
- `apps/worker/test/stage1-sync-failure-audit.test.ts`

## Verification
- `pnpm --filter @as-comms/worker typecheck` on this `main`-based branch still hits unrelated pre-existing package errors outside this PR's allowed scope
- applying this patch on top of PR #13's current head makes `pnpm --filter @as-comms/worker typecheck` pass
- full `pnpm typecheck` on the PR #13 verification checkout still exposed unrelated `apps/web` type errors locally
