### PR TITLE
feat(stage1): deploy worker + crontab-scheduled live Gmail and Salesforce polling

### DIFF
--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -1,0 +1,48 @@
+# Worker
+
+The worker runs the Stage 1 orchestration jobs for canonical ingest, replay, projection rebuilds, parity checks, and cutover support. In production it also owns the live polling schedule that enqueues Gmail live capture every minute and Salesforce live capture every five minutes through Graphile Worker cron.
+
+## Railway
+
+Provision a dedicated `worker` service in the existing Railway project. This repo is a shared `pnpm` workspace, so the service must keep access to the full repository checkout for workspace dependencies; Railway's current `railway.json` schema does not support declaring a root directory in code.
+
+Use the checked-in [railway.json](/Users/nicolas/Downloads/AS%20Comms%20Platform/apps/worker/railway.json) config and confirm these settings in the Railway dashboard:
+
+- service name: `worker`
+- config file path: `/apps/worker/railway.json`
+- build command: `pnpm install --frozen-lockfile && pnpm --filter @as-comms/worker... build`
+- start command: `pnpm --filter @as-comms/worker start`
+- healthcheck: none
+
+Required env vars for the deployed worker:
+
+- `DATABASE_URL`
+- `WORKER_DATABASE_URL`
+- `GMAIL_CAPTURE_BASE_URL`
+- `GMAIL_CAPTURE_TOKEN`
+- `GMAIL_LIVE_ACCOUNT`
+- `GMAIL_PROJECT_INBOX_ALIASES`
+- `GMAIL_LIVE_POLL_INTERVAL_SECONDS`
+- `SALESFORCE_CAPTURE_BASE_URL`
+- `SALESFORCE_CAPTURE_TOKEN`
+- `SALESFORCE_CONTACT_CAPTURE_MODE`
+- `SALESFORCE_MEMBERSHIP_CAPTURE_MODE`
+- `SALESFORCE_TASK_POLL_INTERVAL_SECONDS`
+- `WORKER_BOOT_MODE=run`
+
+Optional env vars:
+
+- `WORKER_CONCURRENCY`
+- `INBOX_REVALIDATE_BASE_URL`
+- `INBOX_REVALIDATE_TOKEN`
+
+## Local Dev
+
+Disable the worker runtime and its cron schedule locally by leaving `WORKER_BOOT_MODE` unset or setting `WORKER_BOOT_MODE=idle`.
+
+Use these commands when you do want the worker running locally:
+
+```bash
+pnpm ops:worker:check-config
+WORKER_BOOT_MODE=run pnpm dev:worker
+```

--- a/apps/worker/railway.json
+++ b/apps/worker/railway.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "RAILPACK",
+    "buildCommand": "pnpm install --frozen-lockfile && pnpm --filter @as-comms/worker... build"
+  },
+  "deploy": {
+    "startCommand": "pnpm --filter @as-comms/worker start",
+    "healthcheckPath": null
+  }
+}

--- a/apps/worker/src/orchestration/service.ts
+++ b/apps/worker/src/orchestration/service.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 
 import { ZodError, type infer as ZodInfer } from "zod";
@@ -17,12 +18,15 @@ import {
   salesforceLiveCaptureBatchPayloadSchema,
   simpleTextingHistoricalCaptureBatchPayloadSchema,
   simpleTextingLiveCaptureBatchPayloadSchema,
+  stage1JobVersion,
   type CanonicalEventRecord,
   type CutoverCheckpointBatchPayload,
+  type GmailLiveCaptureBatchPayload,
   type ParityCheckBatchPayload,
   type ProjectionRebuildBatchPayload,
   type Provider,
   type ReplayBatchPayload,
+  type SalesforceLiveCaptureBatchPayload,
   type SyncJobType
 } from "@as-comms/contracts";
 import {
@@ -77,6 +81,9 @@ const cutoverCheckpointPolicyCode = "stage1.cutover.checkpoint";
 const gmailAndSimpleTextingP95ThresholdSeconds = 120;
 const gmailAndSimpleTextingP99ThresholdSeconds = 300;
 const salesforceLifecycleP95ThresholdSeconds = 600;
+const defaultGmailLivePollIntervalSeconds = 60;
+const defaultSalesforceLivePollIntervalSeconds = 300;
+const livePollMaxRecords = 1000;
 
 type CapturedProviderRecord =
   | GmailRecord
@@ -92,6 +99,11 @@ interface Stage1FreshnessMetrics {
 interface Stage1GmailHistoricalReplayConfig {
   readonly liveAccount: string;
   readonly projectInboxAliases: readonly string[];
+}
+
+interface Stage1LivePollingConfig {
+  readonly gmailPollIntervalSeconds: number;
+  readonly salesforcePollIntervalSeconds: number;
 }
 
 interface ParsedGmailHistoricalPayloadRef {
@@ -130,6 +142,46 @@ function compareEventOrder(
   }
 
   return left.id.localeCompare(right.id);
+}
+
+function buildWorkerOperationId(prefix: string): string {
+  return `${prefix}:${randomUUID()}`;
+}
+
+function subtractSeconds(now: Date, seconds: number): string {
+  return new Date(now.getTime() - seconds * 1000).toISOString();
+}
+
+function resolveLivePollCheckpoint(input: {
+  readonly syncState: {
+    readonly status: string;
+    readonly cursor: string | null;
+    readonly lastSuccessfulAt: string | null;
+    readonly windowStart: string | null;
+    readonly windowEnd: string | null;
+  } | null;
+  readonly fallbackWindowStart: string;
+}): string {
+  if (input.syncState === null) {
+    return input.fallbackWindowStart;
+  }
+
+  if (input.syncState.status === "failed" || input.syncState.status === "quarantined") {
+    return (
+      input.syncState.cursor ??
+      input.syncState.windowStart ??
+      input.syncState.lastSuccessfulAt ??
+      input.syncState.windowEnd ??
+      input.fallbackWindowStart
+    );
+  }
+
+  return (
+    input.syncState.lastSuccessfulAt ??
+    input.syncState.windowEnd ??
+    input.syncState.cursor ??
+    input.fallbackWindowStart
+  );
 }
 
 function isInboxDrivingEvent(
@@ -807,11 +859,98 @@ export function createStage1WorkerOrchestrationService(input: {
   >;
   readonly persistence: Stage1PersistenceService;
   readonly gmailHistoricalReplay: Stage1GmailHistoricalReplayConfig;
+  readonly livePolling?: Partial<Stage1LivePollingConfig>;
   readonly revalidateInboxViews?: (input: {
     readonly contactIds: readonly string[];
   }) => Promise<void>;
 }): Stage1WorkerOrchestrationService {
   const syncState = createStage1SyncStateService(input.persistence);
+  const livePolling: Stage1LivePollingConfig = {
+    gmailPollIntervalSeconds:
+      input.livePolling?.gmailPollIntervalSeconds ??
+      defaultGmailLivePollIntervalSeconds,
+    salesforcePollIntervalSeconds:
+      input.livePolling?.salesforcePollIntervalSeconds ??
+      defaultSalesforceLivePollIntervalSeconds
+  };
+
+  async function planGmailLiveCaptureBatch(
+    now = new Date()
+  ): Promise<GmailLiveCaptureBatchPayload | null> {
+    const latestSyncState = await input.persistence.repositories.syncState.findLatest({
+      scope: "provider",
+      provider: "gmail",
+      jobType: "live_ingest"
+    });
+
+    if (latestSyncState?.status === "running") {
+      return null;
+    }
+
+    const windowEnd = now.toISOString();
+    const windowStart = resolveLivePollCheckpoint({
+      syncState: latestSyncState,
+      fallbackWindowStart: subtractSeconds(
+        now,
+        livePolling.gmailPollIntervalSeconds
+      )
+    });
+
+    return gmailLiveCaptureBatchPayloadSchema.parse({
+      version: stage1JobVersion,
+      jobId: buildWorkerOperationId("stage1:gmail:live:job"),
+      correlationId: buildWorkerOperationId("stage1:gmail:live:correlation"),
+      batchId: buildWorkerOperationId("stage1:gmail:live:batch"),
+      syncStateId: buildWorkerOperationId("stage1:gmail:live:sync-state"),
+      provider: "gmail",
+      mode: "live",
+      jobType: "live_ingest",
+      checkpoint: windowStart,
+      windowStart,
+      windowEnd,
+      maxRecords: livePollMaxRecords
+    });
+  }
+
+  async function planSalesforceLiveCaptureBatch(
+    now = new Date()
+  ): Promise<SalesforceLiveCaptureBatchPayload | null> {
+    const latestSyncState = await input.persistence.repositories.syncState.findLatest(
+      {
+        scope: "provider",
+        provider: "salesforce",
+        jobType: "live_ingest"
+      }
+    );
+
+    if (latestSyncState?.status === "running") {
+      return null;
+    }
+
+    const windowEnd = now.toISOString();
+    const windowStart = resolveLivePollCheckpoint({
+      syncState: latestSyncState,
+      fallbackWindowStart: subtractSeconds(
+        now,
+        livePolling.salesforcePollIntervalSeconds
+      )
+    });
+
+    return salesforceLiveCaptureBatchPayloadSchema.parse({
+      version: stage1JobVersion,
+      jobId: buildWorkerOperationId("stage1:salesforce:live:job"),
+      correlationId: buildWorkerOperationId("stage1:salesforce:live:correlation"),
+      batchId: buildWorkerOperationId("stage1:salesforce:live:batch"),
+      syncStateId: buildWorkerOperationId("stage1:salesforce:live:sync-state"),
+      provider: "salesforce",
+      mode: "live",
+      jobType: "live_ingest",
+      checkpoint: windowStart,
+      windowStart,
+      windowEnd,
+      maxRecords: livePollMaxRecords
+    });
+  }
 
   async function runCapturedBatch<TPayload, TRecord>(params: {
     readonly payload: TPayload;
@@ -1694,6 +1833,8 @@ export function createStage1WorkerOrchestrationService(input: {
   }
 
   return {
+    planGmailLiveCaptureBatch,
+    planSalesforceLiveCaptureBatch,
     runGmailHistoricalCaptureBatch: (payload) => {
       return runCapturedBatch({
         payload,

--- a/apps/worker/src/orchestration/tasks.ts
+++ b/apps/worker/src/orchestration/tasks.ts
@@ -29,6 +29,9 @@ import {
 
 import type { Stage1WorkerOrchestrationService } from "./types.js";
 
+export const pollGmailLiveJobName = "poll-gmail-live" as const;
+export const pollSalesforceLiveJobName = "poll-salesforce-live" as const;
+
 function isFailedStage1TaskOutcome(
   value: unknown
 ): value is {
@@ -76,6 +79,25 @@ function createStage1Task<TPayload>(
   };
 }
 
+function createPollingTask<TPayload>(
+  plan: (now: Date) => Promise<TPayload | null>,
+  input: {
+    readonly jobName: string;
+  }
+): Task {
+  return async (_rawPayload: unknown, helpers) => {
+    const payload = await plan(new Date());
+
+    if (payload === null) {
+      return;
+    }
+
+    await helpers.addJob(input.jobName, payload, {
+      maxAttempts: 1
+    });
+  };
+}
+
 export function createStage1TaskList(
   orchestration: Stage1WorkerOrchestrationService
 ): TaskList {
@@ -88,6 +110,12 @@ export function createStage1TaskList(
       (payload) => gmailLiveCaptureBatchPayloadSchema.parse(payload),
       (payload) => orchestration.runGmailLiveCaptureBatch(payload)
     ),
+    [pollGmailLiveJobName]: createPollingTask(
+      (now) => orchestration.planGmailLiveCaptureBatch(now),
+      {
+        jobName: gmailLiveCaptureBatchJobName
+      }
+    ),
     [salesforceHistoricalCaptureBatchJobName]: createStage1Task(
       (payload) => salesforceHistoricalCaptureBatchPayloadSchema.parse(payload),
       (payload) => orchestration.runSalesforceHistoricalCaptureBatch(payload)
@@ -95,6 +123,12 @@ export function createStage1TaskList(
     [salesforceLiveCaptureBatchJobName]: createStage1Task(
       (payload) => salesforceLiveCaptureBatchPayloadSchema.parse(payload),
       (payload) => orchestration.runSalesforceLiveCaptureBatch(payload)
+    ),
+    [pollSalesforceLiveJobName]: createPollingTask(
+      (now) => orchestration.planSalesforceLiveCaptureBatch(now),
+      {
+        jobName: salesforceLiveCaptureBatchJobName
+      }
     ),
     [simpleTextingHistoricalCaptureBatchJobName]: createStage1Task(
       (payload) => simpleTextingHistoricalCaptureBatchPayloadSchema.parse(payload),

--- a/apps/worker/src/orchestration/types.ts
+++ b/apps/worker/src/orchestration/types.ts
@@ -203,6 +203,12 @@ export interface Stage1CutoverCheckpointJobOutcome extends Stage1JobOutcomeBase 
 }
 
 export interface Stage1WorkerOrchestrationService {
+  planGmailLiveCaptureBatch(
+    now?: Date
+  ): Promise<GmailLiveCaptureBatchPayload | null>;
+  planSalesforceLiveCaptureBatch(
+    now?: Date
+  ): Promise<SalesforceLiveCaptureBatchPayload | null>;
   runGmailHistoricalCaptureBatch(
     payload: GmailHistoricalCaptureBatchPayload
   ): Promise<Stage1CaptureJobOutcome>;

--- a/apps/worker/src/runtime.ts
+++ b/apps/worker/src/runtime.ts
@@ -23,6 +23,7 @@ import {
 
 import { createStage1IngestService } from "./ingest/index.js";
 import {
+  Stage1WorkerConfigError,
   readProjectInboxAliasesFromDb,
   readStage1LaunchScopeConfig,
   stage1LaunchScopeConfigSchema,
@@ -31,6 +32,8 @@ import {
 import {
   createStage1WorkerOrchestrationService,
   type MailchimpCapturePort,
+  pollGmailLiveJobName,
+  pollSalesforceLiveJobName,
   type SimpleTextingCapturePort,
   type Stage1WorkerOrchestrationService
 } from "./orchestration/index.js";
@@ -63,6 +66,32 @@ export interface Stage1WorkerRuntimeServices {
   readonly orchestration: Stage1WorkerOrchestrationService;
   readonly taskList: TaskList;
   dispose(): Promise<void>;
+}
+
+function toCronMinuteInterval(providerLabel: string, seconds: number): number {
+  if (seconds % 60 !== 0) {
+    throw new Stage1WorkerConfigError(
+      `${providerLabel} poll interval must be a whole-number multiple of 60 seconds for Graphile Worker crontab scheduling.`
+    );
+  }
+
+  return seconds / 60;
+}
+
+export function buildWorkerCrontab(config: WorkerConfig): string {
+  const gmailMinutes = toCronMinuteInterval(
+    "Gmail live",
+    config.launchScope.gmail.livePollIntervalSeconds
+  );
+  const salesforceMinutes = toCronMinuteInterval(
+    "Salesforce Task",
+    config.launchScope.salesforce.taskPollIntervalSeconds
+  );
+
+  return [
+    `*/${String(gmailMinutes)} * * * * ${pollGmailLiveJobName} ?id=gmail-live-poll&max=1`,
+    `*/${String(salesforceMinutes)} * * * * ${pollSalesforceLiveJobName} ?id=salesforce-live-poll&max=1`
+  ].join("\n");
 }
 
 function readOptionalCaptureConfig(
@@ -248,6 +277,11 @@ export async function createStage1WorkerRuntimeServices(
     ingest,
     normalization,
     persistence,
+    livePolling: {
+      gmailPollIntervalSeconds: config.launchScope.gmail.livePollIntervalSeconds,
+      salesforcePollIntervalSeconds:
+        config.launchScope.salesforce.taskPollIntervalSeconds
+    },
     revalidateInboxViews,
     gmailHistoricalReplay: {
       liveAccount: config.launchScope.gmail.liveAccount,
@@ -318,6 +352,7 @@ export async function startWorker(
     const runner = await run({
       connectionString: config.connectionString,
       concurrency: config.concurrency,
+      crontab: buildWorkerCrontab(config),
       noHandleSignals: true,
       pollInterval: 2000,
       taskList: runtime.taskList

--- a/apps/worker/test/stage1-live-polling.test.ts
+++ b/apps/worker/test/stage1-live-polling.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+
+import {
+  gmailLiveCaptureBatchJobName,
+  salesforceLiveCaptureBatchJobName
+} from "@as-comms/contracts";
+
+import {
+  createStage1TaskList,
+  pollGmailLiveJobName,
+  pollSalesforceLiveJobName
+} from "../src/orchestration/tasks.js";
+import { createTestWorkerContext } from "./helpers.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+async function saveLiveSyncState(
+  context: Awaited<ReturnType<typeof createTestWorkerContext>>,
+  input: {
+    readonly id: string;
+    readonly provider: "gmail" | "salesforce";
+    readonly status: "running" | "succeeded";
+    readonly cursor: string | null;
+    readonly windowStart: string | null;
+    readonly windowEnd: string | null;
+    readonly lastSuccessfulAt: string | null;
+  }
+): Promise<void> {
+  await context.persistence.saveSyncState({
+    id: input.id,
+    scope: "provider",
+    provider: input.provider,
+    jobType: "live_ingest",
+    status: input.status,
+    cursor: input.cursor,
+    windowStart: input.windowStart,
+    windowEnd: input.windowEnd,
+    parityPercent: null,
+    lastSuccessfulAt: input.lastSuccessfulAt,
+    deadLetterCount: 0,
+    freshnessP95Seconds: null,
+    freshnessP99Seconds: null
+  });
+}
+
+describe("Stage 1 live polling scheduler tasks", () => {
+  it("enqueues a Gmail live capture batch from the latest checkpoint", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-05T00:06:00.000Z"));
+
+    const context = await createTestWorkerContext();
+
+    try {
+      await saveLiveSyncState(context, {
+        id: "sync:gmail:live:latest",
+        provider: "gmail",
+        status: "succeeded",
+        cursor: "gmail:checkpoint:ignored",
+        windowStart: "2026-01-05T00:04:00.000Z",
+        windowEnd: "2026-01-05T00:05:00.000Z",
+        lastSuccessfulAt: "2026-01-05T00:05:00.000Z"
+      });
+
+      const addJob = vi.fn(() => Promise.resolve({ id: "job:gmail:live:enqueued" }));
+      const task = createStage1TaskList(context.orchestration)[pollGmailLiveJobName];
+
+      expect(task).toBeTypeOf("function");
+      if (task === undefined) {
+        throw new Error("Expected Gmail poll task to be registered.");
+      }
+
+      await task({}, { addJob } as never);
+
+      expect(addJob).toHaveBeenCalledTimes(1);
+      expect(addJob).toHaveBeenCalledWith(
+        gmailLiveCaptureBatchJobName,
+        expect.objectContaining({
+          provider: "gmail",
+          mode: "live",
+          jobType: "live_ingest",
+          checkpoint: "2026-01-05T00:05:00.000Z",
+          windowStart: "2026-01-05T00:05:00.000Z",
+          windowEnd: "2026-01-05T00:06:00.000Z",
+          attempt: 1,
+          maxAttempts: 3,
+          cursor: null,
+          maxRecords: 1000,
+          recordIds: []
+        }),
+        {
+          maxAttempts: 1
+        }
+      );
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("does not enqueue Gmail live capture while a prior window is still running", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-05T00:06:00.000Z"));
+
+    const context = await createTestWorkerContext();
+
+    try {
+      await saveLiveSyncState(context, {
+        id: "sync:gmail:live:running",
+        provider: "gmail",
+        status: "running",
+        cursor: "2026-01-05T00:05:00.000Z",
+        windowStart: "2026-01-05T00:05:00.000Z",
+        windowEnd: "2026-01-05T00:06:00.000Z",
+        lastSuccessfulAt: null
+      });
+
+      const addJob = vi.fn(() => Promise.resolve({ id: "job:gmail:live:enqueued" }));
+      const task = createStage1TaskList(context.orchestration)[pollGmailLiveJobName];
+
+      expect(task).toBeTypeOf("function");
+      if (task === undefined) {
+        throw new Error("Expected Gmail poll task to be registered.");
+      }
+
+      await task({}, { addJob } as never);
+
+      expect(addJob).not.toHaveBeenCalled();
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("enqueues a Salesforce live capture batch from the latest checkpoint", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-05T00:10:00.000Z"));
+
+    const context = await createTestWorkerContext();
+
+    try {
+      await saveLiveSyncState(context, {
+        id: "sync:salesforce:live:latest",
+        provider: "salesforce",
+        status: "succeeded",
+        cursor: "salesforce:checkpoint:ignored",
+        windowStart: "2026-01-05T00:00:00.000Z",
+        windowEnd: "2026-01-05T00:05:00.000Z",
+        lastSuccessfulAt: "2026-01-05T00:05:00.000Z"
+      });
+
+      const addJob = vi.fn(() =>
+        Promise.resolve({
+          id: "job:salesforce:live:enqueued"
+        })
+      );
+      const task =
+        createStage1TaskList(context.orchestration)[pollSalesforceLiveJobName];
+
+      expect(task).toBeTypeOf("function");
+      if (task === undefined) {
+        throw new Error("Expected Salesforce poll task to be registered.");
+      }
+
+      await task({}, { addJob } as never);
+
+      expect(addJob).toHaveBeenCalledTimes(1);
+      expect(addJob).toHaveBeenCalledWith(
+        salesforceLiveCaptureBatchJobName,
+        expect.objectContaining({
+          provider: "salesforce",
+          mode: "live",
+          jobType: "live_ingest",
+          checkpoint: "2026-01-05T00:05:00.000Z",
+          windowStart: "2026-01-05T00:05:00.000Z",
+          windowEnd: "2026-01-05T00:10:00.000Z",
+          attempt: 1,
+          maxAttempts: 3,
+          cursor: null,
+          maxRecords: 1000,
+          recordIds: []
+        }),
+        {
+          maxAttempts: 1
+        }
+      );
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("does not enqueue Salesforce live capture while a prior window is still running", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-05T00:10:00.000Z"));
+
+    const context = await createTestWorkerContext();
+
+    try {
+      await saveLiveSyncState(context, {
+        id: "sync:salesforce:live:running",
+        provider: "salesforce",
+        status: "running",
+        cursor: "2026-01-05T00:05:00.000Z",
+        windowStart: "2026-01-05T00:05:00.000Z",
+        windowEnd: "2026-01-05T00:10:00.000Z",
+        lastSuccessfulAt: null
+      });
+
+      const addJob = vi.fn(() =>
+        Promise.resolve({
+          id: "job:salesforce:live:enqueued"
+        })
+      );
+      const task =
+        createStage1TaskList(context.orchestration)[pollSalesforceLiveJobName];
+
+      expect(task).toBeTypeOf("function");
+      if (task === undefined) {
+        throw new Error("Expected Salesforce poll task to be registered.");
+      }
+
+      await task({}, { addJob } as never);
+
+      expect(addJob).not.toHaveBeenCalled();
+    } finally {
+      await context.dispose();
+    }
+  });
+});

--- a/apps/worker/test/stage1-runtime.test.ts
+++ b/apps/worker/test/stage1-runtime.test.ts
@@ -5,7 +5,14 @@ import {
   gmailHistoricalCaptureBatchPayloadSchema
 } from "@as-comms/contracts";
 
-import { readWorkerConfig } from "../src/runtime.js";
+import {
+  buildWorkerCrontab,
+  readWorkerConfig
+} from "../src/runtime.js";
+import {
+  pollGmailLiveJobName,
+  pollSalesforceLiveJobName
+} from "../src/orchestration/tasks.js";
 import { createTaskList } from "../src/tasks.js";
 import {
   buildCapturedBatch,
@@ -119,6 +126,22 @@ describe("Stage 1 worker runtime task registration", () => {
         GMAIL_LIVE_ACCOUNT: "project-antarctica@example.org"
       })
     ).toThrow("Gmail live account must be a volunteers@... address.");
+  });
+
+  it("builds the Graphile Worker crontab for Gmail and Salesforce live polling", () => {
+    const config = readWorkerConfig(launchScopeEnv);
+
+    expect(config).not.toBeNull();
+    if (config === null) {
+      throw new Error("Expected launch-scope config to be present.");
+    }
+
+    expect(buildWorkerCrontab(config)).toBe(
+      [
+        `*/1 * * * * ${pollGmailLiveJobName} ?id=gmail-live-poll&max=1`,
+        `*/5 * * * * ${pollSalesforceLiveJobName} ?id=salesforce-live-poll&max=1`
+      ].join("\n")
+    );
   });
 
   it("registers Stage 1 task names and executes them through the existing orchestration path", async () => {


### PR DESCRIPTION
## Summary
- add internal `poll-gmail-live` and `poll-salesforce-live` scheduler tasks that read the latest provider `sync_state`, skip when a live ingest window is already running, and enqueue the existing live batch handlers with concrete windows
- wire Graphile Worker crontab in the worker runtime for 60-second Gmail polling and 5-minute Salesforce Task polling
- add worker Railway config, deployment docs, and unit coverage for the new scheduler flow and cron wiring

## Validation
- `pnpm --filter @as-comms/worker typecheck`
- `pnpm --filter @as-comms/worker build`
- `pnpm --filter @as-comms/worker test:unit`
- `pnpm lint`
- `pnpm boundaries`
- `pnpm verify`

## Manual Verification After Deploy
1. Provision the Railway `worker` service with `apps/worker/railway.json`, copy the documented env vars, and set `WORKER_BOOT_MODE=run`.
2. Confirm the worker boots cleanly and registers the Graphile cron entries for `poll-gmail-live` and `poll-salesforce-live`.
3. Wait for the scheduled polls or enqueue one-off live windows:
   - `pnpm ops:worker:enqueue -- gmail-live --window-start 2026-01-02T00:00:00.000Z --window-end 2026-01-02T00:05:00.000Z`
   - `pnpm ops:worker:enqueue -- salesforce-live --window-start 2026-01-02T00:00:00.000Z --window-end 2026-01-02T00:05:00.000Z`
4. Inspect the latest live sync state:
   - `pnpm ops:worker:inspect -- sync --provider gmail --job-type live_ingest`
   - `pnpm ops:worker:inspect -- sync --provider salesforce --job-type live_ingest`
5. Confirm fresh Gmail and Salesforce events land for a known contact and propagate through canonical history and inbox projections.
