### PR TITLE
feat(inbox): collapsible filter panel + drop Unread state chip

### DIFF
--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -201,11 +201,6 @@ export function InboxDetail({ detail }: DetailProps) {
               )}
             </div>
             <div className="hidden items-center gap-1.5 sm:flex">
-              {detail.bucket === "new" ? (
-                <span className="inline-flex items-center rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-[11px] font-medium text-sky-800">
-                  Unread
-                </span>
-              ) : null}
               {isFollowUp ? (
                 <span className="inline-flex items-center rounded-full border border-rose-200 bg-rose-50 px-2 py-0.5 text-[11px] font-medium text-rose-800">
                   Needs Follow-Up

--- a/apps/web/app/inbox/_components/inbox-list.tsx
+++ b/apps/web/app/inbox/_components/inbox-list.tsx
@@ -8,12 +8,19 @@ import type {
   InboxListViewModel
 } from "../_lib/view-models";
 import { fetchInboxListPage } from "../_lib/client-api";
+import { DISPLAY_INBOX_FILTERS } from "../_lib/filters";
+import {
+  Collapsible,
+  CollapsibleContent
+} from "@/components/ui/collapsible";
 import { EmptyState } from "@/components/ui/empty-state";
+import { cn } from "@/lib/utils";
 
 import { extractInboxContactId } from "./inbox-keyboard-helpers";
 import { useInboxClient } from "./inbox-client-provider";
 import { FOCUS_RING, LAYOUT, RADIUS, SHADOW, TEXT, TRANSITION } from "@/app/_lib/design-tokens";
 import {
+  FilterIcon,
   InboxIcon,
   SearchIcon,
   SearchXIcon,
@@ -27,12 +34,11 @@ interface ListColumnProps {
   readonly initialFilterId?: InboxFilterId;
 }
 
-const FILTER_IDS: readonly InboxFilterId[] = [
-  "all",
-  "unread",
-  "follow-up",
-  "unresolved"
-];
+const DISPLAY_FILTER_IDS: readonly InboxFilterId[] = DISPLAY_INBOX_FILTERS.map(
+  (filter) => filter.id
+);
+
+const DEFAULT_TITLE = "Inbox";
 
 export function InboxList({
   initialList,
@@ -57,6 +63,7 @@ export function InboxList({
   const [currentList, setCurrentList] = useState(initialList);
   const [queueError, setQueueError] = useState<string | null>(null);
   const [isFilterTransitionPending, startFilterTransition] = useTransition();
+  const [filterPanelOpen, setFilterPanelOpen] = useState(false);
   const activeRequestIdRef = useRef(0);
   const previousFilterRef = useRef<InboxFilterId>(initialFilterId);
   const latestShellStateRef = useRef({
@@ -226,14 +233,38 @@ export function InboxList({
 
   const shouldShowInitialSkeleton = isQueueLoading && currentList.items.length === 0;
   const canLoadMore = currentList.page.hasMore && currentList.page.nextCursor !== null;
+  const titleLabel =
+    filterLabels.get(activeFilter) ??
+    DISPLAY_INBOX_FILTERS.find((filter) => filter.id === activeFilter)?.label ??
+    DEFAULT_TITLE;
 
   return (
     <section className={`relative flex ${LAYOUT.listWidth} shrink-0 flex-col overflow-hidden border-r border-slate-200 bg-white`}>
       <div className="sticky top-0 z-10 bg-white/95 backdrop-blur">
         <div className={`flex ${LAYOUT.headerHeight} items-center gap-2 border-b border-slate-200 px-5`}>
           <h1 className={`min-w-0 flex-1 truncate ${TEXT.headingLg}`}>
-            Inbox
+            {titleLabel}
           </h1>
+          <button
+            type="button"
+            aria-label={filterPanelOpen ? "Close filters" : "Open filters"}
+            aria-expanded={filterPanelOpen}
+            aria-controls="inbox-filter-panel"
+            onClick={() => {
+              setFilterPanelOpen((open) => !open);
+            }}
+            className={cn(
+              `inline-flex h-8 w-8 shrink-0 items-center justify-center ${RADIUS.md} border`,
+              TRANSITION.fast,
+              TRANSITION.reduceMotion,
+              FOCUS_RING,
+              filterPanelOpen
+                ? "border-slate-300 bg-slate-100 text-slate-900"
+                : "border-slate-200 bg-white text-slate-500 hover:bg-slate-50 hover:text-slate-900"
+            )}
+          >
+            <FilterIcon className="h-4 w-4" />
+          </button>
         </div>
 
         <div className="px-5 pb-3 pt-3">
@@ -264,33 +295,55 @@ export function InboxList({
           </label>
         </div>
 
-        <div className="flex flex-wrap gap-1.5 px-5 pb-3">
-          {FILTER_IDS.map((id) => {
-            const isActive = activeFilter === id;
-            return (
-              <button
-                key={id}
-                type="button"
-                aria-pressed={isActive}
-                onClick={() => {
-                  startFilterTransition(() => {
-                    setActiveFilter(id);
-                  });
-                }}
-                className={`rounded-full px-2.5 py-1 text-xs font-medium ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion} ${
-                  isActive
-                    ? "bg-slate-900 text-white"
-                    : "bg-slate-100 text-slate-600 hover:bg-slate-200"
-                }`}
-              >
-                {filterLabels.get(id) ?? id}{" "}
-                <span className={isActive ? "text-slate-300" : "text-slate-400"}>
-                  {filterCounts[id]}
-                </span>
-              </button>
-            );
-          })}
-        </div>
+        <Collapsible open={filterPanelOpen} onOpenChange={setFilterPanelOpen}>
+          <CollapsibleContent
+            id="inbox-filter-panel"
+            className="border-t border-slate-100 px-5 pb-3 pt-3"
+          >
+            <div className="flex flex-col gap-2">
+              <p className={TEXT.label}>Status</p>
+              <div className="flex flex-wrap gap-1.5">
+                {DISPLAY_FILTER_IDS.map((id) => {
+                  const isActive = activeFilter === id;
+                  const showCount = id !== "all";
+                  return (
+                    <button
+                      key={id}
+                      type="button"
+                      aria-pressed={isActive}
+                      onClick={() => {
+                        startFilterTransition(() => {
+                          setActiveFilter(id);
+                        });
+                      }}
+                      className={cn(
+                        "rounded-full px-2.5 py-1 text-xs font-medium",
+                        TRANSITION.fast,
+                        TRANSITION.reduceMotion,
+                        FOCUS_RING,
+                        isActive
+                          ? "bg-slate-900 text-white"
+                          : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                      )}
+                    >
+                      {filterLabels.get(id) ?? id}
+                      {showCount ? (
+                        <span
+                          className={cn(
+                            "ml-1 tabular-nums",
+                            isActive ? "text-slate-300" : "text-slate-400"
+                          )}
+                        >
+                          {filterCounts[id]}
+                        </span>
+                      ) : null}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
 
         {queueError ? (
           <div className="border-t border-rose-100 bg-rose-50 px-5 py-2 text-xs text-rose-700">

--- a/apps/web/app/inbox/_lib/filters.ts
+++ b/apps/web/app/inbox/_lib/filters.ts
@@ -21,3 +21,11 @@ export const INBOX_FILTERS: readonly FilterDefinition[] = [
   { id: "follow-up", label: "Needs Follow-Up", hint: "Flagged by you" },
   { id: "unresolved", label: "Unresolved", hint: "Has pending review items" }
 ];
+
+/**
+ * Filters surfaced in the list column filter panel. Unresolved is tracked
+ * server-side and surfaced via the detail rail + banner, not offered as a
+ * top-level filter — operators triage it per row.
+ */
+export const DISPLAY_INBOX_FILTERS: readonly FilterDefinition[] =
+  INBOX_FILTERS.filter((filter) => filter.id !== "unresolved");


### PR DESCRIPTION
## Summary
- Move status filters behind a Filter button next to the list title. The title itself reflects the active status (**All** / **Unread** / **Needs Follow-Up**), so operators see their current scope in the column header instead of a chip strip.
- Filter button opens a `Collapsible` panel between the search bar and the row list with the three status options. Counts render with `tabular-nums` and the "All" option has no count (per spec).
- **Unresolved** is removed from the top-level filter surface. The `InboxFilterId` type, `INBOX_FILTERS` constant, selector counts, and unit tests all remain intact — operators triage unresolved items per-row via the existing detail rail + amber banner.
- Drops the **Unread** chip in the detail header (`bucket === "new"`). The inbox row indicator already conveys unread state; the detail chip was redundant.
- Needs-Follow-Up and Unresolved state chips in the detail header are unchanged.

## Scope boundary
This is **PR 1** of a planned three. Project filter plumbing is not in this PR — it needs a server-side param on `listPageOrderedByRecency` / `searchPageOrderedByRecency` / `countByFilters` plus a new `getActiveProjects()` selector, which lands next:

- **PR 2 (next)** — server-plumbed project filter driven by Settings Active Projects. Adds `projectId` to the repo signatures + viewmodel + UI.
- **PR 3 (next)** — polish pass using the `make-interfaces-feel-better` skill on rows, timeline, and the filter panel itself.

## Changed files
- `apps/web/app/inbox/_lib/filters.ts` — adds `DISPLAY_INBOX_FILTERS` subset (excludes `unresolved`); keeps `INBOX_FILTERS` and the type untouched so selectors, tests, and the Unresolved state pipeline keep working.
- `apps/web/app/inbox/_components/inbox-list.tsx` — header now renders the active-filter label; adds Filter button (SlidersHorizontal icon) on the right; replaces the flex-wrap chip row with a Radix `Collapsible` panel between search and rows.
- `apps/web/app/inbox/_components/inbox-detail.tsx` — removes the `detail.bucket === "new"` "Unread" chip.

## Non-goals (confirmed with architect)
- Don't remove `unresolved` from `InboxFilterId` / totals — still server-tracked, rail still needs it.
- No project filter in this PR.
- No change to keyboard shortcuts (`/`, `j`, `k`, `Enter`, `Esc`, `f`, `?`).

## Test plan
- [x] `pnpm --filter @as-comms/web lint` — green
- [x] `pnpm --filter @as-comms/web typecheck` — green
- [x] `pnpm boundaries` — green
- [x] `pnpm --filter @as-comms/web test:unit` — 56/56 passing (run in main tree; worktree hit the known macOS rollup-darwin signature gotcha which is environmental)
- [ ] Manual QA on `/inbox`: toggle filter panel, switch between All/Unread/Follow-Up, verify title updates, verify Unresolved chip no longer appears in the filter surface and row/rail indicators remain intact
- [ ] Manual QA on `/inbox/[contactId]`: confirm "Unread" chip no longer renders in the detail header; confirm Follow-Up and Unresolved chips still render when applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)