### PR TITLE
fix(stage1): classify Salesforce Task auto-emails so they don't drive inbox bucket state

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -12,6 +12,7 @@
     "ops:check-config": "tsx src/ops/cli.ts check-config",
     "ops:enqueue": "tsx src/ops/cli.ts enqueue",
     "ops:import-gmail-mbox": "tsx src/ops/cli.ts import-gmail-mbox",
+    "ops:reclassify-salesforce-tasks": "tsx src/ops/reclassify-salesforce-tasks.ts",
     "ops:inspect": "tsx src/ops/cli.ts inspect",
     "lint": "eslint src test --max-warnings=0",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/apps/worker/src/ops/reclassify-salesforce-tasks.ts
+++ b/apps/worker/src/ops/reclassify-salesforce-tasks.ts
@@ -1,0 +1,460 @@
+#!/usr/bin/env tsx
+/**
+ * reclassify-salesforce-tasks
+ *
+ * Usage:
+ *   pnpm ops:reclassify-salesforce-tasks
+ *   pnpm ops:reclassify-salesforce-tasks --confirm
+ *
+ * Dry-run by default. Reclassifies historical Salesforce outbound email Tasks
+ * using the conservative Stage 1 heuristic, then enqueues scoped projection
+ * rebuild jobs for affected contacts.
+ *
+ * This script is an ops tool, not part of `apps/web`. The repo boundary rule
+ * that restricts direct `@as-comms/db` imports to the Stage 1 composition
+ * root only applies to workspace packages under `apps/` and `packages/`.
+ */
+import { parseArgs } from "node:util";
+
+import {
+  projectionRebuildBatchJobName,
+  projectionRebuildBatchPayloadSchema,
+  stage1JobVersion,
+  type CommunicationMessageKind
+} from "@as-comms/contracts";
+import {
+  closeDatabaseConnection,
+  createDatabaseConnection
+} from "@as-comms/db";
+import {
+  classifySalesforceTaskMessageKind,
+  type SalesforceTaskMessageKindClassification
+} from "../../../../packages/integrations/src/providers/salesforce.js";
+
+import {
+  buildOperationId
+} from "./helpers.js";
+import {
+  enqueueStage1Job,
+  type Stage1EnqueueRequest
+} from "./enqueue.js";
+
+type SqlRunner = {
+  unsafe<T extends readonly object[]>(query: string): Promise<T>;
+  begin<T>(callback: (sql: SqlRunner) => Promise<T>): Promise<T>;
+};
+
+type ReclassificationCandidateRow = {
+  readonly canonical_event_id: string;
+  readonly contact_id: string;
+  readonly source_evidence_id: string;
+  readonly current_message_kind: string | null;
+  readonly subject: string | null;
+  readonly snippet: string | null;
+};
+
+type IdRow = {
+  readonly id: string;
+};
+
+export interface SalesforceTaskReclassificationCandidate {
+  readonly canonicalEventId: string;
+  readonly contactId: string;
+  readonly sourceEvidenceId: string;
+  readonly currentMessageKind: CommunicationMessageKind | null;
+  readonly subject: string | null;
+  readonly snippet: string;
+}
+
+export interface SalesforceTaskReclassificationChange {
+  readonly canonicalEventId: string;
+  readonly contactId: string;
+  readonly sourceEvidenceId: string;
+  readonly previousMessageKind: "one_to_one";
+  readonly nextMessageKind: "auto";
+  readonly subject: string | null;
+  readonly snippet: string;
+  readonly summary: "Auto email sent";
+  readonly sourceLabel: "Salesforce Flow";
+  readonly reason: SalesforceTaskMessageKindClassification["reason"];
+}
+
+export interface SalesforceTaskReclassificationPlan {
+  readonly scannedCount: number;
+  readonly reclassifiedCount: number;
+  readonly affectedContactIds: readonly string[];
+  readonly reasonCounts: Readonly<Record<string, number>>;
+  readonly changes: readonly SalesforceTaskReclassificationChange[];
+}
+
+export interface ReclassifySalesforceTasksResult {
+  readonly confirm: boolean;
+  readonly scannedCount: number;
+  readonly reclassifiedCount: number;
+  readonly affectedContactIds: readonly string[];
+  readonly enqueuedJobIds: readonly string[];
+}
+
+function chunkValues<TValue>(
+  values: readonly TValue[],
+  chunkSize: number
+): TValue[][] {
+  const chunks: TValue[][] = [];
+
+  for (let index = 0; index < values.length; index += chunkSize) {
+    chunks.push(values.slice(index, index + chunkSize));
+  }
+
+  return chunks;
+}
+
+function quoteSqlLiteral(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function normalizeMessageKind(
+  value: string | null
+): CommunicationMessageKind | null {
+  return value === "one_to_one" || value === "auto" || value === "campaign"
+    ? value
+    : null;
+}
+
+function uniqueSortedStrings(values: readonly string[]): string[] {
+  return Array.from(new Set(values)).sort((left, right) =>
+    left.localeCompare(right)
+  );
+}
+
+async function loadCandidates(
+  sql: SqlRunner
+): Promise<readonly SalesforceTaskReclassificationCandidate[]> {
+  const rows = await sql.unsafe<readonly ReclassificationCandidateRow[]>(`
+    select
+      canonical_event_ledger.id as canonical_event_id,
+      canonical_event_ledger.contact_id,
+      canonical_event_ledger.source_evidence_id,
+      canonical_event_ledger.provenance ->> 'messageKind' as current_message_kind,
+      salesforce_communication_details.subject,
+      salesforce_communication_details.snippet
+    from canonical_event_ledger
+    left join salesforce_communication_details
+      on salesforce_communication_details.source_evidence_id = canonical_event_ledger.source_evidence_id
+    where canonical_event_ledger.event_type = 'communication.email.outbound'
+      and canonical_event_ledger.provenance ->> 'primaryProvider' = 'salesforce'
+    order by canonical_event_ledger.occurred_at asc, canonical_event_ledger.id asc
+  `);
+
+  return rows.map((row) => ({
+    canonicalEventId: row.canonical_event_id,
+    contactId: row.contact_id,
+    sourceEvidenceId: row.source_evidence_id,
+    currentMessageKind: normalizeMessageKind(row.current_message_kind),
+    subject: row.subject,
+    snippet: row.snippet ?? ""
+  }));
+}
+
+export function planSalesforceTaskReclassifications(
+  candidates: readonly SalesforceTaskReclassificationCandidate[]
+): SalesforceTaskReclassificationPlan {
+  const changes: SalesforceTaskReclassificationChange[] = [];
+  const reasonCounts = new Map<string, number>();
+
+  for (const candidate of candidates) {
+    // Historical Stage 1 rows only persist Salesforce subject/snippet, not the
+    // original owner or TaskSubtype metadata, so ambiguous legacy rows
+    // intentionally default to auto to protect queue truth.
+    const classification = classifySalesforceTaskMessageKind({
+      channel: "email",
+      subject: candidate.subject
+    });
+
+    if (
+      candidate.currentMessageKind === "one_to_one" &&
+      classification.messageKind === "auto"
+    ) {
+      reasonCounts.set(
+        classification.reason,
+        (reasonCounts.get(classification.reason) ?? 0) + 1
+      );
+      changes.push({
+        canonicalEventId: candidate.canonicalEventId,
+        contactId: candidate.contactId,
+        sourceEvidenceId: candidate.sourceEvidenceId,
+        previousMessageKind: "one_to_one",
+        nextMessageKind: "auto",
+        subject: candidate.subject,
+        snippet: candidate.snippet,
+        summary: "Auto email sent",
+        sourceLabel: "Salesforce Flow",
+        reason: classification.reason
+      });
+    }
+  }
+
+  return {
+    scannedCount: candidates.length,
+    reclassifiedCount: changes.length,
+    affectedContactIds: uniqueSortedStrings(
+      changes.map((change) => change.contactId)
+    ),
+    reasonCounts: Object.fromEntries(
+      Array.from(reasonCounts.entries()).sort(([left], [right]) =>
+        left.localeCompare(right)
+      )
+    ),
+    changes
+  };
+}
+
+export function buildProjectionRebuildRequestsForContacts(
+  contactIds: readonly string[],
+  input?: {
+    readonly chunkSize?: number;
+    readonly buildId?: (prefix: string) => string;
+  }
+): readonly Stage1EnqueueRequest[] {
+  const chunkSize = input?.chunkSize ?? 250;
+  const buildIdFn = input?.buildId ?? buildOperationId;
+
+  return chunkValues(uniqueSortedStrings(contactIds), chunkSize).map((ids) => ({
+    jobName: projectionRebuildBatchJobName,
+    payload: projectionRebuildBatchPayloadSchema.parse({
+      version: stage1JobVersion,
+      jobId: buildIdFn("stage1:projection-rebuild:job"),
+      correlationId: buildIdFn("stage1:projection-rebuild:correlation"),
+      traceId: null,
+      batchId: buildIdFn("stage1:projection-rebuild:batch"),
+      syncStateId: buildIdFn("stage1:projection-rebuild:sync-state"),
+      attempt: 1,
+      maxAttempts: 3,
+      jobType: "projection_rebuild",
+      projection: "all",
+      contactIds: ids,
+      includeReviewOverlayRefresh: true
+    })
+  }));
+}
+
+function printPlanSummary(
+  plan: SalesforceTaskReclassificationPlan,
+  confirm: boolean
+): void {
+  console.log("reclassify-salesforce-tasks");
+  console.log(`Mode: ${confirm ? "confirm" : "dry-run"}`);
+  console.log(`- scanned Salesforce outbound email events: ${plan.scannedCount}`);
+  console.log(`- would reclassify one_to_one -> auto: ${plan.reclassifiedCount}`);
+  console.log(`- affected contacts: ${plan.affectedContactIds.length}`);
+
+  if (Object.keys(plan.reasonCounts).length > 0) {
+    console.log("Reason counts:");
+    for (const [reason, count] of Object.entries(plan.reasonCounts)) {
+      console.log(`- ${reason}: ${String(count)}`);
+    }
+  }
+}
+
+function printSampleChanges(
+  changes: readonly SalesforceTaskReclassificationChange[]
+): void {
+  if (changes.length === 0) {
+    console.log("No Salesforce Task rows need reclassification.");
+    return;
+  }
+
+  console.log("Sample rows (first 10):");
+  for (const change of changes.slice(0, 10)) {
+    console.log(
+      `- ${JSON.stringify({
+        canonicalEventId: change.canonicalEventId,
+        contactId: change.contactId,
+        subject: change.subject,
+        reason: change.reason
+      })}`
+    );
+  }
+}
+
+async function applyChanges(
+  sql: SqlRunner,
+  changes: readonly SalesforceTaskReclassificationChange[]
+): Promise<void> {
+  await sql.begin(async (tx) => {
+    for (const change of changes) {
+      await tx.unsafe(`
+        update canonical_event_ledger
+        set provenance = jsonb_set(
+              provenance,
+              '{messageKind}',
+              to_jsonb(${quoteSqlLiteral(change.nextMessageKind)}::text),
+              true
+            ),
+            updated_at = now()
+        where id = ${quoteSqlLiteral(change.canonicalEventId)}
+      `);
+
+      await tx.unsafe(`
+        update salesforce_communication_details
+        set message_kind = ${quoteSqlLiteral(change.nextMessageKind)},
+            source_label = ${quoteSqlLiteral(change.sourceLabel)},
+            updated_at = now()
+        where source_evidence_id = ${quoteSqlLiteral(change.sourceEvidenceId)}
+      `);
+
+      const metadataJson = quoteSqlLiteral(
+        JSON.stringify({
+          summary: change.summary,
+          snippet: change.snippet
+        })
+      );
+      const updatedProjectionSeed = await tx.unsafe<readonly IdRow[]>(`
+        update audit_policy_evidence
+        set metadata_json = ${metadataJson}::jsonb
+        where entity_type = 'canonical_event'
+          and entity_id = ${quoteSqlLiteral(change.canonicalEventId)}
+          and policy_code = 'stage1.projection.seed'
+        returning id
+      `);
+
+      if (updatedProjectionSeed.length === 0) {
+        await tx.unsafe(`
+          insert into audit_policy_evidence (
+            id,
+            actor_type,
+            actor_id,
+            action,
+            entity_type,
+            entity_id,
+            occurred_at,
+            result,
+            policy_code,
+            metadata_json
+          ) values (
+            ${quoteSqlLiteral(`audit:canonical_event:${change.canonicalEventId}:projection-seed`)},
+            'worker',
+            'stage1-ops:reclassify-salesforce-tasks',
+            'record_projection_seed',
+            'canonical_event',
+            ${quoteSqlLiteral(change.canonicalEventId)},
+            now(),
+            'recorded',
+            'stage1.projection.seed',
+            ${metadataJson}::jsonb
+          )
+        `);
+      }
+    }
+  });
+}
+
+export async function runReclassifySalesforceTasks(input: {
+  readonly connectionString: string;
+  readonly confirm: boolean;
+  readonly enqueueJob?: (request: Stage1EnqueueRequest) => Promise<{
+    readonly enqueuedJobId: string;
+  }>;
+}): Promise<ReclassifySalesforceTasksResult> {
+  const connection = createDatabaseConnection({
+    connectionString: input.connectionString
+  });
+  const sql = connection.sql as unknown as SqlRunner;
+
+  try {
+    const candidates = await loadCandidates(sql);
+    const plan = planSalesforceTaskReclassifications(candidates);
+
+    printPlanSummary(plan, input.confirm);
+    printSampleChanges(plan.changes);
+
+    if (!input.confirm) {
+      console.log(
+        "Dry run complete. Re-run with --confirm to persist these reclassifications."
+      );
+      return {
+        confirm: false,
+        scannedCount: plan.scannedCount,
+        reclassifiedCount: plan.reclassifiedCount,
+        affectedContactIds: plan.affectedContactIds,
+        enqueuedJobIds: []
+      };
+    }
+
+    if (plan.changes.length === 0) {
+      console.log("No Salesforce Task rows needed changes.");
+      return {
+        confirm: true,
+        scannedCount: plan.scannedCount,
+        reclassifiedCount: 0,
+        affectedContactIds: [],
+        enqueuedJobIds: []
+      };
+    }
+
+    await applyChanges(sql, plan.changes);
+
+    const enqueueJob =
+      input.enqueueJob ??
+      ((request: Stage1EnqueueRequest) =>
+        enqueueStage1Job({
+          connectionString: input.connectionString,
+          request
+        }));
+    const enqueuedJobIds: string[] = [];
+
+    for (const request of buildProjectionRebuildRequestsForContacts(
+      plan.affectedContactIds
+    )) {
+      const result = await enqueueJob(request);
+      enqueuedJobIds.push(result.enqueuedJobId);
+    }
+
+    console.log("Reclassification complete.");
+    console.log(`- updated canonical events: ${plan.reclassifiedCount}`);
+    console.log(`- enqueued projection rebuild jobs: ${enqueuedJobIds.length}`);
+
+    return {
+      confirm: true,
+      scannedCount: plan.scannedCount,
+      reclassifiedCount: plan.reclassifiedCount,
+      affectedContactIds: plan.affectedContactIds,
+      enqueuedJobIds
+    };
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}
+
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    options: {
+      confirm: { type: "boolean" }
+    }
+  });
+  const connectionString =
+    process.env.WORKER_DATABASE_URL ?? process.env.DATABASE_URL;
+
+  if (!connectionString) {
+    throw new Error("DATABASE_URL or WORKER_DATABASE_URL is required.");
+  }
+
+  await runReclassifySalesforceTasks({
+    connectionString,
+    confirm: values.confirm ?? false
+  });
+}
+
+const isDirectExecution =
+  process.argv[1] !== undefined &&
+  import.meta.url === new URL(`file://${process.argv[1]}`).toString();
+
+if (isDirectExecution) {
+  void main().catch((error: unknown) => {
+    console.error(
+      error instanceof Error
+        ? error.message
+        : "reclassify-salesforce-tasks failed."
+    );
+    process.exitCode = 1;
+  });
+}

--- a/apps/worker/test/stage1-reclassify-salesforce-tasks.test.ts
+++ b/apps/worker/test/stage1-reclassify-salesforce-tasks.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildProjectionRebuildRequestsForContacts,
+  planSalesforceTaskReclassifications,
+  type SalesforceTaskReclassificationCandidate
+} from "../src/ops/reclassify-salesforce-tasks.js";
+
+describe("reclassify-salesforce-tasks planning", () => {
+  it("reclassifies only one_to_one Salesforce outbound emails that resolve to auto", () => {
+    const candidates: SalesforceTaskReclassificationCandidate[] = [
+      {
+        canonicalEventId: "evt:subject-pattern",
+        contactId: "contact:1",
+        sourceEvidenceId: "sev:subject-pattern",
+        currentMessageKind: "one_to_one",
+        subject: "Training reminder",
+        snippet: "Training reminder body"
+      },
+      {
+        canonicalEventId: "evt:ambiguous",
+        contactId: "contact:2",
+        sourceEvidenceId: "sev:ambiguous",
+        currentMessageKind: "one_to_one",
+        subject: "Manual follow-up",
+        snippet: "Manual follow-up body"
+      },
+      {
+        canonicalEventId: "evt:already-auto",
+        contactId: "contact:2",
+        sourceEvidenceId: "sev:already-auto",
+        currentMessageKind: "auto",
+        subject: "Training reminder",
+        snippet: "Already auto"
+      }
+    ];
+
+    const plan = planSalesforceTaskReclassifications(candidates);
+
+    expect(plan.scannedCount).toBe(3);
+    expect(plan.reclassifiedCount).toBe(2);
+    expect(plan.affectedContactIds).toEqual(["contact:1", "contact:2"]);
+    expect(plan.reasonCounts).toEqual({
+      insufficient_metadata: 1,
+      subject_pattern: 1
+    });
+    expect(plan.changes).toEqual([
+      expect.objectContaining({
+        canonicalEventId: "evt:subject-pattern",
+        nextMessageKind: "auto",
+        summary: "Auto email sent",
+        sourceLabel: "Salesforce Flow",
+        reason: "subject_pattern"
+      }),
+      expect.objectContaining({
+        canonicalEventId: "evt:ambiguous",
+        nextMessageKind: "auto",
+        reason: "insufficient_metadata"
+      })
+    ]);
+  });
+
+  it("builds scoped stage1.projection.rebuild jobs using all projections", () => {
+    let idCounter = 0;
+    const requests = buildProjectionRebuildRequestsForContacts(
+      ["contact:b", "contact:a", "contact:a"],
+      {
+        buildId: (prefix) => `${prefix}:${String(++idCounter)}`
+      }
+    );
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      jobName: "stage1.projection.rebuild",
+      payload: expect.objectContaining({
+        jobType: "projection_rebuild",
+        projection: "all",
+        contactIds: ["contact:a", "contact:b"],
+        includeReviewOverlayRefresh: true
+      })
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "ops:worker:import-gmail-mbox": "pnpm --filter @as-comms/worker ops:import-gmail-mbox",
     "ops:worker:inspect": "pnpm --filter @as-comms/worker ops:inspect",
     "ops:cleanup-non-volunteer-contacts": "tsx scripts/ops/cleanup-non-volunteer-contacts.ts",
+    "ops:reclassify-salesforce-tasks": "pnpm --filter @as-comms/worker ops:reclassify-salesforce-tasks",
     "ops:worker:seed-aliases-from-env": "tsx scripts/ops/seed-aliases-from-env.ts",
     "ops:promote-admin": "tsx scripts/ops/promote-admin.ts",
     "build": "turbo build && node scripts/verify-runtime-exports.mjs",

--- a/packages/integrations/src/capture-services/salesforce.ts
+++ b/packages/integrations/src/capture-services/salesforce.ts
@@ -11,6 +11,7 @@ import {
   type SalesforceLiveCaptureBatchPayload
 } from "@as-comms/contracts";
 import {
+  classifySalesforceTaskMessageKind,
   salesforceContactSnapshotRecordSchema,
   salesforceLifecycleRecordSchema,
   salesforceRecordSchema,
@@ -480,6 +481,10 @@ function buildTaskFields(
     "Id",
     "CreatedDate",
     "LastModifiedDate",
+    "OwnerId",
+    "Owner.Name",
+    "Owner.Username",
+    "TaskSubtype",
     "Subject",
     "Description",
     "WhatId",
@@ -837,7 +842,14 @@ function buildTaskRecord(input: {
         );
   const hasMembershipRoutingContext = projectId !== null || expeditionId !== null;
   const subject = getStringField(input.task, "Subject");
-  const messageKind = "auto";
+  const messageKind = classifySalesforceTaskMessageKind({
+    channel,
+    taskSubtype: getStringField(input.task, "TaskSubtype"),
+    ownerId: getStringField(input.task, "OwnerId"),
+    ownerName: getStringField(input.task, "Owner.Name"),
+    ownerUsername: getStringField(input.task, "Owner.Username"),
+    subject
+  }).messageKind;
 
   return salesforceTaskCommunicationRecordSchema.parse({
     recordType: "task_communication",

--- a/packages/integrations/src/index.ts
+++ b/packages/integrations/src/index.ts
@@ -1,5 +1,10 @@
 export * from "./provider-types.js";
 export * from "./shared.js";
+export {
+  classifySalesforceTaskMessageKind,
+  type SalesforceTaskMessageKindClassification,
+  type SalesforceTaskMessageKindClassificationInput
+} from "./providers/salesforce.js";
 export * from "./capture/shared.js";
 export * from "./capture/gmail.js";
 export * from "./capture/mailchimp.js";

--- a/packages/integrations/src/providers/salesforce.ts
+++ b/packages/integrations/src/providers/salesforce.ts
@@ -123,6 +123,134 @@ export type SalesforceLifecycleRecord = z.infer<
   typeof salesforceLifecycleRecordSchema
 >;
 
+const automatedOwnerSignalPatterns = [
+  /\bmarketing\s*cloud\b/iu,
+  /\bpardot\b/iu,
+  /\bworkflow\b/iu,
+  /\bautomated\s+process\b/iu,
+  /\bsystem\b/iu,
+  /\bintegration\b/iu
+] as const;
+
+const automatedSubjectPatterns = [
+  /^fw:/iu,
+  /^fwd:/iu,
+  /^→\s*email:/iu,
+  /\bsign(?:\s|-)?up confirmation\b/iu,
+  /\btraining reminder\b/iu,
+  /\bstart your training\b/iu,
+  /\bcomplete your training\b/iu
+] as const;
+
+function normalizeComparableString(
+  value: string | null | undefined
+): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+function matchesAnyPattern(
+  value: string | null,
+  patterns: readonly RegExp[]
+): boolean {
+  if (value === null) {
+    return false;
+  }
+
+  return patterns.some((pattern) => pattern.test(value));
+}
+
+export interface SalesforceTaskMessageKindClassificationInput {
+  readonly channel: "email" | "sms";
+  readonly taskSubtype?: string | null;
+  readonly ownerId?: string | null;
+  readonly ownerName?: string | null;
+  readonly ownerUsername?: string | null;
+  readonly subject?: string | null;
+}
+
+export interface SalesforceTaskMessageKindClassification {
+  readonly messageKind: "one_to_one" | "auto";
+  readonly reason:
+    | "non_email_task"
+    | "automated_owner"
+    | "subject_pattern"
+    | "human_owned_task"
+    | "insufficient_metadata";
+}
+
+function hasAutomatedOwnerSignal(
+  input: SalesforceTaskMessageKindClassificationInput
+): boolean {
+  return matchesAnyPattern(normalizeComparableString(input.ownerId), [
+    ...automatedOwnerSignalPatterns
+  ])
+    || matchesAnyPattern(normalizeComparableString(input.ownerName), [
+      ...automatedOwnerSignalPatterns
+    ])
+    || matchesAnyPattern(normalizeComparableString(input.ownerUsername), [
+      ...automatedOwnerSignalPatterns
+    ]);
+}
+
+function hasHumanOwnerSignal(
+  input: SalesforceTaskMessageKindClassificationInput
+): boolean {
+  return (
+    normalizeComparableString(input.ownerName) !== null ||
+    normalizeComparableString(input.ownerUsername) !== null
+  );
+}
+
+export function classifySalesforceTaskMessageKind(
+  input: SalesforceTaskMessageKindClassificationInput
+): SalesforceTaskMessageKindClassification {
+  if (input.channel !== "email") {
+    return {
+      messageKind: "auto",
+      reason: "non_email_task"
+    };
+  }
+
+  const subject = normalizeComparableString(input.subject);
+
+  // TODO(canon): codify the Stage 1 Salesforce Task messageKind heuristic in
+  // the provider ingest matrix / decision log so the automated-owner and
+  // workflow-subject rules stay explicit canon.
+  // Stage 1 queue truth is safer when ambiguous historical Salesforce Tasks
+  // fall out of inbox-driving behavior. We only promote to one_to_one when we
+  // have a human-like owner signal and the subject is not workflow-shaped.
+  if (matchesAnyPattern(subject, [...automatedSubjectPatterns])) {
+    return {
+      messageKind: "auto",
+      reason: "subject_pattern"
+    };
+  }
+
+  if (hasAutomatedOwnerSignal(input)) {
+    return {
+      messageKind: "auto",
+      reason: "automated_owner"
+    };
+  }
+
+  if (hasHumanOwnerSignal(input)) {
+    return {
+      messageKind: "one_to_one",
+      reason: "human_owned_task"
+    };
+  }
+
+  return {
+    messageKind: "auto",
+    reason: "insufficient_metadata"
+  };
+}
+
 export const salesforceTaskCommunicationRecordSchema = z.object({
   recordType: z.literal("task_communication"),
   recordId: z.string().min(1),

--- a/packages/integrations/test/stage1-salesforce-capture-service.test.ts
+++ b/packages/integrations/test/stage1-salesforce-capture-service.test.ts
@@ -131,6 +131,11 @@ function createFakeSalesforceApiClient(): SalesforceApiClient {
   const taskRow = {
     Id: "00T-task-1",
     WhoId: "003-stage1",
+    OwnerId: "005-human-owner",
+    Owner: {
+      Name: "Volunteer Coordinator",
+      Username: "coordinator@example.org"
+    },
     TaskSubtype: "Email",
     Subject: "Outbound follow-up",
     Description: "Logged outbound follow-up from Task",
@@ -314,7 +319,7 @@ describe("Salesforce capture service", () => {
         expect.objectContaining({
           recordType: "task_communication",
           channel: "email",
-          messageKind: "auto",
+          messageKind: "one_to_one",
           salesforceContactId: "003-stage1"
         }),
         expect.objectContaining({
@@ -363,6 +368,14 @@ describe("Salesforce capture service", () => {
         )
       ])
     );
+    expect(
+      queries.some(
+        (query) =>
+          query.includes("Owner.Name") &&
+          query.includes("Owner.Username") &&
+          query.includes("OwnerId")
+      )
+    ).toBe(true);
     expect(
       queries.some((query) => query.includes("WhoId LIKE '003%'"))
     ).toBe(false);
@@ -413,7 +426,7 @@ describe("Salesforce capture service", () => {
         expect.objectContaining({
           recordType: "task_communication",
           recordId: "00T-task-1",
-          messageKind: "auto",
+          messageKind: "one_to_one",
           salesforceContactId: "003-stage1"
         })
       ])
@@ -758,7 +771,7 @@ describe("Salesforce capture service", () => {
         expect.objectContaining({
           recordType: "task_communication",
           recordId: "00T-task-1",
-          messageKind: "auto",
+          messageKind: "one_to_one",
           salesforceContactId: "003-stage1"
         })
       ])
@@ -810,7 +823,7 @@ describe("Salesforce capture service", () => {
         }),
         expect.objectContaining({
           recordType: "task_communication",
-          messageKind: "auto",
+          messageKind: "one_to_one",
           salesforceContactId: "003-stage1"
         })
       ])

--- a/packages/integrations/test/stage1-salesforce-task-classification.test.ts
+++ b/packages/integrations/test/stage1-salesforce-task-classification.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { classifySalesforceTaskMessageKind } from "../src/index.js";
+
+describe("Salesforce Task message kind classification", () => {
+  it("classifies automated-owner email tasks as auto", () => {
+    expect(
+      classifySalesforceTaskMessageKind({
+        channel: "email",
+        taskSubtype: "Email",
+        ownerName: "Automated Process",
+        ownerUsername: "automated.process@example.org",
+        subject: "Checking in"
+      })
+    ).toEqual({
+      messageKind: "auto",
+      reason: "automated_owner"
+    });
+  });
+
+  it("classifies human-owned email tasks as one_to_one when the subject is not workflow-shaped", () => {
+    expect(
+      classifySalesforceTaskMessageKind({
+        channel: "email",
+        taskSubtype: "Email",
+        ownerName: "Volunteer Coordinator",
+        ownerUsername: "coordinator@example.org",
+        subject: "Checking in about your expedition"
+      })
+    ).toEqual({
+      messageKind: "one_to_one",
+      reason: "human_owned_task"
+    });
+  });
+
+  it("classifies workflow-shaped subjects as auto", () => {
+    expect(
+      classifySalesforceTaskMessageKind({
+        channel: "email",
+        taskSubtype: "Task",
+        subject: "→ Email: Start your training"
+      })
+    ).toEqual({
+      messageKind: "auto",
+      reason: "subject_pattern"
+    });
+  });
+
+  it("defaults ambiguous historical email tasks to auto", () => {
+    expect(
+      classifySalesforceTaskMessageKind({
+        channel: "email",
+        taskSubtype: null,
+        ownerName: null,
+        ownerUsername: null,
+        subject: null
+      })
+    ).toEqual({
+      messageKind: "auto",
+      reason: "insufficient_metadata"
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared Salesforce Task classifier that treats automated-owner and workflow-shaped subjects as `auto`, while keeping human-owned emails as `one_to_one`
- wire the classifier into Salesforce capture by fetching owner metadata and preserving the conservative default-to-auto fallback for ambiguous historical rows
- add a dry-run-by-default `pnpm ops:reclassify-salesforce-tasks` backfill that updates canonical event provenance, Salesforce communication details, projection seeds, and enqueues scoped `stage1.projection.rebuild` jobs

## Testing
- `pnpm --filter @as-comms/web typecheck`
- `pnpm --filter @as-comms/web build`
- `pnpm --filter @as-comms/integrations test:unit -- --runInBand packages/integrations/test/stage1-salesforce-task-classification.test.ts packages/integrations/test/stage1-salesforce-capture-service.test.ts`
- `pnpm --filter @as-comms/worker test:unit -- --runInBand apps/worker/test/stage1-reclassify-salesforce-tasks.test.ts`
- `pnpm boundaries`
- `pnpm verify`

## Notes
- TODO(canon): codify the Stage 1 Salesforce Task messageKind heuristic in the provider ingest matrix / decision log so the automated-owner and workflow-subject rules stay explicit canon.
