### PR TITLE
feat(web): security hardening + inbox usability pass

### DIFF
--- a/apps/web/app/api/auth/[...nextauth]/route.ts
+++ b/apps/web/app/api/auth/[...nextauth]/route.ts
@@ -1,7 +1,67 @@
+import { NextResponse, type NextRequest } from "next/server";
+
 import { handlers } from "../../../../src/server/auth";
+import {
+  enforceRateLimit,
+  getClientIp,
+} from "../../../../src/server/security/rate-limit";
 
 // The Auth.js v5 callback endpoints must not be pre-rendered — they need to
 // read cookies + set-cookie on every request.
 export const dynamic = "force-dynamic";
 
-export const { GET, POST } = handlers;
+async function rateLimitAuthRequest(
+  request: NextRequest,
+): Promise<NextResponse | null> {
+  const clientIp = getClientIp(request);
+  const decision = await enforceRateLimit({
+    scope: "route:/api/auth",
+    identifier: clientIp,
+    limit: 10,
+    audit: {
+      actorType: "system",
+      actorId: clientIp,
+      action: "auth.request.rate_limited",
+      entityType: "route",
+      entityId: request.nextUrl.pathname,
+      metadataJson: {
+        method: request.method,
+      },
+    },
+  });
+
+  if (decision.allowed) {
+    return null;
+  }
+
+  return NextResponse.json(
+    {
+      ok: false,
+      code: "rate_limit_exceeded",
+    },
+    {
+      status: 429,
+      headers: {
+        "Retry-After": String(decision.retryAfterSeconds),
+      },
+    },
+  );
+}
+
+export async function GET(request: NextRequest): Promise<Response> {
+  const limitedResponse = await rateLimitAuthRequest(request);
+  if (limitedResponse !== null) {
+    return limitedResponse;
+  }
+
+  return handlers.GET(request);
+}
+
+export async function POST(request: NextRequest): Promise<Response> {
+  const limitedResponse = await rateLimitAuthRequest(request);
+  if (limitedResponse !== null) {
+    return limitedResponse;
+  }
+
+  return handlers.POST(request);
+}

--- a/apps/web/app/api/dev-auth/route.ts
+++ b/apps/web/app/api/dev-auth/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse, type NextRequest } from "next/server";
 
 import { getSettingsRepositories } from "../../../src/server/stage1-runtime";
+import {
+  enforceRateLimit,
+  getClientIp,
+} from "../../../src/server/security/rate-limit";
 
 // Dev-only cookie seeder. The production guard MUST be the first thing in
 // the handler — `scripts/verify-stage0.mjs` inspects this file statically
@@ -13,11 +17,43 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     return new NextResponse(null, { status: 404 });
   }
 
+  const clientIp = getClientIp(request);
+  const decision = await enforceRateLimit({
+    scope: "route:/api/dev-auth",
+    identifier: clientIp,
+    limit: 5,
+    audit: {
+      actorType: "system",
+      actorId: clientIp,
+      action: "dev_auth.request.rate_limited",
+      entityType: "route",
+      entityId: request.nextUrl.pathname,
+      metadataJson: {
+        method: request.method,
+      },
+    },
+  });
+
+  if (!decision.allowed) {
+    return NextResponse.json(
+      {
+        ok: false,
+        code: "rate_limit_exceeded",
+      },
+      {
+        status: 429,
+        headers: {
+          "Retry-After": String(decision.retryAfterSeconds),
+        },
+      },
+    );
+  }
+
   const email = request.nextUrl.searchParams.get("email");
   if (!email) {
     return NextResponse.json(
       { ok: false, code: "validation_error", message: "email is required" },
-      { status: 400 }
+      { status: 400 },
     );
   }
 
@@ -26,15 +62,19 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
   if (!user || user.deactivatedAt) {
     return NextResponse.json(
-      { ok: false, code: "not_found", message: "user not found or deactivated" },
-      { status: 404 }
+      {
+        ok: false,
+        code: "not_found",
+        message: "user not found or deactivated",
+      },
+      { status: 404 },
     );
   }
 
   const response = NextResponse.json({
     ok: true,
     email: user.email,
-    role: user.role
+    role: user.role,
   });
   response.cookies.set(
     "dev-session",
@@ -43,8 +83,8 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       httpOnly: true,
       sameSite: "strict",
       path: "/",
-      maxAge: 8 * 60 * 60
-    }
+      maxAge: 8 * 60 * 60,
+    },
   );
   return response;
 }

--- a/apps/web/app/api/inbox/contact/[contactId]/timeline/route.ts
+++ b/apps/web/app/api/inbox/contact/[contactId]/timeline/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { getInboxTimelinePage } from "../../../../../inbox/_lib/selectors";
+import { requireApiSession } from "../../../../../../src/server/auth/api";
 
 export const dynamic = "force-dynamic";
 
@@ -24,25 +25,30 @@ export async function GET(
     readonly params: Promise<{
       readonly contactId: string;
     }>;
-  }
+  },
 ) {
+  const session = await requireApiSession();
+  if (!session.ok) {
+    return session.response;
+  }
+
   const { searchParams } = new URL(request.url);
   const { contactId } = await context.params;
   const limit = parseLimit(searchParams.get("limit"));
   const page = await getInboxTimelinePage(decodeURIComponent(contactId), {
     cursor: searchParams.get("cursor"),
-    ...(limit === undefined ? {} : { limit })
+    ...(limit === undefined ? {} : { limit }),
   });
 
   if (page === null) {
     return NextResponse.json(
       {
         ok: false,
-        code: "inbox_contact_not_found"
+        code: "inbox_contact_not_found",
       },
       {
-        status: 404
-      }
+        status: 404,
+      },
     );
   }
 

--- a/apps/web/app/api/inbox/freshness/route.ts
+++ b/apps/web/app/api/inbox/freshness/route.ts
@@ -1,10 +1,16 @@
 import { NextResponse } from "next/server";
 
 import { getInboxFreshness } from "../../../inbox/_lib/selectors";
+import { requireApiSession } from "../../../../src/server/auth/api";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(request: Request) {
+  const session = await requireApiSession();
+  if (!session.ok) {
+    return session.response;
+  }
+
   const { searchParams } = new URL(request.url);
   const contactId = searchParams.get("contactId");
 

--- a/apps/web/app/api/inbox/list/route.ts
+++ b/apps/web/app/api/inbox/list/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 
 import { getInboxList } from "../../../inbox/_lib/selectors";
+import { requireApiSession } from "../../../../src/server/auth/api";
 
 export const dynamic = "force-dynamic";
 
@@ -22,19 +23,26 @@ function parseLimit(raw: string | null): number | undefined {
 }
 
 export async function GET(request: Request) {
+  const session = await requireApiSession();
+  if (!session.ok) {
+    return session.response;
+  }
+
   const { searchParams } = new URL(request.url);
-  const parsedFilter = filterSchema.safeParse(searchParams.get("filter") ?? "all");
+  const parsedFilter = filterSchema.safeParse(
+    searchParams.get("filter") ?? "all",
+  );
   const limit = parseLimit(searchParams.get("limit"));
 
   if (!parsedFilter.success) {
     return NextResponse.json(
       {
         ok: false,
-        code: "validation_error"
+        code: "validation_error",
       },
       {
-        status: 400
-      }
+        status: 400,
+      },
     );
   }
 
@@ -42,7 +50,7 @@ export async function GET(request: Request) {
     await getInboxList(parsedFilter.data, {
       cursor: searchParams.get("cursor"),
       ...(limit === undefined ? {} : { limit }),
-      query: searchParams.get("q") ?? searchParams.get("query")
-    })
+      query: searchParams.get("q") ?? searchParams.get("query"),
+    }),
   );
 }

--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -1,7 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
-import { useFormStatus } from "react-dom";
+import {
+  useCallback,
+  useEffect,
+  useOptimistic,
+  useRef,
+  useState,
+  useTransition
+} from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -17,6 +23,7 @@ import {
 } from "../actions";
 import { fetchInboxTimelinePage } from "../_lib/client-api";
 import type { InboxDetailViewModel } from "../_lib/view-models";
+import type { UiError, UiResult } from "@/src/server/ui-result";
 import { InboxFreshnessPoller } from "./inbox-freshness-poller";
 import {
   useInboxClient,
@@ -129,9 +136,26 @@ export function InboxDetail({ detail }: DetailProps) {
     }
   }, [contact.contactId, setTimelineLoading, timelinePage]);
 
+  const followUpToggle = useOptimisticBooleanToggle({
+    scopeKey: contact.contactId,
+    value: detail.needsFollowUp,
+    perform: useCallback(
+      async (nextValue: boolean): Promise<UiResult<unknown>> => {
+        const formData = new FormData();
+        formData.set("contactId", contact.contactId);
+
+        if (nextValue) {
+          return markInboxNeedsFollowUpAction(formData);
+        }
+
+        return clearInboxNeedsFollowUpAction(formData);
+      },
+      [contact.contactId]
+    )
+  });
   const activeProject = contact.activeProjects[0] ?? null;
   const firstName = contact.displayName.split(" ")[0] ?? contact.displayName;
-  const isFollowUp = detail.needsFollowUp;
+  const isFollowUp = followUpToggle.value;
   const existingReminder = reminders.get(contact.contactId) ?? null;
 
   const handleSetReminder = () => {
@@ -196,9 +220,11 @@ export function InboxDetail({ detail }: DetailProps) {
           </div>
 
           <div className="flex shrink-0 items-center gap-2">
-            <FollowUpToggleForm
-              contactId={contact.contactId}
+            <FollowUpToggleControl
               needsFollowUp={isFollowUp}
+              isPending={followUpToggle.isPending}
+              error={followUpToggle.error}
+              onToggle={followUpToggle.toggle}
             />
 
             <Popover open={reminderOpen} onOpenChange={setReminderOpen}>
@@ -318,44 +344,56 @@ export function InboxDetail({ detail }: DetailProps) {
   );
 }
 
-function FollowUpToggleForm({
-  contactId,
-  needsFollowUp
+function FollowUpToggleControl({
+  needsFollowUp,
+  isPending,
+  error,
+  onToggle
 }: {
-  readonly contactId: string;
   readonly needsFollowUp: boolean;
+  readonly isPending: boolean;
+  readonly error: UiError | null;
+  readonly onToggle: () => void;
 }) {
-  const action = async (formData: FormData) => {
-    if (needsFollowUp) {
-      await clearInboxNeedsFollowUpAction(formData);
-      return;
-    }
-
-    await markInboxNeedsFollowUpAction(formData);
-  };
-
   return (
-    <form action={action}>
-      <input type="hidden" name="contactId" value={contactId} />
-      <FollowUpToggleButton needsFollowUp={needsFollowUp} />
-    </form>
+    <div className="relative">
+      <FollowUpToggleButton
+        needsFollowUp={needsFollowUp}
+        pending={isPending}
+        onToggle={onToggle}
+      />
+
+      {error ? (
+        <div
+          role="alert"
+          className="absolute right-0 top-full z-10 mt-2 w-72 rounded-md border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-800 shadow-sm"
+        >
+          {error.message}
+        </div>
+      ) : null}
+    </div>
   );
 }
 
 function FollowUpToggleButton({
-  needsFollowUp
+  needsFollowUp,
+  pending,
+  onToggle
 }: {
   readonly needsFollowUp: boolean;
+  readonly pending: boolean;
+  readonly onToggle: () => void;
 }) {
-  const { pending } = useFormStatus();
-
   return (
     <Button
-      type="submit"
+      type="button"
       variant="outline"
       size="sm"
       disabled={pending}
       aria-pressed={needsFollowUp}
+      aria-keyshortcuts="f"
+      data-inbox-follow-up-toggle="true"
+      onClick={onToggle}
       className={cn(
         "gap-1.5",
         needsFollowUp &&
@@ -366,6 +404,57 @@ function FollowUpToggleButton({
       Needs Follow-Up
     </Button>
   );
+}
+
+function useOptimisticBooleanToggle({
+  scopeKey,
+  value,
+  perform
+}: {
+  readonly scopeKey: string;
+  readonly value: boolean;
+  readonly perform: (nextValue: boolean) => Promise<UiResult<unknown>>;
+}) {
+  const serverValueRef = useRef(value);
+  const [committedValue, setCommittedValue] = useState(value);
+  const [error, setError] = useState<UiError | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const [optimisticValue, setOptimisticValue] = useOptimistic(
+    committedValue,
+    (_currentValue: boolean, nextValue: boolean) => nextValue
+  );
+
+  useEffect(() => {
+    serverValueRef.current = value;
+    setCommittedValue(value);
+    setError(null);
+  }, [scopeKey, value]);
+
+  const toggle = useCallback(() => {
+    const nextValue = !optimisticValue;
+
+    startTransition(async () => {
+      setError(null);
+      setOptimisticValue(nextValue);
+      const result = await perform(nextValue);
+
+      if (result.ok) {
+        serverValueRef.current = nextValue;
+        setCommittedValue(nextValue);
+        return;
+      }
+
+      setCommittedValue(serverValueRef.current);
+      setError(result);
+    });
+  }, [optimisticValue, perform, setOptimisticValue]);
+
+  return {
+    value: optimisticValue,
+    isPending,
+    error,
+    toggle
+  } as const;
 }
 
 function UnresolvedBanner() {

--- a/apps/web/app/inbox/_components/inbox-keyboard-helpers.ts
+++ b/apps/web/app/inbox/_components/inbox-keyboard-helpers.ts
@@ -1,0 +1,116 @@
+export const INBOX_ROW_SELECTOR =
+  '[data-inbox-row="true"][data-contact-id]';
+
+export const INBOX_SEARCH_INPUT_SELECTOR =
+  '[data-inbox-search-input="true"]';
+
+export const INBOX_FOLLOW_UP_TOGGLE_SELECTOR =
+  '[data-inbox-follow-up-toggle="true"]';
+
+export type InboxRowDirection = 1 | -1;
+
+export interface ShortcutTargetMeta {
+  readonly tagName: string | null;
+  readonly isContentEditable: boolean;
+}
+
+export function isInboxKeyboardPath(pathname: string | null): boolean {
+  return pathname === "/inbox" || pathname?.startsWith("/inbox/") === true;
+}
+
+export function extractInboxContactId(pathname: string | null): string | null {
+  if (!pathname) return null;
+  const match = /^\/inbox\/([^/]+)/.exec(pathname);
+  if (!match) return null;
+
+  try {
+    return decodeURIComponent(match[1] ?? "");
+  } catch {
+    return match[1] ?? null;
+  }
+}
+
+export function isEditableShortcutTarget(
+  target: ShortcutTargetMeta
+): boolean {
+  if (target.isContentEditable) {
+    return true;
+  }
+
+  switch (target.tagName) {
+    case "INPUT":
+    case "TEXTAREA":
+    case "SELECT":
+      return true;
+    default:
+      return false;
+  }
+}
+
+export function getPreferredFocusedRowContactId(input: {
+  readonly rowContactIds: readonly string[];
+  readonly currentFocusedContactId: string | null;
+  readonly activeContactId: string | null;
+}): string | null {
+  const {
+    rowContactIds,
+    currentFocusedContactId,
+    activeContactId
+  } = input;
+
+  if (rowContactIds.length === 0) {
+    return null;
+  }
+
+  if (
+    currentFocusedContactId &&
+    rowContactIds.includes(currentFocusedContactId)
+  ) {
+    return currentFocusedContactId;
+  }
+
+  if (activeContactId && rowContactIds.includes(activeContactId)) {
+    return activeContactId;
+  }
+
+  return null;
+}
+
+export function getAdjacentFocusedRowContactId(input: {
+  readonly rowContactIds: readonly string[];
+  readonly currentFocusedContactId: string | null;
+  readonly activeContactId: string | null;
+  readonly direction: InboxRowDirection;
+}): string | null {
+  const {
+    rowContactIds,
+    currentFocusedContactId,
+    activeContactId,
+    direction
+  } = input;
+
+  if (rowContactIds.length === 0) {
+    return null;
+  }
+
+  const preferredContactId = getPreferredFocusedRowContactId({
+    rowContactIds,
+    currentFocusedContactId,
+    activeContactId
+  });
+
+  if (preferredContactId === null) {
+    return direction === 1
+      ? (rowContactIds[0] ?? null)
+      : (rowContactIds[rowContactIds.length - 1] ?? null);
+  }
+
+  const currentIndex = rowContactIds.indexOf(preferredContactId);
+  const nextIndex = Math.min(
+    rowContactIds.length - 1,
+    Math.max(0, currentIndex + direction)
+  );
+
+  return rowContactIds[nextIndex] ?? null;
+}
+

--- a/apps/web/app/inbox/_components/inbox-keyboard-provider.tsx
+++ b/apps/web/app/inbox/_components/inbox-keyboard-provider.tsx
@@ -1,0 +1,358 @@
+"use client";
+
+import { usePathname, useRouter } from "next/navigation";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode
+} from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent
+} from "@/components/ui/popover";
+
+import {
+  extractInboxContactId,
+  getAdjacentFocusedRowContactId,
+  getPreferredFocusedRowContactId,
+  INBOX_FOLLOW_UP_TOGGLE_SELECTOR,
+  INBOX_ROW_SELECTOR,
+  INBOX_SEARCH_INPUT_SELECTOR,
+  isEditableShortcutTarget,
+  isInboxKeyboardPath
+} from "./inbox-keyboard-helpers";
+import { XIcon } from "./icons";
+
+interface InboxKeyboardProviderProps {
+  readonly children: ReactNode;
+}
+
+interface RowTarget {
+  readonly contactId: string;
+  readonly element: HTMLElement;
+}
+
+const SHORTCUTS = [
+  { key: "J", description: "Focus the next conversation" },
+  { key: "K", description: "Focus the previous conversation" },
+  { key: "Enter", description: "Open the focused conversation" },
+  { key: "Esc", description: "Return to the inbox list" },
+  { key: "F", description: "Toggle Needs Follow-Up" },
+  { key: "/", description: "Focus search" },
+  { key: "?", description: "Show this shortcuts list" }
+] as const;
+
+export function InboxKeyboardProvider({
+  children
+}: InboxKeyboardProviderProps) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const lastFocusedContactIdRef = useRef<string | null>(null);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
+
+  const getRowTargets = useCallback((): readonly RowTarget[] => {
+    const root = rootRef.current;
+
+    if (!root) {
+      return [];
+    }
+
+    return Array.from(root.querySelectorAll<HTMLElement>(INBOX_ROW_SELECTOR))
+      .map((element) => ({
+        element,
+        contactId: element.dataset.contactId ?? ""
+      }))
+      .filter((target) => target.contactId.length > 0);
+  }, []);
+
+  const getCurrentFocusedContactId = useCallback((): string | null => {
+    const root = rootRef.current;
+
+    if (!root) {
+      return lastFocusedContactIdRef.current;
+    }
+
+    const activeElement = root.ownerDocument.activeElement;
+
+    if (!(activeElement instanceof HTMLElement)) {
+      return lastFocusedContactIdRef.current;
+    }
+
+    const row = activeElement.closest<HTMLElement>(INBOX_ROW_SELECTOR);
+
+    return row?.dataset.contactId ?? lastFocusedContactIdRef.current;
+  }, []);
+
+  const focusAdjacentRow = useCallback(
+    (direction: 1 | -1) => {
+      const rows = getRowTargets();
+      const nextContactId = getAdjacentFocusedRowContactId({
+        rowContactIds: rows.map((row) => row.contactId),
+        currentFocusedContactId: getCurrentFocusedContactId(),
+        activeContactId: extractInboxContactId(pathname),
+        direction
+      });
+
+      if (nextContactId === null) {
+        return;
+      }
+
+      const nextRow = rows.find((row) => row.contactId === nextContactId);
+
+      if (!nextRow) {
+        return;
+      }
+
+      lastFocusedContactIdRef.current = nextContactId;
+      nextRow.element.focus();
+      nextRow.element.scrollIntoView({
+        block: "nearest",
+        inline: "nearest"
+      });
+    },
+    [getCurrentFocusedContactId, getRowTargets, pathname]
+  );
+
+  const openFocusedRow = useCallback(() => {
+    const rows = getRowTargets();
+    const contactId = getPreferredFocusedRowContactId({
+      rowContactIds: rows.map((row) => row.contactId),
+      currentFocusedContactId: getCurrentFocusedContactId(),
+      activeContactId: extractInboxContactId(pathname)
+    });
+
+    if (contactId === null) {
+      return;
+    }
+
+    router.push(`/inbox/${encodeURIComponent(contactId)}`, {
+      scroll: false
+    });
+  }, [getCurrentFocusedContactId, getRowTargets, pathname, router]);
+
+  const focusSearch = useCallback(() => {
+    const root = rootRef.current;
+    const input = root?.querySelector<HTMLInputElement>(
+      INBOX_SEARCH_INPUT_SELECTOR
+    );
+
+    if (!input) {
+      return;
+    }
+
+    input.focus();
+    input.select();
+  }, []);
+
+  const triggerFollowUpToggle = useCallback(() => {
+    const root = rootRef.current;
+    const button = root?.querySelector<HTMLButtonElement>(
+      INBOX_FOLLOW_UP_TOGGLE_SELECTOR
+    );
+
+    if (!button || button.disabled) {
+      return;
+    }
+
+    button.click();
+  }, []);
+
+  useEffect(() => {
+    const root = rootRef.current;
+
+    if (!root) {
+      return;
+    }
+
+    const handleFocusIn = (event: FocusEvent) => {
+      const target = event.target;
+
+      if (!(target instanceof HTMLElement)) {
+        return;
+      }
+
+      const row = target.closest<HTMLElement>(INBOX_ROW_SELECTOR);
+
+      if (row?.dataset.contactId) {
+        lastFocusedContactIdRef.current = row.dataset.contactId;
+      }
+    };
+
+    root.addEventListener("focusin", handleFocusIn);
+
+    return () => {
+      root.removeEventListener("focusin", handleFocusIn);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isInboxKeyboardPath(pathname)) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) {
+        return;
+      }
+
+      if (event.metaKey || event.ctrlKey || event.altKey) {
+        return;
+      }
+
+      const target =
+        event.target instanceof HTMLElement ? event.target : null;
+      const targetMeta = {
+        tagName: target?.closest("input, textarea, select")?.tagName ??
+          target?.tagName ??
+          null,
+        isContentEditable:
+          target?.isContentEditable === true ||
+          target?.closest("[contenteditable='true']") !== null
+      };
+      const isEditable = isEditableShortcutTarget(targetMeta);
+
+      if (event.key === "?") {
+        if (isEditable) {
+          return;
+        }
+
+        event.preventDefault();
+        setShortcutsOpen((previous) => !previous);
+        return;
+      }
+
+      if (event.key === "Escape") {
+        if (shortcutsOpen) {
+          event.preventDefault();
+          setShortcutsOpen(false);
+        }
+
+        if (pathname !== "/inbox") {
+          event.preventDefault();
+          router.push("/inbox", { scroll: false });
+        }
+        return;
+      }
+
+      if (isEditable) {
+        return;
+      }
+
+      switch (event.key.toLowerCase()) {
+        case "j":
+          event.preventDefault();
+          focusAdjacentRow(1);
+          return;
+        case "k":
+          event.preventDefault();
+          focusAdjacentRow(-1);
+          return;
+        case "f":
+          event.preventDefault();
+          triggerFollowUpToggle();
+          return;
+        default:
+          break;
+      }
+
+      if (event.key === "/") {
+        event.preventDefault();
+        focusSearch();
+        return;
+      }
+
+      if (event.key === "Enter") {
+        const activeElement = target;
+        const focusedRow = activeElement?.closest(INBOX_ROW_SELECTOR);
+        const documentBody = rootRef.current?.ownerDocument.body ?? null;
+        const shouldHandleEnter =
+          activeElement === null ||
+          focusedRow !== null ||
+          activeElement === documentBody;
+
+        if (!shouldHandleEnter) {
+          return;
+        }
+
+        event.preventDefault();
+        openFocusedRow();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [
+    focusAdjacentRow,
+    focusSearch,
+    openFocusedRow,
+    pathname,
+    router,
+    shortcutsOpen,
+    triggerFollowUpToggle
+  ]);
+
+  return (
+    <div
+      ref={rootRef}
+      className="relative flex h-screen w-screen overflow-hidden bg-slate-100 text-slate-900 antialiased"
+    >
+      <Popover open={shortcutsOpen} onOpenChange={setShortcutsOpen}>
+        <PopoverAnchor asChild>
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute right-6 top-4 h-px w-px"
+          />
+        </PopoverAnchor>
+        <PopoverContent align="end" className="w-80">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-sm font-semibold text-slate-900">
+                Keyboard shortcuts
+              </p>
+              <p className="mt-1 text-xs text-slate-500">
+                Gmail-style navigation for the inbox.
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 shrink-0 text-slate-400 hover:text-slate-700"
+              aria-label="Close shortcuts"
+              onClick={() => {
+                setShortcutsOpen(false);
+              }}
+            >
+              <XIcon className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+
+          <ul className="mt-4 space-y-2">
+            {SHORTCUTS.map((shortcut) => (
+              <li
+                key={shortcut.key}
+                className="flex items-center justify-between gap-3 text-sm text-slate-700"
+              >
+                <span>{shortcut.description}</span>
+                <kbd className="min-w-10 rounded border border-slate-200 bg-slate-50 px-2 py-1 text-center text-[11px] font-semibold text-slate-600">
+                  {shortcut.key}
+                </kbd>
+              </li>
+            ))}
+          </ul>
+        </PopoverContent>
+      </Popover>
+
+      {children}
+    </div>
+  );
+}

--- a/apps/web/app/inbox/_components/inbox-list.tsx
+++ b/apps/web/app/inbox/_components/inbox-list.tsx
@@ -10,6 +10,7 @@ import type {
 import { fetchInboxListPage } from "../_lib/client-api";
 import { EmptyState } from "@/components/ui/empty-state";
 
+import { extractInboxContactId } from "./inbox-keyboard-helpers";
 import { useInboxClient } from "./inbox-client-provider";
 import { FOCUS_RING, LAYOUT, RADIUS, SHADOW, TEXT, TRANSITION } from "@/app/_lib/design-tokens";
 import {
@@ -40,7 +41,7 @@ export function InboxList({
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const activeContactId = extractContactId(pathname);
+  const activeContactId = extractInboxContactId(pathname);
   const {
     search,
     setSearchQuery,
@@ -239,6 +240,9 @@ export function InboxList({
           <label className={`flex items-center gap-2 ${RADIUS.md} border border-slate-200 bg-white px-3 py-1.5 text-sm ${SHADOW.sm} ${TRANSITION.fast} focus-within:border-slate-400 focus-within:ring-1 focus-within:ring-slate-300`}>
             <SearchIcon className="h-4 w-4 text-slate-400" />
             <input
+              id="inbox-search-input"
+              data-inbox-search-input="true"
+              aria-keyshortcuts="/"
               type="text"
               placeholder="Search people, emails, projects"
               value={search.query}
@@ -384,16 +388,4 @@ function SearchEmptyState({ query }: { readonly query: string }) {
       }
     />
   );
-}
-
-function extractContactId(pathname: string | null): string | null {
-  if (!pathname) return null;
-  const match = /^\/inbox\/([^/]+)/.exec(pathname);
-  if (!match) return null;
-
-  try {
-    return decodeURIComponent(match[1] ?? "");
-  } catch {
-    return match[1] ?? null;
-  }
 }

--- a/apps/web/app/inbox/_components/inbox-row.tsx
+++ b/apps/web/app/inbox/_components/inbox-row.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useCallback, useRef } from "react";
 
 import type { InboxListItemViewModel } from "../_lib/view-models";
 import { InboxAvatar } from "./inbox-avatar";
@@ -19,8 +21,11 @@ interface RowProps {
  * (rose) and review/unresolved (amber) state at a glance.
  */
 export function InboxRow({ item, isActive }: RowProps) {
+  const router = useRouter();
+  const prefetchedRef = useRef(false);
   const isUnread = item.bucket === "new";
   const ChannelIcon = item.latestChannel === "email" ? MailIcon : PhoneIcon;
+  const href = `/inbox/${encodeURIComponent(item.contactId)}`;
 
   const showBadges =
     Boolean(item.projectLabel) ||
@@ -28,11 +33,27 @@ export function InboxRow({ item, isActive }: RowProps) {
     item.hasUnresolved ||
     item.unreadCount > 0;
 
+  const prefetchDetail = useCallback(() => {
+    if (prefetchedRef.current) {
+      return;
+    }
+
+    prefetchedRef.current = true;
+    router.prefetch(href);
+  }, [href, router]);
+
   return (
     <li>
       <Link
-        href={`/inbox/${encodeURIComponent(item.contactId)}`}
+        href={href}
+        prefetch={false}
+        data-inbox-row="true"
+        data-contact-id={item.contactId}
+        data-active={isActive ? "true" : "false"}
         aria-current={isActive ? "page" : undefined}
+        aria-keyshortcuts="Enter"
+        onMouseEnter={prefetchDetail}
+        onFocus={prefetchDetail}
         className={`relative flex gap-3 border-b border-slate-100 ${SPACING.listItem} ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion} ${
           isActive
             ? "bg-sky-50/60 ring-1 ring-inset ring-sky-200"

--- a/apps/web/app/inbox/_components/inbox-shell.tsx
+++ b/apps/web/app/inbox/_components/inbox-shell.tsx
@@ -7,6 +7,7 @@ import type {
 import { InboxClientProvider } from "./inbox-client-provider";
 import { InboxFreshnessPoller } from "./inbox-freshness-poller";
 import { InboxIconRail } from "./inbox-icon-rail";
+import { InboxKeyboardProvider } from "./inbox-keyboard-provider";
 import { InboxList } from "./inbox-list";
 
 interface ShellProps {
@@ -30,8 +31,8 @@ export function InboxShell({
   children
 }: ShellProps) {
   return (
-    <div className="flex h-screen w-screen overflow-hidden bg-slate-100 text-slate-900 antialiased">
-      <InboxClientProvider>
+    <InboxClientProvider>
+      <InboxKeyboardProvider>
         <InboxFreshnessPoller listFreshness={initialList.freshness} />
         <InboxIconRail />
 
@@ -43,7 +44,7 @@ export function InboxShell({
         <main className="flex min-w-0 flex-1 flex-col overflow-hidden">
           {children}
         </main>
-      </InboxClientProvider>
-    </div>
+      </InboxKeyboardProvider>
+    </InboxClientProvider>
   );
 }

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -8,6 +8,7 @@ import type {
   TimelineItem,
 } from "@as-comms/contracts";
 
+import { recordSensitiveReadForCurrentUserDetached } from "@/src/server/security/audit";
 import { getStage1WebRuntime } from "../../../src/server/stage1-runtime";
 
 import { INBOX_FILTERS } from "./filters";
@@ -819,8 +820,8 @@ function campaignHeadlineAndBody(
       parsedPreview.subject !== null
         ? parsedPreview.body
         : parsedPreview.body.length > 0
-        ? parsedPreview.body
-        : (normalizeInlineText(item.summary) ?? "");
+          ? parsedPreview.body
+          : (normalizeInlineText(item.summary) ?? "");
     const split = splitHeadlineAndBody(cleaned);
     const headline =
       parsedPreview.subject ??
@@ -987,11 +988,7 @@ function inferPreviewDirection(
       ? null
       : normalizedContactEmail.toLowerCase();
 
-  if (
-    preview === null ||
-    !preview.structuredEmail ||
-    contactEmail === null
-  ) {
+  if (preview === null || !preview.structuredEmail || contactEmail === null) {
     return null;
   }
 
@@ -1216,8 +1213,7 @@ function buildTimelineEntry(input: {
       ? subject !== null || resolvedBody.trim().length > 0
       : true;
   const finalKind =
-    !hasRenderableEmailContent &&
-    input.item.family === "one_to_one_email"
+    !hasRenderableEmailContent && input.item.family === "one_to_one_email"
       ? "email-activity"
       : kind;
   const isUnread =
@@ -1449,7 +1445,9 @@ async function readInboxListCacheData(input: {
   const pageProjections = hasMore
     ? projectionPage.rows.slice(0, input.limit)
     : projectionPage.rows;
-  const candidateContactIds = pageProjections.map((projection) => projection.contactId);
+  const candidateContactIds = pageProjections.map(
+    (projection) => projection.contactId,
+  );
   const [contacts, memberships, latestMessagePreviewByCanonicalEventId] =
     await Promise.all([
       runtime.repositories.contacts.listByIds(candidateContactIds),
@@ -1844,6 +1842,15 @@ export async function getInboxDetail(
   if (cachedData === null) {
     return null;
   }
+
+  recordSensitiveReadForCurrentUserDetached({
+    action: "contact.timeline.read",
+    entityType: "contact",
+    entityId: contactId,
+    metadataJson: {
+      timelineCount: cachedData.timelinePage.total,
+    },
+  });
 
   const referenceNowIso = new Date().toISOString();
 

--- a/apps/web/app/inbox/actions.ts
+++ b/apps/web/app/inbox/actions.ts
@@ -1,5 +1,8 @@
 "use server";
 
+import { requireSession } from "@/src/server/auth/session";
+import { enforceRateLimit } from "@/src/server/security/rate-limit";
+
 import { setInboxNeedsFollowUp } from "../../src/server/inbox/follow-up";
 import { revalidateInboxContact } from "../../src/server/inbox/revalidate";
 import type { UiResult } from "../../src/server/ui-result";
@@ -12,6 +15,25 @@ export type FollowUpActionData = {
 
 export type FollowUpActionResult = UiResult<FollowUpActionData>;
 
+function unauthorizedError(requestId: string): FollowUpActionResult {
+  return {
+    ok: false,
+    code: "unauthorized",
+    message: "Your session has expired. Please sign in again.",
+    requestId,
+  };
+}
+
+function rateLimitError(requestId: string): FollowUpActionResult {
+  return {
+    ok: false,
+    code: "rate_limit_exceeded",
+    message: "Too many follow-up updates. Please wait a minute and try again.",
+    requestId,
+    retryable: true,
+  };
+}
+
 function readContactId(formData: FormData): string | null {
   const value = formData.get("contactId");
   return typeof value === "string" && value.trim().length > 0 ? value : null;
@@ -19,10 +41,20 @@ function readContactId(formData: FormData): string | null {
 
 async function updateNeedsFollowUp(
   formData: FormData,
-  needsFollowUp: boolean
+  needsFollowUp: boolean,
 ): Promise<FollowUpActionResult> {
   const requestId = crypto.randomUUID();
   const contactId = readContactId(formData);
+
+  let currentUser;
+  try {
+    currentUser = await requireSession();
+  } catch (error) {
+    if (error instanceof Error && error.message === "UNAUTHORIZED") {
+      return unauthorizedError(requestId);
+    }
+    throw error;
+  }
 
   if (contactId === null) {
     return {
@@ -30,13 +62,39 @@ async function updateNeedsFollowUp(
       code: "validation_error",
       message: "Missing contactId",
       requestId,
-      fieldErrors: { contactId: "required" }
+      fieldErrors: { contactId: "required" },
     };
+  }
+
+  const decision = await enforceRateLimit({
+    scope: "server-action:inbox-follow-up",
+    identifier: currentUser.id,
+    limit: 30,
+    audit: {
+      actorType: "user",
+      actorId: currentUser.id,
+      action: "inbox.follow_up.rate_limited",
+      entityType: "server_action",
+      entityId: "inbox.follow_up",
+      metadataJson: {
+        contactId,
+        needsFollowUp,
+      },
+    },
+  });
+
+  if (!decision.allowed) {
+    /**
+     * Server Actions do not expose per-request status/header controls the
+     * same way Route Handlers do, so we surface the denial via the standard
+     * FP-07 error envelope while still recording the audit event.
+     */
+    return rateLimitError(requestId);
   }
 
   const result = await setInboxNeedsFollowUp({
     contactId,
-    needsFollowUp
+    needsFollowUp,
   });
 
   if (!result.ok) {
@@ -45,7 +103,7 @@ async function updateNeedsFollowUp(
       code: "inbox_contact_not_found",
       message: "No inbox row for that contact",
       requestId,
-      retryable: false
+      retryable: false,
     };
   }
 
@@ -54,18 +112,18 @@ async function updateNeedsFollowUp(
   return {
     ok: true,
     data: { contactId, needsFollowUp },
-    requestId
+    requestId,
   };
 }
 
 export async function markInboxNeedsFollowUpAction(
-  formData: FormData
+  formData: FormData,
 ): Promise<FollowUpActionResult> {
   return updateNeedsFollowUp(formData, true);
 }
 
 export async function clearInboxNeedsFollowUpAction(
-  formData: FormData
+  formData: FormData,
 ): Promise<FollowUpActionResult> {
   return updateNeedsFollowUp(formData, false);
 }

--- a/apps/web/app/inbox/layout.tsx
+++ b/apps/web/app/inbox/layout.tsx
@@ -1,10 +1,13 @@
+import { redirect } from "next/navigation";
 import type { ReactNode } from "react";
+
+import { requireSession } from "@/src/server/auth/session";
 
 import { InboxShell } from "./_components/inbox-shell";
 import { getInboxList } from "./_lib/selectors";
 
 export const metadata = {
-  title: "Inbox"
+  title: "Inbox",
 };
 
 /**
@@ -28,17 +31,23 @@ export const dynamic = "force-dynamic";
  * canonical queue state remains server-owned.
  */
 export default async function InboxLayout({
-  children
+  children,
 }: {
   readonly children: ReactNode;
 }) {
+  try {
+    await requireSession();
+  } catch (error) {
+    if (error instanceof Error && error.message === "UNAUTHORIZED") {
+      redirect("/auth/sign-in");
+    }
+    throw error;
+  }
+
   const list = await getInboxList("all");
 
   return (
-    <InboxShell
-      initialList={list}
-      initialFilterId="all"
-    >
+    <InboxShell initialList={list} initialFilterId="all">
       {children}
     </InboxShell>
   );

--- a/apps/web/app/settings/users/page.tsx
+++ b/apps/web/app/settings/users/page.tsx
@@ -1,28 +1,27 @@
 import { redirect } from "next/navigation";
 
 import { requireAdmin } from "@/src/server/auth/session";
+import { recordSensitiveReadDetached } from "@/src/server/security/audit";
 import { getSettingsRepositories } from "@/src/server/stage1-runtime";
 
 import { UsersTable, type UserRowViewModel } from "./_components/users-table";
 
 export const dynamic = "force-dynamic";
 
-function toUserRowViewModel(
-  user: {
-    readonly id: string;
-    readonly email: string;
-    readonly name: string | null;
-    readonly role: "admin" | "operator";
-    readonly deactivatedAt: Date | null;
-  }
-): UserRowViewModel {
+function toUserRowViewModel(user: {
+  readonly id: string;
+  readonly email: string;
+  readonly name: string | null;
+  readonly role: "admin" | "operator";
+  readonly deactivatedAt: Date | null;
+}): UserRowViewModel {
   return {
     id: user.id,
     email: user.email,
     name: user.name,
     role: user.role,
     isDeactivated: user.deactivatedAt !== null,
-    deactivatedAt: user.deactivatedAt?.toISOString() ?? null
+    deactivatedAt: user.deactivatedAt?.toISOString() ?? null,
   };
 }
 
@@ -56,6 +55,15 @@ export default async function UsersPage() {
 
   const { users } = await getSettingsRepositories();
   const allUsers = await users.listAll();
+  recordSensitiveReadDetached({
+    actorId: currentUser.id,
+    action: "settings.users.read",
+    entityType: "settings_page",
+    entityId: "users",
+    metadataJson: {
+      visibleUserCount: allUsers.length,
+    },
+  });
 
   const rows: readonly UserRowViewModel[] = allUsers.map(toUserRowViewModel);
 

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -2,6 +2,53 @@ import { fileURLToPath } from "node:url";
 
 import type { NextConfig } from "next";
 
+const isDev = process.env.NODE_ENV !== "production";
+
+// TODO(canon): document D-035 — security hygiene minimums (headers, rate limits, read audit)
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  [
+    "script-src",
+    "'self'",
+    "'unsafe-inline'",
+    ...(isDev ? ["'unsafe-eval'"] : []),
+    "accounts.google.com",
+  ].join(" "),
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: https:",
+  ["connect-src", "'self'", ...(isDev ? ["ws:", "wss:"] : [])].join(" "),
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self' accounts.google.com",
+].join("; ");
+
+const securityHeaders = [
+  {
+    key: "Content-Security-Policy",
+    value: contentSecurityPolicy,
+  },
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=31536000; includeSubDomains; preload",
+  },
+  {
+    key: "X-Frame-Options",
+    value: "DENY",
+  },
+  {
+    key: "X-Content-Type-Options",
+    value: "nosniff",
+  },
+  {
+    key: "Referrer-Policy",
+    value: "strict-origin-when-cross-origin",
+  },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=()",
+  },
+] as const;
+
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   outputFileTracingRoot: fileURLToPath(new URL("../../", import.meta.url)),
@@ -9,8 +56,16 @@ const nextConfig: NextConfig = {
     "@as-comms/contracts",
     "@as-comms/db",
     "@as-comms/domain",
-    "@as-comms/ui"
-  ]
+    "@as-comms/ui",
+  ],
+  headers() {
+    return Promise.resolve([
+      {
+        source: "/:path*",
+        headers: [...securityHeaders],
+      },
+    ]);
+  },
 };
 
 export default nextConfig;

--- a/apps/web/src/server/auth/api.ts
+++ b/apps/web/src/server/auth/api.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+
+import type { UserRecord } from "@as-comms/domain";
+
+import { requireSession } from "./session";
+
+export async function requireApiSession(): Promise<
+  | {
+      readonly ok: true;
+      readonly user: UserRecord;
+    }
+  | {
+      readonly ok: false;
+      readonly response: NextResponse;
+    }
+> {
+  try {
+    return {
+      ok: true,
+      user: await requireSession(),
+    };
+  } catch (error) {
+    if (error instanceof Error && error.message === "UNAUTHORIZED") {
+      return {
+        ok: false,
+        response: NextResponse.json(
+          {
+            ok: false,
+            code: "unauthorized",
+          },
+          {
+            status: 401,
+          },
+        ),
+      };
+    }
+
+    throw error;
+  }
+}

--- a/apps/web/src/server/security/audit.ts
+++ b/apps/web/src/server/security/audit.ts
@@ -1,0 +1,157 @@
+import { getStage1WebRuntime } from "../stage1-runtime";
+
+type AuditActorType = "system" | "user" | "worker" | "provider";
+type AuditResult = "allowed" | "denied" | "recorded";
+
+interface SecurityAuditInput {
+  readonly actorType: AuditActorType;
+  readonly actorId: string;
+  readonly action: string;
+  readonly entityType: string;
+  readonly entityId: string;
+  readonly result: AuditResult;
+  readonly policyCode: string;
+  readonly metadataJson: Readonly<Record<string, unknown>>;
+  readonly occurredAt?: Date;
+}
+
+interface SensitiveReadAuditInput {
+  readonly action: string;
+  readonly entityType: string;
+  readonly entityId: string;
+  readonly metadataJson?: Readonly<Record<string, unknown>>;
+  readonly policyCode?: string;
+}
+
+const DEFAULT_READ_AUDIT_POLICY = "security.read_audit";
+const pendingAuditTasks = new Set<Promise<void>>();
+
+function buildAuditId(input: SecurityAuditInput, occurredAt: Date): string {
+  return [
+    "audit",
+    input.entityType,
+    input.entityId,
+    input.action,
+    String(occurredAt.getTime()),
+    crypto.randomUUID(),
+  ].join(":");
+}
+
+function trackDetachedAudit(task: () => Promise<void>): void {
+  const tracked = (async () => {
+    try {
+      await task();
+    } catch (error) {
+      console.error("Failed to append detached security audit.", error);
+    }
+  })();
+
+  pendingAuditTasks.add(tracked);
+  void tracked.finally(() => {
+    pendingAuditTasks.delete(tracked);
+  });
+}
+
+export async function appendSecurityAudit(
+  input: SecurityAuditInput,
+): Promise<void> {
+  const runtime = await getStage1WebRuntime();
+  const occurredAt = input.occurredAt ?? new Date();
+
+  await runtime.repositories.auditEvidence.append({
+    id: buildAuditId(input, occurredAt),
+    actorType: input.actorType,
+    actorId: input.actorId,
+    action: input.action,
+    entityType: input.entityType,
+    entityId: input.entityId,
+    occurredAt: occurredAt.toISOString(),
+    result: input.result,
+    policyCode: input.policyCode,
+    metadataJson: input.metadataJson,
+  });
+}
+
+export function recordSensitiveReadDetached(
+  input: SensitiveReadAuditInput & {
+    readonly actorId: string;
+  },
+): void {
+  trackDetachedAudit(async () => {
+    await appendSecurityAudit({
+      actorType: "user",
+      actorId: input.actorId,
+      action: input.action,
+      entityType: input.entityType,
+      entityId: input.entityId,
+      result: "recorded",
+      policyCode: input.policyCode ?? DEFAULT_READ_AUDIT_POLICY,
+      metadataJson: input.metadataJson ?? {},
+    });
+  });
+}
+
+export function recordSensitiveReadFromUserPromiseDetached(
+  userPromise: Promise<{ readonly id: string } | null>,
+  input: SensitiveReadAuditInput,
+): void {
+  trackDetachedAudit(async () => {
+    const user = await userPromise;
+    if (user === null) {
+      return;
+    }
+
+    await appendSecurityAudit({
+      actorType: "user",
+      actorId: user.id,
+      action: input.action,
+      entityType: input.entityType,
+      entityId: input.entityId,
+      result: "recorded",
+      policyCode: input.policyCode ?? DEFAULT_READ_AUDIT_POLICY,
+      metadataJson: input.metadataJson ?? {},
+    });
+  });
+}
+
+export function recordSensitiveReadForCurrentUserDetached(
+  input: SensitiveReadAuditInput,
+): void {
+  trackDetachedAudit(async () => {
+    let getCurrentUser:
+      | (() => Promise<{ readonly id: string } | null>)
+      | undefined;
+
+    try {
+      ({ getCurrentUser } = await import("../auth/session"));
+    } catch {
+      return;
+    }
+
+    let user: { readonly id: string } | null;
+    try {
+      user = await getCurrentUser();
+    } catch {
+      return;
+    }
+
+    if (user === null) {
+      return;
+    }
+
+    await appendSecurityAudit({
+      actorType: "user",
+      actorId: user.id,
+      action: input.action,
+      entityType: input.entityType,
+      entityId: input.entityId,
+      result: "recorded",
+      policyCode: input.policyCode ?? DEFAULT_READ_AUDIT_POLICY,
+      metadataJson: input.metadataJson ?? {},
+    });
+  });
+}
+
+export async function waitForPendingSecurityAuditTasksForTests(): Promise<void> {
+  await Promise.allSettled([...pendingAuditTasks]);
+}

--- a/apps/web/src/server/security/rate-limit.ts
+++ b/apps/web/src/server/security/rate-limit.ts
@@ -1,0 +1,196 @@
+import { appendSecurityAudit } from "./audit";
+
+type AuditActorType = "system" | "user" | "worker" | "provider";
+
+interface RateLimitBucket {
+  count: number;
+  resetAtMs: number;
+}
+
+interface GlobalRateLimitState {
+  buckets: Map<string, RateLimitBucket>;
+  sweepCount: number;
+}
+
+export interface RateLimitDecision {
+  readonly allowed: boolean;
+  readonly limit: number;
+  readonly remaining: number;
+  readonly resetAtMs: number;
+  readonly retryAfterSeconds: number;
+}
+
+export interface IRateLimiter {
+  consume(input: {
+    readonly scope: string;
+    readonly identifier: string;
+    readonly limit: number;
+    readonly windowMs: number;
+    readonly nowMs?: number;
+  }): Promise<RateLimitDecision>;
+}
+
+declare global {
+  var __AS_COMMS_RATE_LIMIT_STATE__: GlobalRateLimitState | undefined;
+}
+
+const ONE_MINUTE_MS = 60_000;
+const SWEEP_INTERVAL = 128;
+
+function getGlobalRateLimitState(): GlobalRateLimitState {
+  globalThis.__AS_COMMS_RATE_LIMIT_STATE__ ??= {
+    buckets: new Map<string, RateLimitBucket>(),
+    sweepCount: 0,
+  };
+
+  return globalThis.__AS_COMMS_RATE_LIMIT_STATE__;
+}
+
+function buildBucketKey(scope: string, identifier: string): string {
+  return `${scope}:${identifier}`;
+}
+
+function toRetryAfterSeconds(resetAtMs: number, nowMs: number): number {
+  return Math.max(1, Math.ceil((resetAtMs - nowMs) / 1000));
+}
+
+export class InMemoryRateLimiter implements IRateLimiter {
+  consume(input: {
+    readonly scope: string;
+    readonly identifier: string;
+    readonly limit: number;
+    readonly windowMs: number;
+    readonly nowMs?: number;
+  }): Promise<RateLimitDecision> {
+    const state = getGlobalRateLimitState();
+    const nowMs = input.nowMs ?? Date.now();
+    const key = buildBucketKey(input.scope, input.identifier);
+    const existingBucket = state.buckets.get(key);
+    const bucket =
+      existingBucket === undefined || existingBucket.resetAtMs <= nowMs
+        ? {
+            count: 0,
+            resetAtMs: nowMs + input.windowMs,
+          }
+        : existingBucket;
+
+    state.sweepCount += 1;
+    if (state.sweepCount % SWEEP_INTERVAL === 0) {
+      for (const [bucketKey, currentBucket] of state.buckets.entries()) {
+        if (currentBucket.resetAtMs <= nowMs) {
+          state.buckets.delete(bucketKey);
+        }
+      }
+    }
+
+    if (bucket.count >= input.limit) {
+      state.buckets.set(key, bucket);
+
+      return Promise.resolve({
+        allowed: false,
+        limit: input.limit,
+        remaining: 0,
+        resetAtMs: bucket.resetAtMs,
+        retryAfterSeconds: toRetryAfterSeconds(bucket.resetAtMs, nowMs),
+      });
+    }
+
+    bucket.count += 1;
+    state.buckets.set(key, bucket);
+
+    return Promise.resolve({
+      allowed: true,
+      limit: input.limit,
+      remaining: Math.max(0, input.limit - bucket.count),
+      resetAtMs: bucket.resetAtMs,
+      retryAfterSeconds: 0,
+    });
+  }
+}
+
+let rateLimiterOverride: IRateLimiter | null = null;
+
+export function getSecurityRateLimiter(): IRateLimiter {
+  return rateLimiterOverride ?? new InMemoryRateLimiter();
+}
+
+export function setSecurityRateLimiterForTests(
+  rateLimiter: IRateLimiter | null,
+): void {
+  rateLimiterOverride = rateLimiter;
+}
+
+export function resetSecurityRateLimiterForTests(): void {
+  const state = getGlobalRateLimitState();
+  state.buckets.clear();
+  state.sweepCount = 0;
+  rateLimiterOverride = null;
+}
+
+export function getClientIp(request: Request): string {
+  const forwardedFor = request.headers.get("x-forwarded-for");
+  if (forwardedFor) {
+    const firstForwardedIp = forwardedFor
+      .split(",")
+      .map((value) => value.trim())
+      .find((value) => value.length > 0);
+
+    if (firstForwardedIp) {
+      return firstForwardedIp;
+    }
+  }
+
+  return (
+    request.headers.get("cf-connecting-ip") ??
+    request.headers.get("x-real-ip") ??
+    "127.0.0.1"
+  );
+}
+
+export async function enforceRateLimit(input: {
+  readonly scope: string;
+  readonly identifier: string;
+  readonly limit: number;
+  readonly windowMs?: number;
+  readonly audit: {
+    readonly actorType: AuditActorType;
+    readonly actorId: string;
+    readonly action: string;
+    readonly entityType: string;
+    readonly entityId: string;
+    readonly metadataJson?: Readonly<Record<string, unknown>>;
+    readonly policyCode?: string;
+  };
+}): Promise<RateLimitDecision> {
+  const windowMs = input.windowMs ?? ONE_MINUTE_MS;
+  const decision = await getSecurityRateLimiter().consume({
+    scope: input.scope,
+    identifier: input.identifier,
+    limit: input.limit,
+    windowMs,
+  });
+
+  if (!decision.allowed) {
+    await appendSecurityAudit({
+      actorType: input.audit.actorType,
+      actorId: input.audit.actorId,
+      action: input.audit.action,
+      entityType: input.audit.entityType,
+      entityId: input.audit.entityId,
+      result: "denied",
+      policyCode: input.audit.policyCode ?? "security.rate_limit",
+      metadataJson: {
+        reason: "rate_limit_exceeded",
+        identifier: input.identifier,
+        limit: input.limit,
+        windowSeconds: Math.ceil(windowMs / 1000),
+        retryAfterSeconds: decision.retryAfterSeconds,
+        ...(input.audit.metadataJson ?? {}),
+      },
+    }).catch((error: unknown) => {
+      console.error("Failed to append rate-limit audit.", error);
+    });
+  }
+
+  return decision;
+}

--- a/apps/web/tests/unit/dev-auth-route.test.ts
+++ b/apps/web/tests/unit/dev-auth-route.test.ts
@@ -1,0 +1,101 @@
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { GET } from "../../app/api/dev-auth/route";
+import { waitForPendingSecurityAuditTasksForTests } from "../../src/server/security/audit";
+import { resetSecurityRateLimiterForTests } from "../../src/server/security/rate-limit";
+import {
+  createStage1WebTestRuntime,
+  type Stage1WebTestRuntime,
+} from "../../src/server/stage1-runtime.test-support";
+
+function buildUser() {
+  const now = new Date("2026-04-14T10:00:00.000Z");
+  return {
+    id: "user:nico",
+    name: "Nico",
+    email: "nico@adventurescientists.org",
+    emailVerified: now,
+    image: null,
+    role: "operator" as const,
+    deactivatedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+describe("dev-auth route rate limiting", () => {
+  let runtime: Stage1WebTestRuntime | null = null;
+
+  beforeEach(async () => {
+    resetSecurityRateLimiterForTests();
+    runtime = await createStage1WebTestRuntime();
+    await runtime.context.settings.users.upsert(buildUser());
+  });
+
+  afterEach(async () => {
+    await waitForPendingSecurityAuditTasksForTests();
+    resetSecurityRateLimiterForTests();
+    await runtime?.dispose();
+    runtime = null;
+  });
+
+  it("returns 429 with Retry-After and audits repeated requests from the same IP", async () => {
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const response = await GET(
+        new NextRequest(
+          "http://localhost/api/dev-auth?email=nico@adventurescientists.org",
+          {
+            headers: {
+              "x-forwarded-for": "203.0.113.5",
+            },
+          },
+        ),
+      );
+
+      expect(response.status).toBe(200);
+    }
+
+    const response = await GET(
+      new NextRequest(
+        "http://localhost/api/dev-auth?email=nico@adventurescientists.org",
+        {
+          headers: {
+            "x-forwarded-for": "203.0.113.5",
+          },
+        },
+      ),
+    );
+    if (!runtime) {
+      throw new Error("runtime not initialized");
+    }
+
+    await waitForPendingSecurityAuditTasksForTests();
+
+    const audits =
+      await runtime.context.repositories.auditEvidence.listByEntity({
+        entityType: "route",
+        entityId: "/api/dev-auth",
+      });
+    const latestAudit = audits.at(-1);
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).not.toBeNull();
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      code: "rate_limit_exceeded",
+    });
+    expect(latestAudit).toMatchObject({
+      actorType: "system",
+      actorId: "203.0.113.5",
+      action: "dev_auth.request.rate_limited",
+      result: "denied",
+      policyCode: "security.rate_limit",
+    });
+    expect(latestAudit?.metadataJson).toMatchObject({
+      reason: "rate_limit_exceeded",
+      identifier: "203.0.113.5",
+      limit: 5,
+    });
+  });
+});

--- a/apps/web/tests/unit/inbox-actions.test.ts
+++ b/apps/web/tests/unit/inbox-actions.test.ts
@@ -2,25 +2,46 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const revalidateTag = vi.hoisted(() => vi.fn());
 const revalidatePath = vi.hoisted(() => vi.fn());
+const requireSession = vi.hoisted(() => vi.fn());
 
 vi.mock("next/cache", () => ({
   unstable_cache: (loader: () => unknown) => loader,
   revalidateTag,
-  revalidatePath
+  revalidatePath,
+}));
+
+vi.mock("@/src/server/auth/session", () => ({
+  requireSession,
 }));
 
 import {
   clearInboxNeedsFollowUpAction,
-  markInboxNeedsFollowUpAction
+  markInboxNeedsFollowUpAction,
 } from "../../app/inbox/actions";
+import { resetSecurityRateLimiterForTests } from "../../src/server/security/rate-limit";
 import { getInboxDetail, getInboxList } from "../../app/inbox/_lib/selectors";
 import {
   createInboxTestRuntime,
   seedInboxContact,
   seedInboxEmailEvent,
   seedInboxProjection,
-  type InboxTestRuntime
+  type InboxTestRuntime,
 } from "./inbox-stage1-helpers";
+
+function buildCurrentUser() {
+  const now = new Date("2026-04-14T10:00:00.000Z");
+  return {
+    id: "user:nico",
+    name: "Nico",
+    email: "nico@adventurescientists.org",
+    emailVerified: now,
+    image: null,
+    role: "operator" as const,
+    deactivatedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
 
 async function seedActionFixture(runtime: InboxTestRuntime): Promise<void> {
   await seedInboxContact(runtime.context, {
@@ -32,7 +53,7 @@ async function seedActionFixture(runtime: InboxTestRuntime): Promise<void> {
     projectId: "project:amazon-basin",
     projectName: "Amazon Basin Research",
     membershipId: "membership:sarah",
-    membershipStatus: "in_training"
+    membershipStatus: "in_training",
   });
   const sarahLatest = await seedInboxEmailEvent(runtime.context, {
     id: "sarah-inbound-1",
@@ -40,7 +61,8 @@ async function seedActionFixture(runtime: InboxTestRuntime): Promise<void> {
     occurredAt: "2026-04-14T13:00:00.000Z",
     direction: "inbound",
     subject: "Re: Amazon Basin equipment list",
-    snippet: "Following up on the field study logistics for the Amazon basin project."
+    snippet:
+      "Following up on the field study logistics for the Amazon basin project.",
   });
   await seedInboxProjection(runtime.context, {
     contactId: "contact:sarah-martinez",
@@ -53,7 +75,7 @@ async function seedActionFixture(runtime: InboxTestRuntime): Promise<void> {
     snippet:
       "Following up on the field study logistics for the Amazon basin project.",
     lastCanonicalEventId: sarahLatest.canonicalEventId,
-    lastEventType: "communication.email.inbound"
+    lastEventType: "communication.email.inbound",
   });
 
   await seedInboxContact(runtime.context, {
@@ -65,7 +87,7 @@ async function seedActionFixture(runtime: InboxTestRuntime): Promise<void> {
     projectId: "project:coral-reefs",
     projectName: "Monitoring Coral Reefs",
     membershipId: "membership:michael",
-    membershipStatus: "in_training"
+    membershipStatus: "in_training",
   });
   const michaelLatest = await seedInboxEmailEvent(runtime.context, {
     id: "michael-inbound-1",
@@ -74,7 +96,7 @@ async function seedActionFixture(runtime: InboxTestRuntime): Promise<void> {
     direction: "inbound",
     subject: "Questions about data collection protocols",
     snippet:
-      "Thanks for the training materials. I have a few questions about the data collection protocols."
+      "Thanks for the training materials. I have a few questions about the data collection protocols.",
   });
   await seedInboxProjection(runtime.context, {
     contactId: "contact:michael-chen",
@@ -87,7 +109,7 @@ async function seedActionFixture(runtime: InboxTestRuntime): Promise<void> {
     snippet:
       "Thanks for the training materials. I have a few questions about the data collection protocols.",
     lastCanonicalEventId: michaelLatest.canonicalEventId,
-    lastEventType: "communication.email.inbound"
+    lastEventType: "communication.email.inbound",
   });
 }
 
@@ -96,11 +118,16 @@ describe("server-backed follow-up actions", () => {
 
   beforeEach(async () => {
     revalidateTag.mockReset();
+    revalidatePath.mockReset();
+    resetSecurityRateLimiterForTests();
+    requireSession.mockReset();
+    requireSession.mockResolvedValue(buildCurrentUser());
     runtime = await createInboxTestRuntime();
     await seedActionFixture(runtime);
   });
 
   afterEach(async () => {
+    resetSecurityRateLimiterForTests();
     await runtime?.dispose();
     runtime = null;
   });
@@ -112,9 +139,10 @@ describe("server-backed follow-up actions", () => {
 
     const result = await markInboxNeedsFollowUpAction(formData);
     if (!runtime) throw new Error("runtime not initialized");
-    const projection = await runtime.context.repositories.inboxProjection.findByContactId(
-      "contact:michael-chen"
-    );
+    const projection =
+      await runtime.context.repositories.inboxProjection.findByContactId(
+        "contact:michael-chen",
+      );
     const after = await getInboxList();
     const detail = await getInboxDetail("contact:michael-chen");
 
@@ -122,39 +150,41 @@ describe("server-backed follow-up actions", () => {
       ok: true,
       data: {
         contactId: "contact:michael-chen",
-        needsFollowUp: true
-      }
+        needsFollowUp: true,
+      },
     });
     expect(before.items.map((item) => item.contactId)).toEqual([
       "contact:sarah-martinez",
-      "contact:michael-chen"
+      "contact:michael-chen",
     ]);
     expect(after.items.map((item) => item.contactId)).toEqual([
       "contact:sarah-martinez",
-      "contact:michael-chen"
+      "contact:michael-chen",
     ]);
     expect(projection).toMatchObject({
       contactId: "contact:michael-chen",
       needsFollowUp: true,
-      bucket: "New"
+      bucket: "New",
     });
-    expect(after.items.find((item) => item.contactId === "contact:michael-chen")).toMatchObject({
+    expect(
+      after.items.find((item) => item.contactId === "contact:michael-chen"),
+    ).toMatchObject({
       needsFollowUp: true,
-      bucket: "new"
+      bucket: "new",
     });
     expect(detail).toMatchObject({
       needsFollowUp: true,
-      bucket: "new"
+      bucket: "new",
     });
     expect(revalidateTag).toHaveBeenCalledTimes(3);
     expect(revalidateTag).toHaveBeenNthCalledWith(1, "inbox");
     expect(revalidateTag).toHaveBeenNthCalledWith(
       2,
-      "inbox:contact:contact:michael-chen"
+      "inbox:contact:contact:michael-chen",
     );
     expect(revalidateTag).toHaveBeenNthCalledWith(
       3,
-      "timeline:contact:contact:michael-chen"
+      "timeline:contact:contact:michael-chen",
     );
   });
 
@@ -166,22 +196,23 @@ describe("server-backed follow-up actions", () => {
 
     const result = await clearInboxNeedsFollowUpAction(formData);
     if (!runtime) throw new Error("runtime not initialized");
-    const projection = await runtime.context.repositories.inboxProjection.findByContactId(
-      "contact:michael-chen"
-    );
+    const projection =
+      await runtime.context.repositories.inboxProjection.findByContactId(
+        "contact:michael-chen",
+      );
     const followUpList = await getInboxList("follow-up");
 
     expect(result).toMatchObject({
       ok: true,
       data: {
         contactId: "contact:michael-chen",
-        needsFollowUp: false
-      }
+        needsFollowUp: false,
+      },
     });
     expect(projection).toMatchObject({
       contactId: "contact:michael-chen",
       needsFollowUp: false,
-      bucket: "New"
+      bucket: "New",
     });
     expect(followUpList.items).toHaveLength(0);
     expect(revalidateTag).toHaveBeenCalledTimes(3);
@@ -194,7 +225,7 @@ describe("server-backed follow-up actions", () => {
 
     const staleProjection =
       await runtime.context.repositories.inboxProjection.findByContactId(
-        "contact:michael-chen"
+        "contact:michael-chen",
       );
     const fresherEvent = await seedInboxEmailEvent(runtime.context, {
       id: "michael-inbound-2",
@@ -202,7 +233,7 @@ describe("server-backed follow-up actions", () => {
       occurredAt: "2026-04-14T14:30:00.000Z",
       direction: "inbound",
       subject: "Latest logistics update",
-      snippet: "Fresh inbound message that arrived after the stale snapshot."
+      snippet: "Fresh inbound message that arrived after the stale snapshot.",
     });
 
     await runtime.context.repositories.inboxProjection.upsert({
@@ -215,7 +246,7 @@ describe("server-backed follow-up actions", () => {
       lastActivityAt: "2026-04-14T14:30:00.000Z",
       snippet: "Fresh inbound message that arrived after the stale snapshot.",
       lastCanonicalEventId: fresherEvent.canonicalEventId,
-      lastEventType: "communication.email.inbound"
+      lastEventType: "communication.email.inbound",
     });
 
     const findByContactIdSpy = vi
@@ -223,7 +254,7 @@ describe("server-backed follow-up actions", () => {
       .mockResolvedValue(staleProjection ?? null);
     const upsertSpy = vi.spyOn(
       runtime.context.repositories.inboxProjection,
-      "upsert"
+      "upsert",
     );
     const formData = new FormData();
     formData.set("contactId", "contact:michael-chen");
@@ -233,16 +264,17 @@ describe("server-backed follow-up actions", () => {
     expect(upsertSpy).not.toHaveBeenCalled();
     findByContactIdSpy.mockRestore();
     upsertSpy.mockRestore();
-    const projection = await runtime.context.repositories.inboxProjection.findByContactId(
-      "contact:michael-chen"
-    );
+    const projection =
+      await runtime.context.repositories.inboxProjection.findByContactId(
+        "contact:michael-chen",
+      );
 
     expect(result).toMatchObject({
       ok: true,
       data: {
         contactId: "contact:michael-chen",
-        needsFollowUp: true
-      }
+        needsFollowUp: true,
+      },
     });
     expect(projection).toMatchObject({
       contactId: "contact:michael-chen",
@@ -253,7 +285,65 @@ describe("server-backed follow-up actions", () => {
       lastActivityAt: "2026-04-14T14:30:00.000Z",
       snippet: "Fresh inbound message that arrived after the stale snapshot.",
       lastCanonicalEventId: fresherEvent.canonicalEventId,
-      lastEventType: "communication.email.inbound"
+      lastEventType: "communication.email.inbound",
+    });
+  });
+
+  it("rejects follow-up mutations when the operator session is missing", async () => {
+    requireSession.mockRejectedValueOnce(new Error("UNAUTHORIZED"));
+    const formData = new FormData();
+    formData.set("contactId", "contact:michael-chen");
+
+    const result = await markInboxNeedsFollowUpAction(formData);
+    if (!runtime) throw new Error("runtime not initialized");
+    const projection =
+      await runtime.context.repositories.inboxProjection.findByContactId(
+        "contact:michael-chen",
+      );
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "unauthorized",
+    });
+    expect(projection).toMatchObject({
+      contactId: "contact:michael-chen",
+      needsFollowUp: false,
+    });
+  });
+
+  it("rate limits repeated follow-up toggles per authenticated user and audits the denial", async () => {
+    const formData = new FormData();
+    formData.set("contactId", "contact:michael-chen");
+
+    for (let attempt = 0; attempt < 30; attempt += 1) {
+      const result = await markInboxNeedsFollowUpAction(formData);
+      expect(result.ok).toBe(true);
+    }
+
+    const limitedResult = await markInboxNeedsFollowUpAction(formData);
+    if (!runtime) throw new Error("runtime not initialized");
+    const audits =
+      await runtime.context.repositories.auditEvidence.listByEntity({
+        entityType: "server_action",
+        entityId: "inbox.follow_up",
+      });
+    const latestAudit = audits.at(-1);
+
+    expect(limitedResult).toMatchObject({
+      ok: false,
+      code: "rate_limit_exceeded",
+    });
+    expect(latestAudit).toMatchObject({
+      actorType: "user",
+      actorId: "user:nico",
+      action: "inbox.follow_up.rate_limited",
+      result: "denied",
+      policyCode: "security.rate_limit",
+    });
+    expect(latestAudit?.metadataJson).toMatchObject({
+      reason: "rate_limit_exceeded",
+      contactId: "contact:michael-chen",
+      limit: 30,
     });
   });
 });

--- a/apps/web/tests/unit/inbox-follow-up-state.test.ts
+++ b/apps/web/tests/unit/inbox-follow-up-state.test.ts
@@ -1,21 +1,39 @@
 import { describe, expect, it, vi } from "vitest";
 
+const requireSession = vi.hoisted(() => vi.fn());
+
 vi.mock("next/cache", () => ({
   unstable_cache: (loader: () => unknown) => loader,
-  revalidateTag: vi.fn()
+  revalidateTag: vi.fn(),
+}));
+
+vi.mock("@/src/server/auth/session", () => ({
+  requireSession,
 }));
 
 import { markInboxNeedsFollowUpAction } from "../../app/inbox/actions";
 
 describe("follow-up action validation", () => {
   it("returns a validation error when contactId is missing", async () => {
+    requireSession.mockResolvedValueOnce({
+      id: "user:nico",
+      name: "Nico",
+      email: "nico@adventurescientists.org",
+      emailVerified: new Date("2026-04-14T10:00:00.000Z"),
+      image: null,
+      role: "operator",
+      deactivatedAt: null,
+      createdAt: new Date("2026-04-14T10:00:00.000Z"),
+      updatedAt: new Date("2026-04-14T10:00:00.000Z"),
+    });
+
     const formData = new FormData();
 
-    await expect(
-      markInboxNeedsFollowUpAction(formData)
-    ).resolves.toMatchObject({
-      ok: false,
-      code: "validation_error"
-    });
+    await expect(markInboxNeedsFollowUpAction(formData)).resolves.toMatchObject(
+      {
+        ok: false,
+        code: "validation_error",
+      },
+    );
   });
 });

--- a/apps/web/tests/unit/inbox-keyboard-helpers.test.ts
+++ b/apps/web/tests/unit/inbox-keyboard-helpers.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  extractInboxContactId,
+  getAdjacentFocusedRowContactId,
+  getPreferredFocusedRowContactId,
+  isEditableShortcutTarget,
+  isInboxKeyboardPath
+} from "../../app/inbox/_components/inbox-keyboard-helpers";
+
+describe("inbox keyboard helpers", () => {
+  it("matches only inbox paths for shortcut handling", () => {
+    expect(isInboxKeyboardPath("/inbox")).toBe(true);
+    expect(isInboxKeyboardPath("/inbox/contact%3Aone")).toBe(true);
+    expect(isInboxKeyboardPath("/settings")).toBe(false);
+    expect(isInboxKeyboardPath(null)).toBe(false);
+  });
+
+  it("extracts decoded contact ids from inbox detail paths", () => {
+    expect(extractInboxContactId("/inbox/contact%3Aone")).toBe(
+      "contact:one"
+    );
+    expect(extractInboxContactId("/inbox")).toBeNull();
+    expect(extractInboxContactId("/settings/users")).toBeNull();
+  });
+
+  it("treats form fields and contenteditable targets as editable", () => {
+    expect(
+      isEditableShortcutTarget({
+        tagName: "INPUT",
+        isContentEditable: false
+      })
+    ).toBe(true);
+    expect(
+      isEditableShortcutTarget({
+        tagName: "TEXTAREA",
+        isContentEditable: false
+      })
+    ).toBe(true);
+    expect(
+      isEditableShortcutTarget({
+        tagName: "DIV",
+        isContentEditable: true
+      })
+    ).toBe(true);
+    expect(
+      isEditableShortcutTarget({
+        tagName: "BUTTON",
+        isContentEditable: false
+      })
+    ).toBe(false);
+  });
+
+  it("prefers the currently focused row, then the active route row", () => {
+    expect(
+      getPreferredFocusedRowContactId({
+        rowContactIds: ["a", "b", "c"],
+        currentFocusedContactId: "b",
+        activeContactId: "c"
+      })
+    ).toBe("b");
+    expect(
+      getPreferredFocusedRowContactId({
+        rowContactIds: ["a", "b", "c"],
+        currentFocusedContactId: null,
+        activeContactId: "c"
+      })
+    ).toBe("c");
+    expect(
+      getPreferredFocusedRowContactId({
+        rowContactIds: ["a", "b", "c"],
+        currentFocusedContactId: "missing",
+        activeContactId: "missing"
+      })
+    ).toBeNull();
+  });
+
+  it("moves row focus forward and backward with clamped edges", () => {
+    const rowContactIds = ["a", "b", "c"] as const;
+
+    expect(
+      getAdjacentFocusedRowContactId({
+        rowContactIds,
+        currentFocusedContactId: "b",
+        activeContactId: null,
+        direction: 1
+      })
+    ).toBe("c");
+    expect(
+      getAdjacentFocusedRowContactId({
+        rowContactIds,
+        currentFocusedContactId: "b",
+        activeContactId: null,
+        direction: -1
+      })
+    ).toBe("a");
+    expect(
+      getAdjacentFocusedRowContactId({
+        rowContactIds,
+        currentFocusedContactId: "c",
+        activeContactId: null,
+        direction: 1
+      })
+    ).toBe("c");
+    expect(
+      getAdjacentFocusedRowContactId({
+        rowContactIds,
+        currentFocusedContactId: null,
+        activeContactId: "b",
+        direction: -1
+      })
+    ).toBe("a");
+  });
+
+  it("falls back to the first or last row when nothing is focused yet", () => {
+    const rowContactIds = ["a", "b", "c"] as const;
+
+    expect(
+      getAdjacentFocusedRowContactId({
+        rowContactIds,
+        currentFocusedContactId: null,
+        activeContactId: null,
+        direction: 1
+      })
+    ).toBe("a");
+    expect(
+      getAdjacentFocusedRowContactId({
+        rowContactIds,
+        currentFocusedContactId: null,
+        activeContactId: null,
+        direction: -1
+      })
+    ).toBe("c");
+  });
+});

--- a/apps/web/tests/unit/inbox-read-audit.test.ts
+++ b/apps/web/tests/unit/inbox-read-audit.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getCurrentUser = vi.hoisted(() => vi.fn());
+
+vi.mock("next/cache", () => ({
+  unstable_cache: (loader: () => unknown) => loader,
+}));
+
+vi.mock("@/src/server/auth/session", () => ({
+  getCurrentUser,
+}));
+
+import { getInboxDetail } from "../../app/inbox/_lib/selectors";
+import { waitForPendingSecurityAuditTasksForTests } from "../../src/server/security/audit";
+import {
+  createInboxTestRuntime,
+  seedInboxContact,
+  seedInboxEmailEvent,
+  seedInboxProjection,
+  type InboxTestRuntime,
+} from "./inbox-stage1-helpers";
+
+function buildCurrentUser() {
+  const now = new Date("2026-04-14T10:00:00.000Z");
+  return {
+    id: "user:nico",
+    name: "Nico",
+    email: "nico@adventurescientists.org",
+    emailVerified: now,
+    image: null,
+    role: "operator" as const,
+    deactivatedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+describe("inbox detail read audit", () => {
+  let runtime: InboxTestRuntime | null = null;
+
+  beforeEach(async () => {
+    getCurrentUser.mockReset();
+    getCurrentUser.mockResolvedValue(buildCurrentUser());
+    runtime = await createInboxTestRuntime();
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:sarah-martinez",
+      salesforceContactId: "003-sarah",
+      displayName: "Sarah Martinez",
+      primaryEmail: "sarah@example.org",
+      primaryPhone: "+15550000001",
+      projectId: "project:amazon-basin",
+      projectName: "Amazon Basin Research",
+      membershipId: "membership:sarah",
+      membershipStatus: "in_training",
+    });
+    const latest = await seedInboxEmailEvent(runtime.context, {
+      id: "sarah-inbound-1",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-14T13:00:00.000Z",
+      direction: "inbound",
+      subject: "Re: Amazon Basin equipment list",
+      snippet:
+        "Following up on the field study logistics for the Amazon basin project.",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:sarah-martinez",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-14T13:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-04-14T13:00:00.000Z",
+      snippet:
+        "Following up on the field study logistics for the Amazon basin project.",
+      lastCanonicalEventId: latest.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+  });
+
+  afterEach(async () => {
+    await waitForPendingSecurityAuditTasksForTests();
+    await runtime?.dispose();
+    runtime = null;
+  });
+
+  it("records who opened a contact timeline without blocking the read", async () => {
+    const detail = await getInboxDetail("contact:sarah-martinez");
+    if (!runtime) {
+      throw new Error("runtime not initialized");
+    }
+
+    await waitForPendingSecurityAuditTasksForTests();
+
+    const audits =
+      await runtime.context.repositories.auditEvidence.listByEntity({
+        entityType: "contact",
+        entityId: "contact:sarah-martinez",
+      });
+    const latestAudit = audits.at(-1);
+
+    expect(detail).not.toBeNull();
+    expect(latestAudit).toMatchObject({
+      actorType: "user",
+      actorId: "user:nico",
+      action: "contact.timeline.read",
+      result: "recorded",
+      policyCode: "security.read_audit",
+    });
+    expect(latestAudit?.metadataJson).toMatchObject({
+      timelineCount: 1,
+    });
+  });
+});

--- a/apps/web/tests/unit/settings-users-read-audit.test.ts
+++ b/apps/web/tests/unit/settings-users-read-audit.test.ts
@@ -1,0 +1,111 @@
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireAdmin = vi.hoisted(() => vi.fn());
+const redirect = vi.hoisted(() => vi.fn());
+
+Object.assign(globalThis, { React });
+
+vi.mock("next/navigation", () => ({
+  redirect,
+}));
+
+vi.mock("@/src/server/auth/session", () => ({
+  requireAdmin,
+}));
+
+import UsersPage from "../../app/settings/users/page";
+import { waitForPendingSecurityAuditTasksForTests } from "../../src/server/security/audit";
+import {
+  createStage1WebTestRuntime,
+  type Stage1WebTestRuntime,
+} from "../../src/server/stage1-runtime.test-support";
+
+function buildUser(input: {
+  readonly id: string;
+  readonly email: string;
+  readonly role: "admin" | "operator";
+}): {
+  readonly id: string;
+  readonly name: string;
+  readonly email: string;
+  readonly emailVerified: Date;
+  readonly image: null;
+  readonly role: "admin" | "operator";
+  readonly deactivatedAt: null;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+} {
+  const now = new Date("2026-04-14T10:00:00.000Z");
+  return {
+    id: input.id,
+    name: input.email.split("@")[0] ?? input.email,
+    email: input.email,
+    emailVerified: now,
+    image: null,
+    role: input.role,
+    deactivatedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+describe("settings users read audit", () => {
+  let runtime: Stage1WebTestRuntime | null = null;
+
+  beforeEach(async () => {
+    redirect.mockReset();
+    requireAdmin.mockReset();
+    runtime = await createStage1WebTestRuntime();
+
+    const admin = buildUser({
+      id: "user:admin",
+      email: "admin@adventurescientists.org",
+      role: "admin",
+    });
+    const operator = buildUser({
+      id: "user:operator",
+      email: "operator@adventurescientists.org",
+      role: "operator",
+    });
+
+    await runtime.context.settings.users.upsert(admin);
+    await runtime.context.settings.users.upsert(operator);
+
+    requireAdmin.mockResolvedValue(admin);
+  });
+
+  afterEach(async () => {
+    await waitForPendingSecurityAuditTasksForTests();
+    await runtime?.dispose();
+    runtime = null;
+  });
+
+  it("records who opened the users-and-roles settings page", async () => {
+    const page = await UsersPage();
+    if (!runtime) {
+      throw new Error("runtime not initialized");
+    }
+
+    await waitForPendingSecurityAuditTasksForTests();
+
+    const audits =
+      await runtime.context.repositories.auditEvidence.listByEntity({
+        entityType: "settings_page",
+        entityId: "users",
+      });
+    const latestAudit = audits.at(-1);
+
+    expect(page).toBeTruthy();
+    expect(latestAudit).toMatchObject({
+      actorType: "user",
+      actorId: "user:admin",
+      action: "settings.users.read",
+      result: "recorded",
+      policyCode: "security.read_audit",
+    });
+    expect(latestAudit?.metadataJson).toMatchObject({
+      visibleUserCount: 2,
+    });
+  });
+});

--- a/docs/03-reference/reference-security-response.md
+++ b/docs/03-reference/reference-security-response.md
@@ -1,0 +1,140 @@
+# Reference Security Response
+
+**Role:** compact incident-response and secret-rotation guide for launch  
+**Audience:** operators and implementers handling credentials, auth abuse, or suspicious access  
+**When to read:** when rotating a secret, containing an auth event, or checking recent security evidence  
+**Authority:** reference-only; implementation truth lives in the current checked-out code and `docs/01-core/*`
+
+## Scope
+
+- This is the minimum response playbook for launch, not a full security policy manual.
+- Assume secrets live in Railway environment variables unless a row below says the upstream system must rotate first.
+- Railway variable edits stage changes; redeploy the affected service to apply them.
+
+## Secret Inventory
+
+| Secret                     | Primary service(s)                          | Where it lives                      | Rotation note                                                             |
+| -------------------------- | ------------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------- |
+| `AUTH_SECRET`              | `web`                                       | Railway service variables           | Rotating invalidates existing Auth.js JWT sessions.                       |
+| `AUTH_GOOGLE_SECRET`       | `web`                                       | Railway service variables           | Generate a new Google OAuth client secret first, then update Railway.     |
+| `DATABASE_URL`             | `web`, `worker`                             | Railway reference/service variables | If Railway Postgres credentials change, redeploy every dependent service. |
+| `WORKER_DATABASE_URL`      | `worker`                                    | Railway service variables           | Rotate with `DATABASE_URL` if the worker uses its own connection string.  |
+| `GMAIL_CAPTURE_TOKEN`      | `worker`, `gmail-capture`                   | Railway service variables           | Must match on both sides of the service-to-service call.                  |
+| `SALESFORCE_CAPTURE_TOKEN` | `worker`, `salesforce-capture`              | Railway service variables           | Must match on both sides of the service-to-service call.                  |
+| `INBOX_REVALIDATE_TOKEN`   | `worker`, `web`                             | Railway service variables           | Internal-only shared secret for inbox revalidation calls.                 |
+| `MAILCHIMP_CAPTURE_TOKEN`  | future `worker` + Mailchimp capture service | Railway service variables           | Deferred until Mailchimp capture resumes.                                 |
+| `SENDGRID_API_KEY`         | future campaigns service                    | Railway service variables           | Deferred until Campaigns Email lands.                                     |
+| `OPENAI_API_KEY`           | future AI service(s)                        | Railway service variables           | Deferred until Stage 4 AI ships.                                          |
+
+Current provider-facing secrets that also need the same treatment:
+
+- Gmail capture OAuth credentials in `gmail-capture`: `GMAIL_GOOGLE_OAUTH_CLIENT_SECRET`, `GMAIL_GOOGLE_OAUTH_REFRESH_TOKEN`
+- Salesforce capture credentials in `salesforce-capture`: `SALESFORCE_CLIENT_ID`, `SALESFORCE_JWT_PRIVATE_KEY`
+
+## Railway Rotation Commands
+
+Use Railway CLI global flags to target the right service and environment:
+
+```bash
+railway variables set KEY='new-value' -s <service> -e production
+railway redeploy -s <service> -e production -y
+```
+
+Examples:
+
+```bash
+railway variables set AUTH_SECRET='new-auth-secret' -s web -e production
+railway redeploy -s web -e production -y
+
+railway variables set AUTH_GOOGLE_SECRET='new-google-secret' -s web -e production
+railway redeploy -s web -e production -y
+
+railway variables set GMAIL_CAPTURE_TOKEN='new-shared-token' -s worker -e production
+railway variables set GMAIL_CAPTURE_TOKEN='new-shared-token' -s gmail-capture -e production
+railway redeploy -s worker -e production -y
+railway redeploy -s gmail-capture -e production -y
+
+railway variables set SALESFORCE_CAPTURE_TOKEN='new-shared-token' -s worker -e production
+railway variables set SALESFORCE_CAPTURE_TOKEN='new-shared-token' -s salesforce-capture -e production
+railway redeploy -s worker -e production -y
+railway redeploy -s salesforce-capture -e production -y
+
+railway variables set INBOX_REVALIDATE_TOKEN='new-revalidate-token' -s worker -e production
+railway variables set INBOX_REVALIDATE_TOKEN='new-revalidate-token' -s web -e production
+railway redeploy -s worker -e production -y
+railway redeploy -s web -e production -y
+```
+
+Database note:
+
+- Railway’s database view documents password regeneration in the database Credentials tab. Rotate the database password there first, then redeploy every service that consumes the derived `DATABASE_URL` or `WORKER_DATABASE_URL`.
+- If you are storing a literal connection string instead of a Railway reference variable, pipe the new value from your shell or secret manager:
+
+```bash
+printf '%s' "$NEW_DATABASE_URL" | railway variables set DATABASE_URL --stdin -s web -e production
+railway redeploy -s web -e production -y
+```
+
+Restart vs redeploy:
+
+- Use `railway redeploy` after any variable change. Railway docs call redeploy the path used to apply environment variable changes.
+- Use `railway restart` only when the secret value did not change in Railway and you just need to recycle a stuck process.
+
+## Incident Flags And First Three Steps
+
+### Suspected credential leak
+
+1. Identify the leaked secret and the services that consume it.
+2. Rotate the upstream credential first if there is one (`AUTH_GOOGLE_SECRET`, Gmail OAuth, Salesforce JWT), then update Railway and redeploy the affected services.
+3. Run the audit query below for the last 24 hours and review application logs around the suspected exposure window.
+
+### Brute-force signal from the rate limiter
+
+1. Pull recent `rate_limit_exceeded` events and confirm the route, IP, and time window.
+2. If the events target `/api/auth/*`, verify whether the same IP also reached a successful operator session; if yes, escalate as possible account compromise.
+3. If the volume persists, rotate the impacted shared secret (for example `AUTH_SECRET` or a capture token) only if there is evidence it may have been guessed or exposed; otherwise keep monitoring and block at the edge if infrastructure controls are available.
+
+### Unauthorized operator sign-in
+
+1. Deactivate the operator in `/settings/users` immediately, or update the user row directly if the UI is unavailable.
+2. Rotate `AUTH_SECRET` to invalidate current JWT-backed sessions, then redeploy `web`.
+3. If the Google account itself is suspect, revoke/rotate the Google OAuth client secret, confirm the Workspace account status, and review recent audit evidence plus platform logs.
+
+## Audit Query Pattern
+
+Use the app database connection to pull recent read-audit and abuse events:
+
+```bash
+psql "$DATABASE_URL" -c "
+select
+  occurred_at,
+  actor_type,
+  actor_id,
+  action,
+  entity_type,
+  entity_id,
+  result,
+  policy_code,
+  metadata_json
+from audit_policy_evidence
+where occurred_at >= now() - interval '24 hours'
+  and (
+    action in (
+      'contact.timeline.read',
+      'settings.users.read',
+      'auth.request.rate_limited',
+      'dev_auth.request.rate_limited',
+      'inbox.follow_up.rate_limited'
+    )
+    or metadata_json->>'reason' = 'rate_limit_exceeded'
+  )
+order by occurred_at desc
+limit 200;
+"
+```
+
+Fast filters operators can add in a pinch:
+
+- `and actor_id = 'user:…'` for a specific operator
+- `and entity_id = 'contact:…'` for a single volunteer record
+- `and metadata_json->>'identifier' = '203.0.113.5'` for a single IP

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,43 +10,46 @@ export default defineConfig({
     alias: [
       {
         find: "@as-comms/db/test-helpers",
-        replacement: path.resolve(repoRoot, "packages/db/src/test-helpers.ts")
+        replacement: path.resolve(repoRoot, "packages/db/src/test-helpers.ts"),
       },
       {
         find: "@as-comms/contracts",
-        replacement: path.resolve(repoRoot, "packages/contracts/src/index.ts")
+        replacement: path.resolve(repoRoot, "packages/contracts/src/index.ts"),
       },
       {
         find: "@as-comms/db",
-        replacement: path.resolve(repoRoot, "packages/db/src/index.ts")
+        replacement: path.resolve(repoRoot, "packages/db/src/index.ts"),
       },
       {
         find: "@as-comms/domain",
-        replacement: path.resolve(repoRoot, "packages/domain/src/index.ts")
+        replacement: path.resolve(repoRoot, "packages/domain/src/index.ts"),
       },
       {
         find: "@as-comms/integrations",
-        replacement: path.resolve(repoRoot, "packages/integrations/src/index.ts")
+        replacement: path.resolve(
+          repoRoot,
+          "packages/integrations/src/index.ts",
+        ),
       },
       {
         find: "@as-comms/ui",
-        replacement: path.resolve(repoRoot, "packages/ui/src/index.ts")
-      }
-    ]
+        replacement: path.resolve(repoRoot, "packages/ui/src/index.ts"),
+      },
+      {
+        find: "@",
+        replacement: path.resolve(repoRoot, "apps/web"),
+      },
+    ],
   },
   test: {
-    include: [
-      "test/**/*.test.ts",
-      "tests/**/*.test.ts",
-      "src/**/*.test.ts"
-    ],
+    include: ["test/**/*.test.ts", "tests/**/*.test.ts", "src/**/*.test.ts"],
     environment: "node",
     testTimeout: 30000,
     hookTimeout: 30000,
     coverage: {
       provider: "v8",
       reporter: ["text", "html"],
-      reportsDirectory: "./coverage/unit"
-    }
-  }
+      reportsDirectory: "./coverage/unit",
+    },
+  },
 });


### PR DESCRIPTION
Bundles two parallel Codex-authored themes on one branch since they commingled on `apps/web/app/inbox/actions.ts` and `vitest.config.ts`; splitting after the fact would have churned both threads.

## Security (per `.codex-security-2026-04-19.md`)

- **CSP + headers**: `apps/web/next.config.ts` sets Content-Security-Policy, HSTS, `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, Referrer-Policy, and Permissions-Policy. CSP includes `accounts.google.com` in `script-src` and `form-action` for Auth.js.
- **Rate limiter**: swappable interface in `apps/web/src/server/security/rate-limit.ts`, wired into Auth.js (`/api/auth/[...nextauth]`), dev-auth, and the follow-up server action. Denials audit with `reason: "rate_limit_exceeded"`.
- **Auth gate on inbox reads**: `apps/web/src/server/auth/api.ts` + `apps/web/app/inbox/layout.tsx` require a real session for inbox layout and API reads.
- **Sensitive read auditing**: `apps/web/src/server/security/audit.ts` is invoked asynchronously by inbox timeline reads (`contact.timeline.read`) and settings user reads (`settings.users.read`).
- **Playbook**: `docs/03-reference/reference-security-response.md` — incident response + secret rotation steps.

Caveats documented by Codex:
- `pnpm security` (`pnpm audit`) can't run against the sandbox network — needs a rerun in an environment with registry access.
- Server Actions can't emit a literal `429` with `Retry-After`; the follow-up action returns the standard error envelope and still audits the limit hit.

## Usability (per `.codex-usability-2026-04-19.md`)

- **Keyboard shortcuts** (`/`, `j`, `k`, `Enter`, `Esc`, `f`, `?`): new `inbox-keyboard-provider.tsx` + `inbox-keyboard-helpers.ts`. Search box protected from hijacked typing; rows keyboard-focusable; `?` opens a shortcuts popover.
- **Hover/focus route prefetch** on inbox rows.
- **Optimistic follow-up toggle** with React 19 transition-wrapped optimistic update and inline error reconciliation.
- Timeline virtualization intentionally deferred — the first three wins landed cleanly without adding another client dep.

## Fixed inline

Codex flagged `next.config.ts:61` lint (`require-await` on the `headers` method). I changed the method to return `Promise.resolve(...)` instead of being `async`. Minimal change.

## Quality gate (all green locally)

- `pnpm --filter @as-comms/web typecheck`
- `pnpm --filter @as-comms/web lint` (zero warnings)
- `pnpm --filter @as-comms/web test:unit` — 50/50 passing
- `pnpm --filter @as-comms/web build`
- `pnpm boundaries`

## Follow-ups (out of scope here, architect tracking)

- Re-run `pnpm security` (audit) in an env with registry access.
- Browser smoke for rate-limit 429 rendering — deferred, infrastructural.
- Timeline virtualization — can ship as a small standalone PR later.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>