### PR TITLE
fix(settings): drop duplicate page title + subtitle copy

### DIFF
--- a/apps/web/app/settings/_components/access-section.tsx
+++ b/apps/web/app/settings/_components/access-section.tsx
@@ -208,7 +208,6 @@ export function AccessSection({
     <SettingsSection
       id="settings-access"
       title="Access"
-      description="Teammates with access to this workspace. Admins can change roles and deactivate accounts."
       action={
         isAdmin ? (
           <Button

--- a/apps/web/app/settings/_components/active-projects-section.tsx
+++ b/apps/web/app/settings/_components/active-projects-section.tsx
@@ -61,7 +61,6 @@ export function ActiveProjectsSection({
     <SettingsSection
       id="settings-active-projects"
       title="Active Projects"
-      description="Each active project receives inbound mail at its connected addresses."
       action={
         isAdmin ? (
           <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>

--- a/apps/web/app/settings/_components/integrations-section.tsx
+++ b/apps/web/app/settings/_components/integrations-section.tsx
@@ -134,7 +134,6 @@ export function IntegrationsSection({
       <SettingsSection
         id="settings-integrations"
         title="Integrations"
-        description="Providers connected to your workspace. Trigger a manual refresh when you need the latest data."
         feedback={feedback}
       >
         <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">

--- a/apps/web/app/settings/_components/project-detail.tsx
+++ b/apps/web/app/settings/_components/project-detail.tsx
@@ -127,11 +127,11 @@ export function ProjectDetail({ project, isAdmin }: ProjectDetailProps) {
 
   return (
     <div className="flex max-w-3xl flex-col gap-8">
-      <div>
+      <div className="flex flex-col gap-2">
         <Link
           href="/settings/active-projects"
           className={cn(
-            "inline-flex items-center gap-1.5 text-sm font-medium text-slate-600 hover:text-slate-900",
+            "inline-flex items-center gap-1.5 self-start text-sm font-medium text-slate-600 hover:text-slate-900",
             TRANSITION.fast,
             FOCUS_RING,
             RADIUS.sm
@@ -140,6 +140,9 @@ export function ProjectDetail({ project, isAdmin }: ProjectDetailProps) {
           <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
           Back to Active Projects
         </Link>
+        <h1 className="text-lg font-semibold tracking-tight text-slate-950">
+          {project.name}
+        </h1>
       </div>
 
       {feedback ? (

--- a/apps/web/app/settings/_components/settings-content.tsx
+++ b/apps/web/app/settings/_components/settings-content.tsx
@@ -1,46 +1,16 @@
 import type { ReactNode } from "react";
 
-import { LAYOUT, TEXT } from "@/app/_lib/design-tokens";
-import { cn } from "@/lib/utils";
-
 interface SettingsContentProps {
-  readonly title: string;
-  readonly description?: string;
-  readonly action?: ReactNode;
   readonly children: ReactNode;
 }
 
 /**
- * Column 3 shell. Matches the inbox detail column: fixed header height,
- * sticky border, then scrollable content beneath. Every section-level page
- * renders through this so header spacing stays consistent.
+ * Column 3 shell. A padded scroll container — page titles live inside each
+ * section (on the grey surface) so the shell stays unopinionated.
  */
-export function SettingsContent({
-  title,
-  description,
-  action,
-  children
-}: SettingsContentProps) {
+export function SettingsContent({ children }: SettingsContentProps) {
   return (
     <div className="flex min-w-0 flex-1 flex-col">
-      <header
-        className={cn(
-          "flex shrink-0 items-center justify-between gap-4 border-b border-slate-200 bg-white px-6",
-          LAYOUT.headerHeight
-        )}
-      >
-        <div className="min-w-0">
-          <h1 className={TEXT.headingSm}>{title}</h1>
-          {description ? (
-            <p className={cn(TEXT.caption, "mt-0.5 truncate")}>
-              {description}
-            </p>
-          ) : null}
-        </div>
-        {action ? (
-          <div className="flex shrink-0 items-center gap-2">{action}</div>
-        ) : null}
-      </header>
       <div className="flex-1 overflow-y-auto px-6 py-6">{children}</div>
     </div>
   );

--- a/apps/web/app/settings/_components/settings-section-nav.tsx
+++ b/apps/web/app/settings/_components/settings-section-nav.tsx
@@ -75,12 +75,7 @@ export function SettingsSectionNav() {
           SPACING.section
         )}
       >
-        <div>
-          <h2 className={TEXT.headingSm}>Settings</h2>
-          <p className={cn(TEXT.caption, "mt-0.5")}>
-            Workspace configuration.
-          </p>
-        </div>
+        <h2 className={TEXT.headingSm}>Settings</h2>
       </div>
 
       <nav className="flex flex-col gap-0.5 p-2">

--- a/apps/web/app/settings/_components/settings-section.tsx
+++ b/apps/web/app/settings/_components/settings-section.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
 
-import { TEXT } from "@/app/_lib/design-tokens";
 import { cn } from "@/lib/utils";
 
 interface FeedbackState {
@@ -11,7 +10,6 @@ interface FeedbackState {
 interface SettingsSectionProps {
   readonly id: string;
   readonly title: string;
-  readonly description: string;
   readonly action?: ReactNode;
   readonly feedback?: FeedbackState | null;
   readonly children: ReactNode;
@@ -27,7 +25,6 @@ interface SettingsSectionProps {
 export function SettingsSection({
   id,
   title,
-  description,
   action,
   feedback,
   children
@@ -40,18 +37,13 @@ export function SettingsSection({
       aria-labelledby={headingId}
       className="flex min-w-0 flex-col gap-4"
     >
-      <header className="flex flex-wrap items-start justify-between gap-4">
-        <div className="min-w-0 flex-1">
-          <h2
-            id={headingId}
-            className="text-lg font-semibold tracking-tight text-slate-950"
-          >
-            {title}
-          </h2>
-          <p className={cn("mt-1 max-w-2xl", TEXT.bodySm, "text-slate-600")}>
-            {description}
-          </p>
-        </div>
+      <header className="flex flex-wrap items-center justify-between gap-4">
+        <h2
+          id={headingId}
+          className="text-lg font-semibold tracking-tight text-slate-950"
+        >
+          {title}
+        </h2>
         {action ? (
           <div className="flex shrink-0 items-center gap-2">{action}</div>
         ) : null}

--- a/apps/web/app/settings/access/page.tsx
+++ b/apps/web/app/settings/access/page.tsx
@@ -48,10 +48,7 @@ export default async function SettingsAccessPage() {
   const isAdmin = currentUser.role === "admin";
 
   return (
-    <SettingsContent
-      title="Access"
-      description="Teammates with access to this workspace. Admins can change roles and deactivate accounts."
-    >
+    <SettingsContent>
       <AccessSection
         users={users}
         currentUserId={currentUser.id}

--- a/apps/web/app/settings/active-projects/[projectId]/page.tsx
+++ b/apps/web/app/settings/active-projects/[projectId]/page.tsx
@@ -37,7 +37,7 @@ export default async function SettingsProjectDetailPage({ params }: PageProps) {
   const isAdmin = currentUser.role === "admin";
 
   return (
-    <SettingsContent title={project.name}>
+    <SettingsContent>
       <ProjectDetail project={project} isAdmin={isAdmin} />
     </SettingsContent>
   );

--- a/apps/web/app/settings/active-projects/page.tsx
+++ b/apps/web/app/settings/active-projects/page.tsx
@@ -30,10 +30,7 @@ export default async function SettingsActiveProjectsPage() {
   const activeProjects = MOCK_PROJECTS.filter((project) => project.active);
 
   return (
-    <SettingsContent
-      title="Active Projects"
-      description="Projects currently routing inbound mail. Click a row to edit its alias and connected addresses."
-    >
+    <SettingsContent>
       <ActiveProjectsSection
         projects={activeProjects}
         inactiveProjects={MOCK_INACTIVE_PROJECTS}

--- a/apps/web/app/settings/integrations/page.tsx
+++ b/apps/web/app/settings/integrations/page.tsx
@@ -26,10 +26,7 @@ export default async function SettingsIntegrationsPage() {
   const isAdmin = currentUser.role === "admin";
 
   return (
-    <SettingsContent
-      title="Integrations"
-      description="Providers connected to your workspace. Syncs run on demand from here."
-    >
+    <SettingsContent>
       <IntegrationsSection
         integrations={MOCK_INTEGRATIONS}
         isAdmin={isAdmin}


### PR DESCRIPTION
## Summary
- Remove the white-bar header rendered by `SettingsContent` — its title duplicated the one the section already shows on the grey surface
- Drop the "Workspace configuration." caption under the left-nav "Settings" heading
- Strip the `description` prop from `SettingsSection`; the three section callers no longer pass subtitle copy
- Move the project-name `<h1>` into `ProjectDetail` so the detail view keeps a visible title after the shell header went away

## Test plan
- [x] Preview verified: `/settings/active-projects`, `/settings/access`, `/settings/integrations`, and `/settings/active-projects/[id]` all render one title each on the grey surface; no white bar, no subtitle copy under section titles
- [x] Left-nav column shows "Settings" without the "Workspace configuration." subtitle
- [x] Typecheck + lint green
- [x] No console errors during navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)