### PR TITLE
Fix composer fromAlias type: widen state to EmailAliasId union

### DIFF
--- a/apps/web/app/inbox/_components/inbox-composer.tsx
+++ b/apps/web/app/inbox/_components/inbox-composer.tsx
@@ -67,6 +67,8 @@ const EMAIL_ALIASES = [
   { id: "noreply", label: "No Reply", email: "noreply@adventurescientists.org" }
 ] as const;
 
+type EmailAliasId = (typeof EMAIL_ALIASES)[number]["id"];
+
 export function InboxComposer({
   contactDisplayName,
   smsEligible,
@@ -81,7 +83,7 @@ export function InboxComposer({
   const [mode, setMode] = useState<ComposerMode>("email");
   const [draft, setDraft] = useState("");
   const [subject, setSubject] = useState("");
-  const [fromAlias, setFromAlias] = useState(EMAIL_ALIASES[0].id);
+  const [fromAlias, setFromAlias] = useState<EmailAliasId>(EMAIL_ALIASES[0].id);
   const [aiPrompt, setAiPrompt] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -314,7 +316,7 @@ export function InboxComposer({
                 value={fromAlias}
                 onChange={(e) => {
                   const target = e.currentTarget as unknown as {
-                    readonly value: string;
+                    readonly value: EmailAliasId;
                   };
                   setFromAlias(target.value);
                 }}


### PR DESCRIPTION
## Summary

Resolves the Next type-checking blocker at `apps/web/app/inbox/_components/inbox-composer.tsx:319`.

## Problem

```
error TS2345: Argument of type 'string' is not assignable to parameter of type 'SetStateAction<"jordan">'.
```

`useState(EMAIL_ALIASES[0].id)` inferred the state type from the initial value — and because `EMAIL_ALIASES` is declared `as const`, `EMAIL_ALIASES[0].id` has literal type `"jordan"`. The `onChange` handler then tried to pass a generic `string` (the value from a `<select>`), which the narrow state type rejected.

## Fix

Derive a union alias-id type from the tuple and type both the state and the `onChange` target accordingly:

```ts
type EmailAliasId = (typeof EMAIL_ALIASES)[number]["id"];
const [fromAlias, setFromAlias] = useState<EmailAliasId>(EMAIL_ALIASES[0].id);
// ...
const target = e.currentTarget as unknown as { readonly value: EmailAliasId };
setFromAlias(target.value);
```

Three options from the const tuple (`"jordan" | "team" | "noreply"`) are all valid; no runtime behavior change.

## Verification

Before (clean `main`, typecheck): **3 errors**
- `inbox-composer.tsx(319,32)` ← this one
- `tests/unit/inbox-actions.test.ts(112,30)` — pre-existing, unrelated
- `tests/unit/inbox-actions.test.ts(163,30)` — pre-existing, unrelated

After this PR:
- `inbox-composer.tsx(319,32)` ✓ fixed
- Two test-file errors remain, untouched (out of scope for this fix)

## Test plan

- [ ] `pnpm --filter web exec tsc --noEmit` — no new inbox errors
- [ ] Open inbox detail, switch email "From:" alias → option change persists
- [ ] Railway build passes the Next type-checking step

🤖 Generated with [Claude Code](https://claude.com/claude-code)