### PR TITLE
fix(web): stop decoding session cookies in middleware

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,7 +1,4 @@
-import NextAuth from "next-auth";
-import { NextResponse } from "next/server";
-
-import { authEdgeConfig } from "./src/server/auth/config";
+import { NextResponse, type NextRequest } from "next/server";
 
 /**
  * Route protection for `/inbox/:path*` and `/settings/:path*`.
@@ -10,53 +7,71 @@ import { authEdgeConfig } from "./src/server/auth/config";
  *   1. `x-dev-operator` header short-circuits auth.
  *   2. `dev-session` cookie short-circuits auth.
  *
- * Production: unauthenticated requests get redirected to `/auth/sign-in`.
+ * Production: gate on Auth.js session cookie *presence only*. We
+ * deliberately do NOT decode the cookie here. Decode is authoritative
+ * in Server Components / Server Actions via `auth()` from
+ * `./src/server/auth/index.ts`; middleware's job is to be the cheap
+ * first filter. Doing decode in middleware creates two failure modes
+ * we saw in prod:
+ *   1. Edge Runtime import chain — even with the edge-only config,
+ *      wiring Auth.js into middleware pulls in extra JOSE/crypto
+ *      code and is fragile across Auth.js upgrades.
+ *   2. Stale cookies from a previous session strategy (e.g., switching
+ *      from `database` to `jwt`) throw `Invalid Compact JWE` on every
+ *      request until the user clears cookies — the redirect itself
+ *      never runs because the wrapper throws before it.
  *
- * Constraint: this file is a Next.js Edge middleware. It must NOT import
- * Node-only modules (fs, pg, node:crypto, etc.) or perform DB calls — so it
- * uses the Edge-safe `authEdgeConfig` from `./src/server/auth/config` rather
- * than the full Node-runtime auth in `./src/server/auth/index.ts`.
- *
- * The full `auth()` wrapper (with DrizzleAdapter + DB-backed callbacks) runs
- * in Server Components, Server Actions, and the Auth.js route handler.
- * Middleware only gates on cookie presence + dev bypass; route handlers do
- * the authoritative role check.
+ * Cookie-presence-only middleware avoids both. A forged cookie gets
+ * past middleware but fails authoritative validation on the route, so
+ * the user sees a normal sign-in redirect rather than a 500 page.
  */
-const { auth } = NextAuth(authEdgeConfig);
 
-// Explicit `unknown` assertion avoids TS2742 portability errors from the
-// Auth.js return type referencing internal `next-auth/lib` paths.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const middleware: any = auth((request) => {
-  if (process.env.NODE_ENV !== "production") {
-    if (request.headers.get("x-dev-operator")) {
-      return NextResponse.next();
-    }
+const SESSION_COOKIE_NAMES = [
+  "authjs.session-token",
+  "__Secure-authjs.session-token"
+];
 
-    const devSessionCookie = request.cookies.get("dev-session");
-    if (devSessionCookie?.value) {
-      try {
-        const payload = JSON.parse(devSessionCookie.value) as {
-          readonly email?: unknown;
-        };
-        if (typeof payload.email === "string" && payload.email.length > 0) {
-          return NextResponse.next();
-        }
-      } catch {
-        // Malformed dev cookie: fall through to the standard session check.
-      }
-    }
+function hasSessionCookie(request: NextRequest): boolean {
+  return SESSION_COOKIE_NAMES.some(
+    (name) => (request.cookies.get(name)?.value ?? "").length > 0
+  );
+}
+
+function tryDevBypass(request: NextRequest): boolean {
+  if (process.env.NODE_ENV === "production") {
+    return false;
   }
 
-  if (!request.auth) {
-    const signInUrl = new URL("/auth/sign-in", request.url);
-    return NextResponse.redirect(signInUrl);
+  if (request.headers.get("x-dev-operator")) {
+    return true;
   }
 
-  return NextResponse.next();
-});
+  const devSessionCookie = request.cookies.get("dev-session");
+  if (!devSessionCookie?.value) {
+    return false;
+  }
 
-export default middleware;
+  try {
+    const payload = JSON.parse(devSessionCookie.value) as {
+      readonly email?: unknown;
+    };
+    return typeof payload.email === "string" && payload.email.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+export default function middleware(request: NextRequest): NextResponse {
+  if (tryDevBypass(request)) {
+    return NextResponse.next();
+  }
+
+  if (hasSessionCookie(request)) {
+    return NextResponse.next();
+  }
+
+  return NextResponse.redirect(new URL("/auth/sign-in", request.url));
+}
 
 export const config = {
   matcher: ["/inbox/:path*", "/settings/:path*"]

--- a/apps/web/tests/smoke/inbox.spec.ts
+++ b/apps/web/tests/smoke/inbox.spec.ts
@@ -1,6 +1,24 @@
 import { expect, test } from "@playwright/test";
 
 test("inbox shell renders with empty live data", async ({ page }) => {
+  // Middleware (apps/web/middleware.ts) now gates /inbox/* on session-
+  // cookie presence. Seed a dev session first so the smoke test can
+  // actually reach the shell. The dev-auth route is non-prod-only; if
+  // the CI/dev environment doesn't expose it (e.g., NODE_ENV=production
+  // with no seeded admin), skip gracefully — same pattern as
+  // settings.spec.ts.
+  const devAuthResponse = await page.request.get(
+    "/api/dev-auth?email=nico@adventurescientists.org"
+  );
+  if (devAuthResponse.status() === 404) {
+    test.skip(
+      true,
+      "Dev user nico@adventurescientists.org not found or dev-auth route unavailable — seed via pnpm ops:promote-admin and run in non-production mode."
+    );
+    return;
+  }
+  expect(devAuthResponse.ok()).toBeTruthy();
+
   await page.goto("/inbox");
 
   await expect(


### PR DESCRIPTION
## Summary

Railway was throwing \`JWTSessionError: Invalid Compact JWE\` on every page load for any browser with a stale session cookie from the pre-JWT deploy. Old cookie is an opaque DB session ID; new middleware tried to JWE-decode it and re-threw before it could redirect. Users couldn't recover without manually clearing cookies.

Fix: cookie-PRESENCE only in middleware. No NextAuth wrapper, no JWE decode, no Auth.js import. Authoritative decode runs in Server Components / Actions via the full \`auth()\`. Stale/forged cookies pass middleware and get rejected at the route → clean sign-in redirect instead of 500.

Middleware bundle: 87.2 kB → 33.8 kB.

## Test plan

- [x] pnpm --filter @as-comms/web typecheck
- [x] pnpm --filter @as-comms/web build
- [x] Local: curl /settings/aliases (no cookie) → 307
- [x] Local: curl /settings/aliases (stale cookie) → 307 (no throw)
- [x] Local: curl /api/dev-auth → 200
- [x] Local: curl /settings/aliases (valid dev cookie) → 200
- [ ] Railway: existing stale-cookie users get redirected cleanly; fresh sign-in works

🤖 Generated with [Claude Code](https://claude.com/claude-code)