### PR TITLE
fix(reconcile): reconstruct from stored DB, drop mbox dependency

### DIFF
--- a/apps/worker/src/ops/_reconcile-from-stored-evidence.ts
+++ b/apps/worker/src/ops/_reconcile-from-stored-evidence.ts
@@ -1,0 +1,550 @@
+import type {
+  ExpeditionDimensionRecord,
+  GmailMessageDetailRecord,
+  IdentityResolutionCase,
+  MailchimpCampaignActivityDetailRecord,
+  NormalizedCanonicalEventIntake,
+  ProjectDimensionRecord,
+  SalesforceCommunicationDetailRecord,
+  SalesforceEventContextRecord,
+  SourceEvidenceRecord
+} from "@as-comms/contracts";
+import type { Stage1RepositoryBundle } from "@as-comms/domain";
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/u;
+const SALESFORCE_CONTACT_ID_PATTERN = /^003[\w-]+$/u;
+const NORMALIZED_PHONE_PATTERN = /^\+[1-9]\d{6,}$/u;
+
+function encodeIdPart(value: string): string {
+  return encodeURIComponent(value);
+}
+
+function buildCanonicalEventCorrelationKey(input: {
+  readonly provider: SourceEvidenceRecord["provider"];
+  readonly providerRecordType: string;
+  readonly providerRecordId: string;
+  readonly eventType: NormalizedCanonicalEventIntake["canonicalEvent"]["eventType"];
+  readonly crossProviderCollapseKey: string | null;
+}): string {
+  if (input.crossProviderCollapseKey !== null) {
+    return `collapse:${input.eventType}:${input.crossProviderCollapseKey}`;
+  }
+
+  return `${input.provider}:${input.providerRecordType}:${input.providerRecordId}`;
+}
+
+function buildCanonicalEventId(input: {
+  readonly provider: SourceEvidenceRecord["provider"];
+  readonly providerRecordType: string;
+  readonly providerRecordId: string;
+  readonly eventType: NormalizedCanonicalEventIntake["canonicalEvent"]["eventType"];
+  readonly crossProviderCollapseKey: string | null;
+}): string {
+  return `canonical-event:${encodeIdPart(buildCanonicalEventCorrelationKey(input))}`;
+}
+
+function buildCanonicalEventIdempotencyKey(input: {
+  readonly provider: SourceEvidenceRecord["provider"];
+  readonly providerRecordType: string;
+  readonly providerRecordId: string;
+  readonly eventType: NormalizedCanonicalEventIntake["canonicalEvent"]["eventType"];
+  readonly crossProviderCollapseKey: string | null;
+}): string {
+  return `canonical-event:${buildCanonicalEventCorrelationKey(input)}`;
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+  return Array.from(
+    new Set(values.map((value) => value.trim()).filter((value) => value.length > 0))
+  ).sort((left, right) => left.localeCompare(right));
+}
+
+function buildIdentityFromCase(input: {
+  readonly caseRecord: IdentityResolutionCase;
+  readonly preferredSalesforceContactId?: string | null;
+}): NormalizedCanonicalEventIntake["identity"] {
+  const normalizedEmails: string[] = [];
+  const normalizedPhones: string[] = [];
+  const volunteerIdPlainValues: string[] = [];
+  let salesforceContactId = input.preferredSalesforceContactId ?? null;
+
+  for (const value of uniqueStrings(input.caseRecord.normalizedIdentityValues)) {
+    if (salesforceContactId !== null && value === salesforceContactId) {
+      continue;
+    }
+
+    if (EMAIL_PATTERN.test(value)) {
+      normalizedEmails.push(value);
+      continue;
+    }
+
+    if (NORMALIZED_PHONE_PATTERN.test(value)) {
+      normalizedPhones.push(value);
+      continue;
+    }
+
+    if (salesforceContactId === null && SALESFORCE_CONTACT_ID_PATTERN.test(value)) {
+      salesforceContactId = value;
+      continue;
+    }
+
+    volunteerIdPlainValues.push(value);
+  }
+
+  return {
+    salesforceContactId,
+    volunteerIdPlainValues: uniqueStrings(volunteerIdPlainValues),
+    normalizedEmails: uniqueStrings(normalizedEmails),
+    normalizedPhones: uniqueStrings(normalizedPhones)
+  };
+}
+
+function requireSingleDetail<TDetail>(
+  detail: TDetail | undefined,
+  message: string
+): TDetail {
+  if (detail === undefined) {
+    throw new Error(message);
+  }
+
+  return detail;
+}
+
+function buildGmailSummary(
+  direction: GmailMessageDetailRecord["direction"]
+): string {
+  return direction === "inbound"
+    ? "Inbound email received"
+    : "Outbound email sent";
+}
+
+function buildSimpleTextingSummary(
+  eventType: NormalizedCanonicalEventIntake["canonicalEvent"]["eventType"]
+): string {
+  switch (eventType) {
+    case "communication.sms.inbound":
+      return "Inbound SMS received";
+    case "communication.sms.outbound":
+      return "Outbound SMS sent";
+    case "communication.sms.opt_in":
+      return "SMS opt-in received";
+    case "communication.sms.opt_out":
+      return "SMS opt-out received";
+    default:
+      throw new Error(
+        `Unsupported SimpleTexting event type ${eventType} for stored-evidence reconciliation.`
+      );
+  }
+}
+
+function buildMailchimpSummary(
+  activityType: MailchimpCampaignActivityDetailRecord["activityType"]
+): string {
+  switch (activityType) {
+    case "sent":
+      return "Campaign email sent";
+    case "opened":
+      return "Campaign email opened";
+    case "clicked":
+      return "Campaign email clicked";
+    case "unsubscribed":
+      return "Campaign email unsubscribed";
+  }
+}
+
+function buildSalesforceTaskSummary(input: {
+  readonly eventType: NormalizedCanonicalEventIntake["canonicalEvent"]["eventType"];
+  readonly messageKind: SalesforceCommunicationDetailRecord["messageKind"];
+}): string {
+  switch (input.eventType) {
+    case "communication.email.inbound":
+      return "Inbound email received";
+    case "communication.email.outbound":
+      return input.messageKind === "auto"
+        ? "Auto email sent"
+        : "Outbound email sent";
+    case "communication.sms.outbound":
+      return input.messageKind === "auto"
+        ? "Auto SMS sent"
+        : "Outbound SMS sent";
+    default:
+      throw new Error(
+        `Unsupported Salesforce event type ${input.eventType} for stored-evidence reconciliation.`
+      );
+  }
+}
+
+function buildRoutingContext(input: {
+  readonly eventContext: SalesforceEventContextRecord | undefined;
+  readonly project: ProjectDimensionRecord | undefined;
+  readonly expedition: ExpeditionDimensionRecord | undefined;
+}): NonNullable<NormalizedCanonicalEventIntake["routing"]> | undefined {
+  if (input.eventContext === undefined) {
+    return undefined;
+  }
+
+  return {
+    required:
+      input.eventContext.projectId !== null || input.eventContext.expeditionId !== null,
+    projectId: input.eventContext.projectId,
+    expeditionId: input.eventContext.expeditionId,
+    projectName: input.project?.projectName ?? null,
+    expeditionName: input.expedition?.expeditionName ?? null
+  };
+}
+
+function parseSubjectDirection(rawSubject: string | null): {
+  readonly direction: "inbound" | "outbound";
+  readonly cleanSubject: string | null;
+} {
+  if (rawSubject === null) {
+    return {
+      direction: "outbound",
+      cleanSubject: null
+    };
+  }
+
+  const trimmed = rawSubject.trim();
+
+  if (trimmed.length === 0) {
+    return {
+      direction: "outbound",
+      cleanSubject: null
+    };
+  }
+
+  const normalizeCleanSubject = (value: string): string | null => {
+    const cleaned = value.trim();
+    return cleaned.length > 0 ? cleaned : null;
+  };
+
+  if (trimmed.startsWith("←") || trimmed.startsWith("⇐")) {
+    return {
+      direction: "inbound",
+      cleanSubject: normalizeCleanSubject(
+        trimmed.replace(/^[←⇐]\s*(?:Email:\s*)?/u, "")
+      )
+    };
+  }
+
+  if (trimmed.startsWith("→") || trimmed.startsWith("⇒")) {
+    return {
+      direction: "outbound",
+      cleanSubject: normalizeCleanSubject(
+        trimmed.replace(/^[→⇒]\s*(?:Email:\s*)?/u, "")
+      )
+    };
+  }
+
+  return {
+    direction: "outbound",
+    cleanSubject: trimmed
+  };
+}
+
+export async function buildEventFromStoredData(input: {
+  readonly repositories: Stage1RepositoryBundle;
+  readonly sourceEvidence: SourceEvidenceRecord;
+  readonly caseRecord: IdentityResolutionCase;
+}): Promise<NormalizedCanonicalEventIntake> {
+  const sourceEvidenceId = input.sourceEvidence.id;
+
+  switch (input.sourceEvidence.provider) {
+    case "gmail": {
+      const detail = requireSingleDetail(
+        (
+          await input.repositories.gmailMessageDetails.listBySourceEvidenceIds([
+            sourceEvidenceId
+          ])
+        )[0],
+        `Expected gmail_message_details to exist for source evidence ${sourceEvidenceId}.`
+      );
+      const crossProviderCollapseKey =
+        detail.rfc822MessageId === null
+          ? null
+          : `rfc822:${detail.rfc822MessageId.toLowerCase()}`;
+      const eventType =
+        detail.direction === "inbound"
+          ? "communication.email.inbound"
+          : "communication.email.outbound";
+      const snippet =
+        detail.snippetClean.trim().length > 0
+          ? detail.snippetClean
+          : detail.bodyTextPreview;
+
+      return {
+        sourceEvidence: input.sourceEvidence,
+        canonicalEvent: {
+          id: buildCanonicalEventId({
+            provider: "gmail",
+            providerRecordType: input.sourceEvidence.providerRecordType,
+            providerRecordId: input.sourceEvidence.providerRecordId,
+            eventType,
+            crossProviderCollapseKey
+          }),
+          eventType,
+          occurredAt: input.sourceEvidence.occurredAt,
+          idempotencyKey: buildCanonicalEventIdempotencyKey({
+            provider: "gmail",
+            providerRecordType: input.sourceEvidence.providerRecordType,
+            providerRecordId: input.sourceEvidence.providerRecordId,
+            eventType,
+            crossProviderCollapseKey
+          }),
+          summary: buildGmailSummary(detail.direction),
+          snippet
+        },
+        identity: buildIdentityFromCase({
+          caseRecord: input.caseRecord
+        }),
+        supportingSources: [],
+        communicationClassification: {
+          messageKind: "one_to_one",
+          sourceRecordType: input.sourceEvidence.providerRecordType,
+          sourceRecordId: input.sourceEvidence.providerRecordId,
+          campaignRef: null,
+          threadRef: {
+            crossProviderCollapseKey,
+            providerThreadId: detail.gmailThreadId
+          },
+          direction: detail.direction
+        },
+        gmailMessageDetail: detail
+      };
+    }
+    case "salesforce": {
+      const [detail, eventContext] = await Promise.all([
+        input.repositories.salesforceCommunicationDetails.listBySourceEvidenceIds([
+          sourceEvidenceId
+        ]),
+        input.repositories.salesforceEventContext.listBySourceEvidenceIds([
+          sourceEvidenceId
+        ])
+      ]);
+      const communicationDetail = requireSingleDetail(
+        detail[0],
+        `Expected salesforce_communication_details to exist for source evidence ${sourceEvidenceId}.`
+      );
+      const context = eventContext[0];
+      const [project, expedition] = await Promise.all([
+        context?.projectId === null || context?.projectId === undefined
+          ? Promise.resolve(undefined)
+          : input.repositories.projectDimensions
+              .listByIds([context.projectId])
+              .then((records) => records[0]),
+        context?.expeditionId === null || context?.expeditionId === undefined
+          ? Promise.resolve(undefined)
+          : input.repositories.expeditionDimensions
+              .listByIds([context.expeditionId])
+              .then((records) => records[0])
+      ]);
+      const subjectDirection =
+        communicationDetail.channel === "email"
+          ? parseSubjectDirection(communicationDetail.subject)
+          : {
+              direction: "outbound" as const,
+              cleanSubject: communicationDetail.subject
+            };
+      const eventType =
+        communicationDetail.channel === "email"
+          ? subjectDirection.direction === "inbound"
+            ? "communication.email.inbound"
+            : "communication.email.outbound"
+          : "communication.sms.outbound";
+      const routing = buildRoutingContext({
+        eventContext: context,
+        project,
+        expedition
+      });
+
+      return {
+        sourceEvidence: input.sourceEvidence,
+        canonicalEvent: {
+          id: buildCanonicalEventId({
+            provider: "salesforce",
+            providerRecordType: input.sourceEvidence.providerRecordType,
+            providerRecordId: input.sourceEvidence.providerRecordId,
+            eventType,
+            crossProviderCollapseKey: null
+          }),
+          eventType,
+          occurredAt: input.sourceEvidence.occurredAt,
+          idempotencyKey: buildCanonicalEventIdempotencyKey({
+            provider: "salesforce",
+            providerRecordType: input.sourceEvidence.providerRecordType,
+            providerRecordId: input.sourceEvidence.providerRecordId,
+            eventType,
+            crossProviderCollapseKey: null
+          }),
+          summary: buildSalesforceTaskSummary({
+            eventType,
+            messageKind: communicationDetail.messageKind
+          }),
+          snippet: communicationDetail.snippet
+        },
+        identity: buildIdentityFromCase({
+          caseRecord: input.caseRecord,
+          preferredSalesforceContactId: context?.salesforceContactId ?? null
+        }),
+        ...(routing === undefined ? {} : { routing }),
+        supportingSources: [],
+        communicationClassification: {
+          messageKind: communicationDetail.messageKind,
+          sourceRecordType: input.sourceEvidence.providerRecordType,
+          sourceRecordId: input.sourceEvidence.providerRecordId,
+          campaignRef: null,
+          threadRef: {
+            crossProviderCollapseKey: null,
+            providerThreadId: null
+          },
+          direction: subjectDirection.direction
+        },
+        salesforceCommunicationDetail: {
+          ...communicationDetail,
+          subject: subjectDirection.cleanSubject
+        },
+        ...(context === undefined ? {} : { salesforceEventContext: context }),
+        projectDimensions:
+          project === undefined
+            ? []
+            : [
+                {
+                  projectId: project.projectId,
+                  projectName: project.projectName,
+                  source: project.source
+                }
+              ],
+        expeditionDimensions:
+          expedition === undefined
+            ? []
+            : [
+                {
+                  expeditionId: expedition.expeditionId,
+                  projectId: expedition.projectId,
+                  expeditionName: expedition.expeditionName,
+                  source: expedition.source
+                }
+              ]
+      };
+    }
+    case "simpletexting": {
+      const detail = requireSingleDetail(
+        (
+          await input.repositories.simpleTextingMessageDetails.listBySourceEvidenceIds([
+            sourceEvidenceId
+          ])
+        )[0],
+        `Expected simpletexting_message_details to exist for source evidence ${sourceEvidenceId}.`
+      );
+      const eventType =
+        detail.direction === "inbound"
+          ? "communication.sms.inbound"
+          : "communication.sms.outbound";
+
+      return {
+        sourceEvidence: input.sourceEvidence,
+        canonicalEvent: {
+          id: buildCanonicalEventId({
+            provider: "simpletexting",
+            providerRecordType: input.sourceEvidence.providerRecordType,
+            providerRecordId: input.sourceEvidence.providerRecordId,
+            eventType,
+            crossProviderCollapseKey: detail.threadKey
+          }),
+          eventType,
+          occurredAt: input.sourceEvidence.occurredAt,
+          idempotencyKey: buildCanonicalEventIdempotencyKey({
+            provider: "simpletexting",
+            providerRecordType: input.sourceEvidence.providerRecordType,
+            providerRecordId: input.sourceEvidence.providerRecordId,
+            eventType,
+            crossProviderCollapseKey: detail.threadKey
+          }),
+          summary: buildSimpleTextingSummary(eventType),
+          snippet: detail.messageTextPreview
+        },
+        identity: buildIdentityFromCase({
+          caseRecord: input.caseRecord
+        }),
+        supportingSources: [],
+        communicationClassification: {
+          messageKind: detail.messageKind,
+          sourceRecordType: input.sourceEvidence.providerRecordType,
+          sourceRecordId: input.sourceEvidence.providerRecordId,
+          campaignRef:
+            detail.messageKind === "campaign"
+              ? {
+                  providerCampaignId: detail.campaignId,
+                  providerAudienceId: null,
+                  providerMessageName: detail.campaignName
+                }
+              : null,
+          threadRef: {
+            crossProviderCollapseKey: detail.threadKey,
+            providerThreadId: detail.providerThreadId
+          },
+          direction: detail.direction
+        },
+        simpleTextingMessageDetail: detail
+      };
+    }
+    case "mailchimp": {
+      const detail = requireSingleDetail(
+        (
+          await input.repositories.mailchimpCampaignActivityDetails.listBySourceEvidenceIds(
+            [sourceEvidenceId]
+          )
+        )[0],
+        `Expected mailchimp_campaign_activity_details to exist for source evidence ${sourceEvidenceId}.`
+      );
+      const eventType =
+        detail.activityType === "sent"
+          ? "campaign.email.sent"
+          : detail.activityType === "opened"
+            ? "campaign.email.opened"
+            : detail.activityType === "clicked"
+              ? "campaign.email.clicked"
+              : "campaign.email.unsubscribed";
+      const crossProviderCollapseKey = [
+        "mailchimp",
+        detail.audienceId,
+        detail.campaignId,
+        detail.memberId,
+        detail.activityType
+      ].join(":");
+
+      return {
+        sourceEvidence: input.sourceEvidence,
+        canonicalEvent: {
+          id: buildCanonicalEventId({
+            provider: "mailchimp",
+            providerRecordType: input.sourceEvidence.providerRecordType,
+            providerRecordId: input.sourceEvidence.providerRecordId,
+            eventType,
+            crossProviderCollapseKey
+          }),
+          eventType,
+          occurredAt: input.sourceEvidence.occurredAt,
+          idempotencyKey: buildCanonicalEventIdempotencyKey({
+            provider: "mailchimp",
+            providerRecordType: input.sourceEvidence.providerRecordType,
+            providerRecordId: input.sourceEvidence.providerRecordId,
+            eventType,
+            crossProviderCollapseKey
+          }),
+          summary: buildMailchimpSummary(detail.activityType),
+          snippet: detail.snippet
+        },
+        identity: buildIdentityFromCase({
+          caseRecord: input.caseRecord
+        }),
+        supportingSources: [],
+        mailchimpCampaignActivityDetail: detail
+      };
+    }
+    case "manual":
+      throw new Error(
+        `Manual source evidence ${sourceEvidenceId} cannot be reconciled through the identity queue operation.`
+      );
+  }
+}

--- a/apps/worker/src/ops/reconcile-identity-queue.ts
+++ b/apps/worker/src/ops/reconcile-identity-queue.ts
@@ -1,11 +1,7 @@
-import { readFile } from "node:fs/promises";
-
 import {
-  stage1JobVersion,
   type IdentityResolutionCase,
   type Provider,
-  type SourceEvidenceRecord,
-  type Stage1OrchestrationMode
+  type SourceEvidenceRecord
 } from "@as-comms/contracts";
 import {
   createStage1RepositoryBundle,
@@ -14,31 +10,14 @@ import {
 import {
   createStage1NormalizationService,
   createStage1PersistenceService,
+  type NormalizedCanonicalEventResult,
   type Stage1RepositoryBundle
 } from "@as-comms/domain";
-import {
-  importGmailMboxRecords,
-  type GmailRecord,
-  type MailchimpRecord,
-  type SalesforceRecord,
-  type SimpleTextingRecord
-} from "@as-comms/integrations";
 
-import {
-  createStage1IngestService,
-  type Stage1IngestResult,
-  type Stage1IngestService
-} from "../ingest/index.js";
 import type { Stage1ProviderCapturePorts } from "../orchestration/index.js";
-import { buildOperationId } from "./helpers.js";
+import { buildEventFromStoredData } from "./_reconcile-from-stored-evidence.js";
 
 const DEFAULT_BATCH_SIZE = 100;
-
-type CapturedProviderRecord =
-  | GmailRecord
-  | SalesforceRecord
-  | SimpleTextingRecord
-  | MailchimpRecord;
 
 interface GmailHistoricalReplayConfig {
   readonly liveAccount: string;
@@ -48,7 +27,6 @@ interface GmailHistoricalReplayConfig {
 interface ReconcileTarget {
   readonly caseRecord: IdentityResolutionCase;
   readonly sourceEvidence: SourceEvidenceRecord;
-  readonly mode: Stage1OrchestrationMode;
 }
 
 export interface ReconcileError {
@@ -79,15 +57,15 @@ interface ReconcileIdentityQueueInput {
   readonly logger?: Pick<Console, "log">;
 }
 
-interface ParsedGmailHistoricalPayloadRef {
-  readonly mboxPath: string;
-  readonly messageNumber: number;
-}
-
-interface ReconcileExecutionResult {
-  readonly ingestResult: Stage1IngestResult;
-  readonly createdNewContact: boolean;
-}
+type ReconcileExecutionResult =
+  | {
+      readonly kind: "processed";
+      readonly normalizationResult: NormalizedCanonicalEventResult;
+      readonly createdNewContact: boolean;
+    }
+  | {
+      readonly kind: "skipped";
+    };
 
 class DryRunRollback extends Error {
   constructor() {
@@ -112,108 +90,6 @@ function chunkValues<TValue>(
   }
 
   return chunks;
-}
-
-function buildHistoricalReplayProjectInboxAliases(input: {
-  readonly configuredAliases: readonly string[];
-  readonly recordedProjectInboxAlias: string | null;
-}): string[] {
-  const aliases = new Set(
-    input.configuredAliases
-      .map((alias) => alias.trim())
-      .filter((alias) => alias.length > 0)
-  );
-
-  if (
-    input.recordedProjectInboxAlias !== null &&
-    input.recordedProjectInboxAlias.trim().length > 0
-  ) {
-    aliases.add(input.recordedProjectInboxAlias.trim());
-  }
-
-  return [...aliases];
-}
-
-function parseGmailHistoricalPayloadRef(
-  payloadRef: string
-): ParsedGmailHistoricalPayloadRef {
-  if (!payloadRef.startsWith("mbox://")) {
-    throw new Error(
-      `Expected Gmail historical replay payloadRef to use the mbox:// scheme, received ${payloadRef}.`
-    );
-  }
-
-  const hashIndex = payloadRef.indexOf("#");
-  const encodedPath = payloadRef.slice(
-    "mbox://".length,
-    hashIndex === -1 ? undefined : hashIndex
-  );
-
-  if (encodedPath.trim().length === 0) {
-    throw new Error(
-      `Expected Gmail historical replay payloadRef to include an mbox path, received ${payloadRef}.`
-    );
-  }
-
-  let mboxPath: string;
-
-  try {
-    mboxPath = decodeURIComponent(encodedPath);
-  } catch {
-    throw new Error(
-      `Expected Gmail historical replay payloadRef to contain a valid encoded mbox path, received ${payloadRef}.`
-    );
-  }
-
-  const searchParams = new URLSearchParams(
-    hashIndex === -1 ? "" : payloadRef.slice(hashIndex + 1)
-  );
-  const messageValue = searchParams.get("message");
-  const messageNumber =
-    messageValue === null ? Number.NaN : Number.parseInt(messageValue, 10);
-
-  if (!Number.isInteger(messageNumber) || messageNumber < 1) {
-    throw new Error(
-      `Expected Gmail historical replay payloadRef to include a positive message number, received ${payloadRef}.`
-    );
-  }
-
-  return {
-    mboxPath,
-    messageNumber
-  };
-}
-
-function buildRecordKey(input: {
-  readonly providerRecordType: string;
-  readonly providerRecordId: string;
-}): string {
-  return `${input.providerRecordType}:${input.providerRecordId}`;
-}
-
-function inferReplayMode(
-  sourceEvidence: SourceEvidenceRecord
-): Stage1OrchestrationMode {
-  switch (sourceEvidence.provider) {
-    case "gmail":
-      return sourceEvidence.payloadRef.startsWith("mbox://")
-        ? "historical"
-        : "live";
-    case "salesforce":
-      return "live";
-    case "simpletexting":
-      return sourceEvidence.payloadRef.startsWith("capture://simpletexting/")
-        ? "live"
-        : "historical";
-    case "mailchimp":
-      return sourceEvidence.payloadRef.startsWith("capture://mailchimp/")
-        ? "transition_live"
-        : "historical";
-    case "manual":
-      throw new Error(
-        `Manual source evidence ${sourceEvidence.id} cannot be reconciled through the identity replay workflow.`
-      );
-  }
 }
 
 async function loadOpenIdentityMissingAnchorTargets(input: {
@@ -252,8 +128,7 @@ async function loadOpenIdentityMissingAnchorTargets(input: {
 
     targets.push({
       caseRecord,
-      sourceEvidence,
-      mode: inferReplayMode(sourceEvidence)
+      sourceEvidence
     });
   }
 
@@ -263,369 +138,16 @@ async function loadOpenIdentityMissingAnchorTargets(input: {
   };
 }
 
-async function loadHistoricalGmailRecords(input: {
-  readonly repositories: Stage1RepositoryBundle;
-  readonly targets: readonly ReconcileTarget[];
-  readonly gmailHistoricalReplay: GmailHistoricalReplayConfig;
-}): Promise<Map<string, GmailRecord>> {
-  const sourceEvidenceIds = input.targets.map((target) => target.sourceEvidence.id);
-  const gmailDetails = await input.repositories.gmailMessageDetails.listBySourceEvidenceIds(
-    sourceEvidenceIds
-  );
-  const gmailDetailBySourceEvidenceId = new Map(
-    gmailDetails.map((detail) => [detail.sourceEvidenceId, detail] as const)
-  );
-  const mboxTextByPath = new Map<string, string>();
-  const importedRecordsByCacheKey = new Map<string, readonly GmailRecord[]>();
-  const recordsBySourceEvidenceId = new Map<string, GmailRecord>();
-
-  for (const target of input.targets) {
-    const gmailDetail = gmailDetailBySourceEvidenceId.get(target.sourceEvidence.id);
-
-    if (gmailDetail === undefined) {
-      throw new Error(
-        `Expected gmail_message_details to exist for historical replay source evidence ${target.sourceEvidence.id}.`
-      );
-    }
-
-    const parsedPayloadRef = parseGmailHistoricalPayloadRef(
-      target.sourceEvidence.payloadRef
-    );
-    let mboxText = mboxTextByPath.get(parsedPayloadRef.mboxPath);
-
-    if (mboxText === undefined) {
-      mboxText = await readFile(parsedPayloadRef.mboxPath, "utf8");
-      mboxTextByPath.set(parsedPayloadRef.mboxPath, mboxText);
-    }
-
-    const capturedMailbox =
-      gmailDetail.capturedMailbox ?? input.gmailHistoricalReplay.liveAccount;
-    const replayProjectInboxAliases = buildHistoricalReplayProjectInboxAliases({
-      configuredAliases: input.gmailHistoricalReplay.projectInboxAliases,
-      recordedProjectInboxAlias: gmailDetail.projectInboxAlias
-    });
-    const cacheKey = JSON.stringify({
-      mboxPath: parsedPayloadRef.mboxPath,
-      capturedMailbox,
-      projectInboxAliases: replayProjectInboxAliases,
-      projectInboxAliasOverride: gmailDetail.projectInboxAlias,
-      receivedAt: target.sourceEvidence.receivedAt
-    });
-    let importedRecords = importedRecordsByCacheKey.get(cacheKey);
-
-    if (importedRecords === undefined) {
-      importedRecords = await importGmailMboxRecords({
-        mboxText,
-        mboxPath: parsedPayloadRef.mboxPath,
-        capturedMailbox,
-        liveAccount: input.gmailHistoricalReplay.liveAccount,
-        projectInboxAliases: replayProjectInboxAliases,
-        projectInboxAliasOverride: gmailDetail.projectInboxAlias,
-        receivedAt: target.sourceEvidence.receivedAt
-      });
-      importedRecordsByCacheKey.set(cacheKey, importedRecords);
-    }
-
-    const replayedRecord = importedRecords[parsedPayloadRef.messageNumber - 1];
-
-    if (
-      replayedRecord?.recordType !== target.sourceEvidence.providerRecordType ||
-      replayedRecord.recordId !== target.sourceEvidence.providerRecordId
-    ) {
-      throw new Error(
-        `Unable to reconstruct Gmail historical replay record ${buildRecordKey(target.sourceEvidence)} from ${parsedPayloadRef.mboxPath}#message=${String(parsedPayloadRef.messageNumber)}.`
-      );
-    }
-
-    recordsBySourceEvidenceId.set(target.sourceEvidence.id, replayedRecord);
-  }
-
-  return recordsBySourceEvidenceId;
-}
-
-async function captureReplayGroup(input: {
-  readonly capture: Stage1ProviderCapturePorts;
-  readonly provider: Provider;
-  readonly mode: Stage1OrchestrationMode;
-  readonly targets: readonly ReconcileTarget[];
-}): Promise<Map<string, CapturedProviderRecord>> {
-  const recordIds = uniqueStrings(
-    input.targets.map((target) => target.sourceEvidence.providerRecordId)
-  );
-  const maxRecords = Math.max(1, Math.min(recordIds.length, 1000));
-  const basePayload = {
-    version: stage1JobVersion,
-    jobId: buildOperationId("stage1:identity-reconcile:job"),
-    correlationId: buildOperationId("stage1:identity-reconcile:correlation"),
-    traceId: null,
-    batchId: buildOperationId("stage1:identity-reconcile:batch"),
-    syncStateId: buildOperationId("stage1:identity-reconcile:sync-state"),
-    attempt: 1,
-    maxAttempts: 1,
-    cursor: null,
-    checkpoint: null,
-    windowStart: null,
-    windowEnd: null,
-    recordIds,
-    maxRecords
-  } as const;
-  const response =
-    input.provider === "gmail"
-      ? await input.capture.gmail.captureLiveBatch({
-          ...basePayload,
-          provider: "gmail",
-          mode: "live",
-          jobType: "live_ingest"
-        })
-      : input.provider === "salesforce"
-        ? input.mode === "historical"
-          ? await input.capture.salesforce.captureHistoricalBatch({
-              ...basePayload,
-              provider: "salesforce",
-              mode: "historical",
-              jobType: "historical_backfill"
-            })
-          : await input.capture.salesforce.captureLiveBatch({
-              ...basePayload,
-              provider: "salesforce",
-              mode: "live",
-              jobType: "live_ingest"
-            })
-        : input.provider === "simpletexting"
-          ? input.mode === "historical"
-            ? await input.capture.simpleTexting.captureHistoricalBatch({
-                ...basePayload,
-                provider: "simpletexting",
-                mode: "historical",
-                jobType: "historical_backfill"
-              })
-            : await input.capture.simpleTexting.captureLiveBatch({
-                ...basePayload,
-                provider: "simpletexting",
-                mode: "live",
-                jobType: "live_ingest"
-              })
-          : input.mode === "historical"
-            ? await input.capture.mailchimp.captureHistoricalBatch({
-                ...basePayload,
-                provider: "mailchimp",
-                mode: "historical",
-                jobType: "historical_backfill"
-              })
-            : await input.capture.mailchimp.captureTransitionBatch({
-                ...basePayload,
-                provider: "mailchimp",
-                mode: "transition_live",
-                jobType: "live_ingest"
-              });
-
-  return new Map(
-    response.records.map((record) => [
-      buildRecordKey({
-        providerRecordType: record.recordType,
-        providerRecordId: record.recordId
-      }),
-      record
-    ])
-  );
-}
-
-async function loadCapturedRecordsForTargets(input: {
-  readonly repositories: Stage1RepositoryBundle;
-  readonly capture: Stage1ProviderCapturePorts;
-  readonly targets: readonly ReconcileTarget[];
-  readonly gmailHistoricalReplay: GmailHistoricalReplayConfig;
-}): Promise<{
-  readonly recordsBySourceEvidenceId: ReadonlyMap<string, CapturedProviderRecord>;
-  readonly errors: readonly ReconcileError[];
-}> {
-  const recordsBySourceEvidenceId = new Map<string, CapturedProviderRecord>();
-  const errors: ReconcileError[] = [];
-  const gmailHistoricalTargets = input.targets.filter(
-    (target) =>
-      target.sourceEvidence.provider === "gmail" && target.mode === "historical"
-  );
-
-  if (gmailHistoricalTargets.length > 0) {
-    try {
-      const historicalRecords = await loadHistoricalGmailRecords({
-        repositories: input.repositories,
-        targets: gmailHistoricalTargets,
-        gmailHistoricalReplay: input.gmailHistoricalReplay
-      });
-
-      for (const [sourceEvidenceId, record] of historicalRecords.entries()) {
-        recordsBySourceEvidenceId.set(sourceEvidenceId, record);
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-
-      for (const target of gmailHistoricalTargets) {
-        errors.push({
-          caseId: target.caseRecord.id,
-          sourceEvidenceId: target.sourceEvidence.id,
-          provider: target.sourceEvidence.provider,
-          providerRecordType: target.sourceEvidence.providerRecordType,
-          providerRecordId: target.sourceEvidence.providerRecordId,
-          message
-        });
-      }
-    }
-  }
-
-  const groupedTargets = new Map<string, ReconcileTarget[]>();
-
-  for (const target of input.targets) {
-    if (
-      target.sourceEvidence.provider === "gmail" &&
-      target.mode === "historical"
-    ) {
-      continue;
-    }
-
-    const key = `${target.sourceEvidence.provider}:${target.mode}`;
-    const existing = groupedTargets.get(key) ?? [];
-    existing.push(target);
-    groupedTargets.set(key, existing);
-  }
-
-  for (const groupTargets of groupedTargets.values()) {
-    const groupLead = groupTargets[0];
-
-    if (groupLead === undefined) {
-      continue;
-    }
-
-    try {
-      const recordsByRecordKey = await captureReplayGroup({
-        capture: input.capture,
-        provider: groupLead.sourceEvidence.provider,
-        mode: groupLead.mode,
-        targets: groupTargets
-      });
-
-      for (const target of groupTargets) {
-        const record = recordsByRecordKey.get(buildRecordKey(target.sourceEvidence));
-
-        if (record === undefined) {
-          errors.push({
-            caseId: target.caseRecord.id,
-            sourceEvidenceId: target.sourceEvidence.id,
-            provider: target.sourceEvidence.provider,
-            providerRecordType: target.sourceEvidence.providerRecordType,
-            providerRecordId: target.sourceEvidence.providerRecordId,
-            message:
-              "Replay capture did not return the expected provider-close record."
-          });
-          continue;
-        }
-
-        recordsBySourceEvidenceId.set(target.sourceEvidence.id, record);
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-
-      for (const target of groupTargets) {
-        errors.push({
-          caseId: target.caseRecord.id,
-          sourceEvidenceId: target.sourceEvidence.id,
-          provider: target.sourceEvidence.provider,
-          providerRecordType: target.sourceEvidence.providerRecordType,
-          providerRecordId: target.sourceEvidence.providerRecordId,
-          message
-        });
-      }
-    }
-  }
-
-  return {
-    recordsBySourceEvidenceId,
-    errors
-  };
-}
-
-async function ingestCapturedRecord(input: {
-  readonly ingest: Stage1IngestService;
-  readonly target: ReconcileTarget;
-  readonly record: CapturedProviderRecord;
-}): Promise<Stage1IngestResult> {
-  switch (input.target.sourceEvidence.provider) {
-    case "gmail":
-      return input.target.mode === "historical"
-        ? input.ingest.ingestGmailHistoricalRecord(input.record as GmailRecord)
-        : input.ingest.ingestGmailLiveRecord(input.record as GmailRecord);
-    case "salesforce":
-      return input.target.mode === "historical"
-        ? input.ingest.ingestSalesforceHistoricalRecord(
-            input.record as SalesforceRecord
-          )
-        : input.ingest.ingestSalesforceLiveRecord(input.record as SalesforceRecord);
-    case "simpletexting":
-      return input.target.mode === "historical"
-        ? input.ingest.ingestSimpleTextingHistoricalRecord(
-            input.record as SimpleTextingRecord
-          )
-        : input.ingest.ingestSimpleTextingLiveRecord(
-            input.record as SimpleTextingRecord
-          );
-    case "mailchimp":
-      return input.target.mode === "historical"
-        ? input.ingest.ingestMailchimpHistoricalRecord(
-            input.record as MailchimpRecord
-          )
-        : input.ingest.ingestMailchimpTransitionRecord(
-            input.record as MailchimpRecord
-          );
-    case "manual":
-      throw new Error("Manual source evidence cannot be re-ingested here.");
-  }
-}
-
-function ingestedCanonicalEvent(
-  result: Stage1IngestResult
-): result is Extract<
-  Stage1IngestResult,
-  { readonly canonicalEventId: string; readonly contactId: string }
-> {
-  return (
-    (result.outcome === "normalized" || result.outcome === "duplicate") &&
-    result.commandKind === "canonical_event" &&
-    result.canonicalEventId !== null &&
-    result.contactId !== null
-  );
-}
-
-function replayCreatedCanonicalEvent(
-  result: Stage1IngestResult
-): result is Extract<
-  Stage1IngestResult,
-  {
-    readonly outcome: "review_opened";
-    readonly canonicalEventId: string;
-    readonly contactId: string;
-  }
-> {
-  return (
-    result.outcome === "review_opened" &&
-    result.canonicalEventId !== null &&
-    result.contactId !== null
-  );
-}
-
-function shouldCloseOriginalCase(result: Stage1IngestResult): boolean {
-  if (ingestedCanonicalEvent(result) || replayCreatedCanonicalEvent(result)) {
+function shouldCloseOriginalCase(result: NormalizedCanonicalEventResult): boolean {
+  if (result.outcome === "applied" || result.outcome === "duplicate") {
     return true;
   }
 
-  if (result.outcome !== "review_opened") {
+  if (result.outcome !== "needs_identity_review") {
     return false;
   }
 
-  return result.reviewCases.some(
-    (reviewCase) =>
-      reviewCase.queue === "identity" &&
-      reviewCase.reasonCode !== "identity_missing_anchor"
-  );
+  return result.identityCase.reasonCode !== "identity_missing_anchor";
 }
 
 async function markIdentityCaseResolved(input: {
@@ -637,7 +159,7 @@ async function markIdentityCaseResolved(input: {
     ...input.caseRecord,
     status: "resolved",
     resolvedAt: input.resolvedAt,
-    explanation: `${input.caseRecord.explanation} Reconciled by replay.`
+    explanation: `${input.caseRecord.explanation} Reconciled from stored evidence.`
   });
 }
 
@@ -646,11 +168,17 @@ function classifyExecution(input: {
   readonly execution: ReconcileExecutionResult;
 }): ReconcileReport {
   const { report, execution } = input;
-  const { ingestResult } = execution;
+
+  if (execution.kind === "skipped") {
+    return {
+      ...report,
+      skipped: report.skipped + 1
+    };
+  }
 
   if (
-    ingestedCanonicalEvent(ingestResult) ||
-    replayCreatedCanonicalEvent(ingestResult)
+    execution.normalizationResult.outcome === "applied" ||
+    execution.normalizationResult.outcome === "duplicate"
   ) {
     return {
       ...report,
@@ -668,7 +196,6 @@ function classifyExecution(input: {
 async function executeTarget(input: {
   readonly db: Stage1Database;
   readonly target: ReconcileTarget;
-  readonly record: CapturedProviderRecord;
   readonly dryRun: boolean;
 }): Promise<ReconcileExecutionResult> {
   const processedAt = new Date().toISOString();
@@ -678,25 +205,46 @@ async function executeTarget(input: {
     const repositories = createStage1RepositoryBundle(tx);
     const persistence = createStage1PersistenceService(repositories);
     const normalization = createStage1NormalizationService(persistence);
-    const ingest = createStage1IngestService(normalization);
-    const beforeContactCount = (await repositories.contacts.listAll()).length;
-    const ingestResult = await ingestCapturedRecord({
-      ingest,
-      target: input.target,
-      record: input.record
+    const currentCase = await repositories.identityResolutionQueue.findById(
+      input.target.caseRecord.id
+    );
+
+    if (
+      currentCase?.status !== "open" ||
+      currentCase.reasonCode !== "identity_missing_anchor"
+    ) {
+      execution = {
+        kind: "skipped"
+      };
+
+      if (input.dryRun) {
+        throw new DryRunRollback();
+      }
+
+      return;
+    }
+
+    const normalizedIntake = await buildEventFromStoredData({
+      repositories,
+      sourceEvidence: input.target.sourceEvidence,
+      caseRecord: currentCase
     });
+    const beforeContactCount = (await repositories.contacts.listAll()).length;
+    const normalizationResult =
+      await normalization.applyNormalizedCanonicalEvent(normalizedIntake);
     const afterContactCount = (await repositories.contacts.listAll()).length;
 
-    if (shouldCloseOriginalCase(ingestResult)) {
+    if (shouldCloseOriginalCase(normalizationResult)) {
       await markIdentityCaseResolved({
         repositories,
-        caseRecord: input.target.caseRecord,
+        caseRecord: currentCase,
         resolvedAt: processedAt
       });
     }
 
     execution = {
-      ingestResult,
+      kind: "processed",
+      normalizationResult,
       createdNewContact: afterContactCount > beforeContactCount
     };
 
@@ -748,53 +296,11 @@ export async function reconcileIdentityQueue(
   const batches = chunkValues(initialTargets.targets, DEFAULT_BATCH_SIZE);
 
   for (const [batchIndex, batch] of batches.entries()) {
-    const captured = await loadCapturedRecordsForTargets({
-      repositories: input.repositories,
-      capture: input.capture,
-      targets: batch,
-      gmailHistoricalReplay: input.gmailHistoricalReplay
-    });
-
-    report = {
-      ...report,
-      errors: [...report.errors, ...captured.errors]
-    };
-
-    const erroredSourceEvidenceIds = new Set(
-      captured.errors.map((error) => error.sourceEvidenceId)
-    );
-
     for (const target of batch) {
-      if (erroredSourceEvidenceIds.has(target.sourceEvidence.id)) {
-        continue;
-      }
-
-      const record = captured.recordsBySourceEvidenceId.get(target.sourceEvidence.id);
-
-      if (record === undefined) {
-        report = {
-          ...report,
-          errors: [
-            ...report.errors,
-            {
-              caseId: target.caseRecord.id,
-              sourceEvidenceId: target.sourceEvidence.id,
-              provider: target.sourceEvidence.provider,
-              providerRecordType: target.sourceEvidence.providerRecordType,
-              providerRecordId: target.sourceEvidence.providerRecordId,
-              message:
-                "Replay preparation finished without a captured provider-close record."
-            }
-          ]
-        };
-        continue;
-      }
-
       try {
         const execution = await executeTarget({
           db: input.db,
           target,
-          record,
           dryRun: input.dryRun
         });
 

--- a/apps/worker/test/stage1-reconcile-identity-queue.test.ts
+++ b/apps/worker/test/stage1-reconcile-identity-queue.test.ts
@@ -2,74 +2,9 @@ import { describe, expect, it } from "vitest";
 
 import { reconcileIdentityQueue } from "../src/ops/reconcile-identity-queue.js";
 import {
-  createEmptyCapturePorts,
   createTestWorkerContext,
   type TestWorkerContext
 } from "./helpers.js";
-
-function buildGmailMessageRecord(input: {
-  readonly recordId: string;
-  readonly occurredAt: string;
-  readonly receivedAt: string;
-  readonly normalizedParticipantEmails: readonly string[];
-}) {
-  return {
-    recordType: "message" as const,
-    recordId: input.recordId,
-    direction: "inbound" as const,
-    occurredAt: input.occurredAt,
-    receivedAt: input.receivedAt,
-    payloadRef: `capture://gmail/${input.recordId}`,
-    checksum: `checksum:${input.recordId}`,
-    snippet: `snippet:${input.recordId}`,
-    subject: `subject:${input.recordId}`,
-    snippetClean: `snippet:${input.recordId}`,
-    bodyTextPreview: `body:${input.recordId}`,
-    threadId: `thread:${input.recordId}`,
-    rfc822MessageId: `<${input.recordId}@example.org>`,
-    capturedMailbox: "volunteers@adventurescientists.org",
-    projectInboxAlias: null,
-    normalizedParticipantEmails: [...input.normalizedParticipantEmails],
-    salesforceContactId: null,
-    volunteerIdPlainValues: [],
-    normalizedPhones: [],
-    supportingRecords: [],
-    crossProviderCollapseKey: null
-  };
-}
-
-async function seedReplayCandidate(
-  context: TestWorkerContext,
-  input: {
-    readonly sourceEvidenceId: string;
-    readonly providerRecordId: string;
-    readonly receivedAt: string;
-  }
-): Promise<void> {
-  await context.repositories.sourceEvidence.append({
-    id: input.sourceEvidenceId,
-    provider: "gmail",
-    providerRecordType: "message",
-    providerRecordId: input.providerRecordId,
-    receivedAt: input.receivedAt,
-    occurredAt: input.receivedAt,
-    payloadRef: `capture://gmail/${input.providerRecordId}`,
-    idempotencyKey: `source-evidence:gmail:message:${input.providerRecordId}`,
-    checksum: `checksum:${input.providerRecordId}`
-  });
-  await context.repositories.identityResolutionQueue.upsert({
-    id: `identity-review:${input.sourceEvidenceId}:identity_missing_anchor`,
-    sourceEvidenceId: input.sourceEvidenceId,
-    candidateContactIds: [],
-    reasonCode: "identity_missing_anchor",
-    status: "open",
-    openedAt: input.receivedAt,
-    resolvedAt: null,
-    normalizedIdentityValues: [],
-    anchoredContactId: null,
-    explanation: "Seeded stuck identity review case for reconciliation."
-  });
-}
 
 async function seedExistingEmailContact(
   context: TestWorkerContext,
@@ -104,48 +39,135 @@ async function seedExistingEmailContact(
   });
 }
 
+async function seedOpenIdentityMissingAnchorCase(
+  context: TestWorkerContext,
+  input: {
+    readonly sourceEvidenceId: string;
+    readonly normalizedIdentityValues: readonly string[];
+    readonly openedAt: string;
+  }
+): Promise<void> {
+  await context.repositories.identityResolutionQueue.upsert({
+    id: `identity-review:${input.sourceEvidenceId}:identity_missing_anchor`,
+    sourceEvidenceId: input.sourceEvidenceId,
+    candidateContactIds: [],
+    reasonCode: "identity_missing_anchor",
+    status: "open",
+    openedAt: input.openedAt,
+    resolvedAt: null,
+    normalizedIdentityValues: [...input.normalizedIdentityValues],
+    anchoredContactId: null,
+    explanation: "Seeded stuck identity review case for reconciliation."
+  });
+}
+
+async function seedStoredGmailCase(
+  context: TestWorkerContext,
+  input: {
+    readonly recordId: string;
+    readonly payloadRef: string;
+    readonly normalizedIdentityValues: readonly string[];
+    readonly subject: string;
+    readonly occurredAt: string;
+    readonly receivedAt: string;
+  }
+): Promise<void> {
+  const sourceEvidenceId = `source-evidence:gmail:message:${input.recordId}`;
+
+  await context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "gmail",
+    providerRecordType: "message",
+    providerRecordId: input.recordId,
+    receivedAt: input.receivedAt,
+    occurredAt: input.occurredAt,
+    payloadRef: input.payloadRef,
+    idempotencyKey: `source-evidence:gmail:message:${input.recordId}`,
+    checksum: `checksum:${input.recordId}`
+  });
+  await context.repositories.gmailMessageDetails.upsert({
+    sourceEvidenceId,
+    providerRecordId: input.recordId,
+    gmailThreadId: `thread:${input.recordId}`,
+    rfc822MessageId: `<${input.recordId}@example.org>`,
+    direction: "inbound",
+    subject: input.subject,
+    snippetClean: `snippet:${input.recordId}`,
+    bodyTextPreview: `body:${input.recordId}`,
+    capturedMailbox: "volunteers@adventurescientists.org",
+    projectInboxAlias: null
+  });
+  await seedOpenIdentityMissingAnchorCase(context, {
+    sourceEvidenceId,
+    normalizedIdentityValues: input.normalizedIdentityValues,
+    openedAt: input.receivedAt
+  });
+}
+
+async function seedStoredSalesforceCase(
+  context: TestWorkerContext,
+  input: {
+    readonly recordId: string;
+    readonly normalizedIdentityValues: readonly string[];
+    readonly subject: string;
+    readonly occurredAt: string;
+    readonly receivedAt: string;
+  }
+): Promise<void> {
+  const sourceEvidenceId =
+    `source-evidence:salesforce:task_communication:${input.recordId}`;
+
+  await context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "salesforce",
+    providerRecordType: "task_communication",
+    providerRecordId: input.recordId,
+    receivedAt: input.receivedAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `capture://salesforce/${input.recordId}`,
+    idempotencyKey: `source-evidence:salesforce:task_communication:${input.recordId}`,
+    checksum: `checksum:${input.recordId}`
+  });
+  await context.repositories.salesforceCommunicationDetails.upsert({
+    sourceEvidenceId,
+    providerRecordId: input.recordId,
+    channel: "email",
+    messageKind: "one_to_one",
+    subject: input.subject,
+    snippet: `snippet:${input.recordId}`,
+    sourceLabel: "Salesforce Task"
+  });
+  await context.repositories.salesforceEventContext.upsert({
+    sourceEvidenceId,
+    salesforceContactId: null,
+    projectId: null,
+    expeditionId: null,
+    sourceField: null
+  });
+  await seedOpenIdentityMissingAnchorCase(context, {
+    sourceEvidenceId,
+    normalizedIdentityValues: input.normalizedIdentityValues,
+    openedAt: input.receivedAt
+  });
+}
+
 async function createReconcileContext(): Promise<TestWorkerContext> {
-  const capture = createEmptyCapturePorts();
-  const recordsById = new Map(
-    [
-      buildGmailMessageRecord({
-        recordId: "gmail-known-1",
-        occurredAt: "2026-01-01T00:01:00.000Z",
-        receivedAt: "2026-01-01T00:01:00.000Z",
-        normalizedParticipantEmails: ["known@example.org"]
-      }),
-      buildGmailMessageRecord({
-        recordId: "gmail-new-1",
-        occurredAt: "2026-01-01T00:02:00.000Z",
-        receivedAt: "2026-01-01T00:02:00.000Z",
-        normalizedParticipantEmails: ["fresh@example.org"]
-      }),
-      buildGmailMessageRecord({
-        recordId: "gmail-ambiguous-1",
-        occurredAt: "2026-01-01T00:03:00.000Z",
-        receivedAt: "2026-01-01T00:03:00.000Z",
-        normalizedParticipantEmails: ["shared@example.org"]
-      })
-    ].map((record) => [record.recordId, record] as const)
-  );
-
-  capture.gmail.captureLiveBatch = (payload) => Promise.resolve({
-    records: payload.recordIds.flatMap((recordId: string) => {
-      const record = recordsById.get(recordId);
-      return record === undefined ? [] : [record];
-    }),
-    nextCursor: null,
-    checkpoint: payload.recordIds.at(-1) ?? null
-  });
-
-  const context = await createTestWorkerContext({
-    capture
-  });
+  const context = await createTestWorkerContext();
 
   await seedExistingEmailContact(context, {
-    contactId: "contact_known",
-    email: "known@example.org",
-    displayName: "Known Contact"
+    contactId: "contact_live_known",
+    email: "known-live@example.org",
+    displayName: "Known Live Contact"
+  });
+  await seedExistingEmailContact(context, {
+    contactId: "contact_mbox_known",
+    email: "known-mbox@example.org",
+    displayName: "Known Mbox Contact"
+  });
+  await seedExistingEmailContact(context, {
+    contactId: "contact_salesforce_known",
+    email: "known-salesforce@example.org",
+    displayName: "Known Salesforce Contact"
   });
   await seedExistingEmailContact(context, {
     contactId: "contact_shared_1",
@@ -158,27 +180,52 @@ async function createReconcileContext(): Promise<TestWorkerContext> {
     displayName: "Shared Contact Two"
   });
 
-  await seedReplayCandidate(context, {
-    sourceEvidenceId: "source-evidence:gmail:message:gmail-known-1",
-    providerRecordId: "gmail-known-1",
+  await seedStoredGmailCase(context, {
+    recordId: "gmail-live-known",
+    payloadRef: "capture://gmail/gmail-live-known",
+    normalizedIdentityValues: ["known-live@example.org"],
+    subject: "Known live message",
+    occurredAt: "2026-01-01T00:01:00.000Z",
     receivedAt: "2026-01-01T00:01:00.000Z"
   });
-  await seedReplayCandidate(context, {
-    sourceEvidenceId: "source-evidence:gmail:message:gmail-new-1",
-    providerRecordId: "gmail-new-1",
+  await seedStoredGmailCase(context, {
+    recordId: "gmail-mbox-known",
+    payloadRef:
+      "mbox://%2Fdefinitely%2Fmissing%2Forcas.mbox#message=17",
+    normalizedIdentityValues: ["known-mbox@example.org"],
+    subject: "Known mbox message",
+    occurredAt: "2026-01-01T00:02:00.000Z",
     receivedAt: "2026-01-01T00:02:00.000Z"
   });
-  await seedReplayCandidate(context, {
-    sourceEvidenceId: "source-evidence:gmail:message:gmail-ambiguous-1",
-    providerRecordId: "gmail-ambiguous-1",
+  await seedStoredSalesforceCase(context, {
+    recordId: "sf-known-1",
+    normalizedIdentityValues: ["known-salesforce@example.org"],
+    subject: "Re: Known Salesforce message",
+    occurredAt: "2026-01-01T00:03:00.000Z",
     receivedAt: "2026-01-01T00:03:00.000Z"
+  });
+  await seedStoredGmailCase(context, {
+    recordId: "gmail-new-1",
+    payloadRef: "capture://gmail/gmail-new-1",
+    normalizedIdentityValues: ["fresh@example.org"],
+    subject: "Fresh message",
+    occurredAt: "2026-01-01T00:04:00.000Z",
+    receivedAt: "2026-01-01T00:04:00.000Z"
+  });
+  await seedStoredGmailCase(context, {
+    recordId: "gmail-ambiguous-1",
+    payloadRef: "capture://gmail/gmail-ambiguous-1",
+    normalizedIdentityValues: ["shared@example.org"],
+    subject: "Shared identity message",
+    occurredAt: "2026-01-01T00:05:00.000Z",
+    receivedAt: "2026-01-01T00:05:00.000Z"
   });
 
   return context;
 }
 
 describe("reconcileIdentityQueue", () => {
-  it("reports resolved, created, and skipped counts in dry-run mode without mutating queue or ledger state", async () => {
+  it("reconstructs Gmail live, Gmail mbox, and Salesforce cases from stored rows in dry-run mode", async () => {
     const context = await createReconcileContext();
 
     try {
@@ -198,8 +245,8 @@ describe("reconcileIdentityQueue", () => {
 
       expect(report).toMatchObject({
         dryRun: true,
-        scanned: 3,
-        resolved: 1,
+        scanned: 5,
+        resolved: 3,
         created: 1,
         skipped: 1
       });
@@ -211,14 +258,14 @@ describe("reconcileIdentityQueue", () => {
         context.repositories.identityResolutionQueue.listOpenByReasonCode(
           "identity_missing_anchor"
         )
-      ).resolves.toHaveLength(3);
-      await expect(context.repositories.contacts.listAll()).resolves.toHaveLength(3);
+      ).resolves.toHaveLength(5);
+      await expect(context.repositories.contacts.listAll()).resolves.toHaveLength(5);
     } finally {
       await context.dispose();
     }
   });
 
-  it("replays stuck items into resolved, created, and reclassified queue outcomes when executed", async () => {
+  it("reconciles stored Gmail live, Gmail mbox, and Salesforce cases without filesystem access when executed", async () => {
     const context = await createReconcileContext();
 
     try {
@@ -238,15 +285,15 @@ describe("reconcileIdentityQueue", () => {
 
       expect(report).toMatchObject({
         dryRun: false,
-        scanned: 3,
-        resolved: 1,
+        scanned: 5,
+        resolved: 3,
         created: 1,
         skipped: 1
       });
       expect(report.errors).toEqual([]);
       await expect(
         context.repositories.canonicalEvents.countAll()
-      ).resolves.toBe(2);
+      ).resolves.toBe(4);
       await expect(
         context.repositories.contacts.findById("contact:email:fresh@example.org")
       ).resolves.toMatchObject({
@@ -263,6 +310,60 @@ describe("reconcileIdentityQueue", () => {
           "identity_multi_candidate"
         )
       ).resolves.toHaveLength(1);
+      await expect(context.repositories.contacts.listAll()).resolves.toHaveLength(6);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("is idempotent on rerun after the original stuck cases have already been cleared", async () => {
+    const context = await createReconcileContext();
+
+    try {
+      const first = await reconcileIdentityQueue({
+        db: context.db,
+        repositories: context.repositories,
+        capture: context.capture,
+        gmailHistoricalReplay: {
+          liveAccount: "volunteers@adventurescientists.org",
+          projectInboxAliases: ["orcas@adventurescientists.org"]
+        },
+        dryRun: false,
+        logger: {
+          log: () => undefined
+        }
+      });
+      const second = await reconcileIdentityQueue({
+        db: context.db,
+        repositories: context.repositories,
+        capture: context.capture,
+        gmailHistoricalReplay: {
+          liveAccount: "volunteers@adventurescientists.org",
+          projectInboxAliases: ["orcas@adventurescientists.org"]
+        },
+        dryRun: false,
+        logger: {
+          log: () => undefined
+        }
+      });
+
+      expect(first).toMatchObject({
+        scanned: 5,
+        resolved: 3,
+        created: 1,
+        skipped: 1
+      });
+      expect(second).toEqual({
+        dryRun: false,
+        scanned: 0,
+        resolved: 0,
+        created: 0,
+        skipped: 0,
+        errors: []
+      });
+      await expect(
+        context.repositories.canonicalEvents.countAll()
+      ).resolves.toBe(4);
     } finally {
       await context.dispose();
     }


### PR DESCRIPTION
## Summary

Rewrites `reconcile-identity-queue` to reconstruct canonical events from the DB (`source_evidence_log` + detail tables) instead of re-parsing mbox files. The original script (PR #73) assumed mbox files were accessible to the worker container; they're not.

## Why

Dry-run against prod (2026-04-21 post-#73) returned:
- Scanned 500 cases, 5 batches
- Resolved: 0, Created: 0, Errors: 499
- Single unique error: `ENOENT: no such file or directory, open '/Users/nicolas/Downloads/AS Comms Platform/mbox files/orcas.mbox'`

Error affected BOTH Gmail mbox AND Salesforce cases, confirming every code path was routed through mbox parsing. The whole 10,881-case reconcile backlog was blocked on this.

## Changes

- `apps/worker/src/ops/_reconcile-from-stored-evidence.ts` (new) — intake builder that reads `source_evidence_log` + detail tables, synthesizes `NormalizedCanonicalEventIntake`.
- `apps/worker/src/ops/reconcile-identity-queue.ts` — rewritten replay path. Drops `importedRecordsByCacheKey`, `mboxTextByPath`, all filesystem calls. Runs stored intake through normalization, preserves report shape + transaction/error behavior.
- `apps/worker/test/stage1-reconcile-identity-queue.test.ts` — seeds DB directly, covers Gmail-live / Gmail-mbox-with-dead-fs-path / Salesforce / create-new-contact / idempotent rerun.

## Prod ops plan

1. Merge
2. Deploy worker (Railway auto-deploys on merge)
3. Dry-run: `railway ssh --service worker "node dist/ops/cli.js reconcile-identity-queue"` — architect reviews
4. Canary `--execute --limit=100` (architect sign-off)
5. Full `--execute` (architect sign-off)

Expected: ~9,480 resolved (match existing contacts) + ~1,496 created (D-027 new-contact path) + handful of genuinely unresolvable.

## Test plan

- [ ] CI green — Codex verified `pnpm test:unit`, `pnpm lint`, `pnpm typecheck` locally
- [ ] Post-deploy dry-run against prod: ZERO ENOENT errors
- [ ] Architect sign-off + canary + full execute

Brief: `.audit-ingestion-2026-04-21/briefs/fix-reconcile-identity-queue.md`