### PR TITLE
fix(web): pass explicit auth-table schema to DrizzleAdapter

### DIFF
--- a/apps/web/src/server/auth/index.ts
+++ b/apps/web/src/server/auth/index.ts
@@ -28,7 +28,11 @@ import NextAuth, {
 } from "next-auth";
 import { DrizzleAdapter } from "@auth/drizzle-adapter";
 
-import { getStage1WebRuntime, getSettingsRepositories } from "../stage1-runtime";
+import {
+  authAdapterTables,
+  getStage1WebRuntime,
+  getSettingsRepositories
+} from "../stage1-runtime";
 import {
   authEdgeConfig,
   SESSION_MAX_AGE_SECONDS,
@@ -53,7 +57,7 @@ async function buildAuthConfig(): Promise<NextAuthConfig> {
       maxAge: SESSION_MAX_AGE_SECONDS,
       updateAge: SESSION_UPDATE_AGE_SECONDS
     },
-    adapter: DrizzleAdapter(runtime.connection.db),
+    adapter: DrizzleAdapter(runtime.connection.db, authAdapterTables),
     callbacks: {
       async signIn({ user }) {
         // Deactivated operators must not be able to sign in, even if an

--- a/apps/web/src/server/stage1-runtime.ts
+++ b/apps/web/src/server/stage1-runtime.ts
@@ -1,9 +1,26 @@
 import {
+  accounts,
   createDatabaseConnection,
   createStage1RepositoryBundleFromConnection,
   createStage2RepositoryBundleFromConnection,
+  sessions,
+  users,
+  verificationTokens,
   type DatabaseConnection
 } from "@as-comms/db";
+
+// Re-export the Auth.js adapter tables so `apps/web/src/server/auth/index.ts`
+// can hand them to `DrizzleAdapter` without crossing the composition-root
+// boundary. Without this explicit schema map, the adapter falls back to its
+// internal defaults (singular `"user"` / `"account"` / `"session"` / `"verificationToken"`
+// table names) which do not exist in our DB and cause 42P01 "relation does not
+// exist" errors at callback time.
+export const authAdapterTables = {
+  usersTable: users,
+  accountsTable: accounts,
+  sessionsTable: sessions,
+  verificationTokensTable: verificationTokens
+} as const;
 import {
   createStage1TimelinePresentationService,
   type Stage1RepositoryBundle,


### PR DESCRIPTION
## Summary

Fixes Railway prod sign-in. Google OAuth callback was hitting \`AdapterError: relation \"account\" does not exist\` (PG 42P01) — \`DrizzleAdapter\` was invoked with no explicit schema map, so it fell back to its internal default table names (singular \`\"user\"\` / \`\"account\"\` / \`\"session\"\` / \`\"verificationToken\"\`). Our migration \`0005_stage2_auth_and_aliases.sql\` uses plural names matching the Drizzle schema exports.

The adapter now gets \`{ usersTable, accountsTable, sessionsTable, verificationTokensTable }\` from the composition root, wired through a new \`authAdapterTables\` re-export in \`apps/web/src/server/stage1-runtime.ts\` to honor the boundary rule that only the composition root imports from \`@as-comms/db\`.

## Test plan

- [x] \`pnpm --filter @as-comms/db build\`
- [x] \`pnpm --filter @as-comms/web typecheck\`
- [x] \`pnpm --filter @as-comms/web build\` (middleware bundle unchanged at 87.2 kB — no Edge Runtime regression)
- [ ] Railway: sign in with Google → lands on /inbox → admin role preserved → /settings/aliases loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)