### PR TITLE
docs: author Stage 4 AI pipeline implementation spec

### DIFF
--- a/docs/04-implementation-specs/stage-4-ai-pipeline.md
+++ b/docs/04-implementation-specs/stage-4-ai-pipeline.md
@@ -1,0 +1,242 @@
+# Stage 4 AI Pipeline
+
+**Role:** implementation-ready Stage 4 AI drafting pipeline and grounding contract
+**Audience:** implementers building the Stage 4 backend orchestration service, Composer integration points, or Notion knowledge cache
+**When to read:** before defining Stage 4 modules, prompt contracts, data model, or the Composer `draft:generate` surface
+**Authority:** implementation-spec guidance under the core canon; `D-032` and `D-008` / `D-009` still win on contradictions
+
+## Summary
+
+- Stage 4 is a **human-in-the-loop drafting assistant**, not an autonomous agent.
+- Implementation is a **single backend orchestration service** living in the restart repo, not a separate microservice.
+- OpenAI is the model provider; the product app owns orchestration, grounding order, safety, fallback, and explainability.
+- **Strict grounding order** (top wins): general instructions → project-specific instructions → approved knowledge → current conversation/contact/project context → reusable approved-reply memory.
+- **One LLM call** by default; a second only for reprompt or hard cases. Deterministic fallback is required.
+- Visible grounding is a **product contract**, not a nice-to-have.
+- Composer landing is a prerequisite (see `D-026`): Stage 4 plugs into a Composer that can already send real messages.
+- Cost ~10–15¢/response is acceptable; optimize for trust, quality, debuggability over marginal cost.
+
+## Locked
+
+- no auto-send (`D-009`)
+- Notion is the knowledge source, background sync/cache, no approval gate (`D-008`)
+- reusable memory is captured **only** from human-approved sent replies
+- raw historical threads are **not** primary model input — retrieval pulls bounded, relevant slices
+- Fin-like product discipline, lighter Fin-like runtime complexity
+
+## Not In Scope
+
+- autonomous agent chains, tool-use loops, multi-step planners
+- real-time streaming drafts
+- voice input
+- multi-model comparison / A-B draft UIs
+- manual memory-curation tooling (bulk edit, delete approved-reply examples)
+- operator-specific style memory (e.g., "Jordan writes shorter"; may ship later)
+- campaign authoring drafts (Stage 5A territory)
+- SMS drafts (Stage 4 scope is email one-to-one; SMS is so terse that LLM drafting is low-value)
+
+## Grounding Order
+
+Every draft request composes a grounding bundle in this fixed priority order. Higher tiers outrank lower tiers on conflict; the prompt must preserve the hierarchy so the model cannot silently invert it.
+
+| Priority | Tier | Typical source | Resolver |
+| --- | --- | --- | --- |
+| 1 | general instructions | Notion page: "AS global AI instructions" | instruction retriever |
+| 2 | project-specific instructions | Notion page per project (e.g., "PNW Biodiversity instructions") | instruction retriever |
+| 3 | approved knowledge | Notion knowledge pages, synced to `aiDurableState` with `kind=knowledge_cache` | knowledge retriever |
+| 4 | current conversation + contact + project context | live Stage 1 projections: inbox row, timeline, memberships | context retriever |
+| 5 | reusable approved-reply memory | past sent replies captured post-approval, stored as `aiDurableState` with `kind=resolved_reply_example` | memory retriever |
+
+### Grounding rules
+
+- instructions and approved knowledge outrank prior examples
+- prior examples are **pattern support**, not templates; the model must not copy them verbatim
+- if a retrieval tier returns nothing, downstream tiers may still fire
+- retrieval limits per tier (defaults — tune per measured quality):
+  - general instructions: 1 page (always)
+  - project-specific instructions: 1 page (if a project context resolves)
+  - approved knowledge: up to 5 relevant chunks
+  - context: full current thread timeline (bounded by contact's recent history) + project metadata
+  - reusable approved-reply memory: up to 3 most similar approved replies
+
+## Runtime Pipeline
+
+A draft request walks this pipeline end-to-end. Each stage is a discrete module; stages fail fast with explicit error taxonomy.
+
+### A. Preflight / refinement
+
+**Inputs:** incoming draft request (contactId, thread excerpt, optional operator prompt, mode `email`)
+**Produces:** classified retrieval task (intent label, safety flags, ambiguity flags) or an early `ask_clarification` / `recommend_handoff` directive.
+
+- classify the inbound message intent (question / request / confirmation / complaint / logistics / etc.)
+- detect safety issues (PII leakage risk, out-of-policy request, legal/medical content)
+- detect ambiguity (multiple plausible interpretations) — may short-circuit to `ask_clarification` response mode before any retrieval
+
+### B. Retrieval / grounding
+
+**Inputs:** classified task
+**Produces:** grounding bundle (ordered by tier, with source provenance per item)
+
+- execute the 5 retrievers in priority order
+- assemble the grounding bundle
+- record retrieval provenance: source kind, source ID, similarity score if applicable
+
+### C. Response-mode decision
+
+**Inputs:** grounding bundle + classification
+**Produces:** one of four modes — `draft` / `ask_clarification` / `recommend_handoff` / `deterministic_fallback`
+
+- `draft`: retrieval produced sufficient grounding to attempt a response
+- `ask_clarification`: the incoming message is too ambiguous; produce a short clarification question instead of a draft
+- `recommend_handoff`: safety or policy flag detected; produce a visible recommendation that the operator escalate (no draft body)
+- `deterministic_fallback`: model is unavailable or retrieval produced nothing usable; fall back to a template response that acknowledges receipt and promises human follow-up
+
+### D. Draft generation
+
+**Inputs:** grounding bundle + response mode = `draft`
+**Produces:** LLM-generated draft with grounding-anchor metadata
+
+- one LLM call with the compact grounding bundle and **masked/minimized** context (redact PII in prompts; never ship raw full message archives)
+- the prompt preserves the grounding priority order and instructs the model to cite the tier each claim is drawn from (internal signal for validation)
+- model temperature tuned for consistency over creativity (draft assistance, not copywriting)
+
+### E. Validation
+
+**Inputs:** generated draft + grounding bundle
+**Produces:** validated draft OR `failed_validation` with reasons
+
+- check: does the draft actually answer the incoming message?
+- check: are all factual claims traceable to the grounding bundle? (no unsupported claims)
+- check: is the grounding hierarchy honored? (no tier 5 example overriding tier 1 instruction)
+- check: does the draft avoid forbidden content categories (raw PII from other contacts, internal notes verbatim, etc.)?
+- on failure: either fall back to `deterministic_fallback` or surface a structured error to the operator
+
+### F. Explainability
+
+**Inputs:** validated draft + grounding bundle + validation result
+**Produces:** response payload returned to the Composer — draft body + grounding-source display + warnings
+
+- every draft ships with a **visible source list** the operator can expand
+- warnings surface when validation flagged something suspect but didn't block
+- the UI must render explainability even when deterministic fallback is used ("AI unavailable; this is a template response")
+
+### G. Memory capture
+
+**Inputs:** human-sent reply (post-Composer send) + the draft that inspired it + the grounding bundle
+**Produces:** new `aiDurableState` row with `kind=resolved_reply_example` (only if human approved/edited/sent)
+
+- only human-sent replies become reusable memory
+- drafts discarded, reprompted, or abandoned **do not** enter memory
+- capture stores the final sent text, the original incoming message, and a summary of the grounding tier that most closely matched, for future similarity search
+
+## Implementation Modules
+
+The orchestration service is a single backend module with internal components. Module names are implementation-ready suggestions; names may change, responsibilities may not.
+
+| Module | Responsibility | Dependencies |
+| --- | --- | --- |
+| request normalizer / classifier | parse draft request, classify intent, detect safety/ambiguity | Stage 1 contact + timeline repos |
+| policy gate | hard-deny out-of-policy requests before retrieval | static policy config |
+| instruction retriever | pull tier-1 + tier-2 Notion instructions from cache | `aiDurableState` knowledge cache |
+| knowledge retriever | retrieve tier-3 approved knowledge chunks | `aiDurableState` knowledge cache, embedding search |
+| context retriever | read live Stage 1 contact timeline, project memberships | Stage 1 repositories via composition root |
+| memory retriever | retrieve tier-5 approved-reply examples by similarity | `aiDurableState` resolved-reply memory, embedding search |
+| grounding assembler | merge retriever outputs into ordered bundle with provenance | above retrievers |
+| response-mode decider | pick draft / clarify / handoff / fallback | classifier + grounding coverage |
+| prompt builder | compose final model prompt with grounding hierarchy, masking | grounding bundle + prompt templates |
+| provider adapter | call OpenAI, handle retries, timeouts | provider credentials, network adapter |
+| validator | post-generation checks (answers, grounded, hierarchy, PII) | grounding bundle + generated draft |
+| fallback builder | deterministic non-LLM response when provider fails or validation blocks | static template set |
+| grounding presenter | shape the explainability payload for the Composer UI | grounding bundle + validation outcome |
+| memory capture service | post-send hook that promotes a sent reply into reusable memory | post-send Composer callback |
+
+## Composer Integration
+
+Composer is the only caller of the draft pipeline in Stage 4 scope.
+
+### Request shape
+
+A Composer "AI draft" action invokes a Server Action that hits the orchestration service with:
+
+- `contactId` — canonical contact whose thread the draft targets
+- `mode` — `email` in Stage 4 (reserved for future SMS)
+- `prompt` — optional operator brief ("ask about training availability")
+- `threadCursor` — optional reference to the specific inbound being replied to
+
+### Response shape
+
+The orchestration service returns a response that the Composer renders directly:
+
+- `draft` — text body (or empty for `recommend_handoff` / `ask_clarification` modes)
+- `mode` — one of `draft` / `ask_clarification` / `recommend_handoff` / `deterministic_fallback`
+- `grounding` — ordered source list for the explainability panel
+- `warnings` — non-blocking validator warnings
+- `draftId` — stable ID for later memory capture linking
+
+### Post-send memory hook
+
+On successful Composer send, the Server Action must call the memory capture service with:
+
+- `draftId` — to link the pre-edit draft and grounding bundle
+- `sentBody` — the final text the operator sent (post-edit)
+- `contactId` + thread context
+
+Capture happens only once the send succeeds. Send failure does not capture memory.
+
+## Data Model
+
+Stage 4 uses the existing `aiDurableState` contract from [`../01-core/interfaces-core.md`](../01-core/interfaces-core.md). No new tables required for the initial implementation.
+
+Expected `kind` values:
+
+| Kind | Content | Source | Lifecycle |
+| --- | --- | --- | --- |
+| `knowledge_cache` | synced Notion page content | background Notion sync | refreshed by background job; no human approval gate per `D-008` |
+| `resolved_reply_example` | final sent reply + inbound + grounding summary | post-Composer-send memory capture | append-only; humans may later mark as low-quality but not auto-purge |
+| `assistant_feedback` | operator feedback on a draft (e.g., "reprompt", "discard", "edited 60%") | inline Composer feedback controls | append-only; used for prompt tuning signals |
+
+## Fallback Contract
+
+Deterministic fallback must succeed when the provider fails or validation blocks.
+
+- template set: curated short acknowledgement responses per intent class (question / logistics / complaint / general)
+- the fallback response is visibly labeled in the UI as a non-LLM template
+- the operator can still edit and send it or discard
+- fallback **does not** produce a reusable memory capture on send (prevents poisoning the memory pool with generic text)
+
+## Explainability Contract
+
+The Composer's grounding panel must answer:
+
+- which instruction(s) shaped the tone?
+- which knowledge pages informed the factual claims?
+- which prior approved replies supported the pattern?
+- what was the response mode, and why?
+- which validation warnings fired?
+
+The UI MAY collapse this behind an "About this draft" disclosure. It MUST NOT hide the fact that AI was used, even for deterministic fallback.
+
+## Cost And Runtime Balance
+
+- one LLM call by default for draft generation
+- a second LLM call only for reprompting (operator clicks "regenerate") or hard validation failures
+- retrieval, classification, validation, and fallback construction stay in normal backend code
+- embedding retrieval calls (if used) are cheap and excluded from the "one LLM call" count
+- target p95 end-to-end latency: 3–6s for a single draft (UX: operator is waiting)
+
+## Explicitly Deferred From Stage 4
+
+- agent-style multi-turn conversation with the assistant
+- auto-send after N hours with no operator review (violates `D-009`)
+- operator style personalization memory
+- multi-model comparison / best-of-N drafts
+- streaming token-by-token UI
+- manual memory curation tools
+- campaign authoring drafts (belongs to Stage 5A)
+- SMS drafting (email-only in Stage 4; SMS may arrive when Stage 1C SimpleTexting activation returns)
+
+## Read Next
+
+- decision context: [`../01-core/decision-core.md`](../01-core/decision-core.md) (`D-008`, `D-009`, `D-026`, `D-032`)
+- data model: [`../01-core/data-core.md`](../01-core/data-core.md) + [`../01-core/interfaces-core.md`](../01-core/interfaces-core.md) (`aiDurableState`)
+- Composer scope: `../02-bundles/composer-bundle.md` (pending — authored when Composer build begins per `D-026`)


### PR DESCRIPTION
## Summary

Authors [`docs/04-implementation-specs/stage-4-ai-pipeline.md`](https://github.com/nico-kneler-as/as-comms-platform/blob/docs/stage-4-ai-pipeline/docs/04-implementation-specs/stage-4-ai-pipeline.md) — the pending canon reference from `D-032` (locked during the 2026-04-18 grilling pass but deferred to a follow-up).

Codifies:

- Stage 4 scope as a drafting assistant, not an agent (per `D-009`)
- 5-tier grounding order with retrieval limits
- Runtime pipeline stages A-G (preflight → retrieval → mode decision → generation → validation → explainability → memory capture)
- Implementation module responsibilities
- Composer integration (`draft:generate` request + response shape + post-send memory hook)
- `aiDurableState` kinds: `knowledge_cache`, `resolved_reply_example`, `assistant_feedback`
- Deterministic fallback contract
- Explainability contract (visible grounding panel required)
- Cost/runtime balance: 1 LLM call default, 2nd only for reprompt, target p95 3-6s

Additive doc only; no code changes. No `docs/01-core/*` supersessions.

## Test plan

- [ ] Canon doc renders correctly on GitHub (tables, links)
- [ ] All internal links resolve (`D-008`, `D-009`, `D-026`, `D-032`, `data-core.md`, `interfaces-core.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)