### PR TITLE
fix(integrations): preserve Salesforce response body in token errors

### DIFF
--- a/apps/worker/test/integration-health-task.test.ts
+++ b/apps/worker/test/integration-health-task.test.ts
@@ -19,34 +19,38 @@ function toRequestUrl(input: string | URL | Request): string {
 describe("integration health poller task", () => {
   it("upserts Gmail and Salesforce health rows without crashing on partial failures", async () => {
     const fetchImplementation = vi.fn(
-      async (input: string | URL | Request): Promise<Response> => {
+      (input: string | URL | Request): Promise<Response> => {
         const url = toRequestUrl(input);
 
         if (url === "https://gmail-capture.example.test/health") {
-          return new Response(
-            JSON.stringify({
-              service: "gmail",
-              status: "healthy",
-              checkedAt: "2026-04-20T16:00:00.000Z",
-              detail: null,
-              version: "gmail-sha"
-            }),
-            {
-              status: 200,
-              headers: {
-                "content-type": "application/json"
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                service: "gmail",
+                status: "healthy",
+                checkedAt: "2026-04-20T16:00:00.000Z",
+                detail: null,
+                version: "gmail-sha"
+              }),
+              {
+                status: 200,
+                headers: {
+                  "content-type": "application/json"
+                }
               }
-            }
+            )
           );
         }
 
         if (url === "https://salesforce-capture.example.test/health") {
-          return new Response("upstream unavailable", {
-            status: 503
-          });
+          return Promise.resolve(
+            new Response("upstream unavailable", {
+              status: 503
+            })
+          );
         }
 
-        throw new Error(`Unexpected health request: ${url}`);
+        return Promise.reject(new Error(`Unexpected health request: ${url}`));
       }
     );
     const context = await createTestWorkerContext();

--- a/packages/integrations/src/capture-services/salesforce.ts
+++ b/packages/integrations/src/capture-services/salesforce.ts
@@ -238,13 +238,13 @@ async function exchangeSalesforceAccessToken(input: {
     if (isDisconnectedSalesforceAuthError(response.status, responseText)) {
       throw new SalesforceHealthCheckError(
         "disconnected",
-        "Invalid or expired credentials."
+        `Invalid or expired credentials: ${responseText}`
       );
     }
 
     throw new SalesforceHealthCheckError(
       "needs_attention",
-      `Salesforce token exchange failed with status ${String(response.status)}.`
+      `Salesforce token exchange failed with status ${String(response.status)}: ${responseText}`
     );
   }
 


### PR DESCRIPTION
Regression from Brief 2 (#60) — the SF token-exchange failure paths now include the response body (invalid_grant, error_description) in the thrown error, restoring the detail the existing unit test expects and giving operators diagnostic info.