### PR TITLE
fix(inbox): campaign email expand shows body not duplicate subject

### DIFF
--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -789,20 +789,60 @@ function splitHeadlineAndBody(value: string): {
   };
 }
 
+function suppressDuplicateHeadlineBody(
+  headline: string | null,
+  body: string,
+): string {
+  const normalizedHeadline = normalizeInlineText(headline);
+  const normalizedBody = normalizeInlineText(body);
+
+  if (
+    normalizedHeadline !== null &&
+    normalizedBody !== null &&
+    normalizedHeadline.toLowerCase() === normalizedBody.toLowerCase()
+  ) {
+    return "";
+  }
+
+  return body;
+}
+
 function campaignHeadlineAndBody(
   item: Extract<TimelineItem, { family: "campaign_email" | "campaign_sms" }>,
 ): {
   readonly headline: string | null;
   readonly body: string;
 } {
-  const resolvedPreview =
-    item.family === "campaign_email"
-      ? resolvePreferredMessagePreview({
-          rawCandidates: [item.snippet],
-        })
-      : resolvePreferredMessagePreview({
-          rawCandidates: [item.messageTextPreview],
-        });
+  if (item.family === "campaign_email") {
+    const parsedPreview = parseCommunicationPreview(item.snippet);
+    const cleaned =
+      parsedPreview.subject !== null
+        ? parsedPreview.body
+        : parsedPreview.body.length > 0
+        ? parsedPreview.body
+        : (normalizeInlineText(item.summary) ?? "");
+    const split = splitHeadlineAndBody(cleaned);
+    const headline =
+      parsedPreview.subject ??
+      split.headline ??
+      normalizeInlineText(item.campaignName) ??
+      normalizeInlineText(item.summary);
+    const body =
+      parsedPreview.subject !== null
+        ? cleaned
+        : split.body.length > 0
+          ? split.body
+          : cleaned;
+
+    return {
+      headline,
+      body: suppressDuplicateHeadlineBody(headline, body),
+    };
+  }
+
+  const resolvedPreview = resolvePreferredMessagePreview({
+    rawCandidates: [item.messageTextPreview],
+  });
   const cleaned =
     resolvedPreview.body.length > 0
       ? resolvedPreview.body
@@ -811,16 +851,10 @@ function campaignHeadlineAndBody(
 
   return {
     headline:
-      resolvedPreview.subject ??
       split.headline ??
       normalizeInlineText(item.campaignName) ??
       normalizeInlineText(item.summary),
-    body:
-      resolvedPreview.subject !== null
-        ? cleaned
-        : split.body.length > 0
-          ? split.body
-          : cleaned,
+    body: split.body.length > 0 ? split.body : cleaned,
   };
 }
 

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -422,7 +422,7 @@ describe("real inbox selectors", () => {
     expect(detail?.timeline[1]).toMatchObject({
       kind: "outbound-campaign-email",
       subject: "Welcome to the new field season.",
-      body: "Welcome to the new field season.",
+      body: "",
     });
     expect(detail?.timeline[2]).toMatchObject({
       kind: "outbound-auto-email",
@@ -1081,6 +1081,38 @@ describe("real inbox selectors", () => {
       kind: "outbound-campaign-email",
       subject: "April field update",
       body: "Hi Sarah,\nPlease bring your field notebook.",
+      isPreview: true,
+    });
+  });
+
+  it("does not duplicate the campaign subject as the expanded body when no body content is cached", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxCampaignEmailEvent(runtime.context, {
+      id: "sarah-campaign-email-subject-only",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-12T16:00:00.000Z",
+      activityType: "sent",
+      campaignName: "April Volunteer Update",
+      snippet: [
+        "From: volunteers@example.org",
+        "To: sarah@example.org",
+        "",
+        "Subject: April field update",
+      ].join("\n"),
+    });
+
+    const detail = await getInboxDetail("contact:sarah-martinez");
+    const campaignEntry = detail?.timeline.find(
+      (entry) => entry.id === "timeline:sarah-campaign-email-subject-only",
+    );
+
+    expect(campaignEntry).toMatchObject({
+      kind: "outbound-campaign-email",
+      subject: "April field update",
+      body: "",
       isPreview: true,
     });
   });


### PR DESCRIPTION
## Summary

Slice 4 of the inbox data-integrity fix series (per .handoff-2026-04-18-inbox-fixes.md).

Fixes Carlos Malara bug: campaign emails rendered subject twice (as both headline and body) when there was no cached body content. Now the expand view shows real body when present; when body is empty, the headline isn't duplicated in the body slot.

Campaign SMS rendering preserved (regression guard).

Authored by Codex overnight. All quality gates passed locally:
- \`pnpm --filter @as-comms/web typecheck\`
- \`pnpm --filter @as-comms/web build\`
- \`pnpm boundaries\`
- \`pnpm verify\`
- Unit tests: \`tests/unit/inbox-selectors.test.ts\`

PR opened after-the-fact because \`gh\` could not reach api.github.com from Codex's execution environment.

## Test plan

- [ ] CI green
- [ ] Manual on Railway: Carlos's campaign email expand shows the actual body (or a sensible empty state), not the subject twice

🤖 Generated with [Claude Code](https://claude.com/claude-code)