### PR TITLE
fix(stage1): restrict Salesforce Contact ingest to volunteers with expedition memberships

### DIFF
--- a/apps/web/components/ui/avatar.tsx
+++ b/apps/web/components/ui/avatar.tsx
@@ -5,11 +5,27 @@ import * as AvatarPrimitive from "@radix-ui/react-avatar"
 
 import { cn } from "@/lib/utils"
 
+const AvatarRoot = AvatarPrimitive.Root as unknown as React.ForwardRefExoticComponent<
+  React.ComponentPropsWithoutRef<"span"> & React.RefAttributes<HTMLSpanElement>
+>
+const AvatarImagePrimitive =
+  AvatarPrimitive.Image as unknown as React.ForwardRefExoticComponent<
+    React.ComponentPropsWithoutRef<"img"> &
+      React.RefAttributes<HTMLImageElement>
+  >
+const AvatarFallbackPrimitive =
+  AvatarPrimitive.Fallback as unknown as React.ForwardRefExoticComponent<
+    React.ComponentPropsWithoutRef<"span"> &
+      React.RefAttributes<HTMLSpanElement> & {
+        delayMs?: number
+      }
+  >
+
 const Avatar = React.forwardRef<
-  React.ComponentRef<typeof AvatarPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
+  HTMLSpanElement,
+  React.ComponentPropsWithoutRef<"span">
 >(({ className, ...props }, ref) => (
-  <AvatarPrimitive.Root
+  <AvatarRoot
     ref={ref}
     className={cn(
       "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
@@ -21,10 +37,10 @@ const Avatar = React.forwardRef<
 Avatar.displayName = AvatarPrimitive.Root.displayName
 
 const AvatarImage = React.forwardRef<
-  React.ComponentRef<typeof AvatarPrimitive.Image>,
-  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+  HTMLImageElement,
+  React.ComponentPropsWithoutRef<"img">
 >(({ className, ...props }, ref) => (
-  <AvatarPrimitive.Image
+  <AvatarImagePrimitive
     ref={ref}
     className={cn("aspect-square h-full w-full", className)}
     {...props}
@@ -33,10 +49,12 @@ const AvatarImage = React.forwardRef<
 AvatarImage.displayName = AvatarPrimitive.Image.displayName
 
 const AvatarFallback = React.forwardRef<
-  React.ComponentRef<typeof AvatarPrimitive.Fallback>,
-  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+  HTMLSpanElement,
+  React.ComponentPropsWithoutRef<"span"> & {
+    delayMs?: number
+  }
 >(({ className, ...props }, ref) => (
-  <AvatarPrimitive.Fallback
+  <AvatarFallbackPrimitive
     ref={ref}
     className={cn(
       "flex h-full w-full items-center justify-center rounded-full bg-muted",

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -4,6 +4,10 @@ import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 
+const SlotPrimitive = Slot as unknown as React.ForwardRefExoticComponent<
+  React.HTMLAttributes<HTMLElement> & React.RefAttributes<HTMLElement>
+>
+
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
@@ -42,14 +46,19 @@ export interface ButtonProps
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button"
-    return (
-      <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
-        ref={ref}
-        {...props}
-      />
-    )
+    const classNames = cn(buttonVariants({ variant, size, className }))
+
+    if (asChild) {
+      return (
+        <SlotPrimitive
+          className={classNames}
+          ref={ref as React.Ref<HTMLElement>}
+          {...(props as React.HTMLAttributes<HTMLElement>)}
+        />
+      )
+    }
+
+    return <button className={classNames} ref={ref} {...props} />
   }
 )
 Button.displayName = "Button"

--- a/apps/web/components/ui/dropdown-menu.tsx
+++ b/apps/web/components/ui/dropdown-menu.tsx
@@ -6,6 +6,32 @@ import { Check, ChevronRight, Circle } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
+type PrimitiveNoRef = React.ComponentType<Record<string, unknown>>
+type PrimitiveWithRef = React.ForwardRefExoticComponent<
+  Record<string, unknown> & React.RefAttributes<HTMLElement>
+>
+
+const DropdownMenuPortalPrimitive =
+  DropdownMenuPrimitive.Portal as unknown as PrimitiveNoRef
+const DropdownMenuSubTriggerPrimitive =
+  DropdownMenuPrimitive.SubTrigger as unknown as PrimitiveWithRef
+const DropdownMenuSubContentPrimitive =
+  DropdownMenuPrimitive.SubContent as unknown as PrimitiveWithRef
+const DropdownMenuContentPrimitive =
+  DropdownMenuPrimitive.Content as unknown as PrimitiveWithRef
+const DropdownMenuItemPrimitive =
+  DropdownMenuPrimitive.Item as unknown as PrimitiveWithRef
+const DropdownMenuCheckboxItemPrimitive =
+  DropdownMenuPrimitive.CheckboxItem as unknown as PrimitiveWithRef
+const DropdownMenuRadioItemPrimitive =
+  DropdownMenuPrimitive.RadioItem as unknown as PrimitiveWithRef
+const DropdownMenuItemIndicatorPrimitive =
+  DropdownMenuPrimitive.ItemIndicator as unknown as PrimitiveNoRef
+const DropdownMenuLabelPrimitive =
+  DropdownMenuPrimitive.Label as unknown as PrimitiveWithRef
+const DropdownMenuSeparatorPrimitive =
+  DropdownMenuPrimitive.Separator as unknown as PrimitiveWithRef
+
 const DropdownMenu = DropdownMenuPrimitive.Root
 
 const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
@@ -18,13 +44,24 @@ const DropdownMenuSub = DropdownMenuPrimitive.Sub
 
 const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup
 
+type DropdownMenuElementProps = React.HTMLAttributes<HTMLDivElement>
+type DropdownMenuSubTriggerProps = DropdownMenuElementProps & {
+  inset?: boolean
+}
+type DropdownMenuContentProps = DropdownMenuElementProps & {
+  sideOffset?: number
+  align?: string
+  side?: string
+}
+type DropdownMenuCheckboxItemProps = DropdownMenuElementProps & {
+  checked?: boolean | "indeterminate"
+}
+
 const DropdownMenuSubTrigger = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.SubTrigger>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
-    inset?: boolean
-  }
+  HTMLElement,
+  DropdownMenuSubTriggerProps
 >(({ className, inset, children, ...props }, ref) => (
-  <DropdownMenuPrimitive.SubTrigger
+  <DropdownMenuSubTriggerPrimitive
     ref={ref}
     className={cn(
       "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
@@ -35,16 +72,16 @@ const DropdownMenuSubTrigger = React.forwardRef<
   >
     {children}
     <ChevronRight className="ml-auto" />
-  </DropdownMenuPrimitive.SubTrigger>
+  </DropdownMenuSubTriggerPrimitive>
 ))
 DropdownMenuSubTrigger.displayName =
   DropdownMenuPrimitive.SubTrigger.displayName
 
 const DropdownMenuSubContent = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.SubContent>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+  HTMLElement,
+  DropdownMenuElementProps
 >(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.SubContent
+  <DropdownMenuSubContentPrimitive
     ref={ref}
     className={cn(
       "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
@@ -57,11 +94,11 @@ DropdownMenuSubContent.displayName =
   DropdownMenuPrimitive.SubContent.displayName
 
 const DropdownMenuContent = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+  HTMLElement,
+  DropdownMenuContentProps
 >(({ className, sideOffset = 4, ...props }, ref) => (
-  <DropdownMenuPrimitive.Portal>
-    <DropdownMenuPrimitive.Content
+  <DropdownMenuPortalPrimitive>
+    <DropdownMenuContentPrimitive
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
@@ -71,17 +108,15 @@ const DropdownMenuContent = React.forwardRef<
       )}
       {...props}
     />
-  </DropdownMenuPrimitive.Portal>
+  </DropdownMenuPortalPrimitive>
 ))
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
 
 const DropdownMenuItem = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
-    inset?: boolean
-  }
+  HTMLElement,
+  DropdownMenuSubTriggerProps
 >(({ className, inset, ...props }, ref) => (
-  <DropdownMenuPrimitive.Item
+  <DropdownMenuItemPrimitive
     ref={ref}
     className={cn(
       "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
@@ -94,10 +129,10 @@ const DropdownMenuItem = React.forwardRef<
 DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
 
 const DropdownMenuCheckboxItem = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.CheckboxItem>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+  HTMLElement,
+  DropdownMenuCheckboxItemProps
 >(({ className, children, checked = false, ...props }, ref) => (
-  <DropdownMenuPrimitive.CheckboxItem
+  <DropdownMenuCheckboxItemPrimitive
     ref={ref}
     className={cn(
       "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
@@ -107,21 +142,21 @@ const DropdownMenuCheckboxItem = React.forwardRef<
     {...props}
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <DropdownMenuPrimitive.ItemIndicator>
+      <DropdownMenuItemIndicatorPrimitive>
         <Check className="h-4 w-4" />
-      </DropdownMenuPrimitive.ItemIndicator>
+      </DropdownMenuItemIndicatorPrimitive>
     </span>
     {children}
-  </DropdownMenuPrimitive.CheckboxItem>
+  </DropdownMenuCheckboxItemPrimitive>
 ))
 DropdownMenuCheckboxItem.displayName =
   DropdownMenuPrimitive.CheckboxItem.displayName
 
 const DropdownMenuRadioItem = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.RadioItem>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+  HTMLElement,
+  DropdownMenuElementProps
 >(({ className, children, ...props }, ref) => (
-  <DropdownMenuPrimitive.RadioItem
+  <DropdownMenuRadioItemPrimitive
     ref={ref}
     className={cn(
       "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
@@ -130,22 +165,20 @@ const DropdownMenuRadioItem = React.forwardRef<
     {...props}
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <DropdownMenuPrimitive.ItemIndicator>
+      <DropdownMenuItemIndicatorPrimitive>
         <Circle className="h-2 w-2 fill-current" />
-      </DropdownMenuPrimitive.ItemIndicator>
+      </DropdownMenuItemIndicatorPrimitive>
     </span>
     {children}
-  </DropdownMenuPrimitive.RadioItem>
+  </DropdownMenuRadioItemPrimitive>
 ))
 DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName
 
 const DropdownMenuLabel = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.Label>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
-    inset?: boolean
-  }
+  HTMLElement,
+  DropdownMenuSubTriggerProps
 >(({ className, inset, ...props }, ref) => (
-  <DropdownMenuPrimitive.Label
+  <DropdownMenuLabelPrimitive
     ref={ref}
     className={cn(
       "px-2 py-1.5 text-sm font-semibold",
@@ -158,10 +191,10 @@ const DropdownMenuLabel = React.forwardRef<
 DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
 
 const DropdownMenuSeparator = React.forwardRef<
-  React.ComponentRef<typeof DropdownMenuPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+  HTMLElement,
+  DropdownMenuElementProps
 >(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.Separator
+  <DropdownMenuSeparatorPrimitive
     ref={ref}
     className={cn("-mx-1 my-1 h-px bg-muted", className)}
     {...props}

--- a/apps/web/components/ui/popover.tsx
+++ b/apps/web/components/ui/popover.tsx
@@ -5,18 +5,35 @@ import * as PopoverPrimitive from "@radix-ui/react-popover"
 
 import { cn } from "@/lib/utils"
 
+type PrimitiveNoRef = React.ComponentType<Record<string, unknown>>
+type PrimitiveWithRef = React.ForwardRefExoticComponent<
+  Record<string, unknown> & React.RefAttributes<HTMLElement>
+>
+
+const PopoverPortalPrimitive =
+  PopoverPrimitive.Portal as unknown as PrimitiveNoRef
+const PopoverContentPrimitive =
+  PopoverPrimitive.Content as unknown as PrimitiveWithRef
+
 const Popover = PopoverPrimitive.Root
 
 const PopoverTrigger = PopoverPrimitive.Trigger
 
 const PopoverAnchor = PopoverPrimitive.Anchor
 
+type PopoverContentProps = React.HTMLAttributes<HTMLDivElement> & {
+  align?: string
+  onOpenAutoFocus?: (event: Event) => void
+  side?: string
+  sideOffset?: number
+}
+
 const PopoverContent = React.forwardRef<
-  React.ComponentRef<typeof PopoverPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+  HTMLElement,
+  PopoverContentProps
 >(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-  <PopoverPrimitive.Portal>
-    <PopoverPrimitive.Content
+  <PopoverPortalPrimitive>
+    <PopoverContentPrimitive
       ref={ref}
       align={align}
       sideOffset={sideOffset}
@@ -26,7 +43,7 @@ const PopoverContent = React.forwardRef<
       )}
       {...props}
     />
-  </PopoverPrimitive.Portal>
+  </PopoverPortalPrimitive>
 ))
 PopoverContent.displayName = PopoverPrimitive.Content.displayName
 

--- a/apps/web/components/ui/progress.tsx
+++ b/apps/web/components/ui/progress.tsx
@@ -5,11 +5,25 @@ import * as ProgressPrimitive from "@radix-ui/react-progress"
 
 import { cn } from "@/lib/utils"
 
+type PrimitiveNoRef = React.ComponentType<Record<string, unknown>>
+type PrimitiveWithRef = React.ForwardRefExoticComponent<
+  Record<string, unknown> & React.RefAttributes<HTMLElement>
+>
+
+const ProgressRootPrimitive =
+  ProgressPrimitive.Root as unknown as PrimitiveWithRef
+const ProgressIndicatorPrimitive =
+  ProgressPrimitive.Indicator as unknown as PrimitiveNoRef
+
+type ProgressProps = React.HTMLAttributes<HTMLDivElement> & {
+  value?: number
+}
+
 const Progress = React.forwardRef<
-  React.ComponentRef<typeof ProgressPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+  HTMLElement,
+  ProgressProps
 >(({ className, value, ...props }, ref) => (
-  <ProgressPrimitive.Root
+  <ProgressRootPrimitive
     ref={ref}
     className={cn(
       "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
@@ -17,11 +31,11 @@ const Progress = React.forwardRef<
     )}
     {...props}
   >
-    <ProgressPrimitive.Indicator
+    <ProgressIndicatorPrimitive
       className="h-full w-full flex-1 bg-primary transition-all"
       style={{ transform: `translateX(-${(100 - (value ?? 0)).toString()}%)` }}
     />
-  </ProgressPrimitive.Root>
+  </ProgressRootPrimitive>
 ))
 Progress.displayName = ProgressPrimitive.Root.displayName
 

--- a/apps/web/components/ui/separator.tsx
+++ b/apps/web/components/ui/separator.tsx
@@ -5,15 +5,27 @@ import * as SeparatorPrimitive from "@radix-ui/react-separator"
 
 import { cn } from "@/lib/utils"
 
+type PrimitiveWithRef = React.ForwardRefExoticComponent<
+  Record<string, unknown> & React.RefAttributes<HTMLElement>
+>
+
+const SeparatorRootPrimitive =
+  SeparatorPrimitive.Root as unknown as PrimitiveWithRef
+
+type SeparatorProps = React.HTMLAttributes<HTMLDivElement> & {
+  decorative?: boolean
+  orientation?: "horizontal" | "vertical"
+}
+
 const Separator = React.forwardRef<
-  React.ComponentRef<typeof SeparatorPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+  HTMLElement,
+  SeparatorProps
 >(
   (
     { className, orientation = "horizontal", decorative = true, ...props },
     ref
   ) => (
-    <SeparatorPrimitive.Root
+    <SeparatorRootPrimitive
       ref={ref}
       decorative={decorative}
       orientation={orientation}

--- a/apps/web/components/ui/toggle-group.tsx
+++ b/apps/web/components/ui/toggle-group.tsx
@@ -7,6 +7,26 @@ import { type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 import { toggleVariants } from "@/components/ui/toggle"
 
+type PrimitiveWithRef = React.ForwardRefExoticComponent<
+  Record<string, unknown> & React.RefAttributes<HTMLElement>
+>
+
+const ToggleGroupRootPrimitive =
+  ToggleGroupPrimitive.Root as unknown as PrimitiveWithRef
+const ToggleGroupItemPrimitive =
+  ToggleGroupPrimitive.Item as unknown as PrimitiveWithRef
+
+type ToggleGroupProps = React.HTMLAttributes<HTMLDivElement> &
+  VariantProps<typeof toggleVariants> & {
+    type?: "single" | "multiple"
+    value?: string | string[]
+    onValueChange?: (value: string | string[]) => void
+  }
+type ToggleGroupItemProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
+  VariantProps<typeof toggleVariants> & {
+    value?: string
+  }
+
 const ToggleGroupContext = React.createContext<
   VariantProps<typeof toggleVariants>
 >({
@@ -15,11 +35,10 @@ const ToggleGroupContext = React.createContext<
 })
 
 const ToggleGroup = React.forwardRef<
-  React.ComponentRef<typeof ToggleGroupPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root> &
-    VariantProps<typeof toggleVariants>
+  HTMLElement,
+  ToggleGroupProps
 >(({ className, variant, size, children, ...props }, ref) => (
-  <ToggleGroupPrimitive.Root
+  <ToggleGroupRootPrimitive
     ref={ref}
     className={cn("flex items-center justify-center gap-1", className)}
     {...props}
@@ -27,20 +46,19 @@ const ToggleGroup = React.forwardRef<
     <ToggleGroupContext.Provider value={{ variant, size }}>
       {children}
     </ToggleGroupContext.Provider>
-  </ToggleGroupPrimitive.Root>
+  </ToggleGroupRootPrimitive>
 ))
 
 ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName
 
 const ToggleGroupItem = React.forwardRef<
-  React.ComponentRef<typeof ToggleGroupPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item> &
-    VariantProps<typeof toggleVariants>
+  HTMLElement,
+  ToggleGroupItemProps
 >(({ className, children, variant, size, ...props }, ref) => {
   const context = React.useContext(ToggleGroupContext)
 
   return (
-    <ToggleGroupPrimitive.Item
+    <ToggleGroupItemPrimitive
       ref={ref}
       className={cn(
         toggleVariants({
@@ -52,7 +70,7 @@ const ToggleGroupItem = React.forwardRef<
       {...props}
     >
       {children}
-    </ToggleGroupPrimitive.Item>
+    </ToggleGroupItemPrimitive>
   )
 })
 

--- a/apps/web/components/ui/toggle.tsx
+++ b/apps/web/components/ui/toggle.tsx
@@ -6,6 +6,16 @@ import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 
+type PrimitiveWithRef = React.ForwardRefExoticComponent<
+  Record<string, unknown> & React.RefAttributes<HTMLElement>
+>
+
+const ToggleRootPrimitive =
+  TogglePrimitive.Root as unknown as PrimitiveWithRef
+
+type ToggleProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
+  VariantProps<typeof toggleVariants>
+
 const toggleVariants = cva(
   "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
@@ -29,11 +39,10 @@ const toggleVariants = cva(
 )
 
 const Toggle = React.forwardRef<
-  React.ComponentRef<typeof TogglePrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> &
-    VariantProps<typeof toggleVariants>
+  HTMLElement,
+  ToggleProps
 >(({ className, variant, size, ...props }, ref) => (
-  <TogglePrimitive.Root
+  <ToggleRootPrimitive
     ref={ref}
     className={cn(toggleVariants({ variant, size, className }))}
     {...props}

--- a/apps/web/components/ui/tooltip.tsx
+++ b/apps/web/components/ui/tooltip.tsx
@@ -5,18 +5,33 @@ import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 
 import { cn } from "@/lib/utils"
 
+type PrimitiveNoRef = React.ComponentType<Record<string, unknown>>
+type PrimitiveWithRef = React.ForwardRefExoticComponent<
+  Record<string, unknown> & React.RefAttributes<HTMLElement>
+>
+
+const TooltipPortalPrimitive =
+  TooltipPrimitive.Portal as unknown as PrimitiveNoRef
+const TooltipContentPrimitive =
+  TooltipPrimitive.Content as unknown as PrimitiveWithRef
+
 const TooltipProvider = TooltipPrimitive.Provider
 
 const Tooltip = TooltipPrimitive.Root
 
 const TooltipTrigger = TooltipPrimitive.Trigger
 
+type TooltipContentProps = React.HTMLAttributes<HTMLDivElement> & {
+  side?: string
+  sideOffset?: number
+}
+
 const TooltipContent = React.forwardRef<
-  React.ComponentRef<typeof TooltipPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+  HTMLElement,
+  TooltipContentProps
 >(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Portal>
-    <TooltipPrimitive.Content
+  <TooltipPortalPrimitive>
+    <TooltipContentPrimitive
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
@@ -25,7 +40,7 @@ const TooltipContent = React.forwardRef<
       )}
       {...props}
     />
-  </TooltipPrimitive.Portal>
+  </TooltipPortalPrimitive>
 ))
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,10 @@
+import { fileURLToPath } from "node:url";
+
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  outputFileTracingRoot: fileURLToPath(new URL("../../", import.meta.url)),
   transpilePackages: [
     "@as-comms/contracts",
     "@as-comms/db",

--- a/apps/worker/test/stage1-gmail-mbox-import.test.ts
+++ b/apps/worker/test/stage1-gmail-mbox-import.test.ts
@@ -46,7 +46,17 @@ async function seedContact(context: TestWorkerContext) {
         verifiedAt: "2026-01-01T00:00:00.000Z"
       }
     ],
-    memberships: []
+    memberships: [
+      {
+        id: `membership:${contactId}:project-stage1`,
+        contactId,
+        projectId: "project-stage1",
+        expeditionId: "expedition-stage1",
+        role: "volunteer",
+        status: "active",
+        source: "salesforce"
+      }
+    ]
   });
 }
 

--- a/apps/worker/test/stage1-inbox-revalidation.test.ts
+++ b/apps/worker/test/stage1-inbox-revalidation.test.ts
@@ -41,7 +41,17 @@ async function seedContact(context: TestWorkerContext): Promise<void> {
         verifiedAt: "2026-01-01T00:00:00.000Z"
       }
     ],
-    memberships: []
+    memberships: [
+      {
+        id: `membership:${contactId}:project-stage1`,
+        contactId,
+        projectId: "project-stage1",
+        expeditionId: "expedition-stage1",
+        role: "volunteer",
+        status: "active",
+        source: "salesforce"
+      }
+    ]
   });
 }
 

--- a/apps/worker/test/stage1-ingest.test.ts
+++ b/apps/worker/test/stage1-ingest.test.ts
@@ -190,7 +190,16 @@ describe("Stage 1 worker ingest service", () => {
       volunteerIdPlainValues: ["VOL-123"],
       createdAt: "2026-01-01T00:00:00.000Z",
       updatedAt: "2026-01-02T00:00:00.000Z",
-      memberships: []
+      memberships: [
+        {
+          projectId: "project_1",
+          projectName: "Project Antarctica",
+          expeditionId: "expedition_1",
+          expeditionName: "Expedition Antarctica",
+          role: "volunteer",
+          status: "active"
+        }
+      ]
     });
 
     expect(result).toEqual({
@@ -205,6 +214,49 @@ describe("Stage 1 worker ingest service", () => {
       contactId: "contact:salesforce:003-stage1"
     });
     expect(upsertNormalizedContactGraph).toHaveBeenCalledTimes(1);
+    expect(applyNormalizedCanonicalEvent).not.toHaveBeenCalled();
+  });
+
+  it("defers Salesforce contact snapshots that do not have expedition memberships", async () => {
+    const applyNormalizedCanonicalEvent = vi.fn(
+      (input: NormalizedCanonicalEventIntake) =>
+        Promise.resolve(buildAppliedCanonicalEventResult(input))
+    );
+    const upsertNormalizedContactGraph = vi.fn(
+      (input: NormalizedContactGraphUpsertInput) =>
+        Promise.resolve(buildContactGraphResult(input))
+    );
+    const service = createStage1IngestService({
+      applyNormalizedCanonicalEvent,
+      upsertNormalizedContactGraph
+    });
+
+    const result = await service.ingestSalesforceHistoricalRecord({
+      recordType: "contact_snapshot",
+      recordId: "003-non-volunteer",
+      salesforceContactId: "003-non-volunteer",
+      displayName: "Non Volunteer Contact",
+      primaryEmail: "donor@example.org",
+      primaryPhone: null,
+      normalizedEmails: ["donor@example.org"],
+      normalizedPhones: [],
+      volunteerIdPlainValues: [],
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-02T00:00:00.000Z",
+      memberships: []
+    });
+
+    expect(result).toEqual({
+      outcome: "deferred",
+      ingestMode: "historical",
+      provider: "salesforce",
+      sourceRecordType: "contact_snapshot",
+      sourceRecordId: "003-non-volunteer",
+      reason: "deferred_record_family",
+      detail:
+        "Salesforce contact_snapshot records without expedition memberships are skipped in Stage 1."
+    });
+    expect(upsertNormalizedContactGraph).not.toHaveBeenCalled();
     expect(applyNormalizedCanonicalEvent).not.toHaveBeenCalled();
   });
 

--- a/apps/worker/test/stage1-mailchimp-artifact-import.test.ts
+++ b/apps/worker/test/stage1-mailchimp-artifact-import.test.ts
@@ -42,7 +42,17 @@ async function seedContact(context: TestWorkerContext) {
         verifiedAt: "2026-01-01T00:00:00.000Z"
       }
     ],
-    memberships: []
+    memberships: [
+      {
+        id: `membership:${contactId}:project-stage1`,
+        contactId,
+        projectId: "project-stage1",
+        expeditionId: "expedition-stage1",
+        role: "volunteer",
+        status: "active",
+        source: "salesforce"
+      }
+    ]
   });
 }
 

--- a/apps/worker/test/stage1-normalization-guard.test.ts
+++ b/apps/worker/test/stage1-normalization-guard.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { createTestWorkerContext } from "./helpers.js";
+
+describe("Stage 1 normalization contact graph safeguards", () => {
+  it("rejects Salesforce-anchored contacts without memberships while still allowing non-Salesforce contacts", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await expect(
+        context.normalization.upsertNormalizedContactGraph({
+          contact: {
+            id: "contact:salesforce:003-non-volunteer",
+            salesforceContactId: "003-non-volunteer",
+            displayName: "Non Volunteer Contact",
+            primaryEmail: "donor@example.org",
+            primaryPhone: null,
+            createdAt: "2026-01-01T00:00:00.000Z",
+            updatedAt: "2026-01-01T00:00:00.000Z"
+          },
+          identities: [
+            {
+              id: "identity:contact:salesforce:003-non-volunteer:salesforce",
+              contactId: "contact:salesforce:003-non-volunteer",
+              kind: "salesforce_contact_id",
+              normalizedValue: "003-non-volunteer",
+              isPrimary: true,
+              source: "salesforce",
+              verifiedAt: "2026-01-01T00:00:00.000Z"
+            }
+          ],
+          memberships: []
+        })
+      ).rejects.toThrow(
+        "Salesforce contact 003-non-volunteer is missing expedition memberships and cannot be upserted into the Stage 1 volunteer contact graph."
+      );
+
+      const nonSalesforceResult =
+        await context.normalization.upsertNormalizedContactGraph({
+          contact: {
+            id: "contact:email:external-partner@example.org",
+            salesforceContactId: null,
+            displayName: "External Partner",
+            primaryEmail: "external-partner@example.org",
+            primaryPhone: null,
+            createdAt: "2026-01-01T00:00:00.000Z",
+            updatedAt: "2026-01-01T00:00:00.000Z"
+          },
+          identities: [
+            {
+              id: "identity:contact:email:external-partner@example.org:email",
+              contactId: "contact:email:external-partner@example.org",
+              kind: "email",
+              normalizedValue: "external-partner@example.org",
+              isPrimary: true,
+              source: "gmail",
+              verifiedAt: "2026-01-01T00:00:00.000Z"
+            }
+          ],
+          memberships: []
+        });
+
+      expect(nonSalesforceResult.contact.id).toBe(
+        "contact:email:external-partner@example.org"
+      );
+      await expect(context.repositories.contacts.listAll()).resolves.toHaveLength(1);
+    } finally {
+      await context.dispose();
+    }
+  });
+});

--- a/apps/worker/test/stage1-runtime.test.ts
+++ b/apps/worker/test/stage1-runtime.test.ts
@@ -62,7 +62,17 @@ async function seedContact(context: TestWorkerContext): Promise<void> {
         verifiedAt: "2026-01-01T00:00:00.000Z"
       }
     ],
-    memberships: []
+    memberships: [
+      {
+        id: `membership:${contactId}:project-stage1`,
+        contactId,
+        projectId: "project-stage1",
+        expeditionId: "expedition-stage1",
+        role: "volunteer",
+        status: "active",
+        source: "salesforce"
+      }
+    ]
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "ops:worker:enqueue": "pnpm --filter @as-comms/worker ops:enqueue",
     "ops:worker:import-gmail-mbox": "pnpm --filter @as-comms/worker ops:import-gmail-mbox",
     "ops:worker:inspect": "pnpm --filter @as-comms/worker ops:inspect",
+    "ops:cleanup-non-volunteer-contacts": "tsx scripts/ops/cleanup-non-volunteer-contacts.ts",
     "ops:worker:seed-aliases-from-env": "tsx scripts/ops/seed-aliases-from-env.ts",
     "ops:promote-admin": "tsx scripts/ops/promote-admin.ts",
     "build": "turbo build && node scripts/verify-runtime-exports.mjs",

--- a/packages/domain/src/normalization.ts
+++ b/packages/domain/src/normalization.ts
@@ -226,6 +226,21 @@ function requireValue<T>(value: T | undefined, message: string): T {
   return value;
 }
 
+function assertVolunteerScopedSalesforceContactGraph(
+  input: NormalizedContactGraphUpsertInput
+): void {
+  const memberships = input.memberships ?? [];
+
+  if (
+    input.contact.salesforceContactId !== null &&
+    memberships.length === 0
+  ) {
+    throw new Error(
+      `Salesforce contact ${input.contact.salesforceContactId} is missing expedition memberships and cannot be upserted into the Stage 1 volunteer contact graph.`
+    );
+  }
+}
+
 function isInboundEvent(eventType: InboxDrivingEventType): boolean {
   return (
     eventType === "communication.email.inbound" ||
@@ -1070,6 +1085,7 @@ export function createStage1NormalizationService(
 
     async upsertNormalizedContactGraph(input) {
       const parsed = normalizedContactGraphUpsertInputSchema.parse(input);
+      assertVolunteerScopedSalesforceContactGraph(parsed);
       const contact = await persistence.upsertCanonicalContact(
         contactSchema.parse(parsed.contact)
       );

--- a/packages/integrations/src/capture-services/salesforce.ts
+++ b/packages/integrations/src/capture-services/salesforce.ts
@@ -503,6 +503,15 @@ function buildContactWindowWhere(window: {
   return `LastModifiedDate >= ${formatSoqlDateTime(window.windowStart)} AND LastModifiedDate < ${formatSoqlDateTime(window.windowEnd)}`;
 }
 
+function buildVolunteerScopedContactWhere(
+  baseWhere: string,
+  config: ResolvedSalesforceCaptureServiceConfig
+): string {
+  // TODO(canon): lock the Stage 1 Salesforce volunteer-only Contact ingest rule in the
+  // provider ingest matrix / decision log so this belt-and-suspenders filter is explicit canon.
+  return `${baseWhere} AND Id IN (SELECT ${config.membershipContactField} FROM ${config.membershipObjectName} WHERE ${config.membershipContactField} != null)`;
+}
+
 function buildTaskWindowWhere(window: {
   readonly mode: "historical" | "live";
   readonly windowStart: string | null;
@@ -906,6 +915,7 @@ export function createSalesforceCaptureService(
     readonly objectName: string;
     readonly fields: readonly string[];
     readonly recordIds: readonly string[];
+    readonly extraWhere?: string;
   }): Promise<readonly SalesforceRow[]> {
     if (input.recordIds.length === 0) {
       return [];
@@ -914,9 +924,14 @@ export function createSalesforceCaptureService(
     const rows: SalesforceRow[] = [];
 
     for (const recordIds of chunkValues(input.recordIds, 200)) {
+      const whereClauses = [
+        `Id IN ${buildInClause(recordIds)}`,
+        ...(input.extraWhere === undefined ? [] : [input.extraWhere])
+      ];
+
       rows.push(
         ...(await apiClient.queryAll(
-          `SELECT ${input.fields.join(", ")} FROM ${input.objectName} WHERE Id IN ${buildInClause(recordIds)}`
+          `SELECT ${input.fields.join(", ")} FROM ${input.objectName} WHERE ${whereClauses.join(" AND ")}`
         ))
       );
     }
@@ -1045,11 +1060,16 @@ export function createSalesforceCaptureService(
         ? await queryRowsByIds({
             objectName: "Contact",
             fields: contactFields,
-            recordIds: input.recordIds
+            recordIds: input.recordIds,
+            extraWhere: buildVolunteerScopedContactWhere(
+              "Id != null",
+              parsedConfig
+            )
           })
         : await apiClient.queryAll(
-            `SELECT ${contactFields.join(", ")} FROM Contact WHERE ${buildContactWindowWhere(
-              window
+            `SELECT ${contactFields.join(", ")} FROM Contact WHERE ${buildVolunteerScopedContactWhere(
+              buildContactWindowWhere(window),
+              parsedConfig
             )}`
           );
     const contactsById = new Map<string, SalesforceRow>();
@@ -1073,7 +1093,8 @@ export function createSalesforceCaptureService(
       const additionalContacts = await queryRowsByIds({
         objectName: "Contact",
         fields: contactFields,
-        recordIds: missingTouchedContactIds
+        recordIds: missingTouchedContactIds,
+        extraWhere: buildVolunteerScopedContactWhere("Id != null", parsedConfig)
       });
 
       for (const contact of additionalContacts) {

--- a/packages/integrations/src/providers/salesforce.ts
+++ b/packages/integrations/src/providers/salesforce.ts
@@ -588,6 +588,17 @@ export function mapSalesforceRecord(
   const contactSnapshot = salesforceContactSnapshotRecordSchema.safeParse(rawRecord);
 
   if (contactSnapshot.success) {
+    if (contactSnapshot.data.memberships.length === 0) {
+      return createDeferredMappingResult({
+        provider: "salesforce",
+        sourceRecordType: contactSnapshot.data.recordType,
+        sourceRecordId: contactSnapshot.data.recordId,
+        reason: "deferred_record_family",
+        detail:
+          "Salesforce contact_snapshot records without expedition memberships are skipped in Stage 1."
+      });
+    }
+
     return createCommandMappingResult({
       provider: "salesforce",
       sourceRecordType: contactSnapshot.data.recordType,

--- a/packages/integrations/test/stage1-mappers.test.ts
+++ b/packages/integrations/test/stage1-mappers.test.ts
@@ -145,6 +145,33 @@ describe("Stage 1 provider-close mappers", () => {
     }
   });
 
+  it("defers Salesforce contact snapshots that are not backed by expedition memberships", () => {
+    const result = mapSalesforceRecord({
+      recordType: "contact_snapshot",
+      recordId: "003-non-volunteer",
+      salesforceContactId: "003-non-volunteer",
+      displayName: "Non Volunteer Contact",
+      primaryEmail: "donor@example.org",
+      primaryPhone: null,
+      normalizedEmails: ["donor@example.org"],
+      normalizedPhones: [],
+      volunteerIdPlainValues: [],
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-02T00:00:00.000Z",
+      memberships: []
+    });
+
+    expect(result).toEqual({
+      outcome: "deferred",
+      provider: "salesforce",
+      sourceRecordType: "contact_snapshot",
+      sourceRecordId: "003-non-volunteer",
+      reason: "deferred_record_family",
+      detail:
+        "Salesforce contact_snapshot records without expedition memberships are skipped in Stage 1."
+    });
+  });
+
   it("maps the four locked Expedition_Members lifecycle source fields into canonical lifecycle events", () => {
     const lifecycleCases = [
       {

--- a/packages/integrations/test/stage1-salesforce-capture-service.test.ts
+++ b/packages/integrations/test/stage1-salesforce-capture-service.test.ts
@@ -347,6 +347,9 @@ describe("Salesforce capture service", () => {
           "FROM Expedition_Members__c WHERE Contact__c != null AND ((CreatedDate >= 2026-01-01T00:00:00.000Z AND CreatedDate < 2026-01-06T00:00:00.000Z)"
         ),
         expect.stringContaining(
+          "FROM Contact WHERE LastModifiedDate >= 2026-01-01T00:00:00.000Z AND LastModifiedDate < 2026-01-06T00:00:00.000Z AND Id IN (SELECT Contact__c FROM Expedition_Members__c WHERE Contact__c != null)"
+        ),
+        expect.stringContaining(
           "Date_Training_Sent__c >= 2026-01-01 AND Date_Training_Sent__c < 2026-01-06"
         ),
         expect.stringContaining(

--- a/scripts/ops/cleanup-non-volunteer-contacts.ts
+++ b/scripts/ops/cleanup-non-volunteer-contacts.ts
@@ -1,0 +1,291 @@
+#!/usr/bin/env tsx
+/**
+ * cleanup-non-volunteer-contacts
+ *
+ * Usage:
+ *   pnpm ops:cleanup-non-volunteer-contacts
+ *   pnpm ops:cleanup-non-volunteer-contacts --confirm
+ *
+ * Dry-run by default. Prints the Salesforce-anchored contacts that have no
+ * expedition memberships plus the dependent rows that would be removed.
+ *
+ * This script is an ops tool, not part of `apps/web`. The repo boundary rule
+ * that restricts direct `@as-comms/db` imports to the Stage 1 composition
+ * root only applies to workspace packages under `apps/` and `packages/`.
+ */
+import {
+  closeDatabaseConnection,
+  createDatabaseConnection
+} from "@as-comms/db";
+
+type ContactSampleRow = {
+  readonly id: string;
+  readonly display_name: string;
+  readonly email: string | null;
+  readonly sf_id: string | null;
+};
+
+type IdRow = {
+  readonly id: string;
+};
+
+type CanonicalEventRow = {
+  readonly id: string;
+  readonly source_evidence_id: string;
+};
+
+type ReviewCaseRow = {
+  readonly id: string;
+  readonly source_evidence_id: string;
+};
+
+type CleanupSummary = {
+  readonly contactCount: number;
+  readonly canonicalEventCount: number;
+  readonly inboxProjectionCount: number;
+  readonly timelineProjectionCount: number;
+  readonly sourceEvidenceCount: number;
+  readonly identityReviewCount: number;
+  readonly routingReviewCount: number;
+};
+
+type SqlRunner = {
+  unsafe<T extends readonly object[]>(query: string): Promise<T>;
+  begin<T>(callback: (sql: SqlRunner) => Promise<T>): Promise<T>;
+};
+
+function chunkValues<TValue>(
+  values: readonly TValue[],
+  chunkSize: number
+): TValue[][] {
+  const chunks: TValue[][] = [];
+
+  for (let index = 0; index < values.length; index += 1) {
+    if (index % chunkSize === 0) {
+      chunks.push(values.slice(index, index + chunkSize));
+    }
+  }
+
+  return chunks;
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+  return Array.from(new Set(values)).sort((left, right) =>
+    left.localeCompare(right)
+  );
+}
+
+function quoteSqlLiteral(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function buildInClause(values: readonly string[]): string {
+  return `(${values.map((value) => quoteSqlLiteral(value)).join(", ")})`;
+}
+
+function buildTextArray(values: readonly string[]): string {
+  return `array[${values.map((value) => quoteSqlLiteral(value)).join(", ")}]::text[]`;
+}
+
+function printSummary(summary: CleanupSummary): void {
+  console.log("Affected rows:");
+  console.log(`- contacts: ${summary.contactCount}`);
+  console.log(`- canonical_event_ledger: ${summary.canonicalEventCount}`);
+  console.log(`- contact_inbox_projection: ${summary.inboxProjectionCount}`);
+  console.log(`- contact_timeline_projection: ${summary.timelineProjectionCount}`);
+  console.log(`- source_evidence_log: ${summary.sourceEvidenceCount}`);
+  console.log(`- identity_resolution_queue: ${summary.identityReviewCount}`);
+  console.log(`- routing_review_queue: ${summary.routingReviewCount}`);
+}
+
+async function selectIds(
+  sql: SqlRunner,
+  query: string
+): Promise<string[]> {
+  const rows = await sql.unsafe<readonly IdRow[]>(query);
+  return rows.map((row) => row.id);
+}
+
+async function main(): Promise<void> {
+  const connectionString = process.env.DATABASE_URL;
+
+  if (!connectionString) {
+    console.error("DATABASE_URL is required");
+    process.exitCode = 1;
+    return;
+  }
+
+  const confirm = process.argv.slice(2).includes("--confirm");
+  const connection = createDatabaseConnection({ connectionString });
+  const sql = connection.sql as unknown as SqlRunner;
+
+  try {
+    const targetContacts = await sql.unsafe<readonly ContactSampleRow[]>(`
+      select
+        c.id,
+        c.display_name,
+        c.primary_email as email,
+        c.salesforce_contact_id as sf_id
+      from contacts c
+      where c.salesforce_contact_id is not null
+        and not exists (
+          select 1
+          from contact_memberships cm
+          where cm.contact_id = c.id
+        )
+      order by c.id asc
+    `);
+    const contactIds = targetContacts.map((contact) => contact.id);
+
+    console.log("cleanup-non-volunteer-contacts");
+    console.log(`Mode: ${confirm ? "confirm" : "dry-run"}`);
+    console.log(
+      `Found ${targetContacts.length} Salesforce contacts without expedition memberships.`
+    );
+
+    if (targetContacts.length > 0) {
+      console.log("Sample contacts (first 10):");
+      for (const contact of targetContacts.slice(0, 10)) {
+        console.log(
+          `- ${JSON.stringify({
+            id: contact.id,
+            display_name: contact.display_name,
+            email: contact.email,
+            sf_id: contact.sf_id
+          })}`
+        );
+      }
+    }
+
+    if (contactIds.length === 0) {
+      console.log("Nothing to clean up.");
+      return;
+    }
+
+    const contactIdInClause = buildInClause(contactIds);
+    const contactIdTextArray = buildTextArray(contactIds);
+
+    const canonicalEvents = await sql.unsafe<readonly CanonicalEventRow[]>(`
+      select id, source_evidence_id
+      from canonical_event_ledger
+      where contact_id in ${contactIdInClause}
+    `);
+    const canonicalEventIds = canonicalEvents.map((event) => event.id);
+    const canonicalSourceEvidenceIds = uniqueStrings(
+      canonicalEvents.map((event) => event.source_evidence_id)
+    );
+
+    const inboxProjectionIds = await selectIds(
+      sql,
+      `
+        select contact_id as id
+        from contact_inbox_projection
+        where contact_id in ${contactIdInClause}
+      `
+    );
+    const timelineProjectionIds = await selectIds(
+      sql,
+      `
+        select id
+        from contact_timeline_projection
+        where contact_id in ${contactIdInClause}
+      `
+    );
+
+    const sourceEvidenceClause =
+      canonicalSourceEvidenceIds.length === 0
+        ? ""
+        : ` or source_evidence_id in ${buildInClause(canonicalSourceEvidenceIds)}`;
+
+    const identityCases = await sql.unsafe<readonly ReviewCaseRow[]>(`
+      select distinct id, source_evidence_id
+      from identity_resolution_queue
+      where anchored_contact_id in ${contactIdInClause}
+         or candidate_contact_ids && ${contactIdTextArray}
+         ${sourceEvidenceClause}
+    `);
+    const identityCaseIds = identityCases.map((record) => record.id);
+
+    const routingCases = await sql.unsafe<readonly ReviewCaseRow[]>(`
+      select distinct id, source_evidence_id
+      from routing_review_queue
+      where contact_id in ${contactIdInClause}
+         ${sourceEvidenceClause}
+    `);
+    const routingCaseIds = routingCases.map((record) => record.id);
+
+    const sourceEvidenceIds = uniqueStrings([
+      ...canonicalSourceEvidenceIds,
+      ...identityCases.map((record) => record.source_evidence_id),
+      ...routingCases.map((record) => record.source_evidence_id)
+    ]);
+
+    const summary: CleanupSummary = {
+      contactCount: targetContacts.length,
+      canonicalEventCount: canonicalEventIds.length,
+      inboxProjectionCount: inboxProjectionIds.length,
+      timelineProjectionCount: timelineProjectionIds.length,
+      sourceEvidenceCount: sourceEvidenceIds.length,
+      identityReviewCount: identityCaseIds.length,
+      routingReviewCount: routingCaseIds.length
+    };
+
+    printSummary(summary);
+
+    if (!confirm) {
+      console.log("Dry run complete. Re-run with --confirm to delete these rows.");
+      return;
+    }
+
+    await sql.begin(async (tx) => {
+      for (const ids of chunkValues(inboxProjectionIds, 500)) {
+        await tx.unsafe(`
+          delete from contact_inbox_projection
+          where contact_id in ${buildInClause(ids)}
+        `);
+      }
+
+      for (const ids of chunkValues(routingCaseIds, 500)) {
+        await tx.unsafe(`
+          delete from routing_review_queue
+          where id in ${buildInClause(ids)}
+        `);
+      }
+
+      for (const ids of chunkValues(identityCaseIds, 500)) {
+        await tx.unsafe(`
+          delete from identity_resolution_queue
+          where id in ${buildInClause(ids)}
+        `);
+      }
+
+      for (const ids of chunkValues(canonicalEventIds, 500)) {
+        await tx.unsafe(`
+          delete from canonical_event_ledger
+          where id in ${buildInClause(ids)}
+        `);
+      }
+
+      for (const ids of chunkValues(sourceEvidenceIds, 500)) {
+        await tx.unsafe(`
+          delete from source_evidence_log
+          where id in ${buildInClause(ids)}
+        `);
+      }
+
+      for (const ids of chunkValues(contactIds, 500)) {
+        await tx.unsafe(`
+          delete from contacts
+          where id in ${buildInClause(ids)}
+        `);
+      }
+    });
+
+    console.log("Delete complete.");
+    printSummary(summary);
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}
+
+await main();


### PR DESCRIPTION
## Summary
- restrict Salesforce Contact capture queries to expedition-member-backed contacts and defer empty-membership contact snapshots before they reach normalization
- reject Salesforce-anchored contact graph upserts without memberships and add the dry-run-first `pnpm ops:cleanup-non-volunteer-contacts` cleanup script
- add mapper/ingest/normalization coverage for the volunteer-only guard and make the existing web build pass cleanly in the worktree environment so the required gate can run green

## Testing
- `pnpm --filter @as-comms/web typecheck`
- `pnpm --filter @as-comms/web build`
- `pnpm boundaries`
- `pnpm verify`
- `cd packages/integrations && pnpm exec vitest run test/stage1-salesforce-capture-service.test.ts test/stage1-mappers.test.ts`
- `cd apps/worker && pnpm exec vitest run test/stage1-ingest.test.ts test/stage1-runtime.test.ts test/stage1-inbox-revalidation.test.ts test/stage1-gmail-mbox-import.test.ts test/stage1-mailchimp-artifact-import.test.ts test/stage1-normalization-guard.test.ts`

TODO(canon): encode the volunteer-only Salesforce Contact ingest rule in the Stage 1 provider ingest matrix / decision log.