### PR TITLE
fix(stage1): stable mbox record IDs across Takeout re-exports

### DIFF
--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -46,3 +46,14 @@ Use these commands when you do want the worker running locally:
 pnpm ops:worker:check-config
 WORKER_BOOT_MODE=run pnpm dev:worker
 ```
+
+Historical Gmail `.mbox` imports also support an optional `--overwrite-bodies` flag:
+
+```bash
+pnpm ops:worker:import-gmail-mbox -- \
+  --mbox-path /absolute/path/project-antarctica.mbox \
+  --captured-mailbox project-antarctica@example.org \
+  --overwrite-bodies
+```
+
+Leave `--overwrite-bodies` off to preserve the existing Gmail detail preview fields on duplicate re-imports. Enable it when a duplicate-safe re-import should refresh `subject`, `snippetClean`, and `bodyTextPreview` from the current `.mbox` parse.

--- a/apps/worker/src/ingest/service.ts
+++ b/apps/worker/src/ingest/service.ts
@@ -33,8 +33,15 @@ export type Stage1IngestNormalizationPort = Pick<
   "applyNormalizedCanonicalEvent" | "upsertNormalizedContactGraph"
 >;
 
+export interface Stage1CanonicalEventIngestOptions {
+  readonly overwriteDuplicateGmailMessageDetail?: boolean;
+}
+
 export interface Stage1IngestService {
-  ingestGmailHistoricalRecord(record: GmailRecord): Promise<Stage1IngestResult>;
+  ingestGmailHistoricalRecord(
+    record: GmailRecord,
+    options?: Stage1CanonicalEventIngestOptions,
+  ): Promise<Stage1IngestResult>;
   ingestGmailLiveRecord(record: GmailRecord): Promise<Stage1IngestResult>;
   ingestSalesforceHistoricalRecord(
     record: SalesforceRecord,
@@ -245,6 +252,7 @@ async function executeMappedCommand(
   normalization: Stage1IngestNormalizationPort,
   ingestMode: Stage1IngestMode,
   mapped: ProviderMappingResult,
+  options?: Stage1CanonicalEventIngestOptions,
 ): Promise<Stage1IngestResult> {
   if (mapped.outcome === "deferred") {
     return mapDeferredResult(mapped, ingestMode);
@@ -263,7 +271,7 @@ async function executeMappedCommand(
   return mapCanonicalEventResult({
     ingestMode,
     mapped,
-    result: await normalization.applyNormalizedCanonicalEvent(command.input),
+    result: await normalization.applyNormalizedCanonicalEvent(command.input, options),
   });
 }
 
@@ -273,12 +281,14 @@ async function ingestRecord<TRecord>(
     readonly ingestMode: Stage1IngestMode;
     readonly mapper: (record: TRecord) => ProviderMappingResult;
     readonly record: TRecord;
+    readonly options?: Stage1CanonicalEventIngestOptions;
   },
 ): Promise<Stage1IngestResult> {
   return executeMappedCommand(
     normalization,
     input.ingestMode,
     input.mapper(input.record),
+    input.options,
   );
 }
 
@@ -286,11 +296,12 @@ export function createStage1IngestService(
   normalization: Stage1IngestNormalizationPort,
 ): Stage1IngestService {
   return {
-    ingestGmailHistoricalRecord(record) {
+    ingestGmailHistoricalRecord(record, options) {
       return ingestRecord(normalization, {
         ingestMode: "historical",
         mapper: mapGmailRecord,
         record,
+        ...(options === undefined ? {} : { options }),
       });
     },
 

--- a/apps/worker/src/ops/cli.ts
+++ b/apps/worker/src/ops/cli.ts
@@ -34,6 +34,7 @@ import {
 import {
   buildOperationId,
   parseCliFlags,
+  readOptionalBooleanFlag,
   readOptionalIntegerFlag,
   readOptionalStringFlag,
   readRequiredFlag
@@ -131,7 +132,8 @@ async function runImportGmailMbox(args: readonly string[]): Promise<void> {
         buildOperationId("stage1:gmail:mbox:correlation"),
       traceId: readOptionalStringFlag(flags, "trace-id"),
       receivedAt: readOptionalStringFlag(flags, "received-at"),
-      limit: readOptionalIntegerFlag(flags, "limit", 0) || null
+      limit: readOptionalIntegerFlag(flags, "limit", 0) || null,
+      overwriteBodies: readOptionalBooleanFlag(flags, "overwrite-bodies", false)
     });
 
     console.info(JSON.stringify(result, null, 2));

--- a/apps/worker/src/ops/gmail-mbox.ts
+++ b/apps/worker/src/ops/gmail-mbox.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 
-import { mapGmailRecord, importGmailMboxRecords } from "@as-comms/integrations";
+import {
+  buildSourceEvidenceIdempotencyKey,
+  importGmailMboxRecords,
+  mapGmailRecord,
+  sha256Text
+} from "@as-comms/integrations";
 import type { Stage1PersistenceService } from "@as-comms/domain";
 import type { SyncStateRecord } from "@as-comms/contracts";
 
@@ -22,7 +27,8 @@ const gmailMboxImportInputSchema = z.object({
   correlationId: z.string().min(1),
   traceId: z.string().min(1).nullable().default(null),
   receivedAt: z.string().datetime().nullable().default(null),
-  limit: z.number().int().positive().nullable().default(null)
+  limit: z.number().int().positive().nullable().default(null),
+  overwriteBodies: z.boolean().default(false)
 });
 
 export type GmailMboxImportInput = z.input<typeof gmailMboxImportInputSchema>;
@@ -123,6 +129,186 @@ function resolveProjectInboxAlias(records: readonly unknown[]): string | null {
   return null;
 }
 
+function normalizeLineEndings(value: string): string {
+  return value.replace(/\r\n/gu, "\n").replace(/\r/gu, "\n");
+}
+
+function splitMboxRawMessages(mboxText: string): string[] {
+  const normalized = normalizeLineEndings(mboxText);
+  const lines = normalized.split("\n");
+  const messages: string[] = [];
+  let currentLines: string[] = [];
+
+  for (const line of lines) {
+    if (line.startsWith("From ")) {
+      if (currentLines.length > 0) {
+        messages.push(currentLines.join("\n").trim());
+        currentLines = [];
+      }
+
+      continue;
+    }
+
+    currentLines.push(line);
+  }
+
+  if (currentLines.length > 0) {
+    messages.push(currentLines.join("\n").trim());
+  }
+
+  return messages.filter((message) => message.length > 0);
+}
+
+function buildLegacyMboxRecordId(input: {
+  readonly rawMessage: string;
+  readonly capturedMailbox: string;
+}): string {
+  return `mbox:${sha256Text(
+    `${input.capturedMailbox.toLowerCase()}\n${normalizeLineEndings(input.rawMessage)}`
+  )}`;
+}
+
+function buildLegacyMboxRecordIdCandidates(input: {
+  readonly rawMessage: string;
+  readonly capturedMailbox: string;
+  readonly liveAccount: string;
+  readonly projectInboxAliases: readonly string[];
+  readonly projectInboxAliasOverride: string | null;
+}): string[] {
+  const candidateMailboxes = Array.from(
+    new Set(
+      [
+        input.capturedMailbox,
+        input.liveAccount,
+        input.projectInboxAliasOverride,
+        ...input.projectInboxAliases
+      ]
+        .filter((value): value is string => typeof value === "string")
+        .map((value) => value.trim().toLowerCase())
+        .filter((value) => value.length > 0)
+    )
+  ).sort((left, right) => left.localeCompare(right));
+
+  return candidateMailboxes.map((capturedMailbox) =>
+    buildLegacyMboxRecordId({
+      rawMessage: input.rawMessage,
+      capturedMailbox
+    })
+  );
+}
+
+function buildSourceEvidenceEntityId(providerRecordId: string): string {
+  return `gmail:message:${providerRecordId}`;
+}
+
+async function recordMboxRecordIdCompatibilityAuditOnce(
+  persistence: Stage1PersistenceService,
+  input: {
+    readonly occurredAt: string;
+    readonly preferredProviderRecordId: string;
+    readonly resolvedProviderRecordId: string;
+    readonly legacyProviderRecordIds: readonly string[];
+  }
+): Promise<void> {
+  const entityId = buildSourceEvidenceEntityId(input.resolvedProviderRecordId);
+  const policyCode = "stage1.mapper.gmail_mbox_record_id_compatibility";
+  const existingRecords = await persistence.repositories.auditEvidence.listByEntity({
+    entityType: "source_evidence",
+    entityId
+  });
+
+  if (existingRecords.some((record) => record.policyCode === policyCode)) {
+    return;
+  }
+
+  await persistence.recordAuditEvidence({
+    id: `audit:source_evidence:${entityId}:gmail_mbox_record_id_compatibility`,
+    actorType: "system",
+    actorId: "stage1-gmail-mbox-import",
+    action: "reuse_legacy_mbox_record_id",
+    entityType: "source_evidence",
+    entityId,
+    occurredAt: input.occurredAt,
+    result: "recorded",
+    policyCode,
+    metadataJson: {
+      preferredProviderRecordId: input.preferredProviderRecordId,
+      resolvedProviderRecordId: input.resolvedProviderRecordId,
+      legacyProviderRecordIds: [...input.legacyProviderRecordIds]
+    }
+  });
+}
+
+export async function resolveGmailMboxRecordId(
+  persistence: Stage1PersistenceService,
+  input: {
+    readonly messageIndex: number;
+    readonly checksum: string;
+    readonly preferredRecordId: string;
+    readonly legacyRecordIds: readonly string[];
+    readonly occurredAt: string;
+  }
+): Promise<string> {
+  const candidateRecordIds = Array.from(
+    new Set([input.preferredRecordId, ...input.legacyRecordIds])
+  );
+  const matches = (
+    await Promise.all(
+      candidateRecordIds.map(async (providerRecordId) => {
+        const existing = await persistence.findSourceEvidenceByIdempotencyKey(
+          buildSourceEvidenceIdempotencyKey("gmail", "message", providerRecordId)
+        );
+
+        if (existing?.checksum !== input.checksum) {
+          return null;
+        }
+
+        return existing;
+      })
+    )
+  ).filter((record): record is NonNullable<typeof record> => record !== null);
+
+  const uniqueMatches = Array.from(
+    new Map(matches.map((record) => [record.providerRecordId, record])).values()
+  );
+  const preferredMatch = uniqueMatches.find(
+    (record) => record.providerRecordId === input.preferredRecordId
+  );
+
+  if (preferredMatch !== undefined) {
+    return preferredMatch.providerRecordId;
+  }
+
+  if (uniqueMatches.length === 0) {
+    return input.preferredRecordId;
+  }
+
+  if (uniqueMatches.length > 1) {
+    throw new Error(
+      `Multiple existing Gmail mbox source evidence rows matched message ${String(
+        input.messageIndex
+      )}; refusing to guess which legacy providerRecordId to reuse.`
+    );
+  }
+
+  const [legacyMatch] = uniqueMatches;
+
+  if (legacyMatch === undefined) {
+    return input.preferredRecordId;
+  }
+
+  if (legacyMatch.providerRecordId !== input.preferredRecordId) {
+    await recordMboxRecordIdCompatibilityAuditOnce(persistence, {
+      occurredAt: input.occurredAt,
+      preferredProviderRecordId: input.preferredRecordId,
+      resolvedProviderRecordId: legacyMatch.providerRecordId,
+      legacyProviderRecordIds: input.legacyRecordIds
+    });
+  }
+
+  return legacyMatch.providerRecordId;
+}
+
 export function createStage1GmailMboxImportService(
   dependencies: Stage1GmailMboxImportDependencies
 ) {
@@ -132,6 +318,7 @@ export function createStage1GmailMboxImportService(
     async importMbox(input: GmailMboxImportInput): Promise<Stage1GmailMboxImportResult> {
       const parsedInput = gmailMboxImportInputSchema.parse(input);
       const receivedAt = parsedInput.receivedAt ?? now().toISOString();
+      const rawMessages = splitMboxRawMessages(parsedInput.mboxText);
       const records = await importGmailMboxRecords({
         mboxText: parsedInput.mboxText,
         mboxPath: parsedInput.mboxPath,
@@ -142,8 +329,45 @@ export function createStage1GmailMboxImportService(
         receivedAt,
         limit: parsedInput.limit
       });
-      const historicalWindow = calculateHistoricalWindow(records);
-      const resolvedProjectInboxAlias = resolveProjectInboxAlias(records);
+      const resolvedRecords = await Promise.all(records.map(async (record, index) => {
+        if (record.recordType !== "message" || !("checksum" in record)) {
+          return record;
+        }
+
+        const rawMessage = rawMessages[index];
+
+        if (rawMessage === undefined) {
+          throw new Error(
+            `Expected raw Gmail mbox message ${String(index + 1)} while resolving providerRecordId compatibility.`
+          );
+        }
+
+        const resolvedRecordId = await resolveGmailMboxRecordId(
+          dependencies.persistence,
+          {
+            messageIndex: index + 1,
+            checksum: record.checksum,
+            preferredRecordId: record.recordId,
+            legacyRecordIds: buildLegacyMboxRecordIdCandidates({
+              rawMessage,
+              capturedMailbox: parsedInput.capturedMailbox,
+              liveAccount: parsedInput.liveAccount,
+              projectInboxAliases: parsedInput.projectInboxAliases,
+              projectInboxAliasOverride: parsedInput.projectInboxAliasOverride
+            }),
+            occurredAt: receivedAt
+          }
+        );
+
+        return resolvedRecordId === record.recordId
+          ? record
+          : {
+              ...record,
+              recordId: resolvedRecordId
+            };
+      }));
+      const historicalWindow = calculateHistoricalWindow(resolvedRecords);
+      const resolvedProjectInboxAlias = resolveProjectInboxAlias(resolvedRecords);
 
       await dependencies.syncState.startWindow({
         syncStateId: parsedInput.syncStateId,
@@ -159,9 +383,13 @@ export function createStage1GmailMboxImportService(
       try {
         const ingestResults: Stage1IngestResult[] = [];
 
-        for (const record of records) {
-          const ingestResult =
-            await dependencies.ingest.ingestGmailHistoricalRecord(record);
+        for (const record of resolvedRecords) {
+          const ingestResult = await dependencies.ingest.ingestGmailHistoricalRecord(
+            record,
+            {
+              overwriteDuplicateGmailMessageDetail: parsedInput.overwriteBodies
+            }
+          );
           ingestResults.push(ingestResult);
 
           if (
@@ -216,7 +444,7 @@ export function createStage1GmailMboxImportService(
           mboxPath: parsedInput.mboxPath,
           capturedMailbox: parsedInput.capturedMailbox,
           projectInboxAlias: resolvedProjectInboxAlias,
-          parsedRecords: records.length,
+          parsedRecords: resolvedRecords.length,
           syncStateId: parsedInput.syncStateId,
           correlationId: parsedInput.correlationId,
           summary,
@@ -242,7 +470,7 @@ export function createStage1GmailMboxImportService(
           mboxPath: parsedInput.mboxPath,
           capturedMailbox: parsedInput.capturedMailbox,
           projectInboxAlias: resolvedProjectInboxAlias,
-          parsedRecords: records.length,
+          parsedRecords: resolvedRecords.length,
           syncStateId: parsedInput.syncStateId,
           correlationId: parsedInput.correlationId,
           summary: {

--- a/apps/worker/test/stage1-gmail-mbox-import.test.ts
+++ b/apps/worker/test/stage1-gmail-mbox-import.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it } from "vitest";
 
-import { createStage1GmailMboxImportService } from "../src/ops/gmail-mbox.js";
+import {
+  buildSourceEvidenceId,
+  buildSourceEvidenceIdempotencyKey,
+  importGmailMboxRecords,
+  mapGmailRecord,
+  sha256Text
+} from "@as-comms/integrations";
+
+import {
+  createStage1GmailMboxImportService,
+  resolveGmailMboxRecordId
+} from "../src/ops/gmail-mbox.js";
 import { createTestWorkerContext, type TestWorkerContext } from "./helpers.js";
 
 const contactId = "contact:salesforce:003-stage1";
@@ -14,6 +25,106 @@ Message-ID: <historical-import-1@example.org>
 
 Reply from the volunteer
 `;
+
+function buildImporter(context: TestWorkerContext) {
+  return createStage1GmailMboxImportService({
+    ingest: context.ingest,
+    persistence: context.persistence,
+    syncState: context.syncState,
+    now: () => new Date("2026-01-04T00:01:00.000Z")
+  });
+}
+
+function buildImportInput(
+  overrides?: Partial<{
+    readonly mboxText: string;
+    readonly mboxPath: string;
+    readonly capturedMailbox: string;
+    readonly syncStateId: string;
+    readonly correlationId: string;
+    readonly receivedAt: string;
+    readonly overwriteBodies: boolean;
+  }>
+) {
+  return {
+    mboxText: overrides?.mboxText ?? mboxText,
+    mboxPath:
+      overrides?.mboxPath ?? "/tmp/project-antarctica.mbox",
+    capturedMailbox:
+      overrides?.capturedMailbox ?? "project-antarctica@example.org",
+    liveAccount: "volunteers@adventurescientists.org",
+    projectInboxAliases: ["project-antarctica@example.org"],
+    syncStateId: overrides?.syncStateId ?? "sync:gmail:mbox",
+    correlationId: overrides?.correlationId ?? "corr:gmail:mbox",
+    traceId: null,
+    receivedAt: overrides?.receivedAt ?? "2026-01-04T00:01:00.000Z",
+    overwriteBodies: overrides?.overwriteBodies ?? false
+  };
+}
+
+function extractLegacyRawMessage(value: string): string {
+  return value
+    .replace(/\r\n/gu, "\n")
+    .replace(/\r/gu, "\n")
+    .split("\n")
+    .slice(1)
+    .join("\n")
+    .trim();
+}
+
+function normalizeLineEndings(value: string): string {
+  return value.replace(/\r\n/gu, "\n").replace(/\r/gu, "\n");
+}
+
+function buildLegacyMboxRecordIdLocal(input: {
+  readonly rawMessage: string;
+  readonly capturedMailbox: string;
+}): string {
+  return `mbox:${sha256Text(
+    `${input.capturedMailbox.toLowerCase()}\n${normalizeLineEndings(input.rawMessage)}`
+  )}`;
+}
+
+async function buildMappedHistoricalCommand(
+  overrides?: Partial<{
+    readonly mboxText: string;
+    readonly mboxPath: string;
+    readonly capturedMailbox: string;
+    readonly receivedAt: string;
+  }>
+) {
+  const [record] = await importGmailMboxRecords({
+    mboxText: overrides?.mboxText ?? mboxText,
+    mboxPath: overrides?.mboxPath ?? "/tmp/project-antarctica.mbox",
+    capturedMailbox:
+      overrides?.capturedMailbox ?? "project-antarctica@example.org",
+    liveAccount: "volunteers@adventurescientists.org",
+    projectInboxAliases: ["project-antarctica@example.org"],
+    receivedAt: overrides?.receivedAt ?? "2026-01-04T00:01:00.000Z"
+  });
+
+  if (record?.recordType !== "message") {
+    throw new Error("Expected a Gmail historical message record.");
+  }
+
+  const mapped = mapGmailRecord(record);
+
+  if (mapped.outcome !== "command" || mapped.command.kind !== "canonical_event") {
+    throw new Error("Expected Gmail historical import to map to a canonical event.");
+  }
+
+  if (mapped.command.input.gmailMessageDetail === undefined) {
+    throw new Error("Expected Gmail historical import to include Gmail detail.");
+  }
+
+  return {
+    record,
+    commandInput: {
+      ...mapped.command.input,
+      gmailMessageDetail: mapped.command.input.gmailMessageDetail
+    }
+  };
+}
 
 async function seedContact(context: TestWorkerContext) {
   await context.normalization.upsertNormalizedContactGraph({
@@ -66,35 +177,21 @@ describe("Stage 1 Gmail .mbox importer", () => {
 
     try {
       await seedContact(context);
-      const importer = createStage1GmailMboxImportService({
-        ingest: context.ingest,
-        persistence: context.persistence,
-        syncState: context.syncState,
-        now: () => new Date("2026-01-04T00:01:00.000Z")
-      });
+      const importer = buildImporter(context);
 
-      const firstRun = await importer.importMbox({
-        mboxText,
-        mboxPath: "/tmp/project-antarctica.mbox",
-        capturedMailbox: "project-antarctica@example.org",
-        liveAccount: "volunteers@adventurescientists.org",
-        projectInboxAliases: ["project-antarctica@example.org"],
-        syncStateId: "sync:gmail:mbox:first",
-        correlationId: "corr:gmail:mbox:first",
-        traceId: null,
-        receivedAt: "2026-01-04T00:01:00.000Z"
-      });
-      const secondRun = await importer.importMbox({
-        mboxText,
-        mboxPath: "/tmp/project-antarctica.mbox",
-        capturedMailbox: "project-antarctica@example.org",
-        liveAccount: "volunteers@adventurescientists.org",
-        projectInboxAliases: ["project-antarctica@example.org"],
-        syncStateId: "sync:gmail:mbox:second",
-        correlationId: "corr:gmail:mbox:second",
-        traceId: null,
-        receivedAt: "2026-01-04T00:02:00.000Z"
-      });
+      const firstRun = await importer.importMbox(
+        buildImportInput({
+          syncStateId: "sync:gmail:mbox:first",
+          correlationId: "corr:gmail:mbox:first"
+        })
+      );
+      const secondRun = await importer.importMbox(
+        buildImportInput({
+          syncStateId: "sync:gmail:mbox:second",
+          correlationId: "corr:gmail:mbox:second",
+          receivedAt: "2026-01-04T00:02:00.000Z"
+        })
+      );
 
       expect(firstRun).toMatchObject({
         outcome: "succeeded",
@@ -152,6 +249,316 @@ describe("Stage 1 Gmail .mbox importer", () => {
       ).resolves.toMatchObject({
         bucket: "New"
       });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("keeps the same Takeout replay duplicate-safe when the mbox file path changes", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact(context);
+      const importer = buildImporter(context);
+      const { record } = await buildMappedHistoricalCommand();
+
+      const firstRun = await importer.importMbox(
+        buildImportInput({
+          mboxPath: "/tmp/original/orcas.mbox",
+          syncStateId: "sync:gmail:mbox:path:first",
+          correlationId: "corr:gmail:mbox:path:first"
+        })
+      );
+      const secondRun = await importer.importMbox(
+        buildImportInput({
+          mboxPath: "/tmp/mbox/MBox Files/orcas.mbox",
+          syncStateId: "sync:gmail:mbox:path:second",
+          correlationId: "corr:gmail:mbox:path:second",
+          receivedAt: "2026-01-04T00:02:00.000Z"
+        })
+      );
+
+      expect(firstRun.summary).toMatchObject({
+        normalized: 1,
+        quarantined: 0
+      });
+      expect(secondRun.summary).toMatchObject({
+        duplicate: 1,
+        quarantined: 0
+      });
+      await expect(context.repositories.canonicalEvents.countAll()).resolves.toBe(1);
+
+      const audits = await context.repositories.auditEvidence.listByEntity({
+        entityType: "source_evidence",
+        entityId: `gmail:message:${record.recordId}`
+      });
+
+      expect(
+        audits.some(
+          (audit) =>
+            audit.policyCode === "stage1.quarantine.replay_checksum_mismatch"
+        )
+      ).toBe(false);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("uses the same source evidence row when capturedMailbox changes", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact(context);
+      const importer = buildImporter(context);
+      const { record } = await buildMappedHistoricalCommand();
+
+      const firstRun = await importer.importMbox(
+        buildImportInput({
+          syncStateId: "sync:gmail:mbox:mailbox:first",
+          correlationId: "corr:gmail:mbox:mailbox:first"
+        })
+      );
+      const secondRun = await importer.importMbox(
+        buildImportInput({
+          capturedMailbox: "volunteers@adventurescientists.org",
+          syncStateId: "sync:gmail:mbox:mailbox:second",
+          correlationId: "corr:gmail:mbox:mailbox:second",
+          receivedAt: "2026-01-04T00:02:00.000Z"
+        })
+      );
+
+      expect(firstRun.summary).toMatchObject({
+        normalized: 1,
+        quarantined: 0
+      });
+      expect(secondRun.summary).toMatchObject({
+        duplicate: 1,
+        quarantined: 0
+      });
+      await expect(context.repositories.canonicalEvents.countAll()).resolves.toBe(1);
+      await expect(
+        context.persistence.findSourceEvidenceByIdempotencyKey(
+          buildSourceEvidenceIdempotencyKey("gmail", "message", record.recordId)
+        )
+      ).resolves.toMatchObject({
+        id: buildSourceEvidenceId("gmail", "message", record.recordId),
+        providerRecordId: record.recordId
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("reuses legacy mbox source evidence ids when a re-import matches an existing row", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact(context);
+      const { commandInput } = await buildMappedHistoricalCommand();
+      const legacyProviderRecordId = buildLegacyMboxRecordIdLocal({
+        rawMessage: extractLegacyRawMessage(mboxText),
+        capturedMailbox: "project-antarctica@example.org"
+      });
+      const legacySourceEvidenceId = buildSourceEvidenceId(
+        "gmail",
+        "message",
+        legacyProviderRecordId
+      );
+      const preferredProviderRecordId =
+        "mbox:stable-provider-record-id-for-legacy-compatibility";
+
+      await context.normalization.applyNormalizedCanonicalEvent({
+        ...commandInput,
+        sourceEvidence: {
+          ...commandInput.sourceEvidence,
+          id: legacySourceEvidenceId,
+          providerRecordId: legacyProviderRecordId,
+          idempotencyKey: buildSourceEvidenceIdempotencyKey(
+            "gmail",
+            "message",
+            legacyProviderRecordId
+          )
+        },
+        gmailMessageDetail: {
+          ...commandInput.gmailMessageDetail,
+          sourceEvidenceId: legacySourceEvidenceId,
+          providerRecordId: legacyProviderRecordId
+        }
+      });
+
+      const resolvedProviderRecordId = await resolveGmailMboxRecordId(
+        context.persistence,
+        {
+          messageIndex: 1,
+          checksum: commandInput.sourceEvidence.checksum,
+          preferredRecordId: preferredProviderRecordId,
+          legacyRecordIds: [legacyProviderRecordId],
+          occurredAt: "2026-01-04T00:02:00.000Z"
+        }
+      );
+
+      expect(resolvedProviderRecordId).toBe(legacyProviderRecordId);
+      await expect(
+        context.persistence.findSourceEvidenceByIdempotencyKey(
+          buildSourceEvidenceIdempotencyKey("gmail", "message", legacyProviderRecordId)
+        )
+      ).resolves.toMatchObject({
+        id: legacySourceEvidenceId,
+        providerRecordId: legacyProviderRecordId
+      });
+      await expect(
+        context.persistence.findSourceEvidenceByIdempotencyKey(
+          buildSourceEvidenceIdempotencyKey(
+            "gmail",
+            "message",
+            preferredProviderRecordId
+          )
+        )
+      ).resolves.toBeNull();
+
+      const audits = await context.repositories.auditEvidence.listByEntity({
+        entityType: "source_evidence",
+        entityId: `gmail:message:${legacyProviderRecordId}`
+      });
+
+      expect(audits).toHaveLength(1);
+      expect(audits[0]).toMatchObject({
+        action: "reuse_legacy_mbox_record_id",
+        policyCode: "stage1.mapper.gmail_mbox_record_id_compatibility"
+      });
+      expect(audits[0]?.metadataJson).toMatchObject({
+        preferredProviderRecordId,
+        resolvedProviderRecordId: legacyProviderRecordId
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("only overwrites Gmail body detail on duplicate re-imports when overwriteBodies is enabled", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact(context);
+      const importer = buildImporter(context);
+      const { commandInput } = await buildMappedHistoricalCommand();
+      const sourceEvidenceId = commandInput.sourceEvidence.id;
+
+      await context.normalization.applyNormalizedCanonicalEvent({
+        ...commandInput,
+        gmailMessageDetail: {
+          ...commandInput.gmailMessageDetail,
+          subject: "Legacy subject",
+          snippetClean: "Legacy snippet",
+          bodyTextPreview: "Legacy body preview"
+        }
+      });
+
+      const defaultReplay = await importer.importMbox(
+        buildImportInput({
+          syncStateId: "sync:gmail:mbox:overwrite:default",
+          correlationId: "corr:gmail:mbox:overwrite:default",
+          receivedAt: "2026-01-04T00:02:00.000Z"
+        })
+      );
+
+      expect(defaultReplay.summary).toMatchObject({
+        duplicate: 1,
+        quarantined: 0
+      });
+      await expect(
+        context.repositories.gmailMessageDetails.listBySourceEvidenceIds([
+          sourceEvidenceId
+        ])
+      ).resolves.toEqual([
+        expect.objectContaining({
+          sourceEvidenceId,
+          subject: "Legacy subject",
+          snippetClean: "Legacy snippet",
+          bodyTextPreview: "Legacy body preview"
+        })
+      ]);
+
+      const overwriteReplay = await importer.importMbox(
+        buildImportInput({
+          syncStateId: "sync:gmail:mbox:overwrite:enabled",
+          correlationId: "corr:gmail:mbox:overwrite:enabled",
+          receivedAt: "2026-01-04T00:03:00.000Z",
+          overwriteBodies: true
+        })
+      );
+
+      expect(overwriteReplay.summary).toMatchObject({
+        duplicate: 1,
+        quarantined: 0
+      });
+      await expect(
+        context.repositories.gmailMessageDetails.listBySourceEvidenceIds([
+          sourceEvidenceId
+        ])
+      ).resolves.toEqual([
+        expect.objectContaining({
+          sourceEvidenceId,
+          subject: "Historical volunteer reply",
+          snippetClean: "Reply from the volunteer",
+          bodyTextPreview: "Reply from the volunteer"
+        })
+      ]);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("creates different rows for distinct mbox messages when Message-ID is absent", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact(context);
+      const importer = buildImporter(context);
+      const messageWithoutMessageIdA = `From MAILER-DAEMON Fri Jan 04 00:00:00 2026
+Date: Sun, 04 Jan 2026 00:00:00 +0000
+From: Volunteer <volunteer@example.org>
+To: Project Antarctica <project-antarctica@example.org>
+Subject: Historical volunteer reply
+
+Reply from the volunteer
+`;
+      const messageWithoutMessageIdB = `From MAILER-DAEMON Fri Jan 04 00:00:00 2026
+Date: Sun, 04 Jan 2026 00:00:00 +0000
+From: Volunteer <volunteer@example.org>
+To: Project Antarctica <project-antarctica@example.org>
+Subject: Historical volunteer reply
+
+Reply from the volunteer with a different body.
+`;
+
+      const firstRun = await importer.importMbox(
+        buildImportInput({
+          mboxText: messageWithoutMessageIdA,
+          mboxPath: "/tmp/no-message-id-a.mbox",
+          syncStateId: "sync:gmail:mbox:no-id:first",
+          correlationId: "corr:gmail:mbox:no-id:first"
+        })
+      );
+      const secondRun = await importer.importMbox(
+        buildImportInput({
+          mboxText: messageWithoutMessageIdB,
+          mboxPath: "/tmp/no-message-id-b.mbox",
+          syncStateId: "sync:gmail:mbox:no-id:second",
+          correlationId: "corr:gmail:mbox:no-id:second",
+          receivedAt: "2026-01-04T00:02:00.000Z"
+        })
+      );
+
+      expect(firstRun.summary).toMatchObject({
+        normalized: 1,
+        quarantined: 0
+      });
+      expect(secondRun.summary).toMatchObject({
+        normalized: 1,
+        quarantined: 0
+      });
+      await expect(context.repositories.canonicalEvents.countAll()).resolves.toBe(2);
     } finally {
       await context.dispose();
     }

--- a/packages/db/test/stage1-persistence.test.ts
+++ b/packages/db/test/stage1-persistence.test.ts
@@ -36,6 +36,18 @@ describe("Stage 1 persistence service", () => {
       checksum: "checksum-1"
     });
 
+    const duplicateFromMovedPayloadResult = await persistence.recordSourceEvidence({
+      id: "sev_2_moved",
+      provider: "gmail",
+      providerRecordType: "message",
+      providerRecordId: "gmail-message-1",
+      receivedAt: "2026-01-01T00:02:30.000Z",
+      occurredAt: "2026-01-01T00:00:00.000Z",
+      payloadRef: "payloads/gmail/archive/gmail-message-1.json",
+      idempotencyKey: "gmail:message:gmail-message-1",
+      checksum: "checksum-1"
+    });
+
     const conflictResult = await persistence.recordSourceEvidence({
       id: "sev_3",
       provider: "gmail",
@@ -54,6 +66,10 @@ describe("Stage 1 persistence service", () => {
 
     expect(firstResult.outcome).toBe("inserted");
     expect(duplicateResult).toEqual({
+      outcome: "duplicate",
+      record: firstResult.record
+    });
+    expect(duplicateFromMovedPayloadResult).toEqual({
       outcome: "duplicate",
       record: firstResult.record
     });

--- a/packages/domain/src/normalization.ts
+++ b/packages/domain/src/normalization.ts
@@ -188,7 +188,10 @@ export interface Stage1NormalizationService {
   ): Promise<InboxProjectionRow | null>;
   updateSyncState(input: SyncStateUpdateInput): Promise<SyncStateRecord>;
   applyNormalizedCanonicalEvent(
-    input: NormalizedCanonicalEventIntake
+    input: NormalizedCanonicalEventIntake,
+    options?: {
+      readonly overwriteDuplicateGmailMessageDetail?: boolean;
+    }
   ): Promise<NormalizedCanonicalEventResult>;
 }
 
@@ -1116,14 +1119,20 @@ async function upsertProviderPresentationDetails(
     | "salesforceEventContext"
     | "projectDimensions"
     | "expeditionDimensions"
-  >
+  >,
+  options?: {
+    readonly allowDuplicateGmailMessageDetailOverwrite?: boolean;
+  }
 ): Promise<void> {
   await upsertProjectAndExpeditionDimensions(persistence, {
     projectDimensions: input.projectDimensions ?? [],
     expeditionDimensions: input.expeditionDimensions ?? []
   });
 
-  if (input.gmailMessageDetail !== undefined) {
+  if (
+    input.gmailMessageDetail !== undefined &&
+    (options?.allowDuplicateGmailMessageDetailOverwrite ?? true)
+  ) {
     await persistence.upsertGmailMessageDetail(
       gmailMessageDetailSchema.parse(input.gmailMessageDetail)
     );
@@ -1422,7 +1431,7 @@ export function createStage1NormalizationService(
       return persistence.saveSyncState(parsed.syncState);
     },
 
-    async applyNormalizedCanonicalEvent(input) {
+    async applyNormalizedCanonicalEvent(input, options) {
       const parsed = normalizedCanonicalEventIntakeSchema.parse(input);
       const sourceEvidenceResult = await service.recordNormalizedSourceEvidence({
         sourceEvidence: parsed.sourceEvidence
@@ -1477,6 +1486,10 @@ export function createStage1NormalizationService(
         salesforceEventContext: parsed.salesforceEventContext,
         projectDimensions: parsed.projectDimensions,
         expeditionDimensions: parsed.expeditionDimensions
+      }, {
+        allowDuplicateGmailMessageDetailOverwrite:
+          sourceEvidenceResult.outcome !== "duplicate" ||
+          (options?.overwriteDuplicateGmailMessageDetail ?? true)
       });
 
       const duplicateCollapseDecision = decideDuplicateCollapse(parsed);

--- a/packages/domain/src/persistence.ts
+++ b/packages/domain/src/persistence.ts
@@ -148,7 +148,6 @@ function sameSourceEvidenceRecord(
     incoming.providerRecordType === existing.providerRecordType &&
     incoming.providerRecordId === existing.providerRecordId &&
     incoming.occurredAt === existing.occurredAt &&
-    incoming.payloadRef === existing.payloadRef &&
     incoming.idempotencyKey === existing.idempotencyKey &&
     incoming.checksum === existing.checksum
   );

--- a/packages/integrations/src/providers/gmail-mbox.ts
+++ b/packages/integrations/src/providers/gmail-mbox.ts
@@ -38,6 +38,25 @@ function normalizeLineEndings(value: string): string {
   return value.replace(/\r\n/gu, "\n").replace(/\r/gu, "\n");
 }
 
+function normalizeRecordIdEmail(value: string | null | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function uniqueNormalizedStrings(values: readonly (string | null | undefined)[]): string[] {
+  return Array.from(
+    new Set(
+      values
+        .map((value) => normalizeRecordIdEmail(value))
+        .filter((value): value is string => value !== null)
+    )
+  ).sort((left, right) => left.localeCompare(right));
+}
+
 function splitMboxMessages(mboxText: string): ParsedMboxMessage[] {
   const normalized = normalizeLineEndings(mboxText);
   const lines = normalized.split("\n");
@@ -141,7 +160,29 @@ function buildThreadId(headers: Readonly<Record<string, string>>): string | null
   return inReplyTo !== null && inReplyTo.length > 0 ? inReplyTo : null;
 }
 
-function buildMboxRecordId(input: {
+function normalizeRfc822MessageId(value: string | null | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized.length > 0 ? normalized : null;
+}
+
+export function buildMboxRecordId(input: {
+  readonly rawMessage: string;
+  readonly rfc822MessageId: string | null | undefined;
+}): string {
+  const normalizedRfc822MessageId = normalizeRfc822MessageId(input.rfc822MessageId);
+
+  if (normalizedRfc822MessageId !== null) {
+    return `mbox:${sha256Text(normalizedRfc822MessageId)}`;
+  }
+
+  return `mbox:${sha256Text(normalizeLineEndings(input.rawMessage))}`;
+}
+
+export function buildLegacyMboxRecordId(input: {
   readonly rawMessage: string;
   readonly capturedMailbox: string;
 }): string {
@@ -150,8 +191,47 @@ function buildMboxRecordId(input: {
   )}`;
 }
 
+export function buildLegacyMboxRecordIdCandidates(input: {
+  readonly rawMessage: string;
+  readonly capturedMailbox: string;
+  readonly liveAccount: string;
+  readonly projectInboxAliases: readonly string[];
+  readonly projectInboxAliasOverride: string | null;
+}): string[] {
+  return uniqueNormalizedStrings([
+    input.capturedMailbox,
+    input.liveAccount,
+    input.projectInboxAliasOverride,
+    ...input.projectInboxAliases
+  ]).map((capturedMailbox) =>
+    buildLegacyMboxRecordId({
+      rawMessage: input.rawMessage,
+      capturedMailbox
+    })
+  );
+}
+
+export interface GmailMboxRecordIdResolutionInput {
+  readonly messageIndex: number;
+  readonly rawMessage: string;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly checksum: string;
+  readonly preferredRecordId: string;
+  readonly legacyRecordIds: readonly string[];
+  readonly rfc822MessageId: string | null;
+  readonly capturedMailbox: string;
+  readonly payloadRef: string;
+}
+
+export interface GmailMboxImportOptions {
+  readonly resolveRecordId?: (
+    input: GmailMboxRecordIdResolutionInput
+  ) => Promise<string> | string;
+}
+
 export async function importGmailMboxRecords(
-  input: GmailMboxImportInput
+  input: GmailMboxImportInput,
+  options?: GmailMboxImportOptions
 ): Promise<GmailRecord[]> {
   const parsedInput = gmailMboxImportSchema.parse(input);
   const messages = splitMboxMessages(parsedInput.mboxText);
@@ -159,14 +239,34 @@ export async function importGmailMboxRecords(
     parsedInput.limit === null ? messages : messages.slice(0, parsedInput.limit);
 
   return Promise.all(selectedMessages.map(async (message) => {
-    const recordId = buildMboxRecordId({
+    const rfc822MessageId = message.headers["Message-ID"]?.trim() ?? null;
+    const preferredRecordId = buildMboxRecordId({
       rawMessage: message.rawMessage,
-      capturedMailbox: parsedInput.capturedMailbox
+      rfc822MessageId
     });
     const payloadRef = `mbox://${encodeURIComponent(parsedInput.mboxPath)}#message=${String(
       message.index + 1
     )}`;
     const checksum = sha256Text(normalizeLineEndings(message.rawMessage));
+    const legacyRecordIds = buildLegacyMboxRecordIdCandidates({
+      rawMessage: message.rawMessage,
+      capturedMailbox: parsedInput.capturedMailbox,
+      liveAccount: parsedInput.liveAccount,
+      projectInboxAliases: parsedInput.projectInboxAliases,
+      projectInboxAliasOverride: parsedInput.projectInboxAliasOverride
+    });
+    const recordId =
+      (await options?.resolveRecordId?.({
+        messageIndex: message.index + 1,
+        rawMessage: message.rawMessage,
+        headers: message.headers,
+        checksum,
+        preferredRecordId,
+        legacyRecordIds,
+        rfc822MessageId,
+        capturedMailbox: parsedInput.capturedMailbox,
+        payloadRef
+      })) ?? preferredRecordId;
     const internalDate =
       toSafeIsoTimestamp(message.headers.Date) ?? parsedInput.receivedAt;
     const bodyTextPreview = await extractGmailBodyPreviewFromMimeMessage({

--- a/packages/integrations/test/stage1-gmail-mbox.test.ts
+++ b/packages/integrations/test/stage1-gmail-mbox.test.ts
@@ -191,6 +191,96 @@ Message-ID: <gmail-mbox-${testCase.name}@example.org>
     }
   });
 
+  it("uses Message-ID to keep mbox record ids stable across captured mailbox changes", async () => {
+    const firstRecord = (await importGmailMboxRecords({
+      mboxText,
+      mboxPath: "/tmp/project-antarctica-a.mbox",
+      capturedMailbox: "project-antarctica@example.org",
+      liveAccount: "volunteers@adventurescientists.org",
+      projectInboxAliases: ["project-antarctica@example.org"],
+      receivedAt: "2026-01-03T00:05:00.000Z"
+    }))[0];
+    const secondRecord = (await importGmailMboxRecords({
+      mboxText,
+      mboxPath: "/tmp/project-antarctica-b.mbox",
+      capturedMailbox: "volunteers@adventurescientists.org",
+      liveAccount: "volunteers@adventurescientists.org",
+      projectInboxAliases: ["project-antarctica@example.org"],
+      receivedAt: "2026-01-03T00:06:00.000Z"
+    }))[0];
+
+    expect(firstRecord).toMatchObject({
+      recordType: "message"
+    });
+    expect(secondRecord).toMatchObject({
+      recordType: "message"
+    });
+
+    if (
+      firstRecord?.recordType !== "message" ||
+      secondRecord?.recordType !== "message" ||
+      !("checksum" in firstRecord) ||
+      !("checksum" in secondRecord)
+    ) {
+      throw new Error("Expected imported Gmail .mbox records to be messages.");
+    }
+
+    expect(firstRecord.recordId).toBe(secondRecord.recordId);
+    expect(firstRecord.checksum).toBe(secondRecord.checksum);
+  });
+
+  it("falls back to content hashing when Message-ID is absent", async () => {
+    const firstRecord = (await importGmailMboxRecords({
+      mboxText: `From MAILER-DAEMON Fri Jan 03 00:00:00 2026
+Date: Fri, 03 Jan 2026 00:00:00 +0000
+From: Volunteer <volunteer@example.org>
+To: Project Antarctica <project-antarctica@example.org>
+Subject: Historical volunteer reply
+
+Hello from an exported mailbox.
+`,
+      mboxPath: "/tmp/project-antarctica-no-id-a.mbox",
+      capturedMailbox: "project-antarctica@example.org",
+      liveAccount: "volunteers@adventurescientists.org",
+      projectInboxAliases: ["project-antarctica@example.org"],
+      receivedAt: "2026-01-03T00:05:00.000Z"
+    }))[0];
+    const secondRecord = (await importGmailMboxRecords({
+      mboxText: `From MAILER-DAEMON Fri Jan 03 00:00:00 2026
+Date: Fri, 03 Jan 2026 00:00:00 +0000
+From: Volunteer <volunteer@example.org>
+To: Project Antarctica <project-antarctica@example.org>
+Subject: Historical volunteer reply
+
+Hello from a different exported mailbox body.
+`,
+      mboxPath: "/tmp/project-antarctica-no-id-b.mbox",
+      capturedMailbox: "project-antarctica@example.org",
+      liveAccount: "volunteers@adventurescientists.org",
+      projectInboxAliases: ["project-antarctica@example.org"],
+      receivedAt: "2026-01-03T00:06:00.000Z"
+    }))[0];
+
+    expect(firstRecord).toMatchObject({
+      recordType: "message"
+    });
+    expect(secondRecord).toMatchObject({
+      recordType: "message"
+    });
+
+    if (
+      firstRecord?.recordType !== "message" ||
+      secondRecord?.recordType !== "message" ||
+      !("checksum" in firstRecord) ||
+      !("checksum" in secondRecord)
+    ) {
+      throw new Error("Expected imported Gmail .mbox records to be messages.");
+    }
+
+    expect(firstRecord.recordId).not.toBe(secondRecord.recordId);
+    expect(firstRecord.checksum).not.toBe(secondRecord.checksum);
+  });
+
   it("normalizes missing or blank subjects to null while preserving non-empty and decoded live subjects", () => {
     const cases = [
       {


### PR DESCRIPTION
## Summary
- stabilize Gmail `.mbox` provider record IDs around RFC 822 `Message-ID`, with a checksum fallback when `Message-ID` is absent
- resolve legacy Stage 1 `.mbox` record IDs in the worker so re-imports reuse existing `source_evidence_log` rows instead of creating new replay or canonical-event conflicts
- treat a moved `.mbox` `payloadRef` as a duplicate-safe replay when the idempotency key and checksum already match, and add an opt-in `--overwrite-bodies` flag for duplicate re-import detail refreshes

## Diagnosed root cause
I reproduced the quarantine path with a single-message import using the Stage 1 Gmail `.mbox` fixture and the real worker import service.

What the repro showed:
- Re-importing the exact same message bytes with the same `capturedMailbox` but a different `mboxPath` reproduced the prod-shaped audit payload:
  - `policyCode = stage1.quarantine.replay_checksum_mismatch`
  - `metadataJson.conflictReason = idempotency_key_mismatch`
  - `incomingId` and `conflictingRecordIds[0]` were the same `source-evidence:gmail:message:mbox:...` row
- Changing only `capturedMailbox` produced a different failure mode (`stage1.quarantine.duplicate_collapse_conflict` on the canonical event), not the replay-checksum quarantine seen in prod.

That means the blocking prod quarantine is coming from `payloadRef` drift on replay, not from the mailbox hash drift itself. The mailbox-derived `providerRecordId` was still a real latent bug though, so this PR fixes both:
- immediate blocker: `payloadRef`-only replays no longer quarantine
- latent bug: new `.mbox` record IDs are stable across mailbox label changes and re-exports

## Implementation details
- `packages/integrations/src/providers/gmail-mbox.ts`
  - `buildMboxRecordId` now prefers lower-cased RFC 822 `Message-ID`
  - falls back to the normalized raw-message checksum hash when `Message-ID` is absent
  - keeps legacy candidate ID helpers so the worker can match existing Stage 1 rows without rewriting them
- `apps/worker/src/ops/gmail-mbox.ts`
  - resolves preferred vs legacy `.mbox` IDs before ingest
  - records `stage1.mapper.gmail_mbox_record_id_compatibility` audit evidence when an existing legacy row is reused
  - threads the new `overwriteBodies` option through historical Gmail ingest
- `packages/domain/src/persistence.ts`
  - replay dedupe no longer treats `payloadRef` drift alone as a source-evidence conflict
- `packages/domain/src/normalization.ts`
  - duplicate Gmail detail overwrites are now controllable, so `.mbox` re-imports preserve existing previews by default and only refresh them when explicitly requested
- `apps/worker/src/ops/cli.ts` + `apps/worker/README.md`
  - adds and documents `--overwrite-bodies`

## Manual verification recipe
1. Against a scratch DB, run a single-message `.mbox` import from one path:
   - `pnpm ops:worker:import-gmail-mbox -- --mbox-path /tmp/original/orcas.mbox --captured-mailbox orcas@adventurescientists.org --limit 1`
2. Re-run the same single message from a second path:
   - `pnpm ops:worker:import-gmail-mbox -- --mbox-path '/tmp/mbox/MBox Files/orcas.mbox' --captured-mailbox orcas@adventurescientists.org --limit 1`
3. Confirm the second run reports `duplicate: 1` and `quarantined: 0`.
4. Re-run with `--overwrite-bodies` only if you want the duplicate replay to refresh `subject`, `snippetClean`, and `bodyTextPreview`.
5. Inspect the matching row with the SQL below to confirm the existing `source_evidence_log` row was reused instead of quarantined.

## Targeted SQL for prod diagnosis / spot-check
Replace the placeholders with the values printed from the single-message dry run (`Message-ID`, checksum, preferred stable record ID, and any legacy candidate record ID you want to compare):

```sql
select
  se.id,
  se.provider_record_id,
  se.idempotency_key,
  se.checksum,
  se.payload_ref,
  se.occurred_at,
  gmd.rfc822_message_id,
  gmd.captured_mailbox,
  gmd.project_inbox_alias
from source_evidence_log se
left join gmail_message_details gmd
  on gmd.source_evidence_id = se.id
where se.provider = 'gmail'
  and se.provider_record_type = 'message'
  and (
    gmd.rfc822_message_id = '<message-id>'
    or se.provider_record_id in ('<preferred-record-id>', '<legacy-record-id>')
    or se.checksum = '<checksum>'
  )
order by se.created_at desc;
```

This query is the quickest way to confirm the prod-shaped failure mode:
- if the row already exists with the same `provider_record_id` and checksum but a different `payload_ref`, the old code would quarantine it as `replay_checksum_mismatch`
- after this fix, the worker should reuse that existing row instead

## Tests and verification
- `pnpm --filter @as-comms/integrations typecheck`
- `pnpm --filter @as-comms/integrations test:unit`
- `pnpm exec vitest run --config ../../vitest.config.ts test/stage1-gmail-mbox-import.test.ts` (from `apps/worker`)
- `pnpm exec vitest run --config ../../vitest.config.ts test/stage1-persistence.test.ts` (from `packages/db`)
- `pnpm --filter @as-comms/worker typecheck`
- `pnpm --filter @as-comms/worker build`
- `pnpm lint`
- `pnpm boundaries`
- `pnpm verify`
