### PR TITLE
fix(stage1): strip multi-dash MIME boundaries + decode RFC 2047 subjects at ingest

### DIFF
--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -467,7 +467,7 @@ function stripMimeScaffolding(value: string): string {
     skippingMimeContinuation = false;
 
     if (
-      /^--(?:Apple-Mail|_mimepart|=_|[0-9A-Za-z][0-9A-Za-z._:-]{8,})/i.test(
+      /^-{2,}(?:Apple-Mail|_mimepart|=_|[0-9A-Za-z][0-9A-Za-z._:-]{8,})/i.test(
         trimmed,
       )
     ) {

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -869,6 +869,59 @@ describe("real inbox selectors", () => {
     });
   });
 
+  it("strips multi-dash MIME boundaries from projection snippet fallbacks", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:alice-mime-boundary",
+      salesforceContactId: "003-alice-mime-boundary",
+      displayName: "Alice Mime Boundary",
+      primaryEmail: "alice.mime@example.org",
+      primaryPhone: null,
+    });
+    const latestLegacyEvent = await seedInboxLegacySalesforceOutboundEmailEvent(
+      runtime.context,
+      {
+        id: "alice-salesforce-legacy-mime-boundary",
+        contactId: "contact:alice-mime-boundary",
+        occurredAt: "2026-04-16T10:00:00.000Z",
+        messageKind: null,
+      },
+    );
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:alice-mime-boundary",
+      bucket: "Opened",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: null,
+      lastOutboundAt: "2026-04-16T10:00:00.000Z",
+      lastActivityAt: "2026-04-16T10:00:00.000Z",
+      snippet: [
+        "------=_Part_2324998_585856288.1775021416555",
+        "rest of body",
+      ].join("\n"),
+      lastCanonicalEventId: latestLegacyEvent.canonicalEventId,
+      lastEventType: "communication.email.outbound",
+    });
+
+    const list = await getInboxList();
+    const detail = await getInboxDetail("contact:alice-mime-boundary");
+    const row = list.items.find(
+      (item) => item.contactId === "contact:alice-mime-boundary",
+    );
+    const latestEntry = detail?.timeline.at(-1);
+
+    expect(row).toMatchObject({
+      snippet: "rest of body",
+    });
+    expect(latestEntry).toMatchObject({
+      kind: "email-activity",
+      body: "rest of body",
+    });
+  });
+
   it("prefers Gmail clean body previews over noisier projection snippets so Maria stays aligned between list and detail", async () => {
     if (runtime === null) {
       throw new Error("Expected inbox test runtime");

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@as-comms/contracts": "workspace:*",
+    "libmime": "^5.3.8",
     "mailparser": "^3.9.8",
     "zod": "^3.24.2"
   },

--- a/packages/integrations/src/libmime.d.ts
+++ b/packages/integrations/src/libmime.d.ts
@@ -1,0 +1,8 @@
+declare module "libmime" {
+  interface LibmimeInstance {
+    decodeWords(value: string): string;
+  }
+
+  const libmime: LibmimeInstance;
+  export default libmime;
+}

--- a/packages/integrations/src/providers/gmail-body.ts
+++ b/packages/integrations/src/providers/gmail-body.ts
@@ -107,7 +107,7 @@ function stripMimeScaffolding(value: string): string {
     skippingMimeContinuation = false;
 
     if (
-      /^--(?:Apple-Mail|_mimepart|=_|[0-9A-Za-z][0-9A-Za-z._:-]{8,})/iu.test(
+      /^-{2,}(?:Apple-Mail|_mimepart|=_|[0-9A-Za-z][0-9A-Za-z._:-]{8,})/iu.test(
         trimmed
       )
     ) {

--- a/packages/integrations/src/providers/gmail-mbox.ts
+++ b/packages/integrations/src/providers/gmail-mbox.ts
@@ -1,5 +1,6 @@
 import {
   buildGmailMessageRecord,
+  normalizeGmailSubject,
   sha256Text,
   toSafeIsoTimestamp,
   type GmailProviderCloseMessageInput
@@ -120,7 +121,7 @@ function buildSnippet(cleanBodyPreview: string, subject: string | undefined): st
     return cleanBodyPreview.slice(0, 280);
   }
 
-  return subject?.trim() ?? "";
+  return normalizeGmailSubject(subject) ?? "";
 }
 
 function buildThreadId(headers: Readonly<Record<string, string>>): string | null {

--- a/packages/integrations/src/providers/gmail-record-builder.ts
+++ b/packages/integrations/src/providers/gmail-record-builder.ts
@@ -1,5 +1,7 @@
 import { createHash } from "node:crypto";
 
+import libmime from "libmime";
+
 import {
   gmailMessageRecordSchema,
   type GmailRecord
@@ -116,6 +118,27 @@ export function sha256Text(value: string): string {
   return createHash("sha256").update(value, "utf8").digest("hex");
 }
 
+export function normalizeGmailSubject(
+  value: string | null | undefined
+): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  try {
+    const decoded = libmime.decodeWords(trimmed).trim();
+    return decoded.length > 0 ? decoded : null;
+  } catch {
+    return trimmed;
+  }
+}
+
 export function buildGmailMessageRecord(
   input: GmailProviderCloseMessageInput
 ): GmailRecord {
@@ -155,11 +178,7 @@ export function buildGmailMessageRecord(
     ? "outbound"
     : "inbound";
   const rfc822MessageId = input.headers["Message-ID"]?.trim() ?? null;
-  const trimmedSubject = input.headers.Subject?.trim();
-  const subject =
-    trimmedSubject === undefined || trimmedSubject.length === 0
-      ? null
-      : trimmedSubject;
+  const subject = normalizeGmailSubject(input.headers.Subject);
   const occurredAt =
     toSafeIsoTimestamp(input.headers.Date) ??
     toSafeIsoTimestamp(input.internalDate ?? undefined) ??

--- a/packages/integrations/test/gmail-body-extraction.test.ts
+++ b/packages/integrations/test/gmail-body-extraction.test.ts
@@ -52,6 +52,14 @@ describe("Gmail body extraction", () => {
     );
   });
 
+  it("strips multi-dash MIME boundary markers from flattened previews", () => {
+    expect(
+      cleanGmailBodyPreviewText(
+        "------=_Part_2324998_585856288.1775021416555\nrest of body"
+      )
+    ).toBe("rest of body");
+  });
+
   it("maps live Gmail full payloads to decoded body previews instead of snippets", async () => {
     const fixtureJson = JSON.parse(
       await readFixtureText("live-message-full.json")

--- a/packages/integrations/test/stage1-gmail-mbox.test.ts
+++ b/packages/integrations/test/stage1-gmail-mbox.test.ts
@@ -133,7 +133,65 @@ Hello from an exported mailbox.
     ]);
   });
 
-  it("normalizes missing or blank subjects to null while preserving non-empty subjects", () => {
+  it("decodes RFC 2047 subjects during mbox import", async () => {
+    const cases = [
+      {
+        name: "quoted-printable",
+        subjectHeader: "=?utf-8?Q?Re:_Training_=3D_=E2=9C=85?=",
+        expectedSubject: "Re: Training = ✅"
+      },
+      {
+        name: "base64",
+        subjectHeader: "=?utf-8?B?UmU6IEludml0YXRpb24=?=",
+        expectedSubject: "Re: Invitation"
+      },
+      {
+        name: "chained-words",
+        subjectHeader: "=?utf-8?Q?Hi?= =?utf-8?Q?_world?=",
+        expectedSubject: "Hi world"
+      },
+      {
+        name: "mixed-charsets",
+        subjectHeader:
+          "=?iso-8859-1?Q?Ol=E1?= =?windows-1252?Q?_price_=80100?=",
+        expectedSubject: "Olá price €100"
+      },
+      {
+        name: "unknown-charset-fallback",
+        subjectHeader: "=?x-unknown?Q?Re:_caf=C3=A9?=",
+        expectedSubject: "Re: café"
+      }
+    ] as const;
+
+    for (const testCase of cases) {
+      const records = await importGmailMboxRecords({
+        mboxText: `From MAILER-DAEMON Fri Jan 03 00:00:00 2026
+Date: Fri, 03 Jan 2026 00:00:00 +0000
+From: Volunteer <volunteer@example.org>
+To: Project Antarctica <project-antarctica@example.org>
+Subject: ${testCase.subjectHeader}
+Message-ID: <gmail-mbox-${testCase.name}@example.org>
+
+`,
+        mboxPath: `/tmp/project-antarctica-${testCase.name}.mbox`,
+        capturedMailbox: "project-antarctica@example.org",
+        liveAccount: "volunteers@adventurescientists.org",
+        projectInboxAliases: ["project-antarctica@example.org"],
+        receivedAt: "2026-01-03T00:05:00.000Z"
+      });
+
+      expect(records).toEqual([
+        expect.objectContaining({
+          recordType: "message",
+          subject: testCase.expectedSubject,
+          snippet: testCase.expectedSubject,
+          snippetClean: testCase.expectedSubject
+        })
+      ]);
+    }
+  });
+
+  it("normalizes missing or blank subjects to null while preserving non-empty and decoded live subjects", () => {
     const cases = [
       {
         name: "missing subject",
@@ -177,6 +235,62 @@ Hello from an exported mailbox.
           "Message-ID": "<gmail-live-normal@example.org>"
         },
         expectedSubject: "Status update"
+      },
+      {
+        name: "quoted-printable",
+        headers: {
+          Date: "Fri, 03 Jan 2026 00:00:00 +0000",
+          From: "Project Antarctica <project-antarctica@example.org>",
+          To: "Volunteer <volunteer@example.org>",
+          Subject: "=?utf-8?Q?Re:_Training_=3D_=E2=9C=85?=",
+          "Message-ID": "<gmail-live-qp@example.org>"
+        },
+        expectedSubject: "Re: Training = ✅"
+      },
+      {
+        name: "base64",
+        headers: {
+          Date: "Fri, 03 Jan 2026 00:00:00 +0000",
+          From: "Project Antarctica <project-antarctica@example.org>",
+          To: "Volunteer <volunteer@example.org>",
+          Subject: "=?utf-8?B?UmU6IEludml0YXRpb24=?=",
+          "Message-ID": "<gmail-live-b64@example.org>"
+        },
+        expectedSubject: "Re: Invitation"
+      },
+      {
+        name: "chained-words",
+        headers: {
+          Date: "Fri, 03 Jan 2026 00:00:00 +0000",
+          From: "Project Antarctica <project-antarctica@example.org>",
+          To: "Volunteer <volunteer@example.org>",
+          Subject: "=?utf-8?Q?Hi?= =?utf-8?Q?_world?=",
+          "Message-ID": "<gmail-live-chained@example.org>"
+        },
+        expectedSubject: "Hi world"
+      },
+      {
+        name: "mixed-charsets",
+        headers: {
+          Date: "Fri, 03 Jan 2026 00:00:00 +0000",
+          From: "Project Antarctica <project-antarctica@example.org>",
+          To: "Volunteer <volunteer@example.org>",
+          Subject:
+            "=?iso-8859-1?Q?Ol=E1?= =?windows-1252?Q?_price_=80100?=",
+          "Message-ID": "<gmail-live-mixed@example.org>"
+        },
+        expectedSubject: "Olá price €100"
+      },
+      {
+        name: "unknown-charset-fallback",
+        headers: {
+          Date: "Fri, 03 Jan 2026 00:00:00 +0000",
+          From: "Project Antarctica <project-antarctica@example.org>",
+          To: "Volunteer <volunteer@example.org>",
+          Subject: "=?x-unknown?Q?Re:_caf=C3=A9?=",
+          "Message-ID": "<gmail-live-unknown@example.org>"
+        },
+        expectedSubject: "Re: café"
       }
     ] as const;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,9 @@ importers:
       '@as-comms/contracts':
         specifier: workspace:*
         version: link:../contracts
+      libmime:
+        specifier: ^5.3.8
+        version: 5.3.8
       mailparser:
         specifier: ^3.9.8
         version: 3.9.8


### PR DESCRIPTION
## What changed
- broadened Gmail MIME boundary stripping to remove boundary lines with two or more leading dashes in both the shared integrations cleaner and the Inbox selector fallback cleaner
- decoded RFC 2047 encoded-word subjects before persisting Gmail message records, and reused that subject normalization for mbox subject-based snippet fallbacks
- added focused unit coverage for multi-dash MIME boundaries and encoded subjects across live and mbox Gmail ingest paths, plus the web selector fallback path

## Why
Prod reparse surfaced two recurring ingest issues:
1. flattened MIME previews could retain Outlook/Apple Mail boundary lines when they started with more than two dashes
2. encoded-word `Subject:` values were stored verbatim instead of decoded, which leaked raw RFC 2047 text into persisted Gmail message details and UI rendering

## Impact
- future Gmail imports and live captures will persist decoded subjects instead of raw encoded words
- Inbox preview fallbacks will strip the multi-dash MIME boundary scaffolding that was still leaking into stored snippets
- existing prod cleanup remains ops-only; this PR prevents new polluted rows at ingest time

## Validation
- `pnpm --filter @as-comms/integrations test:unit`
- `pnpm --filter @as-comms/web test:unit`
- `pnpm --filter @as-comms/integrations typecheck`
- `pnpm --filter @as-comms/integrations build`
- `pnpm --filter @as-comms/web typecheck`
- `pnpm lint`
- `pnpm boundaries`
- `pnpm verify`
