### PR TITLE
fix(stage1): drop Salesforce Tasks for non-volunteer contacts at capture + normalization

### DIFF
--- a/apps/worker/src/ingest/service.ts
+++ b/apps/worker/src/ingest/service.ts
@@ -90,6 +90,7 @@ function buildReviewCases(
 
       return reviewCases;
     }
+    case "skipped":
     case "quarantined":
       return [];
   }
@@ -148,9 +149,10 @@ function mapCanonicalEventResult(input: {
   readonly ingestMode: Stage1IngestMode;
   readonly mapped: ProviderMappingResult & { readonly outcome: "command" };
   readonly result: NormalizedCanonicalEventResult;
-}):
+}): 
   | Stage1NormalizedIngestResult
   | Stage1DuplicateIngestResult
+  | Stage1DeferredIngestResult
   | Stage1ReviewOpenedIngestResult
   | Stage1QuarantinedIngestResult {
   const base = {
@@ -214,6 +216,16 @@ function mapCanonicalEventResult(input: {
         canonicalEventId: null,
         contactId: input.result.identityCase.anchoredContactId,
         reviewCases: buildReviewCases(input.result),
+      };
+    case "skipped":
+      return {
+        outcome: "deferred",
+        ingestMode: input.ingestMode,
+        provider: toStage1IngestProvider(input.mapped.provider),
+        sourceRecordType: input.mapped.sourceRecordType,
+        sourceRecordId: input.mapped.sourceRecordId,
+        reason: "skipped_by_policy",
+        detail: input.result.explanation,
       };
     case "quarantined":
       return {

--- a/apps/worker/src/ingest/types.ts
+++ b/apps/worker/src/ingest/types.ts
@@ -66,7 +66,10 @@ export interface Stage1QuarantinedIngestResult extends Stage1IngestResultBase {
 
 export interface Stage1DeferredIngestResult extends Stage1IngestResultBase {
   readonly outcome: "deferred";
-  readonly reason: "unsupported_record_type" | "deferred_record_family";
+  readonly reason:
+    | "unsupported_record_type"
+    | "deferred_record_family"
+    | "skipped_by_policy";
   readonly detail: string;
 }
 

--- a/packages/db/test/stage1-normalization.test.ts
+++ b/packages/db/test/stage1-normalization.test.ts
@@ -16,6 +16,20 @@ async function seedContactWithEmail(
   }
 ) {
   const context = await createTestStage1Context();
+  const memberships =
+    input.salesforceContactId === undefined || input.salesforceContactId === null
+      ? []
+      : [
+          {
+            id: `membership:${input.contactId}:default`,
+            contactId: input.contactId,
+            projectId: "project_default",
+            expeditionId: "expedition_default",
+            role: "volunteer",
+            status: "active",
+            source: "salesforce" as const
+          }
+        ];
 
   await context.normalization.upsertNormalizedContactGraph({
     contact: {
@@ -36,9 +50,9 @@ async function seedContactWithEmail(
         isPrimary: true,
         source: "salesforce",
         verifiedAt: "2026-01-01T00:00:00.000Z"
-      }
-    ],
-    memberships: []
+        }
+      ],
+    memberships
   });
 
   return context;
@@ -210,6 +224,104 @@ describe("Stage 1 normalization service", () => {
 
     await expect(
       context.repositories.canonicalEvents.listByContactId("contact_1")
+    ).resolves.toEqual([]);
+  });
+
+  it("skips Salesforce task events for non-volunteer contacts without opening review", async () => {
+    const context = await createTestStage1Context();
+
+    await context.repositories.contacts.upsert({
+      id: "contact_non_volunteer",
+      salesforceContactId: "003-non-volunteer",
+      displayName: "Non Volunteer Contact",
+      primaryEmail: "donor@example.org",
+      primaryPhone: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z"
+    });
+
+    const result = await context.normalization.applyNormalizedCanonicalEvent({
+      sourceEvidence: {
+        id: "sev_non_volunteer_task",
+        provider: "salesforce",
+        providerRecordType: "task_communication",
+        providerRecordId: "00T-non-volunteer",
+        receivedAt: "2026-01-01T00:03:00.000Z",
+        occurredAt: "2026-01-01T00:02:00.000Z",
+        payloadRef: "payloads/salesforce/00T-non-volunteer.json",
+        idempotencyKey: "salesforce:task:00T-non-volunteer",
+        checksum: "checksum-non-volunteer-task"
+      },
+      canonicalEvent: {
+        id: "evt_non_volunteer_task",
+        eventType: "communication.email.outbound",
+        occurredAt: "2026-01-01T00:02:00.000Z",
+        idempotencyKey: "canonical:salesforce:task:00T-non-volunteer",
+        summary: "Outbound email sent",
+        snippet: "This Salesforce task should be skipped."
+      },
+      communicationClassification: buildOneToOneCommunicationClassification({
+        sourceRecordType: "task_communication",
+        sourceRecordId: "00T-non-volunteer",
+        direction: "outbound"
+      }),
+      identity: {
+        salesforceContactId: "003-non-volunteer",
+        volunteerIdPlainValues: [],
+        normalizedEmails: [],
+        normalizedPhones: []
+      },
+      supportingSources: [],
+      salesforceCommunicationDetail: {
+        sourceEvidenceId: "sev_non_volunteer_task",
+        providerRecordId: "00T-non-volunteer",
+        channel: "email",
+        messageKind: "one_to_one",
+        subject: "Logged outbound follow-up",
+        snippet: "This Salesforce task should be skipped.",
+        sourceLabel: "Salesforce Task"
+      },
+      salesforceEventContext: {
+        sourceEvidenceId: "sev_non_volunteer_task",
+        salesforceContactId: "003-non-volunteer",
+        projectId: null,
+        expeditionId: null,
+        sourceField: null
+      }
+    });
+
+    expect(result.outcome).toBe("skipped");
+    if (result.outcome === "skipped") {
+      expect(result.reasonCode).toBe("skipped_non_volunteer_task");
+      expect(result.auditEvidence).toMatchObject({
+        action: "skipped_non_volunteer_task",
+        entityType: "source_evidence",
+        entityId: "sev_non_volunteer_task",
+        policyCode: "stage1.skip.skipped_non_volunteer_task"
+      });
+      expect(result.auditEvidence.metadataJson).toEqual({
+        salesforceTaskId: "00T-non-volunteer",
+        whoId: "003-non-volunteer"
+      });
+    }
+
+    await expect(
+      context.repositories.canonicalEvents.listByContactId("contact_non_volunteer")
+    ).resolves.toEqual([]);
+    await expect(
+      context.repositories.routingReviewQueue.listOpenByReasonCode(
+        "routing_missing_membership"
+      )
+    ).resolves.toEqual([]);
+    await expect(
+      context.repositories.salesforceCommunicationDetails.listBySourceEvidenceIds([
+        "sev_non_volunteer_task"
+      ])
+    ).resolves.toEqual([]);
+    await expect(
+      context.repositories.salesforceEventContext.listBySourceEvidenceIds([
+        "sev_non_volunteer_task"
+      ])
     ).resolves.toEqual([]);
   });
 
@@ -745,7 +857,17 @@ describe("Stage 1 normalization service", () => {
         updatedAt: "2026-01-01T00:00:00.000Z"
       },
       identities: [],
-      memberships: []
+      memberships: [
+        {
+          id: "membership_anchor_default",
+          contactId: "contact_anchor",
+          projectId: "project_anchor",
+          expeditionId: "expedition_anchor",
+          role: "volunteer",
+          status: "active",
+          source: "salesforce"
+        }
+      ]
     });
 
     await context.normalization.upsertNormalizedContactGraph({
@@ -848,7 +970,17 @@ describe("Stage 1 normalization service", () => {
           verifiedAt: "2026-01-01T00:00:00.000Z"
         }
       ],
-      memberships: []
+      memberships: [
+        {
+          id: "membership_cached_default",
+          contactId: "contact_cached",
+          projectId: "project_cached",
+          expeditionId: "expedition_cached",
+          role: "volunteer",
+          status: "active",
+          source: "salesforce"
+        }
+      ]
     });
 
     const lookupCounts = {

--- a/packages/domain/src/normalization.ts
+++ b/packages/domain/src/normalization.ts
@@ -148,6 +148,13 @@ export type NormalizedCanonicalEventResult =
       readonly auditEvidence: null;
     }
   | {
+      readonly outcome: "skipped";
+      readonly sourceEvidence: SourceEvidenceRecord;
+      readonly reasonCode: "skipped_non_volunteer_task";
+      readonly explanation: string;
+      readonly auditEvidence: AuditEvidenceRecord;
+    }
+  | {
       readonly outcome: "quarantined";
       readonly sourceEvidence: SourceEvidenceRecord;
       readonly reasonCode: QuarantineReasonCode;
@@ -279,6 +286,14 @@ function buildQuarantineAuditId(
   return `audit:${entityType}:${entityId}:${reasonCode}`;
 }
 
+function buildSkipAuditId(
+  entityType: string,
+  entityId: string,
+  action: "skipped_non_volunteer_task"
+): string {
+  return `audit:${entityType}:${entityId}:${action}`;
+}
+
 function newestTimestamp(
   left: string | null,
   right: string | null
@@ -406,6 +421,19 @@ function buildRoutingExplanation(
     case "routing_context_conflict":
       return "Provider-supplied routing context conflicts with canonical membership state.";
   }
+}
+
+function isSalesforceTaskCommunicationIntake(
+  input: Pick<NormalizedCanonicalEventIntake, "sourceEvidence">
+): boolean {
+  return (
+    input.sourceEvidence.provider === "salesforce" &&
+    input.sourceEvidence.providerRecordType === "task_communication"
+  );
+}
+
+function buildSkippedNonVolunteerTaskExplanation(): string {
+  return "Salesforce task communications for non-volunteer contacts are skipped in Stage 1.";
 }
 
 function decideDuplicateCollapse(
@@ -867,6 +895,64 @@ async function resolveRoutingDecision(
   };
 }
 
+async function resolveNonVolunteerSalesforceTaskSkip(
+  persistence: Stage1PersistenceService,
+  context: IdentityResolutionContext,
+  input: Pick<
+    NormalizedCanonicalEventIntake,
+    "identity" | "salesforceEventContext" | "sourceEvidence"
+  >
+): Promise<
+  | {
+      readonly outcome: "continue";
+    }
+  | {
+      readonly outcome: "skipped";
+      readonly whoId: string;
+    }
+> {
+  if (!isSalesforceTaskCommunicationIntake(input)) {
+    return {
+      outcome: "continue"
+    };
+  }
+
+  const whoId =
+    input.identity.salesforceContactId ??
+    input.salesforceEventContext?.salesforceContactId ??
+    null;
+
+  if (whoId === null) {
+    return {
+      outcome: "continue"
+    };
+  }
+
+  const anchoredContact = await context.findAnchoredContact(whoId);
+
+  if (anchoredContact === null) {
+    return {
+      outcome: "skipped",
+      whoId
+    };
+  }
+
+  const memberships = await persistence.repositories.contactMemberships.listByContactId(
+    anchoredContact.id
+  );
+
+  if (memberships.length > 0) {
+    return {
+      outcome: "continue"
+    };
+  }
+
+  return {
+    outcome: "skipped",
+    whoId
+  };
+}
+
 async function listOpenIdentityCasesForContact(
   persistence: Stage1PersistenceService,
   contactId: string
@@ -943,6 +1029,43 @@ async function recordQuarantineAuditOnce(
       input.entityId,
       input.reasonCode
     ),
+    actorType: "system",
+    actorId: "stage1-normalization",
+    action: input.action,
+    entityType: input.entityType,
+    entityId: input.entityId,
+    occurredAt: input.occurredAt,
+    result: "recorded",
+    policyCode,
+    metadataJson: input.metadataJson
+  });
+}
+
+async function recordSkipAuditOnce(
+  persistence: Stage1PersistenceService,
+  input: {
+    readonly entityType: string;
+    readonly entityId: string;
+    readonly occurredAt: string;
+    readonly action: "skipped_non_volunteer_task";
+    readonly metadataJson: Record<string, unknown>;
+  }
+): Promise<AuditEvidenceRecord> {
+  const policyCode = `stage1.skip.${input.action}`;
+  const existingRecords = await persistence.repositories.auditEvidence.listByEntity({
+    entityType: input.entityType,
+    entityId: input.entityId
+  });
+  const existingRecord = existingRecords.find(
+    (record) => record.policyCode === policyCode
+  );
+
+  if (existingRecord !== undefined) {
+    return existingRecord;
+  }
+
+  return persistence.recordAuditEvidence({
+    id: buildSkipAuditId(input.entityType, input.entityId, input.action),
     actorType: "system",
     actorId: "stage1-normalization",
     action: input.action,
@@ -1314,6 +1437,34 @@ export function createStage1NormalizationService(
             "The incoming source evidence replay conflicted with previously recorded evidence.",
           existingCanonicalEvent: null,
           auditEvidence: sourceEvidenceResult.auditEvidence
+        };
+      }
+
+      const nonVolunteerTaskDecision =
+        await resolveNonVolunteerSalesforceTaskSkip(
+          persistence,
+          identityResolutionContext,
+          parsed
+        );
+
+      if (nonVolunteerTaskDecision.outcome === "skipped") {
+        const auditEvidence = await recordSkipAuditOnce(persistence, {
+          entityType: "source_evidence",
+          entityId: sourceEvidenceResult.record.id,
+          occurredAt: parsed.sourceEvidence.receivedAt,
+          action: "skipped_non_volunteer_task",
+          metadataJson: {
+            salesforceTaskId: parsed.sourceEvidence.providerRecordId,
+            whoId: nonVolunteerTaskDecision.whoId
+          }
+        });
+
+        return {
+          outcome: "skipped",
+          sourceEvidence: sourceEvidenceResult.record,
+          reasonCode: "skipped_non_volunteer_task",
+          explanation: buildSkippedNonVolunteerTaskExplanation(),
+          auditEvidence
         };
       }
 

--- a/packages/integrations/src/capture-services/salesforce.ts
+++ b/packages/integrations/src/capture-services/salesforce.ts
@@ -517,6 +517,14 @@ function buildVolunteerScopedContactWhere(
   return `${baseWhere} AND Id IN (SELECT ${config.membershipContactField} FROM ${config.membershipObjectName} WHERE ${config.membershipContactField} != null)`;
 }
 
+function buildVolunteerScopedTaskWhere(
+  baseWhere: string,
+  config: ResolvedSalesforceCaptureServiceConfig
+): string {
+  // TODO(canon): document D-034 — non-volunteer SF comms are dropped at capture.
+  return `${baseWhere} AND ${config.taskContactField} IN (SELECT ${config.membershipContactField} FROM ${config.membershipObjectName} WHERE ${config.membershipContactField} != null)`;
+}
+
 function buildTaskWindowWhere(window: {
   readonly mode: "historical" | "live";
   readonly windowStart: string | null;
@@ -1020,15 +1028,29 @@ export function createSalesforceCaptureService(
         ? queryRowsByIds({
             objectName: "Task",
             fields: taskFields,
-            recordIds: input.recordIds
+            recordIds: input.recordIds,
+            extraWhere: buildVolunteerScopedTaskWhere(
+              buildTaskWindowWhere(
+                {
+                  mode: input.mode,
+                  windowStart: window.windowStart,
+                  windowEnd: window.windowEnd
+                },
+                parsedConfig
+              ),
+              parsedConfig
+            )
           })
         : apiClient.queryAll(
-            `SELECT ${taskFields.join(", ")} FROM Task WHERE ${buildTaskWindowWhere(
-              {
-                mode: input.mode,
-                windowStart: window.windowStart,
-                windowEnd: window.windowEnd
-              },
+            `SELECT ${taskFields.join(", ")} FROM Task WHERE ${buildVolunteerScopedTaskWhere(
+              buildTaskWindowWhere(
+                {
+                  mode: input.mode,
+                  windowStart: window.windowStart,
+                  windowEnd: window.windowEnd
+                },
+                parsedConfig
+              ),
               parsedConfig
             )}`
           )

--- a/packages/integrations/test/stage1-salesforce-capture-service.test.ts
+++ b/packages/integrations/test/stage1-salesforce-capture-service.test.ts
@@ -155,6 +155,18 @@ function createFakeSalesforceApiClient(): SalesforceApiClient {
         return Promise.resolve([contactRow]);
       }
 
+      if (soql.includes(" FROM Task ")) {
+        if (soql.includes(" WHERE Id IN ")) {
+          return Promise.resolve(soql.includes("'00T-task-1'") ? [taskRow] : []);
+        }
+
+        if (soql.includes(" WHERE WhoId IN ")) {
+          return Promise.resolve(soql.includes("'003-stage1'") ? [taskRow] : []);
+        }
+
+        return Promise.resolve([taskRow]);
+      }
+
       if (soql.includes(" FROM Expedition_Members__c ")) {
         if (soql.includes(" WHERE Id IN ")) {
           return Promise.resolve(
@@ -169,18 +181,6 @@ function createFakeSalesforceApiClient(): SalesforceApiClient {
         }
 
         return Promise.resolve([membershipRow]);
-      }
-
-      if (soql.includes(" FROM Task ")) {
-        if (soql.includes(" WHERE Id IN ")) {
-          return Promise.resolve(soql.includes("'00T-task-1'") ? [taskRow] : []);
-        }
-
-        if (soql.includes(" WHERE WhoId IN ")) {
-          return Promise.resolve(soql.includes("'003-stage1'") ? [taskRow] : []);
-        }
-
-        return Promise.resolve([taskRow]);
       }
 
       return Promise.resolve([]);
@@ -364,7 +364,7 @@ describe("Salesforce capture service", () => {
           "Date_First_Sample_Collected__c >= 2026-01-01 AND Date_First_Sample_Collected__c < 2026-01-06"
         ),
         expect.stringContaining(
-          "FROM Task WHERE Who.Type = 'Contact' AND CreatedDate >= 2026-01-01T00:00:00.000Z AND CreatedDate < 2026-01-06T00:00:00.000Z"
+          "FROM Task WHERE Who.Type = 'Contact' AND CreatedDate >= 2026-01-01T00:00:00.000Z AND CreatedDate < 2026-01-06T00:00:00.000Z AND WhoId IN (SELECT Contact__c FROM Expedition_Members__c WHERE Contact__c != null)"
         )
       ])
     );
@@ -438,6 +438,64 @@ describe("Salesforce capture service", () => {
     );
   });
 
+  it("keeps task-id replays volunteer-scoped at the SOQL boundary", async () => {
+    const queries: string[] = [];
+    const baseApiClient = createFakeSalesforceApiClient();
+    const service = createSalesforceCaptureService(
+      createSalesforceServiceConfig(),
+      {
+        apiClient: {
+          queryAll: (soql) => {
+            queries.push(soql);
+            return baseApiClient.queryAll(soql);
+          }
+        },
+        now: () => new Date("2026-01-05T00:05:00.000Z")
+      }
+    );
+
+    const result = await service.captureHistoricalBatch({
+      version: 1,
+      jobId: "job:salesforce:historical:task-replay",
+      correlationId: "corr:salesforce:historical:task-replay",
+      traceId: null,
+      batchId: "batch:salesforce:historical:task-replay",
+      syncStateId: "sync:salesforce:historical:task-replay",
+      attempt: 1,
+      maxAttempts: 3,
+      provider: "salesforce",
+      mode: "historical",
+      jobType: "historical_backfill",
+      cursor: null,
+      checkpoint: null,
+      windowStart: null,
+      windowEnd: null,
+      recordIds: ["00T-task-1"],
+      maxRecords: 25
+    });
+
+    expect(result.records).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          recordType: "contact_snapshot",
+          salesforceContactId: "003-stage1"
+        }),
+        expect.objectContaining({
+          recordType: "task_communication",
+          recordId: "00T-task-1",
+          salesforceContactId: "003-stage1"
+        })
+      ])
+    );
+    expect(queries).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          "FROM Task WHERE Id IN ('00T-task-1') AND Who.Type = 'Contact' AND WhoId IN (SELECT Contact__c FROM Expedition_Members__c WHERE Contact__c != null)"
+        )
+      ])
+    );
+  });
+
   it("uses contact-safe task filters for live window capture batches", async () => {
     const queries: string[] = [];
     const baseApiClient = createFakeSalesforceApiClient();
@@ -477,7 +535,7 @@ describe("Salesforce capture service", () => {
     expect(queries).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "FROM Task WHERE Who.Type = 'Contact' AND LastModifiedDate >= 2026-01-01T00:00:00.000Z AND LastModifiedDate < 2026-01-06T00:00:00.000Z"
+          "FROM Task WHERE Who.Type = 'Contact' AND LastModifiedDate >= 2026-01-01T00:00:00.000Z AND LastModifiedDate < 2026-01-06T00:00:00.000Z AND WhoId IN (SELECT Contact__c FROM Expedition_Members__c WHERE Contact__c != null)"
         )
       ])
     );
@@ -640,22 +698,6 @@ describe("Salesforce capture service", () => {
               return Promise.resolve([contactRow]);
             }
 
-            if (soql.includes(" FROM Expedition_Members__c ")) {
-              if (soql.includes(" WHERE Id IN ")) {
-                return Promise.resolve(
-                  soql.includes("'a01-membership-auto'") ? [membershipRow] : []
-                );
-              }
-
-              if (soql.includes(" WHERE Contact__c IN ")) {
-                return Promise.resolve(
-                  soql.includes("'003-auto'") ? [membershipRow] : []
-                );
-              }
-
-              return Promise.resolve([membershipRow]);
-            }
-
             if (soql.includes(" FROM Task ")) {
               if (soql.includes(" WHERE Id IN ")) {
                 return Promise.resolve(
@@ -670,6 +712,22 @@ describe("Salesforce capture service", () => {
               }
 
               return Promise.resolve([autoEmailTaskRow]);
+            }
+
+            if (soql.includes(" FROM Expedition_Members__c ")) {
+              if (soql.includes(" WHERE Id IN ")) {
+                return Promise.resolve(
+                  soql.includes("'a01-membership-auto'") ? [membershipRow] : []
+                );
+              }
+
+              if (soql.includes(" WHERE Contact__c IN ")) {
+                return Promise.resolve(
+                  soql.includes("'003-auto'") ? [membershipRow] : []
+                );
+              }
+
+              return Promise.resolve([membershipRow]);
             }
 
             return Promise.resolve([]);


### PR DESCRIPTION
## Summary
- restrict Salesforce Task capture to volunteer `WhoId` values using the same `Expedition_Members__c` subquery pattern as Contact ingest, including task-id replays
- add a normalization-layer skip for Salesforce task events that resolve to non-volunteer contacts, recording `skipped_non_volunteer_task` audit evidence instead of opening review
- add regression coverage for the Task SOQL filter and the normalization skip path

## Why
Non-volunteer contacts must not carry Salesforce-sourced communications in Stage 1. This makes the Task path follow the same volunteer-only rule already enforced for Contact ingest and keeps replayed historical batches from reopening non-volunteer review noise.

## Validation
- pnpm --filter @as-comms/web typecheck
- pnpm --filter @as-comms/worker typecheck
- pnpm --filter @as-comms/integrations typecheck
- pnpm --filter @as-comms/salesforce-capture typecheck
- pnpm --filter @as-comms/salesforce-capture build
- pnpm boundaries
- pnpm verify
- pnpm exec vitest run test/stage1-salesforce-capture-service.test.ts --config ../../vitest.config.ts
- pnpm exec vitest run test/stage1-normalization.test.ts --config ../../vitest.config.ts
