### PR TITLE
feat(composer): inline draft pane + recipient picker + optimistic timeline

### DIFF
--- a/apps/web/app/inbox/_components/composer-recipient-picker.tsx
+++ b/apps/web/app/inbox/_components/composer-recipient-picker.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Chip } from "@/components/ui/chip";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+import { resolveTypedEmailRecipient } from "../_lib/composer-ui";
+import {
+  searchContactsAction,
+  type ContactSearchResult
+} from "../actions";
+import { SearchIcon, XIcon } from "./icons";
+
+export interface ComposerContactRecipient {
+  readonly kind: "contact";
+  readonly contactId: string;
+  readonly displayName: string;
+  readonly primaryEmail: string | null;
+  readonly primaryProjectName: string | null;
+  readonly salesforceContactId: string | null;
+}
+
+export interface ComposerEmailRecipient {
+  readonly kind: "email";
+  readonly emailAddress: string;
+}
+
+export type ComposerRecipientValue =
+  | ComposerContactRecipient
+  | ComposerEmailRecipient;
+
+function toContactRecipient(
+  result: ContactSearchResult
+): ComposerContactRecipient {
+  return {
+    kind: "contact",
+    contactId: result.id,
+    displayName: result.displayName,
+    primaryEmail: result.primaryEmail,
+    primaryProjectName: result.primaryProjectName,
+    salesforceContactId: result.salesforceContactId
+  };
+}
+
+export function ComposerRecipientPicker({
+  recipient,
+  locked = false,
+  onRecipientChange
+}: {
+  readonly recipient: ComposerRecipientValue | null;
+  readonly locked?: boolean;
+  readonly onRecipientChange: (recipient: ComposerRecipientValue | null) => void;
+}) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<readonly ContactSearchResult[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const activeSearchIdRef = useRef(0);
+
+  useEffect(() => {
+    if (recipient !== null) {
+      activeSearchIdRef.current += 1;
+      setQuery("");
+      setResults([]);
+      setIsSearching(false);
+      return undefined;
+    }
+
+    const trimmedQuery = query.trim();
+
+    if (trimmedQuery.length < 2) {
+      activeSearchIdRef.current += 1;
+      setResults([]);
+      setIsSearching(false);
+      return undefined;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      const searchId = activeSearchIdRef.current + 1;
+      activeSearchIdRef.current = searchId;
+      setIsSearching(true);
+
+      void (async () => {
+        try {
+          const result = await searchContactsAction(trimmedQuery);
+
+          if (activeSearchIdRef.current !== searchId) {
+            return;
+          }
+
+          if (!result.ok) {
+            setResults([]);
+            setIsSearching(false);
+            return;
+          }
+
+          setResults(result.data);
+          setIsSearching(false);
+        } catch {
+          if (activeSearchIdRef.current !== searchId) {
+            return;
+          }
+
+          setResults([]);
+          setIsSearching(false);
+        }
+      })();
+    }, 250);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [query, recipient]);
+
+  const shouldShowResults =
+    recipient === null &&
+    (isSearching || results.length > 0 || query.trim().length >= 2);
+
+  return (
+    <div className="space-y-2">
+      <label className="flex items-start gap-3">
+        <span className="mt-2 w-10 text-sm font-medium text-slate-700">To:</span>
+        <div className="flex-1 space-y-2">
+          {recipient ? (
+            <RecipientChip
+              recipient={recipient}
+              locked={locked}
+              onClear={() => {
+                if (!locked) {
+                  onRecipientChange(null);
+                }
+              }}
+            />
+          ) : (
+            <div className="relative">
+              <SearchIcon className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400" />
+              <Input
+                value={query}
+                onChange={(event) => {
+                  setQuery(event.currentTarget.value);
+                }}
+                onKeyDown={(event) => {
+                  if (event.key !== "Enter") {
+                    return;
+                  }
+
+                  const trimmedQuery = query.trim();
+
+                  if (trimmedQuery.length === 0) {
+                    event.preventDefault();
+                    return;
+                  }
+
+                  const typedEmailRecipient = resolveTypedEmailRecipient({
+                    query: trimmedQuery,
+                    results
+                  });
+
+                  if (typedEmailRecipient === null) {
+                    return;
+                  }
+
+                  event.preventDefault();
+                  onRecipientChange(typedEmailRecipient);
+                }}
+                placeholder="Search Salesforce contacts or type an email"
+                className="pl-9"
+              />
+            </div>
+          )}
+
+          {shouldShowResults ? (
+            <div className="rounded-md border border-slate-200 bg-white">
+              {isSearching ? (
+                <div className="px-3 py-2 text-sm text-slate-500">
+                  Searching contacts...
+                </div>
+              ) : results.length > 0 ? (
+                <ul className="divide-y divide-slate-100">
+                  {results.map((result) => (
+                    <li key={result.id}>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          onRecipientChange(toContactRecipient(result));
+                        }}
+                        className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left hover:bg-slate-50"
+                      >
+                        <div className="min-w-0">
+                          <div className="flex items-center gap-2">
+                            <span className="truncate text-sm font-medium text-slate-900">
+                              {result.displayName}
+                            </span>
+                            {result.salesforceContactId ? (
+                              <Chip tone="neutral" className="uppercase">
+                                SF
+                              </Chip>
+                            ) : null}
+                          </div>
+                          <div className="mt-0.5 flex flex-wrap items-center gap-2 text-xs text-slate-500">
+                            {result.primaryEmail ? (
+                              <span className="font-mono text-[11px] text-slate-600">
+                                {result.primaryEmail}
+                              </span>
+                            ) : (
+                              <span>No primary email</span>
+                            )}
+                            {result.primaryProjectName ? (
+                              <span>{result.primaryProjectName}</span>
+                            ) : null}
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              ) : query.trim().length >= 2 ? (
+                <div className="px-3 py-2 text-sm text-slate-500">
+                  No matching contacts.
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </label>
+    </div>
+  );
+}
+
+function RecipientChip({
+  recipient,
+  locked,
+  onClear
+}: {
+  readonly recipient: ComposerRecipientValue;
+  readonly locked: boolean;
+  readonly onClear: () => void;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex min-h-10 w-full items-center justify-between gap-3 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm"
+      )}
+    >
+      <span className="min-w-0">
+        {recipient.kind === "contact" ? (
+          <span className="flex min-w-0 items-center gap-2">
+            <span className="truncate font-medium text-slate-900">
+              {recipient.displayName}
+            </span>
+            {recipient.primaryEmail ? (
+              <span className="truncate font-mono text-[11px] text-slate-500">
+                {recipient.primaryEmail}
+              </span>
+            ) : null}
+          </span>
+        ) : (
+          <span className="flex min-w-0 items-center gap-2">
+            <span className="truncate font-medium text-slate-900">
+              {recipient.emailAddress}
+            </span>
+            <Chip tone="neutral">external</Chip>
+          </span>
+        )}
+      </span>
+
+      {!locked ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label="Clear recipient"
+          className="size-7 text-slate-500 hover:bg-slate-200 hover:text-slate-900"
+          onClick={onClear}
+        >
+          <XIcon className="size-4" />
+        </Button>
+      ) : null}
+    </span>
+  );
+}

--- a/apps/web/app/inbox/_components/inbox-client-provider.tsx
+++ b/apps/web/app/inbox/_components/inbox-client-provider.tsx
@@ -9,27 +9,25 @@ import {
   type ReactNode
 } from "react";
 
-/**
- * Prototype-local client state shared across the Inbox list column and
- * Detail workspace. These are intentionally ephemeral UI concerns only.
- *
- * Extended to cover every interactive state the UI needs:
- *   - reminders
- *   - search query + results
- *   - composer status (idle → saving → saved / error → sending → sent / failed)
- *   - AI draft lifecycle (idle → generating → inserted → edited / discarded)
- *   - queue & timeline loading flags
- */
+import type {
+  InboxComposerAliasOption,
+  InboxComposerReplyContext
+} from "../_lib/view-models";
+import {
+  reduceComposerPane,
+  type ComposerPaneState
+} from "../_lib/composer-ui";
 
-// ---------- Reminder ----------
+/**
+ * Ephemeral Inbox UI state shared across the list column and detail workspace.
+ * This stays strictly session-local by design.
+ */
 
 export interface Reminder {
   readonly value: number;
   readonly unit: "hours" | "days" | "weeks";
   readonly firesAt: string;
 }
-
-// ---------- Composer status ----------
 
 export type ComposerStatus =
   | "idle"
@@ -41,11 +39,9 @@ export type ComposerStatus =
   | "send-failure";
 
 export interface ComposerValidationError {
-  readonly field: "subject" | "body" | "recipient";
+  readonly field: "subject" | "body" | "recipient" | "alias" | "attachments";
   readonly message: string;
 }
-
-// ---------- AI draft lifecycle ----------
 
 export type AiDraftStatus =
   | "idle"
@@ -71,8 +67,6 @@ const INITIAL_AI_DRAFT: AiDraftState = {
   errorMessage: null
 };
 
-// ---------- Search ----------
-
 export interface SearchState {
   readonly query: string;
   readonly isActive: boolean;
@@ -85,33 +79,45 @@ const INITIAL_SEARCH: SearchState = {
   resultContactIds: []
 };
 
-// ---------- Context shape ----------
+export interface InboxToastState {
+  readonly id: number;
+  readonly message: string;
+  readonly tone: "success" | "error";
+}
 
 interface InboxClientState {
-  // Reminders
   readonly reminders: ReadonlyMap<string, Reminder>;
   readonly setReminder: (contactId: string, reminder: Reminder) => void;
   readonly clearReminder: (contactId: string) => void;
 
-  // Search
   readonly search: SearchState;
   readonly setSearchQuery: (query: string) => void;
   readonly setSearchResults: (contactIds: readonly string[]) => void;
   readonly clearSearch: () => void;
 
-  // Loading flags
   readonly isQueueLoading: boolean;
   readonly setQueueLoading: (loading: boolean) => void;
   readonly isTimelineLoading: boolean;
   readonly setTimelineLoading: (loading: boolean) => void;
 
-  // Composer status
+  readonly composerAliases: readonly InboxComposerAliasOption[];
+  readonly composerPane: ComposerPaneState;
+  readonly openNewDraft: () => void;
+  readonly openReplyDraft: (replyContext: InboxComposerReplyContext) => void;
+  readonly closeComposer: () => void;
+
   readonly composerStatus: ComposerStatus;
   readonly composerErrors: readonly ComposerValidationError[];
   readonly setComposerStatus: (status: ComposerStatus) => void;
   readonly setComposerErrors: (errors: readonly ComposerValidationError[]) => void;
 
-  // AI drafting
+  readonly toast: InboxToastState | null;
+  readonly showToast: (
+    message: string,
+    tone?: InboxToastState["tone"]
+  ) => void;
+  readonly clearToast: () => void;
+
   readonly aiDraft: AiDraftState;
   readonly startAiGeneration: (prompt: string) => void;
   readonly insertAiDraft: (text: string) => void;
@@ -123,51 +129,62 @@ interface InboxClientState {
   readonly resetAiDraft: () => void;
 }
 
-const InboxClientContext = createContext<InboxClientState | null>(
-  null
-);
+const InboxClientContext = createContext<InboxClientState | null>(null);
 
 export function InboxClientProvider({
-  children
+  children,
+  composerAliases
 }: {
   readonly children: ReactNode;
+  readonly composerAliases: readonly InboxComposerAliasOption[];
 }) {
-  // Reminders
   const [reminders, setReminders] = useState<ReadonlyMap<string, Reminder>>(
     () => new Map<string, Reminder>()
   );
+  const [search, setSearch] = useState(INITIAL_SEARCH);
+  const [isQueueLoading, setQueueLoading] = useState(false);
+  const [isTimelineLoading, setTimelineLoading] = useState(false);
+  const [composerPane, setComposerPane] = useState<ComposerPaneState>({
+    mode: "closed"
+  });
+  const [composerStatus, setComposerStatus] = useState<ComposerStatus>("idle");
+  const [composerErrors, setComposerErrors] = useState<
+    readonly ComposerValidationError[]
+  >([]);
+  const [toast, setToast] = useState<InboxToastState | null>(null);
+  const [aiDraft, setAiDraft] = useState(INITIAL_AI_DRAFT);
 
   const setReminder = useCallback((contactId: string, reminder: Reminder) => {
-    setReminders((prev) => {
-      const next = new Map(prev);
+    setReminders((previous) => {
+      const next = new Map(previous);
       next.set(contactId, reminder);
       return next;
     });
   }, []);
 
   const clearReminder = useCallback((contactId: string) => {
-    setReminders((prev) => {
-      if (!prev.has(contactId)) return prev;
-      const next = new Map(prev);
+    setReminders((previous) => {
+      if (!previous.has(contactId)) {
+        return previous;
+      }
+
+      const next = new Map(previous);
       next.delete(contactId);
       return next;
     });
   }, []);
 
-  // Search
-  const [search, setSearch] = useState(INITIAL_SEARCH);
-
   const setSearchQuery = useCallback((query: string) => {
-    setSearch((prev) => ({
-      ...prev,
+    setSearch((previous) => ({
+      ...previous,
       query,
       isActive: query.length > 0
     }));
   }, []);
 
   const setSearchResults = useCallback((contactIds: readonly string[]) => {
-    setSearch((prev) => ({
-      ...prev,
+    setSearch((previous) => ({
+      ...previous,
       resultContactIds: contactIds
     }));
   }, []);
@@ -176,18 +193,54 @@ export function InboxClientProvider({
     setSearch(INITIAL_SEARCH);
   }, []);
 
-  // Loading flags
-  const [isQueueLoading, setQueueLoading] = useState(false);
-  const [isTimelineLoading, setTimelineLoading] = useState(false);
+  const openNewDraft = useCallback(() => {
+    setComposerPane((previous) =>
+      reduceComposerPane(previous, {
+        type: "open-new-draft"
+      })
+    );
+    setComposerStatus("idle");
+    setComposerErrors([]);
+  }, []);
 
-  // Composer status
-  const [composerStatus, setComposerStatus] = useState<ComposerStatus>("idle");
-  const [composerErrors, setComposerErrors] = useState<
-    readonly ComposerValidationError[]
-  >([]);
+  const openReplyDraft = useCallback(
+    (replyContext: InboxComposerReplyContext) => {
+      setComposerPane((previous) =>
+        reduceComposerPane(previous, {
+          type: "open-reply",
+          replyContext
+        })
+      );
+      setComposerStatus("idle");
+      setComposerErrors([]);
+    },
+    []
+  );
 
-  // AI draft lifecycle
-  const [aiDraft, setAiDraft] = useState(INITIAL_AI_DRAFT);
+  const closeComposer = useCallback(() => {
+    setComposerPane((previous) =>
+      reduceComposerPane(previous, {
+        type: "close"
+      })
+    );
+    setComposerStatus("idle");
+    setComposerErrors([]);
+  }, []);
+
+  const showToast = useCallback(
+    (message: string, tone: InboxToastState["tone"] = "success") => {
+      setToast({
+        id: Date.now(),
+        message,
+        tone
+      });
+    },
+    []
+  );
+
+  const clearToast = useCallback(() => {
+    setToast(null);
+  }, []);
 
   const startAiGeneration = useCallback((prompt: string) => {
     setAiDraft({
@@ -199,23 +252,23 @@ export function InboxClientProvider({
   }, []);
 
   const insertAiDraft = useCallback((text: string) => {
-    setAiDraft((prev) => ({
-      ...prev,
+    setAiDraft((previous) => ({
+      ...previous,
       status: "inserted",
       generatedText: text
     }));
   }, []);
 
   const markAiDraftEdited = useCallback(() => {
-    setAiDraft((prev) => ({
-      ...prev,
+    setAiDraft((previous) => ({
+      ...previous,
       status: "edited-after-generation"
     }));
   }, []);
 
   const discardAiDraft = useCallback(() => {
-    setAiDraft((prev) => ({
-      ...prev,
+    setAiDraft((previous) => ({
+      ...previous,
       status: "discarded",
       generatedText: ""
     }));
@@ -231,16 +284,16 @@ export function InboxClientProvider({
   }, []);
 
   const setAiUnavailable = useCallback(() => {
-    setAiDraft((prev) => ({
-      ...prev,
+    setAiDraft((previous) => ({
+      ...previous,
       status: "unavailable",
       errorMessage: "AI drafting is currently unavailable."
     }));
   }, []);
 
   const setAiError = useCallback((message: string) => {
-    setAiDraft((prev) => ({
-      ...prev,
+    setAiDraft((previous) => ({
+      ...previous,
       status: "error",
       errorMessage: message
     }));
@@ -263,10 +316,18 @@ export function InboxClientProvider({
       setQueueLoading,
       isTimelineLoading,
       setTimelineLoading,
+      composerAliases,
+      composerPane,
+      openNewDraft,
+      openReplyDraft,
+      closeComposer,
       composerStatus,
       composerErrors,
       setComposerStatus,
       setComposerErrors,
+      toast,
+      showToast,
+      clearToast,
       aiDraft,
       startAiGeneration,
       insertAiDraft,
@@ -287,8 +348,16 @@ export function InboxClientProvider({
       clearSearch,
       isQueueLoading,
       isTimelineLoading,
+      composerAliases,
+      composerPane,
+      openNewDraft,
+      openReplyDraft,
+      closeComposer,
       composerStatus,
       composerErrors,
+      toast,
+      showToast,
+      clearToast,
       aiDraft,
       startAiGeneration,
       insertAiDraft,
@@ -310,10 +379,10 @@ export function InboxClientProvider({
 
 export function useInboxClient(): InboxClientState {
   const value = useContext(InboxClientContext);
+
   if (!value) {
-    throw new Error(
-      "useInboxClient must be used inside InboxClientProvider"
-    );
+    throw new Error("useInboxClient must be used inside InboxClientProvider");
   }
+
   return value;
 }

--- a/apps/web/app/inbox/_components/inbox-composer.tsx
+++ b/apps/web/app/inbox/_components/inbox-composer.tsx
@@ -1,1170 +1,680 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  useTransition,
+  type ChangeEvent
+} from "react";
 
 import { Button } from "@/components/ui/button";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import { cn } from "@/lib/utils";
-
-import {
-  useInboxClient,
-  type AiDraftStatus,
-  type ComposerStatus
-} from "./inbox-client-provider";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger
-} from "@/components/ui/popover";
-import { SectionLabel } from "@/components/ui/section-label";
-import { RADIUS, TONE, TRANSITION } from "@/app/_lib/design-tokens";
+import { Input } from "@/components/ui/input";
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger
 } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
 
 import {
+  sendComposerAction,
+  type ComposerSendActionInput,
+  type ComposerSendActionResult
+} from "../actions";
+import {
+  isComposerSendDisabled,
+  resolveDefaultAlias
+} from "../_lib/composer-ui";
+import {
+  ComposerRecipientPicker,
+  type ComposerContactRecipient,
+  type ComposerRecipientValue
+} from "./composer-recipient-picker";
+import {
+  useInboxClient,
+  type ComposerValidationError
+} from "./inbox-client-provider";
+import {
   AlertCircleIcon,
-  BoldIcon,
-  BotIcon,
-  CheckCircleIcon,
-  ChevronDownIcon,
-  FileDocIcon,
   ImageIcon,
-  ItalicIcon,
-  LinkIcon,
-  ListIcon,
-  ListOrderedIcon,
   LoaderIcon,
   MailIcon,
   NoteIcon,
   PaperclipIcon,
-  PhoneIcon,
-  RefreshCwIcon,
-  RotateCcwIcon,
   SendIcon,
-  SparkleIcon,
-  TrashIcon,
-  UploadIcon,
-  WifiOffIcon,
-  XCircleIcon,
   XIcon
 } from "./icons";
 
-type ComposerMode = "email" | "sms" | "note";
+const MAX_TOTAL_ATTACHMENT_BYTES = 20 * 1024 * 1024;
 
-interface ComposerProps {
-  readonly contactDisplayName: string;
-  readonly smsEligible: boolean;
-  readonly onOpenChange?: (open: boolean) => void;
+interface AttachmentDraft {
+  readonly id: string;
+  readonly filename: string;
+  readonly size: number;
+  readonly contentType: string;
+  readonly contentBase64: string;
 }
 
-const EMAIL_ALIASES = [
-  { id: "jordan", label: "Jordan Cole", email: "jordan@adventurescientists.org" },
-  { id: "team", label: "AS Team", email: "team@adventurescientists.org" },
-  { id: "noreply", label: "No Reply", email: "noreply@adventurescientists.org" }
-] as const;
+interface InlineComposerError {
+  readonly message: string;
+  readonly retryable: boolean;
+}
 
-type EmailAliasId = (typeof EMAIL_ALIASES)[number]["id"];
+type ComposerFieldErrors = readonly ComposerValidationError[];
 
-export function InboxComposer({
-  contactDisplayName,
-  smsEligible,
-  onOpenChange
-}: ComposerProps) {
-  const [isOpen, setIsOpenRaw] = useState(false);
-
-  const setIsOpen = (open: boolean) => {
-    setIsOpenRaw(open);
-    onOpenChange?.(open);
-  };
-  const [mode, setMode] = useState<ComposerMode>("email");
-  const [draft, setDraft] = useState("");
-  const [subject, setSubject] = useState("");
-  const [fromAlias, setFromAlias] = useState<EmailAliasId>(EMAIL_ALIASES[0].id);
-  const [aiPrompt, setAiPrompt] = useState("");
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-
-  const {
-    composerStatus,
-    composerErrors,
-    setComposerStatus,
-    setComposerErrors,
-    aiDraft,
-    startAiGeneration,
-    insertAiDraft,
-    markAiDraftEdited,
-    discardAiDraft,
-    repromptAi,
-    resetAiDraft
-  } = useInboxClient();
-
-  const placeholder = placeholderForMode(mode, contactDisplayName);
-  const firstName =
-    contactDisplayName.split(" ")[0] ?? contactDisplayName;
-
-  // When AI finishes generating, place the text into the textarea
-  const prevStatus = useRef(aiDraft.status);
-  useEffect(() => {
-    if (
-      prevStatus.current !== "inserted" &&
-      aiDraft.status === "inserted" &&
-      aiDraft.generatedText
-    ) {
-      setDraft(aiDraft.generatedText);
-    }
-    if (
-      aiDraft.status === "generating" ||
-      aiDraft.status === "reprompting"
-    ) {
-      setIsOpen(true);
-    }
-    prevStatus.current = aiDraft.status;
-  }, [aiDraft.status, aiDraft.generatedText]);
-
-  // Auto-collapse after successful send
-  useEffect(() => {
-    if (composerStatus !== "sent-success") return undefined;
-    const timer = setTimeout(() => {
-      setIsOpen(false);
-    }, 2000);
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [composerStatus]);
-
-  const handleSend = () => {
-    if (mode === "email" && !subject.trim()) {
-      setComposerErrors([
-        { field: "subject", message: "Subject is required" }
-      ]);
-      setComposerStatus("validation-error");
-      return;
-    }
-    if (!draft.trim()) {
-      setComposerErrors([
-        { field: "body", message: "Message body cannot be empty" }
-      ]);
-      setComposerStatus("validation-error");
-      return;
-    }
-    setComposerErrors([]);
-    setComposerStatus("sending");
-    setTimeout(() => {
-      setComposerStatus("sent-success");
-      setDraft("");
-      setSubject("");
-      resetAiDraft();
-      setTimeout(() => {
-        setComposerStatus("idle");
-      }, 2500);
-    }, 1200);
-  };
-
-  const handleDraftWithAi = () => {
-    if (
-      aiDraft.status === "idle" ||
-      aiDraft.status === "discarded" ||
-      aiDraft.status === "error"
-    ) {
-      startAiGeneration("Draft a helpful reply");
-      setTimeout(() => {
-        insertAiDraft(
-          `Hi ${firstName},\n\nThanks for reaching out. I've looked into this and wanted to follow up with some next steps.\n\nLet me know if you have any questions.\n\nBest,\nJordan`
-        );
-      }, 2000);
-    }
-  };
-
-  const handleReprompt = () => {
-    repromptAi(aiPrompt || "Make it more concise");
-    setAiPrompt("");
-    setTimeout(() => {
-      insertAiDraft(
-        `Hi ${firstName},\n\nFollowing up on your message — here are the next steps. Let me know if questions come up.\n\nBest,\nJordan`
-      );
-    }, 1500);
-  };
-
-  const handleDiscard = () => {
-    setDraft("");
-    discardAiDraft();
-  };
-
-  const isShowingAiDraft =
-    aiDraft.status === "inserted" && draft === aiDraft.generatedText;
-  const isAiEdited = aiDraft.status === "edited-after-generation";
-  const isAiGenerating =
-    aiDraft.status === "generating" || aiDraft.status === "reprompting";
-  const hasAiDraftActive = isShowingAiDraft || isAiEdited;
-
-  // ───── Collapsed reply bar ─────
-  if (!isOpen) {
-    return (
-      <div className="border-t border-slate-200 bg-white">
-        <button
-          type="button"
-          onClick={() => {
-            setIsOpen(true);
-          }}
-          className={`flex w-full items-center gap-2.5 px-5 py-3 text-left text-sm text-slate-400 ${TRANSITION.fast} hover:bg-slate-50 hover:text-slate-600`}
-        >
-          <MailIcon className="h-4 w-4 shrink-0" />
-          <span className="flex-1 truncate">
-            Reply to {contactDisplayName}…
-          </span>
-        </button>
-      </div>
-    );
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   }
 
-  // ───── Expanded composer ─────
+  if (bytes >= 1024) {
+    return `${String(Math.round(bytes / 1024))} KB`;
+  }
+
+  return `${bytes.toString()} B`;
+}
+
+function resolveRecipientLabel(recipient: ComposerRecipientValue): string {
+  return recipient.kind === "contact"
+    ? recipient.displayName
+    : recipient.emailAddress;
+}
+
+function mapFieldErrors(
+  result: Extract<ComposerSendActionResult, { ok: false }>
+): ComposerFieldErrors {
+  if (result.fieldErrors === undefined) {
+    return [];
+  }
+
+  const mappedErrors: ComposerValidationError[] = [];
+
+  for (const [field, message] of Object.entries(result.fieldErrors)) {
+    switch (field) {
+      case "alias":
+        mappedErrors.push({ field: "alias", message });
+        break;
+      case "subject":
+        mappedErrors.push({ field: "subject", message });
+        break;
+      case "attachments":
+        mappedErrors.push({ field: "attachments", message });
+        break;
+      case "bodyPlaintext":
+        mappedErrors.push({ field: "body", message });
+        break;
+      default:
+        if (field.startsWith("recipient")) {
+          mappedErrors.push({ field: "recipient", message });
+        }
+    }
+  }
+
+  return mappedErrors;
+}
+
+function autoResizeTextarea(textarea: HTMLTextAreaElement): void {
+  textarea.style.height = "auto";
+  const lineHeight = 24;
+  textarea.style.height = `${String(Math.min(textarea.scrollHeight, lineHeight * 20))}px`;
+}
+
+async function readFileAsAttachment(file: File): Promise<AttachmentDraft> {
+  const contentBase64 = await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.onload = () => {
+      const result = reader.result;
+
+      if (typeof result !== "string") {
+        reject(new Error("Failed to read file."));
+        return;
+      }
+
+      const [, base64] = result.split(",", 2);
+
+      if (!base64) {
+        reject(new Error("Failed to encode file."));
+        return;
+      }
+
+      resolve(base64);
+    };
+    reader.onerror = () => {
+      reject(reader.error ?? new Error("Failed to read file."));
+    };
+    reader.readAsDataURL(file);
+  });
+
+  return {
+    id: `${file.name}:${file.lastModified.toString()}:${file.size.toString()}`,
+    filename: file.name,
+    size: file.size,
+    contentType: file.type || "application/octet-stream",
+    contentBase64
+  };
+}
+
+export function InboxComposerReplyBar({
+  contactDisplayName,
+  onReply
+}: {
+  readonly contactDisplayName: string;
+  readonly onReply: () => void;
+}) {
   return (
     <div className="border-t border-slate-200 bg-white">
-      {/* Toolbar: mode tabs | AI button + minimize */}
-      <div className="flex items-center justify-between border-b border-slate-100 px-5 py-2">
-        <ToggleGroup
-          type="single"
-          value={mode}
-          onValueChange={(value) => {
-            if (value) setMode(value as ComposerMode);
-          }}
-          size="sm"
-          className="gap-1 rounded-lg bg-slate-100 p-0.5"
-        >
-          <ToggleGroupItem
-            value="email"
-            className="gap-1.5 rounded-md px-2.5 text-xs data-[state=on]:bg-white data-[state=on]:text-slate-900 data-[state=on]:shadow-sm [&_svg]:size-3.5"
-          >
-            <MailIcon className="h-3.5 w-3.5" />
-            Email
-          </ToggleGroupItem>
-          <ToggleGroupItem
-            value="sms"
-            disabled={!smsEligible}
-            title={smsEligible ? undefined : "No verified phone"}
-            className="gap-1.5 rounded-md px-2.5 text-xs data-[state=on]:bg-white data-[state=on]:text-slate-900 data-[state=on]:shadow-sm [&_svg]:size-3.5"
-          >
-            <PhoneIcon className="h-3.5 w-3.5" />
-            SMS
-          </ToggleGroupItem>
-          <ToggleGroupItem
-            value="note"
-            className="gap-1.5 rounded-md px-2.5 text-xs data-[state=on]:bg-white data-[state=on]:text-slate-900 data-[state=on]:shadow-sm [&_svg]:size-3.5"
-          >
-            <NoteIcon className="h-3.5 w-3.5" />
-            Note
-          </ToggleGroupItem>
-        </ToggleGroup>
-
-        <div className="flex items-center gap-1.5">
-          {/* Draft with AI — ALWAYS visible, state changes label */}
-          <AiButton
-            status={aiDraft.status}
-            onDraftWithAi={handleDraftWithAi}
-          />
-          <button
-            type="button"
-            aria-label="Minimize composer"
-            onClick={() => {
-              setIsOpen(false);
-            }}
-            className={`inline-flex h-7 w-7 items-center justify-center ${RADIUS.sm} text-slate-400 ${TRANSITION.fast} hover:bg-slate-100 hover:text-slate-600`}
-          >
-            <ChevronDownIcon className="h-4 w-4" />
-          </button>
-        </div>
-      </div>
-
-      {/* Inline AI status banners */}
-      {aiDraft.status === "error" ? (
-        <div className="flex items-center gap-2 border-b border-red-100 bg-red-50/60 px-5 py-2">
-          <AlertCircleIcon className="h-3.5 w-3.5 shrink-0 text-red-500" />
-          <p className="flex-1 text-xs text-red-700">
-            {aiDraft.errorMessage ?? "Something went wrong."}
-          </p>
-          <button
-            type="button"
-            onClick={resetAiDraft}
-            className="text-xs font-medium text-red-700 hover:text-red-900"
-          >
-            Try again
-          </button>
-        </div>
-      ) : null}
-
-      {aiDraft.status === "unavailable" ? (
-        <div className="flex items-center gap-2 border-b border-slate-100 bg-slate-50 px-5 py-2">
-          <WifiOffIcon className="h-3.5 w-3.5 shrink-0 text-slate-400" />
-          <p className="text-xs text-slate-500">
-            AI drafting is temporarily unavailable.
-          </p>
-        </div>
-      ) : null}
-
-      {/* Compose area */}
-      <div className={mode === "note" ? "bg-amber-50/50" : ""}>
-        {mode === "email" ? (
-          <>
-            <div className="flex items-center gap-2 border-b border-slate-100 px-5 py-2 text-xs">
-              <span className="w-12 shrink-0 font-medium text-slate-700">
-                From:
-              </span>
-              <select
-                value={fromAlias}
-                onChange={(e) => {
-                  const target = e.currentTarget as unknown as {
-                    readonly value: EmailAliasId;
-                  };
-                  setFromAlias(target.value);
-                }}
-                className="flex-1 bg-transparent text-xs text-slate-900 focus:outline-none"
-              >
-                {EMAIL_ALIASES.map((alias) => (
-                  <option key={alias.id} value={alias.id}>
-                    {alias.label} &lt;{alias.email}&gt;
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div className="flex items-center gap-2 border-b border-slate-100 px-5 py-2 text-xs">
-              <span className="w-12 shrink-0 font-medium text-slate-700">
-                To:
-              </span>
-              <span className="text-slate-600">{contactDisplayName}</span>
-            </div>
-            <div className="flex items-center gap-2 border-b border-slate-100 px-5 py-2 text-xs">
-              <label
-                htmlFor="inbox-subject"
-                className="w-12 shrink-0 font-medium text-slate-700"
-              >
-                Subject:
-              </label>
-              <input
-                id="inbox-subject"
-                type="text"
-                value={subject}
-                onChange={(event) => {
-                  const target = event.currentTarget as unknown as {
-                    readonly value: string;
-                  };
-                  setSubject(target.value);
-                  if (composerStatus === "validation-error") {
-                    setComposerStatus("idle");
-                    setComposerErrors([]);
-                  }
-                }}
-                placeholder="Add a subject"
-                className={cn(
-                  "flex-1 bg-transparent text-xs text-slate-900 placeholder:text-slate-400 focus:outline-none",
-                  composerStatus === "validation-error" &&
-                    composerErrors.some((e) => e.field === "subject") &&
-                    "text-red-700 placeholder:text-red-400"
-                )}
-              />
-            </div>
-          </>
-        ) : null}
-
-        {/* Textarea — or AI generating indicator */}
-        <div className="relative">
-          {isAiGenerating ? (
-            <div className="flex min-h-[8rem] items-center justify-center gap-3 px-5">
-              <BotIcon className="h-4 w-4 text-violet-500" />
-              <span className="text-xs text-violet-600">
-                {aiDraft.status === "reprompting"
-                  ? "Regenerating draft…"
-                  : "Writing a draft…"}
-              </span>
-              <div className="flex gap-1">
-                <span className="h-1 w-1 animate-bounce rounded-full bg-violet-400 [animation-delay:0ms]" />
-                <span className="h-1 w-1 animate-bounce rounded-full bg-violet-400 [animation-delay:150ms]" />
-                <span className="h-1 w-1 animate-bounce rounded-full bg-violet-400 [animation-delay:300ms]" />
-              </div>
-            </div>
-          ) : (
-            <textarea
-              ref={textareaRef}
-              value={draft}
-              onChange={(event) => {
-                const target = event.currentTarget as unknown as {
-                  readonly value: string;
-                };
-                setDraft(target.value);
-                if (composerStatus === "validation-error") {
-                  setComposerStatus("idle");
-                  setComposerErrors([]);
-                }
-                if (
-                  aiDraft.status === "inserted" &&
-                  target.value !== aiDraft.generatedText
-                ) {
-                  markAiDraftEdited();
-                }
-              }}
-              placeholder={placeholder}
-              rows={6}
-              className={cn(
-                "block w-full resize-none bg-transparent px-5 py-3 text-sm leading-6 text-slate-900 placeholder:text-slate-400 focus:outline-none",
-                composerStatus === "validation-error" &&
-                  composerErrors.some((e) => e.field === "body") &&
-                  "ring-1 ring-inset ring-red-200"
-              )}
-            />
-          )}
-
-          {hasAiDraftActive ? (
-            <div className="absolute left-0 top-0 h-full w-0.5 bg-violet-300" />
-          ) : null}
-        </div>
-      </div>
-
-      {/* Formatting toolbar */}
-      {!isAiGenerating ? <FormattingToolbar mode={mode} /> : null}
-
-      {/* AI draft toolbar — shown when AI content is in the textarea */}
-      {hasAiDraftActive ? (
-        <AiToolbar
-          isEdited={isAiEdited}
-          aiPrompt={aiPrompt}
-          onPromptChange={setAiPrompt}
-          onReprompt={handleReprompt}
-          onDiscard={handleDiscard}
-          disabled={isAiGenerating}
-        />
-      ) : null}
-
-      {/* Validation errors */}
-      {composerStatus === "validation-error" && composerErrors.length > 0 ? (
-        <div className="border-t border-red-100 bg-red-50/50 px-5 py-2">
-          {composerErrors.map((error) => (
-            <p
-              key={error.field}
-              className="flex items-center gap-1.5 text-xs text-red-700"
-            >
-              <AlertCircleIcon className="h-3 w-3 shrink-0" />
-              {error.message}
-            </p>
-          ))}
-        </div>
-      ) : null}
-
-      {/* Footer: status left, send right */}
-      <div className="flex items-center border-t border-slate-100 px-5 py-2.5">
-        <div className="flex min-w-0 flex-1 items-center gap-2">
-          <ComposerStatusIndicator
-            status={composerStatus}
-            onRetry={handleSend}
-            onDismiss={() => {
-              setComposerStatus("idle");
-            }}
-          />
-
-          {mode === "note" && composerStatus === "idle" ? (
-            <p className="text-[11px] text-slate-500">
-              Only visible to operators.
-            </p>
-          ) : null}
-
-          {composerStatus === "idle" &&
-          draft.length > 0 &&
-          !hasAiDraftActive ? (
-            <span className="flex items-center gap-1 text-[11px] text-slate-400">
-              <CheckCircleIcon className="h-3 w-3" />
-              Auto-saved
-            </span>
-          ) : null}
-        </div>
-
-        <Button
-          size="sm"
-          className="ml-3 gap-1.5"
-          disabled={
-            composerStatus === "sending" ||
-            composerStatus === "sent-success" ||
-            isAiGenerating
-          }
-          onClick={handleSend}
-        >
-          {composerStatus === "sending" ? (
-            <>
-              <LoaderIcon className="h-3.5 w-3.5 animate-spin" />
-              Sending…
-            </>
-          ) : composerStatus === "sent-success" ? (
-            <>
-              <CheckCircleIcon className="h-3.5 w-3.5" />
-              Sent
-            </>
-          ) : (
-            <>
-              <SendIcon className="h-3.5 w-3.5" />
-              {mode === "note" ? "Save note" : "Send"}
-            </>
-          )}
-        </Button>
-      </div>
+      <button
+        type="button"
+        onClick={onReply}
+        className="flex w-full items-center gap-2.5 px-5 py-3 text-left text-sm text-slate-500 hover:bg-slate-50 hover:text-slate-700"
+      >
+        <MailIcon className="size-4 shrink-0" />
+        <span className="truncate">Reply to {contactDisplayName}…</span>
+      </button>
     </div>
   );
 }
 
-// ───── AI button (always visible in toolbar) ─────
+export function InboxComposerDetailPane() {
+  const {
+    composerAliases,
+    composerPane,
+    closeComposer,
+    showToast,
+    composerErrors,
+    setComposerErrors,
+    setComposerStatus
+  } = useInboxClient();
+  const [activeTab, setActiveTab] = useState<"email" | "note">("email");
+  const [recipient, setRecipient] = useState<ComposerRecipientValue | null>(null);
+  const [selectedAlias, setSelectedAlias] = useState<string | null>(null);
+  const [subject, setSubject] = useState("");
+  const [body, setBody] = useState("");
+  const [attachments, setAttachments] = useState<readonly AttachmentDraft[]>([]);
+  const [inlineError, setInlineError] = useState<InlineComposerError | null>(null);
+  const [isSending, startSendTransition] = useTransition();
+  const bodyRef = useRef<HTMLTextAreaElement>(null);
+  const attachmentInputRef = useRef<HTMLInputElement>(null);
+  const imageInputRef = useRef<HTMLInputElement>(null);
 
-function AiButton({
-  status,
-  onDraftWithAi
-}: {
-  readonly status: AiDraftStatus;
-  readonly onDraftWithAi: () => void;
-}) {
-  // Generating / reprompting — show spinner
-  if (status === "generating" || status === "reprompting") {
-    return (
-      <Button variant="outline" size="sm" className="gap-1.5" disabled>
-        <LoaderIcon className="h-3.5 w-3.5 animate-spin text-violet-600" />
-        <span className="text-xs">Generating…</span>
-      </Button>
-    );
+  const replyContext =
+    composerPane.mode === "replying" ? composerPane.replyContext : null;
+
+  useEffect(() => {
+    if (composerPane.mode === "closed") {
+      return;
+    }
+
+    const replyRecipient: ComposerContactRecipient | null =
+      replyContext === null
+        ? null
+        : {
+            kind: "contact",
+            contactId: replyContext.contactId,
+            displayName: replyContext.contactDisplayName,
+            primaryEmail: null,
+            primaryProjectName: null,
+            salesforceContactId: null
+          };
+
+    setActiveTab("email");
+    setRecipient(replyRecipient);
+    setSelectedAlias(replyContext?.defaultAlias ?? null);
+    setSubject(replyContext?.subject ?? "");
+    setBody("");
+    setAttachments([]);
+    setInlineError(null);
+    setComposerStatus("idle");
+    setComposerErrors([]);
+  }, [
+    composerPane.mode,
+    replyContext,
+    setComposerErrors,
+    setComposerStatus
+  ]);
+
+  useEffect(() => {
+    if (!bodyRef.current) {
+      return;
+    }
+
+    autoResizeTextarea(bodyRef.current);
+  }, [body]);
+
+  if (composerPane.mode === "closed") {
+    return null;
   }
 
-  // Unavailable — disabled with note
-  if (status === "unavailable") {
-    return (
-      <Button
-        variant="outline"
-        size="sm"
-        className="gap-1.5 text-slate-400"
-        disabled
-      >
-        <WifiOffIcon className="h-3.5 w-3.5" />
-        <span className="text-xs">AI unavailable</span>
-      </Button>
-    );
-  }
-
-  // Draft is active (inserted or edited) — button still visible but secondary
-  if (status === "inserted" || status === "edited-after-generation") {
-    return (
-      <Button
-        variant="ghost"
-        size="sm"
-        className="gap-1.5 text-slate-400"
-        disabled
-      >
-        <SparkleIcon className="h-3.5 w-3.5" />
-        <span className="text-xs">AI active</span>
-      </Button>
-    );
-  }
-
-  // Default — ready to use
-  return (
-    <Button
-      variant="outline"
-      size="sm"
-      className="gap-1.5"
-      onClick={onDraftWithAi}
-    >
-      <SparkleIcon className="h-3.5 w-3.5 text-violet-600" />
-      <span className="text-xs">Draft with AI</span>
-    </Button>
+  const attachmentBytes = attachments.reduce(
+    (total, attachment) => total + attachment.size,
+    0
   );
-}
-
-// ───── Composer status indicator ─────
-
-function ComposerStatusIndicator({
-  status,
-  onRetry,
-  onDismiss
-}: {
-  readonly status: ComposerStatus;
-  readonly onRetry: () => void;
-  readonly onDismiss: () => void;
-}) {
-  switch (status) {
-    case "idle":
-      return null;
-    case "saving-draft":
-      return (
-        <span className="flex items-center gap-1.5 text-xs text-slate-500">
-          <LoaderIcon className="h-3 w-3 animate-spin" />
-          Saving…
-        </span>
-      );
-    case "draft-saved":
-      return (
-        <span className="flex items-center gap-1.5 text-xs text-emerald-700">
-          <CheckCircleIcon className="h-3 w-3" />
-          Saved
-        </span>
-      );
-    case "validation-error":
-      return (
-        <span className="flex items-center gap-1.5 text-xs text-red-600">
-          <AlertCircleIcon className="h-3 w-3" />
-          Fix errors above
-        </span>
-      );
-    case "sending":
-      return (
-        <span className="flex items-center gap-1.5 text-xs text-slate-500">
-          <LoaderIcon className="h-3 w-3 animate-spin" />
-          Sending…
-        </span>
-      );
-    case "sent-success":
-      return (
-        <span className="flex items-center gap-1.5 text-xs text-emerald-700">
-          <CheckCircleIcon className="h-3 w-3" />
-          Sent
-        </span>
-      );
-    case "send-failure":
-      return (
-        <div className="flex items-center gap-2">
-          <span className="flex items-center gap-1.5 text-xs text-red-600">
-            <XCircleIcon className="h-3 w-3" />
-            Failed
-          </span>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-6 px-2 text-xs text-red-700 hover:text-red-900"
-            onClick={onRetry}
-          >
-            <RefreshCwIcon className="mr-1 h-3 w-3" />
-            Retry
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-6 px-2 text-xs text-slate-500"
-            onClick={onDismiss}
-          >
-            Dismiss
-          </Button>
-        </div>
-      );
-  }
-}
-
-// ───── AI draft toolbar ─────
-
-function AiToolbar({
-  isEdited,
-  aiPrompt,
-  onPromptChange,
-  onReprompt,
-  onDiscard,
-  disabled
-}: {
-  readonly isEdited: boolean;
-  readonly aiPrompt: string;
-  readonly onPromptChange: (v: string) => void;
-  readonly onReprompt: () => void;
-  readonly onDiscard: () => void;
-  readonly disabled: boolean;
-}) {
-  const [repromptOpen, setRepromptOpen] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  const openReprompt = () => {
-    setRepromptOpen(true);
-    setTimeout(() => {
-      const el = inputRef.current;
-      if (el && "focus" in el) {
-        (el as unknown as { focus: () => void }).focus();
-      }
-    }, 50);
+  const isReplying = composerPane.mode === "replying";
+  const isSendDisabled = isComposerSendDisabled({
+    activeTab,
+    recipient,
+    selectedAlias,
+    subject,
+    body,
+    isSending
+  });
+  const aliasError = composerErrors.find((error) => error.field === "alias");
+  const subjectError = composerErrors.find((error) => error.field === "subject");
+  const bodyError = composerErrors.find((error) => error.field === "body");
+  const recipientError = composerErrors.find(
+    (error) => error.field === "recipient"
+  );
+  const attachmentError = composerErrors.find(
+    (error) => error.field === "attachments"
+  );
+  const clearComposerErrors = () => {
+    setInlineError(null);
+    setComposerErrors([]);
   };
 
-  const submitReprompt = () => {
-    onReprompt();
-    setRepromptOpen(false);
+  const handleRecipientChange = (nextRecipient: ComposerRecipientValue | null) => {
+    setRecipient(nextRecipient);
+    clearComposerErrors();
+
+    if (isReplying) {
+      return;
+    }
+
+    setSelectedAlias(
+      resolveDefaultAlias({
+        recipient: nextRecipient,
+        aliases: composerAliases
+      })
+    );
+  };
+
+  const handleFilesSelected = async (
+    event: ChangeEvent<HTMLInputElement>
+  ) => {
+    const files = event.currentTarget.files;
+    event.currentTarget.value = "";
+
+    if (files === null || files.length === 0) {
+      return;
+    }
+
+    const selectedFiles = Array.from(files);
+    const nextTotalBytes =
+      attachmentBytes +
+      selectedFiles.reduce((total, file) => total + file.size, 0);
+
+    if (nextTotalBytes > MAX_TOTAL_ATTACHMENT_BYTES) {
+      setInlineError({
+        message: "Attachments can't exceed 20 MB total.",
+        retryable: false
+      });
+      setComposerErrors([
+        {
+          field: "attachments",
+          message: "Attachments can't exceed 20 MB total."
+        }
+      ]);
+      return;
+    }
+
+    try {
+      const nextAttachments = await Promise.all(
+        selectedFiles.map((file) => readFileAsAttachment(file))
+      );
+
+      setAttachments((previous) => [...previous, ...nextAttachments]);
+      clearComposerErrors();
+    } catch {
+      setInlineError({
+        message: "We couldn't read one of those files. Please try again.",
+        retryable: true
+      });
+    }
+  };
+
+  const submit = () => {
+    if (recipient === null || selectedAlias === null || activeTab !== "email") {
+      return;
+    }
+
+    const payload: ComposerSendActionInput = {
+      recipient:
+        recipient.kind === "contact"
+          ? {
+              kind: "contact",
+              contactId: recipient.contactId
+            }
+          : {
+              kind: "email",
+              emailAddress: recipient.emailAddress
+            },
+      alias: selectedAlias,
+      subject: subject.trim(),
+      bodyPlaintext: body.trim(),
+      attachments: attachments.map((attachment) => ({
+        filename: attachment.filename,
+        contentType: attachment.contentType,
+        contentBase64: attachment.contentBase64
+      })),
+      ...(replyContext?.threadId === null || replyContext === null
+        ? {}
+        : { threadId: replyContext.threadId }),
+      ...(replyContext?.inReplyToRfc822 === null || replyContext === null
+        ? {}
+        : {
+            inReplyToRfc822: replyContext.inReplyToRfc822
+          })
+    };
+
+    setInlineError(null);
+    setComposerErrors([]);
+    setComposerStatus("sending");
+
+    startSendTransition(async () => {
+      const result = await sendComposerAction(payload);
+
+      if (result.ok) {
+        setComposerStatus("sent-success");
+        showToast(`Sent to ${resolveRecipientLabel(recipient)}`, "success");
+        closeComposer();
+        return;
+      }
+
+      setComposerErrors(mapFieldErrors(result));
+      setComposerStatus(
+        result.code === "validation_error" ? "validation-error" : "send-failure"
+      );
+      setInlineError({
+        message: result.message,
+        retryable: result.retryable === true
+      });
+    });
   };
 
   return (
-    <div className={`flex items-center gap-2 border-t border-violet-100 ${TONE.violet.subtle} px-5 py-1.5`}>
-      <SparkleIcon className="h-3 w-3 shrink-0 text-violet-500" />
-      <span className="text-[11px] font-medium text-violet-700">
-        {isEdited ? "AI draft · edited" : "AI draft"}
-      </span>
+    <TooltipProvider>
+      <section className="flex min-h-0 flex-1 flex-col bg-white">
+        <header className="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+          <div>
+            <p className="text-lg font-semibold text-slate-900">
+              {isReplying && recipient?.kind === "contact"
+                ? `Reply to ${recipient.displayName}`
+                : "New draft"}
+            </p>
+            <p className="mt-1 text-sm text-slate-500">
+              Plain-text email with file attachments.
+            </p>
+          </div>
 
-      <div className="ml-auto flex items-center gap-1">
-        {repromptOpen ? (
-          <>
-            <div className="flex items-center overflow-hidden rounded-md border border-violet-200 bg-white shadow-sm">
-              <input
-                ref={inputRef}
-                type="text"
-                value={aiPrompt}
-                onChange={(e) => {
-                  const target = e.currentTarget as unknown as {
-                    readonly value: string;
-                  };
-                  onPromptChange(target.value);
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") submitReprompt();
-                  if (e.key === "Escape") setRepromptOpen(false);
-                }}
-                placeholder="e.g. Make it shorter…"
-                className="w-48 px-2.5 py-1 text-[11px] text-slate-800 placeholder:text-slate-400 focus:outline-none"
-              />
-              <button
-                type="button"
-                onClick={submitReprompt}
-                disabled={disabled}
-                className="flex items-center border-l border-violet-200 bg-violet-50 px-2 py-1 text-violet-600 transition-colors hover:bg-violet-100 disabled:opacity-50"
-              >
-                <SendIcon className="h-3 w-3" />
-              </button>
-            </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label="Close composer"
+            className="size-8"
+            onClick={closeComposer}
+          >
+            <XIcon className="size-4" />
+          </Button>
+        </header>
+
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-6 py-5">
+          <div className="flex items-center gap-2 border-b border-slate-200 pb-4">
             <button
               type="button"
               onClick={() => {
-                setRepromptOpen(false);
+                setActiveTab("email");
               }}
-              className="inline-flex h-6 w-6 items-center justify-center rounded text-slate-400 hover:text-slate-600"
+              className={cn(
+                "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium",
+                activeTab === "email"
+                  ? "bg-slate-900 text-white"
+                  : "bg-slate-100 text-slate-600"
+              )}
             >
-              <XIcon className="h-3 w-3" />
+              <MailIcon className="size-4" />
+              Email
             </button>
-          </>
-        ) : (
-          <button
-            type="button"
-            onClick={openReprompt}
-            disabled={disabled}
-            className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] font-medium text-violet-700 transition-colors hover:bg-violet-100 hover:text-violet-900 disabled:opacity-50"
-          >
-            <RotateCcwIcon className="h-3 w-3" />
-            Redo
-          </button>
-        )}
-        <div className="mx-0.5 h-3 w-px bg-violet-200" />
-        <button
-          type="button"
-          onClick={onDiscard}
-          className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] font-medium text-slate-500 transition-colors hover:text-red-600"
-        >
-          <TrashIcon className="h-3 w-3" />
-          Discard
-        </button>
-      </div>
-    </div>
-  );
-}
 
-// ───── Formatting toolbar ─────
-
-type LinkState = "idle" | "editing" | "inserted";
-type ImageState = "idle" | "picking" | "uploading" | "uploaded" | "error";
-type AttachState = "idle" | "picking" | "uploading" | "attached" | "error";
-
-interface AttachedFile {
-  readonly name: string;
-  readonly size: string;
-}
-
-function FormattingToolbar({ mode }: { readonly mode: ComposerMode }) {
-  // Text formatting (toggle states)
-  const [bold, setBold] = useState(false);
-  const [italic, setItalic] = useState(false);
-  const [list, setList] = useState<"none" | "bullet" | "ordered">("none");
-
-  // Link state
-  const [linkState, setLinkState] = useState<LinkState>("idle");
-  const [linkUrl, setLinkUrl] = useState("");
-  const [linkText, setLinkText] = useState("");
-
-  // Image embed state
-  const [imageState, setImageState] = useState<ImageState>("idle");
-  const [imagePreview, setImagePreview] = useState<string | null>(null);
-
-  // File attach state
-  const [attachState, setAttachState] = useState<AttachState>("idle");
-  const [attachedFiles, setAttachedFiles] = useState<readonly AttachedFile[]>(
-    []
-  );
-
-  const handleInsertLink = () => {
-    if (linkUrl.trim()) {
-      setLinkState("inserted");
-      setTimeout(() => {
-        setLinkState("idle");
-        setLinkUrl("");
-        setLinkText("");
-      }, 1500);
-    }
-  };
-
-  const handleImagePick = () => {
-    setImageState("uploading");
-    setTimeout(() => {
-      setImagePreview("landscape-photo.jpg");
-      setImageState("uploaded");
-    }, 1200);
-  };
-
-  const handleAttachFile = () => {
-    setAttachState("uploading");
-    setTimeout(() => {
-      setAttachedFiles((prev) => [
-        ...prev,
-        { name: "training-schedule.pdf", size: "245 KB" }
-      ]);
-      setAttachState("attached");
-    }, 1000);
-  };
-
-  const handleRemoveFile = (name: string) => {
-    setAttachedFiles((prev) => prev.filter((f) => f.name !== name));
-    if (attachedFiles.length <= 1) {
-      setAttachState("idle");
-    }
-  };
-
-  const handleRemoveImage = () => {
-    setImagePreview(null);
-    setImageState("idle");
-  };
-
-  const isSms = mode === "sms";
-
-  return (
-    <TooltipProvider delayDuration={300}>
-      <div className="border-t border-slate-100">
-        {/* Attached files strip */}
-        {attachedFiles.length > 0 ? (
-          <div className="flex flex-wrap gap-2 border-b border-slate-100 px-5 py-2">
-            {attachedFiles.map((file) => (
-              <span
-                key={file.name}
-                className="inline-flex items-center gap-1.5 rounded-md bg-slate-100 px-2 py-1 text-[11px] text-slate-700"
-              >
-                <FileDocIcon className="h-3 w-3 text-slate-500" />
-                {file.name}
-                <span className="text-slate-400">{file.size}</span>
+            <Tooltip>
+              <TooltipTrigger asChild>
                 <button
                   type="button"
-                  onClick={() => {
-                    handleRemoveFile(file.name);
-                  }}
-                  className="ml-0.5 rounded p-0.5 text-slate-400 hover:text-red-500"
+                  disabled
+                  className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-3 py-1.5 text-sm font-medium text-slate-400"
                 >
-                  <XIcon className="h-2.5 w-2.5" />
+                  <NoteIcon className="size-4" />
+                  Note
                 </button>
-              </span>
-            ))}
+              </TooltipTrigger>
+              <TooltipContent>Coming in next update</TooltipContent>
+            </Tooltip>
           </div>
-        ) : null}
 
-        {/* Embedded image preview */}
-        {imagePreview ? (
-          <div className="border-b border-slate-100 px-5 py-2">
-            <div className="inline-flex items-center gap-2 rounded-md bg-emerald-50 px-2.5 py-1.5 text-[11px] text-emerald-700">
-              <ImageIcon className="h-3 w-3" />
-              <span className="font-medium">{imagePreview}</span>
-              <span className="text-emerald-500">embedded</span>
-              <button
-                type="button"
-                onClick={handleRemoveImage}
-                className="ml-1 rounded p-0.5 text-emerald-500 hover:text-red-500"
-              >
-                <XIcon className="h-2.5 w-2.5" />
-              </button>
-            </div>
-          </div>
-        ) : null}
+          <div className="mt-5 space-y-5">
+            <ComposerRecipientPicker
+              recipient={recipient}
+              locked={isReplying}
+              onRecipientChange={handleRecipientChange}
+            />
+            {recipientError ? (
+              <p className="-mt-3 text-xs text-rose-700">{recipientError.message}</p>
+            ) : null}
 
-        {/* Toolbar buttons */}
-        <div className="flex items-center gap-0.5 px-4 py-1.5">
-          {/* Text formatting — email and note only */}
-          {!isSms ? (
-            <>
-              <ToolbarButton
-                icon={<BoldIcon className="h-3.5 w-3.5" />}
-                label="Bold"
-                active={bold}
-                onClick={() => {
-                  setBold((b) => !b);
-                }}
-              />
-              <ToolbarButton
-                icon={<ItalicIcon className="h-3.5 w-3.5" />}
-                label="Italic"
-                active={italic}
-                onClick={() => {
-                  setItalic((i) => !i);
-                }}
-              />
-              <ToolbarButton
-                icon={<ListIcon className="h-3.5 w-3.5" />}
-                label="Bullet list"
-                active={list === "bullet"}
-                onClick={() => {
-                  setList((l) => (l === "bullet" ? "none" : "bullet"));
-                }}
-              />
-              <ToolbarButton
-                icon={<ListOrderedIcon className="h-3.5 w-3.5" />}
-                label="Numbered list"
-                active={list === "ordered"}
-                onClick={() => {
-                  setList((l) => (l === "ordered" ? "none" : "ordered"));
-                }}
-              />
-
-              <div className="mx-1 h-4 w-px bg-slate-200" />
-            </>
-          ) : null}
-
-          {/* Add Link */}
-          <Popover
-            open={linkState === "editing"}
-            onOpenChange={(open) => {
-              setLinkState(open ? "editing" : "idle");
-            }}
-          >
-            <PopoverTrigger asChild>
-              <span>
-                <ToolbarButton
-                  icon={<LinkIcon className="h-3.5 w-3.5" />}
-                  label={
-                    linkState === "inserted" ? "Link inserted" : "Add link"
-                  }
-                  active={linkState === "editing"}
-                  success={linkState === "inserted"}
-                  onClick={() => {
-                    setLinkState("editing");
-                  }}
-                />
+            <label className="flex items-start gap-3">
+              <span className="mt-2 w-10 text-sm font-medium text-slate-700">
+                From:
               </span>
-            </PopoverTrigger>
-            <PopoverContent
-              align="start"
-              className="w-72"
-              onOpenAutoFocus={(e) => {
-                e.preventDefault();
-              }}
-            >
-              <div className="space-y-2">
-                <SectionLabel as="p">
-                  Insert link
-                </SectionLabel>
-                <input
-                  type="text"
-                  value={linkUrl}
-                  onChange={(e) => {
-                    const target = e.currentTarget as unknown as {
-                      readonly value: string;
-                    };
-                    setLinkUrl(target.value);
+              <div className="flex-1">
+                <select
+                  value={selectedAlias ?? ""}
+                  onChange={(event) => {
+                    const nextAlias = event.currentTarget.value;
+                    setSelectedAlias(nextAlias.length > 0 ? nextAlias : null);
+                    clearComposerErrors();
                   }}
-                  placeholder="https://…"
-                  className="w-full rounded-md border border-slate-200 px-2.5 py-1.5 text-xs text-slate-900 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-300"
-                />
-                <input
-                  type="text"
-                  value={linkText}
-                  onChange={(e) => {
-                    const target = e.currentTarget as unknown as {
-                      readonly value: string;
-                    };
-                    setLinkText(target.value);
+                  className={cn(
+                    "flex h-10 w-full rounded-md border border-slate-200 bg-white px-3 text-sm text-slate-900 shadow-sm focus:outline-none focus:ring-1 focus:ring-slate-300",
+                    aliasError ? "border-rose-300 ring-1 ring-rose-200" : ""
+                  )}
+                >
+                  <option value="">Choose an alias</option>
+                  {composerAliases.map((alias) => (
+                    <option key={alias.id} value={alias.alias}>
+                      {alias.alias} · {alias.projectName}
+                    </option>
+                  ))}
+                </select>
+                {aliasError ? (
+                  <p className="mt-1 text-xs text-rose-700">{aliasError.message}</p>
+                ) : null}
+              </div>
+            </label>
+
+            <label className="flex items-start gap-3">
+              <span className="mt-2 w-10 text-sm font-medium text-slate-700">
+                Subject:
+              </span>
+              <div className="flex-1">
+                <Input
+                  value={subject}
+                  onChange={(event) => {
+                    setSubject(event.currentTarget.value);
+                    clearComposerErrors();
                   }}
-                  placeholder="Display text (optional)"
-                  className="w-full rounded-md border border-slate-200 px-2.5 py-1.5 text-xs text-slate-900 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-300"
+                  placeholder="Subject"
+                  className={cn(
+                    subjectError ? "border-rose-300 ring-1 ring-rose-200" : ""
+                  )}
                 />
-                <div className="flex justify-end gap-2 pt-1">
+                {subjectError ? (
+                  <p className="mt-1 text-xs text-rose-700">{subjectError.message}</p>
+                ) : null}
+              </div>
+            </label>
+
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-slate-700">Message</span>
+                <div className="flex items-center gap-2">
                   <Button
-                    variant="ghost"
+                    type="button"
+                    variant="outline"
                     size="sm"
-                    className="h-7 text-xs"
                     onClick={() => {
-                      setLinkState("idle");
+                      attachmentInputRef.current?.click();
                     }}
                   >
-                    Cancel
+                    <PaperclipIcon className="size-4" />
+                    Attach file
                   </Button>
                   <Button
+                    type="button"
+                    variant="outline"
                     size="sm"
-                    className="h-7 text-xs"
-                    disabled={!linkUrl.trim()}
-                    onClick={handleInsertLink}
+                    onClick={() => {
+                      imageInputRef.current?.click();
+                    }}
                   >
-                    Insert
+                    <ImageIcon className="size-4" />
+                    Embed image
                   </Button>
                 </div>
               </div>
-            </PopoverContent>
-          </Popover>
 
-          {/* Embed Image — email and note only */}
-          {!isSms ? (
-            <Popover
-              open={imageState === "picking"}
-              onOpenChange={(open) => {
-                setImageState(open ? "picking" : "idle");
-              }}
-            >
-              <PopoverTrigger asChild>
-                <span>
-                  <ToolbarButton
-                    icon={
-                      imageState === "uploading" ? (
-                        <LoaderIcon className="h-3.5 w-3.5 animate-spin" />
-                      ) : (
-                        <ImageIcon className="h-3.5 w-3.5" />
-                      )
-                    }
-                    label={
-                      imageState === "uploading"
-                        ? "Uploading…"
-                        : imageState === "uploaded"
-                          ? "Image embedded"
-                          : imageState === "error"
-                            ? "Upload failed"
-                            : "Embed image"
-                    }
-                    active={imageState === "picking"}
-                    success={imageState === "uploaded"}
-                    error={imageState === "error"}
-                    disabled={imageState === "uploading"}
-                    onClick={() => {
-                      if (
-                        imageState === "idle" ||
-                        imageState === "error"
-                      ) {
-                        setImageState("picking");
-                      }
-                    }}
-                  />
-                </span>
-              </PopoverTrigger>
-              <PopoverContent align="start" className="w-64">
-                <div className="space-y-3">
-                  <SectionLabel as="p">
-                    Embed image
-                  </SectionLabel>
-                  <button
-                    type="button"
-                    onClick={handleImagePick}
-                    className="flex w-full items-center justify-center gap-2 rounded-lg border-2 border-dashed border-slate-300 py-6 text-xs text-slate-500 transition-colors hover:border-slate-400 hover:bg-slate-50 hover:text-slate-700"
-                  >
-                    <UploadIcon className="h-4 w-4" />
-                    Choose image or drag here
-                  </button>
-                  <p className="text-center text-[10px] text-slate-400">
-                    PNG, JPG, GIF up to 5 MB
-                  </p>
+              <textarea
+                ref={bodyRef}
+                rows={6}
+                value={body}
+                onChange={(event) => {
+                  setBody(event.currentTarget.value);
+                  clearComposerErrors();
+                }}
+                onInput={(event) => {
+                  autoResizeTextarea(event.currentTarget);
+                }}
+                placeholder="Write your message"
+                className={cn(
+                  "max-h-[30rem] min-h-36 w-full resize-none rounded-md border border-slate-200 px-3 py-2 text-sm leading-6 text-slate-900 shadow-sm focus:outline-none focus:ring-1 focus:ring-slate-300",
+                  bodyError ? "border-rose-300 ring-1 ring-rose-200" : ""
+                )}
+              />
+              {bodyError ? (
+                <p className="text-xs text-rose-700">{bodyError.message}</p>
+              ) : null}
+
+              {attachments.length > 0 ? (
+                <div className="flex flex-wrap gap-2">
+                  {attachments.map((attachment) => (
+                    <span
+                      key={attachment.id}
+                      className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs text-slate-700"
+                    >
+                      <span className="font-medium">{attachment.filename}</span>
+                      <span className="text-slate-500">
+                        {formatBytes(attachment.size)}
+                      </span>
+                      <button
+                        type="button"
+                        aria-label={`Remove ${attachment.filename}`}
+                        onClick={() => {
+                          clearComposerErrors();
+                          setAttachments((previous) =>
+                            previous.filter((item) => item.id !== attachment.id)
+                          );
+                        }}
+                        className="text-slate-400 hover:text-slate-700"
+                      >
+                        <XIcon className="size-3.5" />
+                      </button>
+                    </span>
+                  ))}
                 </div>
-              </PopoverContent>
-            </Popover>
+              ) : null}
+
+              <p className="text-xs text-slate-500">
+                {formatBytes(attachmentBytes)} of {formatBytes(MAX_TOTAL_ATTACHMENT_BYTES)} used
+              </p>
+              {attachmentError ? (
+                <p className="text-xs text-rose-700">{attachmentError.message}</p>
+              ) : null}
+
+              <input
+                ref={attachmentInputRef}
+                type="file"
+                multiple
+                className="hidden"
+                onChange={handleFilesSelected}
+              />
+              <input
+                ref={imageInputRef}
+                type="file"
+                accept="image/*"
+                multiple
+                className="hidden"
+                onChange={handleFilesSelected}
+              />
+            </div>
+          </div>
+        </div>
+
+        <footer className="border-t border-slate-200 px-6 py-4">
+          {inlineError || recipientError || attachmentError ? (
+            <div className="mb-3 flex items-start justify-between gap-3 rounded-md border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-900">
+              <div className="flex items-start gap-2">
+                <AlertCircleIcon className="mt-0.5 size-4 shrink-0" />
+                <span>
+                  {inlineError?.message ??
+                    recipientError?.message ??
+                    attachmentError?.message}
+                </span>
+              </div>
+              {inlineError?.retryable ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="border-rose-200 bg-white text-rose-900 hover:bg-rose-100"
+                  onClick={submit}
+                >
+                  Retry
+                </Button>
+              ) : null}
+            </div>
           ) : null}
 
-          {/* Attach File */}
-          <ToolbarButton
-            icon={
-              attachState === "uploading" ? (
-                <LoaderIcon className="h-3.5 w-3.5 animate-spin" />
+          <div className="flex items-center justify-between">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={closeComposer}
+            >
+              Cancel
+            </Button>
+
+            <Button
+              type="button"
+              disabled={isSendDisabled}
+              onClick={submit}
+            >
+              {isSending ? (
+                <>
+                  <LoaderIcon className="size-4 animate-spin" />
+                  Sending...
+                </>
               ) : (
-                <PaperclipIcon className="h-3.5 w-3.5" />
-              )
-            }
-            label={
-              attachState === "uploading"
-                ? "Uploading…"
-                : attachState === "attached"
-                  ? `${attachedFiles.length.toString()} attached`
-                  : attachState === "error"
-                    ? "Attach failed"
-                    : "Attach file"
-            }
-            error={attachState === "error"}
-            disabled={attachState === "uploading"}
-            onClick={() => {
-              if (
-                attachState === "idle" ||
-                attachState === "attached" ||
-                attachState === "error"
-              ) {
-                handleAttachFile();
-              }
-            }}
-          />
-        </div>
-      </div>
+                <>
+                  <SendIcon className="size-4" />
+                  Send
+                </>
+              )}
+            </Button>
+          </div>
+        </footer>
+      </section>
     </TooltipProvider>
   );
-}
-
-// ───── Toolbar button primitive ─────
-
-function ToolbarButton({
-  icon,
-  label,
-  active = false,
-  success = false,
-  error = false,
-  disabled = false,
-  onClick
-}: {
-  readonly icon: React.ReactNode;
-  readonly label: string;
-  readonly active?: boolean;
-  readonly success?: boolean;
-  readonly error?: boolean;
-  readonly disabled?: boolean;
-  readonly onClick?: () => void;
-}) {
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <button
-          type="button"
-          aria-label={label}
-          aria-pressed={active}
-          disabled={disabled}
-          onClick={onClick}
-          className={cn(
-            `inline-flex h-7 w-7 items-center justify-center ${RADIUS.sm} ${TRANSITION.fast}`,
-            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400",
-            "disabled:pointer-events-none disabled:opacity-40",
-            active
-              ? "bg-slate-200 text-slate-900"
-              : success
-                ? "text-emerald-600"
-                : error
-                  ? "text-red-500"
-                  : "text-slate-500 hover:bg-slate-100 hover:text-slate-900"
-          )}
-        >
-          {icon}
-        </button>
-      </TooltipTrigger>
-      <TooltipContent
-        side="top"
-        className="rounded bg-slate-900 px-2 py-1 text-[11px] text-white"
-      >
-        {label}
-      </TooltipContent>
-    </Tooltip>
-  );
-}
-
-// ───── Helpers ─────
-
-function placeholderForMode(mode: ComposerMode, name: string): string {
-  switch (mode) {
-    case "email":
-      return `Reply to ${name}…`;
-    case "sms":
-      return `Text ${name}…`;
-    case "note":
-      return "Write a note for the team — not visible to the contact.";
-  }
 }

--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -19,7 +19,8 @@ import { cn } from "@/lib/utils";
 
 import {
   clearInboxNeedsFollowUpAction,
-  markInboxNeedsFollowUpAction
+  markInboxNeedsFollowUpAction,
+  sendComposerAction
 } from "../actions";
 import { fetchInboxTimelinePage } from "../_lib/client-api";
 import type { InboxDetailViewModel } from "../_lib/view-models";
@@ -31,7 +32,7 @@ import {
 } from "./inbox-client-provider";
 import { SectionLabel } from "@/components/ui/section-label";
 import { LAYOUT, TEXT, TONE, TRANSITION, SPACING } from "@/app/_lib/design-tokens";
-import { InboxComposer } from "./inbox-composer";
+import { InboxComposerReplyBar } from "./inbox-composer";
 import {
   InboxContactRail,
   InboxProjectStatusBadge
@@ -55,7 +56,7 @@ interface DetailProps {
 type ReminderUnit = "hours" | "days" | "weeks";
 
 export function InboxDetail({ detail }: DetailProps) {
-  const { contact, smsEligible } = detail;
+  const { contact } = detail;
   const timelineScrollRef = useRef<HTMLDivElement>(null);
   const activeTimelineRequestIdRef = useRef(0);
   const {
@@ -63,7 +64,9 @@ export function InboxDetail({ detail }: DetailProps) {
     setReminder,
     clearReminder,
     isTimelineLoading,
-    setTimelineLoading
+    setTimelineLoading,
+    openReplyDraft,
+    showToast
   } = useInboxClient();
 
   const [railOpen, setRailOpen] = useState(false);
@@ -72,6 +75,8 @@ export function InboxDetail({ detail }: DetailProps) {
   const [reminderUnit, setReminderUnit] = useState<ReminderUnit>("hours");
   const [timelineEntries, setTimelineEntries] = useState(detail.timeline);
   const [timelinePage, setTimelinePage] = useState(detail.timelinePage);
+  const [retryingEntryId, setRetryingEntryId] = useState<string | null>(null);
+  const [isRetryPending, startRetryTransition] = useTransition();
 
   useEffect(() => {
     activeTimelineRequestIdRef.current += 1;
@@ -157,6 +162,7 @@ export function InboxDetail({ detail }: DetailProps) {
   const firstName = contact.displayName.split(" ")[0] ?? contact.displayName;
   const isFollowUp = followUpToggle.value;
   const existingReminder = reminders.get(contact.contactId) ?? null;
+  const composerReplyContext = detail.composerReplyContext;
 
   const handleSetReminder = () => {
     const numeric = Number(reminderValue);
@@ -170,6 +176,63 @@ export function InboxDetail({ detail }: DetailProps) {
     clearReminder(contact.contactId);
     setReminderOpen(false);
   };
+
+  const handleRetryPending = useCallback(
+    (entryId: string) => {
+      const entry = timelineEntries.find((item) => item.id === entryId);
+
+      if (
+        entry?.sendStatus === undefined ||
+        entry.sendStatus === null ||
+        entry.sendStatus === "pending" ||
+        entry.attachmentCount > 0 ||
+        entry.mailbox === null
+      ) {
+        return;
+      }
+
+      const pendingId = entry.id.startsWith("pending-outbound:")
+        ? entry.id.slice("pending-outbound:".length)
+        : null;
+
+      if (pendingId === null) {
+        return;
+      }
+
+      const mailbox = entry.mailbox;
+
+      setRetryingEntryId(entry.id);
+      startRetryTransition(async () => {
+        try {
+          const result = await sendComposerAction({
+            recipient: {
+              kind: "contact",
+              contactId: contact.contactId
+            },
+            alias: mailbox,
+            subject: entry.subject ?? "",
+            bodyPlaintext: entry.body,
+            attachments: [],
+            ...(entry.threadId === null ? {} : { threadId: entry.threadId }),
+            ...(entry.inReplyToRfc822 === null
+              ? {}
+              : { inReplyToRfc822: entry.inReplyToRfc822 }),
+            supersedesPendingId: pendingId
+          });
+
+          if (result.ok) {
+            showToast(`Sent to ${contact.displayName}`, "success");
+          } else {
+            showToast(result.message, "error");
+          }
+        } catch {
+          showToast("We could not retry that email right now.", "error");
+        }
+        setRetryingEntryId(null);
+      });
+    },
+    [contact.contactId, contact.displayName, showToast, timelineEntries]
+  );
 
   return (
     <div className="flex min-h-0 flex-1">
@@ -292,6 +355,8 @@ export function InboxDetail({ detail }: DetailProps) {
               volunteerFirstName={firstName}
               hasMore={timelinePage.hasMore}
               isLoadingOlder={isTimelineLoading}
+              retryingEntryId={isRetryPending ? retryingEntryId : null}
+              onRetryPending={handleRetryPending}
               onLoadOlder={() => {
                 void loadOlderTimeline();
               }}
@@ -300,21 +365,14 @@ export function InboxDetail({ detail }: DetailProps) {
         </div>
 
         <div className="shrink-0">
-          <InboxComposer
-            contactDisplayName={contact.displayName}
-            smsEligible={smsEligible}
-            onOpenChange={(open) => {
-              if (open && timelineScrollRef.current) {
-                setTimeout(() => {
-                  const element = timelineScrollRef.current;
-
-                  if (element) {
-                    element.scrollTop = element.scrollHeight;
-                  }
-                }, 50);
-              }
-            }}
-          />
+          {composerReplyContext ? (
+            <InboxComposerReplyBar
+              contactDisplayName={contact.displayName}
+              onReply={() => {
+                openReplyDraft(composerReplyContext);
+              }}
+            />
+          ) : null}
         </div>
       </section>
 

--- a/apps/web/app/inbox/_components/inbox-keyboard-helpers.ts
+++ b/apps/web/app/inbox/_components/inbox-keyboard-helpers.ts
@@ -7,6 +7,9 @@ export const INBOX_SEARCH_INPUT_SELECTOR =
 export const INBOX_FOLLOW_UP_TOGGLE_SELECTOR =
   '[data-inbox-follow-up-toggle="true"]';
 
+export const INBOX_LIST_ROOT_SELECTOR =
+  '[data-inbox-list-root="true"]';
+
 export type InboxRowDirection = 1 | -1;
 
 export interface ShortcutTargetMeta {
@@ -113,4 +116,3 @@ export function getAdjacentFocusedRowContactId(input: {
 
   return rowContactIds[nextIndex] ?? null;
 }
-

--- a/apps/web/app/inbox/_components/inbox-keyboard-provider.tsx
+++ b/apps/web/app/inbox/_components/inbox-keyboard-provider.tsx
@@ -21,11 +21,13 @@ import {
   getAdjacentFocusedRowContactId,
   getPreferredFocusedRowContactId,
   INBOX_FOLLOW_UP_TOGGLE_SELECTOR,
+  INBOX_LIST_ROOT_SELECTOR,
   INBOX_ROW_SELECTOR,
   INBOX_SEARCH_INPUT_SELECTOR,
   isEditableShortcutTarget,
   isInboxKeyboardPath
 } from "./inbox-keyboard-helpers";
+import { useInboxClient } from "./inbox-client-provider";
 import { XIcon } from "./icons";
 
 interface InboxKeyboardProviderProps {
@@ -41,6 +43,7 @@ const SHORTCUTS = [
   { key: "J", description: "Focus the next conversation" },
   { key: "K", description: "Focus the previous conversation" },
   { key: "Enter", description: "Open the focused conversation" },
+  { key: "C", description: "Open a new draft" },
   { key: "Esc", description: "Return to the inbox list" },
   { key: "F", description: "Toggle Needs Follow-Up" },
   { key: "/", description: "Focus search" },
@@ -55,6 +58,7 @@ export function InboxKeyboardProvider({
   const rootRef = useRef<HTMLDivElement>(null);
   const lastFocusedContactIdRef = useRef<string | null>(null);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const { composerPane, closeComposer, openNewDraft } = useInboxClient();
 
   const getRowTargets = useCallback((): readonly RowTarget[] => {
     const root = rootRef.current;
@@ -163,6 +167,17 @@ export function InboxKeyboardProvider({
     button.click();
   }, []);
 
+  const isListFocused = useCallback((target: HTMLElement | null): boolean => {
+    const root = rootRef.current;
+    const listRoot = root?.querySelector<HTMLElement>(INBOX_LIST_ROOT_SELECTOR);
+
+    if (!listRoot || target === null) {
+      return false;
+    }
+
+    return listRoot.contains(target);
+  }, []);
+
   useEffect(() => {
     const root = rootRef.current;
 
@@ -233,6 +248,12 @@ export function InboxKeyboardProvider({
           setShortcutsOpen(false);
         }
 
+        if (composerPane.mode !== "closed") {
+          event.preventDefault();
+          closeComposer();
+          return;
+        }
+
         if (pathname !== "/inbox") {
           event.preventDefault();
           router.push("/inbox", { scroll: false });
@@ -252,6 +273,14 @@ export function InboxKeyboardProvider({
         case "k":
           event.preventDefault();
           focusAdjacentRow(-1);
+          return;
+        case "c":
+          if (!isListFocused(target)) {
+            return;
+          }
+
+          event.preventDefault();
+          openNewDraft();
           return;
         case "f":
           event.preventDefault();
@@ -297,13 +326,17 @@ export function InboxKeyboardProvider({
     pathname,
     router,
     shortcutsOpen,
-    triggerFollowUpToggle
+    triggerFollowUpToggle,
+    composerPane.mode,
+    closeComposer,
+    isListFocused,
+    openNewDraft
   ]);
 
   return (
     <div
       ref={rootRef}
-      className="relative flex h-screen w-screen overflow-hidden bg-slate-100 text-slate-900 antialiased"
+      className="relative flex h-dvh w-full overflow-hidden bg-slate-100 text-slate-900 antialiased"
     >
       <Popover open={shortcutsOpen} onOpenChange={setShortcutsOpen}>
         <PopoverAnchor asChild>

--- a/apps/web/app/inbox/_components/inbox-list.tsx
+++ b/apps/web/app/inbox/_components/inbox-list.tsx
@@ -23,6 +23,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { EmptyState } from "@/components/ui/empty-state";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 import { extractInboxContactId } from "./inbox-keyboard-helpers";
@@ -74,6 +75,7 @@ export function InboxList({
     clearSearch,
     isQueueLoading,
     setQueueLoading,
+    openNewDraft,
   } = useInboxClient();
   const urlQuery = searchParams.get("q") ?? "";
   const deferredQuery = useDeferredValue(search.query);
@@ -388,6 +390,7 @@ export function InboxList({
 
   return (
     <section
+      data-inbox-list-root="true"
       className={`relative flex ${LAYOUT.listWidth} shrink-0 flex-col overflow-hidden border-r border-slate-200 bg-white`}
     >
       <div className="sticky top-0 z-10 bg-white/95 backdrop-blur">
@@ -397,6 +400,14 @@ export function InboxList({
           <h1 className={`min-w-0 flex-1 truncate ${TEXT.headingLg}`}>
             {titleLabel}
           </h1>
+          <Button
+            type="button"
+            size="sm"
+            aria-keyshortcuts="c"
+            onClick={openNewDraft}
+          >
+            Compose
+          </Button>
           <button
             type="button"
             aria-label={filterPanelOpen ? "Close filters" : "Open filters"}

--- a/apps/web/app/inbox/_components/inbox-shell.tsx
+++ b/apps/web/app/inbox/_components/inbox-shell.tsx
@@ -2,7 +2,8 @@ import type { ReactNode } from "react";
 
 import type {
   InboxFilterId,
-  InboxListViewModel
+  InboxListViewModel,
+  InboxComposerAliasOption
 } from "../_lib/view-models";
 import { PrimaryIconRail } from "@/app/_components/primary-icon-rail";
 
@@ -10,10 +11,12 @@ import { InboxClientProvider } from "./inbox-client-provider";
 import { InboxFreshnessPoller } from "./inbox-freshness-poller";
 import { InboxKeyboardProvider } from "./inbox-keyboard-provider";
 import { InboxList } from "./inbox-list";
+import { InboxWorkspace } from "./inbox-workspace";
 
 interface ShellProps {
   readonly initialList: InboxListViewModel;
   readonly initialFilterId: InboxFilterId;
+  readonly composerAliases: readonly InboxComposerAliasOption[];
   readonly children: ReactNode;
 }
 
@@ -29,10 +32,11 @@ interface ShellProps {
 export function InboxShell({
   initialList,
   initialFilterId,
+  composerAliases,
   children
 }: ShellProps) {
   return (
-    <InboxClientProvider>
+    <InboxClientProvider composerAliases={composerAliases}>
       <InboxKeyboardProvider>
         <InboxFreshnessPoller listFreshness={initialList.freshness} />
         <PrimaryIconRail />
@@ -42,9 +46,7 @@ export function InboxShell({
           initialFilterId={initialFilterId}
         />
 
-        <main className="flex min-w-0 flex-1 flex-col overflow-hidden">
-          {children}
-        </main>
+        <InboxWorkspace>{children}</InboxWorkspace>
       </InboxKeyboardProvider>
     </InboxClientProvider>
   );

--- a/apps/web/app/inbox/_components/inbox-timeline.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline.tsx
@@ -7,8 +7,21 @@ import type {
   InboxTimelineEntryViewModel,
 } from "../_lib/view-models";
 import { autolinkText } from "./_autolink";
-import { ChevronRightIcon, MailIcon, NoteIcon, PhoneIcon } from "./icons";
+import {
+  ChevronRightIcon,
+  LoaderIcon,
+  MailIcon,
+  NoteIcon,
+  PhoneIcon,
+  RefreshCwIcon,
+} from "./icons";
 import { DividerLabel } from "@/components/ui/divider-label";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import {
   RADIUS,
@@ -24,6 +37,8 @@ interface TimelineProps {
   readonly hasMore?: boolean;
   readonly isLoadingOlder?: boolean;
   readonly onLoadOlder?: () => void;
+  readonly retryingEntryId?: string | null;
+  readonly onRetryPending?: (entryId: string) => void;
 }
 
 export function InboxTimeline({
@@ -32,6 +47,8 @@ export function InboxTimeline({
   hasMore = false,
   isLoadingOlder = false,
   onLoadOlder,
+  retryingEntryId = null,
+  onRetryPending,
 }: TimelineProps) {
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(
     () => new Set<string>(),
@@ -87,6 +104,8 @@ export function InboxTimeline({
             entry={entry}
             volunteerFirstName={volunteerFirstName}
             isExpanded={expanded.has(entry.id)}
+            retryingEntryId={retryingEntryId}
+            onRetryPending={onRetryPending}
             onToggle={() => {
               toggle(entry.id);
             }}
@@ -101,6 +120,8 @@ interface EntryProps {
   readonly entry: InboxTimelineEntryViewModel;
   readonly volunteerFirstName: string;
   readonly isExpanded: boolean;
+  readonly retryingEntryId: string | null;
+  readonly onRetryPending: ((entryId: string) => void) | undefined;
   readonly onToggle: () => void;
 }
 
@@ -108,6 +129,8 @@ function TimelineEntry({
   entry,
   volunteerFirstName,
   isExpanded,
+  retryingEntryId,
+  onRetryPending,
   onToggle,
 }: EntryProps) {
   const role = roleForKind(entry.kind);
@@ -116,7 +139,13 @@ function TimelineEntry({
     case "inbound":
       return <InboundBubble entry={entry} />;
     case "outbound":
-      return <OutboundBubble entry={entry} />;
+      return (
+        <OutboundBubble
+          entry={entry}
+          isRetrying={retryingEntryId === entry.id}
+          onRetryPending={onRetryPending}
+        />
+      );
     case "automated":
     case "campaign":
     case "activity":
@@ -180,18 +209,82 @@ function InboundBubble({
 
 function OutboundBubble({
   entry,
+  isRetrying,
+  onRetryPending,
 }: {
   readonly entry: InboxTimelineEntryViewModel;
+  readonly isRetrying: boolean;
+  readonly onRetryPending: ((entryId: string) => void) | undefined;
 }) {
   const isEmail = entry.channel === "email";
   const ChannelIcon = isEmail ? MailIcon : PhoneIcon;
   const body = bodyTextForEntry(entry);
+  const canRetry =
+    (entry.sendStatus === "failed" || entry.sendStatus === "orphaned") &&
+    entry.attachmentCount === 0 &&
+    onRetryPending !== undefined;
+  const retryDisabledReason =
+    entry.attachmentCount > 0
+      ? "Re-attach files and send as a new message"
+      : null;
 
   return (
     <li className="flex w-full flex-col items-end">
       <div
         className={`w-full max-w-2xl ${RADIUS.bubble} rounded-br-sm bg-slate-800 px-4 py-3 ${SHADOW.sm}`}
       >
+        {entry.sendStatus === "pending" ? (
+          <div className="mb-2 inline-flex items-center gap-1.5 rounded-full bg-white/10 px-2 py-1 text-[11px] font-medium text-slate-100">
+            <LoaderIcon className="size-3 animate-spin" />
+            Sending...
+          </div>
+        ) : null}
+
+        {entry.sendStatus === "failed" || entry.sendStatus === "orphaned" ? (
+          <div className="mb-3 flex items-center justify-between gap-3 rounded-md border border-rose-300 bg-rose-50 px-3 py-2 text-xs text-rose-900">
+            <span>
+              {entry.sendStatus === "failed"
+                ? "Send failed."
+                : "Send stalled before confirmation."}
+            </span>
+            {retryDisabledReason ? (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      disabled
+                      className="inline-flex items-center gap-1 rounded-md border border-rose-200 bg-white px-2 py-1 font-medium text-rose-500"
+                    >
+                      <RefreshCwIcon className="size-3" />
+                      Retry
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>{retryDisabledReason}</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            ) : (
+              <button
+                type="button"
+                disabled={!canRetry || isRetrying}
+                onClick={() => {
+                  if (canRetry) {
+                    onRetryPending(entry.id);
+                  }
+                }}
+                className="inline-flex items-center gap-1 rounded-md border border-rose-200 bg-white px-2 py-1 font-medium text-rose-800 hover:bg-rose-100 disabled:cursor-not-allowed disabled:opacity-70"
+              >
+                {isRetrying ? (
+                  <LoaderIcon className="size-3 animate-spin" />
+                ) : (
+                  <RefreshCwIcon className="size-3" />
+                )}
+                Retry
+              </button>
+            )}
+          </div>
+        ) : null}
+
         {isEmail && entry.subject ? (
           <p className="mb-1.5 text-balance text-[13px] font-semibold leading-snug text-slate-100">
             {entry.subject}

--- a/apps/web/app/inbox/_components/inbox-workspace.tsx
+++ b/apps/web/app/inbox/_components/inbox-workspace.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, type ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+
+import { useInboxClient } from "./inbox-client-provider";
+import { InboxComposerDetailPane } from "./inbox-composer";
+import { XIcon } from "./icons";
+
+export function InboxWorkspace({
+  children
+}: {
+  readonly children: ReactNode;
+}) {
+  const { composerPane, toast, clearToast } = useInboxClient();
+
+  useEffect(() => {
+    if (toast === null) {
+      return undefined;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      clearToast();
+    }, 3200);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [clearToast, toast]);
+
+  return (
+    <main className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
+      {composerPane.mode === "closed" ? children : <InboxComposerDetailPane />}
+
+      {toast ? (
+        <div className="pointer-events-none absolute right-5 top-5 z-50 flex justify-end">
+          <div
+            role={toast.tone === "error" ? "alert" : "status"}
+            className={`pointer-events-auto flex min-w-80 max-w-sm items-start gap-3 rounded-lg border px-4 py-3 shadow-lg ${
+              toast.tone === "error"
+                ? "border-rose-200 bg-rose-50 text-rose-900"
+                : "border-emerald-200 bg-emerald-50 text-emerald-900"
+            }`}
+          >
+            <p className="flex-1 text-sm font-medium">{toast.message}</p>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label="Dismiss notification"
+              className="size-7 text-current hover:bg-black/5"
+              onClick={clearToast}
+            >
+              <XIcon className="size-4" />
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </main>
+  );
+}

--- a/apps/web/app/inbox/_lib/composer-data.ts
+++ b/apps/web/app/inbox/_lib/composer-data.ts
@@ -1,0 +1,42 @@
+import type { InboxComposerAliasOption } from "./view-models";
+import { getStage1WebRuntime } from "@/src/server/stage1-runtime";
+
+export async function getInboxComposerAliases(): Promise<
+  readonly InboxComposerAliasOption[]
+> {
+  const runtime = await getStage1WebRuntime();
+  const aliases = await runtime.settings.aliases.listAssigned();
+  const projectIds = Array.from(
+    new Set(
+      aliases
+        .map((alias) => alias.projectId)
+        .filter((projectId): projectId is string => projectId !== null)
+    )
+  );
+  const projectDimensions =
+    await runtime.repositories.projectDimensions.listByIds(projectIds);
+  const projectNameById = new Map(
+    projectDimensions.map((project) => [project.projectId, project.projectName])
+  );
+
+  return aliases.flatMap((alias): readonly InboxComposerAliasOption[] => {
+    if (alias.projectId === null) {
+      return [];
+    }
+
+    const projectName = projectNameById.get(alias.projectId);
+
+    if (projectName === undefined) {
+      return [];
+    }
+
+    return [
+      {
+        id: alias.id,
+        alias: alias.alias,
+        projectId: alias.projectId,
+        projectName,
+      },
+    ];
+  });
+}

--- a/apps/web/app/inbox/_lib/composer-ui.ts
+++ b/apps/web/app/inbox/_lib/composer-ui.ts
@@ -1,0 +1,136 @@
+import { z } from "zod";
+
+import type {
+  InboxComposerAliasOption,
+  InboxComposerReplyContext
+} from "./view-models";
+
+const emailSchema = z.string().email();
+
+export type ComposerPaneState =
+  | {
+      readonly mode: "closed";
+    }
+  | {
+      readonly mode: "new-draft";
+    }
+  | {
+      readonly mode: "replying";
+      readonly replyContext: InboxComposerReplyContext;
+    };
+
+export type ComposerPaneAction =
+  | {
+      readonly type: "open-new-draft";
+    }
+  | {
+      readonly type: "open-reply";
+      readonly replyContext: InboxComposerReplyContext;
+    }
+  | {
+      readonly type: "close";
+    };
+
+export function reduceComposerPane(
+  _state: ComposerPaneState,
+  action: ComposerPaneAction
+): ComposerPaneState {
+  switch (action.type) {
+    case "open-new-draft":
+      return {
+        mode: "new-draft"
+      };
+    case "open-reply":
+      return {
+        mode: "replying",
+        replyContext: action.replyContext
+      };
+    case "close":
+      return {
+        mode: "closed"
+      };
+  }
+}
+
+function normalizeEmail(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export function resolveTypedEmailRecipient(input: {
+  readonly query: string;
+  readonly results: readonly {
+    readonly primaryEmail: string | null;
+  }[];
+}): {
+  readonly kind: "email";
+  readonly emailAddress: string;
+} | null {
+  const trimmedQuery = input.query.trim();
+
+  if (trimmedQuery.length === 0) {
+    return null;
+  }
+
+  const parsedEmail = emailSchema.safeParse(trimmedQuery);
+
+  if (!parsedEmail.success) {
+    return null;
+  }
+
+  const normalizedQuery = normalizeEmail(trimmedQuery);
+  const hasExactMatch = input.results.some(
+    (result) =>
+      result.primaryEmail !== null &&
+      normalizeEmail(result.primaryEmail) === normalizedQuery
+  );
+
+  if (hasExactMatch) {
+    return null;
+  }
+
+  return {
+    kind: "email",
+    emailAddress: normalizedQuery
+  };
+}
+
+export function resolveDefaultAlias(input: {
+  readonly recipient:
+    | {
+        readonly kind: string;
+        readonly primaryProjectName?: string | null;
+      }
+    | null;
+  readonly aliases: readonly InboxComposerAliasOption[];
+}): string | null {
+  const recipient = input.recipient;
+
+  if (recipient?.kind !== "contact" || recipient.primaryProjectName === null) {
+    return null;
+  }
+
+  const primaryProjectName = recipient.primaryProjectName;
+
+  return (
+    input.aliases.find((alias) => alias.projectName === primaryProjectName)
+      ?.alias ?? null
+  );
+}
+
+export function isComposerSendDisabled(input: {
+  readonly activeTab: "email" | "note";
+  readonly recipient: { readonly kind: string } | null;
+  readonly selectedAlias: string | null;
+  readonly subject: string;
+  readonly body: string;
+  readonly isSending: boolean;
+}): boolean {
+  return (
+    input.activeTab !== "email" ||
+    input.recipient === null ||
+    input.selectedAlias === null ||
+    input.subject.trim().length === 0 ||
+    input.body.trim().length === 0 ||
+    input.isSending
+  );
+}

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -17,6 +17,7 @@ import type {
   InboxAvatarTone,
   InboxBucket,
   InboxChannel,
+  InboxComposerReplyContext,
   InboxContactSummaryViewModel,
   InboxDetailViewModel,
   InboxFilterId,
@@ -1318,6 +1319,23 @@ function timelineSubject(item: TimelineItem): string | null {
   }
 }
 
+const REPLY_SUBJECT_PREFIX_PATTERN =
+  /^\s*(?:(?:re|fwd?)\s*:\s*)+/i;
+
+function buildReplySubject(subject: string | null): string {
+  const normalizedSubject = normalizeInlineText(subject);
+
+  if (normalizedSubject === null) {
+    return "";
+  }
+
+  const trimmedSubject = normalizeInlineText(
+    normalizedSubject.replace(REPLY_SUBJECT_PREFIX_PATTERN, "")
+  );
+
+  return trimmedSubject === null ? "" : `Re: ${trimmedSubject}`;
+}
+
 function timelineBody(item: TimelineItem): string {
   switch (item.family) {
     case "one_to_one_email":
@@ -1450,6 +1468,54 @@ function buildTimelineEntry(input: {
     channel: timelineChannel(input.item),
     isUnread,
     isPreview: isPreviewTimelineItem(input.item),
+    mailbox:
+      input.item.family === "one_to_one_email" ? input.item.mailbox ?? null : null,
+    threadId:
+      input.item.family === "one_to_one_email" ? input.item.threadId ?? null : null,
+    rfc822MessageId:
+      input.item.family === "one_to_one_email"
+        ? input.item.rfc822MessageId ?? null
+        : null,
+    inReplyToRfc822:
+      input.item.family === "one_to_one_email"
+        ? input.item.inReplyToRfc822 ?? null
+        : null,
+    sendStatus:
+      input.item.family === "one_to_one_email"
+        ? input.item.sendStatus ?? null
+        : null,
+    attachmentCount:
+      input.item.family === "one_to_one_email"
+        ? input.item.attachmentCount ?? 0
+        : 0,
+  };
+}
+
+function buildComposerReplyContext(input: {
+  readonly contact: ContactRecord;
+  readonly timelineItems: readonly TimelineItem[];
+  readonly defaultAlias: string | null;
+}): InboxComposerReplyContext | null {
+  const latestInboundEmail = [...input.timelineItems]
+    .reverse()
+    .find(
+      (
+        item
+      ): item is Extract<TimelineItem, { family: "one_to_one_email" }> =>
+        item.family === "one_to_one_email" && item.direction === "inbound"
+    );
+
+  if (latestInboundEmail === undefined) {
+    return null;
+  }
+
+  return {
+    contactId: input.contact.id,
+    contactDisplayName: input.contact.displayName,
+    subject: buildReplySubject(latestInboundEmail.subject),
+    threadId: latestInboundEmail.threadId ?? null,
+    inReplyToRfc822: latestInboundEmail.rfc822MessageId ?? null,
+    defaultAlias: input.defaultAlias,
   };
 }
 
@@ -2083,7 +2149,15 @@ export async function getInboxDetail(
     },
   });
 
+  const runtime = await getStage1WebRuntime();
   const referenceNowIso = new Date().toISOString();
+  const composerReplyContext = buildComposerReplyContext({
+    contact: cachedData.contact,
+    timelineItems: cachedData.timelineItems,
+    defaultAlias: await runtime.timelinePresentation.findLastInboundAliasForContact(
+      contactId
+    ),
+  });
 
   return {
     contact: buildContactSummary({
@@ -2106,6 +2180,7 @@ export async function getInboxDetail(
     bucket: mapBucket(cachedData.inboxProjection.bucket),
     needsFollowUp: cachedData.inboxProjection.needsFollowUp,
     smsEligible: cachedData.contact.primaryPhone !== null,
+    composerReplyContext,
     timelinePage: cachedData.timelinePage,
     freshness: cachedData.freshness,
   };

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -127,6 +127,12 @@ export type InboxTimelineEntryKind =
   | "internal-note"
   | "system-event";
 
+export type InboxTimelineEntrySendStatus =
+  | "pending"
+  | "failed"
+  | "orphaned"
+  | null;
+
 export interface InboxTimelineEntryViewModel {
   readonly id: string;
   readonly kind: InboxTimelineEntryKind;
@@ -138,6 +144,28 @@ export interface InboxTimelineEntryViewModel {
   readonly channel: InboxChannel | null;
   readonly isUnread: boolean;
   readonly isPreview: boolean;
+  readonly mailbox: string | null;
+  readonly threadId: string | null;
+  readonly rfc822MessageId: string | null;
+  readonly inReplyToRfc822: string | null;
+  readonly sendStatus: InboxTimelineEntrySendStatus;
+  readonly attachmentCount: number;
+}
+
+export interface InboxComposerAliasOption {
+  readonly id: string;
+  readonly alias: string;
+  readonly projectId: string;
+  readonly projectName: string;
+}
+
+export interface InboxComposerReplyContext {
+  readonly contactId: string;
+  readonly contactDisplayName: string;
+  readonly subject: string;
+  readonly threadId: string | null;
+  readonly inReplyToRfc822: string | null;
+  readonly defaultAlias: string | null;
 }
 
 export interface InboxDetailViewModel {
@@ -146,6 +174,7 @@ export interface InboxDetailViewModel {
   readonly bucket: InboxBucket;
   readonly needsFollowUp: boolean;
   readonly smsEligible: boolean;
+  readonly composerReplyContext: InboxComposerReplyContext | null;
   readonly timelinePage: {
     readonly hasMore: boolean;
     readonly nextCursor: string | null;

--- a/apps/web/app/inbox/actions.ts
+++ b/apps/web/app/inbox/actions.ts
@@ -74,6 +74,19 @@ export type ComposerSendActionInput = z.input<
 >;
 export type ComposerSendActionResult = UiResult<ComposerSendActionData>;
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type ContactSearchResult = {
+  readonly id: string;
+  readonly displayName: string;
+  readonly primaryEmail: string | null;
+  readonly salesforceContactId: string | null;
+  readonly primaryProjectName: string | null;
+};
+
+export type ContactSearchActionResult = UiResult<
+  readonly ContactSearchResult[]
+>;
+
 function unauthorizedError(requestId: string): UiResult<never> {
   return {
     ok: false,
@@ -98,6 +111,16 @@ function composerRateLimitError(requestId: string): ComposerSendActionResult {
     ok: false,
     code: "rate_limit_exceeded",
     message: "Too many composer sends. Please wait a minute and try again.",
+    requestId,
+    retryable: true,
+  };
+}
+
+function contactSearchRateLimitError(requestId: string): ContactSearchActionResult {
+  return {
+    ok: false,
+    code: "rate_limit_exceeded",
+    message: "Too many contact searches. Please wait a minute and try again.",
     requestId,
     retryable: true,
   };
@@ -215,6 +238,35 @@ function normalizeEmailAddress(value: string): string | null {
   return normalized.length === 0 ? null : normalized;
 }
 
+function normalizeMembershipStatus(value: string | null): string {
+  return (value ?? "").trim().toLowerCase().replaceAll("_", "-");
+}
+
+function membershipSortRank(
+  membershipStatus: string | null
+): number {
+  switch (normalizeMembershipStatus(membershipStatus)) {
+    case "lead":
+      return 0;
+    case "applied":
+    case "applicant":
+      return 1;
+    case "in-training":
+    case "training":
+      return 2;
+    case "trip-planning":
+      return 3;
+    case "in-field":
+    case "active":
+      return 4;
+    case "successful":
+    case "completed":
+      return 5;
+    default:
+      return 6;
+  }
+}
+
 function sha256Text(value: string): string {
   return createHash("sha256").update(value, "utf8").digest("hex");
 }
@@ -238,6 +290,123 @@ function buildAttachmentMetadata(
     size: Buffer.from(attachment.contentBase64, "base64").length,
     contentType: attachment.contentType,
   }));
+}
+
+export async function searchContactsAction(
+  query: string
+): Promise<ContactSearchActionResult> {
+  const requestId = randomUUID();
+
+  let currentUser;
+  try {
+    currentUser = await requireSession();
+  } catch (error) {
+    if (error instanceof Error && error.message === "UNAUTHORIZED") {
+      return unauthorizedError(requestId);
+    }
+    throw error;
+  }
+
+  const decision = await enforceRateLimit({
+    scope: "server-action:inbox-contact-search",
+    identifier: currentUser.id,
+    limit: 60,
+    audit: {
+      actorType: "user",
+      actorId: currentUser.id,
+      action: "inbox.contact_search.rate_limited",
+      entityType: "server_action",
+      entityId: "inbox.contact_search",
+      metadataJson: {
+        queryLength: query.trim().length,
+      },
+    },
+  });
+
+  if (!decision.allowed) {
+    return contactSearchRateLimitError(requestId);
+  }
+
+  const runtime = await getStage1WebRuntime();
+  const contacts = await runtime.repositories.contacts.searchByQuery({
+    query,
+    limit: 8,
+  });
+
+  if (contacts.length === 0) {
+    return {
+      ok: true,
+      data: [],
+      requestId,
+    };
+  }
+
+  const contactIds = contacts.map((contact) => contact.id);
+  const memberships =
+    await runtime.repositories.contactMemberships.listByContactIds(contactIds);
+  const projectIds = Array.from(
+    new Set(
+      memberships
+        .map((membership) => membership.projectId)
+        .filter((projectId): projectId is string => projectId !== null)
+    )
+  );
+  const projectDimensions =
+    await runtime.repositories.projectDimensions.listByIds(projectIds);
+  const membershipsByContactId = new Map<
+    string,
+    ((typeof memberships)[number])[]
+  >();
+
+  for (const membership of memberships) {
+    const existing = membershipsByContactId.get(membership.contactId);
+
+    if (existing === undefined) {
+      membershipsByContactId.set(membership.contactId, [membership]);
+      continue;
+    }
+
+    existing.push(membership);
+  }
+
+  const projectNameById = new Map(
+    projectDimensions.map((project) => [project.projectId, project.projectName])
+  );
+
+  return {
+    ok: true,
+    data: contacts.map((contact) => {
+      const primaryMembership =
+        [...(membershipsByContactId.get(contact.id) ?? [])].sort(
+          (left, right) => {
+            const rankDifference =
+              membershipSortRank(left.status) - membershipSortRank(right.status);
+
+            if (rankDifference !== 0) {
+              return rankDifference;
+            }
+
+            if (left.projectId !== right.projectId) {
+              return (left.projectId ?? "").localeCompare(right.projectId ?? "");
+            }
+
+            return left.id.localeCompare(right.id);
+          }
+        )[0] ?? null;
+
+      return {
+        id: contact.id,
+        displayName: contact.displayName,
+        primaryEmail: contact.primaryEmail,
+        salesforceContactId: contact.salesforceContactId,
+        primaryProjectName:
+          primaryMembership?.projectId === null || primaryMembership === null
+            ? null
+            : (projectNameById.get(primaryMembership.projectId) ?? null),
+      };
+    }),
+    requestId,
+  };
 }
 
 async function resolveContactEmail(input: {

--- a/apps/web/app/inbox/layout.tsx
+++ b/apps/web/app/inbox/layout.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from "react";
 import { requireSession } from "@/src/server/auth/session";
 
 import { InboxShell } from "./_components/inbox-shell";
+import { getInboxComposerAliases } from "./_lib/composer-data";
 import { getInboxList } from "./_lib/selectors";
 
 export const metadata = {
@@ -44,10 +45,17 @@ export default async function InboxLayout({
     throw error;
   }
 
-  const list = await getInboxList("all");
+  const [list, composerAliases] = await Promise.all([
+    getInboxList("all"),
+    getInboxComposerAliases(),
+  ]);
 
   return (
-    <InboxShell initialList={list} initialFilterId="all">
+    <InboxShell
+      initialList={list}
+      initialFilterId="all"
+      composerAliases={composerAliases}
+    >
       {children}
     </InboxShell>
   );

--- a/apps/web/tests/unit/inbox-timeline.test.ts
+++ b/apps/web/tests/unit/inbox-timeline.test.ts
@@ -47,6 +47,12 @@ const baseEntry = {
   channel: "email" as const,
   isUnread: false,
   isPreview: true,
+  mailbox: null,
+  threadId: null,
+  rfc822MessageId: null,
+  inReplyToRfc822: null,
+  sendStatus: null,
+  attachmentCount: 0,
 };
 
 describe("InboxTimeline", () => {

--- a/apps/web/tests/unit/stage3-composer-ui.test.tsx
+++ b/apps/web/tests/unit/stage3-composer-ui.test.tsx
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import type { InboxComposerReplyContext } from "../../app/inbox/_lib/view-models";
+import {
+  reduceComposerPane,
+  resolveTypedEmailRecipient,
+  isComposerSendDisabled,
+  resolveDefaultAlias,
+  type ComposerPaneState
+} from "../../app/inbox/_lib/composer-ui";
+
+const replyContext: InboxComposerReplyContext = {
+  contactId: "contact-1",
+  contactDisplayName: "Alice Smith",
+  subject: "Re: Trip logistics",
+  threadId: "thread-1",
+  inReplyToRfc822: "message-1",
+  defaultAlias: "field@adventuresci.org"
+};
+
+describe("stage3 composer ui helpers", () => {
+  it("opens a new draft pane and closes it again through the shared reducer", () => {
+    const opened = reduceComposerPane(
+      { mode: "closed" },
+      {
+        type: "open-new-draft"
+      }
+    );
+    const closed = reduceComposerPane(opened, {
+      type: "close"
+    });
+
+    expect(opened).toEqual({
+      mode: "new-draft"
+    } satisfies ComposerPaneState);
+    expect(closed).toEqual({
+      mode: "closed"
+    } satisfies ComposerPaneState);
+  });
+
+  it("stores reply context when opening a reply draft", () => {
+    const replying = reduceComposerPane(
+      { mode: "closed" },
+      {
+        type: "open-reply",
+        replyContext
+      }
+    );
+
+    expect(replying).toEqual({
+      mode: "replying",
+      replyContext
+    } satisfies ComposerPaneState);
+  });
+
+  it("accepts an unmatched valid email as an external recipient", () => {
+    expect(
+      resolveTypedEmailRecipient({
+        query: "outside@example.com",
+        results: []
+      })
+    ).toEqual({
+      kind: "email",
+      emailAddress: "outside@example.com"
+    });
+
+    expect(
+      resolveTypedEmailRecipient({
+        query: "alice@example.com",
+        results: [
+          {
+            primaryEmail: "alice@example.com"
+          }
+        ]
+      })
+    ).toBeNull();
+  });
+
+  it("defaults aliases from the contact project and disables send for missing input", () => {
+    expect(
+      resolveDefaultAlias({
+        recipient: {
+          kind: "contact",
+          primaryProjectName: "Coastal Survey"
+        },
+        aliases: [
+          {
+            id: "alias-1",
+            alias: "coastal@adventuresci.org",
+            projectId: "project-1",
+            projectName: "Coastal Survey"
+          }
+        ]
+      })
+    ).toBe("coastal@adventuresci.org");
+
+    expect(
+      isComposerSendDisabled({
+        activeTab: "email",
+        recipient: null,
+        selectedAlias: "coastal@adventuresci.org",
+        subject: "Hello",
+        body: "Body",
+        isSending: false
+      })
+    ).toBe(true);
+
+    expect(
+      isComposerSendDisabled({
+        activeTab: "email",
+        recipient: {
+          kind: "email"
+        },
+        selectedAlias: "coastal@adventuresci.org",
+        subject: "Hello",
+        body: "",
+        isSending: false
+      })
+    ).toBe(true);
+  });
+});

--- a/apps/web/tests/unit/stage3-timeline-pending.test.tsx
+++ b/apps/web/tests/unit/stage3-timeline-pending.test.tsx
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import React, { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { InboxTimelineEntryViewModel } from "../../app/inbox/_lib/view-models";
+
+Object.assign(globalThis, { React });
+
+vi.mock("@/components/ui/divider-label", () => ({
+  DividerLabel: ({ children }: { readonly children?: React.ReactNode }) =>
+    createElement("span", null, children),
+}));
+
+vi.mock("@/app/_lib/design-tokens", () => ({
+  RADIUS: {
+    bubble: "rounded-2xl",
+    md: "rounded-xl",
+  },
+  SHADOW: {
+    sm: "shadow-sm",
+  },
+  TEXT: {
+    bodySm: "text-sm",
+    micro: "text-xs",
+  },
+  TONE: {
+    amber: {
+      subtle: "bg-amber-50",
+    },
+  },
+  TRANSITION: {
+    fast: "transition-colors",
+    reduceMotion: "motion-reduce:transition-none",
+  },
+}));
+
+import { InboxTimeline } from "../../app/inbox/_components/inbox-timeline";
+
+function buildEntry(
+  overrides: Partial<InboxTimelineEntryViewModel> = {},
+): InboxTimelineEntryViewModel {
+  return {
+    id: "pending-outbound:pending-1",
+    kind: "outbound-email",
+    occurredAt: "2026-04-21T16:00:00.000Z",
+    occurredAtLabel: "Just now",
+    actorLabel: "Operator",
+    subject: "Checking in",
+    body: "Wanted to follow up before Friday.",
+    channel: "email",
+    isUnread: false,
+    isPreview: false,
+    mailbox: "field@adventuresci.org",
+    threadId: "gmail-thread-1",
+    rfc822MessageId: null,
+    inReplyToRfc822: "parent-message-id",
+    sendStatus: "pending",
+    attachmentCount: 0,
+    ...overrides,
+  };
+}
+
+describe("stage3 pending timeline rendering", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders pending outbound rows in a sending state", () => {
+    const markup = renderToStaticMarkup(
+      createElement(InboxTimeline, {
+        entries: [buildEntry()],
+        volunteerFirstName: "Alice",
+      }),
+    );
+
+    expect(markup).toContain("Sending...");
+    expect(markup).toContain("Checking in");
+  });
+
+  it("renders a retry affordance for failed outbound rows", () => {
+    const markup = renderToStaticMarkup(
+      createElement(InboxTimeline, {
+        entries: [buildEntry({ sendStatus: "failed" })],
+        volunteerFirstName: "Alice",
+        onRetryPending: vi.fn(),
+      }),
+    );
+
+    expect(markup).toContain("Send failed.");
+    expect(markup).toContain("Retry");
+  });
+
+  it("disables retry when the failed row had attachments", () => {
+    const markup = renderToStaticMarkup(
+      createElement(InboxTimeline, {
+        entries: [
+          buildEntry({
+            sendStatus: "failed",
+            attachmentCount: 2,
+          }),
+        ],
+        volunteerFirstName: "Alice",
+        onRetryPending: vi.fn(),
+      }),
+    );
+
+    expect(markup).toContain("Retry");
+    expect(markup).toContain("disabled");
+  });
+});

--- a/packages/contracts/src/stage1-timeline.ts
+++ b/packages/contracts/src/stage1-timeline.ts
@@ -99,7 +99,11 @@ export const oneToOneEmailTimelineItemSchema = timelineItemBaseSchema.extend({
   snippet: z.string(),
   bodyPreview: nullableStringSchema,
   mailbox: nullableStringSchema,
-  threadId: nullableStringSchema
+  threadId: nullableStringSchema,
+  rfc822MessageId: nullableStringSchema.optional(),
+  inReplyToRfc822: nullableStringSchema.optional(),
+  sendStatus: z.enum(["pending", "failed", "orphaned"]).nullable().optional(),
+  attachmentCount: z.number().int().nonnegative().optional()
 });
 export type OneToOneEmailTimelineItem = z.infer<
   typeof oneToOneEmailTimelineItemSchema

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -788,6 +788,34 @@ function createStage1RepositoriesInternal(
         return rows.map(mapContactRow);
       },
 
+      async searchByQuery(input) {
+        const normalizedQuery = input.query.trim().toLowerCase();
+
+        if (normalizedQuery.length < 2) {
+          return [];
+        }
+
+        const limit = Math.max(1, Math.min(input.limit, 8));
+        const pattern = `%${normalizedQuery}%`;
+        const rows = await db
+          .select()
+          .from(contacts)
+          .where(
+            or(
+              sql`lower(${contacts.displayName}) like ${pattern}`,
+              sql`lower(coalesce(${contacts.primaryEmail}, '')) like ${pattern}`
+            )
+          )
+          .orderBy(
+            sql`case when lower(${contacts.displayName}) like ${pattern} then 0 else 1 end`,
+            asc(contacts.displayName),
+            asc(contacts.id)
+          )
+          .limit(limit);
+
+        return rows.map(mapContactRow);
+      },
+
       async upsert(record) {
         const values = mapContactToInsert(record);
         const [row] = await db

--- a/packages/db/test/stage3-contact-search.test.ts
+++ b/packages/db/test/stage3-contact-search.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import { createTestStage1Context } from "./helpers.js";
+
+async function seedContactSearchFixture() {
+  const context = await createTestStage1Context();
+  const createdAt = "2026-04-21T12:00:00.000Z";
+
+  await context.repositories.contacts.upsert({
+    id: "contact:alex-carter",
+    salesforceContactId: "003-alex",
+    displayName: "Alex Carter",
+    primaryEmail: "alex@example.org",
+    primaryPhone: null,
+    createdAt,
+    updatedAt: createdAt,
+  });
+  await context.repositories.contacts.upsert({
+    id: "contact:maya-singh",
+    salesforceContactId: null,
+    displayName: "Maya Singh",
+    primaryEmail: "alex.sponsor@example.org",
+    primaryPhone: null,
+    createdAt,
+    updatedAt: createdAt,
+  });
+  await context.repositories.contacts.upsert({
+    id: "contact:zoe-chen",
+    salesforceContactId: "003-zoe",
+    displayName: "Zoe Chen",
+    primaryEmail: "zoe@example.org",
+    primaryPhone: null,
+    createdAt,
+    updatedAt: createdAt,
+  });
+
+  return context;
+}
+
+describe("contact repository searchByQuery", () => {
+  it("matches display names case-insensitively", async () => {
+    const context = await seedContactSearchFixture();
+
+    try {
+      await expect(
+        context.repositories.contacts.searchByQuery({
+          query: "zoe",
+          limit: 8,
+        }),
+      ).resolves.toMatchObject([
+        {
+          id: "contact:zoe-chen",
+          displayName: "Zoe Chen",
+        },
+      ]);
+    } finally {
+      await context.client.close();
+    }
+  });
+
+  it("matches primary emails case-insensitively", async () => {
+    const context = await seedContactSearchFixture();
+
+    try {
+      await expect(
+        context.repositories.contacts.searchByQuery({
+          query: "sponsor@example",
+          limit: 8,
+        }),
+      ).resolves.toMatchObject([
+        {
+          id: "contact:maya-singh",
+          primaryEmail: "alex.sponsor@example.org",
+        },
+      ]);
+    } finally {
+      await context.client.close();
+    }
+  });
+
+  it("returns matches from both name and email fields in a single query", async () => {
+    const context = await seedContactSearchFixture();
+
+    try {
+      await expect(
+        context.repositories.contacts.searchByQuery({
+          query: "alex",
+          limit: 8,
+        }),
+      ).resolves.toMatchObject([
+        {
+          id: "contact:alex-carter",
+        },
+        {
+          id: "contact:maya-singh",
+        },
+      ]);
+    } finally {
+      await context.client.close();
+    }
+  });
+
+  it("returns an empty result for short queries", async () => {
+    const context = await seedContactSearchFixture();
+
+    try {
+      await expect(
+        context.repositories.contacts.searchByQuery({
+          query: "a",
+          limit: 8,
+        }),
+      ).resolves.toEqual([]);
+    } finally {
+      await context.client.close();
+    }
+  });
+});

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -70,6 +70,10 @@ export interface ContactRepository {
   ): Promise<ContactRecord | null>;
   listAll(): Promise<readonly ContactRecord[]>;
   listByIds(ids: readonly string[]): Promise<readonly ContactRecord[]>;
+  searchByQuery(input: {
+    readonly query: string;
+    readonly limit: number;
+  }): Promise<readonly ContactRecord[]>;
   upsert(record: ContactRecord): Promise<ContactRecord>;
 }
 

--- a/packages/domain/src/timeline.ts
+++ b/packages/domain/src/timeline.ts
@@ -209,6 +209,15 @@ function buildPendingTimelineItems(
       bodyPreview: row.bodyPlaintext,
       mailbox: row.fromAlias,
       threadId: row.gmailThreadId,
+      rfc822MessageId: null,
+      inReplyToRfc822: row.inReplyToRfc822,
+      sendStatus:
+        row.status === "pending" ||
+        row.status === "failed" ||
+        row.status === "orphaned"
+          ? row.status
+          : null,
+      attachmentCount: row.attachmentMetadata.length,
     }))
   );
 }
@@ -238,6 +247,7 @@ export interface Stage1TimelinePresentationService {
     readonly nextBeforeSortKey: string | null;
     readonly total: number;
   }>;
+  findLastInboundAliasForContact(contactId: string): Promise<string | null>;
 }
 
 function uniqueStrings(values: readonly (string | null | undefined)[]): string[] {
@@ -463,7 +473,11 @@ function buildTimelineItemsFromRows(input: {
           threadId:
             gmailDetail?.gmailThreadId ??
             provenance.threadRef?.providerThreadId ??
-            null
+            null,
+          rfc822MessageId: gmailDetail?.rfc822MessageId ?? null,
+          inReplyToRfc822: null,
+          sendStatus: null,
+          attachmentCount: 0
         });
         break;
       case "one_to_one_sms":
@@ -569,6 +583,41 @@ export function createStage1TimelinePresentationService(
           pageItemsDescending[pageItemsDescending.length - 1]?.sortKey ?? null,
         total: mergedItems.length
       };
+    },
+
+    async findLastInboundAliasForContact(contactId) {
+      const canonicalEvents =
+        await repositories.canonicalEvents.listByContactId(contactId);
+      const inboundEmailEvents = canonicalEvents
+        .filter((event) => event.eventType === "communication.email.inbound")
+        .sort((left, right) => right.occurredAt.localeCompare(left.occurredAt));
+
+      if (inboundEmailEvents.length === 0) {
+        return null;
+      }
+
+      const gmailDetails =
+        await repositories.gmailMessageDetails.listBySourceEvidenceIds(
+          uniqueStrings(
+            inboundEmailEvents.map((event) => event.sourceEvidenceId)
+          )
+        );
+      const aliasBySourceEvidenceId = new Map(
+        gmailDetails.map((detail) => [
+          detail.sourceEvidenceId,
+          detail.projectInboxAlias
+        ])
+      );
+
+      for (const event of inboundEmailEvents) {
+        const alias = aliasBySourceEvidenceId.get(event.sourceEvidenceId);
+
+        if (typeof alias === "string" && alias.trim().length > 0) {
+          return alias;
+        }
+      }
+
+      return null;
     }
   };
 }

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -45,6 +45,7 @@ describe("defineStage1RepositoryBundle", () => {
         findBySalesforceContactId: () => Promise.resolve(contact),
         listAll: () => Promise.resolve([contact]),
         listByIds: () => Promise.resolve([contact]),
+        searchByQuery: () => Promise.resolve([contact]),
         upsert: (record) => Promise.resolve(record)
       },
       contactIdentities: {

--- a/packages/domain/test/stage3-last-inbound-alias.test.ts
+++ b/packages/domain/test/stage3-last-inbound-alias.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  CanonicalEventRecord,
+  ContactRecord,
+  GmailMessageDetailRecord,
+  InboxProjectionRow,
+  TimelineProjectionRow,
+} from "@as-comms/contracts";
+
+import {
+  createStage1TimelinePresentationService,
+  defineStage1RepositoryBundle,
+  type PendingComposerOutboundRecord,
+  type Stage1RepositoryBundle,
+} from "../src/index.js";
+
+function buildRepositoryBundle(input: {
+  readonly canonicalEvents: readonly CanonicalEventRecord[];
+  readonly gmailDetails: readonly GmailMessageDetailRecord[];
+}): Stage1RepositoryBundle {
+  const contact: ContactRecord = {
+    id: "contact:volunteer",
+    salesforceContactId: "003-volunteer",
+    displayName: "Volunteer Contact",
+    primaryEmail: "volunteer@example.org",
+    primaryPhone: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+
+  return defineStage1RepositoryBundle({
+    sourceEvidence: {
+      append: (record) => Promise.resolve(record),
+      findById: () => Promise.resolve(null),
+      listByIds: () => Promise.resolve([]),
+      findByIdempotencyKey: () => Promise.resolve(null),
+      countByProvider: () => Promise.resolve(0),
+      listByProviderRecord: () => Promise.resolve([]),
+    },
+    canonicalEvents: {
+      findById: () => Promise.resolve(null),
+      findByIdempotencyKey: () => Promise.resolve(null),
+      listByContentFingerprintWindow: () => Promise.resolve([]),
+      countAll: () => Promise.resolve(input.canonicalEvents.length),
+      countByPrimaryProvider: () => Promise.resolve(0),
+      countDistinctInboxContacts: () => Promise.resolve(1),
+      listByIds: () => Promise.resolve(input.canonicalEvents),
+      listByContactId: (contactId) =>
+        Promise.resolve(
+          input.canonicalEvents.filter((event) => event.contactId === contactId)
+        ),
+      upsert: (record) => Promise.resolve(record),
+    },
+    contacts: {
+      findById: () => Promise.resolve(contact),
+      findBySalesforceContactId: () => Promise.resolve(contact),
+      listAll: () => Promise.resolve([contact]),
+      listByIds: () => Promise.resolve([contact]),
+      searchByQuery: () => Promise.resolve([contact]),
+      upsert: (record) => Promise.resolve(record),
+    },
+    contactIdentities: {
+      listByContactId: () => Promise.resolve([]),
+      listByNormalizedValue: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record),
+    },
+    contactMemberships: {
+      listByContactId: () => Promise.resolve([]),
+      listByContactIds: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record),
+    },
+    projectDimensions: {
+      listAll: () => Promise.resolve([]),
+      listActive: () => Promise.resolve([]),
+      listByIds: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record),
+    },
+    expeditionDimensions: {
+      listByIds: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record),
+    },
+    gmailMessageDetails: {
+      listBySourceEvidenceIds: (sourceEvidenceIds) =>
+        Promise.resolve(
+          input.gmailDetails.filter((detail) =>
+            sourceEvidenceIds.includes(detail.sourceEvidenceId)
+          )
+        ),
+      upsert: (record) => Promise.resolve(record),
+    },
+    salesforceEventContext: {
+      listBySourceEvidenceIds: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record),
+    },
+    salesforceCommunicationDetails: {
+      listBySourceEvidenceIds: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record),
+    },
+    simpleTextingMessageDetails: {
+      listBySourceEvidenceIds: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record),
+    },
+    mailchimpCampaignActivityDetails: {
+      listBySourceEvidenceIds: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record),
+    },
+    manualNoteDetails: {
+      listBySourceEvidenceIds: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record),
+    },
+    pendingOutbounds: {
+      insert: ({ id }) => Promise.resolve(id),
+      findByFingerprint: () =>
+        Promise.resolve<PendingComposerOutboundRecord | null>(null),
+      markConfirmed: () => Promise.resolve(),
+      markFailed: () => Promise.resolve(),
+      markSuperseded: () => Promise.resolve(),
+      sweepOrphans: () => Promise.resolve(0),
+      findForContact: () => Promise.resolve([]),
+    },
+    identityResolutionQueue: {
+      findById: () => Promise.resolve(null),
+      listOpenByContactId: () => Promise.resolve([]),
+      listOpenByReasonCode: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record),
+    },
+    routingReviewQueue: {
+      findById: () => Promise.resolve(null),
+      listOpenByContactId: () => Promise.resolve([]),
+      listOpenByReasonCode: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record),
+    },
+    inboxProjection: {
+      countAll: () => Promise.resolve(0),
+      countInvalidRecencyRows: () => Promise.resolve(0),
+      findByContactId: () => Promise.resolve(null),
+      listAllOrderedByRecency: () => Promise.resolve([]),
+      listInvalidRecencyContactIds: () => Promise.resolve([]),
+      searchPageOrderedByRecency: () =>
+        Promise.resolve({
+          rows: [] as InboxProjectionRow[],
+          total: 0,
+        }),
+      listPageOrderedByRecency: () => Promise.resolve([]),
+      countByFilters: () =>
+        Promise.resolve({
+          all: 0,
+          unread: 0,
+          followUp: 0,
+          unresolved: 0,
+        }),
+      getFreshness: () =>
+        Promise.resolve({
+          total: 0,
+          latestUpdatedAt: null,
+        }),
+      getFreshnessByContactId: () => Promise.resolve(null),
+      deleteByContactId: () => Promise.resolve(),
+      setNeedsFollowUp: () => Promise.resolve(null),
+      upsert: (record) => Promise.resolve(record),
+    },
+    timelineProjection: {
+      countAll: () => Promise.resolve(0),
+      findByCanonicalEventId: () => Promise.resolve(null),
+      listByContactId: () => Promise.resolve([] as TimelineProjectionRow[]),
+      listRecentByContactId: () => Promise.resolve([]),
+      countByContactId: () => Promise.resolve(0),
+      getFreshnessByContactId: (contactId) =>
+        Promise.resolve({
+          contactId,
+          total: 0,
+          latestUpdatedAt: null,
+          latestSortKey: null,
+        }),
+      upsert: (record) => Promise.resolve(record),
+    },
+    syncState: {
+      findById: () => Promise.resolve(null),
+      findLatest: () => Promise.resolve(null),
+      listAll: () => Promise.resolve([]),
+      upsert: (record) => Promise.resolve(record),
+    },
+    auditEvidence: {
+      append: (record) => Promise.resolve(record),
+      listByEntity: () => Promise.resolve([]),
+    },
+  });
+}
+
+function buildInboundEvent(input: {
+  readonly id: string;
+  readonly occurredAt: string;
+}): CanonicalEventRecord {
+  return {
+    id: `event:${input.id}`,
+    contactId: "contact:volunteer",
+    eventType: "communication.email.inbound",
+    channel: "email",
+    occurredAt: input.occurredAt,
+    contentFingerprint: null,
+    sourceEvidenceId: `source:${input.id}`,
+    idempotencyKey: `canonical:${input.id}`,
+    provenance: {
+      primaryProvider: "gmail",
+      primarySourceEvidenceId: `source:${input.id}`,
+      supportingSourceEvidenceIds: [],
+      winnerReason: "single_source",
+      sourceRecordType: "message",
+      sourceRecordId: input.id,
+      messageKind: "one_to_one",
+      campaignRef: null,
+      threadRef: null,
+      direction: "inbound",
+      notes: null,
+    },
+    reviewState: "clear",
+  };
+}
+
+function buildGmailDetail(input: {
+  readonly id: string;
+  readonly alias: string | null;
+}): GmailMessageDetailRecord {
+  return {
+    sourceEvidenceId: `source:${input.id}`,
+    providerRecordId: input.id,
+    gmailThreadId: `thread:${input.id}`,
+    rfc822MessageId: `<${input.id}@example.org>`,
+    direction: "inbound",
+    subject: `Subject ${input.id}`,
+    snippetClean: `Snippet ${input.id}`,
+    bodyTextPreview: `Body ${input.id}`,
+    capturedMailbox: "captured@example.org",
+    projectInboxAlias: input.alias,
+  };
+}
+
+describe("findLastInboundAliasForContact", () => {
+  it("returns the most recent inbound alias with a project inbox alias", async () => {
+    const presenter = createStage1TimelinePresentationService(
+      buildRepositoryBundle({
+        canonicalEvents: [
+          buildInboundEvent({
+            id: "older",
+            occurredAt: "2026-04-20T09:00:00.000Z",
+          }),
+          buildInboundEvent({
+            id: "newer-without-alias",
+            occurredAt: "2026-04-21T08:00:00.000Z",
+          }),
+          buildInboundEvent({
+            id: "latest",
+            occurredAt: "2026-04-21T09:00:00.000Z",
+          }),
+        ],
+        gmailDetails: [
+          buildGmailDetail({
+            id: "older",
+            alias: "older-project@example.org",
+          }),
+          buildGmailDetail({
+            id: "newer-without-alias",
+            alias: null,
+          }),
+          buildGmailDetail({
+            id: "latest",
+            alias: "latest-project@example.org",
+          }),
+        ],
+      })
+    );
+
+    await expect(
+      presenter.findLastInboundAliasForContact("contact:volunteer")
+    ).resolves.toBe("latest-project@example.org");
+  });
+
+  it("returns null when the contact has no inbound alias-bearing email", async () => {
+    const presenter = createStage1TimelinePresentationService(
+      buildRepositoryBundle({
+        canonicalEvents: [],
+        gmailDetails: [],
+      })
+    );
+
+    await expect(
+      presenter.findLastInboundAliasForContact("contact:volunteer")
+    ).resolves.toBeNull();
+  });
+});

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -100,6 +100,7 @@ function createRepositoryBundle(input: {
       findBySalesforceContactId: () => Promise.resolve(contact),
       listAll: () => Promise.resolve([contact]),
       listByIds: () => Promise.resolve([contact]),
+      searchByQuery: () => Promise.resolve([contact]),
       upsert: (record) => Promise.resolve(record)
     },
     contactIdentities: {
@@ -467,7 +468,9 @@ describe("Stage 1 timeline presenter", () => {
       family: "one_to_one_email",
       primaryProvider: "manual",
       subject: "Pending outbound",
-      bodyPreview: "Pending outbound body"
+      bodyPreview: "Pending outbound body",
+      sendStatus: "pending",
+      attachmentCount: 0
     });
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -42,7 +42,14 @@ export default defineConfig({
     ],
   },
   test: {
-    include: ["test/**/*.test.ts", "tests/**/*.test.ts", "src/**/*.test.ts"],
+    include: [
+      "test/**/*.test.ts",
+      "test/**/*.test.tsx",
+      "tests/**/*.test.ts",
+      "tests/**/*.test.tsx",
+      "src/**/*.test.ts",
+      "src/**/*.test.tsx",
+    ],
     environment: "node",
     testTimeout: 30000,
     hookTimeout: 30000,


### PR DESCRIPTION
## Summary
Composer UI v1 — inline draft pane with recipient picker, alias dropdown, plaintext body + attachments, and optimistic pending-bubble rendering. Wires to the server action shipped in #80. Notes mode is disabled with a "Coming in next update" tooltip (a follow-up brief enables it).

## Product decisions landed here
- **Plaintext body only** — rich text deferred to v1.1
- **Single To recipient** — CC/BCC deferred to v1.1
- **Session-only drafts** — matches D-030 reminder pattern
- **Attachments** — in-browser base64, 20 MB client-side cap matching server cap
- **SMS mode** — removed (deferred indefinitely per project_stage_sequence)
- **AI draft button** — removed (Stage 4 re-adds it)
- **Rich-text toolbar** (bold/italic/list/link) — hidden

## Scope
- [x] Compose button in inbox header + keyboard shortcut \`c\`
- [x] Inline draft-pane detail (not a modal)
- [x] Recipient picker: SF typeahead + external-email accept
- [x] Alias dropdown with default logic (reply → last-inbound alias; SF contact → primary project alias; external → no default)
- [x] Plaintext composer + attachments (images also flow through attach path)
- [x] Wire \`sendComposerAction\` via useTransition
- [x] Timeline pending bubble (\`Sending...\`) + failed/orphaned (\`Retry\`) rendering
- [x] Retry via \`supersedesPendingId\` (disabled for attachment-bearing rows)
- [x] New domain helpers: \`ContactRepository.searchByQuery\`, \`findLastInboundAliasForContact\`
- [x] Tests: composer-ui helpers, timeline-pending rendering, contact search, last-inbound-alias

## Known follow-ups
- **Preview screenshots not attached** — Codex sandbox refused local socket binds, couldn't run \`next dev\`. User should run manual verification before Brief 5 (or I can via preview tools post-merge).
- **DOM-level RTL tests not present** — Codex couldn't \`npm install @testing-library/react\` in its sandbox. Helpers are unit-tested instead. Low-value to backfill unless we hit a wiring regression.
- **Timeline pagination regression from #80** still carries over — unrelated to this PR. Separate follow-up.

## Test plan
- [ ] CI green (typecheck, lint, unit, boundaries, verify)
- [ ] Manual browser verification via preview_start: SF contact reply, net-new SF, net-new external email, send failure retry
- [ ] Attach screenshots before marking ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)