### PR TITLE
docs(readme): update for shipped stages 0-3 + current state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,60 @@
 # AS Comms Platform
 
-Stage 0 scaffolds the engineering foundation for a fresh rebuild of the AS Comms Platform. Stage 1 now adds the canonical data foundation, provider-close ingest path, worker orchestration, and operational cutover support without starting later product stages. The narrowed launch-scope backend target is Gmail + Salesforce only.
+Internal volunteer communications platform for Adventure Scientists. Backend-first rebuild of an agent-assisted operator inbox that unifies Gmail + Salesforce + SMS + Mailchimp into a single canonical timeline per volunteer.
 
-## Locked Stage 0 stack
+The platform is **pre-production** — running on Railway under a single admin account while ingestion correctness and operator workflows are hardened.
+
+## Stages shipped
+
+| Stage | Status | Surface |
+|---|---|---|
+| 0 — Engineering foundation | ✓ shipped | pnpm + turbo monorepo, Next.js App Router, Drizzle, Graphile Worker, strict TS, Vitest, Playwright, boundary + security gates |
+| 1 — Data foundation | ✓ shipped | canonical event ledger, source-evidence log, identity resolution, Gmail + Salesforce capture services |
+| 1B — Trust pass | ✓ shipped | launch-scope backfills, representative-contact proofs, parity/cutover/replay hardening |
+| 2 — Settings / Admin | ✓ shipped | Auth.js v5 + Google SSO + JWT sessions, single-page Settings for Projects / Access / Integrations, admin mutations, 5-min integration-health cron |
+| 3 — Inbox read surface | ✓ shipped | operator inbox with mixed contact list, filters, follow-up toggle, project filter, keyboard shortcuts, optimistic UI |
+| 3.5 — Composer | ✓ shipped | Gmail send client, per-alias signature, durable send action + pending-outbounds reconciliation, inline draft pane + recipient picker + optimistic timeline, notes mode with author-only edit/delete |
+| 4 — AI drafting assistant | in progress | Notion knowledge sync landing; draft generation pipeline + memory capture next. Provider: Anthropic Claude Sonnet 4.6 for drafts, OpenAI `text-embedding-3-small` for memory similarity |
+| 5A — Email campaigns | deferred | post-validation of Inbox + Composer + AI |
+| 5B — SMS campaigns | deferred | after 5A |
+| 6 — Reporting | deferred | — |
+
+Active sequence: **4 AI (Notion sync + draft pipeline) → 5 Campaigns**. Stage 3.5 Composer shipped in PRs #77, #79, #80, #82, #84 on 2026-04-21. Stage 4 Notion sync landing in #83.
+
+## Locked stack
 
 - Node 24+
 - `pnpm` workspaces + `turbo`
 - Next.js App Router + React 19
-- TypeScript strict
-- Supabase Postgres + Drizzle
+- TypeScript strict (no `any` on boundaries)
+- Postgres (Railway) + Drizzle
 - Graphile Worker
+- Auth.js v5 with Google SSO
 - Zod
-- Tailwind CSS
-- Vitest
-- Playwright
+- Tailwind CSS + shadcn/ui primitives
+- Vitest + Playwright
+- Deployed on Railway (web + worker + gmail-capture + salesforce-capture + Postgres services)
+
+See `docs/01-core/decision-core.md` (D-020) for the authoritative stack canon.
 
 ## Workspace layout
 
 ```text
-apps/web
-apps/worker
-packages/contracts
-packages/db
-packages/domain
-packages/integrations
-packages/ui
+apps/web                        # Next.js app: inbox + settings + auth
+apps/worker                     # Graphile Worker: ingest + ops
+apps/gmail-capture              # Gmail live poller (1-min cadence)
+apps/salesforce-capture         # Salesforce live poller (5-min cadence)
+packages/contracts              # Shared Zod schemas + event taxonomy
+packages/db                     # Drizzle schema, migrations, mappers, repositories
+packages/domain                 # Normalization, persistence, dedup, identity resolution
+packages/integrations           # Provider capture modules (gmail, salesforce, simpletexting, mailchimp)
+packages/ui                     # Shared web UI primitives
+docs/01-core                    # Agent-first canon (decisions, product, data, engineering)
+docs/02-bundles                 # Stage-level spec bundles
+docs/04-implementation-specs    # Detailed impl specs for locked decisions
 ```
 
 ## First-time setup
-
-Install dependencies, then run the baseline verification suite.
 
 ```bash
 corepack enable
@@ -45,57 +70,122 @@ pnpm boundaries
 pnpm security
 ```
 
+**macOS gotcha:** local `pnpm test:unit` may fail with a `rollup-darwin-arm64` code-signature error. Environmental, not a real test failure — CI is authoritative. If you hit it, reinstall node_modules.
+
 ## Common commands
 
 ```bash
-pnpm dev
+# Dev servers
+pnpm dev                                    # all apps
 pnpm dev:web
 WORKER_BOOT_MODE=run DATABASE_URL=postgres://... pnpm dev:worker
 pnpm dev:gmail-capture
 pnpm dev:salesforce-capture
+
+# Worker ops (read packages/worker/src/ops/cli.ts for the full list)
 pnpm ops:worker:check-config
-pnpm ops:worker:import-gmail-mbox -- --mbox-path /absolute/path/project-antarctica.mbox --captured-mailbox project-antarctica@example.org
+pnpm ops:worker:import-gmail-mbox -- --mbox-path ... --captured-mailbox ...
 pnpm ops:worker:inspect -- contact --salesforce-contact-id 003-stage1
+pnpm ops:worker:backfill-salesforce-communication-details -- --dry-run
+pnpm ops:worker:backfill-content-fingerprint -- --dry-run
+pnpm ops:worker:dedup-historical-ledger -- --dry-run
+pnpm ops:worker:reconcile-identity-queue -- --dry-run
+pnpm ops:worker:reclassify-sf-direction -- --dry-run
+
+# Gates + verification
 pnpm lint
 pnpm typecheck
 pnpm build
 pnpm test:unit
 pnpm test:e2e
-pnpm boundaries
-pnpm security
-pnpm verify
+pnpm boundaries          # Enforces repo-shape boundary rules from D-021
+pnpm security            # Security gate (D-017)
+pnpm verify              # Full Stage 0 verification suite
 ```
 
-## Stage 1 worker runtime
+## Key architectural decisions
 
-The worker now boots the Stage 1 task list end to end through the single normalization path. For launch-scope acceptance, Gmail + Salesforce are the required providers; SimpleTexting and Mailchimp remain deferred. See [docs/stage-1-runtime.md](./docs/stage-1-runtime.md) for worker/runtime details, [docs/stage-1-capture-services.md](./docs/stage-1-capture-services.md) for the external Gmail and Salesforce capture services, and [docs/stage-1-acceptance.md](./docs/stage-1-acceptance.md) for the narrowed completion criteria.
+The `docs/01-core/decision-core.md` and `decision-log.md` are the authoritative canon. Most load-bearing decisions:
 
-## Stage 1 validation
+- **D-001** `restart-agent-focus` is the preferred implementation canon.
+- **D-003** Salesforce `Contact.Id` is the primary identity anchor.
+- **D-006** Gmail wins tie-breaks over Salesforce for the same outbound email.
+- **D-020** Stack is locked (see list above).
+- **D-025** Stage 2 Auth uses Auth.js v5 + Google + Drizzle; two flat roles (`admin`, `operator`); trusted-header dev bypass.
+- **D-026** Composer is its own stage between Inbox (3) and AI (4).
+- **D-027** Non-Salesforce contacts are first-class; unmatched emails auto-create a canonical contact with `salesforceContactId=null` instead of opening an identity review case.
+- **D-028** Routing review only fires for Salesforce-anchored contacts.
+- **D-032** Stage 4 AI is human-in-the-loop drafting with strict grounding order and one LLM call by default.
+- **D-033 / D-034** Salesforce comms ingest excludes non-volunteer contacts.
+- **D-035** Stage 2 auth session strategy is JWT, not database-backed (Edge Runtime middleware cannot decode database sessions).
+- **D-036** `project_dimensions.is_active` is admin-owned.
+- **D-037** (superseded 2026-04-21) → AI knowledge is discovered by matching Notion's `Project ID` property to `project_dimensions.project_id`. Activation gate is `ai_knowledge_synced_at IS NOT NULL`. The `ai_knowledge_url` column is retained as a cosmetic drill-through link.
+- **D-038** Integration health is a polled projection, not live-on-demand.
+- **2026-04-21 Stage 4 decisions (Q1–Q5):** Provider is **Anthropic Claude Sonnet 4.6** for drafts + OpenAI `text-embedding-3-small` for memory similarity. Soft cost cap of $20/day org-wide via `AI_DAILY_CAP_USD` (warn, never block). Tier-4 context: last 20 canonical events OR 90 days (smaller). Tier-5 memory masks PII, dedups via cosine > 0.95 within project, no TTL. Composer response envelope uses typed warning codes (`provider_timeout`, `over_budget`, `grounding_empty`, etc.) — over-budget and empty-grounding downgrade or warn, never block drafting.
 
-Use the worker-side ops commands for controlled validation:
+## Deployment (Railway)
 
-- `pnpm ops:worker:check-config`
-- `pnpm ops:worker:import-gmail-mbox -- --mbox-path ... --captured-mailbox ...`
-- `pnpm ops:worker:enqueue -- ...`
-- `pnpm ops:worker:inspect -- ...`
+All services run in the Railway `zucchini-balance` project, `production` environment:
 
-See [docs/stage-1-validation-runbook.md](./docs/stage-1-validation-runbook.md) for the operator flow and evidence checklist. Start the Gmail live capture service and the Salesforce capture service first; historical Gmail backfill now runs through the worker `.mbox` import path while still feeding the same downstream normalization flow.
+- `as-comms-platform` — web service (Next.js)
+- `worker` — Graphile Worker (ingest + ops)
+- `gmail-capture` — Gmail polling (1-min)
+- `salesforce-capture` — Salesforce polling (5-min)
+- `Postgres` — managed Postgres
 
-## What exists now
+Railway **auto-deploys on push to `main`**. Capture services poll on their own cadence; worker picks up their records via the ingest endpoint.
 
-- `apps/web` contains a minimal App Router shell plus `/health`, `/api/health`, and `/api/readiness`.
-- `apps/worker` contains the Stage 0 no-op task plus Stage 1 capture, replay, rebuild, parity, and cutover-support task wiring.
-- `packages/contracts` contains Stage 0 readiness contracts and the Stage 1 data, normalization, and worker job contracts.
-- `packages/db` contains Drizzle schema, migrations, row mappers, and repository implementations for the Stage 1 durable model.
-- `packages/domain` contains the provider-agnostic normalization and persistence application layer.
-- `packages/integrations` contains provider-close mapping and capture-port modules for Stage 1 Gmail and Salesforce launch-scope ingest, while preserving deferred SimpleTexting and Mailchimp paths in the generic architecture.
-- `packages/ui` contains reusable web UI primitives only.
+**⚠ Railway does NOT auto-run migrations on deploy.** Every schema change in `packages/db/drizzle/*.sql` needs a manual `psql` run against Railway Postgres before the matching code deploy completes, or the first query against the new column will 500. Preferred pattern:
 
-## What is still intentionally deferred
+```bash
+cat packages/db/drizzle/NNNN_*.sql | railway connect Postgres
+```
 
-- No Inbox UI, settings/admin/auth, campaigns UI, or notes UX
-- No product-app webhook endpoints
-- No later-stage workflow engine, AI state, or Stage 2+ behavior
-- No web-to-DB or web-to-provider direct imports
+## Operator workflow
 
-See [docs/build-web-apps-scope.md](./docs/build-web-apps-scope.md), [docs/stage-0-summary.md](./docs/stage-0-summary.md), [docs/stage-0-open-questions.md](./docs/stage-0-open-questions.md), [docs/stage-1-runtime.md](./docs/stage-1-runtime.md), [docs/stage-1-capture-services.md](./docs/stage-1-capture-services.md), [docs/stage-1-acceptance.md](./docs/stage-1-acceptance.md), and [docs/stage-1-validation-runbook.md](./docs/stage-1-validation-runbook.md) for the current boundaries and operational notes.
+At 1–3 active operators handling ~20–80 inbound/day, the inbox is a shared mixed list — no assignee partitioning. Daily workflow: unread-first triage, search-by-volunteer name for phone-call lookups, project filter for campaign context. See `docs/02-bundles/inbox-bundle.md` for the full spec.
+
+## Active correctness work (April 2026)
+
+A broad ingestion/display correctness audit against 22 representative contacts surfaced several systemic issues that shipped fixes as of 2026-04-21:
+
+- **D-027 identity resolution** (PR #73) — implements the spec'd "unmatched email auto-creates canonical contact" path. ~10,000 previously-stuck review cases cleared via `reconcile-identity-queue` ops script.
+- **SF Task direction parsing** (PR #74) — 1,245 inbound rows previously mislabeled as outbound now correctly typed; subject arrows stripped.
+- **Gmail body untruncation** (PR #74) — removed the 2,000-char hard cap; tightened quoted-reply regex that was truncating bodies on ordinary phrases like "update on placing…".
+- **Cross-provider + intra-Gmail dedup** (PRs #71, #75) — content-fingerprint fallback for when `rfc822_message_id` isn't available (Salesforce side); collapses the cohort-wide SF Flow double-fire pattern.
+- **Reconcile script redesign** (PR #76) — reconstructs canonical events from stored DB rows instead of re-parsing mbox files; works inside the Railway worker container without local filesystem access.
+
+Prod ops run 2026-04-21 against these fixes: 1,245 inbound rows reclassified + 1,528 stuck queue cases cleared + 2,402 content fingerprints populated + 54 stale projection rows refreshed. Remaining projection gap of 146 contacts (pure-outbound-before-reclassify) awaits the `rebuild-inbox-projections` ops command (brief in `.audit-ingestion-2026-04-21/briefs/fix-projection-rebuild.md`).
+
+See `.audit-ingestion-2026-04-21/SUMMARY.md` for the full audit and prioritized fix list.
+
+## Known P0 operational gap
+
+**Railway does not auto-run drizzle migrations on deploy**, and this has caused three separate ~15-minute prod web outages on 2026-04-21 alone (PRs #79, #80, #84). Every schema PR requires the architect to run `psql -f` manually between merge and deploy-completion. A pre-start migration runner hook on the web + worker services is a **P0 follow-up** — one Codex brief away. Without it, every future schema PR is a prod outage risk.
+
+## Memory / agent context
+
+Architect + reviewer agents working on this repo should auto-load from `~/.claude/projects/-Users-nicolas-Downloads-AS-Comms-Platform/memory/`. Load-bearing entries:
+
+- `project_overview.md`, `project_stage_sequence.md`
+- `project_composer_stage.md`, `project_composer_scope.md`
+- `project_docs_authority.md` (canon wins on contradictions; bundles + impl-specs derive from it)
+- `feedback_role.md` (collaboration mode: architect + reviewer, not primary coder)
+- `feedback_codex_coordination.md`, `feedback_codex_model_effort.md` (Codex dispatch patterns)
+
+## Project discipline
+
+- Feature branches + PRs — never edit `main` directly.
+- Canon first, code second — for architecture decisions, update `docs/01-core/decision-core.md` + `decision-log.md` before building.
+- Don't amend published commits; create new commits.
+- Destructive prod ops need per-session user sign-off each time; earlier approvals do not carry across sessions.
+
+---
+
+## Deeper references
+
+- `docs/01-core/` — canon (decisions, product, data, engineering, delivery, interfaces)
+- `docs/02-bundles/` — stage spec bundles (inbox-bundle.md, settings-bundle.md, etc.)
+- `docs/04-implementation-specs/` — detailed impl specs per decision
+- `docs/stage-1-runtime.md`, `docs/stage-1-capture-services.md`, `docs/stage-1-acceptance.md`, `docs/stage-1-validation-runbook.md`
+- `docs/03-reference/` — Salesforce mapping, legacy-conflict lookup


### PR DESCRIPTION
## Summary

The README still described the repo as "Stage 0 + Stage 1 only" with Inbox UI, Settings, admin, and auth listed as "intentionally deferred." All three shipped (Stage 2 in PRs #51-#67, Stage 3 in PRs #34-#65). This updates the whole doc to match reality.

## What changed

- **Stages shipped table** at the top — clear status for 0, 1, 1B, 2, 3, 3.5, 4, 5A, 5B, 6
- **Workspace layout** now includes `apps/gmail-capture`, `apps/salesforce-capture`, `docs/01-core`, `docs/02-bundles`, `docs/04-implementation-specs`
- **Key architectural decisions** section surfaces D-001 through D-038 with one-line summaries pointing at the canon
- **Deployment (Railway) section** documents the 5 services + the migration gotcha (Railway does NOT auto-run drizzle migrations)
- **Common commands** includes the current ops commands (backfill-content-fingerprint, dedup-historical-ledger, reconcile-identity-queue, reclassify-sf-direction) in addition to the Stage 1 originals
- **Operator workflow** describes the 1-3 operator scale + daily workflow
- **Active correctness work (April 2026)** summarizes the ingestion/display audit + PRs #71, #73, #74, #75, #76
- **Memory / agent context** section for architect + reviewer agents
- **Project discipline** section (feature branches + PRs, canon-first, destructive-ops sign-off rule)

## What was removed

- The "What is still intentionally deferred" list items for features that have since shipped (Inbox UI, settings/admin/auth, notes UX)

## Test plan

Docs-only PR; no CI action beyond the lint gate.

- [ ] Links resolve (canon file paths, audit directory, bundle paths)
- [ ] Stage status table matches current main state
- [ ] No broken code fences or markdown