### PR TITLE
feat(stage-4): Notion knowledge sync worker + ai_knowledge_entries table

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Stage 4 Notion knowledge sync
+# Worker-only at runtime today; mirrored into shared env docs for deployment setup.
+NOTION_API_KEY=
+NOTION_GENERAL_TRAINING_PAGE_ID=3278a9129211804baa72c76a86d084d0
+NOTION_PROJECT_TRAINING_DATABASE_ID=3278a91292118095b86aff5836821428

--- a/apps/worker/src/jobs/notion-knowledge-sync/index.ts
+++ b/apps/worker/src/jobs/notion-knowledge-sync/index.ts
@@ -1,0 +1,22 @@
+import type { Task } from "graphile-worker";
+
+import {
+  readNotionKnowledgeSyncConfig,
+  runNotionKnowledgeSync,
+  type NotionKnowledgeSyncConfig,
+  type NotionKnowledgeSyncDependencies
+} from "./sync.js";
+
+export const notionKnowledgeSyncJobName = "notion-knowledge-sync" as const;
+
+export type { NotionKnowledgeSyncConfig, NotionKnowledgeSyncDependencies };
+
+export { readNotionKnowledgeSyncConfig };
+
+export function createNotionKnowledgeSyncTask(
+  dependencies: NotionKnowledgeSyncDependencies
+): Task {
+  return async () => {
+    await runNotionKnowledgeSync(dependencies);
+  };
+}

--- a/apps/worker/src/jobs/notion-knowledge-sync/sync.ts
+++ b/apps/worker/src/jobs/notion-knowledge-sync/sync.ts
@@ -89,19 +89,28 @@ export function readNotionKnowledgeSyncConfig(
   };
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isUnknownArray(value: unknown): value is readonly unknown[] {
+  return Array.isArray(value);
+}
+
 function extractRichText(value: unknown): string | null {
-  if (!Array.isArray(value)) {
+  if (!isUnknownArray(value)) {
     return null;
   }
 
   const text = value
     .map((item) => {
-      if (typeof item !== "object" || item === null) {
+      if (!isRecord(item)) {
         return "";
       }
 
-      if ("plain_text" in item && typeof item.plain_text === "string") {
-        return item.plain_text;
+      const plainText = item.plain_text;
+      if (typeof plainText === "string") {
+        return plainText;
       }
 
       return "";
@@ -150,16 +159,18 @@ function extractUrlProperty(
   propertyName: string
 ): string | null {
   const property = properties[propertyName];
+  if (!isRecord(property)) {
+    return null;
+  }
+
+  const propertyType = property.type;
+  const url = property.url;
   if (
-    typeof property === "object" &&
-    property !== null &&
-    "type" in property &&
-    property.type === "url" &&
-      "url" in property &&
-      typeof property.url === "string" &&
-      property.url.trim().length > 0
+    propertyType === "url" &&
+    typeof url === "string" &&
+    url.trim().length > 0
   ) {
-    return property.url.trim();
+    return url.trim();
   }
 
   return null;
@@ -170,25 +181,25 @@ function extractMultiSelectProperty(
   propertyName: string
 ): readonly string[] {
   const property = properties[propertyName];
-  if (
-    typeof property !== "object" ||
-    property === null ||
-    !("type" in property) ||
-    property.type !== "multi_select" ||
-    !Array.isArray(property.multi_select)
-  ) {
+  if (!isRecord(property) || property.type !== "multi_select") {
     return [];
   }
 
-  return property.multi_select.flatMap((item) =>
-    typeof item === "object" &&
-    item !== null &&
-    "name" in item &&
-    typeof item.name === "string" &&
-    item.name.trim().length > 0
-      ? [item.name.trim()]
-      : []
-  );
+  const multiSelect = property.multi_select;
+  if (!isUnknownArray(multiSelect)) {
+    return [];
+  }
+
+  return multiSelect.flatMap((item) => {
+    if (!isRecord(item)) {
+      return [];
+    }
+
+    const name = item.name;
+    return typeof name === "string" && name.trim().length > 0
+      ? [name.trim()]
+      : [];
+  });
 }
 
 function extractCreatedTimeProperty(
@@ -196,16 +207,18 @@ function extractCreatedTimeProperty(
   propertyName: string
 ): string | null {
   const property = properties[propertyName];
+  if (!isRecord(property)) {
+    return null;
+  }
+
+  const propertyType = property.type;
+  const createdTime = property.created_time;
   if (
-    typeof property === "object" &&
-    property !== null &&
-    "type" in property &&
-    property.type === "created_time" &&
-    "created_time" in property &&
-    typeof property.created_time === "string" &&
-    property.created_time.trim().length > 0
+    propertyType === "created_time" &&
+    typeof createdTime === "string" &&
+    createdTime.trim().length > 0
   ) {
-    return property.created_time;
+    return createdTime;
   }
 
   return null;
@@ -215,7 +228,7 @@ function compactMetadata(
   metadata: Record<string, unknown>
 ): Record<string, unknown> {
   return Object.fromEntries(
-    Object.entries(metadata).filter(([_key, value]) => {
+    Object.entries(metadata).filter(([, value]) => {
       if (value === null || value === undefined) {
         return false;
       }
@@ -311,16 +324,17 @@ async function writeIntegrationHealth(
 ): Promise<void> {
   await repository.seedDefaults();
   const existingRecord = await repository.findById(NOTION_SERVICE_ID);
+  const recordInput = {
+    baseRecord: existingRecord,
+    checkedAt: input.now.toISOString(),
+    status: input.status,
+    detail: input.detail,
+    ...(input.metadataJson === undefined
+      ? {}
+      : { metadataJson: input.metadataJson })
+  };
 
-  await repository.upsert(
-    buildIntegrationHealthRecord({
-      baseRecord: existingRecord,
-      checkedAt: input.now.toISOString(),
-      status: input.status,
-      detail: input.detail,
-      metadataJson: input.metadataJson
-    })
-  );
+  await repository.upsert(buildIntegrationHealthRecord(recordInput));
 }
 
 async function listKnownProjectIds(db: Stage1Database): Promise<Set<string>> {

--- a/apps/worker/src/jobs/notion-knowledge-sync/sync.ts
+++ b/apps/worker/src/jobs/notion-knowledge-sync/sync.ts
@@ -1,0 +1,616 @@
+import { and, eq, inArray } from "drizzle-orm";
+
+import {
+  aiKnowledgeEntries,
+  projectDimensions,
+  type Stage1Database
+} from "@as-comms/db";
+import type { IntegrationHealthRecord } from "@as-comms/contracts";
+import type { IntegrationHealthRepository } from "@as-comms/domain";
+import {
+  createNotionClient,
+  describeNotionError,
+  fetchPageContent,
+  healthCheck,
+  normalizeNotionId,
+  queryDatabase,
+  type DatabaseRow,
+  type NotionClient
+} from "@as-comms/integrations";
+
+import {
+  upsertAiKnowledgeEntry,
+  type UpsertAiKnowledgeEntryInput,
+  type UpsertAiKnowledgeEntryResult
+} from "./upsert.js";
+
+const NOTION_SERVICE_ID = "notion";
+const PAGE_FETCH_DELAY_MS = 500;
+
+export interface NotionKnowledgeSyncConfig {
+  readonly apiKey: string | null;
+  readonly generalTrainingPageId: string | null;
+  readonly projectTrainingDatabaseId: string | null;
+}
+
+export interface NotionKnowledgeSyncDependencies {
+  readonly db: Stage1Database;
+  readonly integrationHealth: IntegrationHealthRepository;
+  readonly notion: NotionKnowledgeSyncConfig;
+  readonly createClient?: (env: { readonly NOTION_API_KEY: string }) => NotionClient;
+  readonly logger?: Pick<Console, "error" | "info" | "warn">;
+  readonly now?: () => Date;
+  readonly sleep?: (ms: number) => Promise<void>;
+  readonly upsertEntry?: (
+    db: Stage1Database,
+    input: UpsertAiKnowledgeEntryInput
+  ) => Promise<UpsertAiKnowledgeEntryResult>;
+}
+
+export type NotionKnowledgeSyncResult =
+  | {
+      readonly status: "not_configured";
+    }
+  | {
+      readonly status: "error";
+      readonly projectsSyncedCount: number;
+      readonly seenSourceIds: readonly string[];
+      readonly errorDetail: string;
+    }
+  | {
+      readonly status: "healthy";
+      readonly knowledgeEntriesTotal: number;
+      readonly projectsSyncedCount: number;
+      readonly orphanRowsCount: number;
+      readonly deletedSourceIds: readonly string[];
+      readonly seenSourceIds: readonly string[];
+    };
+
+function readOptionalEnvValue(value: string | undefined): string | null {
+  if (value === undefined) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function readNotionKnowledgeSyncConfig(
+  env: NodeJS.ProcessEnv
+): NotionKnowledgeSyncConfig {
+  return {
+    apiKey: readOptionalEnvValue(env.NOTION_API_KEY),
+    generalTrainingPageId: readOptionalEnvValue(
+      env.NOTION_GENERAL_TRAINING_PAGE_ID
+    ),
+    projectTrainingDatabaseId: readOptionalEnvValue(
+      env.NOTION_PROJECT_TRAINING_DATABASE_ID
+    )
+  };
+}
+
+function extractRichText(value: unknown): string | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const text = value
+    .map((item) => {
+      if (typeof item !== "object" || item === null) {
+        return "";
+      }
+
+      if ("plain_text" in item && typeof item.plain_text === "string") {
+        return item.plain_text;
+      }
+
+      return "";
+    })
+    .join("")
+    .trim();
+
+  return text.length > 0 ? text : null;
+}
+
+function extractPlainTextProperty(
+  properties: Record<string, unknown>,
+  propertyName: string
+): string | null {
+  const property = properties[propertyName];
+  if (typeof property !== "object" || property === null || !("type" in property)) {
+    return null;
+  }
+
+  const propertyRecord = property as Record<string, unknown>;
+
+  switch (propertyRecord.type) {
+    case "title":
+      return extractRichText(propertyRecord.title);
+    case "rich_text":
+      return extractRichText(propertyRecord.rich_text);
+    case "select":
+      if (
+        typeof propertyRecord.select === "object" &&
+        propertyRecord.select !== null &&
+        "name" in propertyRecord.select &&
+        typeof propertyRecord.select.name === "string"
+      ) {
+        const name = propertyRecord.select.name.trim();
+        return name.length > 0 ? name : null;
+      }
+
+      return null;
+    default:
+      return null;
+  }
+}
+
+function extractUrlProperty(
+  properties: Record<string, unknown>,
+  propertyName: string
+): string | null {
+  const property = properties[propertyName];
+  if (
+    typeof property === "object" &&
+    property !== null &&
+    "type" in property &&
+    property.type === "url" &&
+      "url" in property &&
+      typeof property.url === "string" &&
+      property.url.trim().length > 0
+  ) {
+    return property.url.trim();
+  }
+
+  return null;
+}
+
+function extractMultiSelectProperty(
+  properties: Record<string, unknown>,
+  propertyName: string
+): readonly string[] {
+  const property = properties[propertyName];
+  if (
+    typeof property !== "object" ||
+    property === null ||
+    !("type" in property) ||
+    property.type !== "multi_select" ||
+    !Array.isArray(property.multi_select)
+  ) {
+    return [];
+  }
+
+  return property.multi_select.flatMap((item) =>
+    typeof item === "object" &&
+    item !== null &&
+    "name" in item &&
+    typeof item.name === "string" &&
+    item.name.trim().length > 0
+      ? [item.name.trim()]
+      : []
+  );
+}
+
+function extractCreatedTimeProperty(
+  properties: Record<string, unknown>,
+  propertyName: string
+): string | null {
+  const property = properties[propertyName];
+  if (
+    typeof property === "object" &&
+    property !== null &&
+    "type" in property &&
+    property.type === "created_time" &&
+    "created_time" in property &&
+    typeof property.created_time === "string" &&
+    property.created_time.trim().length > 0
+  ) {
+    return property.created_time;
+  }
+
+  return null;
+}
+
+function compactMetadata(
+  metadata: Record<string, unknown>
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(metadata).filter(([_key, value]) => {
+      if (value === null || value === undefined) {
+        return false;
+      }
+
+      if (Array.isArray(value)) {
+        return value.length > 0;
+      }
+
+      if (typeof value === "string") {
+        return value.trim().length > 0;
+      }
+
+      return true;
+    })
+  );
+}
+
+function buildProjectKnowledgeMetadata(
+  row: DatabaseRow
+): Record<string, unknown> {
+  return compactMetadata({
+    training_url: extractUrlProperty(row.properties, "Training URL"),
+    internal_source_url: extractUrlProperty(
+      row.properties,
+      "Internal Source URL"
+    ),
+    public_project_url: extractUrlProperty(row.properties, "Public Project URL"),
+    volunteer_homepage_url: extractUrlProperty(
+      row.properties,
+      "Volunteer Homepage URL"
+    ),
+    training_notes: extractPlainTextProperty(row.properties, "Training Notes"),
+    season: extractPlainTextProperty(row.properties, "Season"),
+    tags: extractMultiSelectProperty(row.properties, "Tags"),
+    created_at: extractCreatedTimeProperty(row.properties, "Created")
+  });
+}
+
+function compareIsoTimestamps(left: string, right: string): number {
+  return left.localeCompare(right);
+}
+
+function isNotionSyncConfigured(
+  config: NotionKnowledgeSyncConfig
+): config is {
+  readonly apiKey: string;
+  readonly generalTrainingPageId: string;
+  readonly projectTrainingDatabaseId: string;
+} {
+  return (
+    config.apiKey !== null &&
+    config.generalTrainingPageId !== null &&
+    config.projectTrainingDatabaseId !== null
+  );
+}
+
+function buildIntegrationHealthRecord(input: {
+  readonly baseRecord: IntegrationHealthRecord | null;
+  readonly checkedAt: string;
+  readonly status: IntegrationHealthRecord["status"];
+  readonly detail: string | null;
+  readonly metadataJson?: Record<string, unknown>;
+}): IntegrationHealthRecord {
+  const metadataJson =
+    input.metadataJson === undefined
+      ? input.baseRecord?.metadataJson ?? {}
+      : {
+          ...(input.baseRecord?.metadataJson ?? {}),
+          ...input.metadataJson
+        };
+
+  return {
+    id: NOTION_SERVICE_ID,
+    serviceName: "notion",
+    category: "knowledge",
+    status: input.status,
+    lastCheckedAt: input.checkedAt,
+    detail: input.detail,
+    metadataJson,
+    createdAt: input.baseRecord?.createdAt ?? input.checkedAt,
+    updatedAt: input.checkedAt
+  };
+}
+
+async function writeIntegrationHealth(
+  repository: IntegrationHealthRepository,
+  input: {
+    readonly now: Date;
+    readonly status: IntegrationHealthRecord["status"];
+    readonly detail: string | null;
+    readonly metadataJson?: Record<string, unknown>;
+  }
+): Promise<void> {
+  await repository.seedDefaults();
+  const existingRecord = await repository.findById(NOTION_SERVICE_ID);
+
+  await repository.upsert(
+    buildIntegrationHealthRecord({
+      baseRecord: existingRecord,
+      checkedAt: input.now.toISOString(),
+      status: input.status,
+      detail: input.detail,
+      metadataJson: input.metadataJson
+    })
+  );
+}
+
+async function listKnownProjectIds(db: Stage1Database): Promise<Set<string>> {
+  const rows = await db
+    .select({
+      projectId: projectDimensions.projectId
+    })
+    .from(projectDimensions);
+
+  return new Set(rows.map((row) => row.projectId));
+}
+
+async function collectProjectRows(input: {
+  readonly client: NotionClient;
+  readonly databaseId: string;
+  readonly knownProjectIds: ReadonlySet<string>;
+  readonly logger: Pick<Console, "warn">;
+}): Promise<{
+  readonly rowsByProjectId: ReadonlyMap<string, DatabaseRow>;
+  readonly orphanRowsCount: number;
+}> {
+  const rowsByProjectId = new Map<string, DatabaseRow>();
+  let orphanRowsCount = 0;
+
+  for await (const row of queryDatabase(input.client, input.databaseId)) {
+    const projectId = extractPlainTextProperty(row.properties, "Project ID")?.trim();
+
+    if (projectId === undefined || projectId.length === 0) {
+      input.logger.warn(
+        `Skipping Notion Project Training row ${row.id} because Project ID is empty.`
+      );
+      continue;
+    }
+
+    if (!input.knownProjectIds.has(projectId)) {
+      orphanRowsCount += 1;
+      input.logger.warn(
+        `Skipping Notion Project Training row ${row.id} because Project ID ${projectId} does not match any project_dimensions row.`
+      );
+      continue;
+    }
+
+    const existingRow = rowsByProjectId.get(projectId);
+    if (existingRow === undefined) {
+      rowsByProjectId.set(projectId, row);
+      continue;
+    }
+
+    if (compareIsoTimestamps(row.lastEditedTime, existingRow.lastEditedTime) > 0) {
+      input.logger.warn(
+        `Duplicate Notion Project Training rows found for project ${projectId}; using ${row.id} and skipping ${existingRow.id}.`
+      );
+      rowsByProjectId.set(projectId, row);
+      continue;
+    }
+
+    input.logger.warn(
+      `Duplicate Notion Project Training rows found for project ${projectId}; using ${existingRow.id} and skipping ${row.id}.`
+    );
+  }
+
+  return {
+    rowsByProjectId,
+    orphanRowsCount
+  };
+}
+
+function buildProjectKnowledgeInput(input: {
+  readonly projectId: string;
+  readonly row: DatabaseRow;
+  readonly pageContent: Awaited<ReturnType<typeof fetchPageContent>>;
+  readonly syncedAt: Date;
+}): UpsertAiKnowledgeEntryInput {
+  return {
+    scope: "project",
+    scopeKey: input.projectId,
+    sourceProvider: "notion",
+    sourceId: normalizeNotionId(input.row.id),
+    sourceUrl: input.pageContent.url,
+    title:
+      input.pageContent.title ??
+      extractPlainTextProperty(input.row.properties, "Name"),
+    content: input.pageContent.markdown,
+    metadata: buildProjectKnowledgeMetadata(input.row),
+    sourceLastEditedAt: new Date(input.pageContent.lastEditedTime),
+    syncedAt: input.syncedAt
+  };
+}
+
+function buildGlobalKnowledgeInput(input: {
+  readonly pageId: string;
+  readonly pageContent: Awaited<ReturnType<typeof fetchPageContent>>;
+  readonly syncedAt: Date;
+}): UpsertAiKnowledgeEntryInput {
+  return {
+    scope: "global",
+    scopeKey: null,
+    sourceProvider: "notion",
+    sourceId: normalizeNotionId(input.pageId),
+    sourceUrl: input.pageContent.url,
+    title: null,
+    content: input.pageContent.markdown,
+    metadata: {},
+    sourceLastEditedAt: new Date(input.pageContent.lastEditedTime),
+    syncedAt: input.syncedAt
+  };
+}
+
+async function reconcileRemovedKnowledgeEntries(input: {
+  readonly db: Stage1Database;
+  readonly seenSourceIds: ReadonlySet<string>;
+}): Promise<readonly string[]> {
+  const currentRows = await input.db
+    .select({
+      sourceId: aiKnowledgeEntries.sourceId
+    })
+    .from(aiKnowledgeEntries)
+    .where(eq(aiKnowledgeEntries.sourceProvider, "notion"));
+
+  const staleSourceIds = currentRows.flatMap((row) =>
+    input.seenSourceIds.has(row.sourceId) ? [] : [row.sourceId]
+  );
+
+  if (staleSourceIds.length === 0) {
+    return [];
+  }
+
+  await input.db
+    .delete(aiKnowledgeEntries)
+    .where(
+      and(
+        eq(aiKnowledgeEntries.sourceProvider, "notion"),
+        inArray(aiKnowledgeEntries.sourceId, staleSourceIds)
+      )
+    );
+
+  return staleSourceIds;
+}
+
+export async function runNotionKnowledgeSync(
+  input: NotionKnowledgeSyncDependencies
+): Promise<NotionKnowledgeSyncResult> {
+  const logger = input.logger ?? console;
+  const now = input.now ?? (() => new Date());
+  const sleep =
+    input.sleep ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
+  const upsertEntry = input.upsertEntry ?? upsertAiKnowledgeEntry;
+  const checkedAt = now();
+
+  if (!isNotionSyncConfigured(input.notion)) {
+    await writeIntegrationHealth(input.integrationHealth, {
+      now: checkedAt,
+      status: "not_configured",
+      detail:
+        "Set NOTION_API_KEY, NOTION_GENERAL_TRAINING_PAGE_ID, and NOTION_PROJECT_TRAINING_DATABASE_ID to enable Notion knowledge sync."
+    });
+
+    return {
+      status: "not_configured"
+    };
+  }
+
+  const createClient = input.createClient ?? createNotionClient;
+  const seenSourceIds = new Set<string>();
+  let projectsSyncedCount = 0;
+
+  try {
+    const client = createClient({
+      NOTION_API_KEY: input.notion.apiKey
+    });
+    const health = await healthCheck(client, {
+      generalTrainingPageId: input.notion.generalTrainingPageId,
+      projectTrainingDatabaseId: input.notion.projectTrainingDatabaseId
+    });
+
+    if (health.status === "error") {
+      await writeIntegrationHealth(input.integrationHealth, {
+        now: checkedAt,
+        status: "needs_attention",
+        detail: health.errorDetail
+      });
+
+      return {
+        status: "error",
+        projectsSyncedCount,
+        seenSourceIds: [],
+        errorDetail: health.errorDetail
+      };
+    }
+
+    const globalSyncedAt = now();
+    const generalPageContent = await fetchPageContent(
+      client,
+      input.notion.generalTrainingPageId
+    );
+    const generalResult = await upsertEntry(
+      input.db,
+      buildGlobalKnowledgeInput({
+        pageId: input.notion.generalTrainingPageId,
+        pageContent: generalPageContent,
+        syncedAt: globalSyncedAt
+      })
+    );
+    seenSourceIds.add(generalResult.row.sourceId);
+
+    const knownProjectIds = await listKnownProjectIds(input.db);
+    const { rowsByProjectId, orphanRowsCount } = await collectProjectRows({
+      client,
+      databaseId: input.notion.projectTrainingDatabaseId,
+      knownProjectIds,
+      logger
+    });
+
+    let projectIndex = 0;
+
+    for (const [projectId, row] of rowsByProjectId.entries()) {
+      if (projectIndex > 0) {
+        await sleep(PAGE_FETCH_DELAY_MS);
+      }
+
+      const syncedAt = now();
+      const pageContent = await fetchPageContent(client, row.id);
+
+      await input.db.transaction(async (tx: Stage1Database) => {
+        const result = await upsertEntry(
+          tx,
+          buildProjectKnowledgeInput({
+            projectId,
+            row,
+            pageContent,
+            syncedAt
+          })
+        );
+
+        seenSourceIds.add(result.row.sourceId);
+
+        await tx
+          .update(projectDimensions)
+          .set({
+            aiKnowledgeSyncedAt: syncedAt,
+            updatedAt: syncedAt
+          })
+          .where(eq(projectDimensions.projectId, projectId));
+      });
+
+      projectIndex += 1;
+      projectsSyncedCount += 1;
+    }
+
+    const deletedSourceIds = await reconcileRemovedKnowledgeEntries({
+      db: input.db,
+      seenSourceIds
+    });
+    const successNow = now();
+
+    await writeIntegrationHealth(input.integrationHealth, {
+      now: successNow,
+      status: "healthy",
+      detail: null,
+      metadataJson: {
+        knowledgeEntriesTotal: seenSourceIds.size,
+        projectsSyncedCount,
+        orphanRowsCount,
+        lastSuccessAt: successNow.toISOString()
+      }
+    });
+
+    return {
+      status: "healthy",
+      knowledgeEntriesTotal: seenSourceIds.size,
+      projectsSyncedCount,
+      orphanRowsCount,
+      deletedSourceIds,
+      seenSourceIds: [...seenSourceIds]
+    };
+  } catch (error) {
+    const errorDetail = describeNotionError(error);
+    logger.error(`Notion knowledge sync failed: ${errorDetail}`);
+
+    await writeIntegrationHealth(input.integrationHealth, {
+      now: now(),
+      status: "needs_attention",
+      detail: errorDetail
+    });
+
+    return {
+      status: "error",
+      projectsSyncedCount,
+      seenSourceIds: [...seenSourceIds],
+      errorDetail
+    };
+  }
+}

--- a/apps/worker/src/jobs/notion-knowledge-sync/upsert.ts
+++ b/apps/worker/src/jobs/notion-knowledge-sync/upsert.ts
@@ -1,0 +1,152 @@
+import { createHash } from "node:crypto";
+
+import { and, eq } from "drizzle-orm";
+
+import { aiKnowledgeEntries, type Stage1Database } from "@as-comms/db";
+
+export interface UpsertAiKnowledgeEntryInput {
+  readonly scope: "global" | "project";
+  readonly scopeKey: string | null;
+  readonly sourceProvider: string;
+  readonly sourceId: string;
+  readonly sourceUrl: string | null;
+  readonly title: string | null;
+  readonly content: string;
+  readonly metadata: Record<string, unknown>;
+  readonly sourceLastEditedAt: Date | null;
+  readonly syncedAt: Date;
+}
+
+export interface UpsertAiKnowledgeEntryResult {
+  readonly action: "inserted" | "updated" | "unchanged";
+  readonly row: typeof aiKnowledgeEntries.$inferSelect;
+}
+
+function buildAiKnowledgeEntryId(input: {
+  readonly sourceProvider: string;
+  readonly sourceId: string;
+}): string {
+  return `ai_knowledge:${input.sourceProvider}:${input.sourceId}`;
+}
+
+function sha256Text(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>).sort(
+    ([left], [right]) => left.localeCompare(right)
+  );
+
+  return `{${entries
+    .map(([key, childValue]) => `${JSON.stringify(key)}:${stableStringify(childValue)}`)
+    .join(",")}}`;
+}
+
+function hasStoredChanges(
+  row: typeof aiKnowledgeEntries.$inferSelect,
+  input: UpsertAiKnowledgeEntryInput,
+  contentHash: string
+): boolean {
+  return (
+    row.scope !== input.scope ||
+    row.scopeKey !== input.scopeKey ||
+    row.sourceUrl !== input.sourceUrl ||
+    row.title !== input.title ||
+    row.contentHash !== contentHash ||
+    row.content !== input.content ||
+    stableStringify(row.metadataJson) !== stableStringify(input.metadata) ||
+    row.sourceLastEditedAt?.getTime() !== input.sourceLastEditedAt?.getTime()
+  );
+}
+
+export async function upsertAiKnowledgeEntry(
+  db: Stage1Database,
+  input: UpsertAiKnowledgeEntryInput
+): Promise<UpsertAiKnowledgeEntryResult> {
+  const contentHash = sha256Text(input.content);
+  const [existingRow] = await db
+    .select()
+    .from(aiKnowledgeEntries)
+    .where(
+      and(
+        eq(aiKnowledgeEntries.sourceProvider, input.sourceProvider),
+        eq(aiKnowledgeEntries.sourceId, input.sourceId)
+      )
+    )
+    .limit(1);
+
+  if (existingRow === undefined) {
+    const [insertedRow] = await db
+      .insert(aiKnowledgeEntries)
+      .values({
+        id: buildAiKnowledgeEntryId({
+          sourceProvider: input.sourceProvider,
+          sourceId: input.sourceId
+        }),
+        scope: input.scope,
+        scopeKey: input.scopeKey,
+        sourceProvider: input.sourceProvider,
+        sourceId: input.sourceId,
+        sourceUrl: input.sourceUrl,
+        title: input.title,
+        content: input.content,
+        contentHash,
+        metadataJson: input.metadata,
+        sourceLastEditedAt: input.sourceLastEditedAt,
+        syncedAt: input.syncedAt,
+        updatedAt: input.syncedAt
+      })
+      .returning();
+
+    if (insertedRow === undefined) {
+      throw new Error("Expected inserted ai_knowledge_entries row to be returned.");
+    }
+
+    return {
+      action: "inserted",
+      row: insertedRow
+    };
+  }
+
+  if (!hasStoredChanges(existingRow, input, contentHash)) {
+    return {
+      action: "unchanged",
+      row: existingRow
+    };
+  }
+
+  const [updatedRow] = await db
+    .update(aiKnowledgeEntries)
+    .set({
+      scope: input.scope,
+      scopeKey: input.scopeKey,
+      sourceUrl: input.sourceUrl,
+      title: input.title,
+      content: input.content,
+      contentHash,
+      metadataJson: input.metadata,
+      sourceLastEditedAt: input.sourceLastEditedAt,
+      syncedAt: input.syncedAt,
+      updatedAt: input.syncedAt
+    })
+    .where(eq(aiKnowledgeEntries.id, existingRow.id))
+    .returning();
+
+  if (updatedRow === undefined) {
+    throw new Error("Expected updated ai_knowledge_entries row to be returned.");
+  }
+
+  return {
+    action: "updated",
+    row: updatedRow
+  };
+}

--- a/apps/worker/src/runtime.ts
+++ b/apps/worker/src/runtime.ts
@@ -31,6 +31,10 @@ import {
   type Stage1SafeRuntimeConfigSummary
 } from "./ops/config.js";
 import {
+  notionKnowledgeSyncJobName,
+  readNotionKnowledgeSyncConfig
+} from "./jobs/notion-knowledge-sync/index.js";
+import {
   createStage1WorkerOrchestrationService,
   type MailchimpCapturePort,
   pollGmailLiveJobName,
@@ -95,6 +99,7 @@ export function buildWorkerCrontab(config: WorkerConfig): string {
     `*/${String(gmailMinutes)} * * * * ${pollGmailLiveJobName} ?id=gmail-live-poll&max=1`,
     `*/${String(salesforceMinutes)} * * * * ${pollSalesforceLiveJobName} ?id=salesforce-live-poll&max=1`,
     `*/5 * * * * ${pollIntegrationHealthJobName} ?id=integration-health-poll&max=1`,
+    `*/15 * * * * ${notionKnowledgeSyncJobName} ?id=notion-knowledge-sync&max=1`,
     `*/5 * * * * ${sweepPendingOutboundsJobName} ?id=composer-orphan-sweep&max=1`
   ].join("\n");
 }
@@ -230,6 +235,7 @@ export async function createStage1WorkerRuntimeServices(
   config: WorkerConfig,
   input?: {
     readonly fetchImplementation?: FetchImplementation;
+    readonly env?: NodeJS.ProcessEnv;
   }
 ): Promise<Stage1WorkerRuntimeServices> {
   const connection = createDatabaseConnection({
@@ -246,6 +252,9 @@ export async function createStage1WorkerRuntimeServices(
 
   const repositories = createStage1RepositoryBundleFromConnection(connection);
   const settings = createStage2RepositoryBundleFromConnection(connection);
+  const notionKnowledgeSync = readNotionKnowledgeSyncConfig(
+    input?.env ?? process.env
+  );
   const persistence = createStage1PersistenceService(repositories);
   const normalization = createStage1NormalizationService(persistence);
   const ingest = createStage1IngestService(normalization);
@@ -306,6 +315,11 @@ export async function createStage1WorkerRuntimeServices(
           salesforce: config.capture.salesforce.baseUrl
         },
         fetchImplementation
+      },
+      notionKnowledgeSync: {
+        db: connection.db,
+        integrationHealth: settings.integrationHealth,
+        notion: notionKnowledgeSync
       },
       pendingOutboundSweep: {
         pendingOutbounds: repositories.pendingOutbounds

--- a/apps/worker/src/tasks.ts
+++ b/apps/worker/src/tasks.ts
@@ -7,6 +7,11 @@ import {
   sweepPendingOutboundsJobName,
   type PendingOutboundSweepTaskDependencies
 } from "./jobs/sweep-pending-outbounds.js";
+import {
+  createNotionKnowledgeSyncTask,
+  notionKnowledgeSyncJobName,
+  type NotionKnowledgeSyncDependencies
+} from "./jobs/notion-knowledge-sync/index.js";
 import { runStage0NoopJob } from "./jobs/noop.js";
 import {
   createStage1TaskList,
@@ -18,6 +23,7 @@ export function createTaskList(
   orchestration?: Stage1WorkerOrchestrationService,
   input?: {
     readonly integrationHealth?: IntegrationHealthTaskDependencies;
+    readonly notionKnowledgeSync?: NotionKnowledgeSyncDependencies;
     readonly pendingOutboundSweep?: PendingOutboundSweepTaskDependencies;
   }
 ): TaskList {
@@ -28,6 +34,13 @@ export function createTaskList(
       : {
           [sweepPendingOutboundsJobName]: createSweepPendingOutboundsTask(
             input.pendingOutboundSweep
+          )
+        }),
+    ...(input?.notionKnowledgeSync === undefined
+      ? {}
+      : {
+          [notionKnowledgeSyncJobName]: createNotionKnowledgeSyncTask(
+            input.notionKnowledgeSync
           )
         }),
     ...(orchestration ? createStage1TaskList(orchestration, input) : {})

--- a/apps/worker/test/notion-knowledge-sync.test.ts
+++ b/apps/worker/test/notion-knowledge-sync.test.ts
@@ -1,0 +1,974 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { aiKnowledgeEntries, projectDimensions } from "@as-comms/db";
+import type { NotionClient } from "@as-comms/integrations";
+import { NotionProviderError, normalizeNotionId } from "@as-comms/integrations";
+
+import { runNotionKnowledgeSync } from "../src/jobs/notion-knowledge-sync/sync.js";
+import { createTestWorkerContext } from "./helpers.js";
+
+function buildRichText(text: string) {
+  return [
+    {
+      plain_text: text,
+      href: null,
+      annotations: {
+        bold: false,
+        italic: false,
+        strikethrough: false,
+        code: false
+      }
+    }
+  ];
+}
+
+function buildPage(input: {
+  readonly id: string;
+  readonly title: string;
+  readonly lastEditedTime: string;
+  readonly url: string;
+  readonly properties?: Record<string, unknown>;
+}) {
+  return {
+    id: normalizeNotionId(input.id),
+    url: input.url,
+    last_edited_time: input.lastEditedTime,
+    properties: input.properties ?? {
+      title: {
+        type: "title",
+        title: buildRichText(input.title)
+      }
+    }
+  };
+}
+
+function buildParagraphBlock(id: string, text: string) {
+  return {
+    id: normalizeNotionId(id),
+    type: "paragraph",
+    has_children: false,
+    paragraph: {
+      rich_text: buildRichText(text)
+    }
+  };
+}
+
+function buildProjectRow(input: {
+  readonly id: string;
+  readonly name: string;
+  readonly projectId: string;
+  readonly lastEditedTime: string;
+  readonly url: string;
+  readonly extraProperties?: Record<string, unknown>;
+}) {
+  return {
+    id: normalizeNotionId(input.id),
+    url: input.url,
+    last_edited_time: input.lastEditedTime,
+    properties: {
+      Name: {
+        type: "title",
+        title: buildRichText(input.name)
+      },
+      "Project ID": {
+        type: "rich_text",
+        rich_text: buildRichText(input.projectId)
+      },
+      ...input.extraProperties
+    }
+  };
+}
+
+function createFakeNotionClient(input: {
+  readonly pages: Record<string, Record<string, unknown>>;
+  readonly blockChildren?: Record<string, readonly Record<string, unknown>[]>;
+  readonly databaseResponses?: Record<string, readonly Record<string, unknown>[]>;
+}): NotionClient {
+  const blockQueues = new Map(
+    Object.entries(input.blockChildren ?? {}).map(([blockId, responses]) => [
+      normalizeNotionId(blockId),
+      [...responses]
+    ])
+  );
+  const databaseQueues = new Map(
+    Object.entries(input.databaseResponses ?? {}).map(
+      ([databaseId, responses]) => [normalizeNotionId(databaseId), [...responses]]
+    )
+  );
+
+  return {
+    retrievePage(pageId) {
+      const page = input.pages[normalizeNotionId(pageId)];
+
+      if (page === undefined) {
+        return Promise.reject(new Error(`Missing page fixture for ${pageId}`));
+      }
+
+      return Promise.resolve(page);
+    },
+    listBlockChildren({ blockId }) {
+      return Promise.resolve(
+        blockQueues.get(normalizeNotionId(blockId))?.shift() ?? {
+          results: [],
+          has_more: false,
+          next_cursor: null
+        }
+      );
+    },
+    queryDatabase({ databaseId }) {
+      return Promise.resolve(
+        databaseQueues.get(normalizeNotionId(databaseId))?.shift() ?? {
+          results: [],
+          has_more: false,
+          next_cursor: null
+        }
+      );
+    }
+  };
+}
+
+async function seedProjectDimension(
+  context: Awaited<ReturnType<typeof createTestWorkerContext>>,
+  input: { readonly projectId: string; readonly projectName: string }
+) {
+  await context.repositories.projectDimensions.upsert({
+    projectId: input.projectId,
+    projectName: input.projectName,
+    source: "salesforce"
+  });
+}
+
+async function listKnowledgeEntries(
+  context: Awaited<ReturnType<typeof createTestWorkerContext>>
+) {
+  return context.db
+    .select()
+    .from(aiKnowledgeEntries)
+    .orderBy(aiKnowledgeEntries.scope, aiKnowledgeEntries.sourceId);
+}
+
+describe("Notion knowledge sync", () => {
+  it("marks Notion as not configured without touching knowledge rows", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      const result = await runNotionKnowledgeSync({
+        db: context.db,
+        integrationHealth: context.settings.integrationHealth,
+        notion: {
+          apiKey: null,
+          generalTrainingPageId: null,
+          projectTrainingDatabaseId: null
+        },
+        sleep: () => Promise.resolve()
+      });
+
+      expect(result).toEqual({
+        status: "not_configured"
+      });
+      expect(await listKnowledgeEntries(context)).toEqual([]);
+      await expect(
+        context.settings.integrationHealth.findById("notion")
+      ).resolves.toMatchObject({
+        status: "not_configured"
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("syncs the general page and all matching project rows, then writes healthy integration health", async () => {
+    const context = await createTestWorkerContext();
+    const generalPageId = normalizeNotionId("3278a9129211804baa72c76a86d084d0");
+    const databaseId = normalizeNotionId("3278a91292118095b86aff5836821428");
+
+    await seedProjectDimension(context, {
+      projectId: "project-alpha",
+      projectName: "Project Alpha"
+    });
+    await seedProjectDimension(context, {
+      projectId: "project-beta",
+      projectName: "Project Beta"
+    });
+
+    const client = createFakeNotionClient({
+      pages: {
+        [generalPageId]: buildPage({
+          id: generalPageId,
+          title: "General Training",
+          lastEditedTime: "2026-04-21T12:00:00.000Z",
+          url: "https://www.notion.so/general-training"
+        }),
+        [normalizeNotionId("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]: buildPage({
+          id: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          title: "Project Alpha",
+          lastEditedTime: "2026-04-21T12:05:00.000Z",
+          url: "https://www.notion.so/project-alpha",
+          properties: buildProjectRow({
+            id: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            name: "Project Alpha",
+            projectId: "project-alpha",
+            lastEditedTime: "2026-04-21T12:05:00.000Z",
+            url: "https://www.notion.so/project-alpha",
+            extraProperties: {
+              "Training URL": {
+                type: "url",
+                url: "https://docs.example.org/project-alpha"
+              },
+              Tags: {
+                type: "multi_select",
+                multi_select: [{ name: "marine" }]
+              }
+            }
+          }).properties
+        }),
+        [normalizeNotionId("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")]: buildPage({
+          id: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          title: "Project Beta",
+          lastEditedTime: "2026-04-21T12:06:00.000Z",
+          url: "https://www.notion.so/project-beta",
+          properties: buildProjectRow({
+            id: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            name: "Project Beta",
+            projectId: "project-beta",
+            lastEditedTime: "2026-04-21T12:06:00.000Z",
+            url: "https://www.notion.so/project-beta"
+          }).properties
+        })
+      },
+      blockChildren: {
+        [generalPageId]: [
+          {
+            results: [buildParagraphBlock("10101010101010101010101010101010", "Global guidance")],
+            has_more: false,
+            next_cursor: null
+          }
+        ],
+        [normalizeNotionId("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]: [
+          {
+            results: [buildParagraphBlock("11111111111111111111111111111111", "Alpha training body")],
+            has_more: false,
+            next_cursor: null
+          }
+        ],
+        [normalizeNotionId("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")]: [
+          {
+            results: [buildParagraphBlock("12121212121212121212121212121212", "Beta training body")],
+            has_more: false,
+            next_cursor: null
+          }
+        ]
+      },
+      databaseResponses: {
+        [databaseId]: [
+          {
+            results: [
+              buildProjectRow({
+                id: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                name: "Project Alpha",
+                projectId: "project-alpha",
+                lastEditedTime: "2026-04-21T12:05:00.000Z",
+                url: "https://www.notion.so/project-alpha",
+                extraProperties: {
+                  "Training URL": {
+                    type: "url",
+                    url: "https://docs.example.org/project-alpha"
+                  },
+                  Tags: {
+                    type: "multi_select",
+                    multi_select: [{ name: "marine" }]
+                  }
+                }
+              }),
+              buildProjectRow({
+                id: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                name: "Project Beta",
+                projectId: "project-beta",
+                lastEditedTime: "2026-04-21T12:06:00.000Z",
+                url: "https://www.notion.so/project-beta"
+              })
+            ],
+            has_more: false,
+            next_cursor: null
+          }
+        ]
+      }
+    });
+
+    try {
+      const result = await runNotionKnowledgeSync({
+        db: context.db,
+        integrationHealth: context.settings.integrationHealth,
+        notion: {
+          apiKey: "notion-token",
+          generalTrainingPageId: generalPageId,
+          projectTrainingDatabaseId: databaseId
+        },
+        createClient: () => client,
+        sleep: () => Promise.resolve(),
+        now: (() => {
+          let tick = 0;
+          return () => new Date(Date.parse("2026-04-21T12:10:00.000Z") + tick++ * 1000);
+        })()
+      });
+
+      expect(result).toMatchObject({
+        status: "healthy",
+        knowledgeEntriesTotal: 3,
+        projectsSyncedCount: 2,
+        orphanRowsCount: 0
+      });
+
+      await expect(listKnowledgeEntries(context)).resolves.toMatchObject([
+        {
+          scope: "global",
+          scopeKey: null,
+          sourceProvider: "notion",
+          sourceUrl: "https://www.notion.so/general-training",
+          content: "Global guidance"
+        },
+        {
+          scope: "project",
+          scopeKey: "project-alpha",
+          sourceProvider: "notion",
+          sourceUrl: "https://www.notion.so/project-alpha",
+          title: "Project Alpha",
+          content: "Alpha training body"
+        },
+        {
+          scope: "project",
+          scopeKey: "project-beta",
+          sourceProvider: "notion",
+          sourceUrl: "https://www.notion.so/project-beta",
+          title: "Project Beta",
+          content: "Beta training body"
+        }
+      ]);
+
+      const syncedProjects = await context.db
+        .select({
+          projectId: projectDimensions.projectId,
+          aiKnowledgeSyncedAt: projectDimensions.aiKnowledgeSyncedAt
+        })
+        .from(projectDimensions)
+        .orderBy(projectDimensions.projectId);
+
+      expect(syncedProjects).toEqual([
+        {
+          projectId: "project-alpha",
+          aiKnowledgeSyncedAt: expect.any(Date)
+        },
+        {
+          projectId: "project-beta",
+          aiKnowledgeSyncedAt: expect.any(Date)
+        }
+      ]);
+
+      await expect(
+        context.settings.integrationHealth.findById("notion")
+      ).resolves.toMatchObject({
+        status: "healthy",
+        metadataJson: {
+          knowledgeEntriesTotal: 3,
+          projectsSyncedCount: 2,
+          orphanRowsCount: 0,
+          lastSuccessAt: expect.any(String)
+        }
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("skips orphan rows and logs a warning while syncing other projects", async () => {
+    const context = await createTestWorkerContext();
+    const logger = {
+      warn: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn()
+    };
+    const generalPageId = normalizeNotionId("3278a9129211804baa72c76a86d084d0");
+    const databaseId = normalizeNotionId("3278a91292118095b86aff5836821428");
+    const projectPageId = normalizeNotionId("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+    await seedProjectDimension(context, {
+      projectId: "project-alpha",
+      projectName: "Project Alpha"
+    });
+
+    const client = createFakeNotionClient({
+      pages: {
+        [generalPageId]: buildPage({
+          id: generalPageId,
+          title: "General Training",
+          lastEditedTime: "2026-04-21T12:00:00.000Z",
+          url: "https://www.notion.so/general-training"
+        }),
+        [projectPageId]: buildPage({
+          id: projectPageId,
+          title: "Project Alpha",
+          lastEditedTime: "2026-04-21T12:05:00.000Z",
+          url: "https://www.notion.so/project-alpha",
+          properties: buildProjectRow({
+            id: projectPageId,
+            name: "Project Alpha",
+            projectId: "project-alpha",
+            lastEditedTime: "2026-04-21T12:05:00.000Z",
+            url: "https://www.notion.so/project-alpha"
+          }).properties
+        })
+      },
+      blockChildren: {
+        [generalPageId]: [
+          {
+            results: [buildParagraphBlock("66666666666666666666666666666666", "Global guidance")],
+            has_more: false,
+            next_cursor: null
+          }
+        ],
+        [projectPageId]: [
+          {
+            results: [buildParagraphBlock("77777777777777777777777777777777", "Alpha body")],
+            has_more: false,
+            next_cursor: null
+          }
+        ]
+      },
+      databaseResponses: {
+        [databaseId]: [
+          {
+            results: [
+              buildProjectRow({
+                id: projectPageId,
+                name: "Project Alpha",
+                projectId: "project-alpha",
+                lastEditedTime: "2026-04-21T12:05:00.000Z",
+                url: "https://www.notion.so/project-alpha"
+              }),
+              buildProjectRow({
+                id: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                name: "Unknown Project",
+                projectId: "project-unknown",
+                lastEditedTime: "2026-04-21T12:06:00.000Z",
+                url: "https://www.notion.so/project-unknown"
+              })
+            ],
+            has_more: false,
+            next_cursor: null
+          }
+        ]
+      }
+    });
+
+    try {
+      const result = await runNotionKnowledgeSync({
+        db: context.db,
+        integrationHealth: context.settings.integrationHealth,
+        notion: {
+          apiKey: "notion-token",
+          generalTrainingPageId: generalPageId,
+          projectTrainingDatabaseId: databaseId
+        },
+        createClient: () => client,
+        logger,
+        sleep: () => Promise.resolve()
+      });
+
+      expect(result).toMatchObject({
+        status: "healthy",
+        projectsSyncedCount: 1,
+        orphanRowsCount: 1
+      });
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("project-unknown")
+      );
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("uses the newest row when Project ID duplicates exist", async () => {
+    const context = await createTestWorkerContext();
+    const logger = {
+      warn: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn()
+    };
+    const generalPageId = normalizeNotionId("3278a9129211804baa72c76a86d084d0");
+    const databaseId = normalizeNotionId("3278a91292118095b86aff5836821428");
+    const olderRowId = normalizeNotionId("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    const newerRowId = normalizeNotionId("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+
+    await seedProjectDimension(context, {
+      projectId: "project-alpha",
+      projectName: "Project Alpha"
+    });
+
+    const client = createFakeNotionClient({
+      pages: {
+        [generalPageId]: buildPage({
+          id: generalPageId,
+          title: "General Training",
+          lastEditedTime: "2026-04-21T12:00:00.000Z",
+          url: "https://www.notion.so/general-training"
+        }),
+        [newerRowId]: buildPage({
+          id: newerRowId,
+          title: "Project Alpha New",
+          lastEditedTime: "2026-04-21T12:10:00.000Z",
+          url: "https://www.notion.so/project-alpha-new",
+          properties: buildProjectRow({
+            id: newerRowId,
+            name: "Project Alpha New",
+            projectId: "project-alpha",
+            lastEditedTime: "2026-04-21T12:10:00.000Z",
+            url: "https://www.notion.so/project-alpha-new"
+          }).properties
+        })
+      },
+      blockChildren: {
+        [generalPageId]: [
+          {
+            results: [buildParagraphBlock("88888888888888888888888888888888", "Global guidance")],
+            has_more: false,
+            next_cursor: null
+          }
+        ],
+        [newerRowId]: [
+          {
+            results: [buildParagraphBlock("99999999999999999999999999999999", "Newest body wins")],
+            has_more: false,
+            next_cursor: null
+          }
+        ]
+      },
+      databaseResponses: {
+        [databaseId]: [
+          {
+            results: [
+              buildProjectRow({
+                id: olderRowId,
+                name: "Project Alpha Old",
+                projectId: "project-alpha",
+                lastEditedTime: "2026-04-21T12:05:00.000Z",
+                url: "https://www.notion.so/project-alpha-old"
+              }),
+              buildProjectRow({
+                id: newerRowId,
+                name: "Project Alpha New",
+                projectId: "project-alpha",
+                lastEditedTime: "2026-04-21T12:10:00.000Z",
+                url: "https://www.notion.so/project-alpha-new"
+              })
+            ],
+            has_more: false,
+            next_cursor: null
+          }
+        ]
+      }
+    });
+
+    try {
+      const result = await runNotionKnowledgeSync({
+        db: context.db,
+        integrationHealth: context.settings.integrationHealth,
+        notion: {
+          apiKey: "notion-token",
+          generalTrainingPageId: generalPageId,
+          projectTrainingDatabaseId: databaseId
+        },
+        createClient: () => client,
+        logger,
+        sleep: () => Promise.resolve()
+      });
+
+      expect(result).toMatchObject({
+        status: "healthy",
+        projectsSyncedCount: 1
+      });
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Duplicate Notion Project Training rows")
+      );
+
+      const projectRows = (await listKnowledgeEntries(context)).filter(
+        (row) => row.scope === "project"
+      );
+      expect(projectRows).toHaveLength(1);
+      expect(projectRows[0]).toMatchObject({
+        sourceId: newerRowId,
+        content: "Newest body wins"
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("skips ai_knowledge_entries updates when content is unchanged", async () => {
+    const context = await createTestWorkerContext();
+    const generalPageId = normalizeNotionId("3278a9129211804baa72c76a86d084d0");
+    const databaseId = normalizeNotionId("3278a91292118095b86aff5836821428");
+    const projectPageId = normalizeNotionId("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+    await seedProjectDimension(context, {
+      projectId: "project-alpha",
+      projectName: "Project Alpha"
+    });
+
+    const buildClient = () =>
+      createFakeNotionClient({
+        pages: {
+          [generalPageId]: buildPage({
+            id: generalPageId,
+            title: "General Training",
+            lastEditedTime: "2026-04-21T12:00:00.000Z",
+            url: "https://www.notion.so/general-training"
+          }),
+          [projectPageId]: buildPage({
+            id: projectPageId,
+            title: "Project Alpha",
+            lastEditedTime: "2026-04-21T12:05:00.000Z",
+            url: "https://www.notion.so/project-alpha",
+            properties: buildProjectRow({
+              id: projectPageId,
+              name: "Project Alpha",
+              projectId: "project-alpha",
+              lastEditedTime: "2026-04-21T12:05:00.000Z",
+              url: "https://www.notion.so/project-alpha"
+            }).properties
+          })
+        },
+        blockChildren: {
+          [generalPageId]: [
+            {
+              results: [buildParagraphBlock("abababababababababababababababab", "Global guidance")],
+              has_more: false,
+              next_cursor: null
+            }
+          ],
+          [projectPageId]: [
+            {
+              results: [buildParagraphBlock("cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd", "Stable body")],
+              has_more: false,
+              next_cursor: null
+            }
+          ]
+        },
+        databaseResponses: {
+          [databaseId]: [
+            {
+              results: [
+                buildProjectRow({
+                  id: projectPageId,
+                  name: "Project Alpha",
+                  projectId: "project-alpha",
+                  lastEditedTime: "2026-04-21T12:05:00.000Z",
+                  url: "https://www.notion.so/project-alpha"
+                })
+              ],
+              has_more: false,
+              next_cursor: null
+            }
+          ]
+        }
+      });
+
+    try {
+      await runNotionKnowledgeSync({
+        db: context.db,
+        integrationHealth: context.settings.integrationHealth,
+        notion: {
+          apiKey: "notion-token",
+          generalTrainingPageId: generalPageId,
+          projectTrainingDatabaseId: databaseId
+        },
+        createClient: buildClient,
+        sleep: () => Promise.resolve()
+      });
+
+      const updateSpy = vi.spyOn(context.db, "update");
+
+      await runNotionKnowledgeSync({
+        db: context.db,
+        integrationHealth: context.settings.integrationHealth,
+        notion: {
+          apiKey: "notion-token",
+          generalTrainingPageId: generalPageId,
+          projectTrainingDatabaseId: databaseId
+        },
+        createClient: buildClient,
+        sleep: () => Promise.resolve()
+      });
+
+      expect(
+        updateSpy.mock.calls.some(([table]) => table === aiKnowledgeEntries)
+      ).toBe(false);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("deletes knowledge rows that disappear from Notion on the next sync", async () => {
+    const context = await createTestWorkerContext();
+    const generalPageId = normalizeNotionId("3278a9129211804baa72c76a86d084d0");
+    const databaseId = normalizeNotionId("3278a91292118095b86aff5836821428");
+    const projectPageId = normalizeNotionId("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+    await seedProjectDimension(context, {
+      projectId: "project-alpha",
+      projectName: "Project Alpha"
+    });
+
+    const firstClient = createFakeNotionClient({
+      pages: {
+        [generalPageId]: buildPage({
+          id: generalPageId,
+          title: "General Training",
+          lastEditedTime: "2026-04-21T12:00:00.000Z",
+          url: "https://www.notion.so/general-training"
+        }),
+        [projectPageId]: buildPage({
+          id: projectPageId,
+          title: "Project Alpha",
+          lastEditedTime: "2026-04-21T12:05:00.000Z",
+          url: "https://www.notion.so/project-alpha",
+          properties: buildProjectRow({
+            id: projectPageId,
+            name: "Project Alpha",
+            projectId: "project-alpha",
+            lastEditedTime: "2026-04-21T12:05:00.000Z",
+            url: "https://www.notion.so/project-alpha"
+          }).properties
+        })
+      },
+      blockChildren: {
+        [generalPageId]: [
+          {
+            results: [buildParagraphBlock("dededededededededededededededede", "Global guidance")],
+            has_more: false,
+            next_cursor: null
+          }
+        ],
+        [projectPageId]: [
+          {
+            results: [buildParagraphBlock("efefefefefefefefefefefefefefefef", "Project body")],
+            has_more: false,
+            next_cursor: null
+          }
+        ]
+      },
+      databaseResponses: {
+        [databaseId]: [
+          {
+            results: [
+              buildProjectRow({
+                id: projectPageId,
+                name: "Project Alpha",
+                projectId: "project-alpha",
+                lastEditedTime: "2026-04-21T12:05:00.000Z",
+                url: "https://www.notion.so/project-alpha"
+              })
+            ],
+            has_more: false,
+            next_cursor: null
+          }
+        ]
+      }
+    });
+
+    const secondClient = createFakeNotionClient({
+      pages: {
+        [generalPageId]: buildPage({
+          id: generalPageId,
+          title: "General Training",
+          lastEditedTime: "2026-04-21T12:00:00.000Z",
+          url: "https://www.notion.so/general-training"
+        })
+      },
+      blockChildren: {
+        [generalPageId]: [
+          {
+            results: [buildParagraphBlock("f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0", "Global guidance")],
+            has_more: false,
+            next_cursor: null
+          }
+        ]
+      },
+      databaseResponses: {
+        [databaseId]: [
+          {
+            results: [],
+            has_more: false,
+            next_cursor: null
+          }
+        ]
+      }
+    });
+
+    try {
+      await runNotionKnowledgeSync({
+        db: context.db,
+        integrationHealth: context.settings.integrationHealth,
+        notion: {
+          apiKey: "notion-token",
+          generalTrainingPageId: generalPageId,
+          projectTrainingDatabaseId: databaseId
+        },
+        createClient: () => firstClient,
+        sleep: () => Promise.resolve()
+      });
+
+      await runNotionKnowledgeSync({
+        db: context.db,
+        integrationHealth: context.settings.integrationHealth,
+        notion: {
+          apiKey: "notion-token",
+          generalTrainingPageId: generalPageId,
+          projectTrainingDatabaseId: databaseId
+        },
+        createClient: () => secondClient,
+        sleep: () => Promise.resolve()
+      });
+
+      const projectRows = (await listKnowledgeEntries(context)).filter(
+        (row) => row.scope === "project"
+      );
+      expect(projectRows).toEqual([]);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("records partial progress and writes needs_attention health when Notion fails mid-sync", async () => {
+    const context = await createTestWorkerContext();
+    const generalPageId = normalizeNotionId("3278a9129211804baa72c76a86d084d0");
+    const databaseId = normalizeNotionId("3278a91292118095b86aff5836821428");
+    const projectAlphaPageId = normalizeNotionId("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    const projectBetaPageId = normalizeNotionId("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+
+    await seedProjectDimension(context, {
+      projectId: "project-alpha",
+      projectName: "Project Alpha"
+    });
+    await seedProjectDimension(context, {
+      projectId: "project-beta",
+      projectName: "Project Beta"
+    });
+
+    const client = createFakeNotionClient({
+      pages: {
+        [generalPageId]: buildPage({
+          id: generalPageId,
+          title: "General Training",
+          lastEditedTime: "2026-04-21T12:00:00.000Z",
+          url: "https://www.notion.so/general-training"
+        }),
+        [projectAlphaPageId]: buildPage({
+          id: projectAlphaPageId,
+          title: "Project Alpha",
+          lastEditedTime: "2026-04-21T12:05:00.000Z",
+          url: "https://www.notion.so/project-alpha",
+          properties: buildProjectRow({
+            id: projectAlphaPageId,
+            name: "Project Alpha",
+            projectId: "project-alpha",
+            lastEditedTime: "2026-04-21T12:05:00.000Z",
+            url: "https://www.notion.so/project-alpha"
+          }).properties
+        })
+      },
+      blockChildren: {
+        [generalPageId]: [
+          {
+            results: [buildParagraphBlock("01010101010101010101010101010101", "Global guidance")],
+            has_more: false,
+            next_cursor: null
+          }
+        ],
+        [projectAlphaPageId]: [
+          {
+            results: [buildParagraphBlock("02020202020202020202020202020202", "Alpha body")],
+            has_more: false,
+            next_cursor: null
+          }
+        ]
+      },
+      databaseResponses: {
+        [databaseId]: [
+          {
+            results: [
+              buildProjectRow({
+                id: projectAlphaPageId,
+                name: "Project Alpha",
+                projectId: "project-alpha",
+                lastEditedTime: "2026-04-21T12:05:00.000Z",
+                url: "https://www.notion.so/project-alpha"
+              }),
+              buildProjectRow({
+                id: projectBetaPageId,
+                name: "Project Beta",
+                projectId: "project-beta",
+                lastEditedTime: "2026-04-21T12:06:00.000Z",
+                url: "https://www.notion.so/project-beta"
+              })
+            ],
+            has_more: false,
+            next_cursor: null
+          }
+        ]
+      }
+    });
+
+    const failingClient: NotionClient = {
+      ...client,
+      retrievePage(pageId) {
+        if (normalizeNotionId(pageId) === projectBetaPageId) {
+          return Promise.reject(
+            new NotionProviderError({
+              code: "rate_limited",
+              message: "Too many requests",
+              retryable: true,
+              status: 429,
+              retryAfterSeconds: 5
+            })
+          );
+        }
+
+        return client.retrievePage(pageId);
+      }
+    };
+
+    try {
+      const result = await runNotionKnowledgeSync({
+        db: context.db,
+        integrationHealth: context.settings.integrationHealth,
+        notion: {
+          apiKey: "notion-token",
+          generalTrainingPageId: generalPageId,
+          projectTrainingDatabaseId: databaseId
+        },
+        createClient: () => failingClient,
+        sleep: () => Promise.resolve()
+      });
+
+      expect(result).toMatchObject({
+        status: "error",
+        projectsSyncedCount: 1
+      });
+
+      const storedRows = await listKnowledgeEntries(context);
+      expect(storedRows.map((row) => row.scopeKey)).toEqual([
+        null,
+        "project-alpha"
+      ]);
+
+      await expect(
+        context.settings.integrationHealth.findById("notion")
+      ).resolves.toMatchObject({
+        status: "needs_attention",
+        detail: expect.stringContaining("rate_limited")
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+});

--- a/apps/worker/test/notion-knowledge-sync.test.ts
+++ b/apps/worker/test/notion-knowledge-sync.test.ts
@@ -353,28 +353,26 @@ describe("Notion knowledge sync", () => {
         .from(projectDimensions)
         .orderBy(projectDimensions.projectId);
 
-      expect(syncedProjects).toEqual([
-        {
-          projectId: "project-alpha",
-          aiKnowledgeSyncedAt: expect.any(Date)
-        },
-        {
-          projectId: "project-beta",
-          aiKnowledgeSyncedAt: expect.any(Date)
-        }
+      expect(syncedProjects).toHaveLength(2);
+      expect(syncedProjects.map((project) => project.projectId)).toEqual([
+        "project-alpha",
+        "project-beta"
       ]);
+      for (const project of syncedProjects) {
+        expect(project.aiKnowledgeSyncedAt).toBeInstanceOf(Date);
+      }
 
-      await expect(
-        context.settings.integrationHealth.findById("notion")
-      ).resolves.toMatchObject({
+      const integrationHealth =
+        await context.settings.integrationHealth.findById("notion");
+      expect(integrationHealth).toMatchObject({
         status: "healthy",
         metadataJson: {
           knowledgeEntriesTotal: 3,
           projectsSyncedCount: 2,
-          orphanRowsCount: 0,
-          lastSuccessAt: expect.any(String)
+          orphanRowsCount: 0
         }
       });
+      expect(typeof integrationHealth?.metadataJson.lastSuccessAt).toBe("string");
     } finally {
       await context.dispose();
     }
@@ -961,12 +959,12 @@ describe("Notion knowledge sync", () => {
         "project-alpha"
       ]);
 
-      await expect(
-        context.settings.integrationHealth.findById("notion")
-      ).resolves.toMatchObject({
-        status: "needs_attention",
-        detail: expect.stringContaining("rate_limited")
+      const integrationHealth =
+        await context.settings.integrationHealth.findById("notion");
+      expect(integrationHealth).toMatchObject({
+        status: "needs_attention"
       });
+      expect(integrationHealth?.detail ?? "").toContain("rate_limited");
     } finally {
       await context.dispose();
     }

--- a/apps/worker/test/notion-knowledge-sync.test.ts
+++ b/apps/worker/test/notion-knowledge-sync.test.ts
@@ -96,6 +96,27 @@ function createFakeNotionClient(input: {
     )
   );
 
+  function readPagedResponse(
+    responses: readonly Record<string, unknown>[],
+    startCursor?: string
+  ): Record<string, unknown> | undefined {
+    if (responses.length === 0) {
+      return undefined;
+    }
+
+    if (startCursor === undefined) {
+      return responses[0];
+    }
+
+    const previousPageIndex = responses.findIndex(
+      (response) => response.next_cursor === startCursor
+    );
+
+    return previousPageIndex === -1
+      ? undefined
+      : responses[previousPageIndex + 1];
+  }
+
   return {
     retrievePage(pageId) {
       const page = input.pages[normalizeNotionId(pageId)];
@@ -115,9 +136,10 @@ function createFakeNotionClient(input: {
         }
       );
     },
-    queryDatabase({ databaseId }) {
+    queryDatabase({ databaseId, startCursor }) {
+      const responses = databaseQueues.get(normalizeNotionId(databaseId)) ?? [];
       return Promise.resolve(
-        databaseQueues.get(normalizeNotionId(databaseId))?.shift() ?? {
+        readPagedResponse(responses, startCursor) ?? {
           results: [],
           has_more: false,
           next_cursor: null

--- a/apps/worker/test/stage1-runtime.test.ts
+++ b/apps/worker/test/stage1-runtime.test.ts
@@ -9,6 +9,7 @@ import {
   buildWorkerCrontab,
   readWorkerConfig
 } from "../src/runtime.js";
+import { notionKnowledgeSyncJobName } from "../src/jobs/notion-knowledge-sync/index.js";
 import {
   pollGmailLiveJobName,
   pollIntegrationHealthJobName,
@@ -143,6 +144,7 @@ describe("Stage 1 worker runtime task registration", () => {
         `*/1 * * * * ${pollGmailLiveJobName} ?id=gmail-live-poll&max=1`,
         `*/5 * * * * ${pollSalesforceLiveJobName} ?id=salesforce-live-poll&max=1`,
         `*/5 * * * * ${pollIntegrationHealthJobName} ?id=integration-health-poll&max=1`,
+        `*/15 * * * * ${notionKnowledgeSyncJobName} ?id=notion-knowledge-sync&max=1`,
         `*/5 * * * * ${sweepPendingOutboundsJobName} ?id=composer-orphan-sweep&max=1`
       ].join("\n")
     );

--- a/docs/03-reference/reference-env.md
+++ b/docs/03-reference/reference-env.md
@@ -25,6 +25,16 @@
 - environment values exposed to the browser must be intentionally non-secret
 - runtime-specific security headers still need explicit verification even if the hosting edge provides defaults
 
+## Stage 4 Notion Sync
+
+| Env var | Runtime | Required | Notes |
+| --- | --- | --- | --- |
+| `NOTION_API_KEY` | `worker` | yes | Internal Notion integration token. Keep backend-only. |
+| `NOTION_GENERAL_TRAINING_PAGE_ID` | `worker` | yes | Default local/example value: `3278a9129211804baa72c76a86d084d0`. Read at worker startup; missing config surfaces `integration_health.notion = not_configured`. |
+| `NOTION_PROJECT_TRAINING_DATABASE_ID` | `worker` | yes | Default local/example value: `3278a91292118095b86aff5836821428`. Read at worker startup; missing config surfaces `integration_health.notion = not_configured`. |
+
+The worker cron is the only current consumer. The web service may carry the same env values in shared deployment config, but it does not call Notion directly in this brief.
+
 ## Deep References
 
 - full donor lookup: [`../../restart-prd/env-and-secrets-matrix.md`](../../restart-prd/env-and-secrets-matrix.md)

--- a/docs/03-reference/reference-services.md
+++ b/docs/03-reference/reference-services.md
@@ -25,6 +25,16 @@
 - Mailchimp remains transition ingest scope, not the future authoring UX.
 - SendGrid delivers Email Campaigns but is not the authoring source of truth.
 
+## Notion
+
+- Purpose: source of truth for Stage 4 tiers 1-3 knowledge. The worker polls one General Training page plus the Project Training database and caches page bodies into `ai_knowledge_entries`.
+- Cron cadence: every 15 minutes via the `notion-knowledge-sync` Graphile Worker cron.
+- Env vars: `NOTION_API_KEY`, `NOTION_GENERAL_TRAINING_PAGE_ID`, `NOTION_PROJECT_TRAINING_DATABASE_ID`.
+- Failure modes:
+  missing env writes `integration_health.notion = not_configured` and the worker no-ops.
+  auth / permissions / missing page or database access writes `integration_health.notion = needs_attention`.
+  partial mid-sync failures keep already-committed rows, skip reconcile for that cycle, and surface `needs_attention` until a later successful poll.
+
 ## Deep References
 
 - full service dossiers live in [`../../restart-prd`](../../restart-prd)

--- a/docs/04-implementation-specs/stage-4-ai-pipeline.md
+++ b/docs/04-implementation-specs/stage-4-ai-pipeline.md
@@ -43,7 +43,7 @@ Every draft request composes a grounding bundle in this fixed priority order. Hi
 | --- | --- | --- | --- |
 | 1 | general instructions | Notion page: "AS global AI instructions" | instruction retriever |
 | 2 | project-specific instructions | Notion page per project (e.g., "PNW Biodiversity instructions") | instruction retriever |
-| 3 | approved knowledge | Notion knowledge pages, synced to `aiDurableState` with `kind=knowledge_cache` | knowledge retriever |
+| 3 | approved knowledge | Notion knowledge pages cached in `ai_knowledge_entries` | knowledge retriever |
 | 4 | current conversation + contact + project context | live Stage 1 projections: inbox row, timeline, memberships | context retriever |
 | 5 | reusable approved-reply memory | past sent replies captured post-approval, stored as `aiDurableState` with `kind=resolved_reply_example` | memory retriever |
 
@@ -137,14 +137,14 @@ The orchestration service is a single backend module with internal components. M
 | --- | --- | --- |
 | request normalizer / classifier | parse draft request, classify intent, detect safety/ambiguity | Stage 1 contact + timeline repos |
 | policy gate | hard-deny out-of-policy requests before retrieval | static policy config |
-| instruction retriever | pull tier-1 + tier-2 Notion instructions from cache | `aiDurableState` knowledge cache |
-| knowledge retriever | retrieve tier-3 approved knowledge chunks | `aiDurableState` knowledge cache, embedding search |
+| instruction retriever | pull tier-1 + tier-2 Notion instructions from cache | `ai_knowledge_entries` |
+| knowledge retriever | retrieve tier-3 approved knowledge chunks | `ai_knowledge_entries`, future chunking / retrieval layer |
 | context retriever | read live Stage 1 contact timeline, project memberships | Stage 1 repositories via composition root |
 | memory retriever | retrieve tier-5 approved-reply examples by similarity | `aiDurableState` resolved-reply memory, embedding search |
 | grounding assembler | merge retriever outputs into ordered bundle with provenance | above retrievers |
 | response-mode decider | pick draft / clarify / handoff / fallback | classifier + grounding coverage |
 | prompt builder | compose final model prompt with grounding hierarchy, masking | grounding bundle + prompt templates |
-| provider adapter | call OpenAI, handle retries, timeouts | provider credentials, network adapter |
+| provider adapter | call Anthropic (Claude Sonnet 4.6), handle retries, timeouts | provider credentials, network adapter |
 | validator | post-generation checks (answers, grounded, hierarchy, PII) | grounding bundle + generated draft |
 | fallback builder | deterministic non-LLM response when provider fails or validation blocks | static template set |
 | grounding presenter | shape the explainability payload for the Composer UI | grounding bundle + validation outcome |

--- a/packages/db/drizzle/0020_ai_knowledge_entries.sql
+++ b/packages/db/drizzle/0020_ai_knowledge_entries.sql
@@ -1,0 +1,22 @@
+CREATE TABLE "ai_knowledge_entries" (
+  "id" text PRIMARY KEY,
+  "scope" text NOT NULL,
+  "scope_key" text,
+  "source_provider" text NOT NULL,
+  "source_id" text NOT NULL,
+  "source_url" text,
+  "title" text,
+  "content" text NOT NULL,
+  "content_hash" text NOT NULL,
+  "metadata_json" jsonb NOT NULL DEFAULT '{}'::jsonb,
+  "source_last_edited_at" timestamptz,
+  "synced_at" timestamptz NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX "ai_knowledge_entries_source_idx"
+ON "ai_knowledge_entries" ("source_provider", "source_id");
+
+CREATE INDEX "ai_knowledge_entries_scope_idx"
+ON "ai_knowledge_entries" ("scope", "scope_key");

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -3,6 +3,7 @@ export * from "./tables.js";
 import {
   accounts,
   auditPolicyEvidence,
+  aiKnowledgeEntries,
   canonicalEventLedger,
   contactIdentities,
   contactInboxProjection,
@@ -31,6 +32,7 @@ import {
 
 export const databaseSchema = {
   sourceEvidenceLog,
+  aiKnowledgeEntries,
   contacts,
   contactIdentities,
   contactMemberships,

--- a/packages/db/src/schema/tables.ts
+++ b/packages/db/src/schema/tables.ts
@@ -770,6 +770,42 @@ export const pendingComposerOutbounds = pgTable(
   ],
 );
 
+export const aiKnowledgeEntries = pgTable(
+  "ai_knowledge_entries",
+  {
+    id: text("id").primaryKey(),
+    scope: text("scope").notNull(),
+    scopeKey: text("scope_key"),
+    sourceProvider: text("source_provider").notNull(),
+    sourceId: text("source_id").notNull(),
+    sourceUrl: text("source_url"),
+    title: text("title"),
+    content: text("content").notNull(),
+    contentHash: text("content_hash").notNull(),
+    metadataJson: jsonb("metadata_json")
+      .$type<Record<string, unknown>>()
+      .notNull()
+      .default({}),
+    sourceLastEditedAt: timestamp("source_last_edited_at", {
+      mode: "date",
+      withTimezone: true
+    }),
+    syncedAt: timestamp("synced_at", {
+      mode: "date",
+      withTimezone: true
+    }).notNull(),
+    createdAt: createdAtColumn,
+    updatedAt: updatedAtColumn
+  },
+  (table) => [
+    uniqueIndex("ai_knowledge_entries_source_idx").on(
+      table.sourceProvider,
+      table.sourceId
+    ),
+    index("ai_knowledge_entries_scope_idx").on(table.scope, table.scopeKey)
+  ]
+);
+
 export const integrationHealth = pgTable(
   "integration_health",
   {

--- a/packages/db/src/test-helpers.ts
+++ b/packages/db/src/test-helpers.ts
@@ -22,6 +22,7 @@ export interface TestStage1Context {
   readonly settings: ReturnType<typeof createStage2RepositoryBundle>;
   readonly persistence: ReturnType<typeof createStage1PersistenceService>;
   readonly normalization: ReturnType<typeof createStage1NormalizationService>;
+  readonly dispose: () => Promise<void>;
 }
 
 export async function createTestStage1Context(): Promise<TestStage1Context> {
@@ -56,6 +57,7 @@ export async function createTestStage1Context(): Promise<TestStage1Context> {
     repositories,
     settings,
     persistence,
-    normalization: createStage1NormalizationService(persistence)
+    normalization: createStage1NormalizationService(persistence),
+    dispose: () => client.close()
   };
 }

--- a/packages/db/test/ai-knowledge-entries.test.ts
+++ b/packages/db/test/ai-knowledge-entries.test.ts
@@ -110,7 +110,6 @@ describe("ai_knowledge_entries table", () => {
           .where(eq(aiKnowledgeEntries.id, "ai_knowledge:notion:global"))
       ).resolves.toEqual([]);
     } finally {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       await context.dispose();
     }
   });

--- a/packages/db/test/ai-knowledge-entries.test.ts
+++ b/packages/db/test/ai-knowledge-entries.test.ts
@@ -110,6 +110,7 @@ describe("ai_knowledge_entries table", () => {
           .where(eq(aiKnowledgeEntries.id, "ai_knowledge:notion:global"))
       ).resolves.toEqual([]);
     } finally {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       await context.dispose();
     }
   });

--- a/packages/db/test/ai-knowledge-entries.test.ts
+++ b/packages/db/test/ai-knowledge-entries.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import { and, eq } from "drizzle-orm";
+
+import { aiKnowledgeEntries } from "../src/index.js";
+import { createTestStage1Context } from "./helpers.js";
+
+describe("ai_knowledge_entries table", () => {
+  it("supports insert, upsert by source, and delete by source id", async () => {
+    const context = await createTestStage1Context();
+    const syncedAt = new Date("2026-04-21T12:00:00.000Z");
+
+    try {
+      await context.db.insert(aiKnowledgeEntries).values({
+        id: "ai_knowledge:notion:global",
+        scope: "global",
+        scopeKey: null,
+        sourceProvider: "notion",
+        sourceId: "3278a912-9211-804b-aa72-c76a86d084d0",
+        sourceUrl: "https://www.notion.so/general-training",
+        title: null,
+        content: "Initial content",
+        contentHash: "hash:initial",
+        metadataJson: {},
+        sourceLastEditedAt: new Date("2026-04-21T11:59:00.000Z"),
+        syncedAt
+      });
+
+      const [existingRow] = await context.db
+        .select()
+        .from(aiKnowledgeEntries)
+        .where(eq(aiKnowledgeEntries.id, "ai_knowledge:notion:global"))
+        .limit(1);
+
+      expect(existingRow).toMatchObject({
+        scope: "global",
+        sourceProvider: "notion",
+        content: "Initial content"
+      });
+
+      await context.db
+        .insert(aiKnowledgeEntries)
+        .values({
+          id: "ai_knowledge:notion:global",
+          scope: "global",
+          scopeKey: null,
+          sourceProvider: "notion",
+          sourceId: "3278a912-9211-804b-aa72-c76a86d084d0",
+          sourceUrl: "https://www.notion.so/general-training",
+          title: null,
+          content: "Updated content",
+          contentHash: "hash:updated",
+          metadataJson: {
+            tier: 1
+          },
+          sourceLastEditedAt: new Date("2026-04-21T12:01:00.000Z"),
+          syncedAt: new Date("2026-04-21T12:02:00.000Z")
+        })
+        .onConflictDoUpdate({
+          target: [
+            aiKnowledgeEntries.sourceProvider,
+            aiKnowledgeEntries.sourceId
+          ],
+          set: {
+            content: "Updated content",
+            contentHash: "hash:updated",
+            metadataJson: {
+              tier: 1
+            },
+            sourceLastEditedAt: new Date("2026-04-21T12:01:00.000Z"),
+            syncedAt: new Date("2026-04-21T12:02:00.000Z")
+          }
+        });
+
+      const [upsertedRow] = await context.db
+        .select()
+        .from(aiKnowledgeEntries)
+        .where(
+          and(
+            eq(aiKnowledgeEntries.sourceProvider, "notion"),
+            eq(
+              aiKnowledgeEntries.sourceId,
+              "3278a912-9211-804b-aa72-c76a86d084d0"
+            )
+          )
+        )
+        .limit(1);
+
+      expect(upsertedRow).toMatchObject({
+        content: "Updated content",
+        contentHash: "hash:updated",
+        metadataJson: {
+          tier: 1
+        }
+      });
+
+      await context.db
+        .delete(aiKnowledgeEntries)
+        .where(
+          eq(
+            aiKnowledgeEntries.sourceId,
+            "3278a912-9211-804b-aa72-c76a86d084d0"
+          )
+        );
+
+      await expect(
+        context.db
+          .select()
+          .from(aiKnowledgeEntries)
+          .where(eq(aiKnowledgeEntries.id, "ai_knowledge:notion:global"))
+      ).resolves.toEqual([]);
+    } finally {
+      await context.dispose();
+    }
+  });
+});

--- a/packages/db/test/stage1-schema.test.ts
+++ b/packages/db/test/stage1-schema.test.ts
@@ -10,6 +10,7 @@ import {
 } from "@as-comms/contracts";
 
 import {
+  aiKnowledgeEntries,
   canonicalEventLedger,
   contactInboxProjection,
   contactTimelineProjection,
@@ -22,6 +23,7 @@ describe("Stage 1 DB schema", () => {
     expect(Object.keys(databaseSchema).sort()).toEqual([
       // Auth.js v5 + Stage 2 Settings tables (see D-025)
       "accounts",
+      "aiKnowledgeEntries",
       "auditPolicyEvidence",
       "canonicalEventLedger",
       "contactIdentities",
@@ -51,6 +53,7 @@ describe("Stage 1 DB schema", () => {
   });
 
   it("keeps canonical table names stable", () => {
+    expect(getTableName(aiKnowledgeEntries)).toBe("ai_knowledge_entries");
     expect(getTableName(sourceEvidenceLog)).toBe("source_evidence_log");
     expect(getTableName(canonicalEventLedger)).toBe("canonical_event_ledger");
     expect(getTableName(contactInboxProjection)).toBe(

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@as-comms/contracts": "workspace:*",
+    "@notionhq/client": "^4.0.2",
     "libmime": "^5.3.8",
     "mailparser": "^3.9.8",
     "zod": "^3.24.2"

--- a/packages/integrations/src/index.ts
+++ b/packages/integrations/src/index.ts
@@ -20,5 +20,6 @@ export * from "./providers/gmail-mbox.js";
 export * from "./providers/gmail-send.js";
 export * from "./providers/gmail-record-builder.js";
 export * from "./providers/mailchimp.js";
+export * from "./providers/notion.js";
 export * from "./providers/salesforce.js";
 export * from "./providers/simpletexting.js";

--- a/packages/integrations/src/providers/notion.ts
+++ b/packages/integrations/src/providers/notion.ts
@@ -1,0 +1,833 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+const DEFAULT_NOTION_TIMEOUT_MS = 15_000;
+const DEFAULT_NOTION_API_VERSION = "2022-06-28";
+const DEFAULT_NOTION_PAGE_SIZE = 100;
+
+export type NotionLogger = Pick<Console, "warn">;
+
+export class NotionProviderError extends Error {
+  readonly code:
+    | "timeout"
+    | "rate_limited"
+    | "retryable"
+    | "not_found"
+    | "unauthorized"
+    | "invalid_response"
+    | "unexpected";
+  readonly retryable: boolean;
+  readonly status: number | null;
+  readonly retryAfterSeconds: number | null;
+
+  constructor(input: {
+    readonly code: NotionProviderError["code"];
+    readonly message: string;
+    readonly retryable: boolean;
+    readonly status?: number | null;
+    readonly retryAfterSeconds?: number | null;
+  }) {
+    super(input.message);
+    this.name = "NotionProviderError";
+    this.code = input.code;
+    this.retryable = input.retryable;
+    this.status = input.status ?? null;
+    this.retryAfterSeconds = input.retryAfterSeconds ?? null;
+  }
+}
+
+export interface NotionClient {
+  readonly logger?: NotionLogger;
+  retrievePage(pageId: string): Promise<Record<string, unknown>>;
+  listBlockChildren(input: {
+    readonly blockId: string;
+    readonly startCursor?: string;
+    readonly pageSize?: number;
+  }): Promise<Record<string, unknown>>;
+  queryDatabase(input: {
+    readonly databaseId: string;
+    readonly startCursor?: string;
+    readonly pageSize?: number;
+  }): Promise<Record<string, unknown>>;
+}
+
+export interface NotionPageContent {
+  readonly title: string | null;
+  readonly markdown: string;
+  readonly lastEditedTime: string;
+  readonly url: string | null;
+  readonly properties: Record<string, unknown>;
+}
+
+export interface DatabaseRow {
+  readonly id: string;
+  readonly url: string | null;
+  readonly properties: Record<string, unknown>;
+  readonly lastEditedTime: string;
+}
+
+export type HealthResult =
+  | { readonly status: "ok" }
+  | { readonly status: "error"; readonly errorDetail: string };
+
+interface RichTextToken {
+  readonly plainText: string;
+  readonly href: string | null;
+  readonly annotations: {
+    readonly bold: boolean;
+    readonly italic: boolean;
+    readonly strikethrough: boolean;
+    readonly code: boolean;
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(value: unknown, message: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new NotionProviderError({
+      code: "invalid_response",
+      message,
+      retryable: false
+    });
+  }
+
+  return value;
+}
+
+function readOptionalString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function readBoolean(value: unknown): boolean {
+  return value === true;
+}
+
+function readOptionalNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\u00a0/gu, " ").replace(/\s+\n/gu, "\n").trim();
+}
+
+function ensureMarkdownParagraph(value: string): string {
+  return normalizeWhitespace(value);
+}
+
+function normalizeMarkdownOutput(value: string): string {
+  return value
+    .replace(/\r\n/gu, "\n")
+    .replace(/\n{3,}/gu, "\n\n")
+    .trim();
+}
+
+function indentMarkdown(value: string, spaces: number): string {
+  const prefix = " ".repeat(spaces);
+  return value
+    .split("\n")
+    .map((line) => (line.length === 0 ? line : `${prefix}${line}`))
+    .join("\n");
+}
+
+function escapeTableCell(value: string): string {
+  return value.replace(/\|/gu, "\\|").replace(/\n/gu, "<br>");
+}
+
+function titleCaseBlockType(value: string): string {
+  return value
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function normalizePageId(input: string): string {
+  const normalized = input.trim().replace(/-/gu, "").toLowerCase();
+
+  if (!/^[0-9a-f]{32}$/u.test(normalized)) {
+    throw new NotionProviderError({
+      code: "invalid_response",
+      message: `Invalid Notion ID: ${input}`,
+      retryable: false
+    });
+  }
+
+  return [
+    normalized.slice(0, 8),
+    normalized.slice(8, 12),
+    normalized.slice(12, 16),
+    normalized.slice(16, 20),
+    normalized.slice(20)
+  ].join("-");
+}
+
+export function normalizeNotionId(input: string): string {
+  return normalizePageId(input);
+}
+
+function parseRetryAfterSeconds(retryAfterHeader: string | null): number | null {
+  if (retryAfterHeader === null) {
+    return null;
+  }
+
+  const numericValue = Number.parseInt(retryAfterHeader, 10);
+  if (!Number.isNaN(numericValue) && numericValue >= 0) {
+    return numericValue;
+  }
+
+  const retryAt = Date.parse(retryAfterHeader);
+  if (Number.isNaN(retryAt)) {
+    return null;
+  }
+
+  const retryAfterSeconds = Math.ceil((retryAt - Date.now()) / 1000);
+  return retryAfterSeconds >= 0 ? retryAfterSeconds : 0;
+}
+
+function readRetryAfterSeconds(error: Record<string, unknown>): number | null {
+  const directHeader = readOptionalString(error.retryAfter);
+  if (directHeader !== null) {
+    return parseRetryAfterSeconds(directHeader);
+  }
+
+  const headers = error.headers;
+  if (headers instanceof Headers) {
+    return parseRetryAfterSeconds(headers.get("retry-after"));
+  }
+
+  if (isRecord(headers)) {
+    return parseRetryAfterSeconds(
+      readOptionalString(headers["retry-after"]) ??
+        readOptionalString(headers.retryAfter)
+    );
+  }
+
+  return null;
+}
+
+export function classifyNotionError(
+  error: unknown,
+  context: string
+): NotionProviderError {
+  if (error instanceof NotionProviderError) {
+    return error;
+  }
+
+  if (error instanceof Error && error.name === "TimeoutError") {
+    return new NotionProviderError({
+      code: "timeout",
+      message: `${context} timed out.`,
+      retryable: true
+    });
+  }
+
+  if (error instanceof Error && error.name === "AbortError") {
+    return new NotionProviderError({
+      code: "timeout",
+      message: `${context} was aborted.`,
+      retryable: true
+    });
+  }
+
+  if (!isRecord(error)) {
+    return new NotionProviderError({
+      code: "unexpected",
+      message: `${context} failed with an unexpected error.`,
+      retryable: false
+    });
+  }
+
+  const status = readOptionalNumber(error.status);
+  const code = readOptionalString(error.code);
+  const retryAfterSeconds = readRetryAfterSeconds(error);
+  const message =
+    readOptionalString(error.message) ?? `${context} failed with an unknown error.`;
+
+  if (status === 429 || code === "rate_limited") {
+    return new NotionProviderError({
+      code: "rate_limited",
+      message,
+      retryable: true,
+      status,
+      retryAfterSeconds
+    });
+  }
+
+  if (status === 401 || status === 403 || code === "unauthorized") {
+    return new NotionProviderError({
+      code: "unauthorized",
+      message,
+      retryable: false,
+      status
+    });
+  }
+
+  if (status === 404 || code === "object_not_found") {
+    return new NotionProviderError({
+      code: "not_found",
+      message,
+      retryable: false,
+      status
+    });
+  }
+
+  if (status === 500 || status === 503 || status === 504 || code === "service_unavailable") {
+    return new NotionProviderError({
+      code: "retryable",
+      message,
+      retryable: true,
+      status,
+      retryAfterSeconds
+    });
+  }
+
+  return new NotionProviderError({
+    code: "unexpected",
+    message,
+    retryable: false,
+    status,
+    retryAfterSeconds
+  });
+}
+
+export function describeNotionError(error: unknown): string {
+  const notionError = classifyNotionError(error, "Notion request");
+  const statusPart =
+    notionError.status === null ? "" : ` (status ${String(notionError.status)})`;
+  const retryPart =
+    notionError.retryAfterSeconds === null
+      ? ""
+      : ` Retry after ${String(notionError.retryAfterSeconds)}s.`;
+
+  return `${notionError.code}${statusPart}: ${notionError.message}${retryPart}`;
+}
+
+function executeNotionCall<T>(
+  context: string,
+  run: () => Promise<T>
+): Promise<T> {
+  return run().catch((error: unknown) => {
+    throw classifyNotionError(error, context);
+  });
+}
+
+export function createNotionClient(env: {
+  readonly NOTION_API_KEY: string;
+}): NotionClient {
+  const notionModule = require("@notionhq/client") as {
+    readonly Client: new (input: Record<string, unknown>) => {
+      readonly pages: {
+        retrieve(input: Record<string, unknown>): Promise<Record<string, unknown>>;
+      };
+      readonly blocks: {
+        readonly children: {
+          list(input: Record<string, unknown>): Promise<Record<string, unknown>>;
+        };
+      };
+      readonly databases: {
+        query(input: Record<string, unknown>): Promise<Record<string, unknown>>;
+      };
+    };
+  };
+
+  const notion = new notionModule.Client({
+    auth: env.NOTION_API_KEY,
+    notionVersion: DEFAULT_NOTION_API_VERSION,
+    timeoutMs: DEFAULT_NOTION_TIMEOUT_MS,
+    retry: false
+  });
+
+  return {
+    retrievePage(pageId) {
+      return executeNotionCall("Notion page retrieve", () =>
+        notion.pages.retrieve({
+          page_id: normalizePageId(pageId)
+        })
+      );
+    },
+    listBlockChildren(input) {
+      return executeNotionCall("Notion block children list", () =>
+        notion.blocks.children.list({
+          block_id: normalizePageId(input.blockId),
+          start_cursor: input.startCursor,
+          page_size: input.pageSize ?? DEFAULT_NOTION_PAGE_SIZE
+        })
+      );
+    },
+    queryDatabase(input) {
+      return executeNotionCall("Notion database query", () =>
+        notion.databases.query({
+          database_id: normalizePageId(input.databaseId),
+          start_cursor: input.startCursor,
+          page_size: input.pageSize ?? DEFAULT_NOTION_PAGE_SIZE,
+          sorts: [
+            {
+              timestamp: "last_edited_time",
+              direction: "descending"
+            }
+          ]
+        })
+      );
+    }
+  };
+}
+
+function readRichTextTokens(value: unknown): RichTextToken[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((item) => {
+    if (!isRecord(item)) {
+      return [];
+    }
+
+    const annotations = isRecord(item.annotations) ? item.annotations : {};
+    const text = readOptionalString(item.plain_text);
+
+    if (text === null) {
+      return [];
+    }
+
+    return [
+      {
+        plainText: text,
+        href: readOptionalString(item.href),
+        annotations: {
+          bold: readBoolean(annotations.bold),
+          italic: readBoolean(annotations.italic),
+          strikethrough: readBoolean(annotations.strikethrough),
+          code: readBoolean(annotations.code)
+        }
+      }
+    ];
+  });
+}
+
+function renderRichText(value: unknown): string {
+  return readRichTextTokens(value)
+    .map((token) => {
+      let text = token.plainText;
+
+      if (token.href !== null) {
+        text = `[${text}](${token.href})`;
+      }
+
+      if (token.annotations.code) {
+        text = `\`${text}\``;
+      }
+
+      if (token.annotations.bold) {
+        text = `**${text}**`;
+      }
+
+      if (token.annotations.italic) {
+        text = `*${text}*`;
+      }
+
+      if (token.annotations.strikethrough) {
+        text = `~~${text}~~`;
+      }
+
+      return text;
+    })
+    .join("");
+}
+
+function extractPageTitle(properties: Record<string, unknown>): string | null {
+  for (const property of Object.values(properties)) {
+    if (!isRecord(property) || property.type !== "title") {
+      continue;
+    }
+
+    const title = renderRichText(property.title);
+    return title.trim().length > 0 ? title.trim() : null;
+  }
+
+  return null;
+}
+
+function extractBlockText(block: Record<string, unknown>): string {
+  const type = readOptionalString(block.type);
+  if (type === null) {
+    return "";
+  }
+
+  const data = isRecord(block[type]) ? block[type] : null;
+  if (data === null) {
+    return "";
+  }
+
+  if ("rich_text" in data) {
+    return ensureMarkdownParagraph(renderRichText(data.rich_text));
+  }
+
+  if ("caption" in data) {
+    return ensureMarkdownParagraph(renderRichText(data.caption));
+  }
+
+  if ("title" in data) {
+    return ensureMarkdownParagraph(readOptionalString(data.title) ?? "");
+  }
+
+  if ("url" in data) {
+    return ensureMarkdownParagraph(readOptionalString(data.url) ?? "");
+  }
+
+  return "";
+}
+
+async function listAllBlockChildren(
+  client: NotionClient,
+  blockId: string
+): Promise<readonly Record<string, unknown>[]> {
+  const results: Record<string, unknown>[] = [];
+  let cursor: string | undefined;
+
+  for (;;) {
+    const page = await client.listBlockChildren({
+      blockId,
+      startCursor: cursor,
+      pageSize: DEFAULT_NOTION_PAGE_SIZE
+    });
+    const rawResults = Array.isArray(page.results) ? page.results : [];
+
+    for (const rawResult of rawResults) {
+      if (isRecord(rawResult)) {
+        results.push(rawResult);
+      }
+    }
+
+    if (page.has_more !== true) {
+      return results;
+    }
+
+    cursor = readOptionalString(page.next_cursor) ?? undefined;
+    if (cursor === undefined) {
+      return results;
+    }
+  }
+}
+
+async function renderTableBlock(
+  client: NotionClient,
+  block: Record<string, unknown>,
+  logger: NotionLogger
+): Promise<string> {
+  const table = isRecord(block.table) ? block.table : {};
+  const hasColumnHeader = readBoolean(table.has_column_header);
+  const rows = await listAllBlockChildren(
+    client,
+    readString(block.id, "Notion table block is missing an id.")
+  );
+
+  const normalizedRows = rows.flatMap((row) => {
+    if (row.type !== "table_row" || !isRecord(row.table_row)) {
+      logger.warn("Encountered a non-table-row child while flattening a Notion table.");
+      return [];
+    }
+
+    const cells = Array.isArray(row.table_row.cells) ? row.table_row.cells : [];
+    return [
+      cells.map((cell) => escapeTableCell(ensureMarkdownParagraph(renderRichText(cell))))
+    ];
+  });
+
+  if (normalizedRows.length === 0) {
+    return "";
+  }
+
+  const width = Math.max(
+    readOptionalNumber(table.table_width) ?? 0,
+    ...normalizedRows.map((row) => row.length),
+    1
+  );
+  const paddedRows = normalizedRows.map((row) =>
+    Array.from({ length: width }, (_value, index) => row[index] ?? "")
+  );
+  const header = hasColumnHeader
+    ? paddedRows[0] ?? Array.from({ length: width }, (_value, index) => `Column ${String(index + 1)}`)
+    : Array.from({ length: width }, (_value, index) => `Column ${String(index + 1)}`);
+  const body = hasColumnHeader ? paddedRows.slice(1) : paddedRows;
+
+  return [
+    `| ${header.join(" | ")} |`,
+    `| ${header.map(() => "---").join(" | ")} |`,
+    ...body.map((row) => `| ${row.join(" | ")} |`)
+  ].join("\n");
+}
+
+async function renderNestedChildren(
+  client: NotionClient,
+  block: Record<string, unknown>,
+  logger: NotionLogger
+): Promise<string> {
+  if (block.has_children !== true || block.type === "table") {
+    return "";
+  }
+
+  const childBlocks = await listAllBlockChildren(
+    client,
+    readString(block.id, "Notion block is missing an id.")
+  );
+  if (childBlocks.length === 0) {
+    return "";
+  }
+
+  const markdown = await renderBlocksToMarkdown(client, childBlocks, logger);
+  return markdown.length === 0 ? "" : indentMarkdown(markdown, 2);
+}
+
+async function renderBlock(
+  client: NotionClient,
+  block: Record<string, unknown>,
+  logger: NotionLogger,
+  numberedListIndex: number
+): Promise<{ readonly markdown: string; readonly nextNumberedListIndex: number }> {
+  const type = readOptionalString(block.type);
+  if (type === null) {
+    logger.warn("Encountered a Notion block without a type while flattening page content.");
+    return {
+      markdown: "",
+      nextNumberedListIndex: 0
+    };
+  }
+
+  const text = extractBlockText(block);
+  const nestedMarkdown = await renderNestedChildren(client, block, logger);
+
+  switch (type) {
+    case "paragraph": {
+      const parts = [text, nestedMarkdown].filter((value) => value.length > 0);
+      return {
+        markdown: parts.join("\n\n"),
+        nextNumberedListIndex: 0
+      };
+    }
+    case "heading_1":
+      return {
+        markdown: `# ${text}`,
+        nextNumberedListIndex: 0
+      };
+    case "heading_2":
+      return {
+        markdown: `## ${text}`,
+        nextNumberedListIndex: 0
+      };
+    case "heading_3":
+      return {
+        markdown: `### ${text}`,
+        nextNumberedListIndex: 0
+      };
+    case "bulleted_list_item": {
+      const parts = [`- ${text}`];
+      if (nestedMarkdown.length > 0) {
+        parts.push(nestedMarkdown);
+      }
+
+      return {
+        markdown: parts.join("\n"),
+        nextNumberedListIndex: 0
+      };
+    }
+    case "numbered_list_item": {
+      const nextIndex = numberedListIndex + 1;
+      const parts = [`${String(nextIndex)}. ${text}`];
+      if (nestedMarkdown.length > 0) {
+        parts.push(nestedMarkdown);
+      }
+
+      return {
+        markdown: parts.join("\n"),
+        nextNumberedListIndex: nextIndex
+      };
+    }
+    case "quote":
+      return {
+        markdown: `> ${text}`,
+        nextNumberedListIndex: 0
+      };
+    case "code": {
+      const code = isRecord(block.code) ? block.code : {};
+      const language = readOptionalString(code.language) ?? "";
+      const fencedCode = renderRichText(code.rich_text);
+
+      return {
+        markdown: `\`\`\`${language}\n${fencedCode}\n\`\`\``,
+        nextNumberedListIndex: 0
+      };
+    }
+    case "to_do": {
+      const toDo = isRecord(block.to_do) ? block.to_do : {};
+      const checked = readBoolean(toDo.checked) ? "x" : " ";
+      const parts = [`- [${checked}] ${renderRichText(toDo.rich_text)}`];
+      if (nestedMarkdown.length > 0) {
+        parts.push(nestedMarkdown);
+      }
+
+      return {
+        markdown: parts.join("\n"),
+        nextNumberedListIndex: 0
+      };
+    }
+    case "divider":
+      return {
+        markdown: "---",
+        nextNumberedListIndex: 0
+      };
+    case "table":
+      return {
+        markdown: await renderTableBlock(client, block, logger),
+        nextNumberedListIndex: 0
+      };
+    default: {
+      logger.warn(
+        `Unsupported Notion block type "${type}" encountered; flattening as plain text.`
+      );
+
+      const fallbackText =
+        text.length > 0 ? text : `[${titleCaseBlockType(type)}]`;
+      const parts = [fallbackText];
+      if (nestedMarkdown.length > 0) {
+        parts.push(nestedMarkdown);
+      }
+
+      return {
+        markdown: parts.join("\n\n"),
+        nextNumberedListIndex: 0
+      };
+    }
+  }
+}
+
+async function renderBlocksToMarkdown(
+  client: NotionClient,
+  blocks: readonly Record<string, unknown>[],
+  logger: NotionLogger
+): Promise<string> {
+  const renderedBlocks: string[] = [];
+  let numberedListIndex = 0;
+
+  for (const block of blocks) {
+    const rendered = await renderBlock(client, block, logger, numberedListIndex);
+    numberedListIndex = rendered.nextNumberedListIndex;
+
+    if (
+      readOptionalString(block.type) !== "numbered_list_item" &&
+      rendered.nextNumberedListIndex === 0
+    ) {
+      numberedListIndex = 0;
+    }
+
+    if (rendered.markdown.trim().length > 0) {
+      renderedBlocks.push(rendered.markdown.trim());
+    }
+  }
+
+  return normalizeMarkdownOutput(renderedBlocks.join("\n\n"));
+}
+
+export async function fetchPageContent(
+  client: NotionClient,
+  pageId: string
+): Promise<NotionPageContent> {
+  const normalizedPageId = normalizePageId(pageId);
+  const page = await client.retrievePage(normalizedPageId);
+  const properties = isRecord(page.properties) ? page.properties : {};
+  const title = extractPageTitle(properties);
+  const blocks = await listAllBlockChildren(client, normalizedPageId);
+  const logger = client.logger ?? console;
+
+  return {
+    title,
+    markdown: await renderBlocksToMarkdown(client, blocks, logger),
+    lastEditedTime: readString(
+      page.last_edited_time,
+      "Notion page response is missing last_edited_time."
+    ),
+    url: readOptionalString(page.url),
+    properties
+  };
+}
+
+function toDatabaseRow(result: Record<string, unknown>): DatabaseRow {
+  return {
+    id: normalizePageId(
+      readString(result.id, "Notion database query result is missing an id.")
+    ),
+    url: readOptionalString(result.url),
+    properties: isRecord(result.properties) ? result.properties : {},
+    lastEditedTime: readString(
+      result.last_edited_time,
+      "Notion database query result is missing last_edited_time."
+    )
+  };
+}
+
+export async function* queryDatabase(
+  client: NotionClient,
+  databaseId: string
+): AsyncIterable<DatabaseRow> {
+  const normalizedDatabaseId = normalizePageId(databaseId);
+  let cursor: string | undefined;
+
+  for (;;) {
+    const page = await client.queryDatabase({
+      databaseId: normalizedDatabaseId,
+      startCursor: cursor,
+      pageSize: DEFAULT_NOTION_PAGE_SIZE
+    });
+    const results = Array.isArray(page.results) ? page.results : [];
+
+    for (const result of results) {
+      if (isRecord(result)) {
+        yield toDatabaseRow(result);
+      }
+    }
+
+    if (page.has_more !== true) {
+      return;
+    }
+
+    cursor = readOptionalString(page.next_cursor) ?? undefined;
+    if (cursor === undefined) {
+      return;
+    }
+  }
+}
+
+export async function healthCheck(
+  client: NotionClient,
+  input: {
+    readonly generalTrainingPageId: string;
+    readonly projectTrainingDatabaseId: string;
+  }
+): Promise<HealthResult> {
+  try {
+    await client.retrievePage(input.generalTrainingPageId);
+  } catch (error) {
+    return {
+      status: "error",
+      errorDetail: `General Training page check failed: ${describeNotionError(error)}`
+    };
+  }
+
+  try {
+    await client.queryDatabase({
+      databaseId: input.projectTrainingDatabaseId,
+      pageSize: 1
+    });
+  } catch (error) {
+    return {
+      status: "error",
+      errorDetail: `Project Training database check failed: ${describeNotionError(error)}`
+    };
+  }
+
+  return {
+    status: "ok"
+  };
+}

--- a/packages/integrations/src/providers/notion.ts
+++ b/packages/integrations/src/providers/notion.ts
@@ -490,7 +490,7 @@ async function listAllBlockChildren(
   for (;;) {
     const page = await client.listBlockChildren({
       blockId,
-      startCursor: cursor,
+      ...(cursor !== undefined ? { startCursor: cursor } : {}),
       pageSize: DEFAULT_NOTION_PAGE_SIZE
     });
     const rawResults = Array.isArray(page.results) ? page.results : [];
@@ -777,7 +777,7 @@ export async function* queryDatabase(
   for (;;) {
     const page = await client.queryDatabase({
       databaseId: normalizedDatabaseId,
-      startCursor: cursor,
+      ...(cursor !== undefined ? { startCursor: cursor } : {}),
       pageSize: DEFAULT_NOTION_PAGE_SIZE
     });
     const results = Array.isArray(page.results) ? page.results : [];

--- a/packages/integrations/test/notion-provider.test.ts
+++ b/packages/integrations/test/notion-provider.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyNotionError,
+  fetchPageContent,
+  normalizeNotionId,
+  queryDatabase,
+  type NotionClient
+} from "../src/index.js";
+
+function buildRichText(text: string) {
+  return [
+    {
+      plain_text: text,
+      href: null,
+      annotations: {
+        bold: false,
+        italic: false,
+        strikethrough: false,
+        code: false
+      }
+    }
+  ];
+}
+
+function createFakeNotionClient(input: {
+  readonly pages?: Record<string, Record<string, unknown>>;
+  readonly blockChildren?: Record<string, readonly Record<string, unknown>[]>;
+  readonly databaseResponses?: Record<string, readonly Record<string, unknown>[]>;
+}): NotionClient {
+  const blockQueues = new Map(
+    Object.entries(input.blockChildren ?? {}).map(([blockId, responses]) => [
+      normalizeNotionId(blockId),
+      [...responses]
+    ])
+  );
+  const databaseQueues = new Map(
+    Object.entries(input.databaseResponses ?? {}).map(
+      ([databaseId, responses]) => [normalizeNotionId(databaseId), [...responses]]
+    )
+  );
+
+  return {
+    retrievePage(pageId) {
+      const page = input.pages?.[normalizeNotionId(pageId)];
+      if (page === undefined) {
+        return Promise.reject(new Error(`Missing page fixture for ${pageId}`));
+      }
+
+      return Promise.resolve(page);
+    },
+    listBlockChildren({ blockId }) {
+      const response = blockQueues.get(normalizeNotionId(blockId))?.shift();
+      return Promise.resolve(
+        response ?? {
+          results: [],
+          has_more: false,
+          next_cursor: null
+        }
+      );
+    },
+    queryDatabase({ databaseId }) {
+      const response = databaseQueues.get(normalizeNotionId(databaseId))?.shift();
+      return Promise.resolve(
+        response ?? {
+          results: [],
+          has_more: false,
+          next_cursor: null
+        }
+      );
+    }
+  };
+}
+
+describe("Notion provider helpers", () => {
+  it("flattens supported Notion block types into markdown", async () => {
+    const pageId = normalizeNotionId("3278a9129211804baa72c76a86d084d0");
+    const tableId = normalizeNotionId("11111111111111111111111111111111");
+    const client = createFakeNotionClient({
+      pages: {
+        [pageId]: {
+          id: pageId,
+          url: "https://www.notion.so/general-training",
+          last_edited_time: "2026-04-21T12:00:00.000Z",
+          properties: {
+            title: {
+              type: "title",
+              title: buildRichText("General Training")
+            }
+          }
+        }
+      },
+      blockChildren: {
+        [pageId]: [
+          {
+            results: [
+              {
+                id: normalizeNotionId("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                type: "paragraph",
+                has_children: false,
+                paragraph: {
+                  rich_text: buildRichText("Paragraph body")
+                }
+              },
+              {
+                id: normalizeNotionId("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+                type: "heading_1",
+                has_children: false,
+                heading_1: {
+                  rich_text: buildRichText("Heading One")
+                }
+              },
+              {
+                id: normalizeNotionId("cccccccccccccccccccccccccccccccc"),
+                type: "heading_2",
+                has_children: false,
+                heading_2: {
+                  rich_text: buildRichText("Heading Two")
+                }
+              },
+              {
+                id: normalizeNotionId("dddddddddddddddddddddddddddddddd"),
+                type: "heading_3",
+                has_children: false,
+                heading_3: {
+                  rich_text: buildRichText("Heading Three")
+                }
+              },
+              {
+                id: normalizeNotionId("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
+                type: "bulleted_list_item",
+                has_children: false,
+                bulleted_list_item: {
+                  rich_text: buildRichText("Bullet Item")
+                }
+              },
+              {
+                id: normalizeNotionId("ffffffffffffffffffffffffffffffff"),
+                type: "numbered_list_item",
+                has_children: false,
+                numbered_list_item: {
+                  rich_text: buildRichText("Numbered Item")
+                }
+              },
+              {
+                id: normalizeNotionId("12121212121212121212121212121212"),
+                type: "code",
+                has_children: false,
+                code: {
+                  language: "ts",
+                  rich_text: buildRichText("const answer = 42;")
+                }
+              },
+              {
+                id: tableId,
+                type: "table",
+                has_children: true,
+                table: {
+                  has_column_header: true,
+                  table_width: 2
+                }
+              }
+            ],
+            has_more: false,
+            next_cursor: null
+          }
+        ],
+        [tableId]: [
+          {
+            results: [
+              {
+                id: normalizeNotionId("22222222222222222222222222222222"),
+                type: "table_row",
+                table_row: {
+                  cells: [buildRichText("Column A"), buildRichText("Column B")]
+                }
+              },
+              {
+                id: normalizeNotionId("33333333333333333333333333333333"),
+                type: "table_row",
+                table_row: {
+                  cells: [buildRichText("Value A"), buildRichText("Value B")]
+                }
+              }
+            ],
+            has_more: false,
+            next_cursor: null
+          }
+        ]
+      }
+    });
+
+    const result = await fetchPageContent(client, pageId);
+
+    expect(result.title).toBe("General Training");
+    expect(result.markdown).toContain("Paragraph body");
+    expect(result.markdown).toContain("# Heading One");
+    expect(result.markdown).toContain("## Heading Two");
+    expect(result.markdown).toContain("### Heading Three");
+    expect(result.markdown).toContain("- Bullet Item");
+    expect(result.markdown).toContain("1. Numbered Item");
+    expect(result.markdown).toContain("```ts\nconst answer = 42;\n```");
+    expect(result.markdown).toContain("| Column A | Column B |");
+    expect(result.markdown).toContain("| Value A | Value B |");
+  });
+
+  it("streams paginated database rows", async () => {
+    const databaseId = normalizeNotionId("3278a91292118095b86aff5836821428");
+    const client = createFakeNotionClient({
+      databaseResponses: {
+        [databaseId]: [
+          {
+            results: [
+              {
+                id: normalizeNotionId("44444444444444444444444444444444"),
+                url: "https://www.notion.so/project-one",
+                last_edited_time: "2026-04-21T12:00:00.000Z",
+                properties: {
+                  Name: {
+                    type: "title",
+                    title: buildRichText("Project One")
+                  }
+                }
+              }
+            ],
+            has_more: true,
+            next_cursor: "cursor:page:2"
+          },
+          {
+            results: [
+              {
+                id: normalizeNotionId("55555555555555555555555555555555"),
+                url: "https://www.notion.so/project-two",
+                last_edited_time: "2026-04-21T12:05:00.000Z",
+                properties: {
+                  Name: {
+                    type: "title",
+                    title: buildRichText("Project Two")
+                  }
+                }
+              }
+            ],
+            has_more: false,
+            next_cursor: null
+          }
+        ]
+      }
+    });
+
+    const rows: Array<{ id: string; url: string | null }> = [];
+    for await (const row of queryDatabase(client, databaseId)) {
+      rows.push({
+        id: row.id,
+        url: row.url
+      });
+    }
+
+    expect(rows).toEqual([
+      {
+        id: normalizeNotionId("44444444444444444444444444444444"),
+        url: "https://www.notion.so/project-one"
+      },
+      {
+        id: normalizeNotionId("55555555555555555555555555555555"),
+        url: "https://www.notion.so/project-two"
+      }
+    ]);
+  });
+
+  it("classifies Notion rate limits with retry-after metadata", () => {
+    const error = classifyNotionError(
+      {
+        status: 429,
+        code: "rate_limited",
+        message: "Too many requests",
+        headers: new Headers({
+          "retry-after": "7"
+        })
+      },
+      "Notion database query"
+    );
+
+    expect(error).toMatchObject({
+      code: "rate_limited",
+      retryable: true,
+      status: 429,
+      retryAfterSeconds: 7
+    });
+  });
+});

--- a/packages/integrations/test/notion-provider.test.ts
+++ b/packages/integrations/test/notion-provider.test.ts
@@ -247,7 +247,7 @@ describe("Notion provider helpers", () => {
       }
     });
 
-    const rows: Array<{ id: string; url: string | null }> = [];
+    const rows: { id: string; url: string | null }[] = [];
     for await (const row of queryDatabase(client, databaseId)) {
       rows.push({
         id: row.id,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,6 +246,9 @@ importers:
       '@as-comms/contracts':
         specifier: workspace:*
         version: link:../contracts
+      '@notionhq/client':
+        specifier: ^4.0.2
+        version: 4.0.2
       libmime:
         specifier: ^5.3.8
         version: 5.3.8
@@ -1054,6 +1057,10 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@notionhq/client@4.0.2':
+    resolution: {integrity: sha512-4pk3dm4umhjsRI0umCnJ8lCZh0TMiaMdkY0rz6FV4OqVuTsmYFV3pk+YTR5S8792ZY2Rm4lJHlLj05HQVKDuIg==}
+    engines: {node: '>=18'}
 
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
@@ -3670,6 +3677,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@notionhq/client@4.0.2': {}
 
   '@panva/hkdf@1.2.1': {}
 


### PR DESCRIPTION
## Summary

First Stage 4 AI implementation. Ships the background Notion sync that populates tiers 1–3 of the grounding pipeline per `D-032`. No LLM code yet — draft generation lands in a follow-on PR.

- **New table** `ai_knowledge_entries` (migration `0020`). Keyed by `(source_provider, source_id)`; `scope` column distinguishes `global` (General Training page) from `project` (per-project training rows); `content_hash` lets the upsert skip no-op writes.
- **New provider** `packages/integrations/src/providers/notion.ts` wrapping `@notionhq/client` with structured error classification, normalized page-ID format, and a markdown flattener that handles paragraphs / h1-h3 / bulleted & numbered lists / quotes / code / to-do / dividers / tables (unknown block types degrade to plain text with a warning).
- **New worker job** `apps/worker/src/jobs/notion-knowledge-sync`, registered at `*/15 * * * *`. Walks the Notion Project Training database, matches rows to `project_dimensions` by the `Project ID` property (per D-037 2026-04-21 supersession), upserts into `ai_knowledge_entries` inside a per-row transaction, advances `project_dimensions.ai_knowledge_synced_at` (the new activation-gate signal), and reconciles by hard-deleting entries whose `source_id` wasn't seen this cycle.
- **Integration health** row (`service_name='notion'`, `category='knowledge'`) populated by the job: `not_configured` when env vars are missing, `needs_attention` on Notion API error or health-check failure, `healthy` on success.
- **Rate limiting** at 500ms per page fetch (well under Notion's 3 req/s limit).
- **Docs** updated: `reference-env.md`, `reference-services.md`, `stage-4-ai-pipeline.md` (tier-3 + module references now point at `ai_knowledge_entries`). `.env.example` seeded with the three Notion env vars and the authored page/database IDs.
- **Tests** for the provider (markdown flattener, error classification, pagination), worker sync flow (happy path, missing env, orphan Project IDs, duplicate Project IDs, content-unchanged skip, removed rows, Notion API error), DB round-trip, and cron registration.

## Adjustments from the dispatch brief

Two small, reasonable deviations:

1. Reused existing `integration_health.status` enum values (`healthy` / `needs_attention` / `not_configured`) instead of inventing a new `error` value. `needs_attention` covers every error path uniformly.
2. `lastSuccessAt` is stored inside `integration_health.metadata_json` because the table has no dedicated `last_success_at` column. Settings UI reads it from the JSON.

## Not in scope

- No LLM call yet; retrieval, prompt building, Anthropic adapter, and tier-5 memory capture live in a follow-on PR.
- No Settings UI for browsing knowledge (future pass).
- No external doc parsing — `Training URL` is stored as reference metadata; row body is the canonical content source.

## Rollout

After merge, the admin must:

1. Create a Notion internal integration at https://www.notion.so/profile/integrations (e.g., \"AS Comms AI Knowledge Sync\") and copy the secret.
2. Open the \"Volunteer Comms AI Assistant Training\" Notion page and add the integration via `···` → `Connections` (grants read access to the page tree including the Project Training database).
3. Add `NOTION_API_KEY`, `NOTION_GENERAL_TRAINING_PAGE_ID`, `NOTION_PROJECT_TRAINING_DATABASE_ID` to the worker env in Railway. Defaults for the two page IDs already live in `.env.example`.
4. Populate at least one row in the Project Training database with a valid `Project ID` that matches a `project_dimensions.project_id`.
5. Wait up to 15 min and verify `ai_knowledge_entries` has rows and `integration_health` for `notion` shows `healthy`.

## Test plan

- [ ] CI typecheck, lint, and unit tests pass (local `pnpm test:unit` hit the memoized macOS rollup code-signature gotcha in this worktree — Linux CI is unaffected).
- [ ] Migration `0020_ai_knowledge_entries.sql` applies cleanly on a fresh DB.
- [ ] With env vars unset, the worker boots and `integration_health` shows `notion=not_configured` within 15 min; no errors in logs; Gmail + Salesforce pollers keep running.
- [ ] With env vars set and at least one Project Training row present, `ai_knowledge_entries` gains rows and `integration_health` shows `notion=healthy` within 15 min.
- [ ] Re-running the sync with no Notion changes produces zero DB writes (verify via logs or row `updated_at`).
- [ ] Deleting a Notion row on the next cycle deletes its `ai_knowledge_entries` row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)