### PR TITLE
fix(ci): unblock worker build after integrations types path

### DIFF
--- a/apps/worker/src/ops/reclassify-salesforce-tasks.ts
+++ b/apps/worker/src/ops/reclassify-salesforce-tasks.ts
@@ -29,7 +29,7 @@ import {
 import {
   classifySalesforceTaskMessageKind,
   type SalesforceTaskMessageKindClassification
-} from "../../../../packages/integrations/src/providers/salesforce.js";
+} from "@as-comms/integrations";
 
 import {
   buildOperationId

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
-  "types": "./src/index.ts",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
   },


### PR DESCRIPTION
## Summary
- point  type resolution at built declarations in 
- stop the worker reclassification ops script from importing  directly
- verify the full workspace build, typecheck, lint, and boundary gates pass locally

## Validation
- pnpm --filter @as-comms/integrations build
- pnpm --filter @as-comms/worker build
- pnpm build
- pnpm typecheck
- pnpm lint
- pnpm boundaries