### PR TITLE
fix(inbox): strip signatures, autolink URLs, preserve line breaks, align widths

### DIFF
--- a/apps/web/app/inbox/_components/_autolink.tsx
+++ b/apps/web/app/inbox/_components/_autolink.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+const URL_PATTERN = /(https?:\/\/[^\s<>"]+)/g;
+
+export function autolinkText(
+  body: string,
+  linkClassName: string,
+): ReactNode {
+  return body.split(URL_PATTERN).map((segment, index) => {
+    if (index % 2 === 0) {
+      return segment;
+    }
+
+    return (
+      <a
+        key={`${segment}-${String(index)}`}
+        href={segment}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={cn("underline-offset-2 hover:underline", linkClassName)}
+      >
+        {segment}
+      </a>
+    );
+  });
+}

--- a/apps/web/app/inbox/_components/inbox-timeline.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline.tsx
@@ -6,6 +6,7 @@ import type {
   InboxTimelineEntryKind,
   InboxTimelineEntryViewModel,
 } from "../_lib/view-models";
+import { autolinkText } from "./_autolink";
 import { ChevronRightIcon, MailIcon, NoteIcon, PhoneIcon } from "./icons";
 import { DividerLabel } from "@/components/ui/divider-label";
 import { cn } from "@/lib/utils";
@@ -148,7 +149,7 @@ function InboundBubble({
   return (
     <li className="flex w-full flex-col items-start">
       <div
-        className={`max-w-2xl ${RADIUS.bubble} rounded-bl-sm border border-slate-200 bg-white px-4 py-3 ${SHADOW.sm}`}
+        className={`w-full max-w-2xl ${RADIUS.bubble} rounded-bl-sm border border-slate-200 bg-white px-4 py-3 ${SHADOW.sm}`}
       >
         {isEmail && entry.subject ? (
           <p className="mb-1.5 text-balance text-[13px] font-semibold leading-snug text-slate-900">
@@ -156,7 +157,9 @@ function InboundBubble({
           </p>
         ) : null}
         {body.length > 0 ? (
-          <p className={`whitespace-pre-wrap text-pretty ${TEXT.bodySm}`}>{body}</p>
+          <p className={`whitespace-pre-wrap text-pretty ${TEXT.bodySm}`}>
+            {autolinkText(body, "text-sky-600")}
+          </p>
         ) : null}
       </div>
       <div className={`mt-1.5 flex items-center gap-1.5 px-1 ${TEXT.micro}`}>
@@ -187,7 +190,7 @@ function OutboundBubble({
   return (
     <li className="flex w-full flex-col items-end">
       <div
-        className={`max-w-2xl ${RADIUS.bubble} rounded-br-sm bg-slate-800 px-4 py-3 ${SHADOW.sm}`}
+        className={`w-full max-w-2xl ${RADIUS.bubble} rounded-br-sm bg-slate-800 px-4 py-3 ${SHADOW.sm}`}
       >
         {isEmail && entry.subject ? (
           <p className="mb-1.5 text-balance text-[13px] font-semibold leading-snug text-slate-100">
@@ -196,7 +199,7 @@ function OutboundBubble({
         ) : null}
         {body.length > 0 ? (
           <p className="whitespace-pre-wrap text-pretty text-[13px] leading-relaxed text-slate-200">
-            {body}
+            {autolinkText(body, "text-sky-300")}
           </p>
         ) : null}
       </div>
@@ -271,7 +274,7 @@ function AutomatedRow({
                 isExpanded ? "whitespace-pre-wrap text-pretty" : "line-clamp-1"
               )}
             >
-              {body}
+              {isExpanded ? autolinkText(body, "text-sky-600") : body}
             </p>
           ) : null}
         </div>
@@ -294,7 +297,7 @@ function NoteEntry({ entry }: { readonly entry: InboxTimelineEntryViewModel }) {
   return (
     <li className="flex w-full flex-col items-end">
       <div
-        className={`max-w-2xl ${RADIUS.md} border-l-2 border-amber-400 ${TONE.amber.subtle} px-4 py-2.5`}
+        className={`w-full max-w-2xl ${RADIUS.md} border-l-2 border-amber-400 ${TONE.amber.subtle} px-4 py-2.5`}
       >
         <div className="mb-1 flex items-center gap-1.5 text-[11px] text-amber-700">
           <NoteIcon className="h-3 w-3" />

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -506,6 +506,70 @@ function sanitizePreviewText(value: string): string {
     .trim();
 }
 
+const STRUCTURED_EMAIL_TRANSLATION_MARKER_PATTERN =
+  /\b(?:en|es|fr|de|pt):(?=[A-ZÀ-Ý])/g;
+const STRUCTURED_EMAIL_PARAGRAPH_STARTERS = [
+  "Thank you",
+  "Thanks",
+  "We are",
+  "We're",
+  "This",
+  "These",
+  "That",
+  "The project coordinator",
+  "The",
+  "Gracias",
+  "El coordinador",
+  "Esta",
+  "Este",
+  "Estas",
+  "Estos",
+  "Saludos,",
+] as const;
+const SIGNATURE_SEPARATOR_PATTERN = /^(?:---|--\s)$/;
+const SENT_WITH_SIGNATURE_PATTERN = /^Sent with\b/i;
+const SIGN_OFF_LINE_PATTERN =
+  /^(?:Best,|Thanks,|Warmly,|Cheers,|Sincerely,|Saludos,)(?:\s.*)?$/i;
+
+function restoreStructuredEmailParagraphs(value: string): string {
+  const normalized = value.trim();
+
+  if (normalized.length === 0 || normalized.includes("\n")) {
+    return normalized;
+  }
+
+  const hasGreeting =
+    /^(?:Hi|Hello|Hey|Hola|Dear)\b[^,\n]{0,80},(?=\S)/i.test(normalized);
+  const hasTranslationMarker =
+    STRUCTURED_EMAIL_TRANSLATION_MARKER_PATTERN.test(normalized);
+  const sentenceBreaks = normalized.match(/[.!?](?=\S)/g)?.length ?? 0;
+
+  if (!hasGreeting && !hasTranslationMarker && sentenceBreaks < 3) {
+    return normalized;
+  }
+
+  const paragraphStarterPattern = new RegExp(
+    `([.!?])\\s*(?=(?:¡|¿|${STRUCTURED_EMAIL_PARAGRAPH_STARTERS.map((starter) =>
+      starter.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+    ).join("|")}))`,
+    "g",
+  );
+
+  return normalized
+    .replace(
+      /^((?:Hi|Hello|Hey|Hola|Dear)\b[^,\n]{0,80},)(?=\S)/i,
+      "$1\n\n",
+    )
+    .replace(paragraphStarterPattern, "$1\n\n")
+    .replace(
+      /([.!?])\s*(?=(?:en|es|fr|de|pt):(?=[A-ZÀ-Ý]))/g,
+      "$1\n\n",
+    )
+    .replace(STRUCTURED_EMAIL_TRANSLATION_MARKER_PATTERN, "\n\n$&")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
 interface ParsedPreview {
   readonly structuredEmail: boolean;
   readonly fromAddresses: readonly string[];
@@ -653,6 +717,98 @@ function trimQuotedReplyContent(value: string): string {
   ).trim();
 }
 
+function signatureLooksLikeClosing(
+  lines: readonly string[],
+  index: number,
+): boolean {
+  const trailingLines = lines.slice(index);
+  const trailingNonEmpty = trailingLines.filter(
+    (line) => line.trim().length > 0,
+  );
+
+  if (trailingNonEmpty.length === 0 || trailingNonEmpty.length > 6) {
+    return false;
+  }
+
+  if (index === lines.length - 1) {
+    return true;
+  }
+
+  return trailingLines.slice(1).some((line) => {
+    const trimmed = line.trim();
+
+    return (
+      trimmed.length === 0 ||
+      /^[A-Z][A-Za-zÀ-ÿ'’.-]+(?:\s+[A-Z][A-Za-zÀ-ÿ'’.-]+){0,3}$/.test(
+        trimmed,
+      ) ||
+      /@|https?:\/\/|\b(?:adventure scientists|docuseal|sent from my)\b/i.test(
+        trimmed,
+      )
+    );
+  });
+}
+
+export function stripSignature(body: string): string {
+  const normalized = body.replace(/\r\n?/g, "\n").trim();
+
+  if (normalized.length === 0) {
+    return "";
+  }
+
+  const lines = normalized.split("\n");
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const trimmed = (lines[index] ?? "").trim();
+
+    if (
+      SIGNATURE_SEPARATOR_PATTERN.test(trimmed) ||
+      SENT_WITH_SIGNATURE_PATTERN.test(trimmed) ||
+      /^(?:[-—]\s*)?The Adventure Scientists Team$/i.test(trimmed) ||
+      /^Adventure Scientists$/i.test(trimmed)
+    ) {
+      return lines.slice(0, index).join("\n").trim();
+    }
+  }
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const trimmed = (lines[index] ?? "").trim();
+
+    if (
+      SIGN_OFF_LINE_PATTERN.test(trimmed) &&
+      signatureLooksLikeClosing(lines, index)
+    ) {
+      return lines.slice(0, index).join("\n").trim();
+    }
+  }
+
+  const inlineClosingMatch =
+    /([.!?])\s*(?:Best,|Thanks,|Warmly,|Cheers,|Sincerely,|Saludos,).*/i.exec(
+      normalized,
+    );
+
+  if (
+    inlineClosingMatch !== null &&
+    inlineClosingMatch.index >= normalized.length - 200
+  ) {
+    return normalized.slice(0, inlineClosingMatch.index + 1).trim();
+  }
+
+  const trailingSignatureMatch =
+    /\n+\s*(?:Best,|Thanks,|Warmly,|Cheers,|Sincerely,|Saludos,).*/i.exec(
+      normalized,
+    );
+
+  if (
+    trailingSignatureMatch !== null &&
+    trailingSignatureMatch.index >= normalized.length - 200
+  ) {
+    return normalized.slice(0, trailingSignatureMatch.index).trim();
+  }
+
+  return normalized;
+}
+
 function parseCommunicationPreview(raw: string): ParsedPreview {
   const sanitized = sanitizePreviewText(raw);
 
@@ -700,7 +856,9 @@ function parseCommunicationPreview(raw: string): ParsedPreview {
       fromAddresses,
       recipientAddresses,
       subject,
-      body: trimQuotedReplyContent(bodyMatch[1] ?? ""),
+      body: restoreStructuredEmailParagraphs(
+        trimQuotedReplyContent(bodyMatch[1] ?? ""),
+      ),
     };
   }
 
@@ -719,7 +877,7 @@ function parseCommunicationPreview(raw: string): ParsedPreview {
     fromAddresses,
     recipientAddresses,
     subject,
-    body: trimQuotedReplyContent(body),
+    body: restoreStructuredEmailParagraphs(trimQuotedReplyContent(body)),
   };
 }
 
@@ -770,7 +928,7 @@ function resolvePreferredMessagePreview(input: {
 
   return {
     subject: subjectFromExplicit ?? subjectFromPreview,
-    body: body.length > 0 ? body : sanitizedFallback,
+    body: stripSignature(body.length > 0 ? body : sanitizedFallback),
     directionPreview,
   };
 }
@@ -1115,19 +1273,21 @@ function timelineSubject(item: TimelineItem): string | null {
 function timelineBody(item: TimelineItem): string {
   switch (item.family) {
     case "one_to_one_email":
-      return (
+      return stripSignature(
         trimQuotedReplyContent(item.bodyPreview ?? "") ||
-        parseCommunicationPreview(item.snippet).body ||
-        fallbackOneToOneEmailBody(item)
+          parseCommunicationPreview(item.snippet).body ||
+          fallbackOneToOneEmailBody(item),
       );
     case "one_to_one_sms":
       return item.messageTextPreview;
     case "auto_email":
-      return parseCommunicationPreview(item.snippet).body || item.summary;
+      return stripSignature(
+        parseCommunicationPreview(item.snippet).body || item.summary,
+      );
     case "auto_sms":
       return item.messageTextPreview;
     case "campaign_email":
-      return campaignHeadlineAndBody(item).body;
+      return stripSignature(campaignHeadlineAndBody(item).body);
     case "campaign_sms":
       return campaignHeadlineAndBody(item).body;
     case "internal_note":

--- a/apps/web/tests/unit/inbox-autolink.test.ts
+++ b/apps/web/tests/unit/inbox-autolink.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import React, { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+Object.assign(globalThis, { React });
+
+import { autolinkText } from "../../app/inbox/_components/_autolink";
+
+describe("autolinkText", () => {
+  it("links a URL in the middle of text", () => {
+    const markup = renderToStaticMarkup(
+      createElement(
+        "p",
+        null,
+        autolinkText(
+          "Review the packet at https://example.org/forms before tomorrow.",
+          "text-sky-600",
+        ),
+      ),
+    );
+
+    expect(markup).toContain('href="https://example.org/forms"');
+    expect(markup).toContain('target="_blank"');
+    expect(markup).toContain('rel="noopener noreferrer"');
+    expect(markup).toContain(">https://example.org/forms<");
+  });
+
+  it("links multiple URLs in one body", () => {
+    const markup = renderToStaticMarkup(
+      createElement(
+        "p",
+        null,
+        autolinkText(
+          "Open https://example.org/a and then https://example.org/b for the two checklists.",
+          "text-sky-600",
+        ),
+      ),
+    );
+
+    expect(markup.match(/href=/g)).toHaveLength(2);
+    expect(markup).toContain('href="https://example.org/a"');
+    expect(markup).toContain('href="https://example.org/b"');
+  });
+
+  it("keeps query strings and fragments in the linked URL", () => {
+    const markup = renderToStaticMarkup(
+      createElement(
+        "p",
+        null,
+        autolinkText(
+          "Sign here: https://docuseal.com/e/abc123?review=true#signature",
+          "text-sky-600",
+        ),
+      ),
+    );
+
+    expect(markup).toContain(
+      'href="https://docuseal.com/e/abc123?review=true#signature"',
+    );
+  });
+});

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -56,6 +56,7 @@ import {
   getInboxDetail,
   getInboxList,
   getInboxTimelinePage,
+  stripSignature,
 } from "../../app/inbox/_lib/selectors";
 import { InboxContactRail } from "../../app/inbox/_components/inbox-contact-rail";
 import type { InboxListItemViewModel } from "../../app/inbox/_lib/view-models";
@@ -1405,6 +1406,140 @@ describe("real inbox selectors", () => {
     expect(unresolved.items.map((item) => item.contactId)).toEqual([
       "contact:alex-thompson",
     ]);
+  });
+
+  it("restores paragraph breaks for flattened structured Salesforce email bodies", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:mylee-marques",
+      salesforceContactId: "003-mylee-marques",
+      displayName: "Mylee Marques",
+      primaryEmail: "mylee@example.org",
+      primaryPhone: null,
+    });
+    const latestSalesforceEvent = await seedInboxSalesforceOutboundEmailEvent(
+      runtime.context,
+      {
+        id: "mylee-flattened-salesforce-body",
+        contactId: "contact:mylee-marques",
+        occurredAt: "2026-04-16T14:00:00.000Z",
+        subject:
+          "Email: Aplicacion en Revision: Monitoreo y Restauracion de Arrecifes de Coral",
+        snippet: [
+          "To: mylee@example.org",
+          "",
+          "Subject: Aplicacion en Revision: Monitoreo y Restauracion de Arrecifes de Coral",
+          "Body:",
+          "Hola Mylee,Gracias por aplicar al Proyecto de Monitoreo y Restauracion de Arrecifes de Coral. ¡Estamos emocionados de tenerte a bordo en esta aventura unica!Esta iniciativa multinacional es la primera de su tipo en America Latina en emplear ciencia ciudadana y protocolos de monitoreo globales para generar datos estandarizados y de alta calidad sobre arrecifes de coral. El coordinador del proyecto en tu area estara revisando tu solicitud y, si es aprobada, se pondra en contacto contigo pronto para informarte sobre los siguientes pasos.en:Thank you for applying to the Coral Reef Monitoring and Restoration Project. We are excited for your interest in participating in this one of a kind adventure!This multi-country initiative is the first of its kind in Latin America to employ citizen science and global monitoring protocols to generate high-quality, standardized coral reef data. The project coordinator for your area will be reviewing your application, and if approved, they will be in touch soon about next steps.Saludos,Adventure Scientists",
+        ].join("\n"),
+        messageKind: "one_to_one",
+      },
+    );
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:mylee-marques",
+      bucket: "Opened",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: null,
+      lastOutboundAt: "2026-04-16T14:00:00.000Z",
+      lastActivityAt: "2026-04-16T14:00:00.000Z",
+      snippet: "Flattened Salesforce fallback should not win.",
+      lastCanonicalEventId: latestSalesforceEvent.canonicalEventId,
+      lastEventType: "communication.email.outbound",
+    });
+
+    const detail = await getInboxDetail("contact:mylee-marques");
+    const latestEntry = detail?.timeline.at(-1);
+
+    expect(latestEntry).toMatchObject({
+      kind: "outbound-email",
+      body: [
+        "Hola Mylee,",
+        "",
+        "Gracias por aplicar al Proyecto de Monitoreo y Restauracion de Arrecifes de Coral.",
+        "",
+        "¡Estamos emocionados de tenerte a bordo en esta aventura unica!",
+        "",
+        "Esta iniciativa multinacional es la primera de su tipo en America Latina en emplear ciencia ciudadana y protocolos de monitoreo globales para generar datos estandarizados y de alta calidad sobre arrecifes de coral.",
+        "",
+        "El coordinador del proyecto en tu area estara revisando tu solicitud y, si es aprobada, se pondra en contacto contigo pronto para informarte sobre los siguientes pasos.",
+        "",
+        "en:Thank you for applying to the Coral Reef Monitoring and Restoration Project.",
+        "",
+        "We are excited for your interest in participating in this one of a kind adventure!",
+        "",
+        "This multi-country initiative is the first of its kind in Latin America to employ citizen science and global monitoring protocols to generate high-quality, standardized coral reef data.",
+        "",
+        "The project coordinator for your area will be reviewing your application, and if approved, they will be in touch soon about next steps.",
+      ].join("\n"),
+    });
+  });
+
+  it("strips signature fixtures without stripping inline closing phrases", () => {
+    expect(
+      stripSignature(
+        [
+          "Please review the attached scope update.",
+          "---",
+          "Adventure Scientists",
+        ].join("\n"),
+      ),
+    ).toBe("Please review the attached scope update.");
+
+    expect(
+      stripSignature(
+        [
+          "Your document is ready for signature.",
+          "Sent with DocuSeal Pro",
+          "https://docuseal.com/e/example",
+        ].join("\n"),
+      ),
+    ).toBe("Your document is ready for signature.");
+
+    expect(
+      stripSignature(
+        [
+          "We work with Seaside High School, Neah-kah-nie High School, and Northwest Academy.",
+          "",
+          "Best, Elise",
+        ].join("\n"),
+      ),
+    ).toBe(
+      "We work with Seaside High School, Neah-kah-nie High School, and Northwest Academy.",
+    );
+
+    expect(
+      stripSignature(
+        [
+          "We are thrilled to have you in our pod and look forward to seeing where this project takes us, together.",
+          "The Adventure Scientists Team",
+        ].join("\n"),
+      ),
+    ).toBe(
+      "We are thrilled to have you in our pod and look forward to seeing where this project takes us, together.",
+    );
+
+    expect(
+      stripSignature(
+        [
+          "Got this point moved last week but did not email you that I did.",
+          "",
+          "Thanks,",
+          "John",
+        ].join("\n"),
+      ),
+    ).toBe("Got this point moved last week but did not email you that I did.");
+
+    expect(
+      stripSignature(
+        "Best regards, Samantha mentioned the confirmation timing in the paragraph above.",
+      ),
+    ).toBe(
+      "Best regards, Samantha mentioned the confirmation timing in the paragraph above.",
+    );
   });
 
   it("treats an empty query as the default ordered inbox list", async () => {


### PR DESCRIPTION
## Summary

- Strip signatures from bubble bodies (RFC 3676 sig-sep, "Sent with DocuSeal", common closings).
- Restore paragraph breaks on emails stored as one-line walls of text (the Mylee / Coral Reef Spanish email was the canonical case).
- Autolink raw URLs in bubble bodies via new `_autolink.tsx`. All links `target="_blank" rel="noopener noreferrer"`.
- Normalize bubble wrappers so inbound/outbound/automated/campaign have consistent max widths.

## Test plan

- [ ] CI green on: `pnpm lint`, `pnpm test:unit`, `pnpm typecheck`
- [ ] New unit tests cover signature stripping fixtures + URL autolinking
- [ ] Visual check after deploy: Mylee Spanish email renders with paragraph breaks; DocuSeal "Sent with..." footer is stripped; URLs are clickable

Brief: `.codex-inbox-bubble-polish-2026-04-20.md` (repo root, architect-authored).