### PR TITLE
feat(settings): per-alias signature admin CRUD

### DIFF
--- a/apps/web/app/settings/_components/project-detail.tsx
+++ b/apps/web/app/settings/_components/project-detail.tsx
@@ -31,10 +31,16 @@ import {
   activateProjectAction,
   deactivateProjectAction,
   type ProjectEmailInput,
+  type ProjectEmailMutationData,
   type ProjectMutationData,
   updateProjectAiKnowledgeAction,
+  updateProjectAliasSignatureAction,
   updateProjectEmailsAction
 } from "../actions";
+import {
+  getProjectAliasSignatureValidationError,
+  normalizeProjectAliasSignature
+} from "../_lib/project-alias-signature";
 
 interface FeedbackState {
   readonly kind: "success" | "error";
@@ -65,6 +71,14 @@ function buildProjectState(
   };
 }
 
+function buildSignatureDrafts(
+  emails: readonly ProjectEmailMutationData[]
+): Record<string, string> {
+  return Object.fromEntries(
+    emails.map((email) => [email.id, email.signature] as const)
+  );
+}
+
 function mergeProjectState(
   current: ProjectMutationData,
   patch: Partial<ProjectMutationData>
@@ -84,9 +98,9 @@ function mergeProjectState(
 }
 
 function promotePrimaryEmail(
-  emails: readonly ProjectEmailInput[],
+  emails: readonly ProjectEmailMutationData[],
   address: string
-): readonly ProjectEmailInput[] {
+): readonly ProjectEmailMutationData[] {
   const selected = emails.find((email) => email.address === address);
   if (!selected) {
     return emails;
@@ -94,22 +108,26 @@ function promotePrimaryEmail(
 
   return [
     {
+      id: selected.id,
       address: selected.address,
-      isPrimary: true
+      isPrimary: true,
+      signature: selected.signature
     },
     ...emails
       .filter((email) => email.address !== address)
       .map((email) => ({
+        id: email.id,
         address: email.address,
-        isPrimary: false
+        isPrimary: false,
+        signature: email.signature
       }))
   ];
 }
 
 function removeEmail(
-  emails: readonly ProjectEmailInput[],
+  emails: readonly ProjectEmailMutationData[],
   address: string
-): readonly ProjectEmailInput[] {
+): readonly ProjectEmailMutationData[] {
   const remaining = emails.filter((email) => email.address !== address);
   if (remaining.length === 0) {
     return [];
@@ -120,8 +138,19 @@ function removeEmail(
   }
 
   return remaining.map((email, index) => ({
+    id: email.id,
     address: email.address,
-    isPrimary: index === 0
+    isPrimary: index === 0,
+    signature: email.signature
+  }));
+}
+
+function toProjectEmailInputs(
+  emails: readonly ProjectEmailMutationData[]
+): readonly ProjectEmailInput[] {
+  return emails.map((email) => ({
+    address: email.address,
+    isPrimary: email.isPrimary
   }));
 }
 
@@ -142,12 +171,20 @@ export function ProjectDetail({
     mergeProjectState
   );
   const [knowledgeDraft, setKnowledgeDraft] = useState(project.aiKnowledgeUrl ?? "");
+  const [signatureDrafts, setSignatureDrafts] = useState(() =>
+    buildSignatureDrafts(project.emails)
+  );
+  const [signatureErrors, setSignatureErrors] = useState<
+    Record<string, string | undefined>
+  >({});
   const [newEmail, setNewEmail] = useState("");
   const [feedback, setFeedback] = useState<FeedbackState | null>(null);
   const [activationMessage, setActivationMessage] = useState<string | null>(null);
   const [pendingEmail, setPendingEmail] = useState<string | null>(null);
+  const [pendingSignatureId, setPendingSignatureId] = useState<string | null>(null);
   const [knowledgePending, startKnowledgeTransition] = useTransition();
   const [emailPending, startEmailTransition] = useTransition();
+  const [signaturePending, startSignatureTransition] = useTransition();
   const [activationPending, startActivationTransition] = useTransition();
   const [deactivateOpen, setDeactivateOpen] = useState(false);
 
@@ -161,6 +198,21 @@ export function ProjectDetail({
   function commitProject(nextProject: ProjectMutationData) {
     setProjectState(nextProject);
     setKnowledgeDraft(nextProject.aiKnowledgeUrl ?? "");
+    setSignatureDrafts((current) =>
+      Object.fromEntries(
+        nextProject.emails.map((email) => [
+          email.id,
+          current[email.id] ?? email.signature
+        ])
+      )
+    );
+    setSignatureErrors((current) =>
+      Object.fromEntries(
+        nextProject.emails.flatMap((email) =>
+          current[email.id] === undefined ? [] : [[email.id, current[email.id]]]
+        )
+      )
+    );
     setActivationMessage(null);
   }
 
@@ -185,10 +237,22 @@ export function ProjectDetail({
 
     const nextEmails =
       optimisticProject.emails.length === 0
-        ? [{ address: normalizedAddress, isPrimary: true }]
+        ? [
+            {
+              id: `temp:${normalizedAddress}`,
+              address: normalizedAddress,
+              isPrimary: true,
+              signature: ""
+            }
+          ]
         : [
             ...optimisticProject.emails,
-            { address: normalizedAddress, isPrimary: false }
+            {
+              id: `temp:${normalizedAddress}`,
+              address: normalizedAddress,
+              isPrimary: false,
+              signature: ""
+            }
           ];
 
     setPendingEmail(normalizedAddress);
@@ -196,7 +260,7 @@ export function ProjectDetail({
       applyOptimisticProject({ emails: nextEmails });
       const result = await updateProjectEmailsAction(
         project.projectId,
-        nextEmails
+        toProjectEmailInputs(nextEmails)
       );
       setPendingEmail(null);
 
@@ -219,7 +283,7 @@ export function ProjectDetail({
       applyOptimisticProject({ emails: nextEmails });
       const result = await updateProjectEmailsAction(
         project.projectId,
-        nextEmails
+        toProjectEmailInputs(nextEmails)
       );
       setPendingEmail(null);
 
@@ -241,7 +305,7 @@ export function ProjectDetail({
       applyOptimisticProject({ emails: nextEmails });
       const result = await updateProjectEmailsAction(
         project.projectId,
-        nextEmails
+        toProjectEmailInputs(nextEmails)
       );
       setPendingEmail(null);
 
@@ -252,6 +316,71 @@ export function ProjectDetail({
 
       commitProject(result.data);
       announce(`${address} is now the primary email.`);
+    });
+  }
+
+  function handleSignatureDraftChange(aliasId: string, nextValue: string) {
+    setSignatureDrafts((current) => ({
+      ...current,
+      [aliasId]: nextValue
+    }));
+    setSignatureErrors((current) => ({
+      ...current,
+      [aliasId]: undefined
+    }));
+  }
+
+  function handleSaveSignature(email: ProjectEmailMutationData) {
+    const currentDraft = signatureDrafts[email.id] ?? email.signature;
+    const normalizedSignature = normalizeProjectAliasSignature(currentDraft);
+    const validationError =
+      getProjectAliasSignatureValidationError(normalizedSignature);
+
+    if (validationError !== null) {
+      setSignatureErrors((current) => ({
+        ...current,
+        [email.id]: validationError
+      }));
+      return;
+    }
+
+    startSignatureTransition(async () => {
+      setPendingSignatureId(email.id);
+      const result = await updateProjectAliasSignatureAction(
+        email.id,
+        currentDraft
+      );
+      setPendingSignatureId(null);
+
+      if (!result.ok) {
+        setSignatureErrors((current) => ({
+          ...current,
+          [email.id]: result.fieldErrors?.signature ?? result.message
+        }));
+        announce(result.message, "error");
+        return;
+      }
+
+      setProjectState((current) => ({
+        ...current,
+        emails: current.emails.map((currentEmail) =>
+          currentEmail.id === result.data.id
+            ? {
+                ...currentEmail,
+                signature: result.data.signature
+              }
+            : currentEmail
+        )
+      }));
+      setSignatureDrafts((current) => ({
+        ...current,
+        [result.data.id]: result.data.signature
+      }));
+      setSignatureErrors((current) => ({
+        ...current,
+        [result.data.id]: undefined
+      }));
+      announce(`Saved the signature for ${result.data.alias}.`);
     });
   }
 
@@ -579,56 +708,114 @@ export function ProjectDetail({
         >
           {optimisticProject.emails.map((email) => {
             const isRowPending = emailPending && pendingEmail === email.address;
+            const isSignaturePending =
+              signaturePending && pendingSignatureId === email.id;
+            const signatureDraft = signatureDrafts[email.id] ?? email.signature;
+            const signatureError = signatureErrors[email.id];
+            const signatureDirty =
+              normalizeProjectAliasSignature(signatureDraft) !== email.signature;
             return (
               <li
-                key={email.address}
+                key={email.id}
                 className={cn(
-                  "flex items-center gap-2 px-3 py-2",
+                  "flex flex-col gap-3 px-3 py-3",
                   isRowPending && "opacity-60"
                 )}
               >
-                <span className="min-w-0 flex-1 truncate font-mono text-[13px] text-slate-700">
-                  {email.address}
-                </span>
-                {email.isPrimary ? (
-                  <StatusBadge
-                    label="Primary"
-                    colorClasses="bg-sky-50 text-sky-700 ring-sky-200"
-                    variant="soft"
-                  />
-                ) : null}
-                {project.isAdmin && !email.isPrimary ? (
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    disabled={emailPending}
-                    onClick={() => {
-                      handleMakePrimary(email.address);
-                    }}
+                <div className="flex items-center gap-2">
+                  <span className="min-w-0 flex-1 truncate font-mono text-[13px] text-slate-700">
+                    {email.address}
+                  </span>
+                  {email.isPrimary ? (
+                    <StatusBadge
+                      label="Primary"
+                      colorClasses="bg-sky-50 text-sky-700 ring-sky-200"
+                      variant="soft"
+                    />
+                  ) : null}
+                  {project.isAdmin && !email.isPrimary ? (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      disabled={emailPending}
+                      onClick={() => {
+                        handleMakePrimary(email.address);
+                      }}
+                    >
+                      Make primary
+                    </Button>
+                  ) : null}
+                  {project.isAdmin ? (
+                    <button
+                      type="button"
+                      aria-label={`Remove ${email.address}`}
+                      disabled={isRowPending}
+                      onClick={() => {
+                        handleRemoveEmail(email.address);
+                      }}
+                      className={cn(
+                        "flex h-7 w-7 items-center justify-center text-slate-400 hover:bg-rose-50 hover:text-rose-700",
+                        RADIUS.sm,
+                        TRANSITION.fast,
+                        FOCUS_RING,
+                        "disabled:cursor-not-allowed disabled:opacity-40"
+                      )}
+                    >
+                      <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                    </button>
+                  ) : null}
+                </div>
+
+                <div className="flex flex-col gap-2">
+                  <label
+                    htmlFor={`project-email-signature-${email.id}`}
+                    className={cn(TEXT.label, "text-slate-600")}
                   >
-                    Make primary
-                  </Button>
-                ) : null}
-                {project.isAdmin ? (
-                  <button
-                    type="button"
-                    aria-label={`Remove ${email.address}`}
-                    disabled={isRowPending}
-                    onClick={() => {
-                      handleRemoveEmail(email.address);
+                    Signature
+                  </label>
+                  <textarea
+                    id={`project-email-signature-${email.id}`}
+                    value={signatureDraft}
+                    onChange={(event) => {
+                      handleSignatureDraftChange(email.id, event.target.value);
                     }}
+                    disabled={!project.isAdmin || isSignaturePending}
+                    readOnly={!project.isAdmin}
+                    rows={4}
                     className={cn(
-                      "flex h-7 w-7 items-center justify-center text-slate-400 hover:bg-rose-50 hover:text-rose-700",
+                      "w-full resize-y border border-slate-200 bg-white px-3 py-2 font-mono text-[13px] text-slate-900 outline-none",
                       RADIUS.sm,
-                      TRANSITION.fast,
                       FOCUS_RING,
-                      "disabled:cursor-not-allowed disabled:opacity-40"
+                      signatureError &&
+                        "border-rose-300 bg-rose-50/40 text-rose-900"
                     )}
-                  >
-                    <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
-                  </button>
-                ) : null}
+                    placeholder="Plain-text signature..."
+                  />
+                  <div className="flex items-center justify-between gap-3">
+                    <span className={cn(TEXT.caption, "tabular-nums")}>
+                      {String(normalizeProjectAliasSignature(signatureDraft).length)}/2000
+                    </span>
+                    {project.isAdmin ? (
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        disabled={isSignaturePending || !signatureDirty}
+                        onClick={() => {
+                          handleSaveSignature(email);
+                        }}
+                      >
+                        Save signature
+                      </Button>
+                    ) : null}
+                  </div>
+                  {signatureError ? (
+                    <p className={cn(TEXT.caption, "text-rose-700")}>
+                      {signatureError}
+                    </p>
+                  ) : null}
+                </div>
               </li>
             );
           })}

--- a/apps/web/app/settings/_lib/project-alias-signature.ts
+++ b/apps/web/app/settings/_lib/project-alias-signature.ts
@@ -1,0 +1,22 @@
+export const PROJECT_ALIAS_SIGNATURE_MAX_LENGTH = 2000;
+
+const PROJECT_ALIAS_SIGNATURE_HTML_PATTERN = /<[^>]+>/u;
+const TRAILING_WHITESPACE_PATTERN = /[^\S\r\n]+$/gmu;
+
+export function normalizeProjectAliasSignature(signature: string): string {
+  return signature.replace(TRAILING_WHITESPACE_PATTERN, "");
+}
+
+export function getProjectAliasSignatureValidationError(
+  signature: string
+): string | null {
+  if (signature.length > PROJECT_ALIAS_SIGNATURE_MAX_LENGTH) {
+    return `Signature must be ${String(PROJECT_ALIAS_SIGNATURE_MAX_LENGTH)} characters or fewer.`;
+  }
+
+  if (PROJECT_ALIAS_SIGNATURE_HTML_PATTERN.test(signature)) {
+    return "Signature must be plain text only.";
+  }
+
+  return null;
+}

--- a/apps/web/app/settings/actions.ts
+++ b/apps/web/app/settings/actions.ts
@@ -20,6 +20,11 @@ import {
 import { getSettingsRepositories } from "@/src/server/stage1-runtime";
 import type { UiError, UiResult } from "@/src/server/ui-result";
 
+import {
+  getProjectAliasSignatureValidationError,
+  normalizeProjectAliasSignature
+} from "./_lib/project-alias-signature";
+
 function newRequestId(): string {
   return randomUUID();
 }
@@ -76,7 +81,12 @@ function serializeProjectMutationData(input: {
   readonly isActive: boolean;
   readonly aiKnowledgeUrl: string | null;
   readonly aiKnowledgeSyncedAt: Date | null;
-  readonly emails: readonly { readonly address: string; readonly isPrimary: boolean }[];
+  readonly emails: readonly {
+    readonly id: string;
+    readonly address: string;
+    readonly isPrimary: boolean;
+    readonly signature: string;
+  }[];
 }): ProjectMutationData {
   return {
     projectId: input.projectId,
@@ -89,8 +99,10 @@ function serializeProjectMutationData(input: {
       emails: input.emails
     }),
     emails: input.emails.map((email) => ({
+      id: email.id,
       address: email.address,
-      isPrimary: email.isPrimary
+      isPrimary: email.isPrimary,
+      signature: email.signature
     }))
   };
 }
@@ -342,6 +354,11 @@ export interface ProjectEmailInput {
   readonly isPrimary: boolean;
 }
 
+export interface ProjectEmailMutationData extends ProjectEmailInput {
+  readonly id: string;
+  readonly signature: string;
+}
+
 export interface ProjectMutationData {
   readonly projectId: string;
   readonly projectName: string;
@@ -349,7 +366,17 @@ export interface ProjectMutationData {
   readonly aiKnowledgeUrl: string | null;
   readonly aiKnowledgeSyncedAt: string | null;
   readonly activationRequirementsMet: boolean;
-  readonly emails: readonly ProjectEmailInput[];
+  readonly emails: readonly ProjectEmailMutationData[];
+}
+
+function truncateAuditValue(value: string): string {
+  return value.slice(0, 500);
+}
+
+export interface ProjectAliasSignatureMutationData {
+  readonly id: string;
+  readonly alias: string;
+  readonly signature: string;
 }
 
 // ─── Projects ───────────────────────────────────────────────────────────────
@@ -538,6 +565,70 @@ export async function updateProjectEmailsAction(
   return {
     ok: true,
     data: serializeProjectMutationData(updatedProject),
+    requestId: newRequestId()
+  };
+}
+
+export async function updateProjectAliasSignatureAction(
+  aliasId: string,
+  signature: string
+): Promise<UiResult<ProjectAliasSignatureMutationData>> {
+  const admin = await resolveSettingsAdmin({
+    unauthorizedMessage: "You must be signed in to update an alias signature.",
+    forbiddenMessage: "Only admins can update alias signatures."
+  });
+  if (!admin.ok) {
+    return admin.error;
+  }
+
+  const repositories = await getSettingsRepositories();
+  const alias = await repositories.aliases.findById(aliasId);
+  if (alias?.projectId == null) {
+    return errorResult("not_found", "That project email no longer exists.");
+  }
+
+  const normalizedSignature = normalizeProjectAliasSignature(signature);
+  const validationError =
+    getProjectAliasSignatureValidationError(normalizedSignature);
+  if (validationError !== null) {
+    return errorResult("invalid_signature", validationError, {
+      fieldErrors: {
+        signature: validationError
+      }
+    });
+  }
+
+  const updatedAlias = await repositories.aliases.updateSignature({
+    aliasId,
+    signature: normalizedSignature,
+    actorId: admin.userId
+  });
+  if (updatedAlias === null) {
+    return errorResult("not_found", "That project email no longer exists.");
+  }
+
+  await appendSettingsAudit({
+    actorId: admin.userId,
+    action: "settings.project.alias_signature_updated",
+    entityType: "project_alias",
+    entityId: aliasId,
+    metadataJson: {
+      alias: updatedAlias.alias,
+      projectId: alias.projectId,
+      before: truncateAuditValue(alias.signature),
+      after: truncateAuditValue(updatedAlias.signature)
+    }
+  });
+
+  revalidateProjectSettings(alias.projectId);
+
+  return {
+    ok: true,
+    data: {
+      id: updatedAlias.id,
+      alias: updatedAlias.alias,
+      signature: updatedAlias.signature
+    },
     requestId: newRequestId()
   };
 }

--- a/apps/web/src/server/settings/selectors.ts
+++ b/apps/web/src/server/settings/selectors.ts
@@ -35,8 +35,10 @@ export interface ProjectsSettingsViewModel {
 export interface ProjectSettingsDetailViewModel extends ProjectRowViewModel {
   readonly isAdmin: boolean;
   readonly emails: readonly {
+    readonly id: string;
     readonly address: string;
     readonly isPrimary: boolean;
+    readonly signature: string;
   }[];
   readonly salesforceProjectId: string | null;
 }
@@ -157,7 +159,12 @@ function toProjectRowViewModel(input: {
   readonly isActive: boolean;
   readonly aiKnowledgeUrl: string | null;
   readonly aiKnowledgeSyncedAt: Date | null;
-  readonly emails: readonly { readonly address: string; readonly isPrimary: boolean }[];
+  readonly emails: readonly {
+    readonly id: string;
+    readonly address: string;
+    readonly isPrimary: boolean;
+    readonly signature: string;
+  }[];
   readonly memberCount: number;
 }): ProjectRowViewModel {
   const primaryEmail =

--- a/apps/web/tests/unit/settings-project-actions.test.ts
+++ b/apps/web/tests/unit/settings-project-actions.test.ts
@@ -57,6 +57,7 @@ async function seedProject(
     await runtime.context.settings.aliases.create({
       id: `${input.projectId}:alias:${String(index)}`,
       alias: email,
+      signature: "",
       projectId: input.projectId,
       createdAt: new Date(`2026-04-20T15:0${String(index)}:00.000Z`),
       updatedAt: new Date(`2026-04-20T15:0${String(index)}:00.000Z`),

--- a/apps/web/tests/unit/settings-project-detail-render.test.ts
+++ b/apps/web/tests/unit/settings-project-detail-render.test.ts
@@ -77,6 +77,7 @@ vi.mock("@/components/ui/status-badge", () => ({
 vi.mock("../../app/settings/actions", () => ({
   activateProjectAction: vi.fn(),
   deactivateProjectAction: vi.fn(),
+  updateProjectAliasSignatureAction: vi.fn(),
   updateProjectAiKnowledgeAction: vi.fn(),
   updateProjectEmailsAction: vi.fn()
 }));
@@ -100,8 +101,10 @@ describe("ProjectDetail role-aware rendering", () => {
           isAdmin: false,
           emails: [
             {
+              id: "alias:inactive",
               address: "inactive@asc.internal",
-              isPrimary: true
+              isPrimary: true,
+              signature: ""
             }
           ],
           salesforceProjectId: "project:inactive"
@@ -116,5 +119,6 @@ describe("ProjectDetail role-aware rendering", () => {
     expect(html).not.toContain("Save URL");
     expect(html).not.toContain("Sync");
     expect(html).not.toContain("Make primary");
+    expect(html).not.toContain("Save signature");
   });
 });

--- a/apps/web/tests/unit/settings-selectors.test.ts
+++ b/apps/web/tests/unit/settings-selectors.test.ts
@@ -78,6 +78,7 @@ async function seedProject(
     await runtime.context.settings.aliases.create({
       id: `${input.projectId}:alias:${String(index)}`,
       alias: email,
+      signature: "",
       projectId: input.projectId,
       createdAt: new Date(`2026-04-20T15:0${String(index)}:00.000Z`),
       updatedAt: new Date(`2026-04-20T15:0${String(index)}:00.000Z`),

--- a/apps/web/tests/unit/stage2-alias-signature-action.test.ts
+++ b/apps/web/tests/unit/stage2-alias-signature-action.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveAdminSession = vi.hoisted(() => vi.fn());
+const revalidateProjectSettings = vi.hoisted(() => vi.fn());
+
+vi.mock("@/src/server/auth/api", () => ({
+  resolveAdminSession
+}));
+
+vi.mock("@/src/server/settings/revalidate", () => ({
+  revalidateProjectSettings,
+  revalidateIntegrationHealth: vi.fn()
+}));
+
+import { updateProjectAliasSignatureAction } from "../../app/settings/actions";
+import {
+  createStage1WebTestRuntime,
+  type Stage1WebTestRuntime
+} from "../../src/server/stage1-runtime.test-support";
+
+function adminSession() {
+  return {
+    ok: true as const,
+    user: {
+      id: "user:admin"
+    }
+  };
+}
+
+async function seedAlias(
+  runtime: Stage1WebTestRuntime,
+  input: {
+    readonly projectId: string;
+    readonly aliasId: string;
+    readonly alias: string;
+    readonly signature?: string;
+  }
+): Promise<void> {
+  const now = new Date("2026-04-21T12:00:00.000Z");
+  await runtime.context.repositories.projectDimensions.upsert({
+    projectId: input.projectId,
+    projectName: "Signature Project",
+    source: "salesforce"
+  });
+  await runtime.context.settings.aliases.create({
+    id: input.aliasId,
+    alias: input.alias,
+    signature: input.signature ?? "",
+    projectId: input.projectId,
+    createdAt: now,
+    updatedAt: now,
+    createdBy: "user:admin",
+    updatedBy: "user:admin"
+  });
+}
+
+describe("stage2 alias signature action", () => {
+  let runtime: Stage1WebTestRuntime | null = null;
+
+  beforeEach(async () => {
+    resolveAdminSession.mockReset();
+    revalidateProjectSettings.mockReset();
+    resolveAdminSession.mockResolvedValue(adminSession());
+
+    runtime = await createStage1WebTestRuntime();
+    const now = new Date("2026-04-21T12:00:00.000Z");
+    await runtime.context.settings.users.upsert({
+      id: "user:admin",
+      name: "Admin",
+      email: "admin@adventurescientists.org",
+      emailVerified: now,
+      image: null,
+      role: "admin",
+      deactivatedAt: null,
+      createdAt: now,
+      updatedAt: now
+    });
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    runtime = null;
+  });
+
+  it("returns forbidden for non-admin callers", async () => {
+    resolveAdminSession.mockResolvedValueOnce({
+      ok: false,
+      code: "forbidden"
+    });
+
+    const result = await updateProjectAliasSignatureAction(
+      "alias:signature",
+      "Thanks"
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "forbidden"
+    });
+  });
+
+  it("rejects signatures longer than 2000 characters", async () => {
+    if (!runtime) throw new Error("runtime not initialized");
+
+    await seedAlias(runtime, {
+      projectId: "project:signature",
+      aliasId: "alias:signature",
+      alias: "signature@asc.internal"
+    });
+
+    const result = await updateProjectAliasSignatureAction(
+      "alias:signature",
+      "a".repeat(2001)
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "invalid_signature",
+      fieldErrors: {
+        signature: "Signature must be 2000 characters or fewer."
+      }
+    });
+  });
+
+  it("rejects HTML tags in signatures", async () => {
+    if (!runtime) throw new Error("runtime not initialized");
+
+    await seedAlias(runtime, {
+      projectId: "project:signature",
+      aliasId: "alias:signature",
+      alias: "signature@asc.internal"
+    });
+
+    const result = await updateProjectAliasSignatureAction(
+      "alias:signature",
+      "Thanks,<br />Adventure Scientists"
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "invalid_signature",
+      fieldErrors: {
+        signature: "Signature must be plain text only."
+      }
+    });
+  });
+
+  it("updates the signature, writes an audit row, and revalidates the project detail", async () => {
+    if (!runtime) throw new Error("runtime not initialized");
+
+    await seedAlias(runtime, {
+      projectId: "project:signature",
+      aliasId: "alias:signature",
+      alias: "signature@asc.internal"
+    });
+
+    const result = await updateProjectAliasSignatureAction(
+      "alias:signature",
+      "Thanks,\nAdventure Scientists   "
+    );
+    const updatedAlias = await runtime.context.settings.aliases.findById(
+      "alias:signature"
+    );
+    const audits = await runtime.context.repositories.auditEvidence.listByEntity({
+      entityType: "project_alias",
+      entityId: "alias:signature"
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        id: "alias:signature",
+        alias: "signature@asc.internal",
+        signature: "Thanks,\nAdventure Scientists"
+      }
+    });
+    expect(updatedAlias?.signature).toBe("Thanks,\nAdventure Scientists");
+    expect(audits.at(-1)).toMatchObject({
+      actorType: "user",
+      actorId: "user:admin",
+      action: "settings.project.alias_signature_updated",
+      entityType: "project_alias",
+      entityId: "alias:signature",
+      policyCode: "settings.admin_mutation",
+      metadataJson: {
+        alias: "signature@asc.internal",
+        projectId: "project:signature",
+        before: "",
+        after: "Thanks,\nAdventure Scientists"
+      }
+    });
+    expect(revalidateProjectSettings).toHaveBeenCalledWith("project:signature");
+  });
+});

--- a/packages/db/drizzle/0009_project_alias_signature.sql
+++ b/packages/db/drizzle/0009_project_alias_signature.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "project_aliases" ADD COLUMN "signature" text NOT NULL DEFAULT '';

--- a/packages/db/src/mappers.ts
+++ b/packages/db/src/mappers.ts
@@ -787,6 +787,7 @@ export function mapProjectAliasRow(row: ProjectAliasRow): ProjectAliasRecord {
   return {
     id: row.id,
     alias: row.alias,
+    signature: row.signature,
     projectId: row.projectId,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
@@ -801,6 +802,7 @@ export function mapProjectAliasToInsert(
   return {
     id: record.id,
     alias: record.alias,
+    signature: record.signature,
     projectId: record.projectId,
     createdAt: record.createdAt,
     updatedAt: record.updatedAt,

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -1957,7 +1957,12 @@ function createStage2RepositoriesInternal(
 
     const emailsByProjectId = new Map<
       string,
-      { readonly address: string; readonly createdAt: Date }[]
+      {
+        readonly id: string;
+        readonly address: string;
+        readonly createdAt: Date;
+        readonly signature: string;
+      }[]
     >();
     for (const aliasRow of aliasRows) {
       if (aliasRow.projectId === null) {
@@ -1966,8 +1971,10 @@ function createStage2RepositoriesInternal(
 
       const projectEmails = emailsByProjectId.get(aliasRow.projectId) ?? [];
       projectEmails.push({
+        id: aliasRow.id,
         address: aliasRow.alias,
         createdAt: aliasRow.createdAt,
+        signature: aliasRow.signature
       });
       emailsByProjectId.set(aliasRow.projectId, projectEmails);
     }
@@ -1989,8 +1996,10 @@ function createStage2RepositoriesInternal(
             left.address.localeCompare(right.address),
         )
         .map((email, index) => ({
+          id: email.id,
           address: email.address,
           isPrimary: index === 0,
+          signature: email.signature
         }));
 
       return {
@@ -2256,6 +2265,14 @@ function createStage2RepositoriesInternal(
         readonly actorId: string;
       }) {
         return db.transaction(async (tx: Stage1Database) => {
+          const existingRows = await tx
+            .select()
+            .from(projectAliases)
+            .where(eq(projectAliases.projectId, input.projectId));
+          const signatureByAlias = new Map(
+            existingRows.map((row) => [row.alias, row.signature] as const)
+          );
+
           await tx
             .delete(projectAliases)
             .where(eq(projectAliases.projectId, input.projectId));
@@ -2273,6 +2290,7 @@ function createStage2RepositoriesInternal(
                 return {
                   id: crypto.randomUUID(),
                   alias,
+                  signature: signatureByAlias.get(alias) ?? "",
                   projectId: input.projectId,
                   createdAt: occurredAt,
                   updatedAt: occurredAt,
@@ -2285,6 +2303,20 @@ function createStage2RepositoriesInternal(
 
           return rows.map(mapProjectAliasRow);
         });
+      },
+
+      async updateSignature(input) {
+        const [row] = await db
+          .update(projectAliases)
+          .set({
+            signature: input.signature,
+            updatedAt: new Date(),
+            updatedBy: input.actorId
+          })
+          .where(eq(projectAliases.id, input.aliasId))
+          .returning();
+
+        return row === undefined ? null : mapProjectAliasRow(row);
       },
 
       async create(record: ProjectAliasRecord) {
@@ -2308,6 +2340,7 @@ function createStage2RepositoriesInternal(
           .update(projectAliases)
           .set({
             alias: values.alias,
+            signature: values.signature,
             projectId: values.projectId,
             updatedAt: new Date(),
             updatedBy: values.updatedBy,

--- a/packages/db/src/schema/tables.ts
+++ b/packages/db/src/schema/tables.ts
@@ -684,6 +684,7 @@ export const projectAliases = pgTable(
   {
     id: text("id").primaryKey(),
     alias: text("alias").notNull().unique(),
+    signature: text("signature").notNull().default(""),
     projectId: text("project_id").references(() => projectDimensions.projectId, {
       onDelete: "set null"
     }),

--- a/packages/db/test/stage2-alias-signature.test.ts
+++ b/packages/db/test/stage2-alias-signature.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { createTestStage1Context } from "./helpers.js";
+
+describe("Stage 2 alias signature repository", () => {
+  it("updates an alias signature and persists the stored value for later reads", async () => {
+    const context = await createTestStage1Context();
+
+    try {
+      const now = new Date("2026-04-21T12:00:00.000Z");
+      await context.settings.users.upsert({
+        id: "user:admin",
+        name: "Admin",
+        email: "admin@adventurescientists.org",
+        emailVerified: now,
+        image: null,
+        role: "admin",
+        deactivatedAt: null,
+        createdAt: now,
+        updatedAt: now
+      });
+      await context.repositories.projectDimensions.upsert({
+        projectId: "project:signature",
+        projectName: "Signature Project",
+        source: "salesforce"
+      });
+      await context.settings.aliases.create({
+        id: "alias:signature",
+        alias: "signature@asc.internal",
+        signature: "",
+        projectId: "project:signature",
+        createdAt: now,
+        updatedAt: now,
+        createdBy: "user:admin",
+        updatedBy: "user:admin"
+      });
+
+      const updated = await context.settings.aliases.updateSignature({
+        aliasId: "alias:signature",
+        signature: "Thanks,\nAdventure Scientists",
+        actorId: "user:admin"
+      });
+      const foundById = await context.settings.aliases.findById("alias:signature");
+      const foundByAlias = await context.settings.aliases.findByAlias(
+        "signature@asc.internal"
+      );
+
+      expect(updated).toMatchObject({
+        id: "alias:signature",
+        alias: "signature@asc.internal",
+        signature: "Thanks,\nAdventure Scientists",
+        projectId: "project:signature",
+        updatedBy: "user:admin"
+      });
+      expect(foundById).toMatchObject({
+        id: "alias:signature",
+        signature: "Thanks,\nAdventure Scientists"
+      });
+      expect(foundByAlias).toMatchObject({
+        id: "alias:signature",
+        signature: "Thanks,\nAdventure Scientists"
+      });
+    } finally {
+      await context.client.close();
+    }
+  });
+});

--- a/packages/domain/src/settings/records.ts
+++ b/packages/domain/src/settings/records.ts
@@ -15,6 +15,7 @@ export interface UserRecord {
 export interface ProjectAliasRecord {
   readonly id: string;
   readonly alias: string;
+  readonly signature: string;
   readonly projectId: string | null;
   readonly createdAt: Date;
   readonly updatedAt: Date;
@@ -23,8 +24,10 @@ export interface ProjectAliasRecord {
 }
 
 export interface SettingsProjectEmailRecord {
+  readonly id: string;
   readonly address: string;
   readonly isPrimary: boolean;
+  readonly signature: string;
 }
 
 export interface SettingsProjectRecord {

--- a/packages/domain/src/settings/repositories.ts
+++ b/packages/domain/src/settings/repositories.ts
@@ -26,6 +26,11 @@ export interface ProjectAliasesRepository {
     readonly aliases: readonly string[];
     readonly actorId: string;
   }): Promise<readonly ProjectAliasRecord[]>;
+  updateSignature(input: {
+    readonly aliasId: string;
+    readonly signature: string;
+    readonly actorId: string;
+  }): Promise<ProjectAliasRecord | null>;
   create(record: ProjectAliasRecord): Promise<ProjectAliasRecord>;
   update(record: ProjectAliasRecord): Promise<ProjectAliasRecord>;
   delete(id: string): Promise<void>;


### PR DESCRIPTION
## Summary
- adds a `signature` column to `project_aliases` (migration 0008) and a per-alias signature textarea on the Settings project detail page
- new Server Action `updateProjectAliasSignatureAction`: admin-only, plaintext, 0-2000 chars, HTML-tag rejection, audited via `settings.project.alias_signature_updated`
- signatures are stored but not yet appended at send time — the Composer send action (Brief 2) reads `project_aliases.signature` when that brief lands

## Why
Required by the Composer Stage 3.5 plan ([decision-log 2026-04-18 Composer entry](docs/01-core/decision-log.md)) so recipients see a signed message from the project team, not a bare volunteers@ send. Built alongside Composer rather than deferred — the marginal cost is one textarea and the UX cost of "no signature on first send" was judged larger than the dev cost.

## Scope
- [x] Migration + schema + Drizzle
- [x] Repo method `aliases.updateSignature`
- [x] Server action with admin gate + validation + audit
- [x] UI textarea per alias in project detail
- [x] Tests: repo (`stage2-alias-signature.test.ts`), action (`stage2-alias-signature-action.test.ts`)

## Test plan
- [ ] CI green (typecheck, lint, unit, integration)
- [ ] Manual verification: sign in as admin → Settings → Projects → [project] → edit each alias signature → reload → signatures persist
- [ ] Manual: non-admin role rejected with `forbidden`
- [ ] Audit: `security_audit` row written on each save

## Ops follow-up
- Run `packages/db/drizzle/0008_project_alias_signature.sql` against Railway DB before the web deploy lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)