### PR TITLE
feat(settings): wire real mutations for projects + integration refresh

### DIFF
--- a/apps/web/app/settings/_components/access-section.tsx
+++ b/apps/web/app/settings/_components/access-section.tsx
@@ -1,22 +1,9 @@
-"use client";
-
-import { useMemo, useState, useTransition } from "react";
-
 import {
-  FOCUS_RING,
   RADIUS,
   SHADOW,
   TEXT,
   TRANSITION
 } from "@/app/_lib/design-tokens";
-import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger
-} from "@/components/ui/dropdown-menu";
 import { StatusBadge } from "@/components/ui/status-badge";
 import { ToneAvatar } from "@/components/ui/tone-avatar";
 import { cn } from "@/lib/utils";
@@ -25,23 +12,7 @@ import type {
   UserRowViewModel
 } from "@/src/server/settings/selectors";
 
-import {
-  deactivateUserAction,
-  demoteUserAction,
-  inviteUserAction,
-  promoteUserAction,
-  reactivateUserAction
-} from "../actions";
 import { SettingsSection } from "./settings-section";
-
-interface AccessSectionProps {
-  readonly viewModel: AccessSettingsViewModel;
-}
-
-interface FeedbackState {
-  readonly kind: "success" | "error";
-  readonly message: string;
-}
 
 const AVATAR_TONES = [
   "indigo",
@@ -70,11 +41,10 @@ function initialsFor(user: UserRowViewModel): string {
 
 function toneFor(user: UserRowViewModel): AvatarTone {
   let hash = 0;
-  for (let i = 0; i < user.userId.length; i += 1) {
-    hash = (hash * 31 + user.userId.charCodeAt(i)) | 0;
+  for (let index = 0; index < user.userId.length; index += 1) {
+    hash = (hash * 31 + user.userId.charCodeAt(index)) | 0;
   }
-  const index = Math.abs(hash) % AVATAR_TONES.length;
-  const tone = AVATAR_TONES[index];
+  const tone = AVATAR_TONES[Math.abs(hash) % AVATAR_TONES.length];
   return tone ?? ("slate" as AvatarTone);
 }
 
@@ -98,136 +68,37 @@ function formatRelative(iso: string | null): string {
   return `${String(years)}y ago`;
 }
 
-export function AccessSection({ viewModel }: AccessSectionProps) {
-  const [rows, setRows] = useState([
-    ...viewModel.admins,
-    ...viewModel.internalUsers
-  ]);
-  const [pending, startTransition] = useTransition();
-  const [pendingRowId, setPendingRowId] = useState<string | null>(null);
-  const [feedback, setFeedback] = useState<FeedbackState | null>(null);
+function sortUsers(
+  rows: readonly UserRowViewModel[],
+  currentUserId: string | null
+): readonly UserRowViewModel[] {
+  const statusRank = {
+    active: 0,
+    pending: 1,
+    deactivated: 2
+  } as const;
 
-  const sorted = useMemo(() => {
-    const statusRank = {
-      active: 0,
-      pending: 1,
-      deactivated: 2
-    } as const;
+  return [...rows].sort((left, right) => {
+    if (left.userId === currentUserId) return -1;
+    if (right.userId === currentUserId) return 1;
 
-    return [...rows].sort((left, right) => {
-      if (left.userId === viewModel.currentUserId) return -1;
-      if (right.userId === viewModel.currentUserId) return 1;
+    const statusDelta = statusRank[left.status] - statusRank[right.status];
+    if (statusDelta !== 0) {
+      return statusDelta;
+    }
 
-      const statusDelta = statusRank[left.status] - statusRank[right.status];
-      if (statusDelta !== 0) {
-        return statusDelta;
-      }
+    return left.displayName.localeCompare(right.displayName);
+  });
+}
 
-      return left.displayName.localeCompare(right.displayName);
-    });
-  }, [rows, viewModel.currentUserId]);
-
-  function announce(message: string, kind: FeedbackState["kind"] = "success") {
-    setFeedback({ kind, message });
-    window.setTimeout(() => {
-      setFeedback(null);
-    }, 3500);
-  }
-
-  function updateRow(id: string, patch: Partial<UserRowViewModel>) {
-    setRows((current) =>
-      current.map((row) => (row.userId === id ? { ...row, ...patch } : row))
-    );
-  }
-
-  function handlePromote(user: UserRowViewModel) {
-    setPendingRowId(user.userId);
-    startTransition(async () => {
-      const formData = new FormData();
-      formData.set("id", user.userId);
-      const result = await promoteUserAction(formData);
-      setPendingRowId(null);
-      if (result.ok) {
-        updateRow(user.userId, { role: "admin" });
-        announce(`${user.displayName} is now an admin. (stub)`);
-      }
-    });
-  }
-
-  function handleDemote(user: UserRowViewModel) {
-    setPendingRowId(user.userId);
-    startTransition(async () => {
-      const formData = new FormData();
-      formData.set("id", user.userId);
-      const result = await demoteUserAction(formData);
-      setPendingRowId(null);
-      if (result.ok) {
-        updateRow(user.userId, { role: "internal_user" });
-        announce(`${user.displayName} is now an internal user. (stub)`);
-      }
-    });
-  }
-
-  function handleDeactivate(user: UserRowViewModel) {
-    setPendingRowId(user.userId);
-    startTransition(async () => {
-      const formData = new FormData();
-      formData.set("id", user.userId);
-      const result = await deactivateUserAction(formData);
-      setPendingRowId(null);
-      if (result.ok) {
-        updateRow(user.userId, { status: "deactivated" });
-        announce(`${user.displayName} deactivated. (stub)`);
-      }
-    });
-  }
-
-  function handleReactivate(user: UserRowViewModel) {
-    setPendingRowId(user.userId);
-    startTransition(async () => {
-      const formData = new FormData();
-      formData.set("id", user.userId);
-      const result = await reactivateUserAction(formData);
-      setPendingRowId(null);
-      if (result.ok) {
-        updateRow(user.userId, {
-          status: user.lastActiveAt === null ? "pending" : "active"
-        });
-        announce(`${user.displayName} reactivated. (stub)`);
-      }
-    });
-  }
-
-  function handleInvite() {
-    startTransition(async () => {
-      const formData = new FormData();
-      formData.set("email", "");
-      formData.set("role", "internal_user");
-      const result = await inviteUserAction(formData);
-      if (result.ok) {
-        announce("Invite flow is not wired yet. (stub)");
-      }
-    });
-  }
+export function AccessSection({ viewModel }: { readonly viewModel: AccessSettingsViewModel }) {
+  const rows = sortUsers(
+    [...viewModel.admins, ...viewModel.internalUsers],
+    viewModel.currentUserId
+  );
 
   return (
-    <SettingsSection
-      id="settings-access"
-      title="Access"
-      action={
-        viewModel.isAdmin ? (
-          <Button
-            type="button"
-            size="sm"
-            onClick={handleInvite}
-            disabled={pending}
-          >
-            Invite teammate
-          </Button>
-        ) : null
-      }
-      feedback={feedback}
-    >
+    <SettingsSection id="settings-access" title="Access">
       <div
         className={cn(
           "overflow-hidden",
@@ -269,28 +140,18 @@ export function AccessSection({ viewModel }: AccessSectionProps) {
               >
                 Last active
               </th>
-              <th
-                scope="col"
-                className={cn(
-                  "px-5 py-3 text-right",
-                  TEXT.label,
-                  "tracking-wider"
-                )}
-              >
-                <span className="sr-only">Actions</span>
-              </th>
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-100">
-            {sorted.map((user) => {
+            {rows.map((user) => {
               const isSelf = user.userId === viewModel.currentUserId;
-              const isRowPending = pending && pendingRowId === user.userId;
+
               return (
                 <tr
                   key={user.userId}
                   className={cn(
                     TRANSITION.fast,
-                    isRowPending ? "opacity-60" : "hover:bg-slate-50/80",
+                    "hover:bg-slate-50/80",
                     user.status === "deactivated" && "bg-slate-50/60"
                   )}
                 >
@@ -313,11 +174,11 @@ export function AccessSection({ viewModel }: AccessSectionProps) {
                           >
                             {user.displayName}
                           </p>
-                          {isSelf && (
+                          {isSelf ? (
                             <span className={cn(TEXT.micro, "text-slate-400")}>
                               (you)
                             </span>
-                          )}
+                          ) : null}
                         </div>
                         <p
                           className={cn(
@@ -347,73 +208,6 @@ export function AccessSection({ viewModel }: AccessSectionProps) {
                     >
                       {formatRelative(user.lastActiveAt)}
                     </span>
-                  </td>
-                  <td className="px-5 py-3 align-middle">
-                    <div className="flex justify-end">
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <button
-                            type="button"
-                            disabled={
-                              !viewModel.isAdmin || isSelf || isRowPending
-                            }
-                            aria-label={`Actions for ${user.displayName}`}
-                            className={cn(
-                              "flex h-8 w-8 items-center justify-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-700",
-                              TRANSITION.fast,
-                              FOCUS_RING,
-                              "disabled:cursor-not-allowed disabled:opacity-40"
-                            )}
-                          >
-                            <MoreIcon className="h-4 w-4" aria-hidden="true" />
-                          </button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end" className="w-52">
-                          {user.status === "deactivated" ? (
-                            <DropdownMenuItem
-                              onSelect={(event) => {
-                                event.preventDefault();
-                                handleReactivate(user);
-                              }}
-                            >
-                              Reactivate
-                            </DropdownMenuItem>
-                          ) : (
-                            <>
-                              {user.role === "internal_user" ? (
-                                <DropdownMenuItem
-                                  onSelect={(event) => {
-                                    event.preventDefault();
-                                    handlePromote(user);
-                                  }}
-                                >
-                                  Promote to admin
-                                </DropdownMenuItem>
-                              ) : (
-                                <DropdownMenuItem
-                                  onSelect={(event) => {
-                                    event.preventDefault();
-                                    handleDemote(user);
-                                  }}
-                                >
-                                  Demote to internal user
-                                </DropdownMenuItem>
-                              )}
-                              <DropdownMenuSeparator />
-                              <DropdownMenuItem
-                                onSelect={(event) => {
-                                  event.preventDefault();
-                                  handleDeactivate(user);
-                                }}
-                                className="text-rose-700 focus:bg-rose-50 focus:text-rose-800"
-                              >
-                                Deactivate
-                              </DropdownMenuItem>
-                            </>
-                          )}
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    </div>
                   </td>
                 </tr>
               );
@@ -474,19 +268,4 @@ function UserStatusBadge({
   }
 
   return null;
-}
-
-function MoreIcon({ className }: { readonly className?: string }) {
-  return (
-    <svg
-      className={className}
-      viewBox="0 0 20 20"
-      fill="currentColor"
-      aria-hidden="true"
-    >
-      <circle cx="4" cy="10" r="1.5" />
-      <circle cx="10" cy="10" r="1.5" />
-      <circle cx="16" cy="10" r="1.5" />
-    </svg>
-  );
 }

--- a/apps/web/app/settings/_components/integrations-section.tsx
+++ b/apps/web/app/settings/_components/integrations-section.tsx
@@ -24,7 +24,7 @@ import type {
   IntegrationsSettingsViewModel
 } from "@/src/server/settings/selectors";
 
-import { syncIntegrationAction } from "../actions";
+import { refreshIntegrationHealthAction } from "../actions";
 import { SettingsSection } from "./settings-section";
 
 interface IntegrationsSectionProps {
@@ -111,9 +111,7 @@ export function IntegrationsSection({ viewModel }: IntegrationsSectionProps) {
   function handleRefresh(integration: IntegrationHealthViewModel) {
     setPendingId(integration.serviceName);
     startTransition(async () => {
-      const formData = new FormData();
-      formData.set("id", integration.serviceName);
-      const result = await syncIntegrationAction(formData);
+      const result = await refreshIntegrationHealthAction(integration.serviceName);
       setPendingId(null);
 
       if (result.ok) {
@@ -122,12 +120,14 @@ export function IntegrationsSection({ viewModel }: IntegrationsSectionProps) {
             item.serviceName === integration.serviceName
               ? {
                   ...item,
-                  lastCheckedAt: new Date().toISOString()
+                  status: result.data.status,
+                  detail: result.data.detail,
+                  lastCheckedAt: result.data.lastCheckedAt
                 }
               : item
           )
         );
-        announce(`Refreshing ${integration.displayName}. (stub)`);
+        announce(`Refreshed ${integration.displayName}.`);
         return;
       }
 

--- a/apps/web/app/settings/_components/project-detail.tsx
+++ b/apps/web/app/settings/_components/project-detail.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useState, useTransition } from "react";
+import { useOptimistic, useState, useTransition } from "react";
 import { ArrowLeft, RefreshCw, Trash2 } from "lucide-react";
 
 import {
@@ -28,29 +27,128 @@ import { cn } from "@/lib/utils";
 import type { ProjectSettingsDetailViewModel } from "@/src/server/settings/selectors";
 
 import {
-  addProjectEmailAction,
+  activateProjectAction,
   deactivateProjectAction,
-  removeProjectEmailAction
+  type ProjectEmailInput,
+  type ProjectMutationData,
+  updateProjectAiKnowledgeAction,
+  updateProjectEmailsAction
 } from "../actions";
-
-interface ProjectDetailProps {
-  readonly project: ProjectSettingsDetailViewModel;
-}
 
 interface FeedbackState {
   readonly kind: "success" | "error";
   readonly message: string;
 }
 
-export function ProjectDetail({ project }: ProjectDetailProps) {
-  const router = useRouter();
-  const [emails, setEmails] = useState(project.emails);
+function hasActivationRequirements(input: {
+  readonly aiKnowledgeUrl: string | null;
+  readonly emails: readonly ProjectEmailInput[];
+}): boolean {
+  return (
+    input.emails.length >= 1 &&
+    (input.aiKnowledgeUrl?.trim().length ?? 0) > 0
+  );
+}
+
+function buildProjectState(
+  project: ProjectSettingsDetailViewModel
+): ProjectMutationData {
+  return {
+    projectId: project.projectId,
+    projectName: project.projectName,
+    isActive: project.isActive,
+    aiKnowledgeUrl: project.aiKnowledgeUrl,
+    aiKnowledgeSyncedAt: project.aiKnowledgeSyncedAt,
+    activationRequirementsMet: project.activationRequirementsMet,
+    emails: project.emails
+  };
+}
+
+function mergeProjectState(
+  current: ProjectMutationData,
+  patch: Partial<ProjectMutationData>
+): ProjectMutationData {
+  const next = {
+    ...current,
+    ...patch
+  };
+
+  return {
+    ...next,
+    activationRequirementsMet: hasActivationRequirements({
+      aiKnowledgeUrl: next.aiKnowledgeUrl,
+      emails: next.emails
+    })
+  };
+}
+
+function promotePrimaryEmail(
+  emails: readonly ProjectEmailInput[],
+  address: string
+): readonly ProjectEmailInput[] {
+  const selected = emails.find((email) => email.address === address);
+  if (!selected) {
+    return emails;
+  }
+
+  return [
+    {
+      address: selected.address,
+      isPrimary: true
+    },
+    ...emails
+      .filter((email) => email.address !== address)
+      .map((email) => ({
+        address: email.address,
+        isPrimary: false
+      }))
+  ];
+}
+
+function removeEmail(
+  emails: readonly ProjectEmailInput[],
+  address: string
+): readonly ProjectEmailInput[] {
+  const remaining = emails.filter((email) => email.address !== address);
+  if (remaining.length === 0) {
+    return [];
+  }
+
+  if (remaining.some((email) => email.isPrimary)) {
+    return remaining;
+  }
+
+  return remaining.map((email, index) => ({
+    address: email.address,
+    isPrimary: index === 0
+  }));
+}
+
+function formatLastSynced(iso: string | null): string {
+  return iso
+    ? `Knowledge last synced ${new Date(iso).toLocaleString()}`
+    : "Knowledge has not been synced yet.";
+}
+
+export function ProjectDetail({
+  project
+}: {
+  readonly project: ProjectSettingsDetailViewModel;
+}) {
+  const [projectState, setProjectState] = useState(() => buildProjectState(project));
+  const [optimisticProject, applyOptimisticProject] = useOptimistic(
+    projectState,
+    mergeProjectState
+  );
+  const [knowledgeDraft, setKnowledgeDraft] = useState(project.aiKnowledgeUrl ?? "");
   const [newEmail, setNewEmail] = useState("");
-  const [emailPending, startEmailTransition] = useTransition();
-  const [deactivatePending, startDeactivateTransition] = useTransition();
-  const [pendingEmail, setPendingEmail] = useState<string | null>(null);
-  const [deactivateOpen, setDeactivateOpen] = useState(false);
   const [feedback, setFeedback] = useState<FeedbackState | null>(null);
+  const [activationMessage, setActivationMessage] = useState<string | null>(null);
+  const [pendingEmail, setPendingEmail] = useState<string | null>(null);
+  const [knowledgePending, startKnowledgeTransition] = useTransition();
+  const [emailPending, startEmailTransition] = useTransition();
+  const [activationPending, startActivationTransition] = useTransition();
+  const [deactivateOpen, setDeactivateOpen] = useState(false);
 
   function announce(message: string, kind: FeedbackState["kind"] = "success") {
     setFeedback({ kind, message });
@@ -59,80 +157,170 @@ export function ProjectDetail({ project }: ProjectDetailProps) {
     }, 3500);
   }
 
+  function commitProject(nextProject: ProjectMutationData) {
+    setProjectState(nextProject);
+    setKnowledgeDraft(nextProject.aiKnowledgeUrl ?? "");
+    setActivationMessage(null);
+  }
+
   function handleKnowledgeSync() {
-    announce("Knowledge sync will be wired in a follow-up brief. (stub)");
+    announce("Knowledge sync stays stubbed in this brief.", "error");
   }
 
   function handleAddEmail() {
-    const trimmed = newEmail.trim();
-    if (trimmed.length === 0) return;
-    if (
-      emails.some(
-        (email) => email.address.toLowerCase() === trimmed.toLowerCase()
-      )
-    ) {
-      announce(`${trimmed} is already connected.`, "error");
+    const normalizedAddress = newEmail.trim().toLowerCase();
+    if (normalizedAddress.length === 0) {
       return;
     }
-    setPendingEmail(trimmed);
+
+    if (
+      optimisticProject.emails.some(
+        (email) => email.address.toLowerCase() === normalizedAddress
+      )
+    ) {
+      announce(`${normalizedAddress} is already connected.`, "error");
+      return;
+    }
+
+    const nextEmails =
+      optimisticProject.emails.length === 0
+        ? [{ address: normalizedAddress, isPrimary: true }]
+        : [
+            ...optimisticProject.emails,
+            { address: normalizedAddress, isPrimary: false }
+          ];
+
+    setPendingEmail(normalizedAddress);
     startEmailTransition(async () => {
-      const formData = new FormData();
-      formData.set("projectId", project.projectId);
-      formData.set("email", trimmed);
-      const result = await addProjectEmailAction(formData);
+      applyOptimisticProject({ emails: nextEmails });
+      const result = await updateProjectEmailsAction(
+        project.projectId,
+        nextEmails
+      );
       setPendingEmail(null);
-      if (result.ok) {
-        setEmails((current) => [
-          ...current,
-          { address: trimmed, isPrimary: current.length === 0 }
-        ]);
-        setNewEmail("");
-        announce(`Added ${trimmed}. (stub)`);
+
+      if (!result.ok) {
+        announce(result.message, "error");
+        return;
       }
+
+      commitProject(result.data);
+      setNewEmail("");
+      announce(`Added ${normalizedAddress}.`);
     });
   }
 
-  function handleRemoveEmail(email: string) {
-    setPendingEmail(email);
-    startEmailTransition(async () => {
-      const formData = new FormData();
-      formData.set("projectId", project.projectId);
-      formData.set("email", email);
-      const result = await removeProjectEmailAction(formData);
-      setPendingEmail(null);
-      if (result.ok) {
-        setEmails((current) => {
-          const next = current.filter((value) => value.address !== email);
-          if (next.length === 0 || next.some((value) => value.isPrimary)) {
-            return next;
-          }
+  function handleRemoveEmail(address: string) {
+    const nextEmails = removeEmail(optimisticProject.emails, address);
 
-          return next.map((value, index) => ({
-            ...value,
-            isPrimary: index === 0
-          }));
-        });
-        announce(`Removed ${email}. (stub)`);
+    setPendingEmail(address);
+    startEmailTransition(async () => {
+      applyOptimisticProject({ emails: nextEmails });
+      const result = await updateProjectEmailsAction(
+        project.projectId,
+        nextEmails
+      );
+      setPendingEmail(null);
+
+      if (!result.ok) {
+        announce(result.message, "error");
+        return;
       }
+
+      commitProject(result.data);
+      announce(`Removed ${address}.`);
+    });
+  }
+
+  function handleMakePrimary(address: string) {
+    const nextEmails = promotePrimaryEmail(optimisticProject.emails, address);
+
+    setPendingEmail(address);
+    startEmailTransition(async () => {
+      applyOptimisticProject({ emails: nextEmails });
+      const result = await updateProjectEmailsAction(
+        project.projectId,
+        nextEmails
+      );
+      setPendingEmail(null);
+
+      if (!result.ok) {
+        announce(result.message, "error");
+        return;
+      }
+
+      commitProject(result.data);
+      announce(`${address} is now the primary email.`);
+    });
+  }
+
+  function handleSaveKnowledgeUrl() {
+    const nextUrl = knowledgeDraft.trim().length === 0 ? null : knowledgeDraft.trim();
+
+    startKnowledgeTransition(async () => {
+      applyOptimisticProject({ aiKnowledgeUrl: nextUrl });
+      const result = await updateProjectAiKnowledgeAction(
+        project.projectId,
+        nextUrl
+      );
+
+      if (!result.ok) {
+        announce(result.message, "error");
+        return;
+      }
+
+      commitProject(result.data);
+      announce(
+        nextUrl === null
+          ? "Cleared the AI knowledge URL."
+          : "Updated the AI knowledge URL."
+      );
+    });
+  }
+
+  function handleActivate() {
+    startActivationTransition(async () => {
+      applyOptimisticProject({ isActive: true });
+      const result = await activateProjectAction(project.projectId);
+
+      if (!result.ok) {
+        setActivationMessage(result.message);
+        announce(result.message, "error");
+        return;
+      }
+
+      commitProject(result.data);
+      announce(`${result.data.projectName} is now active.`);
     });
   }
 
   function handleDeactivate() {
-    startDeactivateTransition(async () => {
-      const formData = new FormData();
-      formData.set("id", project.projectId);
-      const result = await deactivateProjectAction(formData);
-      if (result.ok) {
-        setDeactivateOpen(false);
-        router.push("/settings/projects");
-        router.refresh();
+    startActivationTransition(async () => {
+      applyOptimisticProject({ isActive: false });
+      const result = await deactivateProjectAction(project.projectId);
+
+      if (!result.ok) {
+        announce(result.message, "error");
+        return;
       }
+
+      commitProject(result.data);
+      setDeactivateOpen(false);
+      announce(`${result.data.projectName} is now inactive.`);
     });
   }
 
+  const knowledgeDirty =
+    knowledgeDraft.trim() !== (optimisticProject.aiKnowledgeUrl ?? "");
+  const inactiveActivationMessage =
+    activationMessage ??
+    (!optimisticProject.activationRequirementsMet
+      ? "Add at least one email and an AI knowledge URL to activate."
+      : null);
+
   return (
     <div className="flex max-w-3xl flex-col gap-8">
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-4">
         <Link
           href="/settings/projects"
           className={cn(
@@ -143,21 +331,104 @@ export function ProjectDetail({ project }: ProjectDetailProps) {
           )}
         >
           <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
-          Back to Active Projects
+          Back to Projects
         </Link>
-        <div className="flex flex-wrap items-center gap-2">
-          <h1 className="text-lg font-semibold tracking-tight text-slate-950">
-            {project.projectName}
-          </h1>
-          <StatusBadge
-            label={project.isActive ? "Active" : "Inactive"}
-            colorClasses={
-              project.isActive
-                ? "bg-emerald-50 text-emerald-700 ring-emerald-200"
-                : "bg-amber-50 text-amber-800 ring-amber-200"
-            }
-            variant="soft"
-          />
+
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="flex min-w-0 flex-col gap-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="text-lg font-semibold tracking-tight text-slate-950">
+                {project.projectName}
+              </h1>
+              <StatusBadge
+                label={optimisticProject.isActive ? "Active" : "Inactive"}
+                colorClasses={
+                  optimisticProject.isActive
+                    ? "bg-emerald-50 text-emerald-700 ring-emerald-200"
+                    : "bg-amber-50 text-amber-800 ring-amber-200"
+                }
+                variant="soft"
+              />
+            </div>
+            <p className={TEXT.caption}>
+              Activation requires at least one connected inbox email and an AI
+              knowledge source.
+            </p>
+          </div>
+
+          {project.isAdmin ? (
+            <div className="flex min-w-[240px] flex-col items-start gap-2">
+              {optimisticProject.isActive ? (
+                <Dialog open={deactivateOpen} onOpenChange={setDeactivateOpen}>
+                  <DialogTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      disabled={activationPending}
+                    >
+                      Deactivate project
+                    </Button>
+                  </DialogTrigger>
+                  <DialogContent>
+                    <DialogHeader>
+                      <DialogTitle>
+                        Deactivate {project.projectName}?
+                      </DialogTitle>
+                      <DialogDescription>
+                        This will hide the project from the active list.
+                        Continue?
+                      </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter className="mt-4">
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        onClick={() => {
+                          setDeactivateOpen(false);
+                        }}
+                        disabled={activationPending}
+                      >
+                        Cancel
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="destructive"
+                        onClick={handleDeactivate}
+                        disabled={activationPending}
+                      >
+                        Deactivate project
+                      </Button>
+                    </DialogFooter>
+                  </DialogContent>
+                </Dialog>
+              ) : (
+                <Button
+                  type="button"
+                  onClick={handleActivate}
+                  disabled={
+                    activationPending ||
+                    !optimisticProject.activationRequirementsMet
+                  }
+                >
+                  Activate project
+                </Button>
+              )}
+
+              {!optimisticProject.isActive && inactiveActivationMessage ? (
+                <p
+                  className={cn(
+                    "max-w-[240px]",
+                    TEXT.caption,
+                    "text-slate-600"
+                  )}
+                >
+                  {inactiveActivationMessage}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
         </div>
       </div>
 
@@ -189,10 +460,6 @@ export function ProjectDetail({ project }: ProjectDetailProps) {
           <h2 id="project-details-heading" className={TEXT.headingSm}>
             Project details
           </h2>
-          <p className={cn("mt-0.5", TEXT.caption)}>
-            Activation requires at least one connected inbox email and an AI
-            knowledge source.
-          </p>
         </div>
 
         <div className="grid gap-4 md:grid-cols-2">
@@ -219,26 +486,49 @@ export function ProjectDetail({ project }: ProjectDetailProps) {
             >
               AI knowledge source
             </label>
-            <div className="flex items-center gap-2">
-              <Input
-                id="project-ai-knowledge-url"
-                value={project.aiKnowledgeUrl ?? ""}
-                disabled
-                readOnly
-                placeholder="No source configured"
-                className="font-mono text-[13px]"
-              />
-              {project.isAdmin ? (
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  onClick={handleKnowledgeSync}
-                >
-                  <RefreshCw className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
-                  Sync
-                </Button>
-              ) : null}
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center gap-2">
+                <Input
+                  id="project-ai-knowledge-url"
+                  value={knowledgeDraft}
+                  onChange={(event) => {
+                    setKnowledgeDraft(event.target.value);
+                    setActivationMessage(null);
+                  }}
+                  disabled={!project.isAdmin || knowledgePending}
+                  readOnly={!project.isAdmin}
+                  placeholder="https://..."
+                  className="font-mono text-[13px]"
+                />
+                {project.isAdmin ? (
+                  <>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={handleSaveKnowledgeUrl}
+                      disabled={knowledgePending || !knowledgeDirty}
+                    >
+                      Save URL
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={handleKnowledgeSync}
+                    >
+                      <RefreshCw
+                        className="mr-1.5 h-3.5 w-3.5"
+                        aria-hidden="true"
+                      />
+                      Sync
+                    </Button>
+                  </>
+                ) : null}
+              </div>
+              <span className={TEXT.caption}>
+                {formatLastSynced(optimisticProject.aiKnowledgeSyncedAt)}
+              </span>
             </div>
           </div>
         </div>
@@ -246,22 +536,17 @@ export function ProjectDetail({ project }: ProjectDetailProps) {
         <div className="flex flex-wrap items-center gap-2">
           <StatusBadge
             label={
-              project.activationRequirementsMet
+              optimisticProject.activationRequirementsMet
                 ? "Activation ready"
                 : "Needs setup"
             }
             colorClasses={
-              project.activationRequirementsMet
+              optimisticProject.activationRequirementsMet
                 ? "bg-emerald-50 text-emerald-700 ring-emerald-200"
                 : "bg-amber-50 text-amber-800 ring-amber-200"
             }
             variant="soft"
           />
-          <span className={TEXT.caption}>
-            {project.aiKnowledgeSyncedAt
-              ? `Knowledge last synced ${new Date(project.aiKnowledgeSyncedAt).toLocaleString()}`
-              : "Knowledge has not been synced yet."}
-          </span>
         </div>
       </section>
 
@@ -291,7 +576,7 @@ export function ProjectDetail({ project }: ProjectDetailProps) {
             "border border-slate-100"
           )}
         >
-          {emails.map((email) => {
+          {optimisticProject.emails.map((email) => {
             const isRowPending = emailPending && pendingEmail === email.address;
             return (
               <li
@@ -311,7 +596,20 @@ export function ProjectDetail({ project }: ProjectDetailProps) {
                     variant="soft"
                   />
                 ) : null}
-                {project.isAdmin && emails.length > 1 ? (
+                {project.isAdmin && !email.isPrimary ? (
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    disabled={emailPending}
+                    onClick={() => {
+                      handleMakePrimary(email.address);
+                    }}
+                  >
+                    Make primary
+                  </Button>
+                ) : null}
+                {project.isAdmin ? (
                   <button
                     type="button"
                     aria-label={`Remove ${email.address}`}
@@ -333,13 +631,13 @@ export function ProjectDetail({ project }: ProjectDetailProps) {
               </li>
             );
           })}
-          {emails.length === 0 && (
+          {optimisticProject.emails.length === 0 ? (
             <li className="px-3 py-4 text-center">
               <p className={TEXT.caption}>
-                No connected addresses. Add one below.
+                No connected addresses yet.
               </p>
             </li>
-          )}
+          ) : null}
         </ul>
 
         {project.isAdmin ? (
@@ -353,6 +651,7 @@ export function ProjectDetail({ project }: ProjectDetailProps) {
               value={newEmail}
               onChange={(event) => {
                 setNewEmail(event.target.value);
+                setActivationMessage(null);
               }}
               disabled={emailPending}
               placeholder="inbox@asc.internal"
@@ -370,75 +669,6 @@ export function ProjectDetail({ project }: ProjectDetailProps) {
           </div>
         ) : null}
       </section>
-
-      {project.isAdmin ? (
-        <section
-          aria-labelledby="project-danger-heading"
-          className={cn(
-            "flex flex-col gap-3 p-5",
-            RADIUS.md,
-            "border border-rose-200 bg-white ring-1 ring-inset ring-rose-100",
-            SHADOW.sm
-          )}
-        >
-          <div>
-            <h2
-              id="project-danger-heading"
-              className="text-sm font-semibold text-rose-800"
-            >
-              Danger zone
-            </h2>
-            <p className={cn("mt-0.5", TEXT.caption)}>
-              Deactivated projects stop routing inbound mail but are preserved
-              in the record.
-            </p>
-          </div>
-          <Dialog open={deactivateOpen} onOpenChange={setDeactivateOpen}>
-            <DialogTrigger asChild>
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                className="w-fit border-rose-200 text-rose-700 hover:bg-rose-50 hover:text-rose-800"
-              >
-                Deactivate project
-              </Button>
-            </DialogTrigger>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>Deactivate {project.projectName}?</DialogTitle>
-                <DialogDescription>
-                  Deactivated projects stop routing inbound mail but are
-                  preserved in the record. You can reactivate them from a
-                  follow-up admin workflow later.
-                </DialogDescription>
-              </DialogHeader>
-              <DialogFooter className="mt-4">
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  onClick={() => {
-                    setDeactivateOpen(false);
-                  }}
-                  disabled={deactivatePending}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  onClick={handleDeactivate}
-                  disabled={deactivatePending}
-                  className="bg-rose-600 hover:bg-rose-700"
-                >
-                  Deactivate
-                </Button>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
-        </section>
-      ) : null}
     </div>
   );
 }

--- a/apps/web/app/settings/_components/projects-section.tsx
+++ b/apps/web/app/settings/_components/projects-section.tsx
@@ -1,5 +1,4 @@
-"use client";
-
+import type { ReactNode } from "react";
 import Link from "next/link";
 import { Pencil } from "lucide-react";
 
@@ -11,74 +10,159 @@ import {
   TEXT,
   TRANSITION
 } from "@/app/_lib/design-tokens";
+import { Button } from "@/components/ui/button";
+import { StatusBadge } from "@/components/ui/status-badge";
 import { cn } from "@/lib/utils";
-import type { ProjectsSettingsViewModel } from "@/src/server/settings/selectors";
+import type {
+  ProjectRowViewModel,
+  ProjectsSettingsViewModel
+} from "@/src/server/settings/selectors";
 
 import { SettingsSection } from "./settings-section";
 
-interface ProjectsSectionProps {
+export function ProjectsSection({
+  viewModel
+}: {
   readonly viewModel: ProjectsSettingsViewModel;
-}
-
-export function ProjectsSection({ viewModel }: ProjectsSectionProps) {
+}) {
   return (
     <SettingsSection id="settings-projects" title="Active Projects">
-      <ul
-        className={cn(
-          "divide-y divide-slate-100",
-          RADIUS.md,
-          "border border-slate-200 bg-white",
-          SHADOW.sm
-        )}
-      >
-        {viewModel.active.map((project) => (
-          <li
-            key={project.projectId}
-            className={cn(
-              "group flex items-center gap-3",
-              SPACING.listItem,
-              TRANSITION.fast,
-              "hover:bg-slate-50/80"
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center justify-between gap-3">
+            <h3 className="text-sm font-semibold text-slate-900">
+              Currently active
+            </h3>
+            <span className={cn(TEXT.caption, "tabular-nums")}>
+              {String(viewModel.counts.active)} active
+            </span>
+          </div>
+          <ProjectList
+            projects={viewModel.active}
+            emptyMessage="No active projects yet."
+            renderAction={(project) => (
+              <Link
+                href={`/settings/projects/${encodeURIComponent(project.projectId)}`}
+                aria-label={`Open ${project.projectName}`}
+                className={cn(
+                  "flex h-8 w-8 shrink-0 items-center justify-center",
+                  RADIUS.sm,
+                  "text-slate-400 hover:bg-slate-100 hover:text-slate-700",
+                  TRANSITION.fast,
+                  FOCUS_RING
+                )}
+              >
+                <Pencil className="h-4 w-4" aria-hidden="true" />
+              </Link>
             )}
-          >
-            <Link
-              href={`/settings/projects/${encodeURIComponent(project.projectId)}`}
-              className={cn(
-                "flex min-w-0 flex-1 items-center gap-3",
-                FOCUS_RING,
-                RADIUS.sm
-              )}
-              aria-label={`Open ${project.projectName}`}
-            >
-              <div className="min-w-0 flex-1">
-                <p className="truncate text-sm font-medium text-slate-900">
-                  {project.projectName}
-                </p>
-              </div>
-            </Link>
+          />
+        </div>
 
-            <Link
-              href={`/settings/projects/${encodeURIComponent(project.projectId)}`}
-              aria-label={`Open ${project.projectName}`}
-              className={cn(
-                "flex h-8 w-8 shrink-0 items-center justify-center",
-                RADIUS.sm,
-                "text-slate-400 hover:bg-slate-100 hover:text-slate-700",
-                TRANSITION.fast,
-                FOCUS_RING
-              )}
-            >
-              <Pencil className="h-4 w-4" aria-hidden="true" />
-            </Link>
-          </li>
-        ))}
-
-        {viewModel.active.length === 0 && (
-          <li className="px-5 py-10 text-center">
-            <p className={TEXT.caption}>No active projects yet.</p>
-          </li>
-        )}
-      </ul>
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center justify-between gap-3">
+            <h3 className="text-sm font-semibold text-slate-900">
+              Inactive projects
+            </h3>
+            <span className={cn(TEXT.caption, "tabular-nums")}>
+              {String(viewModel.counts.inactive)} inactive
+            </span>
+          </div>
+          <ProjectList
+            projects={viewModel.inactive}
+            emptyMessage="No inactive projects."
+            renderMeta={(project) => (
+              <StatusBadge
+                label={
+                  project.activationRequirementsMet ? "Activation ready" : "Needs setup"
+                }
+                colorClasses={
+                  project.activationRequirementsMet
+                    ? "bg-emerald-50 text-emerald-700 ring-emerald-200"
+                    : "bg-amber-50 text-amber-800 ring-amber-200"
+                }
+                variant="soft"
+              />
+            )}
+            renderAction={(project) =>
+              viewModel.isAdmin ? (
+                <Button asChild size="sm" variant="outline">
+                  <Link
+                    href={`/settings/projects/${encodeURIComponent(project.projectId)}`}
+                  >
+                    Activate
+                  </Link>
+                </Button>
+              ) : null
+            }
+          />
+        </div>
+      </div>
     </SettingsSection>
+  );
+}
+
+function ProjectList({
+  projects,
+  emptyMessage,
+  renderMeta,
+  renderAction
+}: {
+  readonly projects: readonly ProjectRowViewModel[];
+  readonly emptyMessage: string;
+  readonly renderMeta?: (project: ProjectRowViewModel) => ReactNode;
+  readonly renderAction?: (project: ProjectRowViewModel) => ReactNode;
+}) {
+  return (
+    <ul
+      className={cn(
+        "divide-y divide-slate-100",
+        RADIUS.md,
+        "border border-slate-200 bg-white",
+        SHADOW.sm
+      )}
+    >
+      {projects.map((project) => (
+        <li
+          key={project.projectId}
+          className={cn(
+            "group flex items-center gap-3",
+            SPACING.listItem,
+            TRANSITION.fast,
+            "hover:bg-slate-50/80"
+          )}
+        >
+          <Link
+            href={`/settings/projects/${encodeURIComponent(project.projectId)}`}
+            className={cn(
+              "flex min-w-0 flex-1 flex-col gap-1",
+              FOCUS_RING,
+              RADIUS.sm
+            )}
+            aria-label={`Open ${project.projectName}`}
+          >
+            <div className="flex min-w-0 items-center gap-2">
+              <p className="truncate text-sm font-medium text-slate-900">
+                {project.projectName}
+              </p>
+              {renderMeta ? renderMeta(project) : null}
+            </div>
+            <p className={cn(TEXT.caption, "truncate")}>
+              {project.primaryEmail ??
+                (project.aiKnowledgeUrl
+                  ? "AI knowledge source configured"
+                  : "No email aliases configured")}
+            </p>
+          </Link>
+
+          {renderAction ? renderAction(project) : null}
+        </li>
+      ))}
+
+      {projects.length === 0 ? (
+        <li className="px-5 py-10 text-center">
+          <p className={TEXT.caption}>{emptyMessage}</p>
+        </li>
+      ) : null}
+    </ul>
   );
 }

--- a/apps/web/app/settings/actions.ts
+++ b/apps/web/app/settings/actions.ts
@@ -1,35 +1,27 @@
 "use server";
 
-/**
- * Settings stub actions (UI-only redesign).
- *
- * Every export below is a no-op that immediately returns an FP-07 UiSuccess
- * envelope. The shape matches the production envelope in
- * `apps/web/src/server/ui-result.ts`, so swapping a stub for a real action
- * later is a local change — callers don't need to know the difference.
- *
- * TODO(stage2): wire each of these to real repositories and audit events.
- */
-
 import { randomUUID } from "node:crypto";
 
-import type { IntegrationHealthRecord } from "@as-comms/contracts";
+import {
+  createProjectAliasSchema,
+  type IntegrationHealthRecord
+} from "@as-comms/contracts";
 
-import { requireAdmin } from "@/src/server/auth/session";
+import { resolveAdminSession } from "@/src/server/auth/api";
+import { appendSecurityAudit } from "@/src/server/security/audit";
 import {
   isMissingIntegrationHealthTableError,
   refreshIntegrationHealthRecord
 } from "@/src/server/settings/integration-health";
-import { revalidateIntegrationHealth } from "@/src/server/settings/revalidate";
-import type { UiResult, UiSuccess } from "@/src/server/ui-result";
+import {
+  revalidateIntegrationHealth,
+  revalidateProjectSettings
+} from "@/src/server/settings/revalidate";
+import { getSettingsRepositories } from "@/src/server/stage1-runtime";
+import type { UiError, UiResult } from "@/src/server/ui-result";
 
 function newRequestId(): string {
   return randomUUID();
-}
-
-function readString(formData: FormData, name: string): string {
-  const value = formData.get(name);
-  return typeof value === "string" ? value : "";
 }
 
 function readOptionalString(
@@ -42,59 +34,399 @@ function readOptionalString(
   return trimmed.length === 0 ? undefined : trimmed;
 }
 
-/**
- * Boxes a synchronous stub payload in the async envelope all Server Actions
- * must expose. Adding an actual `await` point also satisfies the lint rule
- * that requires `async` functions to contain at least one await — when real
- * persistence lands, that await will be the DB call itself.
- */
-async function stub<T>(data: T): Promise<UiSuccess<T>> {
-  await Promise.resolve();
-  return { ok: true, data, requestId: newRequestId() };
-}
-
 function errorResult(
   code: string,
   message: string,
   input?: {
+    readonly fieldErrors?: Record<string, string>;
     readonly retryable?: boolean;
   }
-) {
+): UiError {
   return {
     ok: false,
     code,
     message,
     requestId: newRequestId(),
+    ...(input?.fieldErrors === undefined
+      ? {}
+      : {
+          fieldErrors: input.fieldErrors
+        }),
     ...(input?.retryable === undefined
       ? {}
       : {
           retryable: input.retryable
         })
-  } as const;
+  };
+}
+
+function hasActivationRequirements(input: {
+  readonly aiKnowledgeUrl: string | null;
+  readonly emails: readonly { readonly address: string; readonly isPrimary: boolean }[];
+}): boolean {
+  return (
+    input.emails.length >= 1 &&
+    (input.aiKnowledgeUrl?.trim().length ?? 0) > 0
+  );
+}
+
+function serializeProjectMutationData(input: {
+  readonly projectId: string;
+  readonly projectName: string;
+  readonly isActive: boolean;
+  readonly aiKnowledgeUrl: string | null;
+  readonly aiKnowledgeSyncedAt: Date | null;
+  readonly emails: readonly { readonly address: string; readonly isPrimary: boolean }[];
+}): ProjectMutationData {
+  return {
+    projectId: input.projectId,
+    projectName: input.projectName,
+    isActive: input.isActive,
+    aiKnowledgeUrl: input.aiKnowledgeUrl,
+    aiKnowledgeSyncedAt: input.aiKnowledgeSyncedAt?.toISOString() ?? null,
+    activationRequirementsMet: hasActivationRequirements({
+      aiKnowledgeUrl: input.aiKnowledgeUrl,
+      emails: input.emails
+    }),
+    emails: input.emails.map((email) => ({
+      address: email.address,
+      isPrimary: email.isPrimary
+    }))
+  };
+}
+
+async function resolveSettingsAdmin(input: {
+  readonly unauthorizedMessage: string;
+  readonly forbiddenMessage: string;
+}): Promise<
+  | {
+      readonly ok: true;
+      readonly userId: string;
+    }
+  | {
+      readonly ok: false;
+      readonly error: UiError;
+    }
+> {
+  const session = await resolveAdminSession();
+  if (!session.ok) {
+    return {
+      ok: false,
+      error:
+        session.code === "unauthorized"
+          ? errorResult("unauthorized", input.unauthorizedMessage)
+          : errorResult("forbidden", input.forbiddenMessage)
+    };
+  }
+
+  return {
+    ok: true,
+    userId: session.user.id
+  };
+}
+
+async function appendSettingsAudit(input: {
+  readonly actorId: string;
+  readonly action: string;
+  readonly entityType: string;
+  readonly entityId: string;
+  readonly metadataJson?: Readonly<Record<string, unknown>>;
+}): Promise<void> {
+  await appendSecurityAudit({
+    actorType: "user",
+    actorId: input.actorId,
+    action: input.action,
+    entityType: input.entityType,
+    entityId: input.entityId,
+    result: "recorded",
+    policyCode: "settings.admin_mutation",
+    metadataJson: input.metadataJson ?? {}
+  });
+}
+
+function notImplementedResult(message: string): UiError {
+  return errorResult("not_implemented", message);
+}
+
+function normalizeIncomingEmail(address: string): string {
+  return address.trim().toLowerCase();
+}
+
+function validateProjectEmails(
+  emails: readonly ProjectEmailInput[]
+):
+  | {
+      readonly ok: true;
+      readonly orderedEmails: readonly ProjectEmailInput[];
+    }
+  | {
+      readonly ok: false;
+      readonly error: UiError;
+    } {
+  const normalizedEmails = emails.map((email) => ({
+    address: normalizeIncomingEmail(email.address),
+    isPrimary: email.isPrimary
+  }));
+
+  for (const email of normalizedEmails) {
+    const parsed = createProjectAliasSchema.shape.alias.safeParse(email.address);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: errorResult(
+          "invalid_email_format",
+          "Enter a valid project email address.",
+          {
+            fieldErrors: {
+              emails: "Enter a valid project email address."
+            }
+          }
+        )
+      };
+    }
+  }
+
+  const distinctEmails = new Set(normalizedEmails.map((email) => email.address));
+  if (distinctEmails.size !== normalizedEmails.length) {
+    return {
+      ok: false,
+      error: errorResult(
+        "duplicate_email",
+        "Each project email must be unique.",
+        {
+          fieldErrors: {
+            emails: "Each project email must be unique."
+          }
+        }
+      )
+    };
+  }
+
+  if (normalizedEmails.length === 0) {
+    return {
+      ok: true,
+      orderedEmails: []
+    };
+  }
+
+  const primaryCount = normalizedEmails.filter((email) => email.isPrimary).length;
+  if (primaryCount === 0) {
+    return {
+      ok: false,
+      error: errorResult(
+        "primary_email_required",
+        "Choose one primary email address.",
+        {
+          fieldErrors: {
+            emails: "Choose one primary email address."
+          }
+        }
+      )
+    };
+  }
+
+  if (primaryCount > 1) {
+    return {
+      ok: false,
+      error: errorResult(
+        "multiple_primary_emails",
+        "Choose exactly one primary email address.",
+        {
+          fieldErrors: {
+            emails: "Choose exactly one primary email address."
+          }
+        }
+      )
+    };
+  }
+
+  const primaryEmail = normalizedEmails.find((email) => email.isPrimary);
+  const orderedEmails = normalizedEmails
+    .filter((email) => !email.isPrimary)
+    .map((email) => ({
+      address: email.address,
+      isPrimary: false
+    }));
+
+  return {
+    ok: true,
+    orderedEmails:
+      primaryEmail === undefined
+        ? orderedEmails
+        : [
+            {
+              address: primaryEmail.address,
+              isPrimary: true
+            },
+            ...orderedEmails
+          ]
+  };
+}
+
+function normalizeAiKnowledgeUrl(
+  rawUrl: string | null
+):
+  | {
+      readonly ok: true;
+      readonly url: string | null;
+    }
+  | {
+      readonly ok: false;
+      readonly error: UiError;
+    } {
+  const trimmed = rawUrl?.trim() ?? "";
+  if (trimmed.length === 0) {
+    return {
+      ok: true,
+      url: null
+    };
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== "https:") {
+      return {
+        ok: false,
+        error: errorResult(
+          "invalid_url",
+          "AI knowledge URL must start with https://.",
+          {
+            fieldErrors: {
+              aiKnowledgeUrl: "AI knowledge URL must start with https://."
+            }
+          }
+        )
+      };
+    }
+
+    return {
+      ok: true,
+      url: parsed.toString()
+    };
+  } catch {
+    return {
+      ok: false,
+      error: errorResult(
+        "invalid_url",
+        "Enter a valid AI knowledge URL.",
+        {
+          fieldErrors: {
+            aiKnowledgeUrl: "Enter a valid AI knowledge URL."
+          }
+        }
+      )
+    };
+  }
+}
+
+function isProjectAliasConflictError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+
+  const message =
+    "message" in error && typeof error.message === "string" ? error.message : "";
+  const code =
+    "code" in error && typeof error.code === "string" ? error.code : null;
+
+  return (
+    code === "23505" ||
+    /project_aliases_alias_unique|duplicate key value violates unique constraint/iu.test(
+      message
+    )
+  );
+}
+
+export interface ProjectEmailInput {
+  readonly address: string;
+  readonly isPrimary: boolean;
+}
+
+export interface ProjectMutationData {
+  readonly projectId: string;
+  readonly projectName: string;
+  readonly isActive: boolean;
+  readonly aiKnowledgeUrl: string | null;
+  readonly aiKnowledgeSyncedAt: string | null;
+  readonly activationRequirementsMet: boolean;
+  readonly emails: readonly ProjectEmailInput[];
 }
 
 // ─── Projects ───────────────────────────────────────────────────────────────
 
-export interface ActivateProjectResult {
-  readonly id: string;
-  readonly name: string;
-  readonly alias: string;
-}
-
-/**
- * Activate a Salesforce project so inbound routing includes it. Replaces the
- * previous `addProjectAction` — the redesigned flow picks an existing
- * non-active project from our cached SF snapshot rather than inventing one.
- */
 export async function activateProjectAction(
-  formData: FormData
-): Promise<UiResult<ActivateProjectResult>> {
-  // TODO(stage2): wire to real persistence
-  return stub({
-    id: readString(formData, "id"),
-    name: readString(formData, "name"),
-    alias: readString(formData, "alias")
+  projectId: string
+): Promise<UiResult<ProjectMutationData>> {
+  const admin = await resolveSettingsAdmin({
+    unauthorizedMessage: "You must be signed in to activate a project.",
+    forbiddenMessage: "Only admins can activate projects."
   });
+  if (!admin.ok) {
+    return admin.error;
+  }
+
+  const repositories = await getSettingsRepositories();
+  const project = await repositories.projects.findById(projectId);
+  if (project === null) {
+    return errorResult("not_found", "That project no longer exists.");
+  }
+
+  if (project.isActive) {
+    return errorResult("already_active", "This project is already active.");
+  }
+
+  if (project.emails.length < 1) {
+    return errorResult(
+      "requirements_not_met",
+      "Add at least one email and an AI knowledge URL to activate this project.",
+      {
+        fieldErrors: {
+          emails: "Add at least one email to activate this project."
+        }
+      }
+    );
+  }
+
+  if ((project.aiKnowledgeUrl?.trim().length ?? 0) === 0) {
+    return errorResult(
+      "requirements_not_met",
+      "Add at least one email and an AI knowledge URL to activate this project.",
+      {
+        fieldErrors: {
+          aiKnowledgeUrl:
+            "Add an AI knowledge URL to activate this project."
+        }
+      }
+    );
+  }
+
+  const updatedProject = await repositories.projects.setActive(projectId, true);
+  if (updatedProject === null) {
+    return errorResult("not_found", "That project no longer exists.");
+  }
+
+  await appendSettingsAudit({
+    actorId: admin.userId,
+    action: "settings.project.activated",
+    entityType: "project",
+    entityId: projectId,
+    metadataJson: {
+      before: {
+        isActive: project.isActive
+      },
+      after: {
+        isActive: updatedProject.isActive
+      }
+    }
+  });
+
+  revalidateProjectSettings(projectId);
+
+  return {
+    ok: true,
+    data: serializeProjectMutationData(updatedProject),
+    requestId: newRequestId()
+  };
 }
 
 export interface UpdateProjectAliasResult {
@@ -102,58 +434,214 @@ export interface UpdateProjectAliasResult {
   readonly alias: string;
 }
 
-/**
- * Rename the short alias used across the platform for this project. Reads
- * `projectId` (preferred) or legacy `id` from the form payload.
- */
 export async function updateProjectAliasAction(
   formData: FormData
 ): Promise<UiResult<UpdateProjectAliasResult>> {
-  // TODO(stage2): wire to real persistence
-  return stub({
-    id: readString(formData, "projectId") || readString(formData, "id"),
-    alias: readString(formData, "alias")
+  const admin = await resolveSettingsAdmin({
+    unauthorizedMessage: "You must be signed in to update project aliases.",
+    forbiddenMessage: "Only admins can update project aliases."
   });
+  if (!admin.ok) {
+    return admin.error;
+  }
+
+  void formData;
+
+  return notImplementedResult(
+    "Project alias editing is not implemented in this brief."
+  );
 }
 
-export interface ProjectEmailResult {
-  readonly projectId: string;
-  readonly email: string;
-}
-
-export async function addProjectEmailAction(
-  formData: FormData
-): Promise<UiResult<ProjectEmailResult>> {
-  // TODO(stage2): wire to real persistence
-  return stub({
-    projectId: readString(formData, "projectId"),
-    email: readString(formData, "email")
+export async function updateProjectEmailsAction(
+  projectId: string,
+  emails: readonly ProjectEmailInput[]
+): Promise<UiResult<ProjectMutationData>> {
+  const admin = await resolveSettingsAdmin({
+    unauthorizedMessage: "You must be signed in to update project emails.",
+    forbiddenMessage: "Only admins can update project emails."
   });
-}
+  if (!admin.ok) {
+    return admin.error;
+  }
 
-export async function removeProjectEmailAction(
-  formData: FormData
-): Promise<UiResult<ProjectEmailResult>> {
-  // TODO(stage2): wire to real persistence
-  return stub({
-    projectId: readString(formData, "projectId"),
-    email: readString(formData, "email")
+  const repositories = await getSettingsRepositories();
+  const project = await repositories.projects.findById(projectId);
+  if (project === null) {
+    return errorResult("not_found", "That project no longer exists.");
+  }
+
+  const validation = validateProjectEmails(emails);
+  if (!validation.ok) {
+    return validation.error;
+  }
+
+  for (const email of validation.orderedEmails) {
+    const existingAlias = await repositories.aliases.findByAlias(email.address);
+    if (
+      existingAlias !== null &&
+      existingAlias.projectId !== null &&
+      existingAlias.projectId !== projectId
+    ) {
+      return errorResult(
+        "email_in_use",
+        `${email.address} is already assigned to another project.`,
+        {
+          fieldErrors: {
+            emails: `${email.address} is already assigned to another project.`
+          }
+        }
+      );
+    }
+  }
+
+  try {
+    await repositories.aliases.replaceForProject({
+      projectId,
+      aliases: validation.orderedEmails.map((email) => email.address),
+      actorId: admin.userId
+    });
+  } catch (error) {
+    if (isProjectAliasConflictError(error)) {
+      return errorResult(
+        "email_in_use",
+        "One of those email addresses is already assigned to another project.",
+        {
+          fieldErrors: {
+            emails:
+              "One of those email addresses is already assigned to another project."
+          }
+        }
+      );
+    }
+
+    throw error;
+  }
+
+  const updatedProject = await repositories.projects.findById(projectId);
+  if (updatedProject === null) {
+    return errorResult("not_found", "That project no longer exists.");
+  }
+
+  await appendSettingsAudit({
+    actorId: admin.userId,
+    action: "settings.project.email_changed",
+    entityType: "project",
+    entityId: projectId,
+    metadataJson: {
+      before: project.emails,
+      after: updatedProject.emails
+    }
   });
+
+  revalidateProjectSettings(projectId);
+
+  return {
+    ok: true,
+    data: serializeProjectMutationData(updatedProject),
+    requestId: newRequestId()
+  };
 }
 
-export interface DeactivateProjectResult {
-  readonly id: string;
+export async function updateProjectAiKnowledgeAction(
+  projectId: string,
+  url: string | null
+): Promise<UiResult<ProjectMutationData>> {
+  const admin = await resolveSettingsAdmin({
+    unauthorizedMessage:
+      "You must be signed in to update the AI knowledge URL.",
+    forbiddenMessage: "Only admins can update the AI knowledge URL."
+  });
+  if (!admin.ok) {
+    return admin.error;
+  }
+
+  const repositories = await getSettingsRepositories();
+  const project = await repositories.projects.findById(projectId);
+  if (project === null) {
+    return errorResult("not_found", "That project no longer exists.");
+  }
+
+  const normalizedUrl = normalizeAiKnowledgeUrl(url);
+  if (!normalizedUrl.ok) {
+    return normalizedUrl.error;
+  }
+
+  const updatedProject = await repositories.projects.setAiKnowledgeUrl(
+    projectId,
+    normalizedUrl.url
+  );
+  if (updatedProject === null) {
+    return errorResult("not_found", "That project no longer exists.");
+  }
+
+  await appendSettingsAudit({
+    actorId: admin.userId,
+    action: "settings.project.ai_knowledge_updated",
+    entityType: "project",
+    entityId: projectId,
+    metadataJson: {
+      before: project.aiKnowledgeUrl,
+      after: updatedProject.aiKnowledgeUrl
+    }
+  });
+
+  revalidateProjectSettings(projectId);
+
+  return {
+    ok: true,
+    data: serializeProjectMutationData(updatedProject),
+    requestId: newRequestId()
+  };
 }
 
-/**
- * Deactivate a project so inbound routing ignores it. Renamed from
- * `archiveProjectAction` to match the product copy on the danger-zone card.
- */
 export async function deactivateProjectAction(
-  formData: FormData
-): Promise<UiResult<DeactivateProjectResult>> {
-  // TODO(stage2): wire to real persistence
-  return stub({ id: readString(formData, "id") });
+  projectId: string
+): Promise<UiResult<ProjectMutationData>> {
+  const admin = await resolveSettingsAdmin({
+    unauthorizedMessage: "You must be signed in to deactivate a project.",
+    forbiddenMessage: "Only admins can deactivate projects."
+  });
+  if (!admin.ok) {
+    return admin.error;
+  }
+
+  const repositories = await getSettingsRepositories();
+  const project = await repositories.projects.findById(projectId);
+  if (project === null) {
+    return errorResult("not_found", "That project no longer exists.");
+  }
+
+  if (!project.isActive) {
+    return errorResult("already_inactive", "This project is already inactive.");
+  }
+
+  const updatedProject = await repositories.projects.setActive(projectId, false);
+  if (updatedProject === null) {
+    return errorResult("not_found", "That project no longer exists.");
+  }
+
+  await appendSettingsAudit({
+    actorId: admin.userId,
+    action: "settings.project.deactivated",
+    entityType: "project",
+    entityId: projectId,
+    metadataJson: {
+      before: {
+        isActive: project.isActive
+      },
+      after: {
+        isActive: updatedProject.isActive
+      }
+    }
+  });
+
+  revalidateProjectSettings(projectId);
+
+  return {
+    ok: true,
+    data: serializeProjectMutationData(updatedProject),
+    requestId: newRequestId()
+  };
 }
 
 // ─── Access (users) ─────────────────────────────────────────────────────────
@@ -166,14 +654,22 @@ export interface InviteUserResult {
 export async function inviteUserAction(
   formData: FormData
 ): Promise<UiResult<InviteUserResult>> {
+  const admin = await resolveSettingsAdmin({
+    unauthorizedMessage: "You must be signed in to invite teammates.",
+    forbiddenMessage: "Only admins can invite teammates."
+  });
+  if (!admin.ok) {
+    return admin.error;
+  }
+
   const rawRole = readOptionalString(formData, "role") ?? "internal_user";
   const role: "admin" | "internal_user" =
     rawRole === "admin" ? "admin" : "internal_user";
-  // TODO(stage2): wire to real persistence
-  return stub({
-    email: readString(formData, "email"),
-    role
-  });
+
+  void role;
+  void formData;
+
+  return notImplementedResult("User invites are intentionally stubbed in this brief.");
 }
 
 export interface UserIdResult {
@@ -183,29 +679,73 @@ export interface UserIdResult {
 export async function promoteUserAction(
   formData: FormData
 ): Promise<UiResult<UserIdResult>> {
-  // TODO(stage2): wire to real persistence
-  return stub({ id: readString(formData, "id") });
+  const admin = await resolveSettingsAdmin({
+    unauthorizedMessage: "You must be signed in to update user access.",
+    forbiddenMessage: "Only admins can update user access."
+  });
+  if (!admin.ok) {
+    return admin.error;
+  }
+
+  void formData;
+
+  return notImplementedResult(
+    "User promotion is intentionally stubbed in this brief."
+  );
 }
 
 export async function demoteUserAction(
   formData: FormData
 ): Promise<UiResult<UserIdResult>> {
-  // TODO(stage2): wire to real persistence
-  return stub({ id: readString(formData, "id") });
+  const admin = await resolveSettingsAdmin({
+    unauthorizedMessage: "You must be signed in to update user access.",
+    forbiddenMessage: "Only admins can update user access."
+  });
+  if (!admin.ok) {
+    return admin.error;
+  }
+
+  void formData;
+
+  return notImplementedResult(
+    "User demotion is intentionally stubbed in this brief."
+  );
 }
 
 export async function deactivateUserAction(
   formData: FormData
 ): Promise<UiResult<UserIdResult>> {
-  // TODO(stage2): wire to real persistence
-  return stub({ id: readString(formData, "id") });
+  const admin = await resolveSettingsAdmin({
+    unauthorizedMessage: "You must be signed in to update user access.",
+    forbiddenMessage: "Only admins can update user access."
+  });
+  if (!admin.ok) {
+    return admin.error;
+  }
+
+  void formData;
+
+  return notImplementedResult(
+    "User deactivation is intentionally stubbed in this brief."
+  );
 }
 
 export async function reactivateUserAction(
   formData: FormData
 ): Promise<UiResult<UserIdResult>> {
-  // TODO(stage2): wire to real persistence
-  return stub({ id: readString(formData, "id") });
+  const admin = await resolveSettingsAdmin({
+    unauthorizedMessage: "You must be signed in to update user access.",
+    forbiddenMessage: "Only admins can update user access."
+  });
+  if (!admin.ok) {
+    return admin.error;
+  }
+
+  void formData;
+
+  return notImplementedResult(
+    "User reactivation is intentionally stubbed in this brief."
+  );
 }
 
 // ─── Integrations ───────────────────────────────────────────────────────────
@@ -214,49 +754,50 @@ export interface IntegrationIdResult {
   readonly id: string;
 }
 
-/**
- * Trigger a one-off sync for an integration. Replaces the previous
- * connect/disconnect/reconfigure trio — the redesigned settings surface
- * treats provider configuration as infrastructure state and exposes only the
- * operator-level "refresh now" action.
- */
 export async function syncIntegrationAction(
   formData: FormData
 ): Promise<UiResult<IntegrationIdResult>> {
-  // TODO(stage2): wire to real persistence
-  return stub({ id: readString(formData, "id") });
+  const admin = await resolveSettingsAdmin({
+    unauthorizedMessage: "You must be signed in to refresh integrations.",
+    forbiddenMessage: "Only admins can refresh integrations."
+  });
+  if (!admin.ok) {
+    return admin.error;
+  }
+
+  void formData;
+
+  return notImplementedResult("Use refreshIntegrationHealthAction instead.");
 }
 
 export async function refreshIntegrationHealthAction(
-  formData: FormData
+  serviceName: string
 ): Promise<UiResult<IntegrationHealthRecord>> {
-  try {
-    await requireAdmin();
-  } catch (error) {
-    if (error instanceof Error && error.message === "UNAUTHORIZED") {
-      return errorResult(
-        "unauthorized",
-        "You must be signed in to refresh integration health."
-      );
-    }
-
-    if (error instanceof Error && error.message === "FORBIDDEN") {
-      return errorResult(
-        "forbidden",
-        "Only admins can refresh integration health."
-      );
-    }
-
-    throw error;
+  const admin = await resolveSettingsAdmin({
+    unauthorizedMessage: "You must be signed in to refresh integration health.",
+    forbiddenMessage: "Only admins can refresh integration health."
+  });
+  if (!admin.ok) {
+    return admin.error;
   }
 
-  const serviceName = readString(formData, "service");
-  if (serviceName.length === 0) {
+  const normalizedServiceName = serviceName.trim();
+  if (normalizedServiceName.length === 0) {
     return errorResult("validation_error", "A service name is required.");
   }
 
   try {
-    const record = await refreshIntegrationHealthRecord(serviceName);
+    const record = await refreshIntegrationHealthRecord(normalizedServiceName);
+    await appendSettingsAudit({
+      actorId: admin.userId,
+      action: "settings.integration.refreshed",
+      entityType: "integration",
+      entityId: record.serviceName,
+      metadataJson: {
+        status: record.status,
+        checkedAt: record.lastCheckedAt
+      }
+    });
     revalidateIntegrationHealth();
     return {
       ok: true,
@@ -274,7 +815,10 @@ export async function refreshIntegrationHealthAction(
       );
     }
 
-    if (error instanceof Error && /invalid_enum_value|Invalid enum value/iu.test(error.message)) {
+    if (
+      error instanceof Error &&
+      /invalid_enum_value|Invalid enum value/iu.test(error.message)
+    ) {
       return errorResult("validation_error", "Unknown integration service.");
     }
 

--- a/apps/web/app/settings/projects/page.tsx
+++ b/apps/web/app/settings/projects/page.tsx
@@ -19,7 +19,7 @@ export default async function SettingsProjectsPage() {
   }
 
   const viewModel = await loadProjectsSettings({
-    filter: "active"
+    filter: "all"
   });
 
   return (

--- a/apps/web/src/server/auth/api.ts
+++ b/apps/web/src/server/auth/api.ts
@@ -38,3 +38,38 @@ export async function requireApiSession(): Promise<
     throw error;
   }
 }
+
+export async function resolveAdminSession(): Promise<
+  | {
+      readonly ok: true;
+      readonly user: UserRecord;
+    }
+  | {
+      readonly ok: false;
+      readonly code: "unauthorized" | "forbidden";
+    }
+> {
+  try {
+    const user = await requireSession();
+    if (user.role !== "admin") {
+      return {
+        ok: false,
+        code: "forbidden"
+      };
+    }
+
+    return {
+      ok: true,
+      user
+    };
+  } catch (error) {
+    if (error instanceof Error && error.message === "UNAUTHORIZED") {
+      return {
+        ok: false,
+        code: "unauthorized"
+      };
+    }
+
+    throw error;
+  }
+}

--- a/apps/web/tests/unit/settings-integration-health-action.test.ts
+++ b/apps/web/tests/unit/settings-integration-health-action.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const requireAdmin = vi.hoisted(() => vi.fn());
+const resolveAdminSession = vi.hoisted(() => vi.fn());
 const refreshIntegrationHealthRecord = vi.hoisted(() => vi.fn());
 const revalidateIntegrationHealth = vi.hoisted(() => vi.fn());
 
-vi.mock("@/src/server/auth/session", () => ({
-  requireAdmin
+vi.mock("@/src/server/auth/api", () => ({
+  resolveAdminSession
 }));
 
 vi.mock("@/src/server/settings/integration-health", () => ({
@@ -18,14 +18,39 @@ vi.mock("@/src/server/settings/revalidate", () => ({
 }));
 
 import { refreshIntegrationHealthAction } from "../../app/settings/actions";
+import {
+  createStage1WebTestRuntime,
+  type Stage1WebTestRuntime
+} from "../../src/server/stage1-runtime.test-support";
 
 describe("refreshIntegrationHealthAction", () => {
-  it("returns a 403-shaped result for non-admin users", async () => {
-    requireAdmin.mockRejectedValue(new Error("FORBIDDEN"));
+  let runtime: Stage1WebTestRuntime | null = null;
 
-    const formData = new FormData();
-    formData.set("service", "gmail");
-    const result = await refreshIntegrationHealthAction(formData);
+  beforeEach(async () => {
+    resolveAdminSession.mockReset();
+    refreshIntegrationHealthRecord.mockReset();
+    revalidateIntegrationHealth.mockReset();
+    resolveAdminSession.mockResolvedValue({
+      ok: true,
+      user: {
+        id: "user:admin"
+      }
+    });
+    runtime = await createStage1WebTestRuntime();
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    runtime = null;
+  });
+
+  it("returns a 403-shaped result for non-admin users", async () => {
+    resolveAdminSession.mockResolvedValueOnce({
+      ok: false,
+      code: "forbidden"
+    });
+
+    const result = await refreshIntegrationHealthAction("gmail");
 
     expect(result).toMatchObject({
       ok: false,
@@ -34,5 +59,44 @@ describe("refreshIntegrationHealthAction", () => {
     });
     expect(refreshIntegrationHealthRecord).not.toHaveBeenCalled();
     expect(revalidateIntegrationHealth).not.toHaveBeenCalled();
+  });
+
+  it("audits and revalidates on a successful refresh", async () => {
+    if (!runtime) throw new Error("runtime not initialized");
+
+    refreshIntegrationHealthRecord.mockResolvedValue({
+      id: "gmail",
+      serviceName: "gmail",
+      category: "messaging",
+      status: "healthy",
+      lastCheckedAt: "2026-04-20T18:00:00.000Z",
+      detail: "Healthy",
+      metadataJson: {},
+      createdAt: "2026-04-20T18:00:00.000Z",
+      updatedAt: "2026-04-20T18:00:00.000Z"
+    });
+
+    const result = await refreshIntegrationHealthAction("gmail");
+    const audits = await runtime.context.repositories.auditEvidence.listByEntity({
+      entityType: "integration",
+      entityId: "gmail"
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        serviceName: "gmail",
+        status: "healthy"
+      }
+    });
+    expect(audits.at(-1)).toMatchObject({
+      actorType: "user",
+      actorId: "user:admin",
+      action: "settings.integration.refreshed",
+      entityType: "integration",
+      entityId: "gmail",
+      policyCode: "settings.admin_mutation"
+    });
+    expect(revalidateIntegrationHealth).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/tests/unit/settings-project-actions.test.ts
+++ b/apps/web/tests/unit/settings-project-actions.test.ts
@@ -1,0 +1,429 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveAdminSession = vi.hoisted(() => vi.fn());
+const revalidateProjectSettings = vi.hoisted(() => vi.fn());
+const revalidateIntegrationHealth = vi.hoisted(() => vi.fn());
+
+vi.mock("@/src/server/auth/api", () => ({
+  resolveAdminSession
+}));
+
+vi.mock("@/src/server/settings/revalidate", () => ({
+  revalidateProjectSettings,
+  revalidateIntegrationHealth
+}));
+
+import {
+  activateProjectAction,
+  deactivateProjectAction,
+  inviteUserAction,
+  updateProjectAiKnowledgeAction,
+  updateProjectEmailsAction
+} from "../../app/settings/actions";
+import {
+  createStage1WebTestRuntime,
+  type Stage1WebTestRuntime
+} from "../../src/server/stage1-runtime.test-support";
+
+function adminSession() {
+  return {
+    ok: true as const,
+    user: {
+      id: "user:admin"
+    }
+  };
+}
+
+async function seedProject(
+  runtime: Stage1WebTestRuntime,
+  input: {
+    readonly projectId: string;
+    readonly projectName: string;
+    readonly isActive: boolean;
+    readonly aiKnowledgeUrl: string | null;
+    readonly emails: readonly string[];
+  }
+): Promise<void> {
+  await runtime.context.repositories.projectDimensions.upsert({
+    projectId: input.projectId,
+    projectName: input.projectName,
+    source: "salesforce",
+    isActive: input.isActive,
+    aiKnowledgeUrl: input.aiKnowledgeUrl,
+    aiKnowledgeSyncedAt: null
+  });
+
+  for (const [index, email] of input.emails.entries()) {
+    await runtime.context.settings.aliases.create({
+      id: `${input.projectId}:alias:${String(index)}`,
+      alias: email,
+      projectId: input.projectId,
+      createdAt: new Date(`2026-04-20T15:0${String(index)}:00.000Z`),
+      updatedAt: new Date(`2026-04-20T15:0${String(index)}:00.000Z`),
+      createdBy: null,
+      updatedBy: null
+    });
+  }
+}
+
+describe("settings project actions", () => {
+  let runtime: Stage1WebTestRuntime | null = null;
+
+  beforeEach(async () => {
+    resolveAdminSession.mockReset();
+    revalidateProjectSettings.mockReset();
+    revalidateIntegrationHealth.mockReset();
+    resolveAdminSession.mockResolvedValue(adminSession());
+    runtime = await createStage1WebTestRuntime();
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    runtime = null;
+  });
+
+  it("returns forbidden for activateProjectAction when the user is not an admin", async () => {
+    resolveAdminSession.mockResolvedValueOnce({
+      ok: false,
+      code: "forbidden"
+    });
+
+    const result = await activateProjectAction("project:inactive");
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "forbidden"
+    });
+  });
+
+  it("returns not_found for activateProjectAction when the project is missing", async () => {
+    const result = await activateProjectAction("project:missing");
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "not_found"
+    });
+  });
+
+  it("returns already_active for activateProjectAction when the project is already active", async () => {
+    if (!runtime) throw new Error("runtime not initialized");
+
+    await seedProject(runtime, {
+      projectId: "project:active",
+      projectName: "Active Project",
+      isActive: true,
+      aiKnowledgeUrl: "https://docs.example.org/active",
+      emails: ["active@asc.internal"]
+    });
+
+    const result = await activateProjectAction("project:active");
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "already_active"
+    });
+  });
+
+  it("returns a requirements error when activateProjectAction is missing emails", async () => {
+    if (!runtime) throw new Error("runtime not initialized");
+
+    await seedProject(runtime, {
+      projectId: "project:no-emails",
+      projectName: "No Emails",
+      isActive: false,
+      aiKnowledgeUrl: "https://docs.example.org/no-emails",
+      emails: []
+    });
+
+    const result = await activateProjectAction("project:no-emails");
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "requirements_not_met",
+      fieldErrors: {
+        emails: "Add at least one email to activate this project."
+      }
+    });
+  });
+
+  it("returns a requirements error when activateProjectAction is missing the AI knowledge URL", async () => {
+    if (!runtime) throw new Error("runtime not initialized");
+
+    await seedProject(runtime, {
+      projectId: "project:no-url",
+      projectName: "No URL",
+      isActive: false,
+      aiKnowledgeUrl: null,
+      emails: ["ready@asc.internal"]
+    });
+
+    const result = await activateProjectAction("project:no-url");
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "requirements_not_met",
+      fieldErrors: {
+        aiKnowledgeUrl: "Add an AI knowledge URL to activate this project."
+      }
+    });
+  });
+
+  it("activates a ready project, records audit evidence, and revalidates the project settings route", async () => {
+    if (!runtime) throw new Error("runtime not initialized");
+
+    await seedProject(runtime, {
+      projectId: "project:ready",
+      projectName: "Ready Project",
+      isActive: false,
+      aiKnowledgeUrl: "https://docs.example.org/ready",
+      emails: ["ready@asc.internal"]
+    });
+
+    const result = await activateProjectAction("project:ready");
+    const updatedProject = await runtime.context.settings.projects.findById(
+      "project:ready"
+    );
+    const audits = await runtime.context.repositories.auditEvidence.listByEntity({
+      entityType: "project",
+      entityId: "project:ready"
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        projectId: "project:ready",
+        isActive: true
+      }
+    });
+    expect(updatedProject?.isActive).toBe(true);
+    expect(audits.at(-1)).toMatchObject({
+      actorType: "user",
+      actorId: "user:admin",
+      action: "settings.project.activated",
+      entityType: "project",
+      entityId: "project:ready",
+      policyCode: "settings.admin_mutation"
+    });
+    expect(revalidateProjectSettings).toHaveBeenCalledWith("project:ready");
+  });
+
+  it("deactivates an active project", async () => {
+    if (!runtime) throw new Error("runtime not initialized");
+
+    await seedProject(runtime, {
+      projectId: "project:to-deactivate",
+      projectName: "Deactivate Me",
+      isActive: true,
+      aiKnowledgeUrl: "https://docs.example.org/deactivate",
+      emails: ["deactivate@asc.internal"]
+    });
+
+    const result = await deactivateProjectAction("project:to-deactivate");
+    const updatedProject = await runtime.context.settings.projects.findById(
+      "project:to-deactivate"
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        projectId: "project:to-deactivate",
+        isActive: false
+      }
+    });
+    expect(updatedProject?.isActive).toBe(false);
+  });
+
+  it("returns already_inactive for deactivateProjectAction when the project is already inactive", async () => {
+    if (!runtime) throw new Error("runtime not initialized");
+
+    await seedProject(runtime, {
+      projectId: "project:inactive",
+      projectName: "Already Inactive",
+      isActive: false,
+      aiKnowledgeUrl: "https://docs.example.org/inactive",
+      emails: ["inactive@asc.internal"]
+    });
+
+    const result = await deactivateProjectAction("project:inactive");
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "already_inactive"
+    });
+  });
+
+  it("updates project emails with one primary email", async () => {
+    if (!runtime) throw new Error("runtime not initialized");
+
+    await seedProject(runtime, {
+      projectId: "project:emails",
+      projectName: "Email Project",
+      isActive: false,
+      aiKnowledgeUrl: "https://docs.example.org/emails",
+      emails: ["first@asc.internal", "second@asc.internal"]
+    });
+
+    const result = await updateProjectEmailsAction("project:emails", [
+      { address: "second@asc.internal", isPrimary: true },
+      { address: "third@asc.internal", isPrimary: false }
+    ]);
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        emails: [
+          { address: "second@asc.internal", isPrimary: true },
+          { address: "third@asc.internal", isPrimary: false }
+        ]
+      }
+    });
+  });
+
+  it("rejects project email updates with an invalid email address", async () => {
+    if (!runtime) throw new Error("runtime not initialized");
+
+    await seedProject(runtime, {
+      projectId: "project:invalid-email",
+      projectName: "Invalid Email Project",
+      isActive: false,
+      aiKnowledgeUrl: null,
+      emails: []
+    });
+
+    const result = await updateProjectEmailsAction("project:invalid-email", [
+      { address: "not-an-email", isPrimary: true }
+    ]);
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "invalid_email_format"
+    });
+  });
+
+  it("rejects project email updates with zero primary emails", async () => {
+    if (!runtime) throw new Error("runtime not initialized");
+
+    await seedProject(runtime, {
+      projectId: "project:no-primary",
+      projectName: "No Primary",
+      isActive: false,
+      aiKnowledgeUrl: null,
+      emails: []
+    });
+
+    const result = await updateProjectEmailsAction("project:no-primary", [
+      { address: "first@asc.internal", isPrimary: false },
+      { address: "second@asc.internal", isPrimary: false }
+    ]);
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "primary_email_required"
+    });
+  });
+
+  it("rejects project email updates with multiple primary emails", async () => {
+    if (!runtime) throw new Error("runtime not initialized");
+
+    await seedProject(runtime, {
+      projectId: "project:multi-primary",
+      projectName: "Multi Primary",
+      isActive: false,
+      aiKnowledgeUrl: null,
+      emails: []
+    });
+
+    const result = await updateProjectEmailsAction("project:multi-primary", [
+      { address: "first@asc.internal", isPrimary: true },
+      { address: "second@asc.internal", isPrimary: true }
+    ]);
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "multiple_primary_emails"
+    });
+  });
+
+  it("updates the AI knowledge URL with a valid https URL", async () => {
+    if (!runtime) throw new Error("runtime not initialized");
+
+    await seedProject(runtime, {
+      projectId: "project:knowledge",
+      projectName: "Knowledge Project",
+      isActive: false,
+      aiKnowledgeUrl: null,
+      emails: ["knowledge@asc.internal"]
+    });
+
+    const result = await updateProjectAiKnowledgeAction(
+      "project:knowledge",
+      "https://docs.example.org/knowledge"
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        aiKnowledgeUrl: "https://docs.example.org/knowledge"
+      }
+    });
+  });
+
+  it("rejects invalid AI knowledge URLs", async () => {
+    if (!runtime) throw new Error("runtime not initialized");
+
+    await seedProject(runtime, {
+      projectId: "project:invalid-url",
+      projectName: "Invalid URL Project",
+      isActive: false,
+      aiKnowledgeUrl: null,
+      emails: []
+    });
+
+    const result = await updateProjectAiKnowledgeAction(
+      "project:invalid-url",
+      "http://docs.example.org/not-https"
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "invalid_url"
+    });
+  });
+
+  it("clears the AI knowledge URL when null is submitted", async () => {
+    if (!runtime) throw new Error("runtime not initialized");
+
+    await seedProject(runtime, {
+      projectId: "project:clear-url",
+      projectName: "Clear URL Project",
+      isActive: false,
+      aiKnowledgeUrl: "https://docs.example.org/existing",
+      emails: []
+    });
+
+    const result = await updateProjectAiKnowledgeAction(
+      "project:clear-url",
+      null
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        aiKnowledgeUrl: null
+      }
+    });
+  });
+
+  it("keeps user invite actions stubbed behind a not_implemented envelope", async () => {
+    const formData = new FormData();
+    formData.set("email", "operator@asc.internal");
+    formData.set("role", "internal_user");
+
+    const result = await inviteUserAction(formData);
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "not_implemented"
+    });
+  });
+});

--- a/apps/web/tests/unit/settings-project-detail-render.test.ts
+++ b/apps/web/tests/unit/settings-project-detail-render.test.ts
@@ -1,0 +1,120 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children
+  }: {
+    readonly children: unknown;
+  }) => children
+}));
+
+vi.mock("lucide-react", () => ({
+  ArrowLeft: () => null,
+  RefreshCw: () => null,
+  Trash2: () => null
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children
+  }: {
+    readonly children: unknown;
+  }) => children
+}));
+
+vi.mock("@/components/ui/input", () => ({
+  Input: () => null
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({
+    children
+  }: {
+    readonly children: unknown;
+  }) => children,
+  DialogContent: ({
+    children
+  }: {
+    readonly children: unknown;
+  }) => children,
+  DialogDescription: ({
+    children
+  }: {
+    readonly children: unknown;
+  }) => children,
+  DialogFooter: ({
+    children
+  }: {
+    readonly children: unknown;
+  }) => children,
+  DialogHeader: ({
+    children
+  }: {
+    readonly children: unknown;
+  }) => children,
+  DialogTitle: ({
+    children
+  }: {
+    readonly children: unknown;
+  }) => children,
+  DialogTrigger: ({
+    children
+  }: {
+    readonly children: unknown;
+  }) => children
+}));
+
+vi.mock("@/components/ui/status-badge", () => ({
+  StatusBadge: ({
+    label
+  }: {
+    readonly label: string;
+  }) => label
+}));
+
+vi.mock("../../app/settings/actions", () => ({
+  activateProjectAction: vi.fn(),
+  deactivateProjectAction: vi.fn(),
+  updateProjectAiKnowledgeAction: vi.fn(),
+  updateProjectEmailsAction: vi.fn()
+}));
+
+import { ProjectDetail } from "../../app/settings/_components/project-detail";
+
+describe("ProjectDetail role-aware rendering", () => {
+  it("does not render mutation controls for non-admin users", () => {
+    const html = renderToStaticMarkup(
+      createElement(ProjectDetail, {
+        project: {
+          projectId: "project:inactive",
+          projectName: "Inactive Project",
+          isActive: false,
+          primaryEmail: "inactive@asc.internal",
+          additionalEmailCount: 0,
+          aiKnowledgeUrl: null,
+          aiKnowledgeSyncedAt: null,
+          memberCount: 0,
+          activationRequirementsMet: false,
+          isAdmin: false,
+          emails: [
+            {
+              address: "inactive@asc.internal",
+              isPrimary: true
+            }
+          ],
+          salesforceProjectId: "project:inactive"
+        }
+      })
+    );
+
+    expect(html).toContain("Connected email addresses");
+    expect(html).not.toContain("Activate project");
+    expect(html).not.toContain("Deactivate project");
+    expect(html).not.toContain("Add email");
+    expect(html).not.toContain("Save URL");
+    expect(html).not.toContain("Sync");
+    expect(html).not.toContain("Make primary");
+  });
+});

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -2003,13 +2003,56 @@ function createStage2RepositoriesInternal(
     },
 
     projects: {
-      async findById(projectId) {
+      async findById(projectId: string) {
         const [row] = await loadSettingsProjects([projectId]);
         return row ?? null;
       },
 
       async listAll() {
         return loadSettingsProjects();
+      },
+
+      async setActive(projectId: string, isActive: boolean) {
+        const [row] = await db
+          .update(projectDimensions)
+          .set({
+            isActive,
+            updatedAt: new Date()
+          })
+          .where(eq(projectDimensions.projectId, projectId))
+          .returning({
+            projectId: projectDimensions.projectId
+          });
+
+        if (row === undefined) {
+          return null;
+        }
+
+        const [project] = await loadSettingsProjects([row.projectId]);
+        return project ?? null;
+      },
+
+      async setAiKnowledgeUrl(
+        projectId: string,
+        aiKnowledgeUrl: string | null
+      ) {
+        const [row] = await db
+          .update(projectDimensions)
+          .set({
+            aiKnowledgeUrl,
+            updatedAt: new Date()
+          })
+          .where(eq(projectDimensions.projectId, projectId))
+          .returning({
+            projectId: projectDimensions.projectId
+          });
+
+        if (row === undefined) {
+          return null;
+        }
+
+        const [project] = await loadSettingsProjects([row.projectId]);
+        return project ?? null;
       }
     },
 
@@ -2139,6 +2182,43 @@ function createStage2RepositoriesInternal(
           .orderBy(asc(projectAliases.alias));
 
         return rows.map(mapProjectAliasRow);
+      },
+
+      async replaceForProject(input: {
+        readonly projectId: string;
+        readonly aliases: readonly string[];
+        readonly actorId: string;
+      }) {
+        return db.transaction(async (tx: Stage1Database) => {
+          await tx
+            .delete(projectAliases)
+            .where(eq(projectAliases.projectId, input.projectId));
+
+          if (input.aliases.length === 0) {
+            return [];
+          }
+
+          const createdAtBase = Date.now();
+          const rows = await tx
+            .insert(projectAliases)
+            .values(
+              input.aliases.map((alias: string, index: number) => {
+                const occurredAt = new Date(createdAtBase + index);
+                return {
+                  id: crypto.randomUUID(),
+                  alias,
+                  projectId: input.projectId,
+                  createdAt: occurredAt,
+                  updatedAt: occurredAt,
+                  createdBy: input.actorId,
+                  updatedBy: input.actorId
+                };
+              })
+            )
+            .returning();
+
+          return rows.map(mapProjectAliasRow);
+        });
       },
 
       async create(record: ProjectAliasRecord) {

--- a/packages/domain/src/settings/repositories.ts
+++ b/packages/domain/src/settings/repositories.ts
@@ -21,6 +21,11 @@ export interface ProjectAliasesRepository {
   findById(id: string): Promise<ProjectAliasRecord | null>;
   findByAlias(alias: string): Promise<ProjectAliasRecord | null>;
   listAssigned(): Promise<readonly ProjectAliasRecord[]>;
+  replaceForProject(input: {
+    readonly projectId: string;
+    readonly aliases: readonly string[];
+    readonly actorId: string;
+  }): Promise<readonly ProjectAliasRecord[]>;
   create(record: ProjectAliasRecord): Promise<ProjectAliasRecord>;
   update(record: ProjectAliasRecord): Promise<ProjectAliasRecord>;
   delete(id: string): Promise<void>;
@@ -29,6 +34,14 @@ export interface ProjectAliasesRepository {
 export interface SettingsProjectsRepository {
   findById(projectId: string): Promise<SettingsProjectRecord | null>;
   listAll(): Promise<readonly SettingsProjectRecord[]>;
+  setActive(
+    projectId: string,
+    isActive: boolean
+  ): Promise<SettingsProjectRecord | null>;
+  setAiKnowledgeUrl(
+    projectId: string,
+    aiKnowledgeUrl: string | null
+  ): Promise<SettingsProjectRecord | null>;
 }
 
 export interface IntegrationHealthRepository {


### PR DESCRIPTION
Brief 3 of the Settings real-data rollout. Pairs with #59 (data foundation) and #60 (integration health poller).

## What shipped

- activateProjectAction — with the requirements gate: ≥1 email AND ai_knowledge_url present; otherwise returns requirements_not_met
- deactivateProjectAction — simple toggle, admin-only
- updateProjectEmailsAction — add/remove/edit, exactly-one-primary validation
- updateProjectAiKnowledgeAction — validates URL format, nullable allowed (clear)
- refreshIntegrationHealthAction — completes the action from Brief 2 with full admin gate + audit
- Audit events added for each mutation
- Admin-only UI controls hide (not disable) for non-admins

## Stays stubbed per architect decision E1

inviteUserAction, updateUserAccessAction, and related access mutations. UI buttons are hidden for now.

## Architect notes

- Salvaged from the Codex worktree at .codex-worktrees/settings-mutations — Codex completed the work but never pushed/opened a PR. Rebased it on top of current main, removed one unused readString helper to pass lint, committed, pushed.
- Typecheck, lint, boundaries all green.

## Follow-ups for architect

- D-036/D-037 canon entries in docs/01-core/decision-log.md for the is_active, ai_knowledge_url, and integration_health schema additions (PRs #59, #60, this one)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>