### PR TITLE
Harden inbox search and exclude forwarded chains from queue state

### DIFF
--- a/apps/web/app/api/inbox/list/route.ts
+++ b/apps/web/app/api/inbox/list/route.ts
@@ -42,7 +42,7 @@ export async function GET(request: Request) {
     await getInboxList(parsedFilter.data, {
       cursor: searchParams.get("cursor"),
       ...(limit === undefined ? {} : { limit }),
-      query: searchParams.get("query")
+      query: searchParams.get("q") ?? searchParams.get("query")
     })
   );
 }

--- a/apps/web/app/inbox/_components/inbox-list.tsx
+++ b/apps/web/app/inbox/_components/inbox-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState, useTransition } from "react";
 
 import type {
@@ -37,7 +37,9 @@ export function InboxList({
   initialList,
   initialFilterId = "all"
 }: ListColumnProps) {
+  const router = useRouter();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const activeContactId = extractContactId(pathname);
   const {
     search,
@@ -46,6 +48,7 @@ export function InboxList({
     isQueueLoading,
     setQueueLoading
   } = useInboxClient();
+  const urlQuery = searchParams.get("q") ?? "";
   const deferredQuery = useDeferredValue(search.query);
   const normalizedQuery = deferredQuery.trim();
   const isServerSearchActive = normalizedQuery.length > 0;
@@ -72,6 +75,36 @@ export function InboxList({
       initialList
     };
   }, [activeFilter, initialList]);
+
+  useEffect(() => {
+    if (search.query !== urlQuery) {
+      setSearchQuery(urlQuery);
+    }
+  }, [search.query, setSearchQuery, urlQuery]);
+
+  useEffect(() => {
+    const currentUrlQuery = urlQuery.trim();
+
+    if (normalizedQuery === currentUrlQuery) {
+      return;
+    }
+
+    const nextParams = new URLSearchParams(searchParams.toString());
+
+    if (normalizedQuery.length === 0) {
+      nextParams.delete("q");
+    } else {
+      nextParams.set("q", normalizedQuery);
+    }
+
+    const nextQueryString = nextParams.toString();
+    const nextHref =
+      nextQueryString.length === 0
+        ? pathname
+        : `${pathname}?${nextQueryString}`;
+
+    router.replace(nextHref, { scroll: false });
+  }, [normalizedQuery, pathname, router, searchParams, urlQuery]);
 
   const loadFilterPage = useCallback(
     async (input: {
@@ -271,9 +304,9 @@ export function InboxList({
               ) : (
                 <>
                   <span className="font-medium text-slate-700">
-                    {displayItems.length}
+                    {currentList.page.total}
                   </span>{" "}
-                  {displayItems.length === 1 ? "result" : "results"} for
+                  {currentList.page.total === 1 ? "result" : "results"} for
                   &ldquo;{search.query}&rdquo;
                 </>
               )}
@@ -346,8 +379,7 @@ function SearchEmptyState({ query }: { readonly query: string }) {
       title="No results"
       description={
         <>
-          Nothing in the loaded queue matches &ldquo;{query}&rdquo;. Try a different
-          search.
+          Nothing in the inbox matches &ldquo;{query}&rdquo;. Try a different search.
         </>
       }
     />

--- a/apps/web/app/inbox/_lib/client-api.ts
+++ b/apps/web/app/inbox/_lib/client-api.ts
@@ -52,7 +52,7 @@ export function fetchInboxListPage(input: {
   const trimmedQuery = input.query?.trim();
 
   if (trimmedQuery !== undefined && trimmedQuery.length > 0) {
-    params.set("query", trimmedQuery);
+    params.set("q", trimmedQuery);
   }
 
   return readJson<InboxListViewModel>(`/api/inbox/list?${params.toString()}`);

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -720,15 +720,6 @@ function parseCommunicationPreview(raw: string): ParsedPreview {
   };
 }
 
-function previewSubjectForSearch(raw: string): string | null {
-  return parseCommunicationPreview(raw).subject;
-}
-
-function previewBodyForSearch(raw: string): string {
-  const parsed = parseCommunicationPreview(raw);
-  return parsed.body.length > 0 ? parsed.body : sanitizePreviewText(raw);
-}
-
 function resolvePreferredMessagePreview(input: {
   readonly explicitSubjects?: readonly (string | null | undefined)[];
   readonly rawCandidates: readonly (string | null | undefined)[];
@@ -1375,50 +1366,6 @@ function totalForFilter(
   }
 }
 
-function primaryProjectLabelForSearch(
-  memberships: readonly ContactMembershipRecord[],
-  projectNameById: Readonly<Record<string, string>>,
-): string | null {
-  const primaryMembership = sortMemberships(memberships)[0] ?? null;
-
-  if (primaryMembership === null) {
-    return null;
-  }
-
-  return resolveProjectName(primaryMembership, projectNameById);
-}
-
-function matchesQueryText(
-  value: string | null | undefined,
-  normalizedQuery: string,
-): boolean {
-  return value?.toLowerCase().includes(normalizedQuery) ?? false;
-}
-
-function matchesInboxListQuery(
-  row: InboxListCacheRow,
-  normalizedQuery: string,
-  projectNameById: Readonly<Record<string, string>>,
-): boolean {
-  const projectionSubject =
-    normalizeInlineText(row.latestMessagePreview?.subject) ??
-    previewSubjectForSearch(row.inboxProjection.snippet) ??
-    fallbackLatestSubject(row.inboxProjection.lastEventType);
-  const projectionSnippet = previewBodyForSearch(row.inboxProjection.snippet);
-  const projectLabel = primaryProjectLabelForSearch(
-    row.memberships,
-    projectNameById,
-  );
-
-  return (
-    matchesQueryText(row.contact.displayName, normalizedQuery) ||
-    matchesQueryText(row.contact.primaryEmail, normalizedQuery) ||
-    matchesQueryText(projectionSubject, normalizedQuery) ||
-    matchesQueryText(projectionSnippet, normalizedQuery) ||
-    matchesQueryText(projectLabel, normalizedQuery)
-  );
-}
-
 async function readInboxListCacheData(input: {
   readonly filterId: InboxFilterId;
   readonly cursor: string | null;
@@ -1427,52 +1374,45 @@ async function readInboxListCacheData(input: {
 }): Promise<InboxListCacheData> {
   const runtime = await getStage1WebRuntime();
   const decodedCursor = decodeInboxListCursor(input.cursor);
-  const normalizedQuery =
-    normalizeInlineText(input.query)?.toLowerCase() ?? null;
-  const [allCandidateProjections, counts, freshness] = await Promise.all([
+  const normalizedQuery = normalizeInlineText(input.query) ?? null;
+  const [projectionPage, counts, freshness] = await Promise.all([
     normalizedQuery === null
-      ? runtime.repositories.inboxProjection.listPageOrderedByRecency({
+      ? runtime.repositories.inboxProjection
+          .listPageOrderedByRecency({
+            filter: input.filterId,
+            limit: input.limit + 1,
+            cursor: decodedCursor,
+          })
+          .then((rows) => ({
+            rows,
+            total: 0,
+          }))
+      : runtime.repositories.inboxProjection.searchPageOrderedByRecency({
           filter: input.filterId,
           limit: input.limit + 1,
           cursor: decodedCursor,
-        })
-      : runtime.repositories.inboxProjection.listAllOrderedByRecency(),
+          query: normalizedQuery,
+        }),
     runtime.repositories.inboxProjection.countByFilters(),
     runtime.repositories.inboxProjection.getFreshness(),
   ]);
-  const filteredProjections =
-    normalizedQuery === null
-      ? allCandidateProjections
-      : allCandidateProjections.filter((projection) => {
-          if (decodedCursor === null) {
-            return true;
-          }
-
-          const sortAt = projection.lastInboundAt ?? projection.lastActivityAt;
-
-          return (
-            sortAt < decodedCursor.sortAt ||
-            (sortAt === decodedCursor.sortAt &&
-              (projection.lastActivityAt < decodedCursor.lastActivityAt ||
-                (projection.lastActivityAt === decodedCursor.lastActivityAt &&
-                  projection.contactId > decodedCursor.contactId)))
-          );
-        });
-  const candidateContactIds = filteredProjections.map(
-    (projection) => projection.contactId,
-  );
+  const hasMore = projectionPage.rows.length > input.limit;
+  const pageProjections = hasMore
+    ? projectionPage.rows.slice(0, input.limit)
+    : projectionPage.rows;
+  const candidateContactIds = pageProjections.map((projection) => projection.contactId);
   const [contacts, memberships, latestMessagePreviewByCanonicalEventId] =
     await Promise.all([
       runtime.repositories.contacts.listByIds(candidateContactIds),
       runtime.repositories.contactMemberships.listByContactIds(
         candidateContactIds,
       ),
-      loadLatestSubjectByCanonicalEventId(filteredProjections),
+      loadLatestSubjectByCanonicalEventId(pageProjections),
     ]);
   const contactById = new Map(contacts.map((contact) => [contact.id, contact]));
   const membershipsByContactId = groupMembershipsByContactId(memberships);
   const projectNameById = await loadProjectNameById(memberships);
-  const candidateRows = filteredProjections.flatMap((inboxProjection) => {
+  const pageRows = pageProjections.flatMap((inboxProjection) => {
     const contact = contactById.get(inboxProjection.contactId);
 
     if (contact === undefined) {
@@ -1492,14 +1432,6 @@ async function readInboxListCacheData(input: {
       } satisfies InboxListCacheRow,
     ];
   });
-  const searchedRows =
-    normalizedQuery === null
-      ? candidateRows
-      : candidateRows.filter((row) =>
-          matchesInboxListQuery(row, normalizedQuery, projectNameById),
-        );
-  const hasMore = searchedRows.length > input.limit;
-  const pageRows = hasMore ? searchedRows.slice(0, input.limit) : searchedRows;
 
   return {
     rows: pageRows,
@@ -1523,7 +1455,7 @@ async function readInboxListCacheData(input: {
       total:
         normalizedQuery === null
           ? totalForFilter(counts, input.filterId)
-          : searchedRows.length,
+          : projectionPage.total,
     },
     freshness,
   };

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -1143,7 +1143,13 @@ describe("real inbox selectors", () => {
     expect(searched.page.hasMore).toBe(false);
   });
 
-  it("matches query terms across subject, project label, and snippet without failing on empty results", async () => {
+  it("matches query terms across display name, email, project label, subject, and snippet", async () => {
+    const byDisplayName = await getInboxList("all", {
+      query: "Alex Thompson",
+    });
+    const byEmail = await getInboxList("all", {
+      query: "sarah@example.org",
+    });
     const bySubject = await getInboxList("all", {
       query: "Safety protocols",
     });
@@ -1157,6 +1163,12 @@ describe("real inbox selectors", () => {
       query: "Michelle Neitzey",
     });
 
+    expect(byDisplayName.items.map((item) => item.contactId)).toEqual([
+      "contact:alex-thompson",
+    ]);
+    expect(byEmail.items.map((item) => item.contactId)).toEqual([
+      "contact:sarah-martinez",
+    ]);
     expect(bySubject.items.map((item) => item.contactId)).toEqual([
       "contact:lisa-zhang",
     ]);
@@ -1169,5 +1181,153 @@ describe("real inbox selectors", () => {
     expect(noMatch.items).toEqual([]);
     expect(noMatch.page.total).toBe(0);
     expect(noMatch.page.hasMore).toBe(false);
+  });
+
+  it("falls back to expedition names when project names are unavailable during search", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:expedition-only",
+      salesforceContactId: "003-expedition-only",
+      displayName: "Expedition Only",
+      primaryEmail: "expedition-only@example.org",
+      primaryPhone: null,
+    });
+    await runtime.context.repositories.expeditionDimensions.upsert({
+      expeditionId: "expedition:amazon-fallback",
+      projectId: null,
+      expeditionName: "Amazon Basin Expedition",
+      source: "salesforce",
+    });
+    await runtime.context.repositories.contactMemberships.upsert({
+      id: "membership:expedition-only",
+      contactId: "contact:expedition-only",
+      projectId: null,
+      expeditionId: "expedition:amazon-fallback",
+      role: "volunteer",
+      status: "active",
+      source: "salesforce",
+    });
+
+    const latest = await seedInboxEmailEvent(runtime.context, {
+      id: "expedition-only-email-1",
+      contactId: "contact:expedition-only",
+      occurredAt: "2026-04-15T16:00:00.000Z",
+      direction: "inbound",
+      subject: "Expedition-only routing",
+      snippet: "I only have expedition context on this contact.",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:expedition-only",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-15T16:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-04-15T16:00:00.000Z",
+      snippet: "I only have expedition context on this contact.",
+      lastCanonicalEventId: latest.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+
+    const searched = await getInboxList("all", {
+      query: "Amazon Basin Expedition",
+    });
+
+    expect(searched.items.map((item) => item.contactId)).toEqual([
+      "contact:expedition-only",
+    ]);
+  });
+
+  it("composes search with unread, follow-up, and unresolved filters", async () => {
+    const unread = await getInboxList("unread", {
+      query: "sarah@example.org",
+    });
+    const followUp = await getInboxList("follow-up", {
+      query: "Sarah",
+    });
+    const unresolved = await getInboxList("unresolved", {
+      query: "weather",
+    });
+
+    expect(unread.items.map((item) => item.contactId)).toEqual([
+      "contact:sarah-martinez",
+    ]);
+    expect(followUp.items.map((item) => item.contactId)).toEqual([
+      "contact:sarah-martinez",
+    ]);
+    expect(unresolved.items.map((item) => item.contactId)).toEqual([
+      "contact:alex-thompson",
+    ]);
+  });
+
+  it("treats an empty query as the default ordered inbox list", async () => {
+    const defaultList = await getInboxList("all");
+    const emptyQueryList = await getInboxList("all", {
+      query: "   ",
+    });
+
+    expect(emptyQueryList.items.map((item) => item.contactId)).toEqual(
+      defaultList.items.map((item) => item.contactId),
+    );
+    expect(emptyQueryList.page).toEqual(defaultList.page);
+  });
+
+  it("paginates search results while preserving recency order", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxEmailOnlyContact(runtime, {
+      contactId: "contact:ridge-alpha",
+      displayName: "Ridge Alpha",
+      salesforceContactId: "003-ridge-alpha",
+      subject: "Ridge weather update",
+      snippet: "The ridge weather shifted again overnight.",
+      occurredAt: "2026-04-15T18:00:00.000Z",
+    });
+    await seedInboxEmailOnlyContact(runtime, {
+      contactId: "contact:ridge-beta",
+      displayName: "Ridge Beta",
+      salesforceContactId: "003-ridge-beta",
+      subject: "Ridge transport note",
+      snippet: "Sharing the ridge transport plan for tomorrow.",
+      occurredAt: "2026-04-15T17:00:00.000Z",
+    });
+    await seedInboxEmailOnlyContact(runtime, {
+      contactId: "contact:ridge-gamma",
+      displayName: "Ridge Gamma",
+      salesforceContactId: "003-ridge-gamma",
+      subject: "Ridge camping logistics",
+      snippet: "The ridge camping checklist is attached.",
+      occurredAt: "2026-04-15T16:00:00.000Z",
+    });
+
+    const firstPage = await getInboxList("all", {
+      query: "ridge",
+      limit: 2,
+    });
+
+    expect(firstPage.items.map((item) => item.contactId)).toEqual([
+      "contact:ridge-alpha",
+      "contact:ridge-beta",
+    ]);
+    expect(firstPage.page.total).toBe(3);
+    expect(firstPage.page.hasMore).toBe(true);
+    expect(firstPage.page.nextCursor).not.toBeNull();
+
+    const secondPage = await getInboxList("all", {
+      query: "ridge",
+      limit: 2,
+      cursor: firstPage.page.nextCursor,
+    });
+
+    expect(secondPage.items.map((item) => item.contactId)).toEqual([
+      "contact:ridge-gamma",
+    ]);
+    expect(secondPage.page.total).toBe(3);
+    expect(secondPage.page.hasMore).toBe(false);
   });
 });

--- a/apps/worker/test/stage1-orchestration.test.ts
+++ b/apps/worker/test/stage1-orchestration.test.ts
@@ -75,7 +75,32 @@ async function seedContact(context: TestWorkerContext): Promise<void> {
   });
 }
 
-function buildGmailMessageRecord() {
+function buildGmailMessageRecord(
+  overrides: Partial<{
+    readonly recordId: string;
+    readonly direction: "inbound" | "outbound";
+    readonly occurredAt: string;
+    readonly receivedAt: string;
+    readonly payloadRef: string;
+    readonly checksum: string;
+    readonly snippet: string;
+    readonly subject: string | null;
+    readonly snippetClean: string;
+    readonly bodyTextPreview: string;
+    readonly threadId: string | null;
+    readonly rfc822MessageId: string | null;
+    readonly normalizedParticipantEmails: readonly string[];
+    readonly salesforceContactId: string | null;
+    readonly volunteerIdPlainValues: readonly string[];
+    readonly normalizedPhones: readonly string[];
+    readonly supportingRecords: readonly {
+      readonly provider: "salesforce";
+      readonly providerRecordType: string;
+      readonly providerRecordId: string;
+    }[];
+    readonly crossProviderCollapseKey: string | null;
+  }> = {}
+) {
   return {
     recordType: "message" as const,
     recordId: "gmail-message-1",
@@ -85,6 +110,9 @@ function buildGmailMessageRecord() {
     payloadRef: "payloads/gmail/gmail-message-1.json",
     checksum: "checksum-1",
     snippet: "Following up by email",
+    subject: null,
+    snippetClean: "Following up by email",
+    bodyTextPreview: "Following up by email",
     threadId: "thread-1",
     rfc822MessageId: "<message-1@example.org>",
     normalizedParticipantEmails: ["volunteer@example.org"],
@@ -98,7 +126,8 @@ function buildGmailMessageRecord() {
         providerRecordId: "task-1"
       }
     ],
-    crossProviderCollapseKey: "collapse:email:1"
+    crossProviderCollapseKey: "collapse:email:1",
+    ...overrides
   };
 }
 
@@ -1046,6 +1075,237 @@ Alias drift outbound message.
       await expect(
         context.repositories.inboxProjection.findByContactId(contactId)
       ).resolves.toBeNull();
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("stores forwarded inbound events while leaving queue-driving inbox state untouched", async () => {
+    const context = await createTestWorkerContext({
+      capture: createEmptyCapturePorts()
+    });
+
+    try {
+      await seedContact(context);
+
+      const baseline = await context.ingest.ingestGmailHistoricalRecord(
+        buildGmailMessageRecord({
+          recordId: "gmail-baseline-outbound",
+          occurredAt: "2026-03-31T17:00:00.000Z",
+          receivedAt: "2026-03-31T17:01:00.000Z",
+          payloadRef: "payloads/gmail/gmail-baseline-outbound.json",
+          checksum: "checksum:baseline:outbound",
+          snippet: "Baseline outbound message",
+          snippetClean: "Baseline outbound message",
+          bodyTextPreview: "Baseline outbound message",
+          crossProviderCollapseKey: "collapse:baseline:outbound"
+        })
+      );
+
+      expect(baseline.outcome).toBe("normalized");
+
+      const inboxBefore = await context.repositories.inboxProjection.findByContactId(
+        contactId
+      );
+
+      const forwarded = await context.ingest.ingestGmailHistoricalRecord(
+        buildGmailMessageRecord({
+          recordId: "gmail-forwarded-inbound",
+          direction: "inbound",
+          occurredAt: "2026-03-31T18:00:00.000Z",
+          receivedAt: "2026-03-31T18:01:00.000Z",
+          payloadRef: "payloads/gmail/gmail-forwarded-inbound.json",
+          checksum: "checksum:forwarded:inbound",
+          subject: "Fwd: Volunteer intro",
+          snippet: "Forwarded volunteer intro",
+          snippetClean: "Forwarded volunteer intro",
+          bodyTextPreview: "Please meet this volunteer.",
+          crossProviderCollapseKey: "collapse:forwarded:inbound"
+        })
+      );
+
+      expect(forwarded.outcome).toBe("normalized");
+      if (forwarded.outcome !== "normalized" || forwarded.canonicalEventId === null) {
+        throw new Error("Expected forwarded inbound ingest to persist a canonical event.");
+      }
+      await expect(context.repositories.canonicalEvents.countAll()).resolves.toBe(2);
+      await expect(context.repositories.timelineProjection.countAll()).resolves.toBe(2);
+
+      const canonicalEvent = await context.repositories.canonicalEvents.findById(
+        forwarded.canonicalEventId
+      );
+      const timelineRow = await context.repositories.timelineProjection.findByCanonicalEventId(
+        forwarded.canonicalEventId
+      );
+      const inboxAfter = await context.repositories.inboxProjection.findByContactId(
+        contactId
+      );
+
+      expect(canonicalEvent?.provenance).toMatchObject({
+        inboxProjectionExclusionReason: "forwarded_chain"
+      });
+      expect(timelineRow).toMatchObject({
+        canonicalEventId: forwarded.canonicalEventId,
+        eventType: "communication.email.inbound"
+      });
+      expect(inboxAfter).toEqual(inboxBefore);
+      expect(inboxAfter).toMatchObject({
+        bucket: "Opened",
+        lastInboundAt: null,
+        lastOutboundAt: "2026-03-31T17:00:00.000Z",
+        lastActivityAt: "2026-03-31T17:00:00.000Z"
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("stores forwarded outbound events while leaving inbox recency and bucket state unchanged", async () => {
+    const context = await createTestWorkerContext({
+      capture: createEmptyCapturePorts()
+    });
+
+    try {
+      await seedContact(context);
+
+      const baseline = await context.ingest.ingestGmailHistoricalRecord(
+        buildGmailMessageRecord({
+          recordId: "gmail-baseline-inbound",
+          direction: "inbound",
+          occurredAt: "2026-03-31T17:00:00.000Z",
+          receivedAt: "2026-03-31T17:01:00.000Z",
+          payloadRef: "payloads/gmail/gmail-baseline-inbound.json",
+          checksum: "checksum:baseline:inbound",
+          subject: "Question about training",
+          snippet: "Can you confirm the training time?",
+          snippetClean: "Can you confirm the training time?",
+          bodyTextPreview: "Can you confirm the training time?",
+          crossProviderCollapseKey: "collapse:baseline:inbound"
+        })
+      );
+
+      expect(baseline.outcome).toBe("normalized");
+
+      const inboxBefore = await context.repositories.inboxProjection.findByContactId(
+        contactId
+      );
+
+      const forwarded = await context.ingest.ingestGmailHistoricalRecord(
+        buildGmailMessageRecord({
+          recordId: "gmail-forwarded-outbound",
+          direction: "outbound",
+          occurredAt: "2026-03-31T18:00:00.000Z",
+          receivedAt: "2026-03-31T18:01:00.000Z",
+          payloadRef: "payloads/gmail/gmail-forwarded-outbound.json",
+          checksum: "checksum:forwarded:outbound",
+          subject: "Volunteer follow-up",
+          snippet: "Forwarded details about a volunteer.",
+          snippetClean: "Forwarded details about a volunteer.",
+          bodyTextPreview: [
+            "---------- Forwarded message ---------",
+            "From: Someone Else <someone@example.org>",
+            "",
+            "Looping this along for reference."
+          ].join("\n"),
+          crossProviderCollapseKey: "collapse:forwarded:outbound"
+        })
+      );
+
+      expect(forwarded.outcome).toBe("normalized");
+      if (forwarded.outcome !== "normalized" || forwarded.canonicalEventId === null) {
+        throw new Error("Expected forwarded outbound ingest to persist a canonical event.");
+      }
+      await expect(context.repositories.canonicalEvents.countAll()).resolves.toBe(2);
+      await expect(context.repositories.timelineProjection.countAll()).resolves.toBe(2);
+
+      const canonicalEvent = await context.repositories.canonicalEvents.findById(
+        forwarded.canonicalEventId
+      );
+      const timelineRow = await context.repositories.timelineProjection.findByCanonicalEventId(
+        forwarded.canonicalEventId
+      );
+      const inboxAfter = await context.repositories.inboxProjection.findByContactId(
+        contactId
+      );
+
+      expect(canonicalEvent?.provenance).toMatchObject({
+        inboxProjectionExclusionReason: "forwarded_chain"
+      });
+      expect(timelineRow).toMatchObject({
+        canonicalEventId: forwarded.canonicalEventId,
+        eventType: "communication.email.outbound"
+      });
+      expect(inboxAfter).toEqual(inboxBefore);
+      expect(inboxAfter).toMatchObject({
+        bucket: "New",
+        lastInboundAt: "2026-03-31T17:00:00.000Z",
+        lastOutboundAt: null,
+        lastActivityAt: "2026-03-31T17:00:00.000Z"
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("continues to let non-forwarded Gmail messages drive inbox projection state", async () => {
+    const context = await createTestWorkerContext({
+      capture: createEmptyCapturePorts()
+    });
+
+    try {
+      await seedContact(context);
+
+      const baseline = await context.ingest.ingestGmailHistoricalRecord(
+        buildGmailMessageRecord({
+          recordId: "gmail-non-forwarded-baseline",
+          occurredAt: "2026-03-31T17:00:00.000Z",
+          receivedAt: "2026-03-31T17:01:00.000Z",
+          payloadRef: "payloads/gmail/gmail-non-forwarded-baseline.json",
+          checksum: "checksum:non-forwarded:baseline",
+          snippet: "Baseline outbound message",
+          snippetClean: "Baseline outbound message",
+          bodyTextPreview: "Baseline outbound message",
+          crossProviderCollapseKey: "collapse:non-forwarded:baseline"
+        })
+      );
+
+      expect(baseline.outcome).toBe("normalized");
+
+      const inbound = await context.ingest.ingestGmailHistoricalRecord(
+        buildGmailMessageRecord({
+          recordId: "gmail-non-forwarded-inbound",
+          direction: "inbound",
+          occurredAt: "2026-03-31T18:00:00.000Z",
+          receivedAt: "2026-03-31T18:01:00.000Z",
+          payloadRef: "payloads/gmail/gmail-non-forwarded-inbound.json",
+          checksum: "checksum:non-forwarded:inbound",
+          subject: "Volunteer replied",
+          snippet: "This is a normal inbox-driving reply.",
+          snippetClean: "This is a normal inbox-driving reply.",
+          bodyTextPreview: "This is a normal inbox-driving reply.",
+          crossProviderCollapseKey: "collapse:non-forwarded:inbound"
+        })
+      );
+
+      expect(inbound.outcome).toBe("normalized");
+      if (inbound.outcome !== "normalized" || inbound.canonicalEventId === null) {
+        throw new Error("Expected normal inbound ingest to persist a canonical event.");
+      }
+
+      const canonicalEvent = await context.repositories.canonicalEvents.findById(
+        inbound.canonicalEventId
+      );
+      const inboxAfter = await context.repositories.inboxProjection.findByContactId(
+        contactId
+      );
+
+      expect(canonicalEvent?.provenance.inboxProjectionExclusionReason).toBeUndefined();
+      expect(inboxAfter).toMatchObject({
+        bucket: "New",
+        lastInboundAt: "2026-03-31T18:00:00.000Z",
+        lastActivityAt: "2026-03-31T18:00:00.000Z",
+        snippet: "This is a normal inbox-driving reply."
+      });
     } finally {
       await context.dispose();
     }

--- a/packages/contracts/src/stage1-records.ts
+++ b/packages/contracts/src/stage1-records.ts
@@ -61,6 +61,10 @@ export const canonicalEventProvenanceSchema = z.object({
   campaignRef: communicationCampaignRefSchema.nullable().default(null),
   threadRef: communicationThreadRefSchema.nullable().default(null),
   direction: communicationDirectionSchema.nullable().default(null),
+  inboxProjectionExclusionReason: z
+    .enum(["forwarded_chain"])
+    .nullable()
+    .optional(),
   notes: z.string().min(1).nullable().optional()
 });
 export type CanonicalEventProvenance = z.infer<

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -9,7 +9,8 @@ import {
   isNull,
   lt,
   or,
-  sql
+  sql,
+  type SQL
 } from "drizzle-orm";
 import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
 
@@ -254,6 +255,134 @@ function requireRow<T>(row: T | undefined, message: string): T {
   }
 
   return row;
+}
+
+type InboxProjectionFilter = "all" | "unread" | "follow-up" | "unresolved";
+
+function buildInboxRecencyExpression() {
+  return sql<Date>`coalesce(${contactInboxProjection.lastInboundAt}, ${contactInboxProjection.lastActivityAt})`;
+}
+
+function buildInboxFilterPredicate(filter: InboxProjectionFilter): SQL | undefined {
+  return filter === "unread"
+    ? eq(contactInboxProjection.bucket, "New")
+    : filter === "follow-up"
+      ? eq(contactInboxProjection.isStarred, true)
+      : filter === "unresolved"
+        ? eq(contactInboxProjection.hasUnresolved, true)
+        : undefined;
+}
+
+function buildInboxCursorPredicate(input: {
+  readonly cursor:
+    | {
+        readonly sortAt: string;
+        readonly lastActivityAt: string;
+        readonly contactId: string;
+      }
+    | null;
+  readonly recencyExpression: SQL<Date>;
+}): SQL | undefined {
+  return input.cursor === null
+    ? undefined
+    : sql`(
+        ${input.recencyExpression} < ${new Date(input.cursor.sortAt)}
+        or (
+          ${input.recencyExpression} = ${new Date(input.cursor.sortAt)}
+          and ${contactInboxProjection.lastActivityAt} < ${new Date(input.cursor.lastActivityAt)}
+        )
+        or (
+          ${input.recencyExpression} = ${new Date(input.cursor.sortAt)}
+          and ${contactInboxProjection.lastActivityAt} = ${new Date(input.cursor.lastActivityAt)}
+          and ${contactInboxProjection.contactId} > ${input.cursor.contactId}
+        )
+      )`;
+}
+
+function combinePredicates(
+  ...predicates: readonly (SQL | undefined)[]
+): SQL | undefined {
+  const definedPredicates = predicates.filter(
+    (predicate): predicate is SQL => predicate !== undefined
+  );
+
+  if (definedPredicates.length === 0) {
+    return undefined;
+  }
+
+  if (definedPredicates.length === 1) {
+    return definedPredicates[0];
+  }
+
+  return and(...definedPredicates);
+}
+
+function escapeIlikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, "\\$&");
+}
+
+function buildInboxPrimaryProjectLabelExpression() {
+  return sql<string>`coalesce((
+    select coalesce(${projectDimensions.projectName}, ${expeditionDimensions.expeditionName})
+    from ${contactMemberships}
+    left join ${projectDimensions}
+      on ${contactMemberships.projectId} = ${projectDimensions.projectId}
+    left join ${expeditionDimensions}
+      on ${contactMemberships.expeditionId} = ${expeditionDimensions.expeditionId}
+    where ${contactMemberships.contactId} = ${contactInboxProjection.contactId}
+    order by
+      case
+        when lower(coalesce(${contactMemberships.status}, '')) = 'lead' then 0
+        when lower(coalesce(${contactMemberships.status}, '')) in ('applied', 'applicant') then 1
+        when lower(coalesce(${contactMemberships.status}, '')) in ('in-training', 'training') then 2
+        when lower(coalesce(${contactMemberships.status}, '')) = 'trip-planning' then 3
+        when lower(coalesce(${contactMemberships.status}, '')) in ('in-field', 'active') then 4
+        when lower(coalesce(${contactMemberships.status}, '')) in ('successful', 'completed') then 5
+        else 6
+      end asc,
+      coalesce(${contactMemberships.projectId}, '') asc,
+      ${contactMemberships.id} asc
+    limit 1
+  ), '')`;
+}
+
+function buildInboxLatestSubjectExpression() {
+  return sql<string>`coalesce((
+    select coalesce(${gmailMessageDetails.subject}, ${salesforceCommunicationDetails.subject})
+    from ${canonicalEventLedger}
+    left join ${gmailMessageDetails}
+      on ${gmailMessageDetails.sourceEvidenceId} = ${canonicalEventLedger.sourceEvidenceId}
+    left join ${salesforceCommunicationDetails}
+      on ${salesforceCommunicationDetailsTable.sourceEvidenceId} = ${canonicalEventLedger.sourceEvidenceId}
+    where ${canonicalEventLedger.id} = ${contactInboxProjection.lastCanonicalEventId}
+    limit 1
+  ), '')`;
+}
+
+function buildInboxSearchPredicate(query: string): SQL {
+  const pattern = `%${escapeIlikePattern(query)}%`;
+  const contactDisplayNameExpression = sql<string>`coalesce((
+    select ${contacts.displayName}
+    from ${contacts}
+    where ${contacts.id} = ${contactInboxProjection.contactId}
+    limit 1
+  ), '')`;
+  const contactPrimaryEmailExpression = sql<string>`coalesce((
+    select ${contacts.primaryEmail}
+    from ${contacts}
+    where ${contacts.id} = ${contactInboxProjection.contactId}
+    limit 1
+  ), '')`;
+  const primaryProjectLabelExpression = buildInboxPrimaryProjectLabelExpression();
+  const latestSubjectExpression = buildInboxLatestSubjectExpression();
+
+  return sql`(
+    ${contactDisplayNameExpression} ilike ${pattern} escape '\\'
+    or ${contactPrimaryEmailExpression} ilike ${pattern} escape '\\'
+    or ${primaryProjectLabelExpression} ilike ${pattern} escape '\\'
+    or ${latestSubjectExpression} ilike ${pattern} escape '\\'
+    or ${contactInboxProjection.snippet} ilike ${pattern} escape '\\'
+  )`;
 }
 
 function createStage1RepositoriesInternal(
@@ -1197,13 +1326,12 @@ function createStage1RepositoriesInternal(
       },
 
       async listAllOrderedByRecency() {
+        const recencyExpression = buildInboxRecencyExpression();
         const rows = await db
           .select()
           .from(contactInboxProjection)
           .orderBy(
-            desc(
-              sql`coalesce(${contactInboxProjection.lastInboundAt}, ${contactInboxProjection.lastActivityAt})`
-            ),
+            desc(recencyExpression),
             desc(contactInboxProjection.lastActivityAt),
             asc(contactInboxProjection.contactId)
           );
@@ -1212,37 +1340,15 @@ function createStage1RepositoriesInternal(
       },
 
       async listPageOrderedByRecency(input) {
-        const recencyExpression = sql<Date>`coalesce(${contactInboxProjection.lastInboundAt}, ${contactInboxProjection.lastActivityAt})`;
-        const filterPredicate =
-          input.filter === "unread"
-            ? eq(contactInboxProjection.bucket, "New")
-            : input.filter === "follow-up"
-              ? eq(contactInboxProjection.isStarred, true)
-              : input.filter === "unresolved"
-                ? eq(contactInboxProjection.hasUnresolved, true)
-                : undefined;
-        const cursorPredicate =
-          input.cursor === null
-            ? undefined
-            : sql`(
-                ${recencyExpression} < ${new Date(input.cursor.sortAt)}
-                or (
-                  ${recencyExpression} = ${new Date(input.cursor.sortAt)}
-                  and ${contactInboxProjection.lastActivityAt} < ${new Date(input.cursor.lastActivityAt)}
-                )
-                or (
-                  ${recencyExpression} = ${new Date(input.cursor.sortAt)}
-                  and ${contactInboxProjection.lastActivityAt} = ${new Date(input.cursor.lastActivityAt)}
-                  and ${contactInboxProjection.contactId} > ${input.cursor.contactId}
-                )
-              )`;
-        const whereClause =
-          filterPredicate !== undefined && cursorPredicate !== undefined
-            ? and(filterPredicate, cursorPredicate)
-            : filterPredicate ?? cursorPredicate;
-        const baseQuery = db
-          .select()
-          .from(contactInboxProjection);
+        const recencyExpression = buildInboxRecencyExpression();
+        const whereClause = combinePredicates(
+          buildInboxFilterPredicate(input.filter),
+          buildInboxCursorPredicate({
+            cursor: input.cursor,
+            recencyExpression
+          })
+        );
+        const baseQuery = db.select().from(contactInboxProjection);
         const filteredQuery =
           whereClause === undefined ? baseQuery : baseQuery.where(whereClause);
         const rows = await filteredQuery
@@ -1254,6 +1360,48 @@ function createStage1RepositoriesInternal(
           .limit(input.limit);
 
         return rows.map(mapInboxProjectionRow);
+      },
+
+      async searchPageOrderedByRecency(input) {
+        const recencyExpression = buildInboxRecencyExpression();
+        const whereClause = combinePredicates(
+          buildInboxFilterPredicate(input.filter),
+          buildInboxCursorPredicate({
+            cursor: input.cursor,
+            recencyExpression
+          }),
+          buildInboxSearchPredicate(input.query)
+        );
+        const filteredQuery = db
+          .select()
+          .from(contactInboxProjection)
+          .where(whereClause);
+        const [rows, totalRow] = await Promise.all([
+          filteredQuery
+            .orderBy(
+              desc(recencyExpression),
+              desc(contactInboxProjection.lastActivityAt),
+              asc(contactInboxProjection.contactId)
+            )
+            .limit(input.limit),
+          db
+            .select({
+              value: count()
+            })
+            .from(contactInboxProjection)
+            .where(
+              combinePredicates(
+                buildInboxFilterPredicate(input.filter),
+                buildInboxSearchPredicate(input.query)
+              )
+            )
+            .then((result) => result[0])
+        ]);
+
+        return {
+          rows: rows.map(mapInboxProjectionRow),
+          total: totalRow?.value ?? 0
+        };
       },
 
       async countByFilters() {

--- a/packages/domain/src/inbox-driving.ts
+++ b/packages/domain/src/inbox-driving.ts
@@ -16,9 +16,16 @@ export function isInboxDrivingEventType(
 function hasTrustedInboxDrivingEvidence(
   provenance: Pick<
     CanonicalEventProvenance,
-    "messageKind" | "primaryProvider" | "sourceRecordType"
+    | "inboxProjectionExclusionReason"
+    | "messageKind"
+    | "primaryProvider"
+    | "sourceRecordType"
   >
 ): boolean {
+  if (provenance.inboxProjectionExclusionReason === "forwarded_chain") {
+    return false;
+  }
+
   if (provenance.sourceRecordType === "internal_only_message") {
     return false;
   }

--- a/packages/domain/src/normalization.ts
+++ b/packages/domain/src/normalization.ts
@@ -279,6 +279,56 @@ function newestTimestamp(
   return left > right ? left : right;
 }
 
+const FORWARDED_SUBJECT_PATTERN = /^\s*fwd?:/i;
+const FORWARDED_BODY_PATTERNS = [
+  /(?:\n|^)\s*-{2,}\s*forwarded message\s*-{2,}\s*(?:\n|$)/i,
+  /(?:\n|^)\s*forwarded message:/i,
+  /(?:\n|^)\s*begin forwarded message:/i
+];
+
+function detectInboxProjectionExclusionReason(
+  input: Pick<
+    NormalizedCanonicalEventIntake,
+    "canonicalEvent" | "gmailMessageDetail" | "sourceEvidence"
+  >
+): "forwarded_chain" | null {
+  if (
+    input.sourceEvidence.provider !== "gmail" ||
+    (input.canonicalEvent.eventType !== "communication.email.inbound" &&
+      input.canonicalEvent.eventType !== "communication.email.outbound")
+  ) {
+    return null;
+  }
+
+  const gmailMessageDetail = input.gmailMessageDetail;
+
+  if (gmailMessageDetail === undefined) {
+    return null;
+  }
+
+  if (
+    gmailMessageDetail.subject !== null &&
+    FORWARDED_SUBJECT_PATTERN.test(gmailMessageDetail.subject)
+  ) {
+    return "forwarded_chain";
+  }
+
+  const previewCandidates = [
+    gmailMessageDetail.bodyTextPreview,
+    gmailMessageDetail.snippetClean
+  ];
+
+  for (const preview of previewCandidates) {
+    for (const pattern of FORWARDED_BODY_PATTERNS) {
+      if (pattern.test(preview)) {
+        return "forwarded_chain";
+      }
+    }
+  }
+
+  return null;
+}
+
 function buildNormalizedIdentityValues(
   identity: NormalizedIdentityEvidence
 ): string[] {
@@ -1326,6 +1376,8 @@ export function createStage1NormalizationService(
       );
       const communicationClassification =
         parsed.communicationClassification ?? null;
+      const inboxProjectionExclusionReason =
+        detectInboxProjectionExclusionReason(parsed);
       const canonicalEvent = canonicalEventSchema.parse({
         id: parsed.canonicalEvent.id,
         contactId: identityDecision.contact.id,
@@ -1349,6 +1401,9 @@ export function createStage1NormalizationService(
           campaignRef: communicationClassification?.campaignRef ?? null,
           threadRef: communicationClassification?.threadRef ?? null,
           direction: communicationClassification?.direction ?? null,
+          ...(inboxProjectionExclusionReason === null
+            ? {}
+            : { inboxProjectionExclusionReason }),
           notes: duplicateCollapseDecision.winner.notes
         },
         reviewState

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -165,6 +165,21 @@ export interface InboxProjectionRepository {
   findByContactId(contactId: string): Promise<InboxProjectionRow | null>;
   listInvalidRecencyContactIds(): Promise<readonly string[]>;
   listAllOrderedByRecency(): Promise<readonly InboxProjectionRow[]>;
+  searchPageOrderedByRecency(input: {
+    readonly filter: "all" | "unread" | "follow-up" | "unresolved";
+    readonly limit: number;
+    readonly query: string;
+    readonly cursor:
+      | {
+          readonly sortAt: string;
+          readonly lastActivityAt: string;
+          readonly contactId: string;
+        }
+      | null;
+  }): Promise<{
+    readonly rows: readonly InboxProjectionRow[];
+    readonly total: number;
+  }>;
   listPageOrderedByRecency(input: {
     readonly filter: "all" | "unread" | "follow-up" | "unresolved";
     readonly limit: number;

--- a/packages/domain/test/inbox-driving.test.ts
+++ b/packages/domain/test/inbox-driving.test.ts
@@ -24,6 +24,8 @@ function buildEvent(
       campaignRef: overrides.campaignRef ?? null,
       threadRef: overrides.threadRef ?? null,
       direction: overrides.direction ?? null,
+      inboxProjectionExclusionReason:
+        overrides.inboxProjectionExclusionReason ?? null,
       notes: overrides.notes ?? null
     }
   };
@@ -63,6 +65,19 @@ describe("inbox-driving predicate", () => {
           primaryProvider: "gmail",
           sourceRecordType: "internal_only_message",
           messageKind: null
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("excludes canonical events flagged as forwarded chains from queue-driving behavior", () => {
+    expect(
+      isInboxDrivingCanonicalEvent(
+        buildEvent({
+          primaryProvider: "gmail",
+          sourceRecordType: "message",
+          messageKind: "one_to_one",
+          inboxProjectionExclusionReason: "forwarded_chain"
         })
       )
     ).toBe(false);

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -105,6 +105,11 @@ describe("defineStage1RepositoryBundle", () => {
         findByContactId: () => Promise.resolve(null),
         listAllOrderedByRecency: () => Promise.resolve([]),
         listInvalidRecencyContactIds: () => Promise.resolve([]),
+        searchPageOrderedByRecency: () =>
+          Promise.resolve({
+            rows: [],
+            total: 0
+          }),
         listPageOrderedByRecency: () => Promise.resolve([]),
         countByFilters: () =>
           Promise.resolve({

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -168,6 +168,11 @@ function createRepositoryBundle(input: {
       findByContactId: () => Promise.resolve(null),
       listAllOrderedByRecency: () => Promise.resolve([]),
       listInvalidRecencyContactIds: () => Promise.resolve([]),
+      searchPageOrderedByRecency: () =>
+        Promise.resolve({
+          rows: [],
+          total: 0
+        }),
       listPageOrderedByRecency: () => Promise.resolve([]),
       countByFilters: () =>
         Promise.resolve({


### PR DESCRIPTION
## Summary

**Stage 4 of the inbox recovery plan: Discoverability.** Hardens the inbox search path and adds provenance-backed forwarded-chain exclusion from queue-driving inbox state.

## What changed

### Search hardening
- Server-backed Postgres ILIKE search via new repository methods (`packages/db/src/repositories.ts` +218 lines), replacing the prior pattern that loaded the full ordered projection set and filtered in app code
- Search composes correctly with `Unread`, `Needs Follow-Up`, and `Unresolved` filters at the DB layer
- Recency ordering and cursor pagination preserved under search
- Project-label search now includes `expeditionName` fallback when `projectName` is null
- Search term lives in URL state (`?q=`) for shareability and survives reload

### Forwarded-chain exclusion (provenance-backed, replay-safe)
- New `inboxProjectionExclusionReason: "forwarded_chain"` field on `canonicalEventProvenanceSchema` — single closed enum, backward-compatible (nullable + optional)
- Forward detection in normalization (`packages/domain/src/normalization.ts`) using a combined heuristic: subject prefix `Fwd:` / `Fw:` plus body markers (`---------- Forwarded message ---------`, `Forwarded message:`, `Begin forwarded message:`)
- `hasTrustedInboxDrivingEvidence` short-circuits when the exclusion reason is set — forwarded events don't advance `lastInboundAt`, don't set bucket = New, don't clear bucket
- The canonical event still gets stored, the timeline still shows it; only inbox projection queue-driving is spared the misattribution

### Out of scope (deferred per plan)
- Forwarded-chain sender recovery / rerouting
- Identity review cases for forwards
- Fancier full-text search (BM25, tsvector, ranking, highlighting)

## Detection trade-off Codex flagged

The chosen heuristic combines subject prefix + body markers, since the repo already had forwarded-body sanitization and an internal-only-message exclusion path — body markers are clearly part of the data shape. **Residual misclassification risk:** a legitimate non-forwarded message that literally starts with `Fw:`/`Fwd:` or contains one of those marker strings in body would be misclassified. No false positives observed in repo sample data.

## Test plan

Locally validated:
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm build`
- [x] `pnpm test:unit` (Homebrew node, per the macOS rollup gotcha) — adds +162 lines of inbox-selector test coverage and +264 lines of orchestration coverage for forwarded-chain exclusion
- [x] `pnpm boundaries`, `pnpm security`, `pnpm verify`
- [ ] Stage 0 CI on Linux including Postgres-backed Playwright smoke — verified by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)