### PR TITLE
Bump drizzle-orm to 0.45.2+ and restore audit threshold to high

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,7 +28,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "drizzle-orm": "^0.41.0",
+    "drizzle-orm": "^0.45.2",
     "lucide-react": "^1.8.0",
     "next": "^15.5.15",
     "react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "autoprefixer": "^10.4.21",
-    "drizzle-kit": "^0.31.1",
+    "drizzle-kit": "^0.31.10",
     "eslint": "^9.23.0",
     "eslint-config-prettier": "^10.1.2",
     "playwright": "^1.52.0",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@as-comms/contracts": "workspace:*",
     "@as-comms/domain": "workspace:*",
-    "drizzle-orm": "^0.41.0",
+    "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.5",
     "zod": "^3.24.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
         specifier: ^10.4.21
         version: 10.4.27(postcss@8.5.8)
       drizzle-kit:
-        specifier: ^0.31.1
+        specifier: ^0.31.10
         version: 0.31.10
       eslint:
         specifier: ^9.23.0
@@ -138,8 +138,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       drizzle-orm:
-        specifier: ^0.41.0
-        version: 0.41.0(@electric-sql/pglite@0.2.17)(@types/pg@8.20.0)(pg@8.20.0)(postgres@3.4.8)
+        specifier: ^0.45.2
+        version: 0.45.2(@electric-sql/pglite@0.2.17)(@types/pg@8.20.0)(pg@8.20.0)(postgres@3.4.8)
       lucide-react:
         specifier: ^1.8.0
         version: 1.8.0(react@19.2.4)
@@ -198,8 +198,8 @@ importers:
         specifier: workspace:*
         version: link:../domain
       drizzle-orm:
-        specifier: ^0.41.0
-        version: 0.41.0(@electric-sql/pglite@0.2.17)(@types/pg@8.20.0)(pg@8.20.0)(postgres@3.4.8)
+        specifier: ^0.45.2
+        version: 0.45.2(@electric-sql/pglite@0.2.17)(@types/pg@8.20.0)(pg@8.20.0)(postgres@3.4.8)
       postgres:
         specifier: ^3.4.5
         version: 3.4.8
@@ -1910,8 +1910,8 @@ packages:
     resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
     hasBin: true
 
-  drizzle-orm@0.41.0:
-    resolution: {integrity: sha512-7A4ZxhHk9gdlXmTdPj/lREtP+3u8KvZ4yEN6MYVxBzZGex5Wtdc+CWSbu7btgF6TB0N+MNPrvW7RKBbxJchs/Q==}
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
@@ -1921,12 +1921,13 @@ packages:
       '@neondatabase/serverless': '>=0.10.0'
       '@op-engineering/op-sqlite': '>=2'
       '@opentelemetry/api': ^1.4.1
-      '@planetscale/database': '>=1'
+      '@planetscale/database': '>=1.13'
       '@prisma/client': '*'
       '@tidbcloud/serverless': '*'
       '@types/better-sqlite3': '*'
       '@types/pg': '*'
       '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
       '@vercel/postgres': '>=0.8.0'
       '@xata.io/client': '*'
       better-sqlite3: '>=7'
@@ -1969,6 +1970,8 @@ packages:
       '@types/pg':
         optional: true
       '@types/sql.js':
+        optional: true
+      '@upstash/redis':
         optional: true
       '@vercel/postgres':
         optional: true
@@ -4300,7 +4303,7 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.41.0(@electric-sql/pglite@0.2.17)(@types/pg@8.20.0)(pg@8.20.0)(postgres@3.4.8):
+  drizzle-orm@0.45.2(@electric-sql/pglite@0.2.17)(@types/pg@8.20.0)(pg@8.20.0)(postgres@3.4.8):
     optionalDependencies:
       '@electric-sql/pglite': 0.2.17
       '@types/pg': 8.20.0

--- a/scripts/security-check.mjs
+++ b/scripts/security-check.mjs
@@ -78,11 +78,7 @@ async function runDependencyAudit() {
     return process.env.CI === "true" ? 1 : 0;
   }
 
-  // TODO: raise back to "high" once the deferred CVE follow-up lands:
-  //   - #23 drizzle-orm 0.41.0 → 0.45.2+ (GHSA-gpj5-g38j-94v9)
-  // Threshold temporarily lowered to "critical" so PR #21 (inbox recovery)
-  // could land without bundling dep bumps that warrant their own focused PRs.
-  const result = spawnSync("pnpm", ["audit", "--audit-level", "critical"], {
+  const result = spawnSync("pnpm", ["audit", "--audit-level", "high"], {
     cwd: repoRoot,
     encoding: "utf8"
   });


### PR DESCRIPTION
## Summary

Closes #23 — bumps `drizzle-orm` (and paired `drizzle-kit`) to a patched version for [GHSA-gpj5-g38j-94v9](https://github.com/advisories/GHSA-gpj5-g38j-94v9) (SQL injection via improperly escaped SQL identifiers).

With this PR all four deferred CVE follow-ups from PR #21 have landed (#22, #24, #25, #23). The audit threshold in `scripts/security-check.mjs` returns to `high` and the TODO comment is removed.

## What landed

- `packages/db`: drizzle-orm `0.41.0` → `0.45.2`
- `apps/web`: drizzle-orm `0.41.0` → `0.45.2` (apps/web had its own copy; needed bumping to fully clear the advisory)
- root `devDependencies`: drizzle-kit → `0.31.10` (paired version)
- `scripts/security-check.mjs`: audit threshold restored to `high`, deferral TODO removed

## Practical exposure

Code audit found no `sql.identifier(...)` calls, no raw/unsafe SQL identifier construction, and no user-input-driven table/column paths. SQL usage in this codebase is fixed-schema tagged SQL with bound values, so the CVE's attack surface was effectively zero before this bump. Patch is now applied for defense in depth.

## Behavior verification

- `drizzle-kit generate` against the new version produces no diff against the existing `packages/db/drizzle/0000-0004*.sql` migrations — schema generation is unchanged.
- All gates green locally: `pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm test:unit` (via Homebrew node per the known macOS rollup gotcha), `pnpm boundaries`, `pnpm security` (now at `high`), `pnpm verify`.

## Test plan

- [x] All Stage 0 gates green locally
- [ ] Stage 0 CI (Linux) — verified by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)