### PR TITLE
feat(integrations): Gmail send client for Composer

### DIFF
--- a/packages/integrations/src/capture-services/gmail.ts
+++ b/packages/integrations/src/capture-services/gmail.ts
@@ -8,8 +8,7 @@ import {
   integrationHealthCheckResponseSchema,
   type GmailHistoricalCaptureBatchPayload,
   type GmailLiveCaptureBatchPayload,
-  type IntegrationHealthCheckResponse,
-  type IntegrationHealthStatus
+  type IntegrationHealthCheckResponse
 } from "@as-comms/contracts";
 import {
   type GmailMessageRecord,
@@ -24,6 +23,11 @@ import {
   extractGmailBodyPreviewFromPayload,
   type GmailApiMessagePart
 } from "../providers/gmail-body.js";
+import {
+  type GmailAccessTokenCacheEntry,
+  GmailOAuthExchangeError,
+  exchangeGmailAccessToken
+} from "../providers/gmail-oauth.js";
 import { z } from "zod";
 
 import type {
@@ -162,29 +166,6 @@ function buildLiveGmailChecksum(message: GmailMessageMetadata): string {
   });
 }
 
-interface GmailAccessTokenCacheEntry {
-  readonly accessToken: string;
-  readonly expiresAtEpochSeconds: number;
-}
-
-class GmailHealthCheckError extends Error {
-  constructor(
-    readonly status: Extract<
-      IntegrationHealthStatus,
-      "needs_attention" | "disconnected"
-    >,
-    message: string
-  ) {
-    super(message);
-    this.name = "GmailHealthCheckError";
-  }
-}
-
-const gmailTokenResponseSchema = z.object({
-  access_token: z.string().min(1),
-  expires_in: z.number().int().positive().default(3600)
-});
-
 const gmailListResponseSchema = z.object({
   messages: z
     .array(
@@ -195,110 +176,6 @@ const gmailListResponseSchema = z.object({
     .default([]),
   nextPageToken: z.string().min(1).optional()
 });
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof Error && error.name === "TimeoutError";
-}
-
-function isDisconnectedGmailTokenError(
-  status: number,
-  responseText: string
-): boolean {
-  if (status !== 400 && status !== 401) {
-    return false;
-  }
-
-  return /(invalid_grant|revoked|permission|access_denied)/iu.test(
-    responseText
-  );
-}
-
-async function exchangeGmailAccessToken(input: {
-  readonly config: ResolvedGmailCaptureServiceConfig;
-  readonly mailbox: string;
-  readonly fetchImplementation: typeof fetch;
-  readonly now: () => Date;
-  readonly accessTokenByMailbox: Map<string, GmailAccessTokenCacheEntry>;
-  readonly timeoutMs: number;
-}): Promise<GmailAccessTokenCacheEntry> {
-  const nowEpochSeconds = Math.floor(input.now().getTime() / 1000);
-  const cachedToken = input.accessTokenByMailbox.get(input.mailbox);
-
-  if (
-    cachedToken !== undefined &&
-    cachedToken.expiresAtEpochSeconds - 30 > nowEpochSeconds
-  ) {
-    return cachedToken;
-  }
-
-  let response: Response;
-
-  try {
-    response = await input.fetchImplementation(input.config.tokenUri, {
-      method: "POST",
-      headers: {
-        accept: "application/json",
-        "content-type": "application/x-www-form-urlencoded"
-      },
-      body: new URLSearchParams({
-        grant_type: "refresh_token",
-        client_id: input.config.oauthClientId,
-        client_secret: input.config.oauthClientSecret,
-        refresh_token: input.config.oauthRefreshToken
-      }).toString(),
-      signal: AbortSignal.timeout(input.timeoutMs)
-    });
-  } catch (error) {
-    if (isAbortError(error)) {
-      throw new GmailHealthCheckError(
-        "needs_attention",
-        "OAuth token exchange timed out."
-      );
-    }
-
-    throw new GmailHealthCheckError(
-      "needs_attention",
-      "OAuth token exchange request failed."
-    );
-  }
-
-  if (!response.ok) {
-    const responseText = await response.text();
-
-    if (isDisconnectedGmailTokenError(response.status, responseText)) {
-      throw new GmailHealthCheckError(
-        "disconnected",
-        "OAuth refresh token expired, was revoked, or lost required permissions."
-      );
-    }
-
-    throw new GmailHealthCheckError(
-      "needs_attention",
-      `OAuth token exchange failed with status ${String(response.status)}.`
-    );
-  }
-
-  let tokenJson: z.infer<typeof gmailTokenResponseSchema>;
-
-  try {
-    tokenJson = gmailTokenResponseSchema.parse(
-      JSON.parse(await response.text()) as unknown
-    );
-  } catch {
-    throw new GmailHealthCheckError(
-      "needs_attention",
-      "OAuth token exchange returned an unexpected response."
-    );
-  }
-
-  const token = {
-    accessToken: tokenJson.access_token,
-    expiresAtEpochSeconds: nowEpochSeconds + tokenJson.expires_in
-  } satisfies GmailAccessTokenCacheEntry;
-  input.accessTokenByMailbox.set(input.mailbox, token);
-
-  return token;
-}
 
 export async function checkGmailCaptureServiceHealth(
   config: GmailCaptureServiceConfig,
@@ -328,12 +205,19 @@ export async function checkGmailCaptureServiceHealth(
 
   try {
     await exchangeGmailAccessToken({
-      config: parsedConfig,
-      mailbox: parsedConfig.liveAccount,
+      config: {
+        oauthClient: {
+          clientId: parsedConfig.oauthClientId,
+          clientSecret: parsedConfig.oauthClientSecret,
+          tokenUri: parsedConfig.tokenUri
+        },
+        oauthRefreshToken: parsedConfig.oauthRefreshToken,
+        timeoutMs
+      },
+      cacheKey: parsedConfig.liveAccount,
       fetchImplementation,
       now,
-      accessTokenByMailbox,
-      timeoutMs
+      accessTokenCache: accessTokenByMailbox
     });
 
     return integrationHealthCheckResponseSchema.parse({
@@ -344,10 +228,13 @@ export async function checkGmailCaptureServiceHealth(
       version: input?.version ?? null
     });
   } catch (error) {
-    if (error instanceof GmailHealthCheckError) {
+    if (error instanceof GmailOAuthExchangeError) {
+      const status =
+        error.reason === "disconnected" ? "disconnected" : "needs_attention";
+
       return integrationHealthCheckResponseSchema.parse({
         service: "gmail",
-        status: error.status,
+        status,
         checkedAt,
         detail: error.message,
         version: input?.version ?? null
@@ -383,12 +270,19 @@ export function createGmailMailboxApiClient(
 
   async function getAccessToken(mailbox: string): Promise<string> {
     const token = await exchangeGmailAccessToken({
-      config: parsedConfig,
-      mailbox,
+      config: {
+        oauthClient: {
+          clientId: parsedConfig.oauthClientId,
+          clientSecret: parsedConfig.oauthClientSecret,
+          tokenUri: parsedConfig.tokenUri
+        },
+        oauthRefreshToken: parsedConfig.oauthRefreshToken,
+        timeoutMs: parsedConfig.timeoutMs
+      },
+      cacheKey: mailbox,
       fetchImplementation,
       now,
-      accessTokenByMailbox,
-      timeoutMs: parsedConfig.timeoutMs
+      accessTokenCache: accessTokenByMailbox
     });
 
     return token.accessToken;

--- a/packages/integrations/src/index.ts
+++ b/packages/integrations/src/index.ts
@@ -16,6 +16,7 @@ export * from "./capture-services/salesforce.js";
 export * from "./providers/gmail.js";
 export * from "./providers/gmail-body.js";
 export * from "./providers/gmail-mbox.js";
+export * from "./providers/gmail-send.js";
 export * from "./providers/gmail-record-builder.js";
 export * from "./providers/mailchimp.js";
 export * from "./providers/salesforce.js";

--- a/packages/integrations/src/providers/gmail-oauth.ts
+++ b/packages/integrations/src/providers/gmail-oauth.ts
@@ -1,0 +1,152 @@
+import { z } from "zod";
+
+const gmailOAuthClientSchema = z.object({
+  clientId: z.string().min(1),
+  clientSecret: z.string().min(1),
+  tokenUri: z.string().url().default("https://oauth2.googleapis.com/token")
+});
+
+const gmailAccessTokenRequestSchema = z.object({
+  oauthClient: gmailOAuthClientSchema,
+  oauthRefreshToken: z.string().min(1),
+  timeoutMs: z.number().int().positive().default(15_000)
+});
+
+export type GmailOAuthClient = z.input<typeof gmailOAuthClientSchema>;
+type ResolvedGmailAccessTokenRequest = z.output<
+  typeof gmailAccessTokenRequestSchema
+>;
+
+export interface GmailAccessTokenCacheEntry {
+  readonly accessToken: string;
+  readonly expiresAtEpochSeconds: number;
+}
+
+export class GmailOAuthExchangeError extends Error {
+  constructor(
+    readonly reason:
+      | "disconnected"
+      | "timeout"
+      | "network"
+      | "invalid_response"
+      | "exchange_failed",
+    message: string
+  ) {
+    super(message);
+    this.name = "GmailOAuthExchangeError";
+  }
+}
+
+const gmailTokenResponseSchema = z.object({
+  access_token: z.string().min(1),
+  expires_in: z.number().int().positive().default(3600)
+});
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "TimeoutError";
+}
+
+function isDisconnectedGmailTokenError(
+  status: number,
+  responseText: string
+): boolean {
+  if (status !== 400 && status !== 401) {
+    return false;
+  }
+
+  return /(invalid_grant|revoked|permission|access_denied)/iu.test(
+    responseText
+  );
+}
+
+export async function exchangeGmailAccessToken(input: {
+  readonly config: {
+    readonly oauthClient: GmailOAuthClient;
+    readonly oauthRefreshToken: string;
+    readonly timeoutMs?: number;
+  };
+  readonly cacheKey: string;
+  readonly fetchImplementation: typeof fetch;
+  readonly now: () => Date;
+  readonly accessTokenCache: Map<string, GmailAccessTokenCacheEntry>;
+}): Promise<GmailAccessTokenCacheEntry> {
+  const parsedConfig: ResolvedGmailAccessTokenRequest =
+    gmailAccessTokenRequestSchema.parse(input.config);
+  const nowEpochSeconds = Math.floor(input.now().getTime() / 1000);
+  const cachedToken = input.accessTokenCache.get(input.cacheKey);
+
+  if (
+    cachedToken !== undefined &&
+    cachedToken.expiresAtEpochSeconds - 30 > nowEpochSeconds
+  ) {
+    return cachedToken;
+  }
+
+  let response: Response;
+
+  try {
+    response = await input.fetchImplementation(parsedConfig.oauthClient.tokenUri, {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        "content-type": "application/x-www-form-urlencoded"
+      },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        client_id: parsedConfig.oauthClient.clientId,
+        client_secret: parsedConfig.oauthClient.clientSecret,
+        refresh_token: parsedConfig.oauthRefreshToken
+      }).toString(),
+      signal: AbortSignal.timeout(parsedConfig.timeoutMs)
+    });
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw new GmailOAuthExchangeError(
+        "timeout",
+        "OAuth token exchange timed out."
+      );
+    }
+
+    throw new GmailOAuthExchangeError(
+      "network",
+      "OAuth token exchange request failed."
+    );
+  }
+
+  if (!response.ok) {
+    const responseText = await response.text();
+
+    if (isDisconnectedGmailTokenError(response.status, responseText)) {
+      throw new GmailOAuthExchangeError(
+        "disconnected",
+        "OAuth refresh token expired, was revoked, or lost required permissions."
+      );
+    }
+
+    throw new GmailOAuthExchangeError(
+      "exchange_failed",
+      `OAuth token exchange failed with status ${String(response.status)}.`
+    );
+  }
+
+  let tokenJson: z.infer<typeof gmailTokenResponseSchema>;
+
+  try {
+    tokenJson = gmailTokenResponseSchema.parse(
+      JSON.parse(await response.text()) as unknown
+    );
+  } catch {
+    throw new GmailOAuthExchangeError(
+      "invalid_response",
+      "OAuth token exchange returned an unexpected response."
+    );
+  }
+
+  const token = {
+    accessToken: tokenJson.access_token,
+    expiresAtEpochSeconds: nowEpochSeconds + tokenJson.expires_in
+  } satisfies GmailAccessTokenCacheEntry;
+  input.accessTokenCache.set(input.cacheKey, token);
+
+  return token;
+}

--- a/packages/integrations/src/providers/gmail-send.ts
+++ b/packages/integrations/src/providers/gmail-send.ts
@@ -1,0 +1,530 @@
+import { randomUUID } from "node:crypto";
+
+import { z } from "zod";
+
+import {
+  type GmailAccessTokenCacheEntry,
+  type GmailOAuthClient,
+  GmailOAuthExchangeError,
+  exchangeGmailAccessToken
+} from "./gmail-oauth.js";
+
+const MAX_ATTACHMENT_TOTAL_BYTES = 20 * 1024 * 1024;
+
+const emailSchema = z.string().email();
+
+const gmailAttachmentSchema = z.object({
+  filename: z.string().min(1),
+  contentType: z.string().min(1),
+  contentBase64: z.string().min(1)
+});
+
+const gmailSendParamsSchema = z.object({
+  fromAlias: emailSchema,
+  to: emailSchema,
+  subject: z.string(),
+  bodyPlaintext: z.string(),
+  attachments: z.array(gmailAttachmentSchema),
+  threadId: z.string().min(1).optional(),
+  inReplyToRfc822MessageId: z.string().min(1).optional(),
+  referencesRfc822MessageIds: z.array(z.string().min(1)).optional()
+});
+
+const gmailSendConfigSchema = z.object({
+  liveAccount: emailSchema,
+  oauthClient: z.object({
+    clientId: z.string().min(1),
+    clientSecret: z.string().min(1),
+    tokenUri: z.string().url().default("https://oauth2.googleapis.com/token")
+  }),
+  oauthRefreshToken: z.string().min(1),
+  fetchImplementation: z.custom<typeof fetch>(
+    (value) => typeof value === "function",
+    {
+      message: "fetchImplementation must be a function."
+    }
+  ),
+  timeoutMs: z.number().int().positive().default(15_000),
+  now: z.function().returns(z.date()).optional(),
+  accessTokenCache: z
+    .custom<Map<string, GmailAccessTokenCacheEntry>>(
+      (value) => value instanceof Map
+    )
+    .optional()
+});
+
+const gmailSendApiSuccessSchema = z.object({
+  id: z.string().min(1),
+  threadId: z.string().min(1).optional()
+});
+
+const gmailApiErrorSchema = z
+  .object({
+    error: z.object({
+      code: z.number().int().optional(),
+      message: z.string().optional(),
+      status: z.string().optional(),
+      errors: z
+        .array(
+          z.object({
+            message: z.string().optional(),
+            domain: z.string().optional(),
+            reason: z.string().optional()
+          })
+        )
+        .optional()
+    })
+  })
+  .partial();
+
+export interface GmailSendParams {
+  readonly fromAlias: string;
+  readonly to: string;
+  readonly subject: string;
+  readonly bodyPlaintext: string;
+  readonly attachments: readonly GmailAttachment[];
+  readonly threadId?: string;
+  readonly inReplyToRfc822MessageId?: string;
+  readonly referencesRfc822MessageIds?: readonly string[];
+}
+
+export interface GmailAttachment {
+  readonly filename: string;
+  readonly contentType: string;
+  readonly contentBase64: string;
+}
+
+export interface GmailSendConfig {
+  readonly liveAccount: string;
+  readonly oauthClient: GmailOAuthClient;
+  readonly oauthRefreshToken: string;
+  readonly fetchImplementation: typeof fetch;
+  readonly timeoutMs?: number;
+  readonly now?: () => Date;
+  readonly accessTokenCache?: Map<string, GmailAccessTokenCacheEntry>;
+}
+
+export interface GmailSendSuccess {
+  readonly kind: "success";
+  readonly gmailMessageId: string;
+  readonly gmailThreadId: string;
+  readonly rfc822MessageId: string;
+}
+
+export type GmailSendError =
+  | { readonly kind: "auth_error"; readonly detail: string }
+  | { readonly kind: "scope_error"; readonly detail: string }
+  | { readonly kind: "send_as_not_authorized"; readonly alias: string }
+  | { readonly kind: "invalid_recipient"; readonly detail: string }
+  | { readonly kind: "attachment_too_large"; readonly totalBytes: number }
+  | { readonly kind: "rate_limited"; readonly retryAfterSeconds: number | null }
+  | { readonly kind: "transient"; readonly detail: string }
+  | { readonly kind: "permanent"; readonly detail: string };
+
+export type GmailSendResult = GmailSendSuccess | GmailSendError;
+
+interface BuiltGmailMimeMessage {
+  readonly raw: string;
+  readonly rfc822MessageId: string;
+}
+
+function normalizeHeaderWhitespace(value: string): string {
+  return value.replace(/\r?\n+/gu, " ").trim();
+}
+
+function normalizeBody(value: string): string {
+  return value.replace(/\r\n/gu, "\n").replace(/\r/gu, "\n").replace(/\n/gu, "\r\n");
+}
+
+function needsEncodedWord(value: string): boolean {
+  return /[^\x20-\x7E]/u.test(value);
+}
+
+function encodeHeaderWordUtf8(value: string): string {
+  const normalizedValue = normalizeHeaderWhitespace(value);
+
+  if (normalizedValue.length === 0) {
+    return "";
+  }
+
+  if (!needsEncodedWord(normalizedValue)) {
+    return normalizedValue;
+  }
+
+  return `=?UTF-8?B?${Buffer.from(normalizedValue, "utf8").toString("base64")}?=`;
+}
+
+function foldBase64(value: string): string {
+  return value.replace(/.{1,76}/gu, "$&\r\n").replace(/\r\n$/u, "");
+}
+
+function escapeQuotedHeaderValue(value: string): string {
+  return value.replace(/(["\\])/gu, "\\$1");
+}
+
+function buildMessageId(fromAlias: string, now: Date): string {
+  const domain = fromAlias.split("@")[1] ?? "local.invalid";
+  return `<${String(now.getTime())}.${randomUUID()}@${domain}>`;
+}
+
+function buildBoundary(): string {
+  return `ascomms_${randomUUID()}`;
+}
+
+function countAttachmentBytes(attachments: readonly GmailAttachment[]): number {
+  let totalBytes = 0;
+
+  for (const attachment of attachments) {
+    totalBytes += Buffer.from(attachment.contentBase64, "base64").length;
+  }
+
+  return totalBytes;
+}
+
+function buildTextPart(bodyPlaintext: string): string {
+  return [
+    "Content-Type: text/plain; charset=UTF-8",
+    "Content-Transfer-Encoding: 8bit",
+    "",
+    normalizeBody(bodyPlaintext)
+  ].join("\r\n");
+}
+
+function buildAttachmentPart(attachment: GmailAttachment): string {
+  return [
+    `Content-Type: ${normalizeHeaderWhitespace(attachment.contentType)}; name="${escapeQuotedHeaderValue(attachment.filename)}"`,
+    "Content-Transfer-Encoding: base64",
+    `Content-Disposition: attachment; filename="${escapeQuotedHeaderValue(attachment.filename)}"`,
+    "",
+    foldBase64(
+      Buffer.from(attachment.contentBase64, "base64").toString("base64")
+    )
+  ].join("\r\n");
+}
+
+function buildMimeMessage(
+  params: z.output<typeof gmailSendParamsSchema>,
+  now: Date
+): BuiltGmailMimeMessage {
+  const rfc822MessageId = buildMessageId(params.fromAlias, now);
+  const headers = [
+    `Date: ${now.toUTCString()}`,
+    `From: <${params.fromAlias}>`,
+    `To: <${params.to}>`,
+    `Subject: ${encodeHeaderWordUtf8(params.subject)}`,
+    `Message-ID: ${rfc822MessageId}`,
+    "MIME-Version: 1.0"
+  ];
+
+  if (params.inReplyToRfc822MessageId !== undefined) {
+    headers.push(
+      `In-Reply-To: ${normalizeHeaderWhitespace(params.inReplyToRfc822MessageId)}`
+    );
+  }
+
+  if (
+    params.referencesRfc822MessageIds !== undefined &&
+    params.referencesRfc822MessageIds.length > 0
+  ) {
+    headers.push(
+      `References: ${params.referencesRfc822MessageIds
+        .map((messageId) => normalizeHeaderWhitespace(messageId))
+        .join(" ")}`
+    );
+  }
+
+  if (params.attachments.length === 0) {
+    const message = [
+      ...headers,
+      "Content-Type: text/plain; charset=UTF-8",
+      "Content-Transfer-Encoding: 8bit",
+      "",
+      normalizeBody(params.bodyPlaintext)
+    ].join("\r\n");
+
+    return {
+      raw: Buffer.from(message, "utf8").toString("base64url"),
+      rfc822MessageId
+    };
+  }
+
+  const boundary = buildBoundary();
+  const parts = [
+    `--${boundary}`,
+    buildTextPart(params.bodyPlaintext),
+    ...params.attachments.flatMap((attachment) => [
+      `--${boundary}`,
+      buildAttachmentPart(attachment)
+    ]),
+    `--${boundary}--`,
+    ""
+  ];
+  const message = [
+    ...headers,
+    `Content-Type: multipart/mixed; boundary="${boundary}"`,
+    "",
+    parts.join("\r\n")
+  ].join("\r\n");
+
+  return {
+    raw: Buffer.from(message, "utf8").toString("base64url"),
+    rfc822MessageId
+  };
+}
+
+function parseRetryAfterSeconds(retryAfterHeader: string | null): number | null {
+  if (retryAfterHeader === null) {
+    return null;
+  }
+
+  const numericValue = Number.parseInt(retryAfterHeader, 10);
+
+  if (Number.isFinite(numericValue) && numericValue >= 0) {
+    return numericValue;
+  }
+
+  const retryAt = Date.parse(retryAfterHeader);
+
+  if (Number.isNaN(retryAt)) {
+    return null;
+  }
+
+  const retryAfterSeconds = Math.ceil((retryAt - Date.now()) / 1000);
+  return retryAfterSeconds > 0 ? retryAfterSeconds : 0;
+}
+
+function readGmailErrorText(input: z.infer<typeof gmailApiErrorSchema>): string {
+  const topLevelMessage = input.error?.message?.trim();
+
+  if (topLevelMessage !== undefined && topLevelMessage.length > 0) {
+    return topLevelMessage;
+  }
+
+  const nestedMessage = input.error?.errors
+    ?.map((entry) => entry.message?.trim() ?? "")
+    .find((value) => value.length > 0);
+
+  return nestedMessage && nestedMessage.length > 0
+    ? nestedMessage
+    : "Gmail API request failed.";
+}
+
+function isScopeError(input: z.infer<typeof gmailApiErrorSchema>): boolean {
+  const messages = [
+    input.error?.message ?? "",
+    ...(input.error?.errors?.map((entry) => entry.message ?? "") ?? []),
+    ...(input.error?.errors?.map((entry) => entry.reason ?? "") ?? [])
+  ].join(" ");
+
+  return (
+    /insufficientpermissions/iu.test(messages) ||
+    /insufficient authentication scopes/iu.test(messages)
+  );
+}
+
+function isSendAsError(input: z.infer<typeof gmailApiErrorSchema>): boolean {
+  const haystack = [
+    input.error?.message ?? "",
+    ...(input.error?.errors?.map((entry) => entry.message ?? "") ?? []),
+    ...(input.error?.errors?.map((entry) => entry.reason ?? "") ?? [])
+  ].join(" ");
+
+  return /(invalid from|from address|send as|delegation denied)/iu.test(haystack);
+}
+
+function isInvalidRecipientError(input: z.infer<typeof gmailApiErrorSchema>): boolean {
+  const haystack = [
+    input.error?.message ?? "",
+    ...(input.error?.errors?.map((entry) => entry.message ?? "") ?? []),
+    ...(input.error?.errors?.map((entry) => entry.reason ?? "") ?? [])
+  ].join(" ");
+
+  return /(invalid to header|recipient address rejected|invalid recipient|invalid argument)/iu.test(
+    haystack
+  );
+}
+
+async function mapSendError(input: {
+  readonly response: Response;
+  readonly fromAlias: string;
+}): Promise<GmailSendError> {
+  const responseText = await input.response.text();
+  let parsedError: z.infer<typeof gmailApiErrorSchema> | null = null;
+
+  try {
+    parsedError = gmailApiErrorSchema.parse(JSON.parse(responseText) as unknown);
+  } catch {
+    parsedError = null;
+  }
+
+  const detail =
+    parsedError === null
+      ? `Gmail API request failed with status ${String(input.response.status)}.`
+      : readGmailErrorText(parsedError);
+
+  if (input.response.status === 401) {
+    return {
+      kind: "auth_error",
+      detail
+    };
+  }
+
+  if (input.response.status === 429) {
+    return {
+      kind: "rate_limited",
+      retryAfterSeconds: parseRetryAfterSeconds(
+        input.response.headers.get("retry-after")
+      )
+    };
+  }
+
+  if (input.response.status >= 500) {
+    return {
+      kind: "transient",
+      detail
+    };
+  }
+
+  if (parsedError !== null && isSendAsError(parsedError)) {
+    return {
+      kind: "send_as_not_authorized",
+      alias: input.fromAlias
+    };
+  }
+
+  if (parsedError !== null && isInvalidRecipientError(parsedError)) {
+    return {
+      kind: "invalid_recipient",
+      detail
+    };
+  }
+
+  if (parsedError !== null && isScopeError(parsedError)) {
+    return {
+      kind: "scope_error",
+      detail
+    };
+  }
+
+  return {
+    kind: "permanent",
+    detail
+  };
+}
+
+export async function sendGmailMessage(
+  params: GmailSendParams,
+  config: GmailSendConfig
+): Promise<GmailSendResult> {
+  let parsedParams: z.output<typeof gmailSendParamsSchema>;
+
+  try {
+    parsedParams = gmailSendParamsSchema.parse(params);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return {
+        kind: "invalid_recipient",
+        detail: error.issues.map((issue) => issue.message).join("; ")
+      };
+    }
+
+    throw error;
+  }
+
+  const parsedConfig = gmailSendConfigSchema.parse(config);
+  const totalAttachmentBytes = countAttachmentBytes(parsedParams.attachments);
+
+  if (totalAttachmentBytes > MAX_ATTACHMENT_TOTAL_BYTES) {
+    return {
+      kind: "attachment_too_large",
+      totalBytes: totalAttachmentBytes
+    };
+  }
+
+  const now = parsedConfig.now ?? (() => new Date());
+  const builtMessage = buildMimeMessage(parsedParams, now());
+  const accessTokenCache =
+    config.accessTokenCache ?? new Map<string, GmailAccessTokenCacheEntry>();
+
+  let accessToken: string;
+
+  try {
+    const token = await exchangeGmailAccessToken({
+      config: {
+        oauthClient: parsedConfig.oauthClient,
+        oauthRefreshToken: parsedConfig.oauthRefreshToken,
+        timeoutMs: parsedConfig.timeoutMs
+      },
+      cacheKey: parsedConfig.liveAccount,
+      fetchImplementation: parsedConfig.fetchImplementation,
+      now,
+      accessTokenCache
+    });
+    accessToken = token.accessToken;
+  } catch (error) {
+    if (error instanceof GmailOAuthExchangeError) {
+      return {
+        kind: "auth_error",
+        detail: error.message
+      };
+    }
+
+    return {
+      kind: "transient",
+      detail: "OAuth token exchange failed unexpectedly."
+    };
+  }
+
+  let response: Response;
+
+  try {
+    response = await parsedConfig.fetchImplementation(
+      "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+          accept: "application/json",
+          "content-type": "application/json"
+        },
+        body: JSON.stringify({
+          raw: builtMessage.raw,
+          ...(parsedParams.threadId === undefined
+            ? {}
+            : { threadId: parsedParams.threadId })
+        }),
+        signal: AbortSignal.timeout(parsedConfig.timeoutMs)
+      }
+    );
+  } catch (error) {
+    if (error instanceof Error && error.name === "TimeoutError") {
+      return {
+        kind: "transient",
+        detail: "Gmail send request timed out."
+      };
+    }
+
+    return {
+      kind: "transient",
+      detail: "Gmail send request failed."
+    };
+  }
+
+  if (!response.ok) {
+    return mapSendError({
+      response,
+      fromAlias: parsedParams.fromAlias
+    });
+  }
+
+  const responsePayload = gmailSendApiSuccessSchema.parse(
+    JSON.parse(await response.text()) as unknown
+  );
+
+  return {
+    kind: "success",
+    gmailMessageId: responsePayload.id,
+    gmailThreadId: responsePayload.threadId ?? parsedParams.threadId ?? responsePayload.id,
+    rfc822MessageId: builtMessage.rfc822MessageId
+  };
+}

--- a/packages/integrations/test/stage3-gmail-send.test.ts
+++ b/packages/integrations/test/stage3-gmail-send.test.ts
@@ -1,0 +1,477 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { sendGmailMessage } from "../src/index.js";
+
+function hasRequestUrl(input: unknown): input is { url: string } {
+  return (
+    typeof input === "object" &&
+    input !== null &&
+    "url" in input &&
+    typeof input.url === "string"
+  );
+}
+
+function resolveRequestUrl(input: unknown): string {
+  if (typeof input === "string") {
+    return input;
+  }
+
+  if (input instanceof URL) {
+    return input.toString();
+  }
+
+  if (hasRequestUrl(input)) {
+    return input.url;
+  }
+
+  throw new Error("Expected request input to be a string, URL, or Request-like object.");
+}
+
+function parseSendRequestBody(
+  call: readonly unknown[]
+): Record<string, unknown> {
+  const init = call[1] as RequestInit | undefined;
+  const body = init?.body;
+
+  if (typeof body !== "string") {
+    throw new Error("Expected fetch body to be a JSON string.");
+  }
+
+  return JSON.parse(body) as Record<string, unknown>;
+}
+
+function getFetchCall(
+  mock: ReturnType<typeof createFetchMock>,
+  index: number
+): readonly unknown[] {
+  const call = mock.mock.calls[index];
+
+  if (call === undefined) {
+    throw new Error(`Expected fetch call at index ${String(index)}.`);
+  }
+
+  return call;
+}
+
+function decodeRawMessage(raw: string): string {
+  return Buffer.from(raw, "base64url").toString("utf8");
+}
+
+function createFetchMock(input?: {
+  readonly sendResponse?: Response;
+  readonly tokenResponse?: Response;
+}) {
+  return vi.fn(
+    (request: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const requestUrl = resolveRequestUrl(request);
+
+      if (requestUrl === "https://oauth2.googleapis.com/token") {
+        return Promise.resolve(
+          input?.tokenResponse ??
+            new Response(
+              JSON.stringify({
+                access_token: "gmail-access-token",
+                expires_in: 3600
+              }),
+              {
+                status: 200,
+                headers: {
+                  "content-type": "application/json"
+                }
+              }
+            )
+        );
+      }
+
+      if (requestUrl === "https://gmail.googleapis.com/gmail/v1/users/me/messages/send") {
+        return Promise.resolve(
+          input?.sendResponse ??
+            new Response(
+              JSON.stringify({
+                id: "gmail-message-1",
+                threadId: "gmail-thread-1"
+              }),
+              {
+                status: 200,
+                headers: {
+                  "content-type": "application/json"
+                }
+              }
+            )
+        );
+      }
+
+      throw new Error(
+        `Unexpected URL: ${requestUrl} with method ${init?.method ?? "GET"}`
+      );
+    }
+  );
+}
+
+const baseConfig = {
+  liveAccount: "volunteers@adventurescientists.org",
+  oauthClient: {
+    clientId: "gmail-oauth-client-id",
+    clientSecret: "gmail-oauth-client-secret",
+    tokenUri: "https://oauth2.googleapis.com/token"
+  },
+  oauthRefreshToken: "gmail-oauth-refresh-token",
+  now: () => new Date("2026-04-21T12:00:00.000Z")
+} as const;
+
+describe("Stage 3 Gmail send client", () => {
+  it("builds a plaintext reply with threading headers and sends the Gmail thread id", async () => {
+    const fetchImplementation = createFetchMock();
+    const result = await sendGmailMessage(
+      {
+        fromAlias: "pnwbio@adventurescientists.org",
+        to: "volunteer@example.org",
+        subject: "Re: Field update",
+        bodyPlaintext: "Thanks for the update.\nWe are reviewing it now.",
+        attachments: [],
+        threadId: "gmail-thread-parent-1",
+        inReplyToRfc822MessageId: "<parent-message@example.org>",
+        referencesRfc822MessageIds: [
+          "<grandparent-message@example.org>",
+          "<parent-message@example.org>"
+        ]
+      },
+      {
+        ...baseConfig,
+        fetchImplementation
+      }
+    );
+
+    expect(result).toMatchObject({
+      kind: "success",
+      gmailMessageId: "gmail-message-1",
+      gmailThreadId: "gmail-thread-1"
+    });
+
+    const sendCall = getFetchCall(fetchImplementation, 1);
+    const requestBody = parseSendRequestBody(sendCall);
+
+    expect(requestBody.threadId).toBe("gmail-thread-parent-1");
+
+    const rawMessage = decodeRawMessage(String(requestBody.raw));
+
+    expect(rawMessage).toContain("From: <pnwbio@adventurescientists.org>");
+    expect(rawMessage).toContain("To: <volunteer@example.org>");
+    expect(rawMessage).toContain("Subject: Re: Field update");
+    expect(rawMessage).toContain("In-Reply-To: <parent-message@example.org>");
+    expect(rawMessage).toContain(
+      "References: <grandparent-message@example.org> <parent-message@example.org>"
+    );
+    expect(rawMessage).toContain("Content-Type: text/plain; charset=UTF-8");
+    expect(rawMessage).not.toContain("multipart/mixed");
+    expect(rawMessage).toContain("Thanks for the update.\r\nWe are reviewing it now.");
+    expect(rawMessage).toMatch(/Message-ID: <[^>]+>/u);
+    expect(result.kind === "success" ? result.rfc822MessageId : "").toMatch(
+      /^<[^>]+>$/u
+    );
+  });
+
+  it("builds a net-new plaintext message without a Gmail thread id", async () => {
+    const fetchImplementation = createFetchMock();
+    const result = await sendGmailMessage(
+      {
+        fromAlias: "pnwbio@adventurescientists.org",
+        to: "new-contact@example.org",
+        subject: "Proyecto Ártico",
+        bodyPlaintext: "Hello from Adventure Scientists.",
+        attachments: []
+      },
+      {
+        ...baseConfig,
+        fetchImplementation
+      }
+    );
+
+    expect(result.kind).toBe("success");
+
+    const sendCall = getFetchCall(fetchImplementation, 1);
+    const requestBody = parseSendRequestBody(sendCall);
+
+    expect("threadId" in requestBody).toBe(false);
+
+    const rawMessage = decodeRawMessage(String(requestBody.raw));
+
+    expect(rawMessage).toContain("To: <new-contact@example.org>");
+    expect(rawMessage).toContain("Subject: =?UTF-8?B?UHJveWVjdG8gw4FydGljbw==?=");
+    expect(rawMessage).not.toContain("In-Reply-To:");
+    expect(rawMessage).not.toContain("References:");
+    expect(rawMessage).toContain("Content-Type: text/plain; charset=UTF-8");
+  });
+
+  it("builds a multipart message when attachments are present", async () => {
+    const fetchImplementation = createFetchMock();
+    const result = await sendGmailMessage(
+      {
+        fromAlias: "pnwbio@adventurescientists.org",
+        to: "volunteer@example.org",
+        subject: "Field kit files",
+        bodyPlaintext: "Attached are the kit files.",
+        attachments: [
+          {
+            filename: "briefing.txt",
+            contentType: "text/plain",
+            contentBase64: Buffer.from("First attachment", "utf8").toString("base64")
+          },
+          {
+            filename: "checklist.csv",
+            contentType: "text/csv",
+            contentBase64: Buffer.from("a,b,c\n1,2,3\n", "utf8").toString("base64")
+          }
+        ]
+      },
+      {
+        ...baseConfig,
+        fetchImplementation
+      }
+    );
+
+    expect(result.kind).toBe("success");
+
+    const sendCall = getFetchCall(fetchImplementation, 1);
+    const rawMessage = decodeRawMessage(
+      String(parseSendRequestBody(sendCall).raw)
+    );
+
+    expect(rawMessage).toContain("Content-Type: multipart/mixed; boundary=");
+    expect(rawMessage).toContain("Content-Type: text/plain; charset=UTF-8");
+    expect(rawMessage).toContain('Content-Disposition: attachment; filename="briefing.txt"');
+    expect(rawMessage).toContain('Content-Disposition: attachment; filename="checklist.csv"');
+    expect(rawMessage).toContain(
+      Buffer.from("First attachment", "utf8").toString("base64")
+    );
+    expect(rawMessage).toContain(
+      Buffer.from("a,b,c\n1,2,3\n", "utf8").toString("base64")
+    );
+  });
+
+  it("maps Gmail and OAuth failures into the typed error variants", async () => {
+    const cases = [
+      {
+        name: "auth_error",
+        fetchImplementation: createFetchMock({
+          tokenResponse: new Response(
+            JSON.stringify({
+              error: "invalid_grant"
+            }),
+            {
+              status: 401,
+              headers: {
+                "content-type": "application/json"
+              }
+            }
+          )
+        }),
+        expected: {
+          kind: "auth_error",
+          detail:
+            "OAuth refresh token expired, was revoked, or lost required permissions."
+        }
+      },
+      {
+        name: "scope_error",
+        fetchImplementation: createFetchMock({
+          sendResponse: new Response(
+            JSON.stringify({
+              error: {
+                code: 403,
+                message: "Request had insufficient authentication scopes.",
+                status: "PERMISSION_DENIED",
+                errors: [
+                  {
+                    message: "Insufficient Permission",
+                    reason: "insufficientPermissions"
+                  }
+                ]
+              }
+            }),
+            {
+              status: 403,
+              headers: {
+                "content-type": "application/json"
+              }
+            }
+          )
+        }),
+        expected: {
+          kind: "scope_error",
+          detail: "Request had insufficient authentication scopes."
+        }
+      },
+      {
+        name: "send_as_not_authorized",
+        fetchImplementation: createFetchMock({
+          sendResponse: new Response(
+            JSON.stringify({
+              error: {
+                code: 403,
+                message: "Delegation denied for pnwbio@adventurescientists.org",
+                status: "PERMISSION_DENIED"
+              }
+            }),
+            {
+              status: 403,
+              headers: {
+                "content-type": "application/json"
+              }
+            }
+          )
+        }),
+        expected: {
+          kind: "send_as_not_authorized",
+          alias: "pnwbio@adventurescientists.org"
+        }
+      },
+      {
+        name: "invalid_recipient",
+        fetchImplementation: createFetchMock({
+          sendResponse: new Response(
+            JSON.stringify({
+              error: {
+                code: 400,
+                message: "Invalid To header",
+                status: "INVALID_ARGUMENT"
+              }
+            }),
+            {
+              status: 400,
+              headers: {
+                "content-type": "application/json"
+              }
+            }
+          )
+        }),
+        expected: {
+          kind: "invalid_recipient",
+          detail: "Invalid To header"
+        }
+      },
+      {
+        name: "rate_limited",
+        fetchImplementation: createFetchMock({
+          sendResponse: new Response(
+            JSON.stringify({
+              error: {
+                code: 429,
+                message: "Rate limit exceeded",
+                status: "RESOURCE_EXHAUSTED"
+              }
+            }),
+            {
+              status: 429,
+              headers: {
+                "content-type": "application/json",
+                "retry-after": "120"
+              }
+            }
+          )
+        }),
+        expected: {
+          kind: "rate_limited",
+          retryAfterSeconds: 120
+        }
+      },
+      {
+        name: "transient",
+        fetchImplementation: createFetchMock({
+          sendResponse: new Response(
+            JSON.stringify({
+              error: {
+                code: 503,
+                message: "Backend error",
+                status: "UNAVAILABLE"
+              }
+            }),
+            {
+              status: 503,
+              headers: {
+                "content-type": "application/json"
+              }
+            }
+          )
+        }),
+        expected: {
+          kind: "transient",
+          detail: "Backend error"
+        }
+      },
+      {
+        name: "permanent",
+        fetchImplementation: createFetchMock({
+          sendResponse: new Response(
+            JSON.stringify({
+              error: {
+                code: 400,
+                message: "Precondition check failed.",
+                status: "FAILED_PRECONDITION"
+              }
+            }),
+            {
+              status: 400,
+              headers: {
+                "content-type": "application/json"
+              }
+            }
+          )
+        }),
+        expected: {
+          kind: "permanent",
+          detail: "Precondition check failed."
+        }
+      }
+    ] as const;
+
+    for (const testCase of cases) {
+      const result = await sendGmailMessage(
+        {
+          fromAlias: "pnwbio@adventurescientists.org",
+          to: "volunteer@example.org",
+          subject: `Case ${testCase.name}`,
+          bodyPlaintext: "Test body",
+          attachments: []
+        },
+        {
+          ...baseConfig,
+          fetchImplementation: testCase.fetchImplementation
+        }
+      );
+
+      expect(result).toEqual(testCase.expected);
+    }
+  });
+
+  it("fails locally when attachments exceed the 20 MB cap without calling Gmail", async () => {
+    const fetchImplementation = createFetchMock();
+    const oversizedAttachment = Buffer.alloc(21 * 1024 * 1024, 1).toString("base64");
+
+    const result = await sendGmailMessage(
+      {
+        fromAlias: "pnwbio@adventurescientists.org",
+        to: "volunteer@example.org",
+        subject: "Too large",
+        bodyPlaintext: "See attachment.",
+        attachments: [
+          {
+            filename: "oversized.bin",
+            contentType: "application/octet-stream",
+            contentBase64: oversizedAttachment
+          }
+        ]
+      },
+      {
+        ...baseConfig,
+        fetchImplementation
+      }
+    );
+
+    expect(result).toEqual({
+      kind: "attachment_too_large",
+      totalBytes: 21 * 1024 * 1024
+    });
+    expect(fetchImplementation).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What changed
- added a new Gmail send client in `packages/integrations/src/providers/gmail-send.ts`
- factored Gmail OAuth refresh into a shared helper so capture and send use the same token exchange flow
- exported the send client from `packages/integrations/src/index.ts`
- added Stage 3 tests covering MIME generation, reply threading, attachment handling, local size enforcement, and Gmail error mapping

## Why
Composer Stage 3.5 needs a backend-only Gmail send primitive that can send net-new messages and replies through the single `volunteers@...` account while preserving alias headers, threading metadata, and typed failure modes for the server action layer above it.

## Impact
- Composer can call a typed send function without pulling Gmail SDK details into app code
- Gmail API failures are normalized into UI-friendly error variants
- attachments are capped locally at 20 MB before any API request is made

## Validation
- `pnpm --filter @as-comms/integrations test:unit`
- `pnpm turbo typecheck`
- `pnpm turbo lint`
