### PR TITLE
fix(dedup): collapse cross-provider + intra-Gmail outbound email duplicates

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -13,6 +13,7 @@
     "ops:check-config": "tsx src/ops/cli.ts check-config",
     "ops:backfill-gmail-message-bodies": "tsx src/ops/backfill-gmail-message-bodies.ts",
     "ops:backfill-salesforce-communication-details": "tsx src/ops/backfill-salesforce-communication-details.ts",
+    "ops:dedup-historical-ledger": "tsx src/ops/dedup-historical-ledger.ts",
     "ops:enqueue": "tsx src/ops/cli.ts enqueue",
     "ops:import-gmail-mbox": "tsx src/ops/cli.ts import-gmail-mbox",
     "ops:reclassify-salesforce-tasks": "tsx src/ops/reclassify-salesforce-tasks.ts",

--- a/apps/worker/src/ops/cli.ts
+++ b/apps/worker/src/ops/cli.ts
@@ -32,6 +32,9 @@ import {
   runBackfillSalesforceCommunicationDetailsCommand
 } from "./backfill-salesforce-communication-details.js";
 import {
+  runDedupHistoricalLedgerCommand
+} from "./dedup-historical-ledger.js";
+import {
   buildOperationId,
   parseCliFlags,
   readOptionalBooleanFlag,
@@ -250,9 +253,12 @@ async function main(): Promise<void> {
     case "backfill-salesforce-communication-details":
       await runBackfillSalesforceCommunicationDetailsCommand(rest, process.env);
       return;
+    case "dedup-historical-ledger":
+      await runDedupHistoricalLedgerCommand(rest, process.env);
+      return;
     default:
       throw new Error(
-        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details."
+        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, dedup-historical-ledger."
       );
   }
 }

--- a/apps/worker/src/ops/dedup-historical-ledger.ts
+++ b/apps/worker/src/ops/dedup-historical-ledger.ts
@@ -1,0 +1,720 @@
+#!/usr/bin/env tsx
+/**
+ * dedup-historical-ledger
+ *
+ * Usage:
+ *   pnpm --filter @as-comms/worker ops dedup-historical-ledger
+ *   pnpm --filter @as-comms/worker ops dedup-historical-ledger --limit 100
+ *   pnpm --filter @as-comms/worker ops dedup-historical-ledger --execute --limit 100
+ *
+ * Dry-run by default. Finds historical outbound-email duplicates using the same
+ * 15 minute fingerprint heuristic as live normalization, emits a JSONL audit
+ * trail to stdout, and can optionally merge the surviving ledger rows in-place.
+ */
+import process from "node:process";
+
+import {
+  asc,
+  eq,
+  inArray
+} from "drizzle-orm";
+
+import {
+  canonicalEventSchema,
+  type CanonicalEventRecord
+} from "@as-comms/contracts";
+import {
+  createDatabaseConnection,
+  closeDatabaseConnection,
+  createStage1RepositoryBundle,
+  createStage1RepositoryBundleFromConnection,
+  canonicalEventLedger,
+  contactInboxProjection,
+  contactTimelineProjection,
+  type Stage1Database
+} from "@as-comms/db";
+import {
+  buildOutboundEmailDuplicateFingerprint,
+  buildPersistedOutboundEmailFingerprintSource,
+  isWithinOutboundEmailFingerprintWindow,
+  resolveOutboundEmailMergedWinnerDecision,
+  selectOutboundEmailDuplicateWinner
+} from "@as-comms/domain";
+
+import {
+  parseCliFlags,
+  readOptionalBooleanFlag,
+  readOptionalIntegerFlag
+} from "./helpers.js";
+
+const executeBatchLoserLimit = 500;
+
+type Stage1Repositories = ReturnType<typeof createStage1RepositoryBundle>;
+
+interface Logger {
+  log(...args: readonly unknown[]): void;
+  error(...args: readonly unknown[]): void;
+}
+
+interface AuditWriter {
+  writeLine(line: string): void;
+}
+
+interface CanonicalEventReference {
+  readonly table: "contact_inbox_projection" | "contact_timeline_projection";
+  readonly column: "last_canonical_event_id" | "canonical_event_id";
+  readonly action: "repoint_to_winner" | "delete_loser_projection_row";
+}
+
+interface HistoricalOutboundEmailCandidate {
+  readonly event: CanonicalEventRecord;
+  readonly fingerprint: string;
+}
+
+interface HistoricalDedupClusterPlan {
+  winner: HistoricalOutboundEmailCandidate;
+  losers: HistoricalOutboundEmailCandidate[];
+}
+
+interface HistoricalDedupAuditLine {
+  readonly winnerId: string;
+  readonly loserId: string;
+  readonly winnerProvider: CanonicalEventRecord["provenance"]["primaryProvider"];
+  readonly loserProvider: CanonicalEventRecord["provenance"]["primaryProvider"];
+  readonly contactId: string;
+  readonly occurredAt: string;
+  readonly operation: "would_merge" | "merged" | "skipped_already_merged";
+}
+
+export interface HistoricalLedgerDedupResult {
+  readonly dryRun: boolean;
+  readonly referenceTargets: readonly CanonicalEventReference[];
+  readonly scannedCandidateCount: number;
+  readonly plannedClusterCount: number;
+  readonly plannedLoserCount: number;
+  readonly deletedCanonicalCount: number;
+  readonly deletedTimelineCount: number;
+  readonly repointedInboxCount: number;
+  readonly skippedAlreadyMergedCount: number;
+  readonly auditLines: readonly HistoricalDedupAuditLine[];
+}
+
+function readConnectionString(env: NodeJS.ProcessEnv): string {
+  const connectionString = env.WORKER_DATABASE_URL ?? env.DATABASE_URL;
+
+  if (connectionString === undefined || connectionString.trim().length === 0) {
+    throw new Error(
+      "DATABASE_URL or WORKER_DATABASE_URL is required for this ops command."
+    );
+  }
+
+  return connectionString;
+}
+
+function normalizeOccurredAt(value: Date | string): string {
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function mergeReviewState(
+  left: CanonicalEventRecord["reviewState"],
+  right: CanonicalEventRecord["reviewState"]
+): CanonicalEventRecord["reviewState"] {
+  if (left === "quarantined" || right === "quarantined") {
+    return "quarantined";
+  }
+
+  if (
+    left === "needs_identity_review" ||
+    right === "needs_identity_review"
+  ) {
+    return "needs_identity_review";
+  }
+
+  if (left === "needs_routing_review" || right === "needs_routing_review") {
+    return "needs_routing_review";
+  }
+
+  return "clear";
+}
+
+function uniqueSortedStrings(values: readonly string[]): string[] {
+  return Array.from(new Set(values)).sort((left, right) =>
+    left.localeCompare(right)
+  );
+}
+
+function compareCandidates(
+  left: HistoricalOutboundEmailCandidate,
+  right: HistoricalOutboundEmailCandidate
+): number {
+  if (left.event.contactId !== right.event.contactId) {
+    return left.event.contactId.localeCompare(right.event.contactId);
+  }
+
+  if (left.event.occurredAt !== right.event.occurredAt) {
+    return left.event.occurredAt.localeCompare(right.event.occurredAt);
+  }
+
+  return left.event.id.localeCompare(right.event.id);
+}
+
+function knownCanonicalEventReferences(): readonly CanonicalEventReference[] {
+  return [
+    {
+      table: "contact_inbox_projection",
+      column: "last_canonical_event_id",
+      action: "repoint_to_winner"
+    },
+    {
+      table: "contact_timeline_projection",
+      column: "canonical_event_id",
+      action: "delete_loser_projection_row"
+    }
+  ];
+}
+
+function buildHistoricalMergedWinnerEvent(input: {
+  readonly winner: CanonicalEventRecord;
+  readonly losers: readonly CanonicalEventRecord[];
+}): CanonicalEventRecord {
+  const supportingSourceEvidenceIds = uniqueSortedStrings([
+    ...input.winner.provenance.supportingSourceEvidenceIds,
+    ...input.losers.flatMap((loser) => [
+      loser.sourceEvidenceId,
+      ...loser.provenance.supportingSourceEvidenceIds
+    ])
+  ]).filter((sourceEvidenceId) => sourceEvidenceId !== input.winner.sourceEvidenceId);
+  const supportingProviders = new Set<
+    CanonicalEventRecord["provenance"]["primaryProvider"]
+  >(input.losers.map((loser) => loser.provenance.primaryProvider));
+
+  if (
+    input.winner.provenance.winnerReason === "gmail_wins_duplicate_collapse"
+  ) {
+    supportingProviders.add("salesforce");
+  }
+
+  if (
+    input.winner.provenance.winnerReason ===
+    "earliest_gmail_wins_duplicate_collapse"
+  ) {
+    supportingProviders.add("gmail");
+  }
+
+  const winnerDecision = resolveOutboundEmailMergedWinnerDecision({
+    primaryProvider: input.winner.provenance.primaryProvider,
+    supportingProviders: [...supportingProviders],
+    fallback: {
+      winnerReason: input.winner.provenance.winnerReason,
+      notes: input.winner.provenance.notes ?? null
+    }
+  });
+
+  return canonicalEventSchema.parse({
+    ...input.winner,
+    provenance: {
+      ...input.winner.provenance,
+      supportingSourceEvidenceIds,
+      winnerReason: winnerDecision.winnerReason,
+      notes: winnerDecision.notes ?? undefined
+    },
+    reviewState: input.losers.reduce(
+      (current, loser) => mergeReviewState(current, loser.reviewState),
+      input.winner.reviewState
+    )
+  });
+}
+
+function applyLimitToPlans(
+  plans: readonly HistoricalDedupClusterPlan[],
+  limit: number | null
+): readonly HistoricalDedupClusterPlan[] {
+  if (limit === null) {
+    return plans;
+  }
+
+  const limitedPlans: HistoricalDedupClusterPlan[] = [];
+  let remaining = limit;
+
+  for (const plan of plans) {
+    if (remaining <= 0) {
+      break;
+    }
+
+    if (plan.losers.length <= remaining) {
+      limitedPlans.push(plan);
+      remaining -= plan.losers.length;
+      continue;
+    }
+
+    limitedPlans.push({
+      winner: plan.winner,
+      losers: plan.losers.slice(0, remaining)
+    });
+    break;
+  }
+
+  return limitedPlans;
+}
+
+function chunkPlansByLoserCount(
+  plans: readonly HistoricalDedupClusterPlan[],
+  limit: number
+): HistoricalDedupClusterPlan[][] {
+  const chunks: HistoricalDedupClusterPlan[][] = [];
+  let currentChunk: HistoricalDedupClusterPlan[] = [];
+  let currentLoserCount = 0;
+
+  for (const plan of plans) {
+    const loserCount = plan.losers.length;
+
+    if (
+      currentChunk.length > 0 &&
+      currentLoserCount + loserCount > limit
+    ) {
+      chunks.push(currentChunk);
+      currentChunk = [];
+      currentLoserCount = 0;
+    }
+
+    currentChunk.push(plan);
+    currentLoserCount += loserCount;
+  }
+
+  if (currentChunk.length > 0) {
+    chunks.push(currentChunk);
+  }
+
+  return chunks;
+}
+
+async function loadHistoricalOutboundEmailCandidates(input: {
+  readonly db: Stage1Database;
+  readonly repositories: Stage1Repositories;
+}): Promise<readonly HistoricalOutboundEmailCandidate[]> {
+  const canonicalRows = await input.db
+    .select()
+    .from(canonicalEventLedger)
+    .where(eq(canonicalEventLedger.eventType, "communication.email.outbound"))
+    .orderBy(
+      asc(canonicalEventLedger.contactId),
+      asc(canonicalEventLedger.occurredAt),
+      asc(canonicalEventLedger.id)
+    );
+  const sourceEvidenceIds = uniqueSortedStrings(
+    canonicalRows.map((row) => row.sourceEvidenceId)
+  );
+  const [gmailMessageDetails, salesforceCommunicationDetails] = await Promise.all([
+    input.repositories.gmailMessageDetails.listBySourceEvidenceIds(sourceEvidenceIds),
+    input.repositories.salesforceCommunicationDetails.listBySourceEvidenceIds(
+      sourceEvidenceIds
+    )
+  ]);
+  const gmailMessageDetailBySourceEvidenceId = new Map(
+    gmailMessageDetails.map((detail) => [detail.sourceEvidenceId, detail] as const)
+  );
+  const salesforceCommunicationDetailBySourceEvidenceId = new Map(
+    salesforceCommunicationDetails.map((detail) => [
+      detail.sourceEvidenceId,
+      detail
+    ] as const)
+  );
+  const candidates: HistoricalOutboundEmailCandidate[] = [];
+
+  for (const row of canonicalRows) {
+    const event = canonicalEventSchema.parse({
+      id: row.id,
+      contactId: row.contactId,
+      eventType: row.eventType,
+      channel: row.channel,
+      occurredAt: normalizeOccurredAt(row.occurredAt),
+      sourceEvidenceId: row.sourceEvidenceId,
+      idempotencyKey: row.idempotencyKey,
+      provenance: row.provenance,
+      reviewState: row.reviewState
+    });
+
+    if (
+      event.provenance.primaryProvider !== "gmail" &&
+      event.provenance.primaryProvider !== "salesforce"
+    ) {
+      continue;
+    }
+
+    const source = buildPersistedOutboundEmailFingerprintSource({
+      event,
+      gmailMessageDetailBySourceEvidenceId,
+      salesforceCommunicationDetailBySourceEvidenceId
+    });
+
+    if (source === null) {
+      continue;
+    }
+
+    const fingerprint = buildOutboundEmailDuplicateFingerprint({
+      subject: source.subject,
+      body: source.body
+    });
+
+    if (fingerprint === null) {
+      continue;
+    }
+
+    candidates.push({
+      event,
+      fingerprint
+    });
+  }
+
+  return candidates.sort(compareCandidates);
+}
+
+export function planHistoricalLedgerDedup(
+  candidates: readonly HistoricalOutboundEmailCandidate[],
+  input?: {
+    readonly limit?: number | null;
+  }
+): readonly HistoricalDedupClusterPlan[] {
+  const clustersByContactAndFingerprint = new Map<
+    string,
+    HistoricalDedupClusterPlan[]
+  >();
+
+  for (const candidate of candidates) {
+    const clusterKey = `${candidate.event.contactId}::${candidate.fingerprint}`;
+    const clusters = clustersByContactAndFingerprint.get(clusterKey) ?? [];
+    let matchedCluster: HistoricalDedupClusterPlan | null = null;
+
+    for (let index = clusters.length - 1; index >= 0; index -= 1) {
+      const cluster = clusters[index];
+
+      if (cluster === undefined) {
+        continue;
+      }
+
+      if (
+        !isWithinOutboundEmailFingerprintWindow({
+          leftOccurredAt: cluster.winner.event.occurredAt,
+          rightOccurredAt: candidate.event.occurredAt
+        })
+      ) {
+        break;
+      }
+
+      const winnerSelection = selectOutboundEmailDuplicateWinner({
+        incoming: {
+          provider: candidate.event.provenance.primaryProvider,
+          occurredAt: candidate.event.occurredAt
+        },
+        existing: {
+          provider: cluster.winner.event.provenance.primaryProvider,
+          occurredAt: cluster.winner.event.occurredAt
+        }
+      });
+
+      if (winnerSelection === null) {
+        continue;
+      }
+
+      matchedCluster = cluster;
+
+      if (winnerSelection.winner === "incoming") {
+        cluster.losers = [...cluster.losers, cluster.winner];
+        cluster.winner = candidate;
+      } else {
+        cluster.losers = [...cluster.losers, candidate];
+      }
+
+      break;
+    }
+
+    if (matchedCluster !== null) {
+      continue;
+    }
+
+    clusters.push({
+      winner: candidate,
+      losers: []
+    });
+    clustersByContactAndFingerprint.set(clusterKey, clusters);
+  }
+
+  const plans = Array.from(clustersByContactAndFingerprint.values())
+    .flat()
+    .filter((plan) => plan.losers.length > 0)
+    .sort((left, right) => compareCandidates(left.winner, right.winner));
+
+  return applyLimitToPlans(plans, input?.limit ?? null);
+}
+
+function buildAuditLinesForPlans(
+  plans: readonly HistoricalDedupClusterPlan[],
+  operation: HistoricalDedupAuditLine["operation"]
+): HistoricalDedupAuditLine[] {
+  return plans.flatMap((plan) =>
+    plan.losers.map((loser) => ({
+      winnerId: plan.winner.event.id,
+      loserId: loser.event.id,
+      winnerProvider: plan.winner.event.provenance.primaryProvider,
+      loserProvider: loser.event.provenance.primaryProvider,
+      contactId: plan.winner.event.contactId,
+      occurredAt: loser.event.occurredAt,
+      operation
+    }))
+  );
+}
+
+async function applyDedupPlans(input: {
+  readonly db: Stage1Database;
+  readonly repositories: Stage1Repositories;
+  readonly plans: readonly HistoricalDedupClusterPlan[];
+  readonly auditWriter: AuditWriter;
+}): Promise<{
+  readonly deletedCanonicalCount: number;
+  readonly deletedTimelineCount: number;
+  readonly repointedInboxCount: number;
+  readonly skippedAlreadyMergedCount: number;
+  readonly auditLines: readonly HistoricalDedupAuditLine[];
+}> {
+  const auditLines: HistoricalDedupAuditLine[] = [];
+  let deletedCanonicalCount = 0;
+  let deletedTimelineCount = 0;
+  let repointedInboxCount = 0;
+  let skippedAlreadyMergedCount = 0;
+
+  for (const batch of chunkPlansByLoserCount(input.plans, executeBatchLoserLimit)) {
+    await input.db.transaction(async (tx) => {
+      const txRepositories = createStage1RepositoryBundle(tx as Stage1Database);
+
+      for (const plan of batch) {
+        const winner = await txRepositories.canonicalEvents.findById(
+          plan.winner.event.id
+        );
+
+        if (winner === null) {
+          for (const loser of plan.losers) {
+            const auditLine: HistoricalDedupAuditLine = {
+              winnerId: plan.winner.event.id,
+              loserId: loser.event.id,
+              winnerProvider: plan.winner.event.provenance.primaryProvider,
+              loserProvider: loser.event.provenance.primaryProvider,
+              contactId: plan.winner.event.contactId,
+              occurredAt: loser.event.occurredAt,
+              operation: "skipped_already_merged"
+            };
+            auditLines.push(auditLine);
+            input.auditWriter.writeLine(JSON.stringify(auditLine));
+            skippedAlreadyMergedCount += 1;
+          }
+
+          continue;
+        }
+
+        const loserIds = plan.losers.map((loser) => loser.event.id);
+        const presentLosers =
+          loserIds.length === 0
+            ? []
+            : await txRepositories.canonicalEvents.listByIds(loserIds);
+        const presentLoserIdSet = new Set(
+          presentLosers.map((loser) => loser.id)
+        );
+        const missingLosers = plan.losers.filter(
+          (loser) => !presentLoserIdSet.has(loser.event.id)
+        );
+
+        for (const loser of missingLosers) {
+          const auditLine: HistoricalDedupAuditLine = {
+            winnerId: winner.id,
+            loserId: loser.event.id,
+            winnerProvider: winner.provenance.primaryProvider,
+            loserProvider: loser.event.provenance.primaryProvider,
+            contactId: winner.contactId,
+            occurredAt: loser.event.occurredAt,
+            operation: "skipped_already_merged"
+          };
+          auditLines.push(auditLine);
+          input.auditWriter.writeLine(JSON.stringify(auditLine));
+          skippedAlreadyMergedCount += 1;
+        }
+
+        if (presentLosers.length === 0) {
+          continue;
+        }
+
+        const mergedWinner = buildHistoricalMergedWinnerEvent({
+          winner,
+          losers: presentLosers
+        });
+        await txRepositories.canonicalEvents.upsert(mergedWinner);
+
+        const presentLoserIds = presentLosers.map((loser) => loser.id);
+        const updatedInboxRows = await tx
+          .update(contactInboxProjection)
+          .set({
+            lastCanonicalEventId: mergedWinner.id,
+            updatedAt: new Date()
+          })
+          .where(inArray(contactInboxProjection.lastCanonicalEventId, presentLoserIds))
+          .returning({
+            contactId: contactInboxProjection.contactId
+          });
+        repointedInboxCount += updatedInboxRows.length;
+
+        const deletedTimelineRows = await tx
+          .delete(contactTimelineProjection)
+          .where(inArray(contactTimelineProjection.canonicalEventId, presentLoserIds))
+          .returning({
+            id: contactTimelineProjection.id
+          });
+        deletedTimelineCount += deletedTimelineRows.length;
+
+        const deletedCanonicalRows = await tx
+          .delete(canonicalEventLedger)
+          .where(inArray(canonicalEventLedger.id, presentLoserIds))
+          .returning({
+            id: canonicalEventLedger.id
+          });
+        deletedCanonicalCount += deletedCanonicalRows.length;
+
+        for (const loser of presentLosers) {
+          const auditLine: HistoricalDedupAuditLine = {
+            winnerId: mergedWinner.id,
+            loserId: loser.id,
+            winnerProvider: mergedWinner.provenance.primaryProvider,
+            loserProvider: loser.provenance.primaryProvider,
+            contactId: mergedWinner.contactId,
+            occurredAt: loser.occurredAt,
+            operation: "merged"
+          };
+          auditLines.push(auditLine);
+          input.auditWriter.writeLine(JSON.stringify(auditLine));
+        }
+      }
+    });
+  }
+
+  return {
+    deletedCanonicalCount,
+    deletedTimelineCount,
+    repointedInboxCount,
+    skippedAlreadyMergedCount,
+    auditLines
+  };
+}
+
+export async function dedupHistoricalLedger(input: {
+  readonly db: Stage1Database;
+  readonly repositories: Stage1Repositories;
+  readonly dryRun?: boolean;
+  readonly limit?: number | null;
+  readonly logger?: Logger;
+  readonly auditWriter?: AuditWriter;
+}): Promise<HistoricalLedgerDedupResult> {
+  const dryRun = input.dryRun ?? true;
+  const logger = input.logger ?? console;
+  const auditWriter = input.auditWriter ?? {
+    writeLine(line: string) {
+      process.stdout.write(`${line}\n`);
+    }
+  };
+  const referenceTargets = knownCanonicalEventReferences();
+  const candidates = await loadHistoricalOutboundEmailCandidates({
+    db: input.db,
+    repositories: input.repositories
+  });
+  const plans = planHistoricalLedgerDedup(candidates, {
+    limit: input.limit ?? null
+  });
+
+  logger.error("dedup-historical-ledger");
+  logger.error(`Mode: ${dryRun ? "dry-run" : "execute"}`);
+  logger.error(
+    `References: ${referenceTargets.map((reference) => `${reference.table}.${reference.column}:${reference.action}`).join(", ")}`
+  );
+  logger.error(`- scanned candidates: ${String(candidates.length)}`);
+  logger.error(`- duplicate clusters: ${String(plans.length)}`);
+  logger.error(
+    `- loser rows in scope: ${String(plans.reduce((total, plan) => total + plan.losers.length, 0))}`
+  );
+
+  if (dryRun) {
+    const auditLines = buildAuditLinesForPlans(plans, "would_merge");
+
+    for (const auditLine of auditLines) {
+      auditWriter.writeLine(JSON.stringify(auditLine));
+    }
+
+    return {
+      dryRun: true,
+      referenceTargets,
+      scannedCandidateCount: candidates.length,
+      plannedClusterCount: plans.length,
+      plannedLoserCount: auditLines.length,
+      deletedCanonicalCount: 0,
+      deletedTimelineCount: 0,
+      repointedInboxCount: 0,
+      skippedAlreadyMergedCount: 0,
+      auditLines
+    };
+  }
+
+  const applied = await applyDedupPlans({
+    db: input.db,
+    repositories: input.repositories,
+    plans,
+    auditWriter
+  });
+
+  return {
+    dryRun: false,
+    referenceTargets,
+    scannedCandidateCount: candidates.length,
+    plannedClusterCount: plans.length,
+    plannedLoserCount: plans.reduce(
+      (total, plan) => total + plan.losers.length,
+      0
+    ),
+    deletedCanonicalCount: applied.deletedCanonicalCount,
+    deletedTimelineCount: applied.deletedTimelineCount,
+    repointedInboxCount: applied.repointedInboxCount,
+    skippedAlreadyMergedCount: applied.skippedAlreadyMergedCount,
+    auditLines: applied.auditLines
+  };
+}
+
+export async function runDedupHistoricalLedgerCommand(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv = process.env
+): Promise<HistoricalLedgerDedupResult> {
+  const flags = parseCliFlags(args);
+  const connection = createDatabaseConnection({
+    connectionString: readConnectionString(env)
+  });
+
+  try {
+    const repositories = createStage1RepositoryBundleFromConnection(connection);
+
+    return await dedupHistoricalLedger({
+      db: connection.db,
+      repositories,
+      dryRun: !readOptionalBooleanFlag(flags, "execute", false),
+      limit: readOptionalIntegerFlag(flags, "limit", 0) || null
+    });
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1] ?? ""}`) {
+  void runDedupHistoricalLedgerCommand(process.argv.slice(2)).catch(
+    (error: unknown) => {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "dedup-historical-ledger failed.";
+
+      console.error(message);
+      process.exitCode = 1;
+    }
+  );
+}

--- a/apps/worker/test/stage1-dedup-historical-ledger.test.ts
+++ b/apps/worker/test/stage1-dedup-historical-ledger.test.ts
@@ -1,0 +1,539 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canonicalEventSchema,
+  resolveCanonicalChannel,
+  type CanonicalEventRecord
+} from "@as-comms/contracts";
+
+import {
+  dedupHistoricalLedger,
+  planHistoricalLedgerDedup,
+  type HistoricalLedgerDedupResult
+} from "../src/ops/dedup-historical-ledger.js";
+import { createTestWorkerContext } from "./helpers.js";
+
+function buildCandidateEvent(input: {
+  readonly id: string;
+  readonly contactId: string;
+  readonly occurredAt: string;
+  readonly primaryProvider: "gmail" | "salesforce";
+  readonly sourceEvidenceId: string;
+  readonly idempotencyKey: string;
+  readonly winnerReason: CanonicalEventRecord["provenance"]["winnerReason"];
+  readonly messageKind: "one_to_one" | "auto";
+}) {
+  return canonicalEventSchema.parse({
+    id: input.id,
+    contactId: input.contactId,
+    eventType: "communication.email.outbound",
+    channel: resolveCanonicalChannel("communication.email.outbound"),
+    occurredAt: input.occurredAt,
+    sourceEvidenceId: input.sourceEvidenceId,
+    idempotencyKey: input.idempotencyKey,
+    provenance: {
+      primaryProvider: input.primaryProvider,
+      primarySourceEvidenceId: input.sourceEvidenceId,
+      supportingSourceEvidenceIds: [],
+      winnerReason: input.winnerReason,
+      sourceRecordType:
+        input.primaryProvider === "gmail" ? "message" : "task_communication",
+      sourceRecordId: input.id.replace("evt_", ""),
+      messageKind: input.messageKind,
+      campaignRef: null,
+      threadRef: null,
+      direction: "outbound",
+      notes: null
+    },
+    reviewState: "clear"
+  });
+}
+
+async function seedContact(input: {
+  readonly context: Awaited<ReturnType<typeof createTestWorkerContext>>;
+  readonly contactId: string;
+  readonly salesforceContactId: string;
+  readonly email: string;
+  readonly displayName: string;
+}): Promise<void> {
+  await input.context.normalization.upsertNormalizedContactGraph({
+    contact: {
+      id: input.contactId,
+      salesforceContactId: input.salesforceContactId,
+      displayName: input.displayName,
+      primaryEmail: input.email,
+      primaryPhone: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z"
+    },
+    identities: [
+      {
+        id: `identity:${input.contactId}:email`,
+        contactId: input.contactId,
+        kind: "email",
+        normalizedValue: input.email,
+        isPrimary: true,
+        source: "salesforce",
+        verifiedAt: "2026-01-01T00:00:00.000Z"
+      }
+    ],
+    memberships: [
+      {
+        id: `membership:${input.contactId}:default`,
+        contactId: input.contactId,
+        projectId: "project_default",
+        expeditionId: "expedition_default",
+        role: "volunteer",
+        status: "active",
+        source: "salesforce"
+      }
+    ]
+  });
+}
+
+async function seedDirtyOutboundEmail(input: {
+  readonly context: Awaited<ReturnType<typeof createTestWorkerContext>>;
+  readonly contactId: string;
+  readonly key: string;
+  readonly provider: "gmail" | "salesforce";
+  readonly occurredAt: string;
+  readonly receivedAt: string;
+  readonly subject: string;
+  readonly body: string;
+  readonly messageKind: "one_to_one" | "auto";
+}): Promise<CanonicalEventRecord> {
+  const sourceEvidenceId = `sev_${input.key}`;
+  const providerRecordId =
+    input.provider === "gmail" ? `gmail-${input.key}` : `task-${input.key}`;
+
+  await input.context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: input.provider,
+    providerRecordType:
+      input.provider === "gmail" ? "message" : "task_communication",
+    providerRecordId,
+    receivedAt: input.receivedAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `payloads/${input.provider}/${input.key}.json`,
+    idempotencyKey: `${input.provider}:${providerRecordId}`,
+    checksum: `checksum:${input.key}`
+  });
+
+  if (input.provider === "gmail") {
+    await input.context.repositories.gmailMessageDetails.upsert({
+      sourceEvidenceId,
+      providerRecordId,
+      gmailThreadId: `thread-${input.key}`,
+      rfc822MessageId: `<${input.key}@example.org>`,
+      direction: "outbound",
+      subject: input.subject,
+      snippetClean: input.body,
+      bodyTextPreview: input.body,
+      capturedMailbox: "volunteers@example.org",
+      projectInboxAlias: null
+    });
+  } else {
+    await input.context.repositories.salesforceCommunicationDetails.upsert({
+      sourceEvidenceId,
+      providerRecordId,
+      channel: "email",
+      messageKind: input.messageKind,
+      subject: input.subject,
+      snippet: input.body,
+      sourceLabel:
+        input.messageKind === "auto" ? "Salesforce Flow" : "Salesforce Task"
+    });
+  }
+
+  const canonicalEvent = buildCandidateEvent({
+    id: `evt_${input.key}`,
+    contactId: input.contactId,
+    occurredAt: input.occurredAt,
+    primaryProvider: input.provider,
+    sourceEvidenceId,
+    idempotencyKey: `canonical:${input.key}`,
+    winnerReason:
+      input.provider === "gmail" ? "single_source" : "salesforce_only_best_evidence",
+    messageKind: input.messageKind
+  });
+  await input.context.repositories.canonicalEvents.upsert(canonicalEvent);
+  await input.context.repositories.timelineProjection.upsert({
+    id: `timeline:${canonicalEvent.id}`,
+    contactId: input.contactId,
+    canonicalEventId: canonicalEvent.id,
+    occurredAt: input.occurredAt,
+    sortKey: `${input.occurredAt}::${canonicalEvent.id}`,
+    eventType: canonicalEvent.eventType,
+    summary:
+      input.provider === "gmail" ? "Outbound email sent" : "Outbound email logged",
+    channel: canonicalEvent.channel,
+    primaryProvider: input.provider,
+    reviewState: canonicalEvent.reviewState
+  });
+
+  return canonicalEvent;
+}
+
+async function seedHistoricalDuplicates(
+  context: Awaited<ReturnType<typeof createTestWorkerContext>>
+): Promise<void> {
+  await seedContact({
+    context,
+    contactId: "contact_tori",
+    salesforceContactId: "003-tori",
+    email: "tori@example.org",
+    displayName: "Tori Rogers"
+  });
+  const toriSalesforce = await seedDirtyOutboundEmail({
+    context,
+    contactId: "contact_tori",
+    key: "tori-salesforce",
+    provider: "salesforce",
+    occurredAt: "2026-04-20T14:40:57.000Z",
+    receivedAt: "2026-04-20T14:45:00.000Z",
+    subject: "Re: Confirmed: Hex 13174",
+    body: "Confirmed. You are all set for Hex 13174.",
+    messageKind: "auto"
+  });
+  await seedDirtyOutboundEmail({
+    context,
+    contactId: "contact_tori",
+    key: "tori-gmail",
+    provider: "gmail",
+    occurredAt: "2026-04-20T14:40:57.000Z",
+    receivedAt: "2026-04-20T14:41:05.000Z",
+    subject: "Re: Confirmed: Hex 13174",
+    body: "Confirmed. You are all set for Hex 13174.",
+    messageKind: "one_to_one"
+  });
+  await context.repositories.inboxProjection.upsert({
+    contactId: "contact_tori",
+    bucket: "Opened",
+    needsFollowUp: false,
+    hasUnresolved: false,
+    lastInboundAt: null,
+    lastOutboundAt: toriSalesforce.occurredAt,
+    lastActivityAt: toriSalesforce.occurredAt,
+    snippet: "Confirmed. You are all set for Hex 13174.",
+    lastCanonicalEventId: toriSalesforce.id,
+    lastEventType: "communication.email.outbound"
+  });
+
+  await seedContact({
+    context,
+    contactId: "contact_rosie",
+    salesforceContactId: "003-rosie",
+    email: "rosie@example.org",
+    displayName: "Rosie Yacoub"
+  });
+  await seedDirtyOutboundEmail({
+    context,
+    contactId: "contact_rosie",
+    key: "rosie-gmail-1",
+    provider: "gmail",
+    occurredAt: "2026-04-20T14:54:44.000Z",
+    receivedAt: "2026-04-20T14:54:50.000Z",
+    subject: "Re: still time to get involved?",
+    body: "There is still time to get involved if you want a spot on the next training.",
+    messageKind: "one_to_one"
+  });
+  const rosieGmail2 = await seedDirtyOutboundEmail({
+    context,
+    contactId: "contact_rosie",
+    key: "rosie-gmail-2",
+    provider: "gmail",
+    occurredAt: "2026-04-20T14:55:46.000Z",
+    receivedAt: "2026-04-20T14:55:52.000Z",
+    subject: "Re: still time to get involved?",
+    body: "There is still time to get involved if you want a spot on the next training.\n\nSent from my iPhone",
+    messageKind: "one_to_one"
+  });
+  await seedDirtyOutboundEmail({
+    context,
+    contactId: "contact_rosie",
+    key: "rosie-salesforce",
+    provider: "salesforce",
+    occurredAt: "2026-04-20T14:56:32.000Z",
+    receivedAt: "2026-04-20T15:00:00.000Z",
+    subject: "Re: still time to get involved?",
+    body: "There is still time to get involved if you want a spot on the next training.",
+    messageKind: "auto"
+  });
+  await context.repositories.inboxProjection.upsert({
+    contactId: "contact_rosie",
+    bucket: "Opened",
+    needsFollowUp: false,
+    hasUnresolved: false,
+    lastInboundAt: null,
+    lastOutboundAt: rosieGmail2.occurredAt,
+    lastActivityAt: rosieGmail2.occurredAt,
+    snippet: "There is still time to get involved if you want a spot on the next training.",
+    lastCanonicalEventId: rosieGmail2.id,
+    lastEventType: "communication.email.outbound"
+  });
+
+  await seedContact({
+    context,
+    contactId: "contact_tani",
+    salesforceContactId: "003-tani",
+    email: "tani@example.org",
+    displayName: "Tani Thomas"
+  });
+  await seedDirtyOutboundEmail({
+    context,
+    contactId: "contact_tani",
+    key: "tani-gmail-1",
+    provider: "gmail",
+    occurredAt: "2026-04-20T14:42:48.000Z",
+    receivedAt: "2026-04-20T14:42:55.000Z",
+    subject: "Re: Hex 31476: Were You Able to Pick Up Your ARU?",
+    body: "Were you able to pick up your ARU? Here is the link: https://example.org/aru?utm_source=gmail&utm_campaign=follow-up",
+    messageKind: "one_to_one"
+  });
+  await seedDirtyOutboundEmail({
+    context,
+    contactId: "contact_tani",
+    key: "tani-gmail-2",
+    provider: "gmail",
+    occurredAt: "2026-04-20T14:43:14.000Z",
+    receivedAt: "2026-04-20T14:43:18.000Z",
+    subject: "Re: Hex 31476: Were You Able to Pick Up Your ARU?",
+    body: "Were you able to pick up your ARU? Here is the link: https://example.org/aru?utm_medium=email&utm_campaign=follow-up",
+    messageKind: "one_to_one"
+  });
+  const taniSalesforce = await seedDirtyOutboundEmail({
+    context,
+    contactId: "contact_tani",
+    key: "tani-salesforce",
+    provider: "salesforce",
+    occurredAt: "2026-04-20T14:43:12.000Z",
+    receivedAt: "2026-04-20T14:48:00.000Z",
+    subject: "→ Email: Re: Hex 31476: Were You Able to Pick Up Your ARU?",
+    body: "Were you able to pick up your ARU? Here is the link: https://example.org/aru?utm_term=aru",
+    messageKind: "auto"
+  });
+  await context.repositories.inboxProjection.upsert({
+    contactId: "contact_tani",
+    bucket: "Opened",
+    needsFollowUp: false,
+    hasUnresolved: false,
+    lastInboundAt: null,
+    lastOutboundAt: taniSalesforce.occurredAt,
+    lastActivityAt: taniSalesforce.occurredAt,
+    snippet:
+      "Were you able to pick up your ARU? Here is the link: https://example.org/aru?utm_term=aru",
+    lastCanonicalEventId: taniSalesforce.id,
+    lastEventType: "communication.email.outbound"
+  });
+}
+
+function createCapturingWriter() {
+  const lines: string[] = [];
+
+  return {
+    lines,
+    writer: {
+      writeLine(line: string) {
+        lines.push(line);
+      }
+    }
+  };
+}
+
+function createSilentLogger() {
+  return {
+    log() {
+      return undefined;
+    },
+    error() {
+      return undefined;
+    }
+  };
+}
+
+describe("dedup-historical-ledger", () => {
+  it("plans Gmail-over-Salesforce and earliest-Gmail winners with the live heuristic", () => {
+    const plans = planHistoricalLedgerDedup([
+      {
+        event: buildCandidateEvent({
+          id: "evt_tori_salesforce",
+          contactId: "contact_tori",
+          occurredAt: "2026-04-20T14:40:57.000Z",
+          primaryProvider: "salesforce",
+          sourceEvidenceId: "sev_tori_salesforce",
+          idempotencyKey: "canonical:tori-salesforce",
+          winnerReason: "salesforce_only_best_evidence",
+          messageKind: "auto"
+        }),
+        fingerprint: "tori"
+      },
+      {
+        event: buildCandidateEvent({
+          id: "evt_tori_gmail",
+          contactId: "contact_tori",
+          occurredAt: "2026-04-20T14:40:57.000Z",
+          primaryProvider: "gmail",
+          sourceEvidenceId: "sev_tori_gmail",
+          idempotencyKey: "canonical:tori-gmail",
+          winnerReason: "single_source",
+          messageKind: "one_to_one"
+        }),
+        fingerprint: "tori"
+      },
+      {
+        event: buildCandidateEvent({
+          id: "evt_rosie_gmail_1",
+          contactId: "contact_rosie",
+          occurredAt: "2026-04-20T14:54:44.000Z",
+          primaryProvider: "gmail",
+          sourceEvidenceId: "sev_rosie_gmail_1",
+          idempotencyKey: "canonical:rosie-gmail-1",
+          winnerReason: "single_source",
+          messageKind: "one_to_one"
+        }),
+        fingerprint: "rosie"
+      },
+      {
+        event: buildCandidateEvent({
+          id: "evt_rosie_gmail_2",
+          contactId: "contact_rosie",
+          occurredAt: "2026-04-20T14:55:46.000Z",
+          primaryProvider: "gmail",
+          sourceEvidenceId: "sev_rosie_gmail_2",
+          idempotencyKey: "canonical:rosie-gmail-2",
+          winnerReason: "single_source",
+          messageKind: "one_to_one"
+        }),
+        fingerprint: "rosie"
+      }
+    ]);
+
+    expect(plans).toHaveLength(2);
+    const toriPlan = plans.find(
+      (plan) => plan.winner.event.contactId === "contact_tori"
+    );
+    const rosiePlan = plans.find(
+      (plan) => plan.winner.event.contactId === "contact_rosie"
+    );
+
+    expect(toriPlan?.winner.event.id).toBe("evt_tori_gmail");
+    expect(toriPlan?.losers.map((loser) => loser.event.id)).toEqual([
+      "evt_tori_salesforce"
+    ]);
+    expect(rosiePlan?.winner.event.id).toBe("evt_rosie_gmail_1");
+    expect(rosiePlan?.losers.map((loser) => loser.event.id)).toEqual([
+      "evt_rosie_gmail_2"
+    ]);
+  });
+
+  it("dry-runs and executes against a seeded dirty database without leaving duplicate rows behind", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedHistoricalDuplicates(context);
+
+      const dryRunWriter = createCapturingWriter();
+      const dryRun = await dedupHistoricalLedger({
+        db: context.db,
+        repositories: context.repositories,
+        dryRun: true,
+        logger: createSilentLogger(),
+        auditWriter: dryRunWriter.writer
+      });
+
+      expect(dryRun).toMatchObject({
+        dryRun: true,
+        scannedCandidateCount: 8,
+        plannedClusterCount: 3,
+        plannedLoserCount: 5
+      });
+      expect(dryRun.referenceTargets).toEqual([
+        {
+          table: "contact_inbox_projection",
+          column: "last_canonical_event_id",
+          action: "repoint_to_winner"
+        },
+        {
+          table: "contact_timeline_projection",
+          column: "canonical_event_id",
+          action: "delete_loser_projection_row"
+        }
+      ]);
+      expect(
+        dryRunWriter.lines.every((line) =>
+          line.includes("\"operation\":\"would_merge\"")
+        )
+      ).toBe(true);
+
+      const executeWriter = createCapturingWriter();
+      const executed = await dedupHistoricalLedger({
+        db: context.db,
+        repositories: context.repositories,
+        dryRun: false,
+        logger: createSilentLogger(),
+        auditWriter: executeWriter.writer
+      });
+
+      expect(executed).toMatchObject<Partial<HistoricalLedgerDedupResult>>({
+        dryRun: false,
+        plannedClusterCount: 3,
+        plannedLoserCount: 5,
+        deletedCanonicalCount: 5,
+        deletedTimelineCount: 5
+      });
+      expect(executed.repointedInboxCount).toBeGreaterThanOrEqual(3);
+      expect(
+        executeWriter.lines.filter((line) =>
+          line.includes("\"operation\":\"merged\"")
+        )
+      ).toHaveLength(5);
+
+      await expect(
+        context.repositories.canonicalEvents.listByContactId("contact_tori")
+      ).resolves.toHaveLength(1);
+      await expect(
+        context.repositories.canonicalEvents.listByContactId("contact_rosie")
+      ).resolves.toHaveLength(1);
+      await expect(
+        context.repositories.canonicalEvents.listByContactId("contact_tani")
+      ).resolves.toHaveLength(1);
+
+      const [toriEvent] =
+        await context.repositories.canonicalEvents.listByContactId("contact_tori");
+      const [rosieEvent] =
+        await context.repositories.canonicalEvents.listByContactId("contact_rosie");
+      const [taniEvent] =
+        await context.repositories.canonicalEvents.listByContactId("contact_tani");
+
+      expect(toriEvent?.sourceEvidenceId).toBe("sev_tori-gmail");
+      expect(toriEvent?.provenance.supportingSourceEvidenceIds).toEqual([
+        "sev_tori-salesforce"
+      ]);
+      expect(rosieEvent?.sourceEvidenceId).toBe("sev_rosie-gmail-1");
+      expect(rosieEvent?.provenance.supportingSourceEvidenceIds).toEqual([
+        "sev_rosie-gmail-2",
+        "sev_rosie-salesforce"
+      ]);
+      expect(taniEvent?.sourceEvidenceId).toBe("sev_tani-gmail-1");
+      expect(taniEvent?.provenance.supportingSourceEvidenceIds).toEqual([
+        "sev_tani-gmail-2",
+        "sev_tani-salesforce"
+      ]);
+
+      const secondDryRunWriter = createCapturingWriter();
+      const secondDryRun = await dedupHistoricalLedger({
+        db: context.db,
+        repositories: context.repositories,
+        dryRun: true,
+        logger: createSilentLogger(),
+        auditWriter: secondDryRunWriter.writer
+      });
+
+      expect(secondDryRun.plannedClusterCount).toBe(0);
+      expect(secondDryRun.plannedLoserCount).toBe(0);
+      expect(secondDryRunWriter.lines).toEqual([]);
+    } finally {
+      await context.dispose();
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build": "turbo build && node scripts/verify-runtime-exports.mjs",
     "lint": "turbo lint",
     "typecheck": "turbo typecheck",
-    "test:unit": "turbo test:unit",
+    "test:unit": "turbo test:unit --concurrency=1",
     "test:e2e": "playwright test",
     "test": "pnpm test:unit && pnpm test:e2e",
     "boundaries": "node scripts/boundary-check.mjs",

--- a/packages/contracts/src/stage1-taxonomy.ts
+++ b/packages/contracts/src/stage1-taxonomy.ts
@@ -97,6 +97,7 @@ export const provenanceWinnerReasonValues = [
   "single_source",
   "manual_review_resolution",
   "gmail_wins_duplicate_collapse",
+  "earliest_gmail_wins_duplicate_collapse",
   "simpletexting_wins_duplicate_collapse",
   "salesforce_only_best_evidence"
 ] as const;

--- a/packages/db/test/stage1-normalization.test.ts
+++ b/packages/db/test/stage1-normalization.test.ts
@@ -94,6 +94,159 @@ function buildAutoCommunicationClassification(input: {
   };
 }
 
+function buildGmailOutboundEmailFixture(input: {
+  readonly key: string;
+  readonly email: string;
+  readonly salesforceContactId: string | null;
+  readonly occurredAt: string;
+  readonly receivedAt: string;
+  readonly subject: string;
+  readonly bodyTextPreview: string;
+  readonly snippetClean?: string;
+  readonly snippet?: string;
+}) {
+  return {
+    sourceEvidence: {
+      id: `sev_${input.key}`,
+      provider: "gmail" as const,
+      providerRecordType: "message",
+      providerRecordId: `gmail-${input.key}`,
+      receivedAt: input.receivedAt,
+      occurredAt: input.occurredAt,
+      payloadRef: `payloads/gmail/${input.key}.json`,
+      idempotencyKey: `gmail:message:${input.key}`,
+      checksum: `checksum:${input.key}`
+    },
+    canonicalEvent: {
+      id: `evt_${input.key}`,
+      eventType: "communication.email.outbound" as const,
+      occurredAt: input.occurredAt,
+      idempotencyKey: `canonical:${input.key}`,
+      summary: "Outbound email sent",
+      snippet: input.snippet ?? input.bodyTextPreview
+    },
+    communicationClassification: buildOneToOneCommunicationClassification({
+      sourceRecordType: "message",
+      sourceRecordId: `gmail-${input.key}`,
+      direction: "outbound"
+    }),
+    identity: {
+      salesforceContactId: input.salesforceContactId,
+      volunteerIdPlainValues: [],
+      normalizedEmails: [input.email],
+      normalizedPhones: []
+    },
+    supportingSources: [],
+    gmailMessageDetail: {
+      sourceEvidenceId: `sev_${input.key}`,
+      providerRecordId: `gmail-${input.key}`,
+      gmailThreadId: `thread-${input.key}`,
+      rfc822MessageId: `<${input.key}@example.org>`,
+      direction: "outbound" as const,
+      subject: input.subject,
+      snippetClean: input.snippetClean ?? input.bodyTextPreview,
+      bodyTextPreview: input.bodyTextPreview,
+      capturedMailbox: "volunteers@example.org",
+      projectInboxAlias: null
+    }
+  };
+}
+
+function buildSalesforceOutboundEmailFixture(input: {
+  readonly key: string;
+  readonly email: string;
+  readonly salesforceContactId: string;
+  readonly occurredAt: string;
+  readonly receivedAt: string;
+  readonly subject: string;
+  readonly snippet: string;
+  readonly messageKind?: "auto" | "one_to_one";
+}) {
+  const messageKind = input.messageKind ?? "auto";
+
+  return {
+    sourceEvidence: {
+      id: `sev_${input.key}`,
+      provider: "salesforce" as const,
+      providerRecordType: "task_communication",
+      providerRecordId: `task-${input.key}`,
+      receivedAt: input.receivedAt,
+      occurredAt: input.occurredAt,
+      payloadRef: `payloads/salesforce/${input.key}.json`,
+      idempotencyKey: `salesforce:task_communication:${input.key}`,
+      checksum: `checksum:${input.key}`
+    },
+    canonicalEvent: {
+      id: `evt_${input.key}`,
+      eventType: "communication.email.outbound" as const,
+      occurredAt: input.occurredAt,
+      idempotencyKey: `canonical:${input.key}`,
+      summary: "Outbound email logged",
+      snippet: input.snippet
+    },
+    communicationClassification:
+      messageKind === "auto"
+        ? buildAutoCommunicationClassification({
+            sourceRecordType: "task_communication",
+            sourceRecordId: `task-${input.key}`,
+            direction: "outbound"
+          })
+        : buildOneToOneCommunicationClassification({
+            sourceRecordType: "task_communication",
+            sourceRecordId: `task-${input.key}`,
+            direction: "outbound"
+          }),
+    identity: {
+      salesforceContactId: input.salesforceContactId,
+      volunteerIdPlainValues: [],
+      normalizedEmails: [input.email],
+      normalizedPhones: []
+    },
+    supportingSources: [],
+    salesforceCommunicationDetail: {
+      sourceEvidenceId: `sev_${input.key}`,
+      providerRecordId: `task-${input.key}`,
+      channel: "email" as const,
+      messageKind,
+      subject: input.subject,
+      snippet: input.snippet,
+      sourceLabel: messageKind === "auto" ? "Salesforce Flow" : "Salesforce Task"
+    },
+    salesforceEventContext: {
+      sourceEvidenceId: `sev_${input.key}`,
+      salesforceContactId: input.salesforceContactId,
+      projectId: "project_default",
+      expeditionId: "expedition_default",
+      sourceField: null
+    }
+  };
+}
+
+async function expectExactlyOneCanonicalEvent(
+  context: Awaited<ReturnType<typeof seedContactWithEmail>>,
+  contactId: string
+) {
+  const canonicalEvents =
+    await context.repositories.canonicalEvents.listByContactId(contactId);
+  const timelineRows =
+    await context.repositories.timelineProjection.listByContactId(contactId);
+
+  expect(canonicalEvents).toHaveLength(1);
+  expect(timelineRows).toHaveLength(1);
+
+  const canonicalEvent = canonicalEvents[0];
+  const timelineProjection = timelineRows[0];
+
+  if (canonicalEvent === undefined || timelineProjection === undefined) {
+    throw new Error("Expected exactly one canonical event and one timeline row.");
+  }
+
+  return {
+    canonicalEvent,
+    timelineProjection
+  };
+}
+
 describe("Stage 1 normalization service", () => {
   it("upserts canonical contact graph state through the application boundary", async () => {
     const { normalization, repositories } = await createTestStage1Context();
@@ -603,6 +756,204 @@ describe("Stage 1 normalization service", () => {
         lastActivityAt: "2026-01-01T00:07:00.000Z"
       });
     }
+  });
+
+  it("keeps Tori Rogers cross-provider duplicates to a single Gmail-ledger row regardless of arrival order", async () => {
+    const toriEmail = "tori@example.org";
+    const toriSalesforceContactId = "003-tori";
+    const runSequence = async (order: readonly ("salesforce" | "gmail")[]) => {
+      const context = await seedContactWithEmail(toriEmail, {
+        contactId: "contact_tori",
+        salesforceContactId: toriSalesforceContactId,
+        displayName: "Tori Rogers"
+      });
+      const gmailFixture = buildGmailOutboundEmailFixture({
+        key: "tori-gmail",
+        email: toriEmail,
+        salesforceContactId: toriSalesforceContactId,
+        occurredAt: "2026-04-20T14:40:57.000Z",
+        receivedAt: "2026-04-20T14:41:05.000Z",
+        subject: "Re: Confirmed: Hex 13174",
+        bodyTextPreview: "Confirmed. You are all set for Hex 13174.",
+        snippetClean: "Confirmed. You are all set for Hex 13174."
+      });
+      const salesforceFixture = buildSalesforceOutboundEmailFixture({
+        key: "tori-salesforce",
+        email: toriEmail,
+        salesforceContactId: toriSalesforceContactId,
+        occurredAt: "2026-04-20T14:40:57.000Z",
+        receivedAt: "2026-04-20T14:45:00.000Z",
+        subject: "Re: Confirmed: Hex 13174",
+        snippet: "Confirmed. You are all set for Hex 13174.",
+        messageKind: "auto"
+      });
+
+      for (const source of order) {
+        await context.normalization.applyNormalizedCanonicalEvent(
+          source === "gmail" ? gmailFixture : salesforceFixture
+        );
+      }
+
+      const { canonicalEvent, timelineProjection } =
+        await expectExactlyOneCanonicalEvent(context, "contact_tori");
+      expect(canonicalEvent.sourceEvidenceId).toBe("sev_tori-gmail");
+      expect(canonicalEvent.provenance.primaryProvider).toBe("gmail");
+      expect(canonicalEvent.provenance.winnerReason).toBe(
+        "gmail_wins_duplicate_collapse"
+      );
+      expect(canonicalEvent.provenance.supportingSourceEvidenceIds).toEqual([
+        "sev_tori-salesforce"
+      ]);
+      expect(canonicalEvent.provenance.messageKind).toBe("one_to_one");
+      expect(timelineProjection.primaryProvider).toBe("gmail");
+
+      await expect(
+        context.repositories.salesforceCommunicationDetails.listBySourceEvidenceIds([
+          "sev_tori-salesforce"
+        ])
+      ).resolves.toHaveLength(1);
+    };
+
+    await runSequence(["salesforce", "gmail"]);
+    await runSequence(["gmail", "salesforce"]);
+  });
+
+  it("keeps Rosie Yacoub duplicates to the earliest Gmail row while preserving Salesforce evidence", async () => {
+    const context = await seedContactWithEmail("rosie@example.org", {
+      contactId: "contact_rosie",
+      salesforceContactId: "003-rosie",
+      displayName: "Rosie Yacoub"
+    });
+    const firstGmail = buildGmailOutboundEmailFixture({
+      key: "rosie-gmail-1",
+      email: "rosie@example.org",
+      salesforceContactId: "003-rosie",
+      occurredAt: "2026-04-20T14:54:44.000Z",
+      receivedAt: "2026-04-20T14:54:50.000Z",
+      subject: "Re: still time to get involved?",
+      bodyTextPreview:
+        "There is still time to get involved if you want a spot on the next training.",
+      snippetClean:
+        "There is still time to get involved if you want a spot on the next training."
+    });
+    const secondGmail = buildGmailOutboundEmailFixture({
+      key: "rosie-gmail-2",
+      email: "rosie@example.org",
+      salesforceContactId: "003-rosie",
+      occurredAt: "2026-04-20T14:55:46.000Z",
+      receivedAt: "2026-04-20T14:55:52.000Z",
+      subject: "Re: still time to get involved?",
+      bodyTextPreview:
+        "There is still time to get involved if you want a spot on the next training.\n\nSent from my iPhone",
+      snippetClean:
+        "There is still time to get involved if you want a spot on the next training."
+    });
+    const salesforce = buildSalesforceOutboundEmailFixture({
+      key: "rosie-salesforce",
+      email: "rosie@example.org",
+      salesforceContactId: "003-rosie",
+      occurredAt: "2026-04-20T14:56:32.000Z",
+      receivedAt: "2026-04-20T15:00:00.000Z",
+      subject: "Re: still time to get involved?",
+      snippet:
+        "There is still time to get involved if you want a spot on the next training.",
+      messageKind: "auto"
+    });
+
+    for (let pass = 0; pass < 2; pass += 1) {
+      await context.normalization.applyNormalizedCanonicalEvent(firstGmail);
+      await context.normalization.applyNormalizedCanonicalEvent(secondGmail);
+      await context.normalization.applyNormalizedCanonicalEvent(salesforce);
+    }
+
+    const { canonicalEvent, timelineProjection } =
+      await expectExactlyOneCanonicalEvent(context, "contact_rosie");
+    expect(canonicalEvent.sourceEvidenceId).toBe("sev_rosie-gmail-1");
+    expect(canonicalEvent.provenance.primaryProvider).toBe("gmail");
+    expect(canonicalEvent.provenance.supportingSourceEvidenceIds).toEqual([
+      "sev_rosie-gmail-2",
+      "sev_rosie-salesforce"
+    ]);
+    expect(canonicalEvent.provenance.winnerReason).toBe(
+      "gmail_wins_duplicate_collapse"
+    );
+    expect(canonicalEvent.provenance.messageKind).toBe("one_to_one");
+    expect(canonicalEvent.occurredAt).toBe("2026-04-20T14:54:44.000Z");
+    expect(timelineProjection.primaryProvider).toBe("gmail");
+    await expect(
+      context.repositories.inboxProjection.findByContactId("contact_rosie")
+    ).resolves.toMatchObject({
+      lastCanonicalEventId: "evt_rosie-gmail-1",
+      lastOutboundAt: "2026-04-20T14:54:44.000Z"
+    });
+  });
+
+  it("keeps Tani Thomas duplicates to the earliest Gmail row after normalization strips reply noise and tracking params", async () => {
+    const context = await seedContactWithEmail("tani@example.org", {
+      contactId: "contact_tani",
+      salesforceContactId: "003-tani",
+      displayName: "Tani Thomas"
+    });
+    const firstGmail = buildGmailOutboundEmailFixture({
+      key: "tani-gmail-1",
+      email: "tani@example.org",
+      salesforceContactId: "003-tani",
+      occurredAt: "2026-04-20T14:42:48.000Z",
+      receivedAt: "2026-04-20T14:42:55.000Z",
+      subject: "Re: Hex 31476: Were You Able to Pick Up Your ARU?",
+      bodyTextPreview:
+        "Were you able to pick up your ARU? Here is the link: https://example.org/aru?utm_source=gmail&utm_campaign=follow-up",
+      snippetClean:
+        "Were you able to pick up your ARU? Here is the link: https://example.org/aru?utm_source=gmail&utm_campaign=follow-up"
+    });
+    const secondGmail = buildGmailOutboundEmailFixture({
+      key: "tani-gmail-2",
+      email: "tani@example.org",
+      salesforceContactId: "003-tani",
+      occurredAt: "2026-04-20T14:43:14.000Z",
+      receivedAt: "2026-04-20T14:43:18.000Z",
+      subject: "Re: Hex 31476: Were You Able to Pick Up Your ARU?",
+      bodyTextPreview:
+        "Were you able to pick up your ARU? Here is the link: https://example.org/aru?utm_medium=email&utm_campaign=follow-up\n\n--\nCecilia\n\nOn Mon, Apr 20, 2026 at 10:00 AM Tani wrote:\n> Checking in",
+      snippetClean:
+        "Were you able to pick up your ARU? Here is the link: https://example.org/aru?utm_medium=email&utm_campaign=follow-up"
+    });
+    const salesforce = buildSalesforceOutboundEmailFixture({
+      key: "tani-salesforce",
+      email: "tani@example.org",
+      salesforceContactId: "003-tani",
+      occurredAt: "2026-04-20T14:43:12.000Z",
+      receivedAt: "2026-04-20T14:48:00.000Z",
+      subject: "→ Email: Re: Hex 31476: Were You Able to Pick Up Your ARU?",
+      snippet:
+        "Were you able to pick up your ARU? Here is the link: https://example.org/aru?utm_term=aru",
+      messageKind: "auto"
+    });
+
+    for (let pass = 0; pass < 2; pass += 1) {
+      await context.normalization.applyNormalizedCanonicalEvent(firstGmail);
+      await context.normalization.applyNormalizedCanonicalEvent(salesforce);
+      await context.normalization.applyNormalizedCanonicalEvent(secondGmail);
+    }
+
+    const { canonicalEvent, timelineProjection } =
+      await expectExactlyOneCanonicalEvent(context, "contact_tani");
+    expect(canonicalEvent.sourceEvidenceId).toBe("sev_tani-gmail-1");
+    expect(canonicalEvent.provenance.primaryProvider).toBe("gmail");
+    expect(canonicalEvent.provenance.supportingSourceEvidenceIds).toEqual([
+      "sev_tani-gmail-2",
+      "sev_tani-salesforce"
+    ]);
+    expect(canonicalEvent.provenance.winnerReason).toBe(
+      "gmail_wins_duplicate_collapse"
+    );
+    expect(canonicalEvent.occurredAt).toBe("2026-04-20T14:42:48.000Z");
+    expect(timelineProjection.primaryProvider).toBe("gmail");
+    await expect(
+      context.repositories.salesforceCommunicationDetails.listBySourceEvidenceIds([
+        "sev_tani-salesforce"
+      ])
+    ).resolves.toHaveLength(1);
   });
 
   it("keeps Salesforce auto task messages out of inbox projection mutation", async () => {

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./inbox-driving.js";
 export * from "./notes.js";
 export * from "./normalization.js";
+export * from "./outbound-email-dedup.js";
 export * from "./readiness.js";
 export * from "./persistence.js";
 export * from "./records.js";

--- a/packages/domain/src/normalization.ts
+++ b/packages/domain/src/normalization.ts
@@ -30,6 +30,7 @@ import {
   type ContactMembershipRecord,
   type ContactRecord,
   type ExpeditionDimensionRecord,
+  type GmailMessageDetailRecord,
   type IdentityAmbiguityInput,
   type IdentityResolutionCase,
   type InboxDrivingEventType,
@@ -45,6 +46,8 @@ import {
   type QuarantineReasonCode,
   type RoutingAmbiguityInput,
   type RoutingReviewCase,
+  type SalesforceCommunicationDetailRecord,
+  type SimpleTextingMessageDetailRecord,
   type SourceEvidenceRecord,
   type SyncStateRecord,
   type SyncStateUpdateInput,
@@ -55,6 +58,14 @@ import {
 import {
   isInboxDrivingCanonicalEvent
 } from "./inbox-driving.js";
+import {
+  buildIncomingOutboundEmailFingerprintSource,
+  buildOutboundEmailDuplicateFingerprint,
+  buildPersistedOutboundEmailFingerprintSource,
+  isWithinOutboundEmailFingerprintWindow,
+  resolveOutboundEmailMergedWinnerDecision,
+  selectOutboundEmailDuplicateWinner
+} from "./outbound-email-dedup.js";
 import type { Stage1PersistenceService } from "./persistence.js";
 
 type ContactLookupMap = ReadonlyMap<string, ContactRecord>;
@@ -71,6 +82,29 @@ interface IdentityResolutionContext {
 interface WinnerDecision {
   readonly winnerReason: ProvenanceWinnerReason;
   readonly notes: string | null;
+}
+
+interface ProviderDetailMaps {
+  readonly gmailMessageDetailBySourceEvidenceId: ReadonlyMap<
+    string,
+    GmailMessageDetailRecord
+  >;
+  readonly salesforceCommunicationDetailBySourceEvidenceId: ReadonlyMap<
+    string,
+    SalesforceCommunicationDetailRecord
+  >;
+  readonly simpleTextingMessageDetailBySourceEvidenceId: ReadonlyMap<
+    string,
+    SimpleTextingMessageDetailRecord
+  >;
+}
+
+interface OutboundEmailDuplicateMatch {
+  readonly existingEvent: CanonicalEventRecord;
+  readonly existingTimelineProjection: TimelineProjectionRow | null;
+  readonly winner: WinnerDecision & {
+    readonly keepIncomingAsPrimary: boolean;
+  };
 }
 
 type DuplicateCollapseDecision =
@@ -386,6 +420,308 @@ function pickCanonicalReviewState(input: {
   }
 
   return "clear";
+}
+
+function mergeCanonicalReviewState(
+  left: CanonicalEventRecord["reviewState"],
+  right: CanonicalEventRecord["reviewState"]
+): CanonicalEventRecord["reviewState"] {
+  if (left === "quarantined" || right === "quarantined") {
+    return "quarantined";
+  }
+
+  if (
+    left === "needs_identity_review" ||
+    right === "needs_identity_review"
+  ) {
+    return "needs_identity_review";
+  }
+
+  if (left === "needs_routing_review" || right === "needs_routing_review") {
+    return "needs_routing_review";
+  }
+
+  return "clear";
+}
+
+function mapBySourceEvidenceId<TValue extends { readonly sourceEvidenceId: string }>(
+  values: readonly TValue[]
+): ReadonlyMap<string, TValue> {
+  return new Map(values.map((value) => [value.sourceEvidenceId, value]));
+}
+
+async function loadProviderDetailMaps(
+  persistence: Stage1PersistenceService,
+  sourceEvidenceIds: readonly string[]
+): Promise<ProviderDetailMaps> {
+  const uniqueSourceEvidenceIds = uniqueStrings(sourceEvidenceIds);
+  const [gmailMessageDetails, salesforceCommunicationDetails, simpleTextingMessageDetails] =
+    await Promise.all([
+      persistence.repositories.gmailMessageDetails.listBySourceEvidenceIds(
+        uniqueSourceEvidenceIds
+      ),
+      persistence.repositories.salesforceCommunicationDetails.listBySourceEvidenceIds(
+        uniqueSourceEvidenceIds
+      ),
+      persistence.repositories.simpleTextingMessageDetails.listBySourceEvidenceIds(
+        uniqueSourceEvidenceIds
+      )
+    ]);
+
+  return {
+    gmailMessageDetailBySourceEvidenceId: mapBySourceEvidenceId(gmailMessageDetails),
+    salesforceCommunicationDetailBySourceEvidenceId: mapBySourceEvidenceId(
+      salesforceCommunicationDetails
+    ),
+    simpleTextingMessageDetailBySourceEvidenceId: mapBySourceEvidenceId(
+      simpleTextingMessageDetails
+    )
+  };
+}
+
+function findCanonicalEventForSourceEvidence(
+  events: readonly CanonicalEventRecord[],
+  sourceEvidenceId: string
+): CanonicalEventRecord | null {
+  return (
+    events.find(
+      (event) =>
+        event.sourceEvidenceId === sourceEvidenceId ||
+        event.provenance.supportingSourceEvidenceIds.includes(sourceEvidenceId)
+    ) ?? null
+  );
+}
+
+function compareDuplicateCandidateEvents(
+  left: CanonicalEventRecord,
+  right: CanonicalEventRecord
+): number {
+  if (
+    left.provenance.primaryProvider !== right.provenance.primaryProvider
+  ) {
+    return left.provenance.primaryProvider === "gmail" ? -1 : 1;
+  }
+
+  if (left.occurredAt !== right.occurredAt) {
+    return left.occurredAt.localeCompare(right.occurredAt);
+  }
+
+  return left.id.localeCompare(right.id);
+}
+
+async function findOutboundEmailDuplicateMatch(
+  persistence: Stage1PersistenceService,
+  input: {
+    readonly existingEvents: readonly CanonicalEventRecord[];
+    readonly incoming: Pick<
+      NormalizedCanonicalEventIntake,
+      | "canonicalEvent"
+      | "sourceEvidence"
+      | "gmailMessageDetail"
+      | "salesforceCommunicationDetail"
+    >;
+  }
+): Promise<OutboundEmailDuplicateMatch | null> {
+  if (
+    input.incoming.canonicalEvent.eventType !== "communication.email.outbound"
+  ) {
+    return null;
+  }
+
+  const incomingSource = buildIncomingOutboundEmailFingerprintSource(
+    input.incoming
+  );
+
+  if (incomingSource === null) {
+    return null;
+  }
+
+  const incomingFingerprint = buildOutboundEmailDuplicateFingerprint({
+    subject: incomingSource.subject,
+    body: incomingSource.body
+  });
+
+  if (incomingFingerprint === null) {
+    return null;
+  }
+
+  const candidateEvents = input.existingEvents
+    .filter(
+      (event) =>
+        event.eventType === "communication.email.outbound" &&
+        (event.provenance.primaryProvider === "gmail" ||
+          event.provenance.primaryProvider === "salesforce") &&
+        isWithinOutboundEmailFingerprintWindow({
+          leftOccurredAt: event.occurredAt,
+          rightOccurredAt: input.incoming.canonicalEvent.occurredAt
+        })
+    )
+    .sort(compareDuplicateCandidateEvents);
+
+  if (candidateEvents.length === 0) {
+    return null;
+  }
+
+  const detailMaps = await loadProviderDetailMaps(
+    persistence,
+    candidateEvents.map((event) => event.sourceEvidenceId)
+  );
+
+  for (const existingEvent of candidateEvents) {
+    const existingSource = buildPersistedOutboundEmailFingerprintSource({
+      event: existingEvent,
+      gmailMessageDetailBySourceEvidenceId:
+        detailMaps.gmailMessageDetailBySourceEvidenceId,
+      salesforceCommunicationDetailBySourceEvidenceId:
+        detailMaps.salesforceCommunicationDetailBySourceEvidenceId
+    });
+
+    if (existingSource === null) {
+      continue;
+    }
+
+    const existingFingerprint = buildOutboundEmailDuplicateFingerprint({
+      subject: existingSource.subject,
+      body: existingSource.body
+    });
+
+    if (existingFingerprint === null || existingFingerprint !== incomingFingerprint) {
+      continue;
+    }
+
+    const winnerSelection = selectOutboundEmailDuplicateWinner({
+      incoming: {
+        provider: input.incoming.sourceEvidence.provider,
+        occurredAt: input.incoming.canonicalEvent.occurredAt
+      },
+      existing: {
+        provider: existingEvent.provenance.primaryProvider,
+        occurredAt: existingEvent.occurredAt
+      }
+    });
+
+    if (winnerSelection === null) {
+      continue;
+    }
+
+    return {
+      existingEvent,
+      existingTimelineProjection:
+        await persistence.repositories.timelineProjection.findByCanonicalEventId(
+          existingEvent.id
+        ),
+      winner: {
+        winnerReason: winnerSelection.winnerReason,
+        notes: winnerSelection.notes,
+        keepIncomingAsPrimary: winnerSelection.winner === "incoming"
+      }
+    };
+  }
+
+  return null;
+}
+
+function resolveInboxSnippet(
+  event: CanonicalEventRecord,
+  detailMaps: ProviderDetailMaps
+): string {
+  if (event.provenance.primaryProvider === "gmail") {
+    const detail = detailMaps.gmailMessageDetailBySourceEvidenceId.get(
+      event.sourceEvidenceId
+    );
+
+    if (detail === undefined) {
+      return "";
+    }
+
+    return detail.snippetClean.length > 0
+      ? detail.snippetClean
+      : detail.bodyTextPreview;
+  }
+
+  if (event.provenance.primaryProvider === "salesforce") {
+    return (
+      detailMaps.salesforceCommunicationDetailBySourceEvidenceId.get(
+        event.sourceEvidenceId
+      )?.snippet ?? ""
+    );
+  }
+
+  if (event.provenance.primaryProvider === "simpletexting") {
+    return (
+      detailMaps.simpleTextingMessageDetailBySourceEvidenceId.get(
+        event.sourceEvidenceId
+      )?.messageTextPreview ?? ""
+    );
+  }
+
+  return "";
+}
+
+async function rebuildInboxProjectionForContact(
+  persistence: Stage1PersistenceService,
+  contactId: string
+): Promise<InboxProjectionRow | null> {
+  const existing = await persistence.repositories.inboxProjection.findByContactId(
+    contactId
+  );
+  const events = await persistence.repositories.canonicalEvents.listByContactId(
+    contactId
+  );
+  const inboxDrivingEvents = events.filter(
+    (
+      event
+    ): event is CanonicalEventRecord & { readonly eventType: InboxDrivingEventType } =>
+      isInboxDrivingCanonicalEvent(event)
+  );
+
+  if (inboxDrivingEvents.length === 0) {
+    if (existing !== null) {
+      await persistence.repositories.inboxProjection.deleteByContactId(contactId);
+    }
+
+    return null;
+  }
+
+  const detailMaps = await loadProviderDetailMaps(
+    persistence,
+    inboxDrivingEvents.map((event) => event.sourceEvidenceId)
+  );
+  const latestEvent = requireValue(
+    inboxDrivingEvents[inboxDrivingEvents.length - 1],
+    "Expected an inbox-driving event when rebuilding inbox projection."
+  );
+  let lastInboundAt: string | null = null;
+  let lastOutboundAt: string | null = null;
+
+  for (const event of inboxDrivingEvents) {
+    if (isInboundEvent(event.eventType)) {
+      lastInboundAt = newestTimestamp(lastInboundAt, event.occurredAt);
+    } else {
+      lastOutboundAt = newestTimestamp(lastOutboundAt, event.occurredAt);
+    }
+  }
+
+  const lastActivityAt = newestTimestamp(lastInboundAt, lastOutboundAt);
+
+  if (lastActivityAt === null) {
+    return null;
+  }
+
+  return persistence.saveInboxProjection({
+    contactId,
+    bucket:
+      existing?.bucket ??
+      (isInboundEvent(latestEvent.eventType) ? "New" : "Opened"),
+    needsFollowUp: existing?.needsFollowUp ?? false,
+    hasUnresolved: await contactHasUnresolved(persistence, contactId),
+    lastInboundAt,
+    lastOutboundAt,
+    lastActivityAt,
+    snippet: resolveInboxSnippet(latestEvent, detailMaps),
+    lastCanonicalEventId: latestEvent.id,
+    lastEventType: latestEvent.eventType
+  });
 }
 
 function buildIdentityMissingAnchorExplanation(
@@ -1588,9 +1924,253 @@ export function createStage1NormalizationService(
         },
         reviewState
       });
-      const eventWriteResult = await persistence.persistCanonicalEvent(
-        canonicalEvent
-      );
+      let contactEvents: readonly CanonicalEventRecord[] | null = null;
+      const getContactEvents = async (): Promise<
+        readonly CanonicalEventRecord[]
+      > => {
+        if (contactEvents !== null) {
+          return contactEvents;
+        }
+
+        contactEvents = await persistence.repositories.canonicalEvents.listByContactId(
+          identityDecision.contact.id
+        );
+        return contactEvents;
+      };
+      const alreadyMergedEvent =
+        sourceEvidenceResult.outcome === "duplicate"
+          ? findCanonicalEventForSourceEvidence(
+              await getContactEvents(),
+              sourceEvidenceResult.record.id
+            )
+          : null;
+
+      if (alreadyMergedEvent !== null) {
+        const persistedEvent =
+          alreadyMergedEvent.reviewState === reviewState
+            ? alreadyMergedEvent
+            : await persistence.repositories.canonicalEvents.upsert({
+                ...alreadyMergedEvent,
+                reviewState: mergeCanonicalReviewState(
+                  alreadyMergedEvent.reviewState,
+                  reviewState
+                )
+              });
+        const identityCase =
+          identityDecision.reviewInput === null
+            ? null
+            : (
+                await service.saveIdentityAmbiguityCase(
+                  identityDecision.reviewInput
+                )
+              ).caseRecord;
+        const routingCase =
+          routingDecision.reviewInput === null
+            ? null
+            : (
+                await service.saveRoutingAmbiguityCase(
+                  routingDecision.reviewInput
+                )
+              )
+                .caseRecord;
+        const existingTimelineProjection =
+          await persistence.repositories.timelineProjection.findByCanonicalEventId(
+            persistedEvent.id
+          );
+        const timelineProjection =
+          existingTimelineProjection === null
+            ? await service.applyTimelineProjection({
+                canonicalEvent: persistedEvent,
+                summary: parsed.canonicalEvent.summary
+              })
+            : persistedEvent.reviewState === alreadyMergedEvent.reviewState
+              ? existingTimelineProjection
+              : await service.applyTimelineProjection({
+                  canonicalEvent: persistedEvent,
+                  summary: existingTimelineProjection.summary
+                });
+        const inboxProjection = isInboxDrivingCanonicalEvent(persistedEvent)
+          ? await rebuildInboxProjectionForContact(
+              persistence,
+              persistedEvent.contactId
+            )
+          : await service.refreshInboxReviewOverlay({
+              contactId: persistedEvent.contactId
+            });
+
+        return {
+          outcome: "duplicate",
+          sourceEvidence: sourceEvidenceResult.record,
+          canonicalEvent: persistedEvent,
+          timelineProjection,
+          inboxProjection,
+          identityCase,
+          routingCase,
+          auditEvidence: null
+        };
+      }
+
+      const duplicateMatch =
+        parsed.canonicalEvent.eventType === "communication.email.outbound"
+          ? await findOutboundEmailDuplicateMatch(persistence, {
+              existingEvents: await getContactEvents(),
+              incoming: {
+                canonicalEvent: parsed.canonicalEvent,
+                sourceEvidence: sourceEvidenceResult.record,
+                gmailMessageDetail: parsed.gmailMessageDetail,
+                salesforceCommunicationDetail:
+                  parsed.salesforceCommunicationDetail
+              }
+            })
+          : null;
+
+      if (duplicateMatch !== null) {
+        const mergedSupportingSourceEvidenceIds = uniqueStrings([
+          ...duplicateMatch.existingEvent.provenance.supportingSourceEvidenceIds,
+          ...supportingSourceEvidenceIds,
+          duplicateMatch.existingEvent.sourceEvidenceId,
+          sourceEvidenceResult.record.id
+        ]).filter(
+          (sourceEvidenceId) =>
+            sourceEvidenceId !==
+            (duplicateMatch.winner.keepIncomingAsPrimary
+              ? sourceEvidenceResult.record.id
+              : duplicateMatch.existingEvent.sourceEvidenceId)
+        );
+        const supportingProviders = new Set<
+          CanonicalEventRecord["provenance"]["primaryProvider"]
+        >([
+          ...parsed.supportingSources.map((entry) => entry.provider),
+          duplicateMatch.winner.keepIncomingAsPrimary
+            ? duplicateMatch.existingEvent.provenance.primaryProvider
+            : parsed.sourceEvidence.provider
+        ]);
+
+        if (
+          duplicateMatch.existingEvent.provenance.winnerReason ===
+          "gmail_wins_duplicate_collapse"
+        ) {
+          supportingProviders.add("salesforce");
+        }
+
+        if (
+          duplicateMatch.existingEvent.provenance.winnerReason ===
+          "earliest_gmail_wins_duplicate_collapse"
+        ) {
+          supportingProviders.add("gmail");
+        }
+
+        const mergedWinner = resolveOutboundEmailMergedWinnerDecision({
+          primaryProvider: duplicateMatch.winner.keepIncomingAsPrimary
+            ? canonicalEvent.provenance.primaryProvider
+            : duplicateMatch.existingEvent.provenance.primaryProvider,
+          supportingProviders: [...supportingProviders],
+          fallback: duplicateMatch.winner
+        });
+        const persistedEvent = await persistence.repositories.canonicalEvents.upsert(
+          canonicalEventSchema.parse({
+            id: duplicateMatch.existingEvent.id,
+            contactId: identityDecision.contact.id,
+            eventType: canonicalEvent.eventType,
+            channel: canonicalEvent.channel,
+            occurredAt: duplicateMatch.winner.keepIncomingAsPrimary
+              ? canonicalEvent.occurredAt
+              : duplicateMatch.existingEvent.occurredAt,
+            sourceEvidenceId: duplicateMatch.winner.keepIncomingAsPrimary
+              ? sourceEvidenceResult.record.id
+              : duplicateMatch.existingEvent.sourceEvidenceId,
+            idempotencyKey: duplicateMatch.winner.keepIncomingAsPrimary
+              ? canonicalEvent.idempotencyKey
+              : duplicateMatch.existingEvent.idempotencyKey,
+            provenance: {
+              primaryProvider: duplicateMatch.winner.keepIncomingAsPrimary
+                ? canonicalEvent.provenance.primaryProvider
+                : duplicateMatch.existingEvent.provenance.primaryProvider,
+              primarySourceEvidenceId: duplicateMatch.winner.keepIncomingAsPrimary
+                ? sourceEvidenceResult.record.id
+                : duplicateMatch.existingEvent.sourceEvidenceId,
+              supportingSourceEvidenceIds: mergedSupportingSourceEvidenceIds,
+              winnerReason: mergedWinner.winnerReason,
+              sourceRecordType: duplicateMatch.winner.keepIncomingAsPrimary
+                ? canonicalEvent.provenance.sourceRecordType
+                : duplicateMatch.existingEvent.provenance.sourceRecordType,
+              sourceRecordId: duplicateMatch.winner.keepIncomingAsPrimary
+                ? canonicalEvent.provenance.sourceRecordId
+                : duplicateMatch.existingEvent.provenance.sourceRecordId,
+              messageKind: duplicateMatch.winner.keepIncomingAsPrimary
+                ? canonicalEvent.provenance.messageKind
+                : duplicateMatch.existingEvent.provenance.messageKind,
+              campaignRef: duplicateMatch.winner.keepIncomingAsPrimary
+                ? canonicalEvent.provenance.campaignRef
+                : duplicateMatch.existingEvent.provenance.campaignRef,
+              threadRef: duplicateMatch.winner.keepIncomingAsPrimary
+                ? canonicalEvent.provenance.threadRef
+                : duplicateMatch.existingEvent.provenance.threadRef,
+              direction: duplicateMatch.winner.keepIncomingAsPrimary
+                ? canonicalEvent.provenance.direction
+                : duplicateMatch.existingEvent.provenance.direction,
+              ...((duplicateMatch.winner.keepIncomingAsPrimary
+                ? canonicalEvent.provenance.inboxProjectionExclusionReason
+                : duplicateMatch.existingEvent.provenance
+                    .inboxProjectionExclusionReason) === undefined
+                ? {}
+                : {
+                    inboxProjectionExclusionReason:
+                      duplicateMatch.winner.keepIncomingAsPrimary
+                        ? canonicalEvent.provenance.inboxProjectionExclusionReason
+                        : duplicateMatch.existingEvent.provenance
+                            .inboxProjectionExclusionReason
+                  }),
+              notes: mergedWinner.notes
+            },
+            reviewState: mergeCanonicalReviewState(
+              duplicateMatch.existingEvent.reviewState,
+              canonicalEvent.reviewState
+            )
+          })
+        );
+        const identityCase =
+          identityDecision.reviewInput === null
+            ? null
+            : (
+                await service.saveIdentityAmbiguityCase(
+                  identityDecision.reviewInput
+                )
+              ).caseRecord;
+        const routingCase =
+          routingDecision.reviewInput === null
+            ? null
+            : (
+                await service.saveRoutingAmbiguityCase(
+                  routingDecision.reviewInput
+                )
+              )
+                .caseRecord;
+        const timelineProjection = await service.applyTimelineProjection({
+          canonicalEvent: persistedEvent,
+          summary: duplicateMatch.winner.keepIncomingAsPrimary
+            ? parsed.canonicalEvent.summary
+            : duplicateMatch.existingTimelineProjection?.summary ??
+              parsed.canonicalEvent.summary
+        });
+        const inboxProjection = await rebuildInboxProjectionForContact(
+          persistence,
+          persistedEvent.contactId
+        );
+
+        return {
+          outcome: "applied",
+          sourceEvidence: sourceEvidenceResult.record,
+          canonicalEvent: persistedEvent,
+          timelineProjection,
+          inboxProjection,
+          identityCase,
+          routingCase,
+          auditEvidence: null
+        };
+      }
+
+      const eventWriteResult = await persistence.persistCanonicalEvent(canonicalEvent);
 
       if (eventWriteResult.outcome === "conflict") {
         const auditEvidence = await recordQuarantineAuditOnce(persistence, {

--- a/packages/domain/src/outbound-email-dedup.ts
+++ b/packages/domain/src/outbound-email-dedup.ts
@@ -1,0 +1,447 @@
+import type {
+  CanonicalEventRecord,
+  GmailMessageDetailRecord,
+  NormalizedCanonicalEventIntake,
+  Provider,
+  ProvenanceWinnerReason,
+  SalesforceCommunicationDetailRecord
+} from "@as-comms/contracts";
+
+export const outboundEmailFingerprintWindowMs = 15 * 60 * 1000;
+
+const trackedQueryParamPattern =
+  /^(utm_[a-z0-9_]+|fbclid|gclid|msclkid|mc_cid|mc_eid|vero_[a-z0-9_]+)$/iu;
+const emailPrefixPattern = /^\s*→\s*email:\s*/iu;
+const conservativeSignatureBoundaryPatterns = [
+  /^\s*--\s*$/u,
+  /^\s*sent from my (iphone|ipad|android|mobile device)\s*$/iu,
+  /^\s*get outlook for (ios|android)\s*$/iu
+] as const;
+const quotedReplyBoundaryPatterns = [
+  /(?:\n|^)\s*On .+ wrote:\s*$/imu,
+  /(?:\bOn .+? wrote:)\s*>/isu,
+  /(?:\n|^)\s*From:\s.+?(?:Date:|Sent:)\s.+/isu,
+  /(?:\n|^)\s*-{2,}\s*Original Message\s*-{2,}/imu,
+  /(?:\n|^)\s*Begin forwarded message:/imu,
+  /(?:\n|^)\s*Forwarded message:/imu,
+  /(?:\n|^)\s*>/mu
+] as const;
+
+export interface OutboundEmailFingerprintSource {
+  readonly provider: Provider;
+  readonly subject: string | null;
+  readonly body: string;
+}
+
+export interface OutboundEmailDuplicateWinnerSelection {
+  readonly winner: "incoming" | "existing";
+  readonly winnerReason:
+    | "gmail_wins_duplicate_collapse"
+    | "earliest_gmail_wins_duplicate_collapse";
+  readonly notes: string;
+}
+
+export interface OutboundEmailWinnerDecision {
+  readonly winnerReason: ProvenanceWinnerReason;
+  readonly notes: string | null;
+}
+
+function normalizeLineEndings(value: string): string {
+  return value.replace(/\r\n/gu, "\n").replace(/\r/gu, "\n");
+}
+
+function stripCampaignQueryParamsFromUrls(value: string): string {
+  return value.replace(
+    /https?:\/\/[^\s<>()]+/giu,
+    (candidateUrl) => {
+      const trailingPunctuationMatch =
+        /[),.;:!?]+$/u.exec(candidateUrl)?.[0] ?? "";
+      const urlWithoutTrailing =
+        trailingPunctuationMatch.length > 0
+          ? candidateUrl.slice(0, -trailingPunctuationMatch.length)
+          : candidateUrl;
+
+      try {
+        const parsed = new URL(urlWithoutTrailing);
+        const entries = Array.from(parsed.searchParams.entries());
+
+        for (const [name] of entries) {
+          if (trackedQueryParamPattern.test(name)) {
+            parsed.searchParams.delete(name);
+          }
+        }
+
+        const normalizedSearch = parsed.searchParams.toString();
+        parsed.search = normalizedSearch.length === 0 ? "" : `?${normalizedSearch}`;
+
+        return `${parsed.toString()}${trailingPunctuationMatch}`;
+      } catch {
+        return candidateUrl;
+      }
+    }
+  );
+}
+
+function stripTrackingPixelMarkup(value: string): string {
+  return value
+    .replace(
+      /<img\b[^>]*(?:width\s*=\s*["']?1\b|height\s*=\s*["']?1\b|display\s*:\s*none|visibility\s*:\s*hidden|tracking|pixel)[^>]*>/giu,
+      " "
+    )
+    .replace(
+      /\[\s*image:\s*tracking pixel\s*\]/giu,
+      " "
+    );
+}
+
+function findForwardedHeaderBlockStart(value: string): number {
+  const lines = value.split("\n");
+  let offset = 0;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    const trimmed = line.trim();
+
+    if (!/^(From|To|Recipients|Cc|Bcc|Reply-To|Sent|Date|Subject):/iu.test(trimmed)) {
+      offset += line.length + 1;
+      continue;
+    }
+
+    let headerCount = 0;
+    let candidateIndex = index;
+
+    while (candidateIndex < lines.length) {
+      const candidate = lines[candidateIndex] ?? "";
+      const candidateTrimmed = candidate.trim();
+
+      if (candidateTrimmed.length === 0) {
+        break;
+      }
+
+      if (/^(From|To|Recipients|Cc|Bcc|Reply-To|Sent|Date|Subject):/iu.test(candidateTrimmed)) {
+        headerCount += 1;
+        candidateIndex += 1;
+        continue;
+      }
+
+      if (/^[\t ]/u.test(candidate)) {
+        candidateIndex += 1;
+        continue;
+      }
+
+      break;
+    }
+
+    if (headerCount >= 3) {
+      return offset;
+    }
+
+    offset += line.length + 1;
+  }
+
+  return -1;
+}
+
+function stripQuotedReplyBlocks(value: string): string {
+  let earliestBoundary = -1;
+
+  for (const pattern of quotedReplyBoundaryPatterns) {
+    const match = pattern.exec(value);
+
+    if (match === null) {
+      continue;
+    }
+
+    if (earliestBoundary === -1 || match.index < earliestBoundary) {
+      earliestBoundary = match.index;
+    }
+  }
+
+  const forwardedHeaderBoundary = findForwardedHeaderBlockStart(value);
+
+  if (
+    forwardedHeaderBoundary !== -1 &&
+    (earliestBoundary === -1 || forwardedHeaderBoundary < earliestBoundary)
+  ) {
+    earliestBoundary = forwardedHeaderBoundary;
+  }
+
+  return (
+    earliestBoundary === -1 ? value : value.slice(0, earliestBoundary)
+  ).trim();
+}
+
+function stripConservativeSignatureBlock(value: string): string {
+  const lines = value.split("\n");
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]?.trim() ?? "";
+
+    if (
+      conservativeSignatureBoundaryPatterns.some((pattern) =>
+        pattern.test(line)
+      )
+    ) {
+      return lines.slice(0, index).join("\n").trim();
+    }
+  }
+
+  return value.trim();
+}
+
+function collapseWhitespace(value: string): string {
+  return value.replace(/\s+/gu, " ").trim();
+}
+
+function firstNonEmptyString(
+  ...values: readonly (string | null | undefined)[]
+): string {
+  for (const value of values) {
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+
+  return "";
+}
+
+function normalizeSubject(value: string | null): string {
+  if (value === null) {
+    return "";
+  }
+
+  return collapseWhitespace(
+    value.replace(emailPrefixPattern, "").toLowerCase()
+  );
+}
+
+/**
+ * Normalizes an outbound email fingerprint conservatively so we collapse only
+ * very high-confidence duplicates. The normalizer:
+ * - lowercases text
+ * - collapses repeated whitespace
+ * - strips the Salesforce "→ Email:" subject prefix
+ * - trims quoted-reply / forwarded-message blocks
+ * - strips only conservative signature markers ("--" and common mobile footers)
+ * - removes obvious tracking-pixel markup when literal <img ...> tags survive
+ * - drops campaign-style URL query params such as utm_*, fbclid, gclid, mc_*
+ *
+ * We intentionally do not strip broader valedictions or arbitrary HTML because
+ * false negatives are safer than collapsing two distinct operator emails.
+ */
+export function buildOutboundEmailDuplicateFingerprint(input: {
+  readonly subject: string | null;
+  readonly body: string;
+}): string | null {
+  const normalizedSubject = normalizeSubject(input.subject);
+  const normalizedBody = collapseWhitespace(
+    stripConservativeSignatureBlock(
+      stripQuotedReplyBlocks(
+        stripCampaignQueryParamsFromUrls(
+          stripTrackingPixelMarkup(
+            normalizeLineEndings(input.body).toLowerCase()
+          )
+        )
+      )
+    )
+  );
+
+  if (normalizedSubject.length === 0 && normalizedBody.length === 0) {
+    return null;
+  }
+
+  return `${normalizedSubject}\n${normalizedBody}`;
+}
+
+export function buildIncomingOutboundEmailFingerprintSource(
+  input: Pick<
+    NormalizedCanonicalEventIntake,
+    | "canonicalEvent"
+    | "sourceEvidence"
+    | "gmailMessageDetail"
+    | "salesforceCommunicationDetail"
+  >
+): OutboundEmailFingerprintSource | null {
+  switch (input.sourceEvidence.provider) {
+    case "gmail":
+      return {
+        provider: "gmail",
+        subject: input.gmailMessageDetail?.subject ?? null,
+        body: firstNonEmptyString(
+          input.gmailMessageDetail?.bodyTextPreview,
+          input.gmailMessageDetail?.snippetClean,
+          input.canonicalEvent.snippet
+        )
+      };
+    case "salesforce":
+      return {
+        provider: "salesforce",
+        subject: input.salesforceCommunicationDetail?.subject ?? null,
+        body: firstNonEmptyString(
+          input.salesforceCommunicationDetail?.snippet,
+          input.canonicalEvent.snippet
+        )
+      };
+    default:
+      return null;
+  }
+}
+
+export function buildPersistedOutboundEmailFingerprintSource(input: {
+  readonly event: Pick<CanonicalEventRecord, "sourceEvidenceId" | "provenance">;
+  readonly gmailMessageDetailBySourceEvidenceId: ReadonlyMap<
+    string,
+    GmailMessageDetailRecord
+  >;
+  readonly salesforceCommunicationDetailBySourceEvidenceId: ReadonlyMap<
+    string,
+    SalesforceCommunicationDetailRecord
+  >;
+}): OutboundEmailFingerprintSource | null {
+  if (input.event.provenance.primaryProvider === "gmail") {
+    const detail = input.gmailMessageDetailBySourceEvidenceId.get(
+      input.event.sourceEvidenceId
+    );
+
+    if (detail === undefined) {
+      return null;
+    }
+
+    return {
+      provider: "gmail",
+      subject: detail.subject,
+      body: detail.bodyTextPreview || detail.snippetClean
+    };
+  }
+
+  if (input.event.provenance.primaryProvider === "salesforce") {
+    const detail = input.salesforceCommunicationDetailBySourceEvidenceId.get(
+      input.event.sourceEvidenceId
+    );
+
+    if (detail === undefined) {
+      return null;
+    }
+
+    return {
+      provider: "salesforce",
+      subject: detail.subject,
+      body: detail.snippet
+    };
+  }
+
+  return null;
+}
+
+export function isWithinOutboundEmailFingerprintWindow(input: {
+  readonly leftOccurredAt: string;
+  readonly rightOccurredAt: string;
+}): boolean {
+  const left = Date.parse(input.leftOccurredAt);
+  const right = Date.parse(input.rightOccurredAt);
+
+  if (Number.isNaN(left) || Number.isNaN(right)) {
+    return false;
+  }
+
+  return Math.abs(left - right) <= outboundEmailFingerprintWindowMs;
+}
+
+export function selectOutboundEmailDuplicateWinner(input: {
+  readonly incoming: Pick<CanonicalEventRecord, "occurredAt"> & {
+    readonly provider: Provider;
+  };
+  readonly existing: Pick<CanonicalEventRecord, "occurredAt"> & {
+    readonly provider: Provider;
+  };
+}): OutboundEmailDuplicateWinnerSelection | null {
+  const providers = new Set([input.incoming.provider, input.existing.provider]);
+
+  if (!providers.has("gmail")) {
+    return null;
+  }
+
+  if (providers.has("salesforce")) {
+    return input.incoming.provider === "gmail"
+      ? {
+          winner: "incoming",
+          winnerReason: "gmail_wins_duplicate_collapse",
+          notes:
+            "Gmail remained the canonical winner over Salesforce for the same outbound email fingerprint within the 15 minute dedup window."
+        }
+      : {
+          winner: "existing",
+          winnerReason: "gmail_wins_duplicate_collapse",
+          notes:
+            "Gmail remained the canonical winner over Salesforce for the same outbound email fingerprint within the 15 minute dedup window."
+        };
+  }
+
+  if (input.incoming.provider === "gmail" && input.existing.provider === "gmail") {
+    const incomingOccurredAt = Date.parse(input.incoming.occurredAt);
+    const existingOccurredAt = Date.parse(input.existing.occurredAt);
+
+    if (
+      Number.isNaN(incomingOccurredAt) ||
+      Number.isNaN(existingOccurredAt)
+    ) {
+      return {
+        winner: "existing",
+        winnerReason: "earliest_gmail_wins_duplicate_collapse",
+        notes:
+          "The earliest Gmail evidence remains canonical for the same outbound email fingerprint; exact timestamps could not be parsed, so the existing row was kept."
+      };
+    }
+
+    if (incomingOccurredAt < existingOccurredAt) {
+      return {
+        winner: "incoming",
+        winnerReason: "earliest_gmail_wins_duplicate_collapse",
+        notes:
+          "The earliest Gmail evidence remained canonical for the same outbound email fingerprint within the 15 minute dedup window."
+      };
+    }
+
+    return {
+      winner: "existing",
+      winnerReason: "earliest_gmail_wins_duplicate_collapse",
+      notes:
+        "The earliest Gmail evidence remained canonical for the same outbound email fingerprint within the 15 minute dedup window."
+    };
+  }
+
+  return null;
+}
+
+export function resolveOutboundEmailMergedWinnerDecision(input: {
+  readonly primaryProvider: Provider;
+  readonly supportingProviders: readonly Provider[];
+  readonly fallback: OutboundEmailWinnerDecision;
+}): OutboundEmailWinnerDecision {
+  const supportingProviders = new Set(input.supportingProviders);
+
+  if (
+    input.primaryProvider === "gmail" &&
+    supportingProviders.has("salesforce")
+  ) {
+    return {
+      winnerReason: "gmail_wins_duplicate_collapse",
+      notes: supportingProviders.has("gmail")
+        ? "Gmail remained canonical over Salesforce for the same outbound email fingerprint within the 15 minute dedup window, and later Gmail duplicates were retained as supporting evidence."
+        : "Gmail remained canonical over Salesforce for the same outbound email fingerprint within the 15 minute dedup window."
+    };
+  }
+
+  if (
+    input.primaryProvider === "gmail" &&
+    supportingProviders.has("gmail")
+  ) {
+    return {
+      winnerReason: "earliest_gmail_wins_duplicate_collapse",
+      notes:
+        "The earliest Gmail evidence remained canonical for the same outbound email fingerprint within the 15 minute dedup window."
+    };
+  }
+
+  return input.fallback;
+}


### PR DESCRIPTION
## Summary

Catches duplicate outbound emails that the existing collapse framework misses. Two distinct duplicate classes observed in prod:

1. **Cross-provider (Gmail + Salesforce)** — same outbound email written via both capture paths. Neither side emits a cross-provider collapse key, so normalization never fires. **Rule: Gmail wins regardless of arrival order.**
2. **Intra-Gmail** — Gmail writes the same message twice (observed: Rosie had two outbound rows 62s apart, byte-identical; Tani similar). Root cause is upstream in the Gmail capture path; this PR catches the downstream effect. **Rule: earliest Gmail wins.**

## Strategy pivot

Narrow Strategy B from the brief. Architect-approved mid-flight after the diagnostic showed Strategy A alone wouldn't fix intra-Gmail dupes. Conditions imposed at approval:
- 15-minute fingerprint window (Salesforce polls every 5min, 3× buffer)
- Documented normalization rules (case, whitespace, quoted replies, narrow signatures, `→ Email:` prefix, UTM params)
- Both rules explicit in code + tests

## Diagnostic (from prod)

- Strict query by `(contact_id, occurred_at::date, checksum)`: **0 groups** — checksums differ across providers for the same email.
- Fingerprint heuristic (contact + subject + trimmed body + 15min): **50 candidate duplicate groups / 104 rows**.
- Three concrete cases → regression fixtures: Tori (cross-provider), Rosie (both classes in one thread), Tani (similar to Rosie).

## Fingerprint normalization

Documented inline in `outbound-email-dedup.ts`:
- Case, whitespace, line-ending normalization
- Quoted-reply blocks (`On X wrote:`, forwarded headers, `>` lines)
- Conservative signature markers (`--`, "Sent from my iPhone", "Get Outlook for iOS")
- `→ Email:` prefix stripping
- Campaign-style URL query params (`utm_*`, `fbclid`, `gclid`, `mc_cid`, `mc_eid`, `vero_*`)

## Historical cleanup script

`apps/worker/src/ops/dedup-historical-ledger.ts`:
- Dry-run default; `--execute` for destructive; `--limit N` for canaries
- Uses same fingerprint as live normalization
- Plans Gmail-wins merges, repoints `contact_inbox_projection.lastCanonicalEventId`, removes loser timeline rows
- Preserves Salesforce detail via surviving canonical provenance + source evidence linkage
- Idempotent
- Emits JSONL audit trail

**⚠ Not executed against prod in this PR.** Dry-run + destructive `--execute` pending per-session architect sign-off each.

## Scope note

Also serializes root `test:unit` Turbo parallelism in `package.json`. Codex made this change to keep web/worker suites under their 30s timeout budget while running the new test fixtures. Small DX tweak in this PR; flag in review if the serialization should be separated.

## Follow-ups (not in this PR)

- **Gmail-twin upstream root cause** — why the Gmail capture path writes the same message twice (live-poll + mbox re-import overlap? retry w/o idempotency?). Fix upstream; this PR handles the downstream effect.
- **Optional partial unique index** on `canonical_event_ledger` as a belt-and-suspenders guard. Intentionally not added here (migration-free).

## Test plan

- [ ] CI green on `pnpm lint`, `pnpm test:unit`, `pnpm typecheck`
- [ ] Regression fixtures for Tori / Rosie / Tani exercise both rule branches
- [ ] Historical cleanup integration tests
- [ ] Prod dry-run (pending separate sign-off)
- [ ] Prod destructive execute (pending separate per-session sign-off)

Brief: `.codex-event-dedup-2026-04-20.md`.