### PR TITLE
fix(identity): implement D-027 + reconcile identity queue

### DIFF
--- a/apps/worker/src/ops/cli.ts
+++ b/apps/worker/src/ops/cli.ts
@@ -10,6 +10,12 @@ import {
   createStage1NormalizationService,
   createStage1PersistenceService
 } from "@as-comms/domain";
+import {
+  createGmailCapturePort,
+  createMailchimpCapturePort,
+  createSalesforceCapturePort,
+  createSimpleTextingCapturePort
+} from "@as-comms/integrations";
 
 import {
   buildSafeRuntimeConfigSummary,
@@ -31,6 +37,7 @@ import {
 import {
   runBackfillSalesforceCommunicationDetailsCommand
 } from "./backfill-salesforce-communication-details.js";
+import { reconcileIdentityQueue } from "./reconcile-identity-queue.js";
 import {
   runDedupHistoricalLedgerCommand
 } from "./dedup-historical-ledger.js";
@@ -54,6 +61,30 @@ function readConnectionString(env: NodeJS.ProcessEnv): string {
   }
 
   return connectionString;
+}
+
+function rejectUnconfiguredProvider(providerLabel: string): Promise<never> {
+  return Promise.reject(
+    new Error(`${providerLabel} capture is not configured for this worker runtime.`)
+  );
+}
+
+function readOptionalLimitArg(args: readonly string[]): number | undefined {
+  const inlineLimit = args.find((arg) => arg.startsWith("--limit="));
+
+  if (inlineLimit !== undefined) {
+    const parsed = Number.parseInt(inlineLimit.split("=")[1] ?? "", 10);
+
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      throw new Error("Flag --limit must be a positive integer.");
+    }
+
+    return parsed;
+  }
+
+  const flags = parseCliFlags(args);
+  const parsed = readOptionalIntegerFlag(flags, "limit", 0);
+  return parsed === 0 ? undefined : parsed;
 }
 
 function runCheckConfig(): void {
@@ -234,6 +265,63 @@ async function runInspect(args: readonly string[]): Promise<void> {
   }
 }
 
+async function runReconcileIdentityQueue(args: readonly string[]): Promise<void> {
+  const dryRun = !args.includes("--execute");
+  const limit = readOptionalLimitArg(args);
+  const config = readWorkerConfig({
+    ...process.env,
+    WORKER_BOOT_MODE: "run"
+  });
+
+  if (config === null) {
+    throw new Error("Expected a validated worker config.");
+  }
+
+  const connection = createDatabaseConnection({
+    connectionString: readConnectionString(process.env)
+  });
+
+  try {
+    const repositories = createStage1RepositoryBundleFromConnection(connection);
+    const report = await reconcileIdentityQueue({
+      db: connection.db,
+      repositories,
+      capture: {
+        gmail: createGmailCapturePort(config.capture.gmail),
+        salesforce: createSalesforceCapturePort(config.capture.salesforce),
+        simpleTexting:
+          config.capture.simpleTexting === undefined
+            ? {
+                captureHistoricalBatch: () =>
+                  rejectUnconfiguredProvider("SimpleTexting"),
+                captureLiveBatch: () =>
+                  rejectUnconfiguredProvider("SimpleTexting")
+              }
+            : createSimpleTextingCapturePort(config.capture.simpleTexting),
+        mailchimp:
+          config.capture.mailchimp === undefined
+            ? {
+                captureHistoricalBatch: () =>
+                  rejectUnconfiguredProvider("Mailchimp"),
+                captureTransitionBatch: () =>
+                  rejectUnconfiguredProvider("Mailchimp")
+              }
+            : createMailchimpCapturePort(config.capture.mailchimp)
+      },
+      gmailHistoricalReplay: {
+        liveAccount: config.launchScope.gmail.liveAccount,
+        projectInboxAliases: [...config.launchScope.gmail.projectInboxAliases]
+      },
+      dryRun,
+      ...(limit === undefined ? {} : { limit })
+    });
+
+    console.log("Final report:", report);
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}
+
 async function main(): Promise<void> {
   const [command, ...rest] = process.argv.slice(2);
 
@@ -256,9 +344,12 @@ async function main(): Promise<void> {
     case "dedup-historical-ledger":
       await runDedupHistoricalLedgerCommand(rest, process.env);
       return;
+    case "reconcile-identity-queue":
+      await runReconcileIdentityQueue(rest);
+      return;
     default:
       throw new Error(
-        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, dedup-historical-ledger."
+        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, dedup-historical-ledger, reconcile-identity-queue."
       );
   }
 }

--- a/apps/worker/src/ops/reconcile-identity-queue.ts
+++ b/apps/worker/src/ops/reconcile-identity-queue.ts
@@ -1,0 +1,841 @@
+import { readFile } from "node:fs/promises";
+
+import {
+  stage1JobVersion,
+  type IdentityResolutionCase,
+  type Provider,
+  type SourceEvidenceRecord,
+  type Stage1OrchestrationMode
+} from "@as-comms/contracts";
+import {
+  createStage1RepositoryBundle,
+  type Stage1Database
+} from "@as-comms/db";
+import {
+  createStage1NormalizationService,
+  createStage1PersistenceService,
+  type Stage1RepositoryBundle
+} from "@as-comms/domain";
+import {
+  importGmailMboxRecords,
+  type GmailRecord,
+  type MailchimpRecord,
+  type SalesforceRecord,
+  type SimpleTextingRecord
+} from "@as-comms/integrations";
+
+import {
+  createStage1IngestService,
+  type Stage1IngestResult,
+  type Stage1IngestService
+} from "../ingest/index.js";
+import type { Stage1ProviderCapturePorts } from "../orchestration/index.js";
+import { buildOperationId } from "./helpers.js";
+
+const DEFAULT_BATCH_SIZE = 100;
+
+type CapturedProviderRecord =
+  | GmailRecord
+  | SalesforceRecord
+  | SimpleTextingRecord
+  | MailchimpRecord;
+
+interface GmailHistoricalReplayConfig {
+  readonly liveAccount: string;
+  readonly projectInboxAliases: readonly string[];
+}
+
+interface ReconcileTarget {
+  readonly caseRecord: IdentityResolutionCase;
+  readonly sourceEvidence: SourceEvidenceRecord;
+  readonly mode: Stage1OrchestrationMode;
+}
+
+export interface ReconcileError {
+  readonly caseId: string;
+  readonly sourceEvidenceId: string;
+  readonly provider?: Provider;
+  readonly providerRecordType?: string;
+  readonly providerRecordId?: string;
+  readonly message: string;
+}
+
+export interface ReconcileReport {
+  readonly dryRun: boolean;
+  readonly scanned: number;
+  readonly resolved: number;
+  readonly created: number;
+  readonly skipped: number;
+  readonly errors: readonly ReconcileError[];
+}
+
+interface ReconcileIdentityQueueInput {
+  readonly db: Stage1Database;
+  readonly repositories: Stage1RepositoryBundle;
+  readonly capture: Stage1ProviderCapturePorts;
+  readonly gmailHistoricalReplay: GmailHistoricalReplayConfig;
+  readonly dryRun: boolean;
+  readonly limit?: number;
+  readonly logger?: Pick<Console, "log">;
+}
+
+interface ParsedGmailHistoricalPayloadRef {
+  readonly mboxPath: string;
+  readonly messageNumber: number;
+}
+
+interface ReconcileExecutionResult {
+  readonly ingestResult: Stage1IngestResult;
+  readonly createdNewContact: boolean;
+}
+
+class DryRunRollback extends Error {
+  constructor() {
+    super("dry-run-rollback");
+  }
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+  return Array.from(new Set(values)).sort((left, right) =>
+    left.localeCompare(right)
+  );
+}
+
+function chunkValues<TValue>(
+  values: readonly TValue[],
+  chunkSize: number
+): TValue[][] {
+  const chunks: TValue[][] = [];
+
+  for (let index = 0; index < values.length; index += chunkSize) {
+    chunks.push(values.slice(index, index + chunkSize));
+  }
+
+  return chunks;
+}
+
+function buildHistoricalReplayProjectInboxAliases(input: {
+  readonly configuredAliases: readonly string[];
+  readonly recordedProjectInboxAlias: string | null;
+}): string[] {
+  const aliases = new Set(
+    input.configuredAliases
+      .map((alias) => alias.trim())
+      .filter((alias) => alias.length > 0)
+  );
+
+  if (
+    input.recordedProjectInboxAlias !== null &&
+    input.recordedProjectInboxAlias.trim().length > 0
+  ) {
+    aliases.add(input.recordedProjectInboxAlias.trim());
+  }
+
+  return [...aliases];
+}
+
+function parseGmailHistoricalPayloadRef(
+  payloadRef: string
+): ParsedGmailHistoricalPayloadRef {
+  if (!payloadRef.startsWith("mbox://")) {
+    throw new Error(
+      `Expected Gmail historical replay payloadRef to use the mbox:// scheme, received ${payloadRef}.`
+    );
+  }
+
+  const hashIndex = payloadRef.indexOf("#");
+  const encodedPath = payloadRef.slice(
+    "mbox://".length,
+    hashIndex === -1 ? undefined : hashIndex
+  );
+
+  if (encodedPath.trim().length === 0) {
+    throw new Error(
+      `Expected Gmail historical replay payloadRef to include an mbox path, received ${payloadRef}.`
+    );
+  }
+
+  let mboxPath: string;
+
+  try {
+    mboxPath = decodeURIComponent(encodedPath);
+  } catch {
+    throw new Error(
+      `Expected Gmail historical replay payloadRef to contain a valid encoded mbox path, received ${payloadRef}.`
+    );
+  }
+
+  const searchParams = new URLSearchParams(
+    hashIndex === -1 ? "" : payloadRef.slice(hashIndex + 1)
+  );
+  const messageValue = searchParams.get("message");
+  const messageNumber =
+    messageValue === null ? Number.NaN : Number.parseInt(messageValue, 10);
+
+  if (!Number.isInteger(messageNumber) || messageNumber < 1) {
+    throw new Error(
+      `Expected Gmail historical replay payloadRef to include a positive message number, received ${payloadRef}.`
+    );
+  }
+
+  return {
+    mboxPath,
+    messageNumber
+  };
+}
+
+function buildRecordKey(input: {
+  readonly providerRecordType: string;
+  readonly providerRecordId: string;
+}): string {
+  return `${input.providerRecordType}:${input.providerRecordId}`;
+}
+
+function inferReplayMode(
+  sourceEvidence: SourceEvidenceRecord
+): Stage1OrchestrationMode {
+  switch (sourceEvidence.provider) {
+    case "gmail":
+      return sourceEvidence.payloadRef.startsWith("mbox://")
+        ? "historical"
+        : "live";
+    case "salesforce":
+      return "live";
+    case "simpletexting":
+      return sourceEvidence.payloadRef.startsWith("capture://simpletexting/")
+        ? "live"
+        : "historical";
+    case "mailchimp":
+      return sourceEvidence.payloadRef.startsWith("capture://mailchimp/")
+        ? "transition_live"
+        : "historical";
+    case "manual":
+      throw new Error(
+        `Manual source evidence ${sourceEvidence.id} cannot be reconciled through the identity replay workflow.`
+      );
+  }
+}
+
+async function loadOpenIdentityMissingAnchorTargets(input: {
+  readonly repositories: Stage1RepositoryBundle;
+  readonly limit?: number;
+}): Promise<{
+  readonly targets: readonly ReconcileTarget[];
+  readonly errors: readonly ReconcileError[];
+}> {
+  const cases = await input.repositories.identityResolutionQueue.listOpenByReasonCode(
+    "identity_missing_anchor"
+  );
+  const selectedCases =
+    input.limit === undefined ? cases : cases.slice(0, input.limit);
+  const sourceEvidenceById = new Map(
+    (
+      await input.repositories.sourceEvidence.listByIds(
+        uniqueStrings(selectedCases.map((caseRecord) => caseRecord.sourceEvidenceId))
+      )
+    ).map((record) => [record.id, record] as const)
+  );
+  const targets: ReconcileTarget[] = [];
+  const errors: ReconcileError[] = [];
+
+  for (const caseRecord of selectedCases) {
+    const sourceEvidence = sourceEvidenceById.get(caseRecord.sourceEvidenceId);
+
+    if (sourceEvidence === undefined) {
+      errors.push({
+        caseId: caseRecord.id,
+        sourceEvidenceId: caseRecord.sourceEvidenceId,
+        message: `Missing source evidence ${caseRecord.sourceEvidenceId} for open identity review case.`
+      });
+      continue;
+    }
+
+    targets.push({
+      caseRecord,
+      sourceEvidence,
+      mode: inferReplayMode(sourceEvidence)
+    });
+  }
+
+  return {
+    targets,
+    errors
+  };
+}
+
+async function loadHistoricalGmailRecords(input: {
+  readonly repositories: Stage1RepositoryBundle;
+  readonly targets: readonly ReconcileTarget[];
+  readonly gmailHistoricalReplay: GmailHistoricalReplayConfig;
+}): Promise<Map<string, GmailRecord>> {
+  const sourceEvidenceIds = input.targets.map((target) => target.sourceEvidence.id);
+  const gmailDetails = await input.repositories.gmailMessageDetails.listBySourceEvidenceIds(
+    sourceEvidenceIds
+  );
+  const gmailDetailBySourceEvidenceId = new Map(
+    gmailDetails.map((detail) => [detail.sourceEvidenceId, detail] as const)
+  );
+  const mboxTextByPath = new Map<string, string>();
+  const importedRecordsByCacheKey = new Map<string, readonly GmailRecord[]>();
+  const recordsBySourceEvidenceId = new Map<string, GmailRecord>();
+
+  for (const target of input.targets) {
+    const gmailDetail = gmailDetailBySourceEvidenceId.get(target.sourceEvidence.id);
+
+    if (gmailDetail === undefined) {
+      throw new Error(
+        `Expected gmail_message_details to exist for historical replay source evidence ${target.sourceEvidence.id}.`
+      );
+    }
+
+    const parsedPayloadRef = parseGmailHistoricalPayloadRef(
+      target.sourceEvidence.payloadRef
+    );
+    let mboxText = mboxTextByPath.get(parsedPayloadRef.mboxPath);
+
+    if (mboxText === undefined) {
+      mboxText = await readFile(parsedPayloadRef.mboxPath, "utf8");
+      mboxTextByPath.set(parsedPayloadRef.mboxPath, mboxText);
+    }
+
+    const capturedMailbox =
+      gmailDetail.capturedMailbox ?? input.gmailHistoricalReplay.liveAccount;
+    const replayProjectInboxAliases = buildHistoricalReplayProjectInboxAliases({
+      configuredAliases: input.gmailHistoricalReplay.projectInboxAliases,
+      recordedProjectInboxAlias: gmailDetail.projectInboxAlias
+    });
+    const cacheKey = JSON.stringify({
+      mboxPath: parsedPayloadRef.mboxPath,
+      capturedMailbox,
+      projectInboxAliases: replayProjectInboxAliases,
+      projectInboxAliasOverride: gmailDetail.projectInboxAlias,
+      receivedAt: target.sourceEvidence.receivedAt
+    });
+    let importedRecords = importedRecordsByCacheKey.get(cacheKey);
+
+    if (importedRecords === undefined) {
+      importedRecords = await importGmailMboxRecords({
+        mboxText,
+        mboxPath: parsedPayloadRef.mboxPath,
+        capturedMailbox,
+        liveAccount: input.gmailHistoricalReplay.liveAccount,
+        projectInboxAliases: replayProjectInboxAliases,
+        projectInboxAliasOverride: gmailDetail.projectInboxAlias,
+        receivedAt: target.sourceEvidence.receivedAt
+      });
+      importedRecordsByCacheKey.set(cacheKey, importedRecords);
+    }
+
+    if (importedRecords === undefined) {
+      throw new Error(
+        `Expected imported Gmail historical records for ${parsedPayloadRef.mboxPath}.`
+      );
+    }
+
+    const replayedRecord = importedRecords[parsedPayloadRef.messageNumber - 1];
+
+    if (
+      replayedRecord?.recordType !== target.sourceEvidence.providerRecordType ||
+      replayedRecord.recordId !== target.sourceEvidence.providerRecordId
+    ) {
+      throw new Error(
+        `Unable to reconstruct Gmail historical replay record ${buildRecordKey(target.sourceEvidence)} from ${parsedPayloadRef.mboxPath}#message=${String(parsedPayloadRef.messageNumber)}.`
+      );
+    }
+
+    recordsBySourceEvidenceId.set(target.sourceEvidence.id, replayedRecord);
+  }
+
+  return recordsBySourceEvidenceId;
+}
+
+async function captureReplayGroup(input: {
+  readonly capture: Stage1ProviderCapturePorts;
+  readonly provider: Provider;
+  readonly mode: Stage1OrchestrationMode;
+  readonly targets: readonly ReconcileTarget[];
+}): Promise<Map<string, CapturedProviderRecord>> {
+  const recordIds = uniqueStrings(
+    input.targets.map((target) => target.sourceEvidence.providerRecordId)
+  );
+  const maxRecords = Math.max(1, Math.min(recordIds.length, 1000));
+  const basePayload = {
+    version: stage1JobVersion,
+    jobId: buildOperationId("stage1:identity-reconcile:job"),
+    correlationId: buildOperationId("stage1:identity-reconcile:correlation"),
+    traceId: null,
+    batchId: buildOperationId("stage1:identity-reconcile:batch"),
+    syncStateId: buildOperationId("stage1:identity-reconcile:sync-state"),
+    attempt: 1,
+    maxAttempts: 1,
+    cursor: null,
+    checkpoint: null,
+    windowStart: null,
+    windowEnd: null,
+    recordIds,
+    maxRecords
+  } as const;
+  const response =
+    input.provider === "gmail"
+      ? await input.capture.gmail.captureLiveBatch({
+          ...basePayload,
+          provider: "gmail",
+          mode: "live",
+          jobType: "live_ingest"
+        })
+      : input.provider === "salesforce"
+        ? input.mode === "historical"
+          ? await input.capture.salesforce.captureHistoricalBatch({
+              ...basePayload,
+              provider: "salesforce",
+              mode: "historical",
+              jobType: "historical_backfill"
+            })
+          : await input.capture.salesforce.captureLiveBatch({
+              ...basePayload,
+              provider: "salesforce",
+              mode: "live",
+              jobType: "live_ingest"
+            })
+        : input.provider === "simpletexting"
+          ? input.mode === "historical"
+            ? await input.capture.simpleTexting.captureHistoricalBatch({
+                ...basePayload,
+                provider: "simpletexting",
+                mode: "historical",
+                jobType: "historical_backfill"
+              })
+            : await input.capture.simpleTexting.captureLiveBatch({
+                ...basePayload,
+                provider: "simpletexting",
+                mode: "live",
+                jobType: "live_ingest"
+              })
+          : input.mode === "historical"
+            ? await input.capture.mailchimp.captureHistoricalBatch({
+                ...basePayload,
+                provider: "mailchimp",
+                mode: "historical",
+                jobType: "historical_backfill"
+              })
+            : await input.capture.mailchimp.captureTransitionBatch({
+                ...basePayload,
+                provider: "mailchimp",
+                mode: "transition_live",
+                jobType: "live_ingest"
+              });
+
+  return new Map(
+    response.records.map((record) => [
+      buildRecordKey({
+        providerRecordType: record.recordType,
+        providerRecordId: record.recordId
+      }),
+      record
+    ])
+  );
+}
+
+async function loadCapturedRecordsForTargets(input: {
+  readonly repositories: Stage1RepositoryBundle;
+  readonly capture: Stage1ProviderCapturePorts;
+  readonly targets: readonly ReconcileTarget[];
+  readonly gmailHistoricalReplay: GmailHistoricalReplayConfig;
+}): Promise<{
+  readonly recordsBySourceEvidenceId: ReadonlyMap<string, CapturedProviderRecord>;
+  readonly errors: readonly ReconcileError[];
+}> {
+  const recordsBySourceEvidenceId = new Map<string, CapturedProviderRecord>();
+  const errors: ReconcileError[] = [];
+  const gmailHistoricalTargets = input.targets.filter(
+    (target) =>
+      target.sourceEvidence.provider === "gmail" && target.mode === "historical"
+  );
+
+  if (gmailHistoricalTargets.length > 0) {
+    try {
+      const historicalRecords = await loadHistoricalGmailRecords({
+        repositories: input.repositories,
+        targets: gmailHistoricalTargets,
+        gmailHistoricalReplay: input.gmailHistoricalReplay
+      });
+
+      for (const [sourceEvidenceId, record] of historicalRecords.entries()) {
+        recordsBySourceEvidenceId.set(sourceEvidenceId, record);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+
+      for (const target of gmailHistoricalTargets) {
+        errors.push({
+          caseId: target.caseRecord.id,
+          sourceEvidenceId: target.sourceEvidence.id,
+          provider: target.sourceEvidence.provider,
+          providerRecordType: target.sourceEvidence.providerRecordType,
+          providerRecordId: target.sourceEvidence.providerRecordId,
+          message
+        });
+      }
+    }
+  }
+
+  const groupedTargets = new Map<string, ReconcileTarget[]>();
+
+  for (const target of input.targets) {
+    if (
+      target.sourceEvidence.provider === "gmail" &&
+      target.mode === "historical"
+    ) {
+      continue;
+    }
+
+    const key = `${target.sourceEvidence.provider}:${target.mode}`;
+    const existing = groupedTargets.get(key) ?? [];
+    existing.push(target);
+    groupedTargets.set(key, existing);
+  }
+
+  for (const groupTargets of groupedTargets.values()) {
+    const groupLead = groupTargets[0];
+
+    if (groupLead === undefined) {
+      continue;
+    }
+
+    try {
+      const recordsByRecordKey = await captureReplayGroup({
+        capture: input.capture,
+        provider: groupLead.sourceEvidence.provider,
+        mode: groupLead.mode,
+        targets: groupTargets
+      });
+
+      for (const target of groupTargets) {
+        const record = recordsByRecordKey.get(buildRecordKey(target.sourceEvidence));
+
+        if (record === undefined) {
+          errors.push({
+            caseId: target.caseRecord.id,
+            sourceEvidenceId: target.sourceEvidence.id,
+            provider: target.sourceEvidence.provider,
+            providerRecordType: target.sourceEvidence.providerRecordType,
+            providerRecordId: target.sourceEvidence.providerRecordId,
+            message:
+              "Replay capture did not return the expected provider-close record."
+          });
+          continue;
+        }
+
+        recordsBySourceEvidenceId.set(target.sourceEvidence.id, record);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+
+      for (const target of groupTargets) {
+        errors.push({
+          caseId: target.caseRecord.id,
+          sourceEvidenceId: target.sourceEvidence.id,
+          provider: target.sourceEvidence.provider,
+          providerRecordType: target.sourceEvidence.providerRecordType,
+          providerRecordId: target.sourceEvidence.providerRecordId,
+          message
+        });
+      }
+    }
+  }
+
+  return {
+    recordsBySourceEvidenceId,
+    errors
+  };
+}
+
+async function ingestCapturedRecord(input: {
+  readonly ingest: Stage1IngestService;
+  readonly target: ReconcileTarget;
+  readonly record: CapturedProviderRecord;
+}): Promise<Stage1IngestResult> {
+  switch (input.target.sourceEvidence.provider) {
+    case "gmail":
+      return input.target.mode === "historical"
+        ? input.ingest.ingestGmailHistoricalRecord(input.record as GmailRecord)
+        : input.ingest.ingestGmailLiveRecord(input.record as GmailRecord);
+    case "salesforce":
+      return input.target.mode === "historical"
+        ? input.ingest.ingestSalesforceHistoricalRecord(
+            input.record as SalesforceRecord
+          )
+        : input.ingest.ingestSalesforceLiveRecord(input.record as SalesforceRecord);
+    case "simpletexting":
+      return input.target.mode === "historical"
+        ? input.ingest.ingestSimpleTextingHistoricalRecord(
+            input.record as SimpleTextingRecord
+          )
+        : input.ingest.ingestSimpleTextingLiveRecord(
+            input.record as SimpleTextingRecord
+          );
+    case "mailchimp":
+      return input.target.mode === "historical"
+        ? input.ingest.ingestMailchimpHistoricalRecord(
+            input.record as MailchimpRecord
+          )
+        : input.ingest.ingestMailchimpTransitionRecord(
+            input.record as MailchimpRecord
+          );
+    case "manual":
+      throw new Error("Manual source evidence cannot be re-ingested here.");
+  }
+}
+
+function ingestedCanonicalEvent(
+  result: Stage1IngestResult
+): result is Extract<
+  Stage1IngestResult,
+  { readonly canonicalEventId: string; readonly contactId: string }
+> {
+  return (
+    (result.outcome === "normalized" || result.outcome === "duplicate") &&
+    result.commandKind === "canonical_event" &&
+    result.canonicalEventId !== null &&
+    result.contactId !== null
+  );
+}
+
+function replayCreatedCanonicalEvent(
+  result: Stage1IngestResult
+): result is Extract<
+  Stage1IngestResult,
+  {
+    readonly outcome: "review_opened";
+    readonly canonicalEventId: string;
+    readonly contactId: string;
+  }
+> {
+  return (
+    result.outcome === "review_opened" &&
+    result.canonicalEventId !== null &&
+    result.contactId !== null
+  );
+}
+
+function shouldCloseOriginalCase(result: Stage1IngestResult): boolean {
+  if (ingestedCanonicalEvent(result) || replayCreatedCanonicalEvent(result)) {
+    return true;
+  }
+
+  if (result.outcome !== "review_opened") {
+    return false;
+  }
+
+  return result.reviewCases.some(
+    (reviewCase) =>
+      reviewCase.queue === "identity" &&
+      reviewCase.reasonCode !== "identity_missing_anchor"
+  );
+}
+
+async function markIdentityCaseResolved(input: {
+  readonly repositories: Stage1RepositoryBundle;
+  readonly caseRecord: IdentityResolutionCase;
+  readonly resolvedAt: string;
+}): Promise<void> {
+  await input.repositories.identityResolutionQueue.upsert({
+    ...input.caseRecord,
+    status: "resolved",
+    resolvedAt: input.resolvedAt,
+    explanation: `${input.caseRecord.explanation} Reconciled by replay.`
+  });
+}
+
+function classifyExecution(input: {
+  readonly report: ReconcileReport;
+  readonly execution: ReconcileExecutionResult;
+}): ReconcileReport {
+  const { report, execution } = input;
+  const { ingestResult } = execution;
+
+  if (
+    ingestedCanonicalEvent(ingestResult) ||
+    replayCreatedCanonicalEvent(ingestResult)
+  ) {
+    return {
+      ...report,
+      resolved: report.resolved + (execution.createdNewContact ? 0 : 1),
+      created: report.created + (execution.createdNewContact ? 1 : 0)
+    };
+  }
+
+  return {
+    ...report,
+    skipped: report.skipped + 1
+  };
+}
+
+async function executeTarget(input: {
+  readonly db: Stage1Database;
+  readonly target: ReconcileTarget;
+  readonly record: CapturedProviderRecord;
+  readonly dryRun: boolean;
+}): Promise<ReconcileExecutionResult> {
+  const processedAt = new Date().toISOString();
+  let execution: ReconcileExecutionResult | null = null;
+
+  const runInTransaction = async (tx: Stage1Database) => {
+    const repositories = createStage1RepositoryBundle(tx);
+    const persistence = createStage1PersistenceService(repositories);
+    const normalization = createStage1NormalizationService(persistence);
+    const ingest = createStage1IngestService(normalization);
+    const beforeContactCount = (await repositories.contacts.listAll()).length;
+    const ingestResult = await ingestCapturedRecord({
+      ingest,
+      target: input.target,
+      record: input.record
+    });
+    const afterContactCount = (await repositories.contacts.listAll()).length;
+
+    if (shouldCloseOriginalCase(ingestResult)) {
+      await markIdentityCaseResolved({
+        repositories,
+        caseRecord: input.target.caseRecord,
+        resolvedAt: processedAt
+      });
+    }
+
+    execution = {
+      ingestResult,
+      createdNewContact: afterContactCount > beforeContactCount
+    };
+
+    if (input.dryRun) {
+      throw new DryRunRollback();
+    }
+  };
+
+  if (input.dryRun) {
+    try {
+      await input.db.transaction(runInTransaction);
+    } catch (error) {
+      if (!(error instanceof DryRunRollback)) {
+        throw error;
+      }
+    }
+  } else {
+    await input.db.transaction(runInTransaction);
+  }
+
+  if (execution === null) {
+    throw new Error(
+      `Expected reconcile execution result for source evidence ${input.target.sourceEvidence.id}.`
+    );
+  }
+
+  return execution;
+}
+
+export async function reconcileIdentityQueue(
+  input: ReconcileIdentityQueueInput
+): Promise<ReconcileReport> {
+  const logger = input.logger ?? console;
+  const initialTargets = await loadOpenIdentityMissingAnchorTargets({
+    repositories: input.repositories,
+    ...(input.limit === undefined ? {} : { limit: input.limit })
+  });
+  let report: ReconcileReport = {
+    dryRun: input.dryRun,
+    scanned: initialTargets.targets.length,
+    resolved: 0,
+    created: 0,
+    skipped: 0,
+    errors: initialTargets.errors
+  };
+  const batches = chunkValues(initialTargets.targets, DEFAULT_BATCH_SIZE);
+
+  for (const [batchIndex, batch] of batches.entries()) {
+    const captured = await loadCapturedRecordsForTargets({
+      repositories: input.repositories,
+      capture: input.capture,
+      targets: batch,
+      gmailHistoricalReplay: input.gmailHistoricalReplay
+    });
+
+    report = {
+      ...report,
+      errors: [...report.errors, ...captured.errors]
+    };
+
+    const erroredSourceEvidenceIds = new Set(
+      captured.errors.map((error) => error.sourceEvidenceId)
+    );
+
+    for (const target of batch) {
+      if (erroredSourceEvidenceIds.has(target.sourceEvidence.id)) {
+        continue;
+      }
+
+      const record = captured.recordsBySourceEvidenceId.get(target.sourceEvidence.id);
+
+      if (record === undefined) {
+        report = {
+          ...report,
+          errors: [
+            ...report.errors,
+            {
+              caseId: target.caseRecord.id,
+              sourceEvidenceId: target.sourceEvidence.id,
+              provider: target.sourceEvidence.provider,
+              providerRecordType: target.sourceEvidence.providerRecordType,
+              providerRecordId: target.sourceEvidence.providerRecordId,
+              message:
+                "Replay preparation finished without a captured provider-close record."
+            }
+          ]
+        };
+        continue;
+      }
+
+      try {
+        const execution = await executeTarget({
+          db: input.db,
+          target,
+          record,
+          dryRun: input.dryRun
+        });
+
+        report = classifyExecution({
+          report,
+          execution
+        });
+      } catch (error) {
+        report = {
+          ...report,
+          errors: [
+            ...report.errors,
+            {
+              caseId: target.caseRecord.id,
+              sourceEvidenceId: target.sourceEvidence.id,
+              provider: target.sourceEvidence.provider,
+              providerRecordType: target.sourceEvidence.providerRecordType,
+              providerRecordId: target.sourceEvidence.providerRecordId,
+              message: error instanceof Error ? error.message : String(error)
+            }
+          ]
+        };
+      }
+    }
+
+    logger.log(
+      JSON.stringify({
+        batchIndex: batchIndex + 1,
+        batchSize: batch.length,
+        scanned: report.scanned,
+        resolved: report.resolved,
+        created: report.created,
+        skipped: report.skipped,
+        errors: report.errors.length,
+        dryRun: report.dryRun
+      })
+    );
+  }
+
+  return report;
+}

--- a/apps/worker/src/ops/reconcile-identity-queue.ts
+++ b/apps/worker/src/ops/reconcile-identity-queue.ts
@@ -326,12 +326,6 @@ async function loadHistoricalGmailRecords(input: {
       importedRecordsByCacheKey.set(cacheKey, importedRecords);
     }
 
-    if (importedRecords === undefined) {
-      throw new Error(
-        `Expected imported Gmail historical records for ${parsedPayloadRef.mboxPath}.`
-      );
-    }
-
     const replayedRecord = importedRecords[parsedPayloadRef.messageNumber - 1];
 
     if (
@@ -723,6 +717,9 @@ async function executeTarget(input: {
     await input.db.transaction(runInTransaction);
   }
 
+  // TS can't narrow through the closure assignment in runInTransaction, so this
+  // check looks unnecessary to the linter even though it's a real runtime guard.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (execution === null) {
     throw new Error(
       `Expected reconcile execution result for source evidence ${input.target.sourceEvidence.id}.`

--- a/apps/worker/test/stage1-reconcile-identity-queue.test.ts
+++ b/apps/worker/test/stage1-reconcile-identity-queue.test.ts
@@ -129,7 +129,7 @@ async function createReconcileContext(): Promise<TestWorkerContext> {
     ].map((record) => [record.recordId, record] as const)
   );
 
-  capture.gmail.captureLiveBatch = async (payload) => ({
+  capture.gmail.captureLiveBatch = (payload) => Promise.resolve({
     records: payload.recordIds.flatMap((recordId: string) => {
       const record = recordsById.get(recordId);
       return record === undefined ? [] : [record];
@@ -192,7 +192,7 @@ describe("reconcileIdentityQueue", () => {
         },
         dryRun: true,
         logger: {
-          log() {}
+          log: () => undefined
         }
       });
 
@@ -232,7 +232,7 @@ describe("reconcileIdentityQueue", () => {
         },
         dryRun: false,
         logger: {
-          log() {}
+          log: () => undefined
         }
       });
 

--- a/apps/worker/test/stage1-reconcile-identity-queue.test.ts
+++ b/apps/worker/test/stage1-reconcile-identity-queue.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from "vitest";
+
+import { reconcileIdentityQueue } from "../src/ops/reconcile-identity-queue.js";
+import {
+  createEmptyCapturePorts,
+  createTestWorkerContext,
+  type TestWorkerContext
+} from "./helpers.js";
+
+function buildGmailMessageRecord(input: {
+  readonly recordId: string;
+  readonly occurredAt: string;
+  readonly receivedAt: string;
+  readonly normalizedParticipantEmails: readonly string[];
+}) {
+  return {
+    recordType: "message" as const,
+    recordId: input.recordId,
+    direction: "inbound" as const,
+    occurredAt: input.occurredAt,
+    receivedAt: input.receivedAt,
+    payloadRef: `capture://gmail/${input.recordId}`,
+    checksum: `checksum:${input.recordId}`,
+    snippet: `snippet:${input.recordId}`,
+    subject: `subject:${input.recordId}`,
+    snippetClean: `snippet:${input.recordId}`,
+    bodyTextPreview: `body:${input.recordId}`,
+    threadId: `thread:${input.recordId}`,
+    rfc822MessageId: `<${input.recordId}@example.org>`,
+    capturedMailbox: "volunteers@adventurescientists.org",
+    projectInboxAlias: null,
+    normalizedParticipantEmails: [...input.normalizedParticipantEmails],
+    salesforceContactId: null,
+    volunteerIdPlainValues: [],
+    normalizedPhones: [],
+    supportingRecords: [],
+    crossProviderCollapseKey: null
+  };
+}
+
+async function seedReplayCandidate(
+  context: TestWorkerContext,
+  input: {
+    readonly sourceEvidenceId: string;
+    readonly providerRecordId: string;
+    readonly receivedAt: string;
+  }
+): Promise<void> {
+  await context.repositories.sourceEvidence.append({
+    id: input.sourceEvidenceId,
+    provider: "gmail",
+    providerRecordType: "message",
+    providerRecordId: input.providerRecordId,
+    receivedAt: input.receivedAt,
+    occurredAt: input.receivedAt,
+    payloadRef: `capture://gmail/${input.providerRecordId}`,
+    idempotencyKey: `source-evidence:gmail:message:${input.providerRecordId}`,
+    checksum: `checksum:${input.providerRecordId}`
+  });
+  await context.repositories.identityResolutionQueue.upsert({
+    id: `identity-review:${input.sourceEvidenceId}:identity_missing_anchor`,
+    sourceEvidenceId: input.sourceEvidenceId,
+    candidateContactIds: [],
+    reasonCode: "identity_missing_anchor",
+    status: "open",
+    openedAt: input.receivedAt,
+    resolvedAt: null,
+    normalizedIdentityValues: [],
+    anchoredContactId: null,
+    explanation: "Seeded stuck identity review case for reconciliation."
+  });
+}
+
+async function seedExistingEmailContact(
+  context: TestWorkerContext,
+  input: {
+    readonly contactId: string;
+    readonly email: string;
+    readonly displayName: string;
+  }
+): Promise<void> {
+  await context.normalization.upsertNormalizedContactGraph({
+    contact: {
+      id: input.contactId,
+      salesforceContactId: null,
+      displayName: input.displayName,
+      primaryEmail: input.email,
+      primaryPhone: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z"
+    },
+    identities: [
+      {
+        id: `identity:${input.contactId}:email`,
+        contactId: input.contactId,
+        kind: "email",
+        normalizedValue: input.email,
+        isPrimary: true,
+        source: "gmail",
+        verifiedAt: "2026-01-01T00:00:00.000Z"
+      }
+    ],
+    memberships: []
+  });
+}
+
+async function createReconcileContext(): Promise<TestWorkerContext> {
+  const capture = createEmptyCapturePorts();
+  const recordsById = new Map(
+    [
+      buildGmailMessageRecord({
+        recordId: "gmail-known-1",
+        occurredAt: "2026-01-01T00:01:00.000Z",
+        receivedAt: "2026-01-01T00:01:00.000Z",
+        normalizedParticipantEmails: ["known@example.org"]
+      }),
+      buildGmailMessageRecord({
+        recordId: "gmail-new-1",
+        occurredAt: "2026-01-01T00:02:00.000Z",
+        receivedAt: "2026-01-01T00:02:00.000Z",
+        normalizedParticipantEmails: ["fresh@example.org"]
+      }),
+      buildGmailMessageRecord({
+        recordId: "gmail-ambiguous-1",
+        occurredAt: "2026-01-01T00:03:00.000Z",
+        receivedAt: "2026-01-01T00:03:00.000Z",
+        normalizedParticipantEmails: ["shared@example.org"]
+      })
+    ].map((record) => [record.recordId, record] as const)
+  );
+
+  capture.gmail.captureLiveBatch = async (payload) => ({
+    records: payload.recordIds.flatMap((recordId: string) => {
+      const record = recordsById.get(recordId);
+      return record === undefined ? [] : [record];
+    }),
+    nextCursor: null,
+    checkpoint: payload.recordIds.at(-1) ?? null
+  });
+
+  const context = await createTestWorkerContext({
+    capture
+  });
+
+  await seedExistingEmailContact(context, {
+    contactId: "contact_known",
+    email: "known@example.org",
+    displayName: "Known Contact"
+  });
+  await seedExistingEmailContact(context, {
+    contactId: "contact_shared_1",
+    email: "shared@example.org",
+    displayName: "Shared Contact One"
+  });
+  await seedExistingEmailContact(context, {
+    contactId: "contact_shared_2",
+    email: "shared@example.org",
+    displayName: "Shared Contact Two"
+  });
+
+  await seedReplayCandidate(context, {
+    sourceEvidenceId: "source-evidence:gmail:message:gmail-known-1",
+    providerRecordId: "gmail-known-1",
+    receivedAt: "2026-01-01T00:01:00.000Z"
+  });
+  await seedReplayCandidate(context, {
+    sourceEvidenceId: "source-evidence:gmail:message:gmail-new-1",
+    providerRecordId: "gmail-new-1",
+    receivedAt: "2026-01-01T00:02:00.000Z"
+  });
+  await seedReplayCandidate(context, {
+    sourceEvidenceId: "source-evidence:gmail:message:gmail-ambiguous-1",
+    providerRecordId: "gmail-ambiguous-1",
+    receivedAt: "2026-01-01T00:03:00.000Z"
+  });
+
+  return context;
+}
+
+describe("reconcileIdentityQueue", () => {
+  it("reports resolved, created, and skipped counts in dry-run mode without mutating queue or ledger state", async () => {
+    const context = await createReconcileContext();
+
+    try {
+      const report = await reconcileIdentityQueue({
+        db: context.db,
+        repositories: context.repositories,
+        capture: context.capture,
+        gmailHistoricalReplay: {
+          liveAccount: "volunteers@adventurescientists.org",
+          projectInboxAliases: ["orcas@adventurescientists.org"]
+        },
+        dryRun: true,
+        logger: {
+          log() {}
+        }
+      });
+
+      expect(report).toMatchObject({
+        dryRun: true,
+        scanned: 3,
+        resolved: 1,
+        created: 1,
+        skipped: 1
+      });
+      expect(report.errors).toEqual([]);
+      await expect(
+        context.repositories.canonicalEvents.countAll()
+      ).resolves.toBe(0);
+      await expect(
+        context.repositories.identityResolutionQueue.listOpenByReasonCode(
+          "identity_missing_anchor"
+        )
+      ).resolves.toHaveLength(3);
+      await expect(context.repositories.contacts.listAll()).resolves.toHaveLength(3);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("replays stuck items into resolved, created, and reclassified queue outcomes when executed", async () => {
+    const context = await createReconcileContext();
+
+    try {
+      const report = await reconcileIdentityQueue({
+        db: context.db,
+        repositories: context.repositories,
+        capture: context.capture,
+        gmailHistoricalReplay: {
+          liveAccount: "volunteers@adventurescientists.org",
+          projectInboxAliases: ["orcas@adventurescientists.org"]
+        },
+        dryRun: false,
+        logger: {
+          log() {}
+        }
+      });
+
+      expect(report).toMatchObject({
+        dryRun: false,
+        scanned: 3,
+        resolved: 1,
+        created: 1,
+        skipped: 1
+      });
+      expect(report.errors).toEqual([]);
+      await expect(
+        context.repositories.canonicalEvents.countAll()
+      ).resolves.toBe(2);
+      await expect(
+        context.repositories.contacts.findById("contact:email:fresh@example.org")
+      ).resolves.toMatchObject({
+        salesforceContactId: null,
+        primaryEmail: "fresh@example.org"
+      });
+      await expect(
+        context.repositories.identityResolutionQueue.listOpenByReasonCode(
+          "identity_missing_anchor"
+        )
+      ).resolves.toHaveLength(0);
+      await expect(
+        context.repositories.identityResolutionQueue.listOpenByReasonCode(
+          "identity_multi_candidate"
+        )
+      ).resolves.toHaveLength(1);
+    } finally {
+      await context.dispose();
+    }
+  });
+});

--- a/packages/db/test/stage1-normalization.test.ts
+++ b/packages/db/test/stage1-normalization.test.ts
@@ -302,6 +302,270 @@ describe("Stage 1 normalization service", () => {
     );
   });
 
+  it("creates a new canonical contact for an unmatched email and writes the canonical event", async () => {
+    const context = await createTestStage1Context();
+
+    const result = await context.normalization.applyNormalizedCanonicalEvent({
+      sourceEvidence: {
+        id: "sev_unknown_email_1",
+        provider: "gmail",
+        providerRecordType: "message",
+        providerRecordId: "gmail-unknown-email-1",
+        receivedAt: "2026-01-01T00:05:00.000Z",
+        occurredAt: "2026-01-01T00:04:00.000Z",
+        payloadRef: "payloads/gmail/gmail-unknown-email-1.json",
+        idempotencyKey: "gmail:message:gmail-unknown-email-1",
+        checksum: "checksum-unknown-email-1"
+      },
+      canonicalEvent: {
+        id: "evt_unknown_email_1",
+        eventType: "communication.email.inbound",
+        occurredAt: "2026-01-01T00:04:00.000Z",
+        idempotencyKey: "canonical:gmail-unknown-email-1",
+        summary: "Inbound email received",
+        snippet: "Hello from a new external partner"
+      },
+      communicationClassification: buildOneToOneCommunicationClassification({
+        sourceRecordType: "message",
+        sourceRecordId: "gmail-unknown-email-1",
+        direction: "inbound"
+      }),
+      identity: {
+        salesforceContactId: null,
+        volunteerIdPlainValues: [],
+        normalizedEmails: ["fresh-partner@example.org"],
+        normalizedPhones: []
+      },
+      supportingSources: [],
+      gmailMessageDetail: {
+        sourceEvidenceId: "sev_unknown_email_1",
+        providerRecordId: "gmail-unknown-email-1",
+        gmailThreadId: "thread-unknown-email-1",
+        rfc822MessageId: "<gmail-unknown-email-1@example.org>",
+        direction: "inbound",
+        subject: "New partner outreach",
+        snippetClean: "Hello from a new external partner",
+        bodyTextPreview: "Hello from a new external partner",
+        capturedMailbox: "volunteers@adventurescientists.org",
+        projectInboxAlias: null
+      }
+    });
+
+    expect(result.outcome).toBe("applied");
+    if (result.outcome === "applied") {
+      expect(result.canonicalEvent.contactId).toBe(
+        "contact:email:fresh-partner@example.org"
+      );
+      expect(result.identityCase).toBeNull();
+    }
+
+    await expect(
+      context.repositories.contacts.findById(
+        "contact:email:fresh-partner@example.org"
+      )
+    ).resolves.toMatchObject({
+      id: "contact:email:fresh-partner@example.org",
+      salesforceContactId: null,
+      displayName: "fresh-partner@example.org",
+      primaryEmail: "fresh-partner@example.org",
+      primaryPhone: null
+    });
+    await expect(
+      context.repositories.contactIdentities.listByContactId(
+        "contact:email:fresh-partner@example.org"
+      )
+    ).resolves.toEqual([
+      expect.objectContaining({
+        contactId: "contact:email:fresh-partner@example.org",
+        kind: "email",
+        normalizedValue: "fresh-partner@example.org",
+        isPrimary: true,
+        source: "gmail"
+      })
+    ]);
+    await expect(
+      context.repositories.canonicalEvents.listByContactId(
+        "contact:email:fresh-partner@example.org"
+      )
+    ).resolves.toHaveLength(1);
+  });
+
+  it("creates a new canonical contact for an unmatched phone-only identity and writes the canonical event", async () => {
+    const context = await createTestStage1Context();
+
+    const result = await context.normalization.applyNormalizedCanonicalEvent({
+      sourceEvidence: {
+        id: "sev_unknown_phone_1",
+        provider: "simpletexting",
+        providerRecordType: "conversation_message",
+        providerRecordId: "sms-unknown-phone-1",
+        receivedAt: "2026-01-01T00:05:00.000Z",
+        occurredAt: "2026-01-01T00:04:00.000Z",
+        payloadRef: "payloads/simpletexting/sms-unknown-phone-1.json",
+        idempotencyKey: "simpletexting:conversation_message:sms-unknown-phone-1",
+        checksum: "checksum-unknown-phone-1"
+      },
+      canonicalEvent: {
+        id: "evt_unknown_phone_1",
+        eventType: "communication.sms.inbound",
+        occurredAt: "2026-01-01T00:04:00.000Z",
+        idempotencyKey: "canonical:sms-unknown-phone-1",
+        summary: "Inbound SMS received",
+        snippet: "Text from a new phone number"
+      },
+      communicationClassification: buildOneToOneCommunicationClassification({
+        sourceRecordType: "conversation_message",
+        sourceRecordId: "sms-unknown-phone-1",
+        direction: "inbound"
+      }),
+      identity: {
+        salesforceContactId: null,
+        volunteerIdPlainValues: [],
+        normalizedEmails: [],
+        normalizedPhones: ["+15555550999"]
+      },
+      supportingSources: [],
+      simpleTextingMessageDetail: {
+        sourceEvidenceId: "sev_unknown_phone_1",
+        providerRecordId: "sms-unknown-phone-1",
+        direction: "inbound",
+        messageKind: "one_to_one",
+        messageTextPreview: "Text from a new phone number",
+        normalizedPhone: "+15555550999",
+        campaignId: null,
+        campaignName: null,
+        providerThreadId: "thread-sms-unknown-phone-1",
+        threadKey: "thread-sms-unknown-phone-1"
+      }
+    });
+
+    expect(result.outcome).toBe("applied");
+    if (result.outcome === "applied") {
+      expect(result.canonicalEvent.contactId).toBe("contact:phone:+15555550999");
+      expect(result.identityCase).toBeNull();
+    }
+
+    await expect(
+      context.repositories.contacts.findById("contact:phone:+15555550999")
+    ).resolves.toMatchObject({
+      id: "contact:phone:+15555550999",
+      salesforceContactId: null,
+      displayName: "+15555550999",
+      primaryEmail: null,
+      primaryPhone: "+15555550999"
+    });
+    await expect(
+      context.repositories.contactIdentities.listByContactId(
+        "contact:phone:+15555550999"
+      )
+    ).resolves.toEqual([
+      expect.objectContaining({
+        contactId: "contact:phone:+15555550999",
+        kind: "phone",
+        normalizedValue: "+15555550999",
+        isPrimary: true,
+        source: "simpletexting"
+      })
+    ]);
+  });
+
+  it("resolves an unmatched Salesforce-less email to the existing canonical contact when the identity already exists", async () => {
+    const context = await seedContactWithEmail("known@example.org", {
+      contactId: "contact_known_email",
+      displayName: "Known Contact"
+    });
+
+    const result = await context.normalization.applyNormalizedCanonicalEvent({
+      sourceEvidence: {
+        id: "sev_known_email_1",
+        provider: "gmail",
+        providerRecordType: "message",
+        providerRecordId: "gmail-known-email-1",
+        receivedAt: "2026-01-01T00:05:00.000Z",
+        occurredAt: "2026-01-01T00:04:00.000Z",
+        payloadRef: "payloads/gmail/gmail-known-email-1.json",
+        idempotencyKey: "gmail:message:gmail-known-email-1",
+        checksum: "checksum-known-email-1"
+      },
+      canonicalEvent: {
+        id: "evt_known_email_1",
+        eventType: "communication.email.inbound",
+        occurredAt: "2026-01-01T00:04:00.000Z",
+        idempotencyKey: "canonical:gmail-known-email-1",
+        summary: "Inbound email received",
+        snippet: "Known contact checking in"
+      },
+      communicationClassification: buildOneToOneCommunicationClassification({
+        sourceRecordType: "message",
+        sourceRecordId: "gmail-known-email-1",
+        direction: "inbound"
+      }),
+      identity: {
+        salesforceContactId: null,
+        volunteerIdPlainValues: [],
+        normalizedEmails: ["known@example.org"],
+        normalizedPhones: []
+      },
+      supportingSources: []
+    });
+
+    expect(result.outcome).toBe("applied");
+    if (result.outcome === "applied") {
+      expect(result.canonicalEvent.contactId).toBe("contact_known_email");
+    }
+
+    await expect(context.repositories.contacts.listAll()).resolves.toHaveLength(1);
+    await expect(
+      context.repositories.canonicalEvents.listByContactId("contact_known_email")
+    ).resolves.toHaveLength(1);
+  });
+
+  it("still opens identity_missing_anchor when a Salesforce Contact ID is present but the anchored contact does not exist", async () => {
+    const context = await createTestStage1Context();
+
+    const result = await context.normalization.applyNormalizedCanonicalEvent({
+      sourceEvidence: {
+        id: "sev_missing_sf_anchor_1",
+        provider: "gmail",
+        providerRecordType: "message",
+        providerRecordId: "gmail-missing-sf-anchor-1",
+        receivedAt: "2026-01-01T00:05:00.000Z",
+        occurredAt: "2026-01-01T00:04:00.000Z",
+        payloadRef: "payloads/gmail/gmail-missing-sf-anchor-1.json",
+        idempotencyKey: "gmail:message:gmail-missing-sf-anchor-1",
+        checksum: "checksum-missing-sf-anchor-1"
+      },
+      canonicalEvent: {
+        id: "evt_missing_sf_anchor_1",
+        eventType: "communication.email.inbound",
+        occurredAt: "2026-01-01T00:04:00.000Z",
+        idempotencyKey: "canonical:gmail-missing-sf-anchor-1",
+        summary: "Inbound email received",
+        snippet: "Anchored contact is missing"
+      },
+      communicationClassification: buildOneToOneCommunicationClassification({
+        sourceRecordType: "message",
+        sourceRecordId: "gmail-missing-sf-anchor-1",
+        direction: "inbound"
+      }),
+      identity: {
+        salesforceContactId: "003-missing-anchor",
+        volunteerIdPlainValues: [],
+        normalizedEmails: [],
+        normalizedPhones: []
+      },
+      supportingSources: []
+    });
+
+    expect(result.outcome).toBe("needs_identity_review");
+    if (result.outcome === "needs_identity_review") {
+      expect(result.identityCase.reasonCode).toBe("identity_missing_anchor");
+      expect(result.identityCase.anchoredContactId).toBeNull();
+    }
+
+    await expect(context.repositories.contacts.listAll()).resolves.toHaveLength(0);
+  });
+
   it("opens identity review instead of guessing when multiple contacts share one normalized email", async () => {
     const context = await seedContactWithEmail("shared@example.org", {
       contactId: "contact_1",

--- a/packages/domain/src/normalization.ts
+++ b/packages/domain/src/normalization.ts
@@ -2038,7 +2038,7 @@ export function createStage1NormalizationService(
         }
 
         contactEvents = await persistence.repositories.canonicalEvents.listByContactId(
-          identityDecision.contact.id
+          resolvedContact.id
         );
         return contactEvents;
       };
@@ -2062,11 +2062,11 @@ export function createStage1NormalizationService(
                 )
               });
         const identityCase =
-          identityDecision.reviewInput === null
+          identityReviewInput === null
             ? null
             : (
                 await service.saveIdentityAmbiguityCase(
-                  identityDecision.reviewInput
+                  identityReviewInput
                 )
               ).caseRecord;
         const routingCase =
@@ -2175,7 +2175,7 @@ export function createStage1NormalizationService(
         const persistedEvent = await persistence.repositories.canonicalEvents.upsert(
           canonicalEventSchema.parse({
             id: duplicateMatch.existingEvent.id,
-            contactId: identityDecision.contact.id,
+            contactId: resolvedContact.id,
             eventType: canonicalEvent.eventType,
             channel: canonicalEvent.channel,
             occurredAt: duplicateMatch.winner.keepIncomingAsPrimary
@@ -2235,11 +2235,11 @@ export function createStage1NormalizationService(
           })
         );
         const identityCase =
-          identityDecision.reviewInput === null
+          identityReviewInput === null
             ? null
             : (
                 await service.saveIdentityAmbiguityCase(
-                  identityDecision.reviewInput
+                  identityReviewInput
                 )
               ).caseRecord;
         const routingCase =

--- a/packages/domain/src/normalization.ts
+++ b/packages/domain/src/normalization.ts
@@ -125,6 +125,11 @@ type IdentityResolutionDecision =
       readonly reviewInput: IdentityAmbiguityInput | null;
     }
   | {
+      readonly outcome: "create_new_contact";
+      readonly normalizedEmail: string | null;
+      readonly normalizedPhone: string | null;
+    }
+  | {
       readonly outcome: "needs_identity_review";
       readonly reviewInput: IdentityAmbiguityInput;
     };
@@ -329,6 +334,77 @@ function buildSkipAuditId(
   action: "skipped_non_volunteer_task"
 ): string {
   return `audit:${entityType}:${entityId}:${action}`;
+}
+
+function buildSyntheticContactId(input: {
+  readonly normalizedEmail: string | null;
+  readonly normalizedPhone: string | null;
+}): string {
+  if (input.normalizedEmail !== null) {
+    return `contact:email:${input.normalizedEmail}`;
+  }
+
+  if (input.normalizedPhone !== null) {
+    return `contact:phone:${input.normalizedPhone}`;
+  }
+
+  throw new Error("Cannot build a synthetic contact id without an email or phone.");
+}
+
+function buildSyntheticContactGraphInput(input: {
+  readonly normalizedEmail: string | null;
+  readonly normalizedPhone: string | null;
+  readonly createdAt: string;
+  readonly source: ContactIdentityRecord["source"];
+}): NormalizedContactGraphUpsertInput {
+  const contactId = buildSyntheticContactId({
+    normalizedEmail: input.normalizedEmail,
+    normalizedPhone: input.normalizedPhone
+  });
+
+  const identities: ContactIdentityRecord[] = [];
+
+  if (input.normalizedEmail !== null) {
+    identities.push(
+      contactIdentitySchema.parse({
+        id: `contact-identity:${contactId}:email:${input.normalizedEmail}`,
+        contactId,
+        kind: "email",
+        normalizedValue: input.normalizedEmail,
+        isPrimary: true,
+        source: input.source,
+        verifiedAt: input.createdAt
+      })
+    );
+  }
+
+  if (input.normalizedPhone !== null) {
+    identities.push(
+      contactIdentitySchema.parse({
+        id: `contact-identity:${contactId}:phone:${input.normalizedPhone}`,
+        contactId,
+        kind: "phone",
+        normalizedValue: input.normalizedPhone,
+        isPrimary: true,
+        source: input.source,
+        verifiedAt: input.createdAt
+      })
+    );
+  }
+
+  return {
+    contact: contactSchema.parse({
+      id: contactId,
+      salesforceContactId: null,
+      displayName: input.normalizedEmail ?? input.normalizedPhone ?? "(unknown)",
+      primaryEmail: input.normalizedEmail,
+      primaryPhone: input.normalizedPhone,
+      createdAt: input.createdAt,
+      updatedAt: input.createdAt
+    }),
+    identities,
+    memberships: []
+  };
 }
 
 function newestTimestamp(
@@ -1112,6 +1188,17 @@ async function resolveIdentityDecision(
     };
   }
 
+  const fallbackNormalizedEmail = identity.normalizedEmails[0] ?? null;
+  const fallbackNormalizedPhone = identity.normalizedPhones[0] ?? null;
+
+  if (fallbackNormalizedEmail !== null || fallbackNormalizedPhone !== null) {
+    return {
+      outcome: "create_new_contact",
+      normalizedEmail: fallbackNormalizedEmail,
+      normalizedPhone: fallbackNormalizedPhone
+    };
+  }
+
   return {
     outcome: "needs_identity_review",
     reviewInput: identityAmbiguityInputSchema.parse({
@@ -1877,14 +1964,32 @@ export function createStage1NormalizationService(
         };
       }
 
+      const resolvedContact =
+        identityDecision.outcome === "create_new_contact"
+          ? (
+              await service.upsertNormalizedContactGraph(
+                buildSyntheticContactGraphInput({
+                  normalizedEmail: identityDecision.normalizedEmail,
+                  normalizedPhone: identityDecision.normalizedPhone,
+                  createdAt: parsed.sourceEvidence.receivedAt,
+                  source: parsed.sourceEvidence.provider
+                })
+              )
+            ).contact
+          : identityDecision.contact;
+      const identityReviewInput =
+        identityDecision.outcome === "resolved"
+          ? identityDecision.reviewInput
+          : null;
+
       const routingDecision = await resolveRoutingDecision(persistence, {
-        contactId: identityDecision.contact.id,
+        contactId: resolvedContact.id,
         sourceEvidenceId: sourceEvidenceResult.record.id,
         openedAt: parsed.sourceEvidence.receivedAt,
         routing: parsed.routing
       });
       const reviewState = pickCanonicalReviewState({
-        hasIdentityReview: identityDecision.reviewInput !== null,
+        hasIdentityReview: identityReviewInput !== null,
         hasRoutingReview: routingDecision.reviewInput !== null
       });
       const supportingSourceEvidenceIds = uniqueStrings(
@@ -1896,7 +2001,7 @@ export function createStage1NormalizationService(
         detectInboxProjectionExclusionReason(parsed);
       const canonicalEvent = canonicalEventSchema.parse({
         id: parsed.canonicalEvent.id,
-        contactId: identityDecision.contact.id,
+        contactId: resolvedContact.id,
         eventType: parsed.canonicalEvent.eventType,
         channel: resolveCanonicalChannel(parsed.canonicalEvent.eventType),
         occurredAt: parsed.canonicalEvent.occurredAt,
@@ -2199,11 +2304,11 @@ export function createStage1NormalizationService(
 
       const persistedEvent = eventWriteResult.record;
       const identityCase =
-        identityDecision.reviewInput === null
+        identityReviewInput === null
           ? null
           : (
               await service.saveIdentityAmbiguityCase(
-                identityDecision.reviewInput
+                identityReviewInput
               )
             ).caseRecord;
       const routingCase =


### PR DESCRIPTION
## Summary

Implements canon D-027 which was specced 2026-04-18 but never landed in code, plus a reconciliation worker script to clear the accumulated backlog of stuck review cases.

## Why

Overnight audit (`.audit-ingestion-2026-04-21/identity-resolution.md`) found:

- Every event whose email/phone finds zero matches in `contact_identities` + has no SF contact ID falls into `identity_missing_anchor` (normalization.ts:779) instead of creating a new canonical contact with `salesforceContactId=null` per D-027.
- 10,976 review cases have accumulated in April 2026. 7,837 of those source-evidence rows never reached the ledger — invisible to operators.
- 13,699 of 14,169 stuck identities (97%) match an existing `contact_identities` row RIGHT NOW. A reconciliation pass clears most immediately.

## Changes

- `packages/domain/src/normalization.ts` — new `create_new_contact` outcome; replace terminal `identity_missing_anchor` branch for zero-match-no-SF-ID cases; wire `applyNormalizedCanonicalEvent` to synthesize contact + identity rows.
- `apps/worker/src/ops/reconcile-identity-queue.ts` — new ops script with `--dry-run` default, per-case transaction rollback, batch reporting.
- `apps/worker/src/ops/cli.ts` — CLI dispatch for the new op.
- Test coverage in `stage1-normalization.test.ts` + new `stage1-reconcile-identity-queue.test.ts`.

## Deliberate constraints

- Volunteer-ID-only evidence with no email/phone still opens `identity_missing_anchor`. There's no safe way to mint a canonical contact id from a VID alone (we'd need an email or phone for the anchor). Left in place.
- The existing SF-ID-present-but-unresolvable review path is intact.

## Prod ops plan

1. Merge this PR
2. Deploy worker
3. Dry-run: \`railway ssh --service worker "node dist/ops/cli.js reconcile-identity-queue --dry-run"\` — architect reviews the JSONL output
4. Canary: same with \`--execute --limit=100\`
5. Full: same with \`--execute\`

Destructive steps need per-session architect sign-off each time.

## Test plan

- [ ] CI green: `pnpm lint`, `pnpm test:unit`, `pnpm typecheck`
- [ ] Unit coverage: unknown email → new contact; unknown phone → new contact; known email → resolved; SF-ID-present-not-in-contacts → identity_missing_anchor; multi-email → identity_multi_candidate
- [ ] Ops script dry-run against dev DB with seeded missing-anchor cases reports expected counts
- [ ] Post-deploy dry-run against prod reports ~9,480 resolvable + ~1,496 via create-new-contact

Brief: `.audit-ingestion-2026-04-21/briefs/fix-d027-identity-resolution.md`