### PR TITLE
fix(web): allow Google OAuth to link to pre-seeded admin users by email

### DIFF
--- a/apps/web/src/server/auth/config.ts
+++ b/apps/web/src/server/auth/config.ts
@@ -18,12 +18,23 @@ import Google from "next-auth/providers/google";
 export const SESSION_MAX_AGE_SECONDS = 30 * 24 * 60 * 60; // 30-day rolling session
 export const SESSION_UPDATE_AGE_SECONDS = 24 * 60 * 60;
 
-export const authEdgeConfig = {
-  providers: [Google],
+export const authEdgeConfig: NextAuthConfig = {
+  providers: [
+    // `allowDangerousEmailAccountLinking` lets Google OAuth link to an
+    // existing `users` row matched by email, rather than refusing with
+    // `OAuthAccountNotLinked`. The admin pre-seeding workflow (users
+    // rows are created by `ops:promote-admin` or the initial setup
+    // script before the operator has ever OAuth'd) relies on this. Safe
+    // here because Google is our only provider and the operator pool is
+    // restricted to the verified `@adventurescientists.org` Workspace
+    // domain; there is no third-party OAuth surface that could spoof a
+    // Workspace email.
+    Google({ allowDangerousEmailAccountLinking: true })
+  ],
   pages: {
     signIn: "/auth/sign-in"
   },
   // `trustHost` is required under hosted previews / Railway where the
   // request host is not identical to `AUTH_URL`.
   trustHost: true
-} satisfies NextAuthConfig;
+};


### PR DESCRIPTION
## Summary

Railway sign-in now gets past the adapter but fails with \`OAuthAccountNotLinked\`. Our admin pre-seeding workflow inserts \`users\` rows before the operator has ever OAuth'd — Auth.js v5's default refuses to link a new Google account to an existing user-by-email as a cross-provider safety.

Fix: \`allowDangerousEmailAccountLinking: true\` on the Google provider. Safe for a single-provider setup on a verified Workspace domain (\`@adventurescientists.org\`).

Also fixed TS2742 (non-portable inferred type) by replacing \`satisfies NextAuthConfig\` with an explicit \`: NextAuthConfig\` annotation — required once the Google provider is called with options.

## Test plan

- [x] \`pnpm --filter @as-comms/web typecheck\`
- [x] \`pnpm --filter @as-comms/web build\` (middleware at 87.3 kB, negligible delta)
- [ ] Railway: sign in with Google → links to pre-seeded admin users row → \`/settings/aliases\` loads with admin-only UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)