### PR TITLE
fix(inbox): render 1:1 email body + show auto-email subject only in collapsed view

### DIFF
--- a/apps/web/app/inbox/_components/inbox-timeline.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline.tsx
@@ -228,6 +228,10 @@ function AutomatedRow({
           : "Campaign SMS";
   const headline = entry.subject;
   const body = bodyTextForEntry(entry);
+  const hideCollapsedBody =
+    !isExpanded &&
+    (role === "campaign" ||
+      (entry.kind === "outbound-auto-email" && headline !== null));
 
   return (
     <li className="flex w-full flex-col items-end">
@@ -246,7 +250,7 @@ function AutomatedRow({
               {headline}
             </p>
           ) : null}
-          {!(role === "campaign" && !isExpanded) && body.length > 0 ? (
+          {!hideCollapsedBody && body.length > 0 ? (
             <p
               className={`text-[13px] leading-relaxed text-slate-600 ${
                 headline ? "mt-1.5" : ""

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -824,6 +824,21 @@ function campaignHeadlineAndBody(
   };
 }
 
+function fallbackOneToOneEmailBody(
+  item: Extract<TimelineItem, { family: "one_to_one_email" }>,
+): string {
+  const normalizedSummary = normalizeInlineText(item.summary) ?? "";
+
+  if (
+    item.primaryProvider === "salesforce" &&
+    /^(outbound|inbound) email (sent|received)$/i.test(normalizedSummary)
+  ) {
+    return "Email body not cached - open in Salesforce";
+  }
+
+  return normalizedSummary;
+}
+
 function timelineLifecycleBodyLabel(
   item: Extract<TimelineItem, { family: "salesforce_event" }>,
 ): string {
@@ -1070,7 +1085,7 @@ function timelineBody(item: TimelineItem): string {
       return (
         trimQuotedReplyContent(item.bodyPreview ?? "") ||
         parseCommunicationPreview(item.snippet).body ||
-        item.summary
+        fallbackOneToOneEmailBody(item)
       );
     case "one_to_one_sms":
       return item.messageTextPreview;

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -813,7 +813,7 @@ describe("real inbox selectors", () => {
     expect(activityEntries.at(-1)).toMatchObject({
       kind: "email-activity",
       subject: null,
-      body: "Outbound email sent",
+      body: "Email body not cached - open in Salesforce",
     });
   });
 
@@ -985,6 +985,65 @@ describe("real inbox selectors", () => {
       kind: "outbound-email",
       subject: "Field schedule update",
       body: "Here is the clean Salesforce body for Maria.",
+    });
+  });
+
+  it("shows an informative fallback when a Salesforce 1:1 email has no cached body", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:maria-no-body",
+      salesforceContactId: "003-maria-no-body",
+      displayName: "Maria No Body",
+      primaryEmail: "maria.nobody@example.org",
+      primaryPhone: null,
+    });
+    const latestSalesforceEvent = await seedInboxSalesforceOutboundEmailEvent(
+      runtime.context,
+      {
+        id: "maria-no-body-latest",
+        contactId: "contact:maria-no-body",
+        occurredAt: "2026-04-16T12:30:00.000Z",
+        subject: "Volunteer onboarding details",
+        snippet: "",
+        messageKind: "one_to_one",
+      },
+    );
+    await runtime.context.repositories.timelineProjection.upsert({
+      id: "timeline:maria-no-body-latest",
+      contactId: "contact:maria-no-body",
+      canonicalEventId: latestSalesforceEvent.canonicalEventId,
+      occurredAt: "2026-04-16T12:30:00.000Z",
+      sortKey:
+        "2026-04-16T12:30:00.000Z::event:maria-no-body-latest",
+      eventType: "communication.email.outbound",
+      summary: "Outbound Email Sent",
+      channel: "email",
+      primaryProvider: "salesforce",
+      reviewState: "clear",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:maria-no-body",
+      bucket: "Opened",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: null,
+      lastOutboundAt: "2026-04-16T12:30:00.000Z",
+      lastActivityAt: "2026-04-16T12:30:00.000Z",
+      snippet: "",
+      lastCanonicalEventId: latestSalesforceEvent.canonicalEventId,
+      lastEventType: "communication.email.outbound",
+    });
+
+    const detail = await getInboxDetail("contact:maria-no-body");
+    const latestEntry = detail?.timeline.at(-1);
+
+    expect(latestEntry).toMatchObject({
+      kind: "outbound-email",
+      subject: "Volunteer onboarding details",
+      body: "Email body not cached - open in Salesforce",
     });
   });
 

--- a/apps/web/tests/unit/inbox-timeline.test.ts
+++ b/apps/web/tests/unit/inbox-timeline.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import React, { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+Object.assign(globalThis, { React });
+
+vi.mock("@/components/ui/divider-label", () => ({
+  DividerLabel: ({ children }: { readonly children?: React.ReactNode }) =>
+    createElement("span", null, children),
+}));
+
+vi.mock("@/app/_lib/design-tokens", () => ({
+  RADIUS: {
+    bubble: "rounded-2xl",
+    md: "rounded-xl",
+  },
+  SHADOW: {
+    sm: "shadow-sm",
+  },
+  TEXT: {
+    bodySm: "text-sm",
+    micro: "text-xs",
+  },
+  TONE: {
+    amber: {
+      subtle: "bg-amber-50",
+    },
+  },
+  TRANSITION: {
+    fast: "transition-colors",
+  },
+}));
+
+import { InboxTimeline } from "../../app/inbox/_components/inbox-timeline";
+
+const baseEntry = {
+  id: "timeline:auto-email-1",
+  kind: "outbound-auto-email" as const,
+  occurredAt: "2026-04-16T12:30:00.000Z",
+  occurredAtLabel: "2h ago",
+  actorLabel: "Salesforce Flow",
+  subject: "Training details",
+  body: "Thanks for signing up. Bring your field notebook.",
+  channel: "email" as const,
+  isUnread: false,
+  isPreview: true,
+};
+
+describe("InboxTimeline", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps auto-email rows collapsed to the subject line by default", () => {
+    const markup = renderToStaticMarkup(
+      createElement(InboxTimeline, {
+        entries: [baseEntry],
+        volunteerFirstName: "Alice",
+      }),
+    );
+
+    expect(markup).toContain("Training details");
+    expect(markup).not.toContain(
+      "Thanks for signing up. Bring your field notebook.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Slice 3 of the inbox data-integrity fix series (per .handoff-2026-04-18-inbox-fixes.md).

Fixes two inbox UI rendering bugs reported from production walkthrough:

- **1:1 email body missing** (Allegra Sundstrom): Salesforce-sourced 1:1 emails with no cached body were falling back to the generic "Outbound/Inbound Email Sent" placeholder. Now show "Email body not cached — open in Salesforce" so operators know to jump to SF for the full message.
- **Auto-email collapsed view** (Alice Chang display portion): auto-email rows in the timeline were showing a body snippet in the collapsed view. Now show the subject only when collapsed; body still expands on click (which already worked).

Authored by Codex overnight. All quality gates passed locally before commit:
- \`pnpm --filter @as-comms/web typecheck\`
- \`pnpm --filter @as-comms/web build\`
- \`pnpm boundaries\`
- \`pnpm verify\`
- Unit tests: \`tests/unit/inbox-selectors.test.ts\`, \`tests/unit/inbox-timeline.test.ts\`

PR opened after-the-fact because \`gh\` could not reach api.github.com from Codex's execution environment (see BLOCKED note in .handoff-status-2026-04-19.md).

## Test plan

- [ ] CI green
- [ ] Manual on Railway: Allegra's 1:1 SF-sourced emails show the new fallback copy
- [ ] Manual on Railway: Alice's auto-email row shows subject only when collapsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)