### PR TITLE
fix(ci): lint cleanup in reclassify-salesforce-tasks ops script

### DIFF
--- a/apps/worker/src/ops/reclassify-salesforce-tasks.ts
+++ b/apps/worker/src/ops/reclassify-salesforce-tasks.ts
@@ -39,23 +39,23 @@ import {
   type Stage1EnqueueRequest
 } from "./enqueue.js";
 
-type SqlRunner = {
+interface SqlRunner {
   unsafe<T extends readonly object[]>(query: string): Promise<T>;
   begin<T>(callback: (sql: SqlRunner) => Promise<T>): Promise<T>;
-};
+}
 
-type ReclassificationCandidateRow = {
+interface ReclassificationCandidateRow {
   readonly canonical_event_id: string;
   readonly contact_id: string;
   readonly source_evidence_id: string;
   readonly current_message_kind: string | null;
   readonly subject: string | null;
   readonly snippet: string | null;
-};
+}
 
-type IdRow = {
+interface IdRow {
   readonly id: string;
-};
+}
 
 export interface SalesforceTaskReclassificationCandidate {
   readonly canonicalEventId: string;
@@ -252,9 +252,15 @@ function printPlanSummary(
 ): void {
   console.log("reclassify-salesforce-tasks");
   console.log(`Mode: ${confirm ? "confirm" : "dry-run"}`);
-  console.log(`- scanned Salesforce outbound email events: ${plan.scannedCount}`);
-  console.log(`- would reclassify (one_to_one|null) -> auto: ${plan.reclassifiedCount}`);
-  console.log(`- affected contacts: ${plan.affectedContactIds.length}`);
+  console.log(
+    `- scanned Salesforce outbound email events: ${String(plan.scannedCount)}`
+  );
+  console.log(
+    `- would reclassify (one_to_one|null) -> auto: ${String(plan.reclassifiedCount)}`
+  );
+  console.log(
+    `- affected contacts: ${String(plan.affectedContactIds.length)}`
+  );
 
   if (Object.keys(plan.reasonCounts).length > 0) {
     console.log("Reason counts:");
@@ -419,8 +425,10 @@ export async function runReclassifySalesforceTasks(input: {
     }
 
     console.log("Reclassification complete.");
-    console.log(`- updated canonical events: ${plan.reclassifiedCount}`);
-    console.log(`- enqueued projection rebuild jobs: ${enqueuedJobIds.length}`);
+    console.log(`- updated canonical events: ${String(plan.reclassifiedCount)}`);
+    console.log(
+      `- enqueued projection rebuild jobs: ${String(enqueuedJobIds.length)}`
+    );
 
     return {
       confirm: true,

--- a/apps/worker/test/stage1-reclassify-salesforce-tasks.test.ts
+++ b/apps/worker/test/stage1-reclassify-salesforce-tasks.test.ts
@@ -68,16 +68,23 @@ describe("reclassify-salesforce-tasks planning", () => {
         buildId: (prefix) => `${prefix}:${String(++idCounter)}`
       }
     );
+    const firstRequest: (typeof requests)[number] | undefined = requests[0];
+    const payload = firstRequest?.payload as
+      | {
+          readonly jobType: string;
+          readonly projection: string;
+          readonly contactIds: readonly string[];
+          readonly includeReviewOverlayRefresh: boolean;
+        }
+      | undefined;
 
     expect(requests).toHaveLength(1);
-    expect(requests[0]).toMatchObject({
-      jobName: "stage1.projection.rebuild",
-      payload: expect.objectContaining({
-        jobType: "projection_rebuild",
-        projection: "all",
-        contactIds: ["contact:a", "contact:b"],
-        includeReviewOverlayRefresh: true
-      })
+    expect(firstRequest?.jobName).toBe("stage1.projection.rebuild");
+    expect(payload).toMatchObject({
+      jobType: "projection_rebuild",
+      projection: "all",
+      contactIds: ["contact:a", "contact:b"],
+      includeReviewOverlayRefresh: true
     });
   });
 });


### PR DESCRIPTION
## Summary
- convert the three object-shape aliases in `reclassify-salesforce-tasks.ts` to interfaces to satisfy the worker lint rule
- wrap numeric template interpolations with `String(...)` in the ops script to match existing repo convention
- narrow the test payload assertion with an explicit typed intermediate so the worker test file passes `no-unsafe-assignment` without changing behavior

## Validation
- pnpm --filter @as-comms/worker lint
- pnpm --filter @as-comms/worker typecheck
- pnpm --filter @as-comms/worker test:unit -- stage1-reclassify-salesforce-tasks
- pnpm lint
