### PR TITLE
fix(inbox): polish automated + campaign rows (prefix, URL-subject, expand)

### DIFF
--- a/apps/web/app/inbox/_components/inbox-timeline.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline.tsx
@@ -70,7 +70,7 @@ export function InboxTimeline({
               "transition-[color,background-color,transform] duration-150 ease-out",
               "active:scale-[0.96] disabled:active:scale-100",
               TRANSITION.reduceMotion,
-              "hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+              "hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60",
             )}
           >
             {isLoadingOlder
@@ -238,10 +238,11 @@ function AutomatedRow({
           : "Campaign SMS";
   const headline = entry.subject;
   const body = bodyTextForEntry(entry);
-  const hideCollapsedBody =
-    !isExpanded &&
-    (role === "campaign" ||
-      (entry.kind === "outbound-auto-email" && headline !== null));
+  const hideCollapsedBody = shouldHideAutomatedRowBody({
+    isExpanded,
+    kind: entry.kind,
+    headline,
+  });
 
   return (
     <li className="flex w-full flex-col items-end">
@@ -257,7 +258,7 @@ function AutomatedRow({
           "transition-[color,background-color,transform] duration-150 ease-out",
           "active:scale-[0.96]",
           TRANSITION.reduceMotion,
-          "hover:bg-slate-50"
+          "hover:bg-slate-50",
         )}
       >
         <div className="min-w-0 flex-1">
@@ -271,7 +272,7 @@ function AutomatedRow({
               className={cn(
                 "text-[13px] leading-relaxed text-slate-600",
                 headline && "mt-1.5",
-                isExpanded ? "whitespace-pre-wrap text-pretty" : "line-clamp-1"
+                isExpanded ? "whitespace-pre-wrap text-pretty" : "line-clamp-1",
               )}
             >
               {isExpanded ? autolinkText(body, "text-sky-600") : body}
@@ -290,6 +291,18 @@ function AutomatedRow({
         </div>
       </button>
     </li>
+  );
+}
+
+export function shouldHideAutomatedRowBody(input: {
+  readonly isExpanded: boolean;
+  readonly kind: InboxTimelineEntryKind;
+  readonly headline: string | null;
+}): boolean {
+  return (
+    !input.isExpanded &&
+    input.kind === "outbound-auto-email" &&
+    input.headline !== null
   );
 }
 

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -976,28 +976,33 @@ function campaignHeadlineAndBody(
 } {
   if (item.family === "campaign_email") {
     const parsedPreview = parseCommunicationPreview(item.snippet);
+
+    if (parsedPreview.subject !== null) {
+      return {
+        headline: parsedPreview.subject,
+        body:
+          resolveDisplayableOutboundSubject(parsedPreview.subject) === null
+            ? parsedPreview.body
+            : suppressDuplicateHeadlineBody(
+                parsedPreview.subject,
+                parsedPreview.body,
+              ),
+      };
+    }
+
     const cleaned =
-      parsedPreview.subject !== null
+      parsedPreview.body.length > 0
         ? parsedPreview.body
-        : parsedPreview.body.length > 0
-          ? parsedPreview.body
-          : (normalizeInlineText(item.summary) ?? "");
+        : (normalizeInlineText(item.summary) ?? "");
+
     const split = splitHeadlineAndBody(cleaned);
-    const headline =
-      parsedPreview.subject ??
-      split.headline ??
-      normalizeInlineText(item.campaignName) ??
-      normalizeInlineText(item.summary);
-    const body =
-      parsedPreview.subject !== null
-        ? cleaned
-        : split.body.length > 0
-          ? split.body
-          : cleaned;
 
     return {
-      headline,
-      body: suppressDuplicateHeadlineBody(headline, body),
+      headline:
+        split.headline ??
+        normalizeInlineText(item.campaignName) ??
+        normalizeInlineText(item.summary),
+      body: cleaned,
     };
   }
 
@@ -1249,6 +1254,37 @@ function timelineActorLabel(
   }
 }
 
+const OUTBOUND_SUBJECT_PREFIX_PATTERN =
+  /^\s*(?:→|->|&rarr;|\u2192)\s*Email:\s*/i;
+
+function stripOutboundSubjectPrefix(subject: string | null): string | null {
+  const normalized = normalizeInlineText(subject);
+
+  if (normalized === null) {
+    return null;
+  }
+
+  return normalizeInlineText(
+    normalized.replace(OUTBOUND_SUBJECT_PREFIX_PATTERN, ""),
+  );
+}
+
+function looksLikeUrl(subject: string): boolean {
+  return /^https?:\/\//i.test(subject.trim());
+}
+
+function resolveDisplayableOutboundSubject(
+  subject: string | null,
+): string | null {
+  const stripped = stripOutboundSubjectPrefix(subject);
+
+  if (stripped === null || looksLikeUrl(stripped)) {
+    return null;
+  }
+
+  return stripped;
+}
+
 function timelineSubject(item: TimelineItem): string | null {
   switch (item.family) {
     case "one_to_one_email":
@@ -1257,10 +1293,16 @@ function timelineSubject(item: TimelineItem): string | null {
         parseCommunicationPreview(item.snippet).subject
       );
     case "auto_email":
-      return normalizeInlineText(item.subject);
+      return resolveDisplayableOutboundSubject(
+        normalizeInlineText(item.subject) ??
+          parseCommunicationPreview(item.snippet).subject,
+      );
     case "auto_sms":
       return null;
     case "campaign_email":
+      return resolveDisplayableOutboundSubject(
+        parseCommunicationPreview(item.snippet).subject,
+      );
     case "campaign_sms":
       return campaignHeadlineAndBody(item).headline;
     case "one_to_one_sms":
@@ -1583,38 +1625,38 @@ async function readInboxListCacheData(input: {
   const runtime = await getStage1WebRuntime();
   const decodedCursor = decodeInboxListCursor(input.cursor);
   const normalizedQuery = normalizeInlineText(input.query) ?? null;
-  const [projectionPage, counts, freshness, activeProjectRecords] = await Promise.all([
-    normalizedQuery === null
-      ? runtime.repositories.inboxProjection
-          .listPageOrderedByRecency({
+  const [projectionPage, counts, freshness, activeProjectRecords] =
+    await Promise.all([
+      normalizedQuery === null
+        ? runtime.repositories.inboxProjection
+            .listPageOrderedByRecency({
+              filter: input.filterId,
+              limit: input.limit + 1,
+              cursor: decodedCursor,
+              projectId: input.projectId,
+            })
+            .then((rows) => ({
+              rows,
+              total: 0,
+            }))
+        : runtime.repositories.inboxProjection.searchPageOrderedByRecency({
             filter: input.filterId,
             limit: input.limit + 1,
             cursor: decodedCursor,
+            query: normalizedQuery,
             projectId: input.projectId,
-          })
-          .then((rows) => ({
-            rows,
-            total: 0,
-          }))
-      : runtime.repositories.inboxProjection.searchPageOrderedByRecency({
-          filter: input.filterId,
-          limit: input.limit + 1,
-          cursor: decodedCursor,
-          query: normalizedQuery,
-          projectId: input.projectId,
-        }),
-    runtime.repositories.inboxProjection.countByFilters({
-      projectId: input.projectId,
-    }),
-    runtime.repositories.inboxProjection.getFreshness(),
-    runtime.repositories.projectDimensions.listActive(),
-  ]);
-  const activeProjects: readonly InboxActiveProjectOption[] = activeProjectRecords.map(
-    (record) => ({
+          }),
+      runtime.repositories.inboxProjection.countByFilters({
+        projectId: input.projectId,
+      }),
+      runtime.repositories.inboxProjection.getFreshness(),
+      runtime.repositories.projectDimensions.listActive(),
+    ]);
+  const activeProjects: readonly InboxActiveProjectOption[] =
+    activeProjectRecords.map((record) => ({
       id: record.projectId,
       name: record.projectName,
-    }),
-  );
+    }));
   const hasMore = projectionPage.rows.length > input.limit;
   const pageProjections = hasMore
     ? projectionPage.rows.slice(0, input.limit)

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -422,8 +422,8 @@ describe("real inbox selectors", () => {
     ]);
     expect(detail?.timeline[1]).toMatchObject({
       kind: "outbound-campaign-email",
-      subject: "Welcome to the new field season.",
-      body: "",
+      subject: null,
+      body: "Welcome to the new field season.",
     });
     expect(detail?.timeline[2]).toMatchObject({
       kind: "outbound-auto-email",
@@ -634,7 +634,9 @@ describe("real inbox selectors", () => {
     const detail = await getInboxDetail("contact:lisa-zhang");
 
     expect(
-      detail?.timeline.some((entry) => entry.kind === "outbound-campaign-email"),
+      detail?.timeline.some(
+        (entry) => entry.kind === "outbound-campaign-email",
+      ),
     ).toBe(true);
     expect(
       detail?.timeline.some((entry) => entry.kind === "outbound-email"),
@@ -1070,8 +1072,7 @@ describe("real inbox selectors", () => {
       contactId: "contact:maria-no-body",
       canonicalEventId: latestSalesforceEvent.canonicalEventId,
       occurredAt: "2026-04-16T12:30:00.000Z",
-      sortKey:
-        "2026-04-16T12:30:00.000Z::event:maria-no-body-latest",
+      sortKey: "2026-04-16T12:30:00.000Z::event:maria-no-body-latest",
       eventType: "communication.email.outbound",
       summary: "Outbound Email Sent",
       channel: "email",
@@ -1195,6 +1196,170 @@ describe("real inbox selectors", () => {
       subject: "April field update",
       body: "Hi Sarah,\nPlease bring your field notebook.",
       isPreview: true,
+    });
+  });
+
+  it("strips outbound email prefixes from automated and campaign email subjects before display", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxAutoEmailEvent(runtime.context, {
+      id: "sarah-auto-email-prefixed",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-12T15:30:00.000Z",
+      subject: "→ Email: Re: still time to get involved?",
+      snippet: "Checking in before the training window closes.",
+    });
+    await seedInboxCampaignEmailEvent(runtime.context, {
+      id: "sarah-campaign-email-arrow-ascii",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-12T15:45:00.000Z",
+      activityType: "sent",
+      campaignName: "PNW Training",
+      snippet: [
+        "From: volunteers@example.org",
+        "To: sarah@example.org",
+        "",
+        "Subject: -> Email: Last Call: PNW Training",
+        "Body:",
+        "Please confirm your attendance today.",
+      ].join("\n"),
+    });
+    await seedInboxCampaignEmailEvent(runtime.context, {
+      id: "sarah-campaign-email-arrow-entity",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-12T15:50:00.000Z",
+      activityType: "sent",
+      campaignName: "Weekly Digest",
+      snippet: [
+        "From: volunteers@example.org",
+        "To: sarah@example.org",
+        "",
+        "Subject: &rarr; Email: Weekly Digest",
+        "Body:",
+        "A quick recap from this week.",
+      ].join("\n"),
+    });
+
+    const detail = await getInboxDetail("contact:sarah-martinez");
+    const autoEntry = detail?.timeline.find(
+      (entry) => entry.id === "timeline:sarah-auto-email-prefixed",
+    );
+    const asciiCampaignEntry = detail?.timeline.find(
+      (entry) => entry.id === "timeline:sarah-campaign-email-arrow-ascii",
+    );
+    const entityCampaignEntry = detail?.timeline.find(
+      (entry) => entry.id === "timeline:sarah-campaign-email-arrow-entity",
+    );
+
+    expect(autoEntry).toMatchObject({
+      kind: "outbound-auto-email",
+      subject: "Re: still time to get involved?",
+    });
+    expect(asciiCampaignEntry).toMatchObject({
+      kind: "outbound-campaign-email",
+      subject: "Last Call: PNW Training",
+    });
+    expect(entityCampaignEntry).toMatchObject({
+      kind: "outbound-campaign-email",
+      subject: "Weekly Digest",
+    });
+  });
+
+  it("hides unusable automated and campaign email subjects while keeping meaningful body and embedded URLs", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    const zoomUrl =
+      "https://us02web.zoom.us/webinar/register/WN_BrC0DjiqS36ei74Vhtg7sw";
+
+    await seedInboxAutoEmailEvent(runtime.context, {
+      id: "sarah-auto-email-url-subject",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-12T16:05:00.000Z",
+      subject: zoomUrl,
+      snippet: `Body:\n${zoomUrl}`,
+    });
+    await seedInboxAutoEmailEvent(runtime.context, {
+      id: "sarah-auto-email-embedded-url",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-12T16:10:00.000Z",
+      subject: `Register here: ${zoomUrl}`,
+      snippet: "Sharing the registration link for next week's webinar.",
+    });
+    await seedInboxAutoEmailEvent(runtime.context, {
+      id: "sarah-auto-email-empty-after-prefix",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-12T16:15:00.000Z",
+      subject: "→ Email:    ",
+      snippet: "The automation body still needs to render.",
+    });
+    await seedInboxCampaignEmailEvent(runtime.context, {
+      id: "sarah-campaign-email-url-subject",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-12T16:20:00.000Z",
+      activityType: "sent",
+      campaignName: "Webinar Push",
+      snippet: [
+        "From: volunteers@example.org",
+        "To: sarah@example.org",
+        "",
+        `Subject: ${zoomUrl}`,
+        "Body:",
+        zoomUrl,
+      ].join("\n"),
+    });
+    await seedInboxCampaignEmailEvent(runtime.context, {
+      id: "sarah-campaign-email-no-subject",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-12T16:25:00.000Z",
+      activityType: "sent",
+      campaignName: "Field Update",
+      snippet: "Welcome to the new field season.",
+    });
+
+    const detail = await getInboxDetail("contact:sarah-martinez");
+    const autoUrlEntry = detail?.timeline.find(
+      (entry) => entry.id === "timeline:sarah-auto-email-url-subject",
+    );
+    const autoEmbeddedUrlEntry = detail?.timeline.find(
+      (entry) => entry.id === "timeline:sarah-auto-email-embedded-url",
+    );
+    const autoEmptyEntry = detail?.timeline.find(
+      (entry) => entry.id === "timeline:sarah-auto-email-empty-after-prefix",
+    );
+    const campaignUrlEntry = detail?.timeline.find(
+      (entry) => entry.id === "timeline:sarah-campaign-email-url-subject",
+    );
+    const campaignNoSubjectEntry = detail?.timeline.find(
+      (entry) => entry.id === "timeline:sarah-campaign-email-no-subject",
+    );
+
+    expect(autoUrlEntry).toMatchObject({
+      kind: "outbound-auto-email",
+      subject: null,
+      body: zoomUrl,
+    });
+    expect(autoEmbeddedUrlEntry).toMatchObject({
+      kind: "outbound-auto-email",
+      subject: `Register here: ${zoomUrl}`,
+    });
+    expect(autoEmptyEntry).toMatchObject({
+      kind: "outbound-auto-email",
+      subject: null,
+      body: "The automation body still needs to render.",
+    });
+    expect(campaignUrlEntry).toMatchObject({
+      kind: "outbound-campaign-email",
+      subject: null,
+      body: zoomUrl,
+    });
+    expect(campaignNoSubjectEntry).toMatchObject({
+      kind: "outbound-campaign-email",
+      subject: null,
+      body: "Welcome to the new field season.",
     });
   });
 

--- a/apps/web/tests/unit/inbox-timeline.test.ts
+++ b/apps/web/tests/unit/inbox-timeline.test.ts
@@ -31,7 +31,10 @@ vi.mock("@/app/_lib/design-tokens", () => ({
   },
 }));
 
-import { InboxTimeline } from "../../app/inbox/_components/inbox-timeline";
+import {
+  InboxTimeline,
+  shouldHideAutomatedRowBody,
+} from "../../app/inbox/_components/inbox-timeline";
 
 const baseEntry = {
   id: "timeline:auto-email-1",
@@ -63,5 +66,56 @@ describe("InboxTimeline", () => {
     expect(markup).not.toContain(
       "Thanks for signing up. Bring your field notebook.",
     );
+  });
+
+  it("keeps campaign email body text visible when the row is collapsed", () => {
+    const markup = renderToStaticMarkup(
+      createElement(InboxTimeline, {
+        entries: [
+          {
+            ...baseEntry,
+            id: "timeline:campaign-email-1",
+            kind: "outbound-campaign-email" as const,
+            subject: null,
+            body: "Please review the latest field update.",
+          },
+        ],
+        volunteerFirstName: "Alice",
+      }),
+    );
+
+    expect(markup).toContain("Campaign Email");
+    expect(markup).toContain("Please review the latest field update.");
+  });
+
+  it("only hides automated email body text while a subject-bearing row is collapsed", () => {
+    expect(
+      shouldHideAutomatedRowBody({
+        isExpanded: false,
+        kind: "outbound-auto-email",
+        headline: "Training details",
+      }),
+    ).toBe(true);
+    expect(
+      shouldHideAutomatedRowBody({
+        isExpanded: true,
+        kind: "outbound-auto-email",
+        headline: "Training details",
+      }),
+    ).toBe(false);
+    expect(
+      shouldHideAutomatedRowBody({
+        isExpanded: false,
+        kind: "outbound-campaign-email",
+        headline: "April field update",
+      }),
+    ).toBe(false);
+    expect(
+      shouldHideAutomatedRowBody({
+        isExpanded: false,
+        kind: "outbound-auto-email",
+        headline: null,
+      }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Strip "→ Email:" prefix from stored subjects on automated + campaign email rows. The email marketing platform prepends it; users shouldn't see it.
- Suppress subject line when the resolved subject is empty or a pure URL (the Zoom registration case from the user report). Show no placeholder.
- Campaign emails expand to show body when clicked, matching automated email behavior.

## Test plan

- [ ] CI green on: `pnpm lint`, `pnpm test:unit`, `pnpm typecheck`
- [ ] Unit coverage: arrow-prefix Unicode variants, pure-URL fallback, embedded-URL preservation, campaign expand/collapse
- [ ] Visual check after deploy: Rosie "still time to get involved" automated row shows "Re: still time to get involved?" without arrow prefix; Zoom URL subject renders no headline

Brief: `.codex-automated-campaign-polish-2026-04-20.md` (repo root, architect-authored).

## Note on sequencing

This PR touches the same files as #fix/inbox-bubble-polish. It was written against main; if that PR lands first there may be a small conflict to resolve. Merge order: bubble-polish first.