### PR TITLE
fix(integrations): SF direction arrows + Gmail body untruncation

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -16,6 +16,7 @@
     "ops:dedup-historical-ledger": "tsx src/ops/dedup-historical-ledger.ts",
     "ops:enqueue": "tsx src/ops/cli.ts enqueue",
     "ops:import-gmail-mbox": "tsx src/ops/cli.ts import-gmail-mbox",
+    "ops:reclassify-sf-direction": "tsx src/ops/cli.ts reclassify-sf-direction",
     "ops:reclassify-salesforce-tasks": "tsx src/ops/reclassify-salesforce-tasks.ts",
     "ops:inspect": "tsx src/ops/cli.ts inspect",
     "lint": "eslint src test --max-warnings=0",

--- a/apps/worker/src/ops/cli.ts
+++ b/apps/worker/src/ops/cli.ts
@@ -42,6 +42,9 @@ import {
   runDedupHistoricalLedgerCommand
 } from "./dedup-historical-ledger.js";
 import {
+  runReclassifySfDirectionCommand
+} from "./reclassify-sf-direction.js";
+import {
   buildOperationId,
   parseCliFlags,
   readOptionalBooleanFlag,
@@ -347,9 +350,12 @@ async function main(): Promise<void> {
     case "reconcile-identity-queue":
       await runReconcileIdentityQueue(rest);
       return;
+    case "reclassify-sf-direction":
+      await runReclassifySfDirectionCommand(rest, process.env);
+      return;
     default:
       throw new Error(
-        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, dedup-historical-ledger, reconcile-identity-queue."
+        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, dedup-historical-ledger, reconcile-identity-queue, reclassify-sf-direction."
       );
   }
 }

--- a/apps/worker/src/ops/reclassify-sf-direction.ts
+++ b/apps/worker/src/ops/reclassify-sf-direction.ts
@@ -1,0 +1,430 @@
+#!/usr/bin/env tsx
+/**
+ * reclassify-sf-direction
+ *
+ * Usage:
+ *   pnpm --filter @as-comms/worker ops reclassify-sf-direction --dry-run
+ *   pnpm --filter @as-comms/worker ops reclassify-sf-direction --execute
+ *   pnpm --filter @as-comms/worker ops reclassify-sf-direction --execute --limit 100
+ *
+ * Dry-run by default. Reclassifies historical Salesforce Task email rows whose
+ * subject arrow indicates inbound direction, strips the stored arrow prefix
+ * from Salesforce detail subjects, and rebuilds projections for affected
+ * contacts after writes.
+ */
+import process from "node:process";
+
+import {
+  closeDatabaseConnection,
+  createDatabaseConnection
+} from "@as-comms/db";
+import {
+  parseSubjectDirection
+} from "@as-comms/integrations";
+
+import {
+  enqueueStage1Job,
+  type Stage1EnqueueRequest
+} from "./enqueue.js";
+import {
+  buildOperationId,
+  parseCliFlags,
+  readOptionalBooleanFlag,
+  readOptionalIntegerFlag
+} from "./helpers.js";
+import {
+  buildProjectionRebuildRequestsForContacts
+} from "./reclassify-salesforce-tasks.js";
+
+interface SqlRunner {
+  unsafe<T extends readonly object[]>(query: string): Promise<T>;
+  begin<T>(callback: (sql: SqlRunner) => Promise<T>): Promise<T>;
+}
+
+interface CandidateRow {
+  readonly canonical_event_id: string;
+  readonly contact_id: string;
+  readonly source_evidence_id: string;
+  readonly event_type: string;
+  readonly subject: string | null;
+  readonly cross_provider_collapse_key: string | null;
+}
+
+export interface SfDirectionCandidate {
+  readonly canonicalEventId: string;
+  readonly contactId: string;
+  readonly sourceEvidenceId: string;
+  readonly eventType: "communication.email.inbound" | "communication.email.outbound";
+  readonly subject: string | null;
+  readonly crossProviderCollapseKey: string | null;
+}
+
+export interface SfDirectionReclassificationChange {
+  readonly canonicalEventId: string;
+  readonly contactId: string;
+  readonly sourceEvidenceId: string;
+  readonly previousEventType:
+    | "communication.email.inbound"
+    | "communication.email.outbound";
+  readonly nextEventType:
+    | "communication.email.inbound"
+    | "communication.email.outbound";
+  readonly previousSubject: string | null;
+  readonly nextSubject: string | null;
+  readonly direction: "inbound" | "outbound";
+  readonly reclassifiesEventType: boolean;
+}
+
+export interface SfDirectionReclassificationPlan {
+  readonly scannedCount: number;
+  readonly reclassifiedCount: number;
+  readonly cleanedSubjectCount: number;
+  readonly skippedCrossProviderRows: readonly string[];
+  readonly affectedContactIds: readonly string[];
+  readonly changes: readonly SfDirectionReclassificationChange[];
+}
+
+function quoteSqlLiteral(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function toSqlNullableLiteral(value: string | null): string {
+  return value === null ? "null" : quoteSqlLiteral(value);
+}
+
+function normalizeEventType(
+  value: string
+): "communication.email.inbound" | "communication.email.outbound" {
+  if (
+    value !== "communication.email.inbound" &&
+    value !== "communication.email.outbound"
+  ) {
+    throw new Error(`Unsupported Salesforce direction event type ${value}.`);
+  }
+
+  return value;
+}
+
+function uniqueSortedStrings(values: readonly string[]): string[] {
+  return Array.from(new Set(values)).sort((left, right) =>
+    left.localeCompare(right)
+  );
+}
+
+async function loadCandidates(
+  sql: SqlRunner,
+  limit: number
+): Promise<readonly SfDirectionCandidate[]> {
+  const rows = await sql.unsafe<readonly CandidateRow[]>(`
+    select
+      canonical_event_ledger.id as canonical_event_id,
+      canonical_event_ledger.contact_id,
+      canonical_event_ledger.source_evidence_id,
+      canonical_event_ledger.event_type,
+      salesforce_communication_details.subject,
+      canonical_event_ledger.provenance #>> '{threadRef,crossProviderCollapseKey}'
+        as cross_provider_collapse_key
+    from canonical_event_ledger
+    inner join salesforce_communication_details
+      on salesforce_communication_details.source_evidence_id = canonical_event_ledger.source_evidence_id
+    where canonical_event_ledger.provenance ->> 'primaryProvider' = 'salesforce'
+      and salesforce_communication_details.channel = 'email'
+      and salesforce_communication_details.subject is not null
+      and salesforce_communication_details.subject ~ '^[[:space:]]*[←⇐→⇒]'
+    order by canonical_event_ledger.occurred_at asc, canonical_event_ledger.id asc
+    limit ${String(limit)}
+  `);
+
+  return rows.map((row) => ({
+    canonicalEventId: row.canonical_event_id,
+    contactId: row.contact_id,
+    sourceEvidenceId: row.source_evidence_id,
+    eventType: normalizeEventType(row.event_type),
+    subject: row.subject,
+    crossProviderCollapseKey: row.cross_provider_collapse_key
+  }));
+}
+
+export function planSfDirectionReclassifications(
+  candidates: readonly SfDirectionCandidate[]
+): SfDirectionReclassificationPlan {
+  const changes: SfDirectionReclassificationChange[] = [];
+  const skippedCrossProviderRows: string[] = [];
+  let reclassifiedCount = 0;
+
+  for (const candidate of candidates) {
+    const parsed = parseSubjectDirection(candidate.subject);
+    const reclassifiesEventType =
+      parsed.direction === "inbound" &&
+      candidate.eventType === "communication.email.outbound";
+    const cleansSubject = parsed.cleanSubject !== candidate.subject;
+
+    if (!reclassifiesEventType && !cleansSubject) {
+      continue;
+    }
+
+    if (
+      reclassifiesEventType &&
+      candidate.crossProviderCollapseKey !== null &&
+      candidate.crossProviderCollapseKey.trim().length > 0
+    ) {
+      skippedCrossProviderRows.push(candidate.canonicalEventId);
+      continue;
+    }
+
+    if (reclassifiesEventType) {
+      reclassifiedCount += 1;
+    }
+
+    changes.push({
+      canonicalEventId: candidate.canonicalEventId,
+      contactId: candidate.contactId,
+      sourceEvidenceId: candidate.sourceEvidenceId,
+      previousEventType: candidate.eventType,
+      nextEventType:
+        parsed.direction === "inbound"
+          ? "communication.email.inbound"
+          : "communication.email.outbound",
+      previousSubject: candidate.subject,
+      nextSubject: parsed.cleanSubject,
+      direction: parsed.direction,
+      reclassifiesEventType
+    });
+  }
+
+  return {
+    scannedCount: candidates.length,
+    reclassifiedCount,
+    cleanedSubjectCount: changes.length,
+    skippedCrossProviderRows: uniqueSortedStrings(skippedCrossProviderRows),
+    affectedContactIds: uniqueSortedStrings(
+      changes
+        .filter((change) => change.reclassifiesEventType)
+        .map((change) => change.contactId)
+    ),
+    changes
+  };
+}
+
+function printPlanSummary(
+  plan: SfDirectionReclassificationPlan,
+  dryRun: boolean
+): void {
+  console.log("reclassify-sf-direction");
+  console.log(`Mode: ${dryRun ? "dry-run" : "execute"}`);
+  console.log(
+    `- scanned arrow-prefixed Salesforce email rows: ${String(plan.scannedCount)}`
+  );
+  console.log(
+    `- would reclassify outbound -> inbound rows: ${String(plan.reclassifiedCount)}`
+  );
+  console.log(
+    `- would clean stored Salesforce subjects: ${String(plan.cleanedSubjectCount)}`
+  );
+  console.log(
+    `- affected contacts for projection rebuild: ${String(plan.affectedContactIds.length)}`
+  );
+
+  if (plan.skippedCrossProviderRows.length > 0) {
+    console.log(
+      `- skipped rows with cross-provider collapse keys: ${String(plan.skippedCrossProviderRows.length)}`
+    );
+  }
+}
+
+function printSampleChanges(
+  changes: readonly SfDirectionReclassificationChange[],
+  dryRun: boolean
+): void {
+  if (changes.length === 0) {
+    console.log("No Salesforce Task direction rows need updates.");
+    return;
+  }
+
+  console.log("Sample rows (first 10):");
+  for (const change of changes.slice(0, 10)) {
+    console.log(
+      JSON.stringify({
+        ledgerId: change.canonicalEventId,
+        contactId: change.contactId,
+        oldType: change.previousEventType,
+        newType: change.nextEventType,
+        subjectPreview: change.previousSubject?.slice(0, 60) ?? null,
+        cleanedSubjectPreview: change.nextSubject?.slice(0, 60) ?? null,
+        operation: dryRun ? "would_update" : "updated"
+      })
+    );
+  }
+}
+
+async function applyChanges(
+  sql: SqlRunner,
+  changes: readonly SfDirectionReclassificationChange[]
+): Promise<void> {
+  await sql.begin(async (tx) => {
+    for (const change of changes) {
+      if (change.reclassifiesEventType) {
+        await tx.unsafe(`
+          update canonical_event_ledger
+          set event_type = ${quoteSqlLiteral(change.nextEventType)},
+              provenance = jsonb_set(
+                provenance,
+                '{direction}',
+                to_jsonb(${quoteSqlLiteral(change.direction)}::text),
+                true
+              ),
+              updated_at = now()
+          where id = ${quoteSqlLiteral(change.canonicalEventId)}
+        `);
+      }
+
+      await tx.unsafe(`
+        update salesforce_communication_details
+        set subject = ${toSqlNullableLiteral(change.nextSubject)},
+            updated_at = now()
+        where source_evidence_id = ${quoteSqlLiteral(change.sourceEvidenceId)}
+      `);
+    }
+  });
+}
+
+export async function runReclassifySfDirection(input: {
+  readonly connectionString: string;
+  readonly dryRun: boolean;
+  readonly limit?: number;
+  readonly enqueueJob?: (request: Stage1EnqueueRequest) => Promise<{
+    readonly enqueuedJobId: string;
+  }>;
+}): Promise<{
+  readonly dryRun: boolean;
+  readonly scannedCount: number;
+  readonly reclassifiedCount: number;
+  readonly cleanedSubjectCount: number;
+  readonly affectedContactIds: readonly string[];
+  readonly enqueuedJobIds: readonly string[];
+}> {
+  const connection = createDatabaseConnection({
+    connectionString: input.connectionString
+  });
+  const sql = connection.sql as unknown as SqlRunner;
+
+  try {
+    const candidates = await loadCandidates(
+      sql,
+      input.limit ?? Number.MAX_SAFE_INTEGER
+    );
+    const plan = planSfDirectionReclassifications(candidates);
+
+    printPlanSummary(plan, input.dryRun);
+    printSampleChanges(plan.changes, input.dryRun);
+
+    if (input.dryRun) {
+      console.log(
+        "Dry run complete. Re-run with --execute to persist these direction updates."
+      );
+      return {
+        dryRun: true,
+        scannedCount: plan.scannedCount,
+        reclassifiedCount: plan.reclassifiedCount,
+        cleanedSubjectCount: plan.cleanedSubjectCount,
+        affectedContactIds: plan.affectedContactIds,
+        enqueuedJobIds: []
+      };
+    }
+
+    if (plan.changes.length === 0) {
+      console.log("No Salesforce Task direction rows needed changes.");
+      return {
+        dryRun: false,
+        scannedCount: plan.scannedCount,
+        reclassifiedCount: 0,
+        cleanedSubjectCount: 0,
+        affectedContactIds: [],
+        enqueuedJobIds: []
+      };
+    }
+
+    await applyChanges(sql, plan.changes);
+
+    const enqueueJob =
+      input.enqueueJob ??
+      ((request: Stage1EnqueueRequest) =>
+        enqueueStage1Job({
+          connectionString: input.connectionString,
+          request
+        }));
+    const enqueuedJobIds: string[] = [];
+
+    for (const request of buildProjectionRebuildRequestsForContacts(
+      plan.affectedContactIds,
+      {
+        buildId: buildOperationId
+      }
+    )) {
+      const result = await enqueueJob(request);
+      enqueuedJobIds.push(result.enqueuedJobId);
+    }
+
+    console.log("Direction reclassification complete.");
+    console.log(`- reclassified rows: ${String(plan.reclassifiedCount)}`);
+    console.log(
+      `- cleaned Salesforce subjects: ${String(plan.cleanedSubjectCount)}`
+    );
+    console.log(
+      `- enqueued projection rebuild jobs: ${String(enqueuedJobIds.length)}`
+    );
+
+    return {
+      dryRun: false,
+      scannedCount: plan.scannedCount,
+      reclassifiedCount: plan.reclassifiedCount,
+      cleanedSubjectCount: plan.cleanedSubjectCount,
+      affectedContactIds: plan.affectedContactIds,
+      enqueuedJobIds
+    };
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}
+
+export async function runReclassifySfDirectionCommand(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv
+): Promise<void> {
+  const flags = parseCliFlags(args);
+  const dryRunRequested = readOptionalBooleanFlag(flags, "dry-run", false);
+  const executeRequested = readOptionalBooleanFlag(flags, "execute", false);
+
+  if (dryRunRequested && executeRequested) {
+    throw new Error("Use either --dry-run or --execute, not both.");
+  }
+
+  const connectionString = env.WORKER_DATABASE_URL ?? env.DATABASE_URL;
+
+  if (connectionString === undefined || connectionString.trim().length === 0) {
+    throw new Error("DATABASE_URL or WORKER_DATABASE_URL is required.");
+  }
+
+  await runReclassifySfDirection({
+    connectionString,
+    dryRun: !executeRequested,
+    limit: readOptionalIntegerFlag(flags, "limit", Number.MAX_SAFE_INTEGER)
+  });
+}
+
+const isDirectExecution =
+  process.argv[1] !== undefined &&
+  import.meta.url === new URL(`file://${process.argv[1]}`).toString();
+
+if (isDirectExecution) {
+  void runReclassifySfDirectionCommand(process.argv.slice(2), process.env).catch(
+    (error: unknown) => {
+      console.error(
+        error instanceof Error
+          ? error.message
+          : "reclassify-sf-direction failed."
+      );
+      process.exitCode = 1;
+    }
+  );
+}

--- a/apps/worker/test/stage1-reclassify-sf-direction.test.ts
+++ b/apps/worker/test/stage1-reclassify-sf-direction.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  planSfDirectionReclassifications,
+  type SfDirectionCandidate
+} from "../src/ops/reclassify-sf-direction.js";
+
+function buildCandidate(input: {
+  readonly index: number;
+  readonly eventType?: "communication.email.inbound" | "communication.email.outbound";
+  readonly subject?: string | null;
+  readonly crossProviderCollapseKey?: string | null;
+}): SfDirectionCandidate {
+  return {
+    canonicalEventId: `evt:${String(input.index)}`,
+    contactId: `contact:${String(Math.ceil(input.index / 5))}`,
+    sourceEvidenceId: `sev:${String(input.index)}`,
+    eventType: input.eventType ?? "communication.email.outbound",
+    subject: input.subject ?? `← Email: Field update ${String(input.index)}`,
+    crossProviderCollapseKey: input.crossProviderCollapseKey ?? null
+  };
+}
+
+describe("reclassify-sf-direction planning", () => {
+  it("plans the expected dry-run counts across a 50-row mock batch", () => {
+    const inboundCandidates = Array.from({ length: 25 }, (_, index) =>
+      buildCandidate({
+        index: index + 1
+      })
+    );
+    const outboundCleanupOnly = Array.from({ length: 24 }, (_, index) =>
+      buildCandidate({
+        index: index + 26,
+        subject: `→ Outbound follow-up ${String(index + 26)}`
+      })
+    );
+    const skippedCrossProvider = buildCandidate({
+      index: 50,
+      crossProviderCollapseKey: "rfc822:message-50@example.org"
+    });
+    const plan = planSfDirectionReclassifications([
+      ...inboundCandidates,
+      ...outboundCleanupOnly,
+      skippedCrossProvider
+    ]);
+
+    expect(plan.scannedCount).toBe(50);
+    expect(plan.reclassifiedCount).toBe(25);
+    expect(plan.cleanedSubjectCount).toBe(49);
+    expect(plan.affectedContactIds).toEqual([
+      "contact:1",
+      "contact:2",
+      "contact:3",
+      "contact:4",
+      "contact:5"
+    ]);
+    expect(plan.skippedCrossProviderRows).toEqual(["evt:50"]);
+    expect(plan.changes[0]).toEqual(
+      expect.objectContaining({
+        canonicalEventId: "evt:1",
+        previousEventType: "communication.email.outbound",
+        nextEventType: "communication.email.inbound",
+        nextSubject: "Field update 1",
+        direction: "inbound",
+        reclassifiesEventType: true
+      })
+    );
+    expect(plan.changes[30]).toEqual(
+      expect.objectContaining({
+        previousEventType: "communication.email.outbound",
+        nextEventType: "communication.email.outbound",
+        direction: "outbound",
+        reclassifiesEventType: false
+      })
+    );
+  });
+});

--- a/packages/integrations/src/providers/gmail-body.ts
+++ b/packages/integrations/src/providers/gmail-body.ts
@@ -19,12 +19,8 @@ export interface GmailApiMessagePart {
   readonly parts?: readonly GmailApiMessagePart[] | null | undefined;
 }
 
-const BODY_PREVIEW_LIMIT = 2_000;
-
 const MIME_HEADER_LINE_PATTERN =
   /^(Content-Type|Content-Transfer-Encoding|Content-Disposition|MIME-Version|charset|boundary|name|filename):/i;
-const FORWARDED_HEADER_LINE_PATTERN =
-  /^(From|To|Recipients|Cc|Bcc|Reply-To|Sent|Date|Subject):/i;
 
 const SIMPLE_PARSER_OPTIONS = {
   skipImageLinks: true,
@@ -143,54 +139,6 @@ function sanitizePreviewText(value: string): string {
     .trim();
 }
 
-function findForwardedHeaderBlockStart(value: string): number {
-  const lines = value.split("\n");
-  let offset = 0;
-
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index] ?? "";
-    const trimmed = line.trim();
-
-    if (!FORWARDED_HEADER_LINE_PATTERN.test(trimmed)) {
-      offset += line.length + 1;
-      continue;
-    }
-
-    let headerCount = 0;
-    let lineIndex = index;
-
-    while (lineIndex < lines.length) {
-      const candidate = lines[lineIndex] ?? "";
-      const candidateTrimmed = candidate.trim();
-
-      if (candidateTrimmed.length === 0) {
-        break;
-      }
-
-      if (FORWARDED_HEADER_LINE_PATTERN.test(candidateTrimmed)) {
-        headerCount += 1;
-        lineIndex += 1;
-        continue;
-      }
-
-      if (/^[\t ]/u.test(candidate)) {
-        lineIndex += 1;
-        continue;
-      }
-
-      break;
-    }
-
-    if (headerCount >= 3) {
-      return offset;
-    }
-
-    offset += line.length + 1;
-  }
-
-  return -1;
-}
-
 export function trimQuotedReplyContent(value: string): string {
   const normalized = sanitizePreviewText(value);
 
@@ -200,8 +148,7 @@ export function trimQuotedReplyContent(value: string): string {
 
   const boundaries = [
     /(?:\n|^)\s*On .+ wrote:\s*$/imu,
-    /(?:\bOn .+? wrote:)\s*>/isu,
-    /(?:\n|^)\s*From:\s.+?(?:Date:|Sent:)\s.+/isu,
+    /(?:\n|^)\s*On .+? wrote:\s*>/su,
     /(?:\n|^)\s*-{2,}\s*Original Message\s*-{2,}/imu,
     /(?:\n|^)\s*Begin forwarded message:/imu,
     /(?:\n|^)\s*Forwarded message:/imu,
@@ -221,15 +168,6 @@ export function trimQuotedReplyContent(value: string): string {
     }
   }
 
-  const forwardedHeaderBoundary = findForwardedHeaderBlockStart(normalized);
-
-  if (
-    forwardedHeaderBoundary !== -1 &&
-    (earliestBoundary === -1 || forwardedHeaderBoundary < earliestBoundary)
-  ) {
-    earliestBoundary = forwardedHeaderBoundary;
-  }
-
   return (
     earliestBoundary === -1 ? normalized : normalized.slice(0, earliestBoundary)
   ).trim();
@@ -242,7 +180,7 @@ export function cleanGmailBodyPreviewText(value: string): string {
       ? trimmedQuotedReply
       : sanitizePreviewText(value);
 
-  return normalized.slice(0, BODY_PREVIEW_LIMIT);
+  return normalized;
 }
 
 function decodeBase64Url(value: string): Buffer {

--- a/packages/integrations/src/providers/salesforce.ts
+++ b/packages/integrations/src/providers/salesforce.ts
@@ -341,6 +341,55 @@ function buildLifecycleSummary(eventType: CanonicalEventType): string {
   }
 }
 
+export function parseSubjectDirection(rawSubject: string | null): {
+  readonly direction: "inbound" | "outbound";
+  readonly cleanSubject: string | null;
+} {
+  if (rawSubject === null) {
+    return {
+      direction: "outbound",
+      cleanSubject: null
+    };
+  }
+
+  const trimmed = rawSubject.trim();
+
+  if (trimmed.length === 0) {
+    return {
+      direction: "outbound",
+      cleanSubject: null
+    };
+  }
+
+  const normalizeCleanSubject = (value: string): string | null => {
+    const cleaned = value.trim();
+    return cleaned.length > 0 ? cleaned : null;
+  };
+
+  if (trimmed.startsWith("←") || trimmed.startsWith("⇐")) {
+    return {
+      direction: "inbound",
+      cleanSubject: normalizeCleanSubject(
+        trimmed.replace(/^[←⇐]\s*(?:Email:\s*)?/u, "")
+      )
+    };
+  }
+
+  if (trimmed.startsWith("→") || trimmed.startsWith("⇒")) {
+    return {
+      direction: "outbound",
+      cleanSubject: normalizeCleanSubject(
+        trimmed.replace(/^[→⇒]\s*(?:Email:\s*)?/u, "")
+      )
+    };
+  }
+
+  return {
+    direction: "outbound",
+    cleanSubject: trimmed
+  };
+}
+
 function mapSalesforceContactSnapshot(
   record: SalesforceContactSnapshotRecord
 ): NormalizedContactGraphUpsertInput {
@@ -575,6 +624,8 @@ function buildSalesforceTaskSummary(input: {
   readonly messageKind: "one_to_one" | "auto";
 }): string {
   switch (input.eventType) {
+    case "communication.email.inbound":
+      return "Inbound email received";
     case "communication.email.outbound":
       return input.messageKind === "auto"
         ? "Auto email sent"
@@ -591,9 +642,18 @@ function buildSalesforceTaskSummary(input: {
 function mapSalesforceTaskCommunicationRecord(
   record: SalesforceTaskCommunicationRecord
 ): NormalizedCanonicalEventIntake {
+  const subjectDirection =
+    record.channel === "email"
+      ? parseSubjectDirection(record.subject)
+      : {
+          direction: "outbound" as const,
+          cleanSubject: record.subject
+        };
   const eventType: CanonicalEventType =
     record.channel === "email"
-      ? "communication.email.outbound"
+      ? subjectDirection.direction === "inbound"
+        ? "communication.email.inbound"
+        : "communication.email.outbound"
       : "communication.sms.outbound";
   const providerRecordType = record.recordType;
   const providerRecordId = record.recordId;
@@ -658,7 +718,7 @@ function mapSalesforceTaskCommunicationRecord(
         crossProviderCollapseKey: record.crossProviderCollapseKey,
         providerThreadId: null
       },
-      direction: "outbound"
+      direction: subjectDirection.direction
     },
     salesforceCommunicationDetail: {
       sourceEvidenceId: buildSourceEvidenceId(
@@ -669,7 +729,7 @@ function mapSalesforceTaskCommunicationRecord(
       providerRecordId,
       channel: record.channel,
       messageKind: record.messageKind,
-      subject: record.subject,
+      subject: subjectDirection.cleanSubject,
       snippet: record.snippet,
       sourceLabel:
         record.messageKind === "auto" ? "Salesforce Flow" : "Salesforce Task"

--- a/packages/integrations/test/gmail-body-extraction.test.ts
+++ b/packages/integrations/test/gmail-body-extraction.test.ts
@@ -107,4 +107,51 @@ describe("Gmail body extraction", () => {
       )
     ).toBe("Thanks for the clarification.");
   });
+
+  it("does not trim plain body content that happens to include From and Sent lines", () => {
+    expect(
+      trimQuotedReplyContent(
+        [
+          "Hello Samantha,",
+          "Here is an update on placing the ARUs.",
+          "From: Basin Ridge",
+          "Sent: after the snow melted"
+        ].join("\n")
+      )
+    ).toBe(
+      [
+        "Hello Samantha,",
+        "Here is an update on placing the ARUs.",
+        "From: Basin Ridge",
+        "Sent: after the snow melted"
+      ].join("\n")
+    );
+  });
+
+  it("does not treat a normal sentence containing 'on' as an On ... wrote quote marker", () => {
+    expect(
+      trimQuotedReplyContent(
+        [
+          "Hello Samantha,",
+          "",
+          "Here is an update on placing the ARUs for HEX 08456.",
+          "",
+          "On Fri, Apr 3, 2026 at 12:19 PM PNW Forest Biodiversity wrote:",
+          "> Prior message"
+        ].join("\n")
+      )
+    ).toBe(
+      [
+        "Hello Samantha,",
+        "",
+        "Here is an update on placing the ARUs for HEX 08456."
+      ].join("\n")
+    );
+  });
+
+  it("preserves bodies longer than 2000 characters", () => {
+    const longBody = `Hello Samantha,\n\n${"A".repeat(2_600)}`;
+
+    expect(cleanGmailBodyPreviewText(longBody)).toBe(longBody);
+  });
 });

--- a/packages/integrations/test/stage1-gmail-capture-service.test.ts
+++ b/packages/integrations/test/stage1-gmail-capture-service.test.ts
@@ -368,6 +368,73 @@ describe("Gmail capture service", () => {
     );
   });
 
+  it("captures live Gmail bodies longer than 2000 characters without truncating them", async () => {
+    const longBody = `Hello Samantha,\n\n${"A".repeat(2_600)}`;
+    const service = createGmailCaptureService(
+      {
+        bearerToken: "gmail-token",
+        liveAccount: "volunteers@example.org",
+        projectInboxAliases: ["project-oceans@example.org"],
+        oauthClientId: "gmail-oauth-client-id",
+        oauthClientSecret: "gmail-oauth-client-secret",
+        oauthRefreshToken: "gmail-oauth-refresh-token"
+      },
+      {
+        apiClient: {
+          listMessageIds: () => Promise.resolve(["gmail-live-long-1"]),
+          getMessage: ({ messageId }) =>
+            Promise.resolve({
+              id: messageId,
+              threadId: "thread-live-long-1",
+              snippet: "Long inbound field update",
+              internalDate: String(Date.parse("2026-01-05T00:00:00.000Z")),
+              payload: buildFullMessagePayload({
+                bodyText: longBody,
+                headers: {
+                  Date: "Mon, 05 Jan 2026 00:00:00 +0000",
+                  From: "Volunteer <volunteer@example.org>",
+                  To: "Project Oceans <project-oceans@example.org>",
+                  Subject: "Long field update",
+                  "Message-ID": "<gmail-live-long-1@example.org>"
+                }
+              })
+            })
+        },
+        now: () => new Date("2026-01-05T00:01:00.000Z")
+      }
+    );
+
+    const result = await service.captureLiveBatch({
+      version: 1,
+      jobId: "job:gmail:live:long-body",
+      correlationId: "corr:gmail:live:long-body",
+      traceId: null,
+      batchId: "batch:gmail:live:long-body",
+      syncStateId: "sync:gmail:live:long-body",
+      attempt: 1,
+      maxAttempts: 3,
+      provider: "gmail",
+      mode: "live",
+      jobType: "live_ingest",
+      cursor: null,
+      checkpoint: null,
+      windowStart: "2026-01-05T00:00:00.000Z",
+      windowEnd: "2026-01-05T00:05:00.000Z",
+      recordIds: [],
+      maxRecords: 25
+    });
+
+    expect(result.records[0]).toMatchObject({
+      recordType: "message",
+      direction: "inbound",
+      subject: "Long field update",
+      bodyTextPreview: longBody
+    });
+    const record = gmailMessageRecordSchema.parse(result.records[0]);
+
+    expect(record.bodyTextPreview).toHaveLength(longBody.length);
+  });
+
   it("uses OAuth refresh-token exchange before polling the live mailbox", async () => {
     const requests: {
       readonly url: string;

--- a/packages/integrations/test/stage1-mappers.test.ts
+++ b/packages/integrations/test/stage1-mappers.test.ts
@@ -4,10 +4,50 @@ import {
   mapGmailRecord,
   mapMailchimpRecord,
   mapSalesforceRecord,
+  parseSubjectDirection,
   mapSimpleTextingRecord
 } from "../src/index.js";
 
 describe("Stage 1 provider-close mappers", () => {
+  it("parses Salesforce inbound task subjects and strips the arrow prefix", () => {
+    expect(parseSubjectDirection("← Email: Re: Field update")).toEqual({
+      direction: "inbound",
+      cleanSubject: "Re: Field update"
+    });
+  });
+
+  it("parses Salesforce outbound task subjects and strips the arrow prefix", () => {
+    expect(parseSubjectDirection("→ Follow-up from AS")).toEqual({
+      direction: "outbound",
+      cleanSubject: "Follow-up from AS"
+    });
+  });
+
+  it("defaults Salesforce task subjects without an arrow to outbound", () => {
+    expect(parseSubjectDirection(" Status check ")).toEqual({
+      direction: "outbound",
+      cleanSubject: "Status check"
+    });
+  });
+
+  it("supports the unicode Salesforce arrow variants", () => {
+    expect(parseSubjectDirection("⇐ Email: Inbound variant")).toEqual({
+      direction: "inbound",
+      cleanSubject: "Inbound variant"
+    });
+    expect(parseSubjectDirection("⇒ Outbound variant")).toEqual({
+      direction: "outbound",
+      cleanSubject: "Outbound variant"
+    });
+  });
+
+  it("defaults null Salesforce task subjects to outbound with no subject", () => {
+    expect(parseSubjectDirection(null)).toEqual({
+      direction: "outbound",
+      cleanSubject: null
+    });
+  });
+
   it("maps Gmail one-to-one messages into normalized canonical event intake", () => {
     const result = mapGmailRecord({
       recordType: "message",
@@ -339,6 +379,68 @@ describe("Stage 1 provider-close mappers", () => {
         expect(taskResult.command.input.canonicalEvent.idempotencyKey).toBe(
           "canonical-event:collapse:communication.email.outbound:email-thread-1"
         );
+      }
+    }
+  });
+
+  it("maps Salesforce inbound task communication records into inbound canonical events", () => {
+    const taskResult = mapSalesforceRecord({
+      recordType: "task_communication",
+      recordId: "task-inbound-1",
+      channel: "email",
+      messageKind: "one_to_one",
+      salesforceContactId: "003-stage1",
+      occurredAt: "2026-01-01T00:02:00.000Z",
+      receivedAt: "2026-01-01T00:03:00.000Z",
+      payloadRef: "payloads/salesforce/task-inbound-1.json",
+      checksum: "checksum-task-inbound-1",
+      subject: "← Email: Re: Field update",
+      snippet: "Inbound update from the volunteer",
+      normalizedEmails: ["volunteer@example.org"],
+      normalizedPhones: [],
+      volunteerIdPlainValues: [],
+      supportingRecords: [],
+      crossProviderCollapseKey: null,
+      routing: {
+        required: false,
+        projectId: null,
+        expeditionId: null,
+        projectName: null,
+        expeditionName: null
+      }
+    });
+
+    expect(taskResult.outcome).toBe("command");
+    if (taskResult.outcome === "command") {
+      expect(taskResult.command.kind).toBe("canonical_event");
+      if (taskResult.command.kind === "canonical_event") {
+        expect(taskResult.command.input.canonicalEvent.eventType).toBe(
+          "communication.email.inbound"
+        );
+        expect(taskResult.command.input.canonicalEvent.summary).toBe(
+          "Inbound email received"
+        );
+        expect(taskResult.command.input.communicationClassification).toEqual({
+          messageKind: "one_to_one",
+          sourceRecordType: "task_communication",
+          sourceRecordId: "task-inbound-1",
+          campaignRef: null,
+          threadRef: {
+            crossProviderCollapseKey: null,
+            providerThreadId: null
+          },
+          direction: "inbound"
+        });
+        expect(taskResult.command.input.salesforceCommunicationDetail).toEqual({
+          sourceEvidenceId:
+            "source-evidence:salesforce:task_communication:task-inbound-1",
+          providerRecordId: "task-inbound-1",
+          channel: "email",
+          messageKind: "one_to_one",
+          subject: "Re: Field update",
+          snippet: "Inbound update from the volunteer",
+          sourceLabel: "Salesforce Task"
+        });
       }
     }
   });


### PR DESCRIPTION
## Summary

Two defects in the integrations capture layer, fixed together because both live in the same provider modules.

## SF Task direction parsing (1,245 mislabeled inbound rows in prod)

SF Task subjects carry `←` / `⇐` (inbound from contact) or `→` / `⇒` (outbound from AS). Ingestion was ignoring the arrow and labeling every SF Task as outbound. Verified: 1,245 inbound events in prod currently labeled outbound.

- `packages/integrations/src/providers/salesforce.ts` — direction parser: strips arrow, sets `event_type` accordingly
- `apps/worker/src/ops/reclassify-sf-direction.ts` — ops script to correct historical rows + rebuild affected contact projections
- Unit tests cover ← / ⇐ / → / ⇒ / no-arrow / null-subject variants

## Gmail body untruncation (D1)

Every Gmail body was hard-capped at 2000 chars by `BODY_PREVIEW_LIMIT` in `gmail-body.ts:22`. Long emails were permanently cut off. Heidi Gill's Apr 10 inbound showed as 34 chars against a real 2,527-char body in the mbox payload.

- `packages/integrations/src/providers/gmail-body.ts` — cap removed
- Tightened quoted-reply regex to require line-start anchor + typical header shape (`^On .* wrote:$` etc.). The prior case-insensitive pattern matched ordinary phrases like "update on placing..." mid-sentence, truncating clean bodies
- DB column `body_text_preview` is already unbounded `text`; no migration
- Test for >2000-char body fixture + Heidi-style regression

## Prod ops plan

1. Merge this PR
2. Deploy web + worker
3. Dry-run: `railway ssh --service worker "node dist/ops/cli.js reclassify-sf-direction --dry-run"`
4. Architect reviews dry-run sample (50-row preview showed 29 reclassified + 50 subjects cleaned + 14 projections rebuilt)
5. `--execute` after sign-off

Destructive steps need per-session architect sign-off each time.

## Out of scope

- Historical Gmail bodies remain truncated in existing rows. Re-ingestion requires re-fetching from Gmail API — separate brief.
- `[External Email]` prefix stripping (USDA-style) — left in subjects for now.

## Test plan

- [ ] CI green: `pnpm lint`, `pnpm test:unit`, `pnpm typecheck` — all passed locally per Codex
- [ ] Direction parser unit tests for all arrow variants
- [ ] Gmail body capture test with >2000-char body lands full length in DB
- [ ] Post-deploy reclassify dry-run against prod matches the 1,245 expected count

Brief: `.audit-ingestion-2026-04-21/briefs/fix-direction-parsing-and-body-truncation.md`