### PR TITLE
feat(composer): notes mode end-to-end with author-only edit/delete

### DIFF
--- a/apps/web/app/inbox/[contactId]/page.tsx
+++ b/apps/web/app/inbox/[contactId]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 
+import { requireSession } from "@/src/server/auth/session";
 import { InboxDetail } from "../_components/inbox-detail";
 import { getInboxDetail } from "../_lib/selectors";
 
@@ -9,9 +10,10 @@ interface PageProps {
 
 export default async function InboxContactPage({ params }: PageProps) {
   const { contactId } = await params;
+  const currentUser = await requireSession();
   const detail = await getInboxDetail(decodeURIComponent(contactId));
   if (!detail) {
     notFound();
   }
-  return <InboxDetail detail={detail} />;
+  return <InboxDetail detail={detail} currentOperatorUserId={currentUser.id} />;
 }

--- a/apps/web/app/inbox/_components/inbox-composer.tsx
+++ b/apps/web/app/inbox/_components/inbox-composer.tsx
@@ -1,11 +1,12 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import {
   useEffect,
   useRef,
   useState,
   useTransition,
-  type ChangeEvent
+  type ChangeEvent,
 } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -14,27 +15,32 @@ import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
-  TooltipTrigger
+  TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import {
+  getInternalNoteValidationError,
+  normalizeInternalNoteBody,
+} from "@/src/lib/internal-note-validation";
+import type { UiError } from "@/src/server/ui-result";
 
 import {
+  createNoteAction,
   sendComposerAction,
   type ComposerSendActionInput,
-  type ComposerSendActionResult
 } from "../actions";
 import {
   isComposerSendDisabled,
-  resolveDefaultAlias
+  resolveDefaultAlias,
 } from "../_lib/composer-ui";
 import {
   ComposerRecipientPicker,
   type ComposerContactRecipient,
-  type ComposerRecipientValue
+  type ComposerRecipientValue,
 } from "./composer-recipient-picker";
 import {
   useInboxClient,
-  type ComposerValidationError
+  type ComposerValidationError,
 } from "./inbox-client-provider";
 import {
   AlertCircleIcon,
@@ -44,7 +50,7 @@ import {
   NoteIcon,
   PaperclipIcon,
   SendIcon,
-  XIcon
+  XIcon,
 } from "./icons";
 
 const MAX_TOTAL_ATTACHMENT_BYTES = 20 * 1024 * 1024;
@@ -83,7 +89,7 @@ function resolveRecipientLabel(recipient: ComposerRecipientValue): string {
 }
 
 function mapFieldErrors(
-  result: Extract<ComposerSendActionResult, { ok: false }>
+  result: Pick<UiError, "fieldErrors">,
 ): ComposerFieldErrors {
   if (result.fieldErrors === undefined) {
     return [];
@@ -102,6 +108,7 @@ function mapFieldErrors(
       case "attachments":
         mappedErrors.push({ field: "attachments", message });
         break;
+      case "body":
       case "bodyPlaintext":
         mappedErrors.push({ field: "body", message });
         break;
@@ -153,13 +160,13 @@ async function readFileAsAttachment(file: File): Promise<AttachmentDraft> {
     filename: file.name,
     size: file.size,
     contentType: file.type || "application/octet-stream",
-    contentBase64
+    contentBase64,
   };
 }
 
 export function InboxComposerReplyBar({
   contactDisplayName,
-  onReply
+  onReply,
 }: {
   readonly contactDisplayName: string;
   readonly onReply: () => void;
@@ -179,6 +186,7 @@ export function InboxComposerReplyBar({
 }
 
 export function InboxComposerDetailPane() {
+  const router = useRouter();
   const {
     composerAliases,
     composerPane,
@@ -186,16 +194,23 @@ export function InboxComposerDetailPane() {
     showToast,
     composerErrors,
     setComposerErrors,
-    setComposerStatus
+    setComposerStatus,
   } = useInboxClient();
   const [activeTab, setActiveTab] = useState<"email" | "note">("email");
-  const [recipient, setRecipient] = useState<ComposerRecipientValue | null>(null);
+  const [recipient, setRecipient] = useState<ComposerRecipientValue | null>(
+    null,
+  );
   const [selectedAlias, setSelectedAlias] = useState<string | null>(null);
   const [subject, setSubject] = useState("");
   const [body, setBody] = useState("");
-  const [attachments, setAttachments] = useState<readonly AttachmentDraft[]>([]);
-  const [inlineError, setInlineError] = useState<InlineComposerError | null>(null);
+  const [attachments, setAttachments] = useState<readonly AttachmentDraft[]>(
+    [],
+  );
+  const [inlineError, setInlineError] = useState<InlineComposerError | null>(
+    null,
+  );
   const [isSending, startSendTransition] = useTransition();
+  const [isSavingNote, startSaveNoteTransition] = useTransition();
   const bodyRef = useRef<HTMLTextAreaElement>(null);
   const attachmentInputRef = useRef<HTMLInputElement>(null);
   const imageInputRef = useRef<HTMLInputElement>(null);
@@ -217,7 +232,7 @@ export function InboxComposerDetailPane() {
             displayName: replyContext.contactDisplayName,
             primaryEmail: null,
             primaryProjectName: null,
-            salesforceContactId: null
+            salesforceContactId: null,
           };
 
     setActiveTab("email");
@@ -229,12 +244,7 @@ export function InboxComposerDetailPane() {
     setInlineError(null);
     setComposerStatus("idle");
     setComposerErrors([]);
-  }, [
-    composerPane.mode,
-    replyContext,
-    setComposerErrors,
-    setComposerStatus
-  ]);
+  }, [composerPane.mode, replyContext, setComposerErrors, setComposerStatus]);
 
   useEffect(() => {
     if (!bodyRef.current) {
@@ -250,32 +260,42 @@ export function InboxComposerDetailPane() {
 
   const attachmentBytes = attachments.reduce(
     (total, attachment) => total + attachment.size,
-    0
+    0,
   );
   const isReplying = composerPane.mode === "replying";
+  const canUseNoteTab = isReplying && replyContext !== null;
   const isSendDisabled = isComposerSendDisabled({
     activeTab,
     recipient,
     selectedAlias,
     subject,
     body,
-    isSending
+    isSending,
   });
+  const isSaveNoteDisabled =
+    activeTab !== "note" ||
+    !canUseNoteTab ||
+    body.trim().length === 0 ||
+    isSavingNote;
   const aliasError = composerErrors.find((error) => error.field === "alias");
-  const subjectError = composerErrors.find((error) => error.field === "subject");
+  const subjectError = composerErrors.find(
+    (error) => error.field === "subject",
+  );
   const bodyError = composerErrors.find((error) => error.field === "body");
   const recipientError = composerErrors.find(
-    (error) => error.field === "recipient"
+    (error) => error.field === "recipient",
   );
   const attachmentError = composerErrors.find(
-    (error) => error.field === "attachments"
+    (error) => error.field === "attachments",
   );
   const clearComposerErrors = () => {
     setInlineError(null);
     setComposerErrors([]);
   };
 
-  const handleRecipientChange = (nextRecipient: ComposerRecipientValue | null) => {
+  const handleRecipientChange = (
+    nextRecipient: ComposerRecipientValue | null,
+  ) => {
     setRecipient(nextRecipient);
     clearComposerErrors();
 
@@ -286,14 +306,12 @@ export function InboxComposerDetailPane() {
     setSelectedAlias(
       resolveDefaultAlias({
         recipient: nextRecipient,
-        aliases: composerAliases
-      })
+        aliases: composerAliases,
+      }),
     );
   };
 
-  const handleFilesSelected = async (
-    event: ChangeEvent<HTMLInputElement>
-  ) => {
+  const handleFilesSelected = async (event: ChangeEvent<HTMLInputElement>) => {
     const files = event.currentTarget.files;
     event.currentTarget.value = "";
 
@@ -309,20 +327,20 @@ export function InboxComposerDetailPane() {
     if (nextTotalBytes > MAX_TOTAL_ATTACHMENT_BYTES) {
       setInlineError({
         message: "Attachments can't exceed 20 MB total.",
-        retryable: false
+        retryable: false,
       });
       setComposerErrors([
         {
           field: "attachments",
-          message: "Attachments can't exceed 20 MB total."
-        }
+          message: "Attachments can't exceed 20 MB total.",
+        },
       ]);
       return;
     }
 
     try {
       const nextAttachments = await Promise.all(
-        selectedFiles.map((file) => readFileAsAttachment(file))
+        selectedFiles.map((file) => readFileAsAttachment(file)),
       );
 
       setAttachments((previous) => [...previous, ...nextAttachments]);
@@ -330,7 +348,7 @@ export function InboxComposerDetailPane() {
     } catch {
       setInlineError({
         message: "We couldn't read one of those files. Please try again.",
-        retryable: true
+        retryable: true,
       });
     }
   };
@@ -345,11 +363,11 @@ export function InboxComposerDetailPane() {
         recipient.kind === "contact"
           ? {
               kind: "contact",
-              contactId: recipient.contactId
+              contactId: recipient.contactId,
             }
           : {
               kind: "email",
-              emailAddress: recipient.emailAddress
+              emailAddress: recipient.emailAddress,
             },
       alias: selectedAlias,
       subject: subject.trim(),
@@ -357,7 +375,7 @@ export function InboxComposerDetailPane() {
       attachments: attachments.map((attachment) => ({
         filename: attachment.filename,
         contentType: attachment.contentType,
-        contentBase64: attachment.contentBase64
+        contentBase64: attachment.contentBase64,
       })),
       ...(replyContext?.threadId === null || replyContext === null
         ? {}
@@ -365,8 +383,8 @@ export function InboxComposerDetailPane() {
       ...(replyContext?.inReplyToRfc822 === null || replyContext === null
         ? {}
         : {
-            inReplyToRfc822: replyContext.inReplyToRfc822
-          })
+            inReplyToRfc822: replyContext.inReplyToRfc822,
+          }),
     };
 
     setInlineError(null);
@@ -385,11 +403,63 @@ export function InboxComposerDetailPane() {
 
       setComposerErrors(mapFieldErrors(result));
       setComposerStatus(
-        result.code === "validation_error" ? "validation-error" : "send-failure"
+        result.code === "validation_error"
+          ? "validation-error"
+          : "send-failure",
       );
       setInlineError({
         message: result.message,
-        retryable: result.retryable === true
+        retryable: result.retryable === true,
+      });
+    });
+  };
+
+  const saveNote = () => {
+    if (!isReplying || replyContext === null) {
+      return;
+    }
+
+    const normalizedBody = normalizeInternalNoteBody(body);
+    const validationError = getInternalNoteValidationError(normalizedBody);
+
+    if (validationError !== null) {
+      setInlineError({
+        message: validationError,
+        retryable: false,
+      });
+      setComposerErrors([
+        {
+          field: "body",
+          message: validationError,
+        },
+      ]);
+      return;
+    }
+
+    setInlineError(null);
+    setComposerErrors([]);
+    setComposerStatus("saving-draft");
+
+    startSaveNoteTransition(async () => {
+      const result = await createNoteAction({
+        contactId: replyContext.contactId,
+        body: normalizedBody,
+      });
+
+      if (result.ok) {
+        setComposerStatus("draft-saved");
+        setBody("");
+        closeComposer();
+        router.refresh();
+        showToast("Note saved.", "success");
+        return;
+      }
+
+      setComposerErrors(mapFieldErrors(result));
+      setComposerStatus("validation-error");
+      setInlineError({
+        message: result.message,
+        retryable: result.retryable === true,
       });
     });
   };
@@ -405,7 +475,9 @@ export function InboxComposerDetailPane() {
                 : "New draft"}
             </p>
             <p className="mt-1 text-sm text-slate-500">
-              Plain-text email with file attachments.
+              {activeTab === "note"
+                ? "Internal note for the team timeline."
+                : "Plain-text email with file attachments."}
             </p>
           </div>
 
@@ -432,117 +504,158 @@ export function InboxComposerDetailPane() {
                 "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium",
                 activeTab === "email"
                   ? "bg-slate-900 text-white"
-                  : "bg-slate-100 text-slate-600"
+                  : "bg-slate-100 text-slate-600",
               )}
             >
               <MailIcon className="size-4" />
               Email
             </button>
 
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  disabled
-                  className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-3 py-1.5 text-sm font-medium text-slate-400"
-                >
-                  <NoteIcon className="size-4" />
-                  Note
-                </button>
-              </TooltipTrigger>
-              <TooltipContent>Coming in next update</TooltipContent>
-            </Tooltip>
+            {canUseNoteTab ? (
+              <button
+                type="button"
+                onClick={() => {
+                  setActiveTab("note");
+                  clearComposerErrors();
+                }}
+                className={cn(
+                  "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium",
+                  activeTab === "note"
+                    ? "bg-slate-900 text-white"
+                    : "bg-slate-100 text-slate-600",
+                )}
+              >
+                <NoteIcon className="size-4" />
+                Note
+              </button>
+            ) : (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    disabled
+                    className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-3 py-1.5 text-sm font-medium text-slate-400"
+                  >
+                    <NoteIcon className="size-4" />
+                    Note
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  Notes are available when replying to a contact.
+                </TooltipContent>
+              </Tooltip>
+            )}
           </div>
 
           <div className="mt-5 space-y-5">
-            <ComposerRecipientPicker
-              recipient={recipient}
-              locked={isReplying}
-              onRecipientChange={handleRecipientChange}
-            />
-            {recipientError ? (
-              <p className="-mt-3 text-xs text-rose-700">{recipientError.message}</p>
-            ) : null}
-
-            <label className="flex items-start gap-3">
-              <span className="mt-2 w-10 text-sm font-medium text-slate-700">
-                From:
-              </span>
-              <div className="flex-1">
-                <select
-                  value={selectedAlias ?? ""}
-                  onChange={(event) => {
-                    const nextAlias = event.currentTarget.value;
-                    setSelectedAlias(nextAlias.length > 0 ? nextAlias : null);
-                    clearComposerErrors();
-                  }}
-                  className={cn(
-                    "flex h-10 w-full rounded-md border border-slate-200 bg-white px-3 text-sm text-slate-900 shadow-sm focus:outline-none focus:ring-1 focus:ring-slate-300",
-                    aliasError ? "border-rose-300 ring-1 ring-rose-200" : ""
-                  )}
-                >
-                  <option value="">Choose an alias</option>
-                  {composerAliases.map((alias) => (
-                    <option key={alias.id} value={alias.alias}>
-                      {alias.alias} · {alias.projectName}
-                    </option>
-                  ))}
-                </select>
-                {aliasError ? (
-                  <p className="mt-1 text-xs text-rose-700">{aliasError.message}</p>
-                ) : null}
-              </div>
-            </label>
-
-            <label className="flex items-start gap-3">
-              <span className="mt-2 w-10 text-sm font-medium text-slate-700">
-                Subject:
-              </span>
-              <div className="flex-1">
-                <Input
-                  value={subject}
-                  onChange={(event) => {
-                    setSubject(event.currentTarget.value);
-                    clearComposerErrors();
-                  }}
-                  placeholder="Subject"
-                  className={cn(
-                    subjectError ? "border-rose-300 ring-1 ring-rose-200" : ""
-                  )}
+            {activeTab === "email" ? (
+              <>
+                <ComposerRecipientPicker
+                  recipient={recipient}
+                  locked={isReplying}
+                  onRecipientChange={handleRecipientChange}
                 />
-                {subjectError ? (
-                  <p className="mt-1 text-xs text-rose-700">{subjectError.message}</p>
+                {recipientError ? (
+                  <p className="-mt-3 text-xs text-rose-700">
+                    {recipientError.message}
+                  </p>
                 ) : null}
-              </div>
-            </label>
+
+                <label className="flex items-start gap-3">
+                  <span className="mt-2 w-10 text-sm font-medium text-slate-700">
+                    From:
+                  </span>
+                  <div className="flex-1">
+                    <select
+                      value={selectedAlias ?? ""}
+                      onChange={(event) => {
+                        const nextAlias = event.currentTarget.value;
+                        setSelectedAlias(
+                          nextAlias.length > 0 ? nextAlias : null,
+                        );
+                        clearComposerErrors();
+                      }}
+                      className={cn(
+                        "flex h-10 w-full rounded-md border border-slate-200 bg-white px-3 text-sm text-slate-900 shadow-sm focus:outline-none focus:ring-1 focus:ring-slate-300",
+                        aliasError
+                          ? "border-rose-300 ring-1 ring-rose-200"
+                          : "",
+                      )}
+                    >
+                      <option value="">Choose an alias</option>
+                      {composerAliases.map((alias) => (
+                        <option key={alias.id} value={alias.alias}>
+                          {alias.alias} · {alias.projectName}
+                        </option>
+                      ))}
+                    </select>
+                    {aliasError ? (
+                      <p className="mt-1 text-xs text-rose-700">
+                        {aliasError.message}
+                      </p>
+                    ) : null}
+                  </div>
+                </label>
+
+                <label className="flex items-start gap-3">
+                  <span className="mt-2 w-10 text-sm font-medium text-slate-700">
+                    Subject:
+                  </span>
+                  <div className="flex-1">
+                    <Input
+                      value={subject}
+                      onChange={(event) => {
+                        setSubject(event.currentTarget.value);
+                        clearComposerErrors();
+                      }}
+                      placeholder="Subject"
+                      className={cn(
+                        subjectError
+                          ? "border-rose-300 ring-1 ring-rose-200"
+                          : "",
+                      )}
+                    />
+                    {subjectError ? (
+                      <p className="mt-1 text-xs text-rose-700">
+                        {subjectError.message}
+                      </p>
+                    ) : null}
+                  </div>
+                </label>
+              </>
+            ) : null}
 
             <div className="space-y-3">
               <div className="flex items-center justify-between">
-                <span className="text-sm font-medium text-slate-700">Message</span>
-                <div className="flex items-center gap-2">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => {
-                      attachmentInputRef.current?.click();
-                    }}
-                  >
-                    <PaperclipIcon className="size-4" />
-                    Attach file
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => {
-                      imageInputRef.current?.click();
-                    }}
-                  >
-                    <ImageIcon className="size-4" />
-                    Embed image
-                  </Button>
-                </div>
+                <span className="text-sm font-medium text-slate-700">
+                  {activeTab === "note" ? "Note" : "Message"}
+                </span>
+                {activeTab === "email" ? (
+                  <div className="flex items-center gap-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        attachmentInputRef.current?.click();
+                      }}
+                    >
+                      <PaperclipIcon className="size-4" />
+                      Attach file
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        imageInputRef.current?.click();
+                      }}
+                    >
+                      <ImageIcon className="size-4" />
+                      Embed image
+                    </Button>
+                  </div>
+                ) : null}
               </div>
 
               <textarea
@@ -556,17 +669,21 @@ export function InboxComposerDetailPane() {
                 onInput={(event) => {
                   autoResizeTextarea(event.currentTarget);
                 }}
-                placeholder="Write your message"
+                placeholder={
+                  activeTab === "note"
+                    ? "Write a team-visible note"
+                    : "Write your message"
+                }
                 className={cn(
                   "max-h-[30rem] min-h-36 w-full resize-none rounded-md border border-slate-200 px-3 py-2 text-sm leading-6 text-slate-900 shadow-sm focus:outline-none focus:ring-1 focus:ring-slate-300",
-                  bodyError ? "border-rose-300 ring-1 ring-rose-200" : ""
+                  bodyError ? "border-rose-300 ring-1 ring-rose-200" : "",
                 )}
               />
               {bodyError ? (
                 <p className="text-xs text-rose-700">{bodyError.message}</p>
               ) : null}
 
-              {attachments.length > 0 ? (
+              {activeTab === "email" && attachments.length > 0 ? (
                 <div className="flex flex-wrap gap-2">
                   {attachments.map((attachment) => (
                     <span
@@ -583,7 +700,9 @@ export function InboxComposerDetailPane() {
                         onClick={() => {
                           clearComposerErrors();
                           setAttachments((previous) =>
-                            previous.filter((item) => item.id !== attachment.id)
+                            previous.filter(
+                              (item) => item.id !== attachment.id,
+                            ),
                           );
                         }}
                         className="text-slate-400 hover:text-slate-700"
@@ -595,11 +714,18 @@ export function InboxComposerDetailPane() {
                 </div>
               ) : null}
 
-              <p className="text-xs text-slate-500">
-                {formatBytes(attachmentBytes)} of {formatBytes(MAX_TOTAL_ATTACHMENT_BYTES)} used
-              </p>
-              {attachmentError ? (
-                <p className="text-xs text-rose-700">{attachmentError.message}</p>
+              {activeTab === "email" ? (
+                <>
+                  <p className="text-xs text-slate-500">
+                    {formatBytes(attachmentBytes)} of{" "}
+                    {formatBytes(MAX_TOTAL_ATTACHMENT_BYTES)} used
+                  </p>
+                  {attachmentError ? (
+                    <p className="text-xs text-rose-700">
+                      {attachmentError.message}
+                    </p>
+                  ) : null}
+                </>
               ) : null}
 
               <input
@@ -647,20 +773,30 @@ export function InboxComposerDetailPane() {
           ) : null}
 
           <div className="flex items-center justify-between">
-            <Button
-              type="button"
-              variant="ghost"
-              onClick={closeComposer}
-            >
+            <Button type="button" variant="ghost" onClick={closeComposer}>
               Cancel
             </Button>
 
             <Button
               type="button"
-              disabled={isSendDisabled}
-              onClick={submit}
+              disabled={
+                activeTab === "note" ? isSaveNoteDisabled : isSendDisabled
+              }
+              onClick={activeTab === "note" ? saveNote : submit}
             >
-              {isSending ? (
+              {activeTab === "note" ? (
+                isSavingNote ? (
+                  <>
+                    <LoaderIcon className="size-4 animate-spin" />
+                    Saving...
+                  </>
+                ) : (
+                  <>
+                    <NoteIcon className="size-4" />
+                    Save note
+                  </>
+                )
+              ) : isSending ? (
                 <>
                   <LoaderIcon className="size-4 animate-spin" />
                   Sending...

--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -6,36 +6,39 @@ import {
   useOptimistic,
   useRef,
   useState,
-  useTransition
+  useTransition,
 } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
   Popover,
   PopoverContent,
-  PopoverTrigger
+  PopoverTrigger,
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 
 import {
   clearInboxNeedsFollowUpAction,
   markInboxNeedsFollowUpAction,
-  sendComposerAction
+  sendComposerAction,
 } from "../actions";
 import { fetchInboxTimelinePage } from "../_lib/client-api";
 import type { InboxDetailViewModel } from "../_lib/view-models";
 import type { UiError, UiResult } from "@/src/server/ui-result";
 import { InboxFreshnessPoller } from "./inbox-freshness-poller";
-import {
-  useInboxClient,
-  type Reminder
-} from "./inbox-client-provider";
+import { useInboxClient, type Reminder } from "./inbox-client-provider";
 import { SectionLabel } from "@/components/ui/section-label";
-import { LAYOUT, TEXT, TONE, TRANSITION, SPACING } from "@/app/_lib/design-tokens";
+import {
+  LAYOUT,
+  TEXT,
+  TONE,
+  TRANSITION,
+  SPACING,
+} from "@/app/_lib/design-tokens";
 import { InboxComposerReplyBar } from "./inbox-composer";
 import {
   InboxContactRail,
-  InboxProjectStatusBadge
+  InboxProjectStatusBadge,
 } from "./inbox-contact-rail";
 import { TimelineSkeleton } from "./inbox-loading";
 import { InboxTimeline } from "./inbox-timeline";
@@ -46,16 +49,17 @@ import {
   ClockIcon,
   CornerUpLeftIcon,
   PanelRightOpenIcon,
-  XIcon
+  XIcon,
 } from "./icons";
 
 interface DetailProps {
   readonly detail: InboxDetailViewModel;
+  readonly currentOperatorUserId: string;
 }
 
 type ReminderUnit = "hours" | "days" | "weeks";
 
-export function InboxDetail({ detail }: DetailProps) {
+export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
   const { contact } = detail;
   const timelineScrollRef = useRef<HTMLDivElement>(null);
   const activeTimelineRequestIdRef = useRef(0);
@@ -66,7 +70,7 @@ export function InboxDetail({ detail }: DetailProps) {
     isTimelineLoading,
     setTimelineLoading,
     openReplyDraft,
-    showToast
+    showToast,
   } = useInboxClient();
 
   const [railOpen, setRailOpen] = useState(false);
@@ -90,7 +94,7 @@ export function InboxDetail({ detail }: DetailProps) {
     detail.freshness.timelineUpdatedAt,
     detail.timeline,
     detail.timelinePage,
-    setTimelineLoading
+    setTimelineLoading,
   ]);
 
   const loadOlderTimeline = useCallback(async () => {
@@ -108,7 +112,7 @@ export function InboxDetail({ detail }: DetailProps) {
     try {
       const nextPage = await fetchInboxTimelinePage({
         contactId: contact.contactId,
-        cursor: timelinePage.nextCursor
+        cursor: timelinePage.nextCursor,
       });
 
       if (activeTimelineRequestIdRef.current !== requestId) {
@@ -117,7 +121,7 @@ export function InboxDetail({ detail }: DetailProps) {
 
       setTimelineEntries((previousEntries) => [
         ...nextPage.entries,
-        ...previousEntries
+        ...previousEntries,
       ]);
       setTimelinePage(nextPage.page);
 
@@ -155,8 +159,8 @@ export function InboxDetail({ detail }: DetailProps) {
 
         return clearInboxNeedsFollowUpAction(formData);
       },
-      [contact.contactId]
-    )
+      [contact.contactId],
+    ),
   });
   const activeProject = contact.activeProjects[0] ?? null;
   const firstName = contact.displayName.split(" ")[0] ?? contact.displayName;
@@ -207,7 +211,7 @@ export function InboxDetail({ detail }: DetailProps) {
           const result = await sendComposerAction({
             recipient: {
               kind: "contact",
-              contactId: contact.contactId
+              contactId: contact.contactId,
             },
             alias: mailbox,
             subject: entry.subject ?? "",
@@ -217,7 +221,7 @@ export function InboxDetail({ detail }: DetailProps) {
             ...(entry.inReplyToRfc822 === null
               ? {}
               : { inReplyToRfc822: entry.inReplyToRfc822 }),
-            supersedesPendingId: pendingId
+            supersedesPendingId: pendingId,
           });
 
           if (result.ok) {
@@ -231,7 +235,7 @@ export function InboxDetail({ detail }: DetailProps) {
         setRetryingEntryId(null);
       });
     },
-    [contact.contactId, contact.displayName, showToast, timelineEntries]
+    [contact.contactId, contact.displayName, showToast, timelineEntries],
   );
 
   return (
@@ -242,7 +246,9 @@ export function InboxDetail({ detail }: DetailProps) {
       />
 
       <section className="flex min-w-0 flex-1 flex-col border-r border-slate-200 bg-white">
-        <header className={`flex ${LAYOUT.headerHeight} items-center justify-between gap-4 border-b border-slate-200 px-6`}>
+        <header
+          className={`flex ${LAYOUT.headerHeight} items-center justify-between gap-4 border-b border-slate-200 px-6`}
+        >
           <div className="flex min-w-0 items-center gap-4">
             <h1 className={`truncate ${TEXT.headingLg}`}>
               {contact.displayName}
@@ -252,8 +258,7 @@ export function InboxDetail({ detail }: DetailProps) {
               {activeProject ? (
                 <div className="flex min-w-0 items-center gap-2 text-xs">
                   <span className="min-w-0 truncate font-medium text-slate-700">
-                    {activeProject.projectName}{" "}
-                    {activeProject.year.toString()}
+                    {activeProject.projectName} {activeProject.year.toString()}
                   </span>
                   <InboxProjectStatusBadge status={activeProject.status} />
                 </div>
@@ -353,6 +358,7 @@ export function InboxDetail({ detail }: DetailProps) {
             <InboxTimeline
               entries={timelineEntries}
               volunteerFirstName={firstName}
+              currentOperatorUserId={currentOperatorUserId}
               hasMore={timelinePage.hasMore}
               isLoadingOlder={isTimelineLoading}
               retryingEntryId={isRetryPending ? retryingEntryId : null}
@@ -381,7 +387,7 @@ export function InboxDetail({ detail }: DetailProps) {
           `overflow-hidden border-l ${TRANSITION.layout} ${TRANSITION.reduceMotion}`,
           railOpen
             ? `${LAYOUT.railWidth} border-slate-200 opacity-100`
-            : "w-0 border-transparent opacity-0"
+            : "w-0 border-transparent opacity-0",
         )}
       >
         <div className={LAYOUT.railWidth}>
@@ -401,7 +407,7 @@ function FollowUpToggleControl({
   needsFollowUp,
   isPending,
   error,
-  onToggle
+  onToggle,
 }: {
   readonly needsFollowUp: boolean;
   readonly isPending: boolean;
@@ -431,7 +437,7 @@ function FollowUpToggleControl({
 function FollowUpToggleButton({
   needsFollowUp,
   pending,
-  onToggle
+  onToggle,
 }: {
   readonly needsFollowUp: boolean;
   readonly pending: boolean;
@@ -450,7 +456,7 @@ function FollowUpToggleButton({
       className={cn(
         "gap-1.5",
         needsFollowUp &&
-          "border-rose-300 bg-rose-50 text-rose-800 hover:bg-rose-100 hover:text-rose-800"
+          "border-rose-300 bg-rose-50 text-rose-800 hover:bg-rose-100 hover:text-rose-800",
       )}
     >
       <CornerUpLeftIcon className="h-3.5 w-3.5" />
@@ -462,7 +468,7 @@ function FollowUpToggleButton({
 function useOptimisticBooleanToggle({
   scopeKey,
   value,
-  perform
+  perform,
 }: {
   readonly scopeKey: string;
   readonly value: boolean;
@@ -474,7 +480,7 @@ function useOptimisticBooleanToggle({
   const [isPending, startTransition] = useTransition();
   const [optimisticValue, setOptimisticValue] = useOptimistic(
     committedValue,
-    (_currentValue: boolean, nextValue: boolean) => nextValue
+    (_currentValue: boolean, nextValue: boolean) => nextValue,
   );
 
   useEffect(() => {
@@ -506,7 +512,7 @@ function useOptimisticBooleanToggle({
     value: optimisticValue,
     isPending,
     error,
-    toggle
+    toggle,
   } as const;
 }
 
@@ -545,7 +551,7 @@ function ReminderPopoverBody({
   onChangeUnit,
   onClose,
   onSet,
-  onClear
+  onClear,
 }: ReminderPopoverBodyProps) {
   const numeric = Number(value);
   const canSet = value.length > 0 && Number.isFinite(numeric) && numeric > 0;
@@ -555,9 +561,7 @@ function ReminderPopoverBody({
     return (
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
-          <SectionLabel as="p">
-            Reminder set
-          </SectionLabel>
+          <SectionLabel as="p">Reminder set</SectionLabel>
           <p className="mt-1 text-sm font-medium text-slate-900">
             {formatLongReminder(existing)}
           </p>
@@ -580,9 +584,7 @@ function ReminderPopoverBody({
 
   return (
     <>
-      <SectionLabel as="p">
-        Remind me in
-      </SectionLabel>
+      <SectionLabel as="p">Remind me in</SectionLabel>
       <div className="mt-2 flex items-center gap-2">
         <div className="flex h-9 w-16 items-center overflow-hidden rounded-md border border-slate-200 shadow-sm">
           <span
@@ -631,7 +633,7 @@ function ReminderPopoverBody({
                   "flex-1 rounded-md px-1.5 py-1 capitalize transition-colors duration-150",
                   isActive
                     ? "bg-white text-slate-900 shadow-sm"
-                    : "text-slate-500 hover:text-slate-900"
+                    : "text-slate-500 hover:text-slate-900",
                 )}
               >
                 {option}
@@ -643,7 +645,7 @@ function ReminderPopoverBody({
       <p
         className={cn(
           "mt-2 min-h-4 text-[11px]",
-          preview ? "text-slate-500" : "text-transparent"
+          preview ? "text-slate-500" : "text-transparent",
         )}
         aria-live="polite"
       >
@@ -699,15 +701,15 @@ function formatAbsolute(target: Date): string {
   const startOfToday = new Date(
     now.getFullYear(),
     now.getMonth(),
-    now.getDate()
+    now.getDate(),
   ).getTime();
   const startOfTarget = new Date(
     target.getFullYear(),
     target.getMonth(),
-    target.getDate()
+    target.getDate(),
   ).getTime();
   const dayDelta = Math.round(
-    (startOfTarget - startOfToday) / (24 * 60 * 60 * 1000)
+    (startOfTarget - startOfToday) / (24 * 60 * 60 * 1000),
   );
 
   const time = formatTime(target);
@@ -731,24 +733,34 @@ function formatTime(target: Date): string {
 }
 
 function weekdayName(day: number): string {
-  return ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"][
-    day
-  ] ?? "Unknown";
+  return (
+    [
+      "Sunday",
+      "Monday",
+      "Tuesday",
+      "Wednesday",
+      "Thursday",
+      "Friday",
+      "Saturday",
+    ][day] ?? "Unknown"
+  );
 }
 
 function monthName(month: number): string {
-  return [
-    "January",
-    "February",
-    "March",
-    "April",
-    "May",
-    "June",
-    "July",
-    "August",
-    "September",
-    "October",
-    "November",
-    "December"
-  ][month] ?? "Unknown";
+  return (
+    [
+      "January",
+      "February",
+      "March",
+      "April",
+      "May",
+      "June",
+      "July",
+      "August",
+      "September",
+      "October",
+      "November",
+      "December",
+    ][month] ?? "Unknown"
+  );
 }

--- a/apps/web/app/inbox/_components/inbox-timeline.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline.tsx
@@ -1,12 +1,21 @@
 "use client";
 
-import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
 
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import type {
   InboxTimelineEntryKind,
   InboxTimelineEntryViewModel,
 } from "../_lib/view-models";
 import { autolinkText } from "./_autolink";
+import { deleteNoteAction, updateNoteAction } from "../actions";
+import { getInternalNoteValidationError } from "@/src/lib/internal-note-validation";
 import {
   ChevronRightIcon,
   LoaderIcon,
@@ -34,6 +43,7 @@ import {
 interface TimelineProps {
   readonly entries: readonly InboxTimelineEntryViewModel[];
   readonly volunteerFirstName: string;
+  readonly currentOperatorUserId: string;
   readonly hasMore?: boolean;
   readonly isLoadingOlder?: boolean;
   readonly onLoadOlder?: () => void;
@@ -44,6 +54,7 @@ interface TimelineProps {
 export function InboxTimeline({
   entries,
   volunteerFirstName,
+  currentOperatorUserId,
   hasMore = false,
   isLoadingOlder = false,
   onLoadOlder,
@@ -103,6 +114,7 @@ export function InboxTimeline({
             key={entry.id}
             entry={entry}
             volunteerFirstName={volunteerFirstName}
+            currentOperatorUserId={currentOperatorUserId}
             isExpanded={expanded.has(entry.id)}
             retryingEntryId={retryingEntryId}
             onRetryPending={onRetryPending}
@@ -119,6 +131,7 @@ export function InboxTimeline({
 interface EntryProps {
   readonly entry: InboxTimelineEntryViewModel;
   readonly volunteerFirstName: string;
+  readonly currentOperatorUserId: string;
   readonly isExpanded: boolean;
   readonly retryingEntryId: string | null;
   readonly onRetryPending: ((entryId: string) => void) | undefined;
@@ -128,6 +141,7 @@ interface EntryProps {
 function TimelineEntry({
   entry,
   volunteerFirstName,
+  currentOperatorUserId,
   isExpanded,
   retryingEntryId,
   onRetryPending,
@@ -158,7 +172,12 @@ function TimelineEntry({
         />
       );
     case "note":
-      return <NoteEntry entry={entry} />;
+      return (
+        <NoteEntry
+          entry={entry}
+          currentOperatorUserId={currentOperatorUserId}
+        />
+      );
     case "system":
       return (
         <SystemDivider entry={entry} volunteerFirstName={volunteerFirstName} />
@@ -399,23 +418,220 @@ export function shouldHideAutomatedRowBody(input: {
   );
 }
 
-function NoteEntry({ entry }: { readonly entry: InboxTimelineEntryViewModel }) {
+function NoteEntry({
+  entry,
+  currentOperatorUserId,
+}: {
+  readonly entry: InboxTimelineEntryViewModel;
+  readonly currentOperatorUserId: string;
+}) {
+  const router = useRouter();
+  const [isEditing, setIsEditing] = useState(false);
+  const [draftBody, setDraftBody] = useState(entry.body);
+  const [inlineError, setInlineError] = useState<string | null>(null);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [isSaving, startSaveTransition] = useTransition();
+  const [isDeleting, startDeleteTransition] = useTransition();
+  const canManageNote =
+    entry.noteId !== null &&
+    entry.noteId !== undefined &&
+    entry.authorId === currentOperatorUserId;
+
+  const saveEdit = () => {
+    const noteId = entry.noteId;
+
+    if (
+      typeof noteId !== "string" ||
+      entry.authorId !== currentOperatorUserId
+    ) {
+      return;
+    }
+
+    const validationError = getInternalNoteValidationError(draftBody);
+
+    if (validationError !== null) {
+      setInlineError(validationError);
+      return;
+    }
+
+    setInlineError(null);
+    startSaveTransition(async () => {
+      const result = await updateNoteAction({
+        noteId,
+        body: draftBody,
+      });
+
+      if (!result.ok) {
+        setInlineError(result.message);
+        return;
+      }
+
+      setIsEditing(false);
+      router.refresh();
+    });
+  };
+
+  const deleteNote = () => {
+    const noteId = entry.noteId;
+
+    if (
+      typeof noteId !== "string" ||
+      entry.authorId !== currentOperatorUserId
+    ) {
+      return;
+    }
+
+    setInlineError(null);
+    startDeleteTransition(async () => {
+      const result = await deleteNoteAction({
+        noteId,
+      });
+
+      if (!result.ok) {
+        setInlineError(result.message);
+        return;
+      }
+
+      setDeleteOpen(false);
+      router.refresh();
+    });
+  };
+
   return (
     <li className="flex w-full flex-col items-end">
       <div
         className={`w-full max-w-2xl ${RADIUS.md} border-l-2 border-amber-400 ${TONE.amber.subtle} px-4 py-2.5`}
       >
-        <div className="mb-1 flex items-center gap-1.5 text-[11px] text-amber-700">
-          <NoteIcon className="h-3 w-3" />
-          <span className="font-medium">Note</span>
-          <span className="text-amber-300">·</span>
-          <span>{entry.actorLabel}</span>
-          <span className="text-amber-300">·</span>
-          <span>{entry.occurredAtLabel}</span>
+        <div className="mb-1 flex items-center justify-between gap-3 text-[11px] text-amber-700">
+          <div className="flex items-center gap-1.5">
+            <NoteIcon className="h-3 w-3" />
+            <span className="font-medium">Note</span>
+            <span className="text-amber-300">·</span>
+            <span>{entry.actorLabel}</span>
+            <span className="text-amber-300">·</span>
+            <span>{entry.occurredAtLabel}</span>
+          </div>
+          {canManageNote ? (
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-auto px-2 py-1 text-[11px] text-amber-800 hover:bg-amber-100"
+                onClick={() => {
+                  setDraftBody(entry.body);
+                  setInlineError(null);
+                  setIsEditing(true);
+                }}
+              >
+                Edit
+              </Button>
+              <Popover open={deleteOpen} onOpenChange={setDeleteOpen}>
+                <PopoverTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-auto px-2 py-1 text-[11px] text-amber-800 hover:bg-amber-100"
+                  >
+                    Delete
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-64 space-y-3" align="end">
+                  <p className="text-sm font-medium text-slate-900">
+                    Delete this note?
+                  </p>
+                  <p className="text-xs text-slate-500">
+                    This removes the note from the shared timeline.
+                  </p>
+                  <div className="flex justify-end gap-2">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => {
+                        setDeleteOpen(false);
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      disabled={isDeleting}
+                      onClick={deleteNote}
+                    >
+                      {isDeleting ? (
+                        <>
+                          <LoaderIcon className="size-3 animate-spin" />
+                          Deleting...
+                        </>
+                      ) : (
+                        "Delete"
+                      )}
+                    </Button>
+                  </div>
+                </PopoverContent>
+              </Popover>
+            </div>
+          ) : null}
         </div>
-        <p className="whitespace-pre-wrap text-pretty text-[13px] leading-relaxed text-amber-900">
-          {entry.body}
-        </p>
+        {isEditing ? (
+          <div className="space-y-3">
+            <textarea
+              rows={4}
+              value={draftBody}
+              onChange={(event) => {
+                setDraftBody(event.currentTarget.value);
+                if (inlineError !== null) {
+                  setInlineError(null);
+                }
+              }}
+              className="w-full resize-y rounded-md border border-amber-200 bg-white px-3 py-2 text-[13px] leading-relaxed text-slate-900 shadow-sm focus:outline-none focus:ring-1 focus:ring-amber-300"
+            />
+            {inlineError ? (
+              <p className="text-xs text-rose-700">{inlineError}</p>
+            ) : null}
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setDraftBody(entry.body);
+                  setInlineError(null);
+                  setIsEditing(false);
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                disabled={isSaving}
+                onClick={saveEdit}
+              >
+                {isSaving ? (
+                  <>
+                    <LoaderIcon className="size-3 animate-spin" />
+                    Saving...
+                  </>
+                ) : (
+                  "Save"
+                )}
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <p className="whitespace-pre-wrap text-pretty text-[13px] leading-relaxed text-amber-900">
+              {entry.body}
+            </p>
+            {inlineError ? (
+              <p className="mt-2 text-xs text-rose-700">{inlineError}</p>
+            ) : null}
+          </>
+        )}
       </div>
     </li>
   );

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -545,8 +545,9 @@ function restoreStructuredEmailParagraphs(value: string): string {
     return normalized;
   }
 
-  const hasGreeting =
-    /^(?:Hi|Hello|Hey|Hola|Dear)\b[^,\n]{0,80},(?=\S)/i.test(normalized);
+  const hasGreeting = /^(?:Hi|Hello|Hey|Hola|Dear)\b[^,\n]{0,80},(?=\S)/i.test(
+    normalized,
+  );
   const hasTranslationMarker =
     STRUCTURED_EMAIL_TRANSLATION_MARKER_PATTERN.test(normalized);
   const sentenceBreaks = normalized.match(/[.!?](?=\S)/g)?.length ?? 0;
@@ -563,15 +564,9 @@ function restoreStructuredEmailParagraphs(value: string): string {
   );
 
   return normalized
-    .replace(
-      /^((?:Hi|Hello|Hey|Hola|Dear)\b[^,\n]{0,80},)(?=\S)/i,
-      "$1\n\n",
-    )
+    .replace(/^((?:Hi|Hello|Hey|Hola|Dear)\b[^,\n]{0,80},)(?=\S)/i, "$1\n\n")
     .replace(paragraphStarterPattern, "$1\n\n")
-    .replace(
-      /([.!?])\s*(?=(?:en|es|fr|de|pt):(?=[A-ZÀ-Ý]))/g,
-      "$1\n\n",
-    )
+    .replace(/([.!?])\s*(?=(?:en|es|fr|de|pt):(?=[A-ZÀ-Ý]))/g, "$1\n\n")
     .replace(STRUCTURED_EMAIL_TRANSLATION_MARKER_PATTERN, "\n\n$&")
     .replace(/\n{3,}/g, "\n\n")
     .trim();
@@ -1319,8 +1314,7 @@ function timelineSubject(item: TimelineItem): string | null {
   }
 }
 
-const REPLY_SUBJECT_PREFIX_PATTERN =
-  /^\s*(?:(?:re|fwd?)\s*:\s*)+/i;
+const REPLY_SUBJECT_PREFIX_PATTERN = /^\s*(?:(?:re|fwd?)\s*:\s*)+/i;
 
 function buildReplySubject(subject: string | null): string {
   const normalizedSubject = normalizeInlineText(subject);
@@ -1330,7 +1324,7 @@ function buildReplySubject(subject: string | null): string {
   }
 
   const trimmedSubject = normalizeInlineText(
-    normalizedSubject.replace(REPLY_SUBJECT_PREFIX_PATTERN, "")
+    normalizedSubject.replace(REPLY_SUBJECT_PREFIX_PATTERN, ""),
   );
 
   return trimmedSubject === null ? "" : `Re: ${trimmedSubject}`;
@@ -1469,25 +1463,32 @@ function buildTimelineEntry(input: {
     isUnread,
     isPreview: isPreviewTimelineItem(input.item),
     mailbox:
-      input.item.family === "one_to_one_email" ? input.item.mailbox ?? null : null,
+      input.item.family === "one_to_one_email"
+        ? (input.item.mailbox ?? null)
+        : null,
     threadId:
-      input.item.family === "one_to_one_email" ? input.item.threadId ?? null : null,
+      input.item.family === "one_to_one_email"
+        ? (input.item.threadId ?? null)
+        : null,
     rfc822MessageId:
       input.item.family === "one_to_one_email"
-        ? input.item.rfc822MessageId ?? null
+        ? (input.item.rfc822MessageId ?? null)
         : null,
     inReplyToRfc822:
       input.item.family === "one_to_one_email"
-        ? input.item.inReplyToRfc822 ?? null
+        ? (input.item.inReplyToRfc822 ?? null)
         : null,
     sendStatus:
       input.item.family === "one_to_one_email"
-        ? input.item.sendStatus ?? null
+        ? (input.item.sendStatus ?? null)
         : null,
     attachmentCount:
       input.item.family === "one_to_one_email"
-        ? input.item.attachmentCount ?? 0
+        ? (input.item.attachmentCount ?? 0)
         : 0,
+    noteId: input.item.family === "internal_note" ? input.item.noteId : null,
+    authorId:
+      input.item.family === "internal_note" ? input.item.authorId : null,
   };
 }
 
@@ -1499,10 +1500,8 @@ function buildComposerReplyContext(input: {
   const latestInboundEmail = [...input.timelineItems]
     .reverse()
     .find(
-      (
-        item
-      ): item is Extract<TimelineItem, { family: "one_to_one_email" }> =>
-        item.family === "one_to_one_email" && item.direction === "inbound"
+      (item): item is Extract<TimelineItem, { family: "one_to_one_email" }> =>
+        item.family === "one_to_one_email" && item.direction === "inbound",
     );
 
   if (latestInboundEmail === undefined) {
@@ -2154,9 +2153,10 @@ export async function getInboxDetail(
   const composerReplyContext = buildComposerReplyContext({
     contact: cachedData.contact,
     timelineItems: cachedData.timelineItems,
-    defaultAlias: await runtime.timelinePresentation.findLastInboundAliasForContact(
-      contactId
-    ),
+    defaultAlias:
+      await runtime.timelinePresentation.findLastInboundAliasForContact(
+        contactId,
+      ),
   });
 
   return {

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -150,6 +150,8 @@ export interface InboxTimelineEntryViewModel {
   readonly inReplyToRfc822: string | null;
   readonly sendStatus: InboxTimelineEntrySendStatus;
   readonly attachmentCount: number;
+  readonly noteId?: string | null;
+  readonly authorId?: string | null;
 }
 
 export interface InboxComposerAliasOption {

--- a/apps/web/app/inbox/actions.ts
+++ b/apps/web/app/inbox/actions.ts
@@ -9,6 +9,10 @@ import { requireSession } from "@/src/server/auth/session";
 import { sendComposerGmailMessage } from "@/src/server/composer/gmail-send";
 import { setInboxNeedsFollowUp } from "@/src/server/inbox/follow-up";
 import { revalidateInboxContact } from "@/src/server/inbox/revalidate";
+import {
+  getInternalNoteValidationError,
+  normalizeInternalNoteBody,
+} from "@/src/lib/internal-note-validation";
 import { getStage1WebRuntime } from "@/src/server/stage1-runtime";
 import { appendSecurityAudit } from "@/src/server/security/audit";
 import { enforceRateLimit } from "@/src/server/security/rate-limit";
@@ -32,12 +36,11 @@ const composerAttachmentSchema = z.object({
   contentBase64: z.string().min(1),
 });
 
-const composerBodyPlaintextSchema = z.string().refine(
-  (value) => value.trim().length > 0,
-  {
+const composerBodyPlaintextSchema = z
+  .string()
+  .refine((value) => value.trim().length > 0, {
     message: "Body is required.",
-  }
-);
+  });
 
 const composerSendActionInputSchema = z.object({
   recipient: composerRecipientSchema,
@@ -73,6 +76,20 @@ export type ComposerSendActionInput = z.input<
   typeof composerSendActionInputSchema
 >;
 export type ComposerSendActionResult = UiResult<ComposerSendActionData>;
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type NoteCreateActionData = {
+  readonly noteId: string;
+  readonly contactId: string;
+};
+
+export type NoteCreateActionResult = UiResult<NoteCreateActionData>;
+export type NoteUpdateActionResult = UiResult<{
+  readonly noteId: string;
+}>;
+export type NoteDeleteActionResult = UiResult<{
+  readonly noteId: string;
+}>;
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type ContactSearchResult = {
@@ -116,11 +133,43 @@ function composerRateLimitError(requestId: string): ComposerSendActionResult {
   };
 }
 
-function contactSearchRateLimitError(requestId: string): ContactSearchActionResult {
+function contactSearchRateLimitError(
+  requestId: string,
+): ContactSearchActionResult {
   return {
     ok: false,
     code: "rate_limit_exceeded",
     message: "Too many contact searches. Please wait a minute and try again.",
+    requestId,
+    retryable: true,
+  };
+}
+
+function noteCreateRateLimitError(requestId: string): NoteCreateActionResult {
+  return {
+    ok: false,
+    code: "rate_limit_exceeded",
+    message: "Too many note saves. Please wait a minute and try again.",
+    requestId,
+    retryable: true,
+  };
+}
+
+function noteUpdateRateLimitError(requestId: string): NoteUpdateActionResult {
+  return {
+    ok: false,
+    code: "rate_limit_exceeded",
+    message: "Too many note edits. Please wait a minute and try again.",
+    requestId,
+    retryable: true,
+  };
+}
+
+function noteDeleteRateLimitError(requestId: string): NoteDeleteActionResult {
+  return {
+    ok: false,
+    code: "rate_limit_exceeded",
+    message: "Too many note deletes. Please wait a minute and try again.",
     requestId,
     retryable: true,
   };
@@ -131,7 +180,7 @@ function composerValidationError(
   input: {
     readonly message: string;
     readonly fieldErrors?: Record<string, string>;
-  }
+  },
 ): ComposerSendActionResult {
   return {
     ok: false,
@@ -139,12 +188,53 @@ function composerValidationError(
     message: input.message,
     requestId,
     retryable: false,
-    ...(input.fieldErrors === undefined ? {} : { fieldErrors: input.fieldErrors }),
+    ...(input.fieldErrors === undefined
+      ? {}
+      : { fieldErrors: input.fieldErrors }),
+  };
+}
+
+function noteValidationError(
+  requestId: string,
+  input: {
+    readonly message: string;
+    readonly fieldErrors?: Record<string, string>;
+  },
+): UiResult<never> {
+  return {
+    ok: false,
+    code: "validation_error",
+    message: input.message,
+    requestId,
+    retryable: false,
+    ...(input.fieldErrors === undefined
+      ? {}
+      : { fieldErrors: input.fieldErrors }),
+  };
+}
+
+function noteForbiddenError(requestId: string): UiResult<never> {
+  return {
+    ok: false,
+    code: "forbidden",
+    message: "You can only edit or delete your own notes.",
+    requestId,
+    retryable: false,
+  };
+}
+
+function noteNotFoundError(requestId: string): UiResult<never> {
+  return {
+    ok: false,
+    code: "not_found",
+    message: "That note could not be found.",
+    requestId,
+    retryable: false,
   };
 }
 
 function composerGenericRetryableError(
-  requestId: string
+  requestId: string,
 ): ComposerSendActionResult {
   return {
     ok: false,
@@ -165,7 +255,7 @@ function mapComposerProviderError(
     | "attachment_too_large"
     | "rate_limited"
     | "transient"
-    | "permanent"
+    | "permanent",
 ): ComposerSendActionResult {
   switch (kind) {
     case "auth_error":
@@ -238,13 +328,46 @@ function normalizeEmailAddress(value: string): string | null {
   return normalized.length === 0 ? null : normalized;
 }
 
+function resolveCurrentUserDisplayName(input: {
+  readonly name: string | null | undefined;
+  readonly email: string | null | undefined;
+}): string {
+  const trimmedName = input.name?.trim();
+
+  if (trimmedName && trimmedName.length > 0) {
+    return trimmedName;
+  }
+
+  const localPart = input.email?.split("@", 1)[0]?.trim();
+
+  if (localPart && localPart.length > 0) {
+    return localPart;
+  }
+
+  return "Internal note";
+}
+
+function buildManualNoteCanonicalEventId(noteId: string): string {
+  return `canonical-event:manual:note:${noteId}`;
+}
+
+async function resolveManualNoteContactId(input: {
+  readonly runtime: Awaited<ReturnType<typeof getStage1WebRuntime>>;
+  readonly noteId: string;
+}): Promise<string | null> {
+  const canonicalEvent =
+    await input.runtime.repositories.canonicalEvents.findById(
+      buildManualNoteCanonicalEventId(input.noteId),
+    );
+
+  return canonicalEvent?.contactId ?? null;
+}
+
 function normalizeMembershipStatus(value: string | null): string {
   return (value ?? "").trim().toLowerCase().replaceAll("_", "-");
 }
 
-function membershipSortRank(
-  membershipStatus: string | null
-): number {
+function membershipSortRank(membershipStatus: string | null): number {
   switch (normalizeMembershipStatus(membershipStatus)) {
     case "lead":
       return 0;
@@ -279,11 +402,13 @@ function readAliasSignature(aliasRecord: Record<string, unknown>): string {
 }
 
 function appendSignature(bodyPlaintext: string, signature: string): string {
-  return signature.length > 0 ? `${bodyPlaintext}\n\n${signature}` : bodyPlaintext;
+  return signature.length > 0
+    ? `${bodyPlaintext}\n\n${signature}`
+    : bodyPlaintext;
 }
 
 function buildAttachmentMetadata(
-  attachments: ComposerSendActionParsedInput["attachments"]
+  attachments: ComposerSendActionParsedInput["attachments"],
 ) {
   return attachments.map((attachment) => ({
     filename: attachment.filename,
@@ -293,7 +418,7 @@ function buildAttachmentMetadata(
 }
 
 export async function searchContactsAction(
-  query: string
+  query: string,
 ): Promise<ContactSearchActionResult> {
   const requestId = randomUUID();
 
@@ -348,14 +473,14 @@ export async function searchContactsAction(
     new Set(
       memberships
         .map((membership) => membership.projectId)
-        .filter((projectId): projectId is string => projectId !== null)
-    )
+        .filter((projectId): projectId is string => projectId !== null),
+    ),
   );
   const projectDimensions =
     await runtime.repositories.projectDimensions.listByIds(projectIds);
   const membershipsByContactId = new Map<
     string,
-    ((typeof memberships)[number])[]
+    (typeof memberships)[number][]
   >();
 
   for (const membership of memberships) {
@@ -370,7 +495,10 @@ export async function searchContactsAction(
   }
 
   const projectNameById = new Map(
-    projectDimensions.map((project) => [project.projectId, project.projectName])
+    projectDimensions.map((project) => [
+      project.projectId,
+      project.projectName,
+    ]),
   );
 
   return {
@@ -380,18 +508,21 @@ export async function searchContactsAction(
         [...(membershipsByContactId.get(contact.id) ?? [])].sort(
           (left, right) => {
             const rankDifference =
-              membershipSortRank(left.status) - membershipSortRank(right.status);
+              membershipSortRank(left.status) -
+              membershipSortRank(right.status);
 
             if (rankDifference !== 0) {
               return rankDifference;
             }
 
             if (left.projectId !== right.projectId) {
-              return (left.projectId ?? "").localeCompare(right.projectId ?? "");
+              return (left.projectId ?? "").localeCompare(
+                right.projectId ?? "",
+              );
             }
 
             return left.id.localeCompare(right.id);
-          }
+          },
         )[0] ?? null;
 
       return {
@@ -413,7 +544,9 @@ async function resolveContactEmail(input: {
   readonly runtime: Awaited<ReturnType<typeof getStage1WebRuntime>>;
   readonly contactId: string;
 }): Promise<string | null> {
-  const contact = await input.runtime.repositories.contacts.findById(input.contactId);
+  const contact = await input.runtime.repositories.contacts.findById(
+    input.contactId,
+  );
 
   if (contact === null) {
     return null;
@@ -429,10 +562,13 @@ async function resolveContactEmail(input: {
   }
 
   const identities =
-    await input.runtime.repositories.contactIdentities.listByContactId(contact.id);
+    await input.runtime.repositories.contactIdentities.listByContactId(
+      contact.id,
+    );
 
   return (
-    identities.find((identity) => identity.kind === "email")?.normalizedValue ?? null
+    identities.find((identity) => identity.kind === "email")?.normalizedValue ??
+    null
   );
 }
 
@@ -513,8 +649,301 @@ async function updateNeedsFollowUp(
   };
 }
 
+export async function createNoteAction(rawInput: {
+  readonly contactId: string;
+  readonly body: string;
+}): Promise<NoteCreateActionResult> {
+  const requestId = randomUUID();
+  const contactId = rawInput.contactId.trim();
+  const body = normalizeInternalNoteBody(rawInput.body);
+
+  if (contactId.length === 0) {
+    return noteValidationError(requestId, {
+      message: "A contact is required to save a note.",
+      fieldErrors: {
+        contactId: "Contact is required.",
+      },
+    });
+  }
+
+  const bodyValidationError = getInternalNoteValidationError(body);
+
+  if (bodyValidationError !== null) {
+    return noteValidationError(requestId, {
+      message: bodyValidationError,
+      fieldErrors: {
+        body: bodyValidationError,
+      },
+    });
+  }
+
+  let currentUser;
+  try {
+    currentUser = await requireSession();
+  } catch (error) {
+    if (error instanceof Error && error.message === "UNAUTHORIZED") {
+      return unauthorizedError(requestId);
+    }
+    throw error;
+  }
+
+  const decision = await enforceRateLimit({
+    scope: "server-action:inbox-note-create",
+    identifier: currentUser.id,
+    limit: 60,
+    audit: {
+      actorType: "user",
+      actorId: currentUser.id,
+      action: "inbox.note_create.rate_limited",
+      entityType: "server_action",
+      entityId: "inbox.note_create",
+      metadataJson: {
+        contactId,
+      },
+    },
+  });
+
+  if (!decision.allowed) {
+    return noteCreateRateLimitError(requestId);
+  }
+
+  const runtime = await getStage1WebRuntime();
+  const noteId = randomUUID();
+
+  await runtime.internalNotes.createNote({
+    noteId,
+    contactId,
+    body,
+    occurredAt: new Date().toISOString(),
+    authorDisplayName: resolveCurrentUserDisplayName({
+      name: currentUser.name,
+      email: currentUser.email,
+    }),
+    authorId: currentUser.id,
+  });
+
+  await appendSecurityAudit({
+    actorType: "user",
+    actorId: currentUser.id,
+    action: "inbox.note_created",
+    entityType: "internal_note",
+    entityId: noteId,
+    result: "recorded",
+    policyCode: "inbox.note",
+    metadataJson: {
+      contactId,
+      noteId,
+    },
+  });
+
+  revalidateInboxContact(contactId);
+
+  return {
+    ok: true,
+    data: {
+      noteId,
+      contactId,
+    },
+    requestId,
+  };
+}
+
+export async function updateNoteAction(rawInput: {
+  readonly noteId: string;
+  readonly body: string;
+}): Promise<NoteUpdateActionResult> {
+  const requestId = randomUUID();
+  const noteId = rawInput.noteId.trim();
+  const body = normalizeInternalNoteBody(rawInput.body);
+
+  if (noteId.length === 0) {
+    return noteValidationError(requestId, {
+      message: "A note id is required.",
+      fieldErrors: {
+        noteId: "Note id is required.",
+      },
+    });
+  }
+
+  const bodyValidationError = getInternalNoteValidationError(body);
+
+  if (bodyValidationError !== null) {
+    return noteValidationError(requestId, {
+      message: bodyValidationError,
+      fieldErrors: {
+        body: bodyValidationError,
+      },
+    });
+  }
+
+  let currentUser;
+  try {
+    currentUser = await requireSession();
+  } catch (error) {
+    if (error instanceof Error && error.message === "UNAUTHORIZED") {
+      return unauthorizedError(requestId);
+    }
+    throw error;
+  }
+
+  const decision = await enforceRateLimit({
+    scope: "server-action:inbox-note-update",
+    identifier: currentUser.id,
+    limit: 60,
+    audit: {
+      actorType: "user",
+      actorId: currentUser.id,
+      action: "inbox.note_update.rate_limited",
+      entityType: "server_action",
+      entityId: "inbox.note_update",
+      metadataJson: {
+        noteId,
+      },
+    },
+  });
+
+  if (!decision.allowed) {
+    return noteUpdateRateLimitError(requestId);
+  }
+
+  const runtime = await getStage1WebRuntime();
+  const contactId = await resolveManualNoteContactId({
+    runtime,
+    noteId,
+  });
+  const result = await runtime.internalNotes.updateNote({
+    noteId,
+    body,
+    authorId: currentUser.id,
+  });
+
+  if (result.outcome === "not_authorized") {
+    return noteForbiddenError(requestId);
+  }
+
+  if (result.outcome === "not_found") {
+    return noteNotFoundError(requestId);
+  }
+
+  await appendSecurityAudit({
+    actorType: "user",
+    actorId: currentUser.id,
+    action: "inbox.note_updated",
+    entityType: "internal_note",
+    entityId: noteId,
+    result: "recorded",
+    policyCode: "inbox.note",
+    metadataJson: {
+      contactId,
+      noteId,
+    },
+  });
+
+  if (contactId !== null) {
+    revalidateInboxContact(contactId);
+  }
+
+  return {
+    ok: true,
+    data: {
+      noteId,
+    },
+    requestId,
+  };
+}
+
+export async function deleteNoteAction(rawInput: {
+  readonly noteId: string;
+}): Promise<NoteDeleteActionResult> {
+  const requestId = randomUUID();
+  const noteId = rawInput.noteId.trim();
+
+  if (noteId.length === 0) {
+    return noteValidationError(requestId, {
+      message: "A note id is required.",
+      fieldErrors: {
+        noteId: "Note id is required.",
+      },
+    });
+  }
+
+  let currentUser;
+  try {
+    currentUser = await requireSession();
+  } catch (error) {
+    if (error instanceof Error && error.message === "UNAUTHORIZED") {
+      return unauthorizedError(requestId);
+    }
+    throw error;
+  }
+
+  const decision = await enforceRateLimit({
+    scope: "server-action:inbox-note-delete",
+    identifier: currentUser.id,
+    limit: 60,
+    audit: {
+      actorType: "user",
+      actorId: currentUser.id,
+      action: "inbox.note_delete.rate_limited",
+      entityType: "server_action",
+      entityId: "inbox.note_delete",
+      metadataJson: {
+        noteId,
+      },
+    },
+  });
+
+  if (!decision.allowed) {
+    return noteDeleteRateLimitError(requestId);
+  }
+
+  const runtime = await getStage1WebRuntime();
+  const contactId = await resolveManualNoteContactId({
+    runtime,
+    noteId,
+  });
+  const result = await runtime.internalNotes.deleteNote({
+    noteId,
+    authorId: currentUser.id,
+  });
+
+  if (result.outcome === "not_authorized") {
+    return noteForbiddenError(requestId);
+  }
+
+  if (result.outcome === "not_found") {
+    return noteNotFoundError(requestId);
+  }
+
+  await appendSecurityAudit({
+    actorType: "user",
+    actorId: currentUser.id,
+    action: "inbox.note_deleted",
+    entityType: "internal_note",
+    entityId: noteId,
+    result: "recorded",
+    policyCode: "inbox.note",
+    metadataJson: {
+      contactId,
+      noteId,
+    },
+  });
+
+  if (contactId !== null) {
+    revalidateInboxContact(contactId);
+  }
+
+  return {
+    ok: true,
+    data: {
+      noteId,
+    },
+    requestId,
+  };
+}
+
 export async function sendComposerAction(
-  rawInput: ComposerSendActionInput
+  rawInput: ComposerSendActionInput,
 ): Promise<ComposerSendActionResult> {
   const requestId = randomUUID();
   const parsedInput = composerSendActionInputSchema.safeParse(rawInput);
@@ -526,7 +955,7 @@ export async function sendComposerAction(
         parsedInput.error.issues.map((issue) => [
           issue.path.join("."),
           issue.message,
-        ])
+        ]),
       ),
     });
   }
@@ -564,7 +993,7 @@ export async function sendComposerAction(
 
   const runtime = await getStage1WebRuntime();
   const alias = await runtime.settings.aliases.findByAlias(
-    parsedInput.data.alias.trim().toLowerCase()
+    parsedInput.data.alias.trim().toLowerCase(),
   );
 
   if (alias === null) {
@@ -584,7 +1013,7 @@ export async function sendComposerAction(
 
   if (parsedInput.data.recipient.kind === "contact") {
     const contact = await runtime.repositories.contacts.findById(
-      parsedInput.data.recipient.contactId
+      parsedInput.data.recipient.contactId,
     );
 
     if (contact === null) {
@@ -598,7 +1027,7 @@ export async function sendComposerAction(
     });
   } else {
     toEmailNormalized = normalizeEmailAddress(
-      parsedInput.data.recipient.emailAddress
+      parsedInput.data.recipient.emailAddress,
     );
 
     if (toEmailNormalized === null) {
@@ -617,8 +1046,13 @@ export async function sendComposerAction(
     return mapComposerProviderError(requestId, "invalid_recipient");
   }
 
-  const signature = readAliasSignature(alias as unknown as Record<string, unknown>);
-  const bodyPlaintext = appendSignature(parsedInput.data.bodyPlaintext, signature);
+  const signature = readAliasSignature(
+    alias as unknown as Record<string, unknown>,
+  );
+  const bodyPlaintext = appendSignature(
+    parsedInput.data.bodyPlaintext,
+    signature,
+  );
   const fingerprint = computePendingComposerOutboundFingerprint({
     contactId: canonicalContactId,
     subject: parsedInput.data.subject,
@@ -711,7 +1145,7 @@ export async function sendComposerAction(
 
       if (parsedInput.data.supersedesPendingId !== undefined) {
         await runtime.repositories.pendingOutbounds.markSuperseded(
-          parsedInput.data.supersedesPendingId
+          parsedInput.data.supersedesPendingId,
         );
       }
 

--- a/apps/web/app/settings/_lib/project-alias-signature.ts
+++ b/apps/web/app/settings/_lib/project-alias-signature.ts
@@ -1,20 +1,22 @@
+import {
+  containsHtmlTags,
+  trimTrailingWhitespace,
+} from "@/src/lib/plaintext-validation";
+
 export const PROJECT_ALIAS_SIGNATURE_MAX_LENGTH = 2000;
 
-const PROJECT_ALIAS_SIGNATURE_HTML_PATTERN = /<[^>]+>/u;
-const TRAILING_WHITESPACE_PATTERN = /[^\S\r\n]+$/gmu;
-
 export function normalizeProjectAliasSignature(signature: string): string {
-  return signature.replace(TRAILING_WHITESPACE_PATTERN, "");
+  return trimTrailingWhitespace(signature);
 }
 
 export function getProjectAliasSignatureValidationError(
-  signature: string
+  signature: string,
 ): string | null {
   if (signature.length > PROJECT_ALIAS_SIGNATURE_MAX_LENGTH) {
     return `Signature must be ${String(PROJECT_ALIAS_SIGNATURE_MAX_LENGTH)} characters or fewer.`;
   }
 
-  if (PROJECT_ALIAS_SIGNATURE_HTML_PATTERN.test(signature)) {
+  if (containsHtmlTags(signature)) {
     return "Signature must be plain text only.";
   }
 

--- a/apps/web/src/lib/internal-note-validation.ts
+++ b/apps/web/src/lib/internal-note-validation.ts
@@ -1,0 +1,28 @@
+import {
+  containsHtmlTags,
+  trimTrailingWhitespace,
+} from "./plaintext-validation";
+
+export const INTERNAL_NOTE_MAX_LENGTH = 10_000;
+
+export function normalizeInternalNoteBody(body: string): string {
+  return trimTrailingWhitespace(body);
+}
+
+export function getInternalNoteValidationError(body: string): string | null {
+  const normalized = normalizeInternalNoteBody(body);
+
+  if (normalized.trim().length === 0) {
+    return "Note body is required.";
+  }
+
+  if (normalized.length > INTERNAL_NOTE_MAX_LENGTH) {
+    return `Note body must be ${String(INTERNAL_NOTE_MAX_LENGTH)} characters or fewer.`;
+  }
+
+  if (containsHtmlTags(normalized)) {
+    return "Note body must be plain text only.";
+  }
+
+  return null;
+}

--- a/apps/web/src/lib/plaintext-validation.ts
+++ b/apps/web/src/lib/plaintext-validation.ts
@@ -1,0 +1,10 @@
+export const PLAINTEXT_HTML_TAG_PATTERN = /<[^>]+>/u;
+export const TRAILING_WHITESPACE_PATTERN = /[^\S\r\n]+$/gmu;
+
+export function trimTrailingWhitespace(value: string): string {
+  return value.replace(TRAILING_WHITESPACE_PATTERN, "");
+}
+
+export function containsHtmlTags(value: string): boolean {
+  return PLAINTEXT_HTML_TAG_PATTERN.test(value);
+}

--- a/apps/web/src/server/stage1-runtime.test-support.ts
+++ b/apps/web/src/server/stage1-runtime.test-support.ts
@@ -12,11 +12,14 @@
  * and related helpers.
  */
 import type { TestStage1Context } from "@as-comms/db/test-helpers";
-import { createStage1TimelinePresentationService } from "@as-comms/domain";
+import {
+  createStage1InternalNoteService,
+  createStage1TimelinePresentationService,
+} from "@as-comms/domain";
 
 import {
   setStage1WebRuntimeForTests,
-  type Stage1WebRuntime
+  type Stage1WebRuntime,
 } from "./stage1-runtime";
 
 export type { TestStage1Context } from "@as-comms/db/test-helpers";
@@ -36,8 +39,12 @@ export async function createStage1WebTestRuntime(): Promise<Stage1WebTestRuntime
     settings: context.settings,
     normalization: context.normalization,
     timelinePresentation: createStage1TimelinePresentationService(
-      context.repositories
-    )
+      context.repositories,
+    ),
+    internalNotes: createStage1InternalNoteService({
+      persistence: context.persistence,
+      normalization: context.normalization,
+    }),
   };
   setStage1WebRuntimeForTests(runtime);
 
@@ -46,6 +53,6 @@ export async function createStage1WebTestRuntime(): Promise<Stage1WebTestRuntime
     async dispose() {
       setStage1WebRuntimeForTests(null);
       await context.client.close();
-    }
+    },
   };
 }

--- a/apps/web/src/server/stage1-runtime.ts
+++ b/apps/web/src/server/stage1-runtime.ts
@@ -6,16 +6,18 @@ import {
   sessions,
   users,
   verificationTokens,
-  type DatabaseConnection
+  type DatabaseConnection,
 } from "@as-comms/db";
 import {
+  createStage1InternalNoteService,
   createStage1NormalizationService,
   createStage1PersistenceService,
   createStage1TimelinePresentationService,
+  type Stage1InternalNoteService,
   type Stage1NormalizationService,
   type Stage1RepositoryBundle,
   type Stage1TimelinePresentationService,
-  type Stage2RepositoryBundle
+  type Stage2RepositoryBundle,
 } from "@as-comms/domain";
 
 // Re-export the Auth.js adapter tables so `apps/web/src/server/auth/index.ts`
@@ -28,7 +30,7 @@ export const authAdapterTables = {
   usersTable: users,
   accountsTable: accounts,
   sessionsTable: sessions,
-  verificationTokensTable: verificationTokens
+  verificationTokensTable: verificationTokens,
 } as const;
 
 /**
@@ -53,6 +55,7 @@ export interface Stage1WebRuntime {
   readonly settings: Stage2RepositoryBundle;
   readonly normalization: Stage1NormalizationService;
   readonly timelinePresentation: Stage1TimelinePresentationService;
+  readonly internalNotes: Stage1InternalNoteService;
 }
 
 let runtimeOverride: Stage1WebRuntime | null = null;
@@ -62,23 +65,30 @@ function createRuntime(): Stage1WebRuntime {
   const connectionString = process.env.DATABASE_URL;
 
   if (!connectionString) {
-    throw new Error("DATABASE_URL must be set before using the Stage 1 inbox runtime.");
+    throw new Error(
+      "DATABASE_URL must be set before using the Stage 1 inbox runtime.",
+    );
   }
 
   const connection = createDatabaseConnection({
-    connectionString
+    connectionString,
   });
   const repositories = createStage1RepositoryBundleFromConnection(connection);
   const settings = createStage2RepositoryBundleFromConnection(connection);
   const persistence = createStage1PersistenceService(repositories);
   const normalization = createStage1NormalizationService(persistence);
+  const internalNotes = createStage1InternalNoteService({
+    persistence,
+    normalization,
+  });
 
   return {
     connection,
     repositories,
     settings,
     normalization,
-    timelinePresentation: createStage1TimelinePresentationService(repositories)
+    timelinePresentation: createStage1TimelinePresentationService(repositories),
+    internalNotes,
   };
 }
 
@@ -97,7 +107,7 @@ export async function getSettingsRepositories(): Promise<Stage2RepositoryBundle>
 }
 
 export function setStage1WebRuntimeForTests(
-  runtime: Stage1WebRuntime | null
+  runtime: Stage1WebRuntime | null,
 ): void {
   runtimeOverride = runtime;
   runtimePromise = null;

--- a/apps/web/tests/unit/inbox-stage1-helpers.ts
+++ b/apps/web/tests/unit/inbox-stage1-helpers.ts
@@ -707,6 +707,7 @@ export async function seedInboxInternalNoteEvent(
     readonly occurredAt: string;
     readonly body: string;
     readonly authorDisplayName: string;
+    readonly authorId?: string | null;
   },
 ): Promise<{ readonly canonicalEventId: string }> {
   const sourceEvidenceId = `source:${input.id}`;
@@ -754,6 +755,7 @@ export async function seedInboxInternalNoteEvent(
     providerRecordId: input.id,
     body: input.body,
     authorDisplayName: input.authorDisplayName,
+    authorId: input.authorId ?? null,
   });
 
   await context.repositories.timelineProjection.upsert({

--- a/apps/web/tests/unit/inbox-timeline.test.ts
+++ b/apps/web/tests/unit/inbox-timeline.test.ts
@@ -4,6 +4,11 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 Object.assign(globalThis, { React });
 
+vi.mock("../../app/inbox/actions", () => ({
+  updateNoteAction: vi.fn(),
+  deleteNoteAction: vi.fn(),
+}));
+
 vi.mock("@/components/ui/divider-label", () => ({
   DividerLabel: ({ children }: { readonly children?: React.ReactNode }) =>
     createElement("span", null, children),
@@ -65,6 +70,7 @@ describe("InboxTimeline", () => {
       createElement(InboxTimeline, {
         entries: [baseEntry],
         volunteerFirstName: "Alice",
+        currentOperatorUserId: "user:operator",
       }),
     );
 
@@ -87,6 +93,7 @@ describe("InboxTimeline", () => {
           },
         ],
         volunteerFirstName: "Alice",
+        currentOperatorUserId: "user:operator",
       }),
     );
 

--- a/apps/web/tests/unit/stage3-note-actions.test.ts
+++ b/apps/web/tests/unit/stage3-note-actions.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createStage1InternalNoteService } from "@as-comms/domain";
+
+const revalidateTag = vi.hoisted(() => vi.fn());
+const revalidatePath = vi.hoisted(() => vi.fn());
+const requireSession = vi.hoisted(() => vi.fn());
+
+vi.mock("next/cache", () => ({
+  unstable_cache: (loader: () => unknown) => loader,
+  revalidateTag,
+  revalidatePath,
+}));
+
+vi.mock("@/src/server/auth/session", () => ({
+  requireSession,
+}));
+
+import {
+  createNoteAction,
+  deleteNoteAction,
+  updateNoteAction,
+} from "../../app/inbox/actions";
+import { resetSecurityRateLimiterForTests } from "../../src/server/security/rate-limit";
+import {
+  createStage1WebTestRuntime,
+  type Stage1WebTestRuntime,
+} from "../../src/server/stage1-runtime.test-support";
+
+function buildCurrentUser(input?: {
+  readonly id?: string;
+  readonly name?: string | null;
+  readonly email?: string;
+}) {
+  const now = new Date("2026-04-21T12:00:00.000Z");
+
+  return {
+    id: input?.id ?? "user:operator",
+    name: input?.name ?? "Operator Name",
+    email: input?.email ?? "operator@example.org",
+    emailVerified: now,
+    image: null,
+    role: "operator" as const,
+    deactivatedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+async function seedOperator(
+  runtime: Stage1WebTestRuntime,
+  user = buildCurrentUser(),
+): Promise<void> {
+  await runtime.context.settings.users.upsert(user);
+}
+
+async function seedContact(runtime: Stage1WebTestRuntime): Promise<void> {
+  await runtime.context.repositories.contacts.upsert({
+    id: "contact:existing",
+    salesforceContactId: null,
+    displayName: "Existing Contact",
+    primaryEmail: "existing@example.org",
+    primaryPhone: null,
+    createdAt: "2026-04-21T12:00:00.000Z",
+    updatedAt: "2026-04-21T12:00:00.000Z",
+  });
+}
+
+describe("note server actions", () => {
+  let runtime: Stage1WebTestRuntime | null = null;
+
+  beforeEach(async () => {
+    revalidateTag.mockReset();
+    revalidatePath.mockReset();
+    requireSession.mockReset();
+    resetSecurityRateLimiterForTests();
+    requireSession.mockResolvedValue(buildCurrentUser());
+    runtime = await createStage1WebTestRuntime();
+    await seedOperator(runtime);
+    await seedContact(runtime);
+  });
+
+  afterEach(async () => {
+    resetSecurityRateLimiterForTests();
+    await runtime?.dispose();
+    runtime = null;
+  });
+
+  it("creates an authored note, records audit, and revalidates the inbox contact", async () => {
+    const result = await createNoteAction({
+      contactId: "contact:existing",
+      body: "Call back on Thursday",
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        contactId: "contact:existing",
+      },
+    });
+
+    if (!runtime || !result.ok) {
+      throw new Error("Expected runtime and successful result.");
+    }
+
+    const sourceEvidenceId = `source-evidence:manual:note:${result.data.noteId}`;
+    const notes =
+      await runtime.context.repositories.manualNoteDetails.listBySourceEvidenceIds(
+        [sourceEvidenceId],
+      );
+    const audits =
+      await runtime.context.repositories.auditEvidence.listByEntity({
+        entityType: "internal_note",
+        entityId: result.data.noteId,
+      });
+
+    expect(notes).toEqual([
+      expect.objectContaining({
+        sourceEvidenceId,
+        body: "Call back on Thursday",
+        authorDisplayName: "Operator Name",
+        authorId: "user:operator",
+      }),
+    ]);
+    expect(audits.map((audit) => audit.action)).toEqual(["inbox.note_created"]);
+    expect(revalidateTag).toHaveBeenCalledTimes(3);
+    expect(revalidateTag).toHaveBeenNthCalledWith(1, "inbox");
+    expect(revalidateTag).toHaveBeenNthCalledWith(
+      2,
+      "inbox:contact:contact:existing",
+    );
+    expect(revalidateTag).toHaveBeenNthCalledWith(
+      3,
+      "timeline:contact:contact:existing",
+    );
+  });
+
+  it("rejects invalid note bodies", async () => {
+    await expect(
+      createNoteAction({
+        contactId: "contact:existing",
+        body: "   ",
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      code: "validation_error",
+    });
+
+    await expect(
+      createNoteAction({
+        contactId: "contact:existing",
+        body: "a".repeat(10_001),
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      code: "validation_error",
+    });
+
+    await expect(
+      createNoteAction({
+        contactId: "contact:existing",
+        body: "<b>not plaintext</b>",
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      code: "validation_error",
+    });
+  });
+
+  it("returns forbidden when another operator tries to update a note", async () => {
+    if (runtime === null) {
+      throw new Error("Expected runtime.");
+    }
+
+    await runtime.context.settings.users.upsert(
+      buildCurrentUser({
+        id: "user:author",
+        name: "Author User",
+        email: "author@example.org",
+      }),
+    );
+
+    const internalNotes = createStage1InternalNoteService({
+      persistence: runtime.context.persistence,
+      normalization: runtime.context.normalization,
+    });
+
+    await internalNotes.createNote({
+      noteId: "note-update-forbidden",
+      contactId: "contact:existing",
+      body: "Original body",
+      occurredAt: "2026-04-21T12:00:00.000Z",
+      authorDisplayName: "Author User",
+      authorId: "user:author",
+    });
+
+    await expect(
+      updateNoteAction({
+        noteId: "note-update-forbidden",
+        body: "Changed body",
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      code: "forbidden",
+    });
+  });
+
+  it("returns forbidden when another operator tries to delete a note", async () => {
+    if (runtime === null) {
+      throw new Error("Expected runtime.");
+    }
+
+    await runtime.context.settings.users.upsert(
+      buildCurrentUser({
+        id: "user:author",
+        name: "Author User",
+        email: "author@example.org",
+      }),
+    );
+
+    const internalNotes = createStage1InternalNoteService({
+      persistence: runtime.context.persistence,
+      normalization: runtime.context.normalization,
+    });
+
+    await internalNotes.createNote({
+      noteId: "note-delete-forbidden",
+      contactId: "contact:existing",
+      body: "Original body",
+      occurredAt: "2026-04-21T12:00:00.000Z",
+      authorDisplayName: "Author User",
+      authorId: "user:author",
+    });
+
+    await expect(
+      deleteNoteAction({
+        noteId: "note-delete-forbidden",
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      code: "forbidden",
+    });
+  });
+
+  it("rate limits note creation after 60 requests per minute", async () => {
+    for (let index = 0; index < 60; index += 1) {
+      const result = await createNoteAction({
+        contactId: "contact:existing",
+        body: `Note ${String(index)}`,
+      });
+
+      expect(result.ok).toBe(true);
+    }
+
+    await expect(
+      createNoteAction({
+        contactId: "contact:existing",
+        body: "Rate limited note",
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      code: "rate_limit_exceeded",
+    });
+  });
+});

--- a/apps/web/tests/unit/stage3-timeline-pending.test.tsx
+++ b/apps/web/tests/unit/stage3-timeline-pending.test.tsx
@@ -6,6 +6,11 @@ import type { InboxTimelineEntryViewModel } from "../../app/inbox/_lib/view-mode
 
 Object.assign(globalThis, { React });
 
+vi.mock("../../app/inbox/actions", () => ({
+  updateNoteAction: vi.fn(),
+  deleteNoteAction: vi.fn(),
+}));
+
 vi.mock("@/components/ui/divider-label", () => ({
   DividerLabel: ({ children }: { readonly children?: React.ReactNode }) =>
     createElement("span", null, children),
@@ -70,6 +75,7 @@ describe("stage3 pending timeline rendering", () => {
       createElement(InboxTimeline, {
         entries: [buildEntry()],
         volunteerFirstName: "Alice",
+        currentOperatorUserId: "user:operator",
       }),
     );
 
@@ -82,6 +88,7 @@ describe("stage3 pending timeline rendering", () => {
       createElement(InboxTimeline, {
         entries: [buildEntry({ sendStatus: "failed" })],
         volunteerFirstName: "Alice",
+        currentOperatorUserId: "user:operator",
         onRetryPending: vi.fn(),
       }),
     );
@@ -100,6 +107,7 @@ describe("stage3 pending timeline rendering", () => {
           }),
         ],
         volunteerFirstName: "Alice",
+        currentOperatorUserId: "user:operator",
         onRetryPending: vi.fn(),
       }),
     );

--- a/packages/contracts/src/stage1-records.ts
+++ b/packages/contracts/src/stage1-records.ts
@@ -21,7 +21,7 @@ import {
   routingReviewReasonCodeSchema,
   syncScopeSchema,
   syncJobTypeSchema,
-  syncStatusSchema
+  syncStatusSchema,
 } from "./stage1-taxonomy.js";
 
 const idSchema = z.string().min(1);
@@ -35,7 +35,7 @@ const nullableStringSchema = z.string().min(1).nullable();
 export const communicationCampaignRefSchema = z.object({
   providerCampaignId: nullableStringSchema.default(null),
   providerAudienceId: nullableStringSchema.default(null),
-  providerMessageName: nullableStringSchema.default(null)
+  providerMessageName: nullableStringSchema.default(null),
 });
 export type CommunicationCampaignRef = z.infer<
   typeof communicationCampaignRefSchema
@@ -43,7 +43,7 @@ export type CommunicationCampaignRef = z.infer<
 
 export const communicationThreadRefSchema = z.object({
   crossProviderCollapseKey: nullableStringSchema.default(null),
-  providerThreadId: nullableStringSchema.default(null)
+  providerThreadId: nullableStringSchema.default(null),
 });
 export type CommunicationThreadRef = z.infer<
   typeof communicationThreadRefSchema
@@ -65,7 +65,7 @@ export const canonicalEventProvenanceSchema = z.object({
     .enum(["forwarded_chain"])
     .nullable()
     .optional(),
-  notes: z.string().min(1).nullable().optional()
+  notes: z.string().min(1).nullable().optional(),
 });
 export type CanonicalEventProvenance = z.infer<
   typeof canonicalEventProvenanceSchema
@@ -80,7 +80,7 @@ export const sourceEvidenceSchema = z.object({
   occurredAt: timestampSchema,
   payloadRef: z.string().min(1),
   idempotencyKey: z.string().min(1),
-  checksum: z.string().min(1)
+  checksum: z.string().min(1),
 });
 export type SourceEvidenceRecord = z.infer<typeof sourceEvidenceSchema>;
 
@@ -95,13 +95,13 @@ export const canonicalEventSchema = z
     sourceEvidenceId: idSchema,
     idempotencyKey: z.string().min(1),
     provenance: canonicalEventProvenanceSchema,
-    reviewState: reviewStateSchema
+    reviewState: reviewStateSchema,
   })
   .superRefine((value, context) => {
     if (value.channel !== resolveCanonicalChannel(value.eventType)) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
-        message: "channel must match the canonical event type"
+        message: "channel must match the canonical event type",
       });
     }
 
@@ -109,7 +109,7 @@ export const canonicalEventSchema = z
       context.addIssue({
         code: z.ZodIssueCode.custom,
         message:
-          "sourceEvidenceId must match provenance.primarySourceEvidenceId"
+          "sourceEvidenceId must match provenance.primarySourceEvidenceId",
       });
     }
   });
@@ -122,7 +122,7 @@ export const contactSchema = z.object({
   primaryEmail: z.string().min(1).nullable(),
   primaryPhone: z.string().min(1).nullable(),
   createdAt: timestampSchema,
-  updatedAt: timestampSchema
+  updatedAt: timestampSchema,
 });
 export type ContactRecord = z.infer<typeof contactSchema>;
 
@@ -133,7 +133,7 @@ export const contactIdentitySchema = z.object({
   normalizedValue: z.string().min(1),
   isPrimary: z.boolean(),
   source: recordSourceSchema,
-  verifiedAt: optionalTimestampSchema
+  verifiedAt: optionalTimestampSchema,
 });
 export type ContactIdentityRecord = z.infer<typeof contactIdentitySchema>;
 
@@ -144,7 +144,7 @@ export const contactMembershipSchema = z.object({
   expeditionId: z.string().min(1).nullable(),
   role: z.string().min(1).nullable(),
   status: z.string().min(1).nullable(),
-  source: recordSourceSchema
+  source: recordSourceSchema,
 });
 export type ContactMembershipRecord = z.infer<typeof contactMembershipSchema>;
 
@@ -154,7 +154,7 @@ export const projectDimensionSchema = z.object({
   source: recordSourceSchema,
   isActive: z.boolean().optional(),
   aiKnowledgeUrl: nullableStringSchema.optional(),
-  aiKnowledgeSyncedAt: optionalTimestampSchema.optional()
+  aiKnowledgeSyncedAt: optionalTimestampSchema.optional(),
 });
 export type ProjectDimensionRecord = z.infer<typeof projectDimensionSchema>;
 
@@ -162,7 +162,7 @@ export const expeditionDimensionSchema = z.object({
   expeditionId: idSchema,
   projectId: nullableStringSchema,
   expeditionName: z.string().min(1),
-  source: recordSourceSchema
+  source: recordSourceSchema,
 });
 export type ExpeditionDimensionRecord = z.infer<
   typeof expeditionDimensionSchema
@@ -181,7 +181,7 @@ export const gmailMessageDetailSchema = z.object({
   snippetClean: z.string(),
   bodyTextPreview: z.string(),
   capturedMailbox: nullableStringSchema,
-  projectInboxAlias: nullableStringSchema
+  projectInboxAlias: nullableStringSchema,
 });
 export type GmailMessageDetailRecord = z.infer<typeof gmailMessageDetailSchema>;
 
@@ -190,7 +190,7 @@ export const salesforceEventContextSchema = z.object({
   salesforceContactId: nullableStringSchema,
   projectId: nullableStringSchema,
   expeditionId: nullableStringSchema,
-  sourceField: nullableStringSchema.default(null)
+  sourceField: nullableStringSchema.default(null),
 });
 export type SalesforceEventContextRecord = z.infer<
   typeof salesforceEventContextSchema
@@ -203,7 +203,7 @@ export const salesforceCommunicationDetailSchema = z.object({
   messageKind: communicationMessageKindSchema,
   subject: nullableStringSchema,
   snippet: z.string(),
-  sourceLabel: z.string().min(1)
+  sourceLabel: z.string().min(1),
 });
 export type SalesforceCommunicationDetailRecord = z.infer<
   typeof salesforceCommunicationDetailSchema
@@ -219,7 +219,7 @@ export const simpleTextingMessageDetailSchema = z.object({
   campaignId: nullableStringSchema,
   campaignName: nullableStringSchema,
   providerThreadId: nullableStringSchema,
-  threadKey: nullableStringSchema
+  threadKey: nullableStringSchema,
 });
 export type SimpleTextingMessageDetailRecord = z.infer<
   typeof simpleTextingMessageDetailSchema
@@ -233,7 +233,7 @@ export const mailchimpCampaignActivityDetailSchema = z.object({
   audienceId: nullableStringSchema,
   memberId: nullableStringSchema,
   campaignName: nullableStringSchema,
-  snippet: z.string()
+  snippet: z.string(),
 });
 export type MailchimpCampaignActivityDetailRecord = z.infer<
   typeof mailchimpCampaignActivityDetailSchema
@@ -243,7 +243,8 @@ export const manualNoteDetailSchema = z.object({
   sourceEvidenceId: idSchema,
   providerRecordId: z.string().min(1),
   body: z.string().min(1),
-  authorDisplayName: nullableStringSchema.default(null)
+  authorDisplayName: nullableStringSchema.default(null),
+  authorId: nullableStringSchema.default(null),
 });
 export type ManualNoteDetailRecord = z.infer<typeof manualNoteDetailSchema>;
 
@@ -258,13 +259,13 @@ export const identityResolutionSchema = z
     resolvedAt: optionalTimestampSchema,
     normalizedIdentityValues: stringArraySchema.default([]),
     anchoredContactId: optionalIdSchema,
-    explanation: z.string().min(1)
+    explanation: z.string().min(1),
   })
   .superRefine((value, context) => {
     if (value.status === "resolved" && value.resolvedAt === null) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
-        message: "resolved identity cases must include resolvedAt"
+        message: "resolved identity cases must include resolvedAt",
       });
     }
   });
@@ -280,13 +281,13 @@ export const routingReviewSchema = z
     openedAt: timestampSchema,
     resolvedAt: optionalTimestampSchema,
     candidateMembershipIds: stringArraySchema.default([]),
-    explanation: z.string().min(1)
+    explanation: z.string().min(1),
   })
   .superRefine((value, context) => {
     if (value.status === "resolved" && value.resolvedAt === null) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
-        message: "resolved routing cases must include resolvedAt"
+        message: "resolved routing cases must include resolvedAt",
       });
     }
   });
@@ -303,14 +304,14 @@ export const inboxProjectionSchema = z
     lastActivityAt: timestampSchema,
     snippet: z.string(),
     lastCanonicalEventId: idSchema,
-    lastEventType: inboxDrivingEventTypeSchema
+    lastEventType: inboxDrivingEventTypeSchema,
   })
   .superRefine((value, context) => {
     if (value.lastInboundAt === null && value.lastOutboundAt === null) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
         message:
-          "an inbox projection must include at least one inbound or outbound timestamp"
+          "an inbox projection must include at least one inbound or outbound timestamp",
       });
     }
 
@@ -322,7 +323,7 @@ export const inboxProjectionSchema = z
       context.addIssue({
         code: z.ZodIssueCode.custom,
         message:
-          "outbound-only inbox rows must set lastActivityAt to lastOutboundAt"
+          "outbound-only inbox rows must set lastActivityAt to lastOutboundAt",
       });
     }
 
@@ -333,7 +334,7 @@ export const inboxProjectionSchema = z
       context.addIssue({
         code: z.ZodIssueCode.custom,
         message:
-          "lastActivityAt must be at least as recent as lastInboundAt when inbound history exists"
+          "lastActivityAt must be at least as recent as lastInboundAt when inbound history exists",
       });
     }
 
@@ -353,7 +354,7 @@ export const inboxProjectionSchema = z
       context.addIssue({
         code: z.ZodIssueCode.custom,
         message:
-          "lastActivityAt must equal the newest inbound or outbound timestamp"
+          "lastActivityAt must equal the newest inbound or outbound timestamp",
       });
     }
   });
@@ -370,47 +371,49 @@ export const timelineProjectionSchema = z
     summary: z.string().min(1),
     channel: channelSchema,
     primaryProvider: providerSchema,
-    reviewState: reviewStateSchema
+    reviewState: reviewStateSchema,
   })
   .superRefine((value, context) => {
     if (value.channel !== resolveCanonicalChannel(value.eventType)) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
-        message: "timeline channel must match the canonical event type"
+        message: "timeline channel must match the canonical event type",
       });
     }
   });
 export type TimelineProjectionRow = z.infer<typeof timelineProjectionSchema>;
 
-export const syncStateSchema = z.object({
-  id: idSchema,
-  scope: syncScopeSchema,
-  provider: providerSchema.nullable(),
-  jobType: syncJobTypeSchema,
-  cursor: z.string().min(1).nullable(),
-  windowStart: optionalTimestampSchema,
-  windowEnd: optionalTimestampSchema,
-  status: syncStatusSchema,
-  parityPercent: z.number().min(0).max(100).nullable(),
-  freshnessP95Seconds: z.number().int().nonnegative().nullable(),
-  freshnessP99Seconds: z.number().int().nonnegative().nullable(),
-  lastSuccessfulAt: optionalTimestampSchema,
-  deadLetterCount: z.number().int().nonnegative()
-}).superRefine((value, context) => {
-  if (value.scope === "provider" && value.provider === null) {
-    context.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "provider-scoped sync state must include a provider"
-    });
-  }
+export const syncStateSchema = z
+  .object({
+    id: idSchema,
+    scope: syncScopeSchema,
+    provider: providerSchema.nullable(),
+    jobType: syncJobTypeSchema,
+    cursor: z.string().min(1).nullable(),
+    windowStart: optionalTimestampSchema,
+    windowEnd: optionalTimestampSchema,
+    status: syncStatusSchema,
+    parityPercent: z.number().min(0).max(100).nullable(),
+    freshnessP95Seconds: z.number().int().nonnegative().nullable(),
+    freshnessP99Seconds: z.number().int().nonnegative().nullable(),
+    lastSuccessfulAt: optionalTimestampSchema,
+    deadLetterCount: z.number().int().nonnegative(),
+  })
+  .superRefine((value, context) => {
+    if (value.scope === "provider" && value.provider === null) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "provider-scoped sync state must include a provider",
+      });
+    }
 
-  if (value.scope === "orchestration" && value.provider !== null) {
-    context.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "orchestration-scoped sync state must not include a provider"
-    });
-  }
-});
+    if (value.scope === "orchestration" && value.provider !== null) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "orchestration-scoped sync state must not include a provider",
+      });
+    }
+  });
 export type SyncStateRecord = z.infer<typeof syncStateSchema>;
 
 export const auditEvidenceSchema = z.object({
@@ -423,6 +426,6 @@ export const auditEvidenceSchema = z.object({
   occurredAt: timestampSchema,
   result: auditResultSchema,
   policyCode: z.string().min(1),
-  metadataJson: metadataJsonSchema
+  metadataJson: metadataJsonSchema,
 });
 export type AuditEvidenceRecord = z.infer<typeof auditEvidenceSchema>;

--- a/packages/contracts/src/stage1-timeline.ts
+++ b/packages/contracts/src/stage1-timeline.ts
@@ -1,9 +1,6 @@
 import { z } from "zod";
 
-import {
-  providerSchema,
-  reviewStateSchema
-} from "./stage1-taxonomy.js";
+import { providerSchema, reviewStateSchema } from "./stage1-taxonomy.js";
 
 const idSchema = z.string().min(1);
 const timestampSchema = z.string().datetime();
@@ -15,13 +12,13 @@ const timelineFamilySchema = z.enum([
   "campaign_sms",
   "one_to_one_email",
   "one_to_one_sms",
-  "internal_note"
+  "internal_note",
 ]);
 const campaignEmailActivityTypeSchema = z.enum([
   "sent",
   "opened",
   "clicked",
-  "unsubscribed"
+  "unsubscribed",
 ]);
 
 const timelineItemBaseSchema = z.object({
@@ -33,7 +30,7 @@ const timelineItemBaseSchema = z.object({
   sortKey: z.string().min(1),
   reviewState: reviewStateSchema,
   primaryProvider: providerSchema,
-  summary: z.string().min(1)
+  summary: z.string().min(1),
 });
 
 export const salesforceTimelineItemSchema = timelineItemBaseSchema.extend({
@@ -42,11 +39,11 @@ export const salesforceTimelineItemSchema = timelineItemBaseSchema.extend({
     "signed_up",
     "received_training",
     "completed_training",
-    "submitted_first_data"
+    "submitted_first_data",
   ]),
   projectName: nullableStringSchema,
   expeditionName: nullableStringSchema,
-  sourceField: nullableStringSchema
+  sourceField: nullableStringSchema,
 });
 export type SalesforceTimelineItem = z.infer<
   typeof salesforceTimelineItemSchema
@@ -57,7 +54,7 @@ export const autoEmailTimelineItemSchema = timelineItemBaseSchema.extend({
   direction: z.literal("outbound"),
   subject: nullableStringSchema,
   snippet: z.string(),
-  sourceLabel: z.string().min(1)
+  sourceLabel: z.string().min(1),
 });
 export type AutoEmailTimelineItem = z.infer<typeof autoEmailTimelineItemSchema>;
 
@@ -65,7 +62,7 @@ export const autoSmsTimelineItemSchema = timelineItemBaseSchema.extend({
   family: z.literal("auto_sms"),
   direction: z.literal("outbound"),
   messageTextPreview: z.string(),
-  sourceLabel: z.string().min(1)
+  sourceLabel: z.string().min(1),
 });
 export type AutoSmsTimelineItem = z.infer<typeof autoSmsTimelineItemSchema>;
 
@@ -75,7 +72,7 @@ export const campaignEmailTimelineItemSchema = timelineItemBaseSchema.extend({
   campaignName: nullableStringSchema,
   campaignId: nullableStringSchema,
   audienceId: nullableStringSchema,
-  snippet: z.string()
+  snippet: z.string(),
 });
 export type CampaignEmailTimelineItem = z.infer<
   typeof campaignEmailTimelineItemSchema
@@ -86,7 +83,7 @@ export const campaignSmsTimelineItemSchema = timelineItemBaseSchema.extend({
   direction: z.literal("outbound"),
   messageTextPreview: z.string(),
   campaignName: nullableStringSchema,
-  campaignId: nullableStringSchema
+  campaignId: nullableStringSchema,
 });
 export type CampaignSmsTimelineItem = z.infer<
   typeof campaignSmsTimelineItemSchema
@@ -103,7 +100,7 @@ export const oneToOneEmailTimelineItemSchema = timelineItemBaseSchema.extend({
   rfc822MessageId: nullableStringSchema.optional(),
   inReplyToRfc822: nullableStringSchema.optional(),
   sendStatus: z.enum(["pending", "failed", "orphaned"]).nullable().optional(),
-  attachmentCount: z.number().int().nonnegative().optional()
+  attachmentCount: z.number().int().nonnegative().optional(),
 });
 export type OneToOneEmailTimelineItem = z.infer<
   typeof oneToOneEmailTimelineItemSchema
@@ -114,7 +111,7 @@ export const oneToOneSmsTimelineItemSchema = timelineItemBaseSchema.extend({
   direction: z.enum(["inbound", "outbound"]),
   messageTextPreview: z.string(),
   phone: nullableStringSchema,
-  threadKey: nullableStringSchema
+  threadKey: nullableStringSchema,
 });
 export type OneToOneSmsTimelineItem = z.infer<
   typeof oneToOneSmsTimelineItemSchema
@@ -122,8 +119,10 @@ export type OneToOneSmsTimelineItem = z.infer<
 
 export const internalNoteTimelineItemSchema = timelineItemBaseSchema.extend({
   family: z.literal("internal_note"),
+  noteId: z.string().min(1),
   body: z.string().min(1),
-  authorDisplayName: nullableStringSchema
+  authorDisplayName: nullableStringSchema,
+  authorId: nullableStringSchema.default(null),
 });
 export type InternalNoteTimelineItem = z.infer<
   typeof internalNoteTimelineItemSchema
@@ -137,7 +136,7 @@ export const timelineItemSchema = z.discriminatedUnion("family", [
   campaignSmsTimelineItemSchema,
   oneToOneEmailTimelineItemSchema,
   oneToOneSmsTimelineItemSchema,
-  internalNoteTimelineItemSchema
+  internalNoteTimelineItemSchema,
 ]);
 export type TimelineItem = z.infer<typeof timelineItemSchema>;
 

--- a/packages/db/drizzle/0011_manual_note_author.sql
+++ b/packages/db/drizzle/0011_manual_note_author.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "manual_note_details" ADD COLUMN "author_id" text REFERENCES "users"("id") ON DELETE SET NULL;
+
+CREATE INDEX "manual_note_details_author_idx" ON "manual_note_details" ("author_id");

--- a/packages/db/src/mappers.ts
+++ b/packages/db/src/mappers.ts
@@ -38,13 +38,13 @@ import {
   type SimpleTextingMessageDetailRecord,
   type SourceEvidenceRecord,
   type SyncStateRecord,
-  type TimelineProjectionRow
+  type TimelineProjectionRow,
 } from "@as-comms/contracts";
 
 import type {
   PendingComposerOutboundRecord,
   ProjectAliasRecord,
-  UserRecord
+  UserRecord,
 } from "@as-comms/domain";
 
 import type {
@@ -70,7 +70,7 @@ import type {
   simpleTextingMessageDetails,
   sourceEvidenceLog,
   syncState,
-  users
+  users,
 } from "./schema/index.js";
 
 type SourceEvidenceRow = typeof sourceEvidenceLog.$inferSelect;
@@ -108,7 +108,9 @@ function toDate(value: string): Date {
   return new Date(value);
 }
 
-export function mapSourceEvidenceRow(row: SourceEvidenceRow): SourceEvidenceRecord {
+export function mapSourceEvidenceRow(
+  row: SourceEvidenceRow,
+): SourceEvidenceRecord {
   return sourceEvidenceSchema.parse({
     id: row.id,
     provider: row.provider,
@@ -118,12 +120,12 @@ export function mapSourceEvidenceRow(row: SourceEvidenceRow): SourceEvidenceReco
     occurredAt: row.occurredAt.toISOString(),
     payloadRef: row.payloadRef,
     idempotencyKey: row.idempotencyKey,
-    checksum: row.checksum
+    checksum: row.checksum,
   });
 }
 
 export function mapSourceEvidenceToInsert(
-  record: SourceEvidenceRecord
+  record: SourceEvidenceRecord,
 ): typeof sourceEvidenceLog.$inferInsert {
   const parsed = sourceEvidenceSchema.parse(record);
 
@@ -136,11 +138,13 @@ export function mapSourceEvidenceToInsert(
     occurredAt: toDate(parsed.occurredAt),
     payloadRef: parsed.payloadRef,
     idempotencyKey: parsed.idempotencyKey,
-    checksum: parsed.checksum
+    checksum: parsed.checksum,
   };
 }
 
-export function mapCanonicalEventRow(row: CanonicalEventRow): CanonicalEventRecord {
+export function mapCanonicalEventRow(
+  row: CanonicalEventRow,
+): CanonicalEventRecord {
   return canonicalEventSchema.parse({
     id: row.id,
     contactId: row.contactId,
@@ -151,12 +155,12 @@ export function mapCanonicalEventRow(row: CanonicalEventRow): CanonicalEventReco
     sourceEvidenceId: row.sourceEvidenceId,
     idempotencyKey: row.idempotencyKey,
     provenance: row.provenance,
-    reviewState: row.reviewState
+    reviewState: row.reviewState,
   });
 }
 
 export function mapCanonicalEventToInsert(
-  record: CanonicalEventRecord
+  record: CanonicalEventRecord,
 ): typeof canonicalEventLedger.$inferInsert {
   const parsed = canonicalEventSchema.parse(record);
 
@@ -170,7 +174,7 @@ export function mapCanonicalEventToInsert(
     sourceEvidenceId: parsed.sourceEvidenceId,
     idempotencyKey: parsed.idempotencyKey,
     provenance: parsed.provenance,
-    reviewState: parsed.reviewState
+    reviewState: parsed.reviewState,
   };
 }
 
@@ -182,12 +186,12 @@ export function mapContactRow(row: ContactRow): ContactRecord {
     primaryEmail: row.primaryEmail,
     primaryPhone: row.primaryPhone,
     createdAt: row.createdAt.toISOString(),
-    updatedAt: row.updatedAt.toISOString()
+    updatedAt: row.updatedAt.toISOString(),
   });
 }
 
 export function mapContactToInsert(
-  record: ContactRecord
+  record: ContactRecord,
 ): typeof contacts.$inferInsert {
   const parsed = contactSchema.parse(record);
 
@@ -198,12 +202,12 @@ export function mapContactToInsert(
     primaryEmail: parsed.primaryEmail,
     primaryPhone: parsed.primaryPhone,
     createdAt: toDate(parsed.createdAt),
-    updatedAt: toDate(parsed.updatedAt)
+    updatedAt: toDate(parsed.updatedAt),
   };
 }
 
 export function mapContactIdentityRow(
-  row: ContactIdentityRow
+  row: ContactIdentityRow,
 ): ContactIdentityRecord {
   return contactIdentitySchema.parse({
     id: row.id,
@@ -212,12 +216,12 @@ export function mapContactIdentityRow(
     normalizedValue: row.normalizedValue,
     isPrimary: row.isPrimary,
     source: row.source,
-    verifiedAt: fromDate(row.verifiedAt)
+    verifiedAt: fromDate(row.verifiedAt),
   });
 }
 
 export function mapContactIdentityToInsert(
-  record: ContactIdentityRecord
+  record: ContactIdentityRecord,
 ): typeof contactIdentities.$inferInsert {
   const parsed = contactIdentitySchema.parse(record);
 
@@ -228,12 +232,12 @@ export function mapContactIdentityToInsert(
     normalizedValue: parsed.normalizedValue,
     isPrimary: parsed.isPrimary,
     source: parsed.source,
-    verifiedAt: parsed.verifiedAt === null ? null : toDate(parsed.verifiedAt)
+    verifiedAt: parsed.verifiedAt === null ? null : toDate(parsed.verifiedAt),
   };
 }
 
 export function mapContactMembershipRow(
-  row: ContactMembershipRow
+  row: ContactMembershipRow,
 ): ContactMembershipRecord {
   return contactMembershipSchema.parse({
     id: row.id,
@@ -242,12 +246,12 @@ export function mapContactMembershipRow(
     expeditionId: row.expeditionId,
     role: row.role,
     status: row.status,
-    source: row.source
+    source: row.source,
   });
 }
 
 export function mapContactMembershipToInsert(
-  record: ContactMembershipRecord
+  record: ContactMembershipRecord,
 ): typeof contactMemberships.$inferInsert {
   const parsed = contactMembershipSchema.parse(record);
 
@@ -258,12 +262,12 @@ export function mapContactMembershipToInsert(
     expeditionId: parsed.expeditionId,
     role: parsed.role,
     status: parsed.status,
-    source: parsed.source
+    source: parsed.source,
   };
 }
 
 export function mapProjectDimensionRow(
-  row: ProjectDimensionRow
+  row: ProjectDimensionRow,
 ): ProjectDimensionRecord {
   return projectDimensionSchema.parse({
     projectId: row.projectId,
@@ -271,12 +275,12 @@ export function mapProjectDimensionRow(
     source: row.source,
     isActive: row.isActive,
     aiKnowledgeUrl: row.aiKnowledgeUrl,
-    aiKnowledgeSyncedAt: fromDate(row.aiKnowledgeSyncedAt)
+    aiKnowledgeSyncedAt: fromDate(row.aiKnowledgeSyncedAt),
   });
 }
 
 export function mapProjectDimensionToInsert(
-  record: ProjectDimensionRecord
+  record: ProjectDimensionRecord,
 ): typeof projectDimensions.$inferInsert {
   const parsed = projectDimensionSchema.parse(record);
 
@@ -290,12 +294,12 @@ export function mapProjectDimensionToInsert(
       parsed.aiKnowledgeSyncedAt === null
         ? null
         : toDate(parsed.aiKnowledgeSyncedAt),
-    source: parsed.source
+    source: parsed.source,
   };
 }
 
 export function mapIntegrationHealthRow(
-  row: IntegrationHealthRow
+  row: IntegrationHealthRow,
 ): IntegrationHealthRecord {
   return integrationHealthSchema.parse({
     id: row.id,
@@ -306,12 +310,12 @@ export function mapIntegrationHealthRow(
     detail: row.detail,
     metadataJson: row.metadataJson,
     createdAt: row.createdAt.toISOString(),
-    updatedAt: row.updatedAt.toISOString()
+    updatedAt: row.updatedAt.toISOString(),
   });
 }
 
 export function mapIntegrationHealthToInsert(
-  record: IntegrationHealthRecord
+  record: IntegrationHealthRecord,
 ): typeof integrationHealth.$inferInsert {
   const parsed = integrationHealthSchema.parse(record);
 
@@ -325,23 +329,23 @@ export function mapIntegrationHealthToInsert(
     detail: parsed.detail,
     metadataJson: parsed.metadataJson,
     createdAt: toDate(parsed.createdAt),
-    updatedAt: toDate(parsed.updatedAt)
+    updatedAt: toDate(parsed.updatedAt),
   };
 }
 
 export function mapExpeditionDimensionRow(
-  row: ExpeditionDimensionRow
+  row: ExpeditionDimensionRow,
 ): ExpeditionDimensionRecord {
   return expeditionDimensionSchema.parse({
     expeditionId: row.expeditionId,
     projectId: row.projectId,
     expeditionName: row.expeditionName,
-    source: row.source
+    source: row.source,
   });
 }
 
 export function mapExpeditionDimensionToInsert(
-  record: ExpeditionDimensionRecord
+  record: ExpeditionDimensionRecord,
 ): typeof expeditionDimensions.$inferInsert {
   const parsed = expeditionDimensionSchema.parse(record);
 
@@ -349,12 +353,12 @@ export function mapExpeditionDimensionToInsert(
     expeditionId: parsed.expeditionId,
     projectId: parsed.projectId,
     expeditionName: parsed.expeditionName,
-    source: parsed.source
+    source: parsed.source,
   };
 }
 
 export function mapGmailMessageDetailRow(
-  row: GmailMessageDetailRow
+  row: GmailMessageDetailRow,
 ): GmailMessageDetailRecord {
   return gmailMessageDetailSchema.parse({
     sourceEvidenceId: row.sourceEvidenceId,
@@ -366,12 +370,12 @@ export function mapGmailMessageDetailRow(
     snippetClean: row.snippetClean,
     bodyTextPreview: row.bodyTextPreview,
     capturedMailbox: row.capturedMailbox,
-    projectInboxAlias: row.projectInboxAlias
+    projectInboxAlias: row.projectInboxAlias,
   });
 }
 
 export function mapGmailMessageDetailToInsert(
-  record: GmailMessageDetailRecord
+  record: GmailMessageDetailRecord,
 ): typeof gmailMessageDetails.$inferInsert {
   const parsed = gmailMessageDetailSchema.parse(record);
 
@@ -385,24 +389,24 @@ export function mapGmailMessageDetailToInsert(
     snippetClean: parsed.snippetClean,
     bodyTextPreview: parsed.bodyTextPreview,
     capturedMailbox: parsed.capturedMailbox,
-    projectInboxAlias: parsed.projectInboxAlias
+    projectInboxAlias: parsed.projectInboxAlias,
   };
 }
 
 export function mapSalesforceEventContextRow(
-  row: SalesforceEventContextRow
+  row: SalesforceEventContextRow,
 ): SalesforceEventContextRecord {
   return salesforceEventContextSchema.parse({
     sourceEvidenceId: row.sourceEvidenceId,
     salesforceContactId: row.salesforceContactId,
     projectId: row.projectId,
     expeditionId: row.expeditionId,
-    sourceField: row.sourceField
+    sourceField: row.sourceField,
   });
 }
 
 export function mapSalesforceEventContextToInsert(
-  record: SalesforceEventContextRecord
+  record: SalesforceEventContextRecord,
 ): typeof salesforceEventContext.$inferInsert {
   const parsed = salesforceEventContextSchema.parse(record);
 
@@ -411,12 +415,12 @@ export function mapSalesforceEventContextToInsert(
     salesforceContactId: parsed.salesforceContactId,
     projectId: parsed.projectId,
     expeditionId: parsed.expeditionId,
-    sourceField: parsed.sourceField
+    sourceField: parsed.sourceField,
   };
 }
 
 export function mapSalesforceCommunicationDetailRow(
-  row: SalesforceCommunicationDetailRow
+  row: SalesforceCommunicationDetailRow,
 ): SalesforceCommunicationDetailRecord {
   return salesforceCommunicationDetailSchema.parse({
     sourceEvidenceId: row.sourceEvidenceId,
@@ -425,12 +429,12 @@ export function mapSalesforceCommunicationDetailRow(
     messageKind: row.messageKind,
     subject: row.subject,
     snippet: row.snippet,
-    sourceLabel: row.sourceLabel
+    sourceLabel: row.sourceLabel,
   });
 }
 
 export function mapSalesforceCommunicationDetailToInsert(
-  record: SalesforceCommunicationDetailRecord
+  record: SalesforceCommunicationDetailRecord,
 ): typeof salesforceCommunicationDetails.$inferInsert {
   const parsed = salesforceCommunicationDetailSchema.parse(record);
 
@@ -441,12 +445,12 @@ export function mapSalesforceCommunicationDetailToInsert(
     messageKind: parsed.messageKind,
     subject: parsed.subject,
     snippet: parsed.snippet,
-    sourceLabel: parsed.sourceLabel
+    sourceLabel: parsed.sourceLabel,
   };
 }
 
 export function mapSimpleTextingMessageDetailRow(
-  row: SimpleTextingMessageDetailRow
+  row: SimpleTextingMessageDetailRow,
 ): SimpleTextingMessageDetailRecord {
   return simpleTextingMessageDetailSchema.parse({
     sourceEvidenceId: row.sourceEvidenceId,
@@ -458,12 +462,12 @@ export function mapSimpleTextingMessageDetailRow(
     campaignId: row.campaignId,
     campaignName: row.campaignName,
     providerThreadId: row.providerThreadId,
-    threadKey: row.threadKey
+    threadKey: row.threadKey,
   });
 }
 
 export function mapSimpleTextingMessageDetailToInsert(
-  record: SimpleTextingMessageDetailRecord
+  record: SimpleTextingMessageDetailRecord,
 ): typeof simpleTextingMessageDetails.$inferInsert {
   const parsed = simpleTextingMessageDetailSchema.parse(record);
 
@@ -477,12 +481,12 @@ export function mapSimpleTextingMessageDetailToInsert(
     campaignId: parsed.campaignId,
     campaignName: parsed.campaignName,
     providerThreadId: parsed.providerThreadId,
-    threadKey: parsed.threadKey
+    threadKey: parsed.threadKey,
   };
 }
 
 export function mapMailchimpCampaignActivityDetailRow(
-  row: MailchimpCampaignActivityDetailRow
+  row: MailchimpCampaignActivityDetailRow,
 ): MailchimpCampaignActivityDetailRecord {
   return mailchimpCampaignActivityDetailSchema.parse({
     sourceEvidenceId: row.sourceEvidenceId,
@@ -492,12 +496,12 @@ export function mapMailchimpCampaignActivityDetailRow(
     audienceId: row.audienceId,
     memberId: row.memberId,
     campaignName: row.campaignName,
-    snippet: row.snippet
+    snippet: row.snippet,
   });
 }
 
 export function mapMailchimpCampaignActivityDetailToInsert(
-  record: MailchimpCampaignActivityDetailRecord
+  record: MailchimpCampaignActivityDetailRecord,
 ): typeof mailchimpCampaignActivityDetails.$inferInsert {
   const parsed = mailchimpCampaignActivityDetailSchema.parse(record);
 
@@ -509,23 +513,24 @@ export function mapMailchimpCampaignActivityDetailToInsert(
     audienceId: parsed.audienceId,
     memberId: parsed.memberId,
     campaignName: parsed.campaignName,
-    snippet: parsed.snippet
+    snippet: parsed.snippet,
   };
 }
 
 export function mapManualNoteDetailRow(
-  row: ManualNoteDetailRow
+  row: ManualNoteDetailRow,
 ): ManualNoteDetailRecord {
   return manualNoteDetailSchema.parse({
     sourceEvidenceId: row.sourceEvidenceId,
     providerRecordId: row.providerRecordId,
     body: row.body,
-    authorDisplayName: row.authorDisplayName
+    authorDisplayName: row.authorDisplayName,
+    authorId: row.authorId,
   });
 }
 
 export function mapManualNoteDetailToInsert(
-  record: ManualNoteDetailRecord
+  record: ManualNoteDetailRecord,
 ): typeof manualNoteDetails.$inferInsert {
   const parsed = manualNoteDetailSchema.parse(record);
 
@@ -533,12 +538,13 @@ export function mapManualNoteDetailToInsert(
     sourceEvidenceId: parsed.sourceEvidenceId,
     providerRecordId: parsed.providerRecordId,
     body: parsed.body,
-    authorDisplayName: parsed.authorDisplayName
+    authorDisplayName: parsed.authorDisplayName,
+    authorId: parsed.authorId,
   };
 }
 
 export function mapIdentityResolutionRow(
-  row: IdentityResolutionRow
+  row: IdentityResolutionRow,
 ): IdentityResolutionCase {
   return identityResolutionSchema.parse({
     id: row.id,
@@ -550,12 +556,12 @@ export function mapIdentityResolutionRow(
     resolvedAt: fromDate(row.resolvedAt),
     normalizedIdentityValues: row.normalizedIdentityValues,
     anchoredContactId: row.anchoredContactId,
-    explanation: row.explanation
+    explanation: row.explanation,
   });
 }
 
 export function mapIdentityResolutionToInsert(
-  record: IdentityResolutionCase
+  record: IdentityResolutionCase,
 ): typeof identityResolutionQueue.$inferInsert {
   const parsed = identityResolutionSchema.parse(record);
 
@@ -569,7 +575,7 @@ export function mapIdentityResolutionToInsert(
     resolvedAt: parsed.resolvedAt === null ? null : toDate(parsed.resolvedAt),
     normalizedIdentityValues: [...parsed.normalizedIdentityValues],
     anchoredContactId: parsed.anchoredContactId,
-    explanation: parsed.explanation
+    explanation: parsed.explanation,
   };
 }
 
@@ -583,12 +589,12 @@ export function mapRoutingReviewRow(row: RoutingReviewRow): RoutingReviewCase {
     openedAt: row.openedAt.toISOString(),
     resolvedAt: fromDate(row.resolvedAt),
     candidateMembershipIds: row.candidateMembershipIds,
-    explanation: row.explanation
+    explanation: row.explanation,
   });
 }
 
 export function mapRoutingReviewToInsert(
-  record: RoutingReviewCase
+  record: RoutingReviewCase,
 ): typeof routingReviewQueue.$inferInsert {
   const parsed = routingReviewSchema.parse(record);
 
@@ -601,12 +607,12 @@ export function mapRoutingReviewToInsert(
     openedAt: toDate(parsed.openedAt),
     resolvedAt: parsed.resolvedAt === null ? null : toDate(parsed.resolvedAt),
     candidateMembershipIds: [...parsed.candidateMembershipIds],
-    explanation: parsed.explanation
+    explanation: parsed.explanation,
   };
 }
 
 export function mapInboxProjectionRow(
-  row: InboxProjectionRowDb
+  row: InboxProjectionRowDb,
 ): InboxProjectionRow {
   return inboxProjectionSchema.parse({
     contactId: row.contactId,
@@ -618,12 +624,12 @@ export function mapInboxProjectionRow(
     lastActivityAt: row.lastActivityAt.toISOString(),
     snippet: row.snippet,
     lastCanonicalEventId: row.lastCanonicalEventId,
-    lastEventType: row.lastEventType
+    lastEventType: row.lastEventType,
   });
 }
 
 export function mapInboxProjectionToInsert(
-  record: InboxProjectionRow
+  record: InboxProjectionRow,
 ): typeof contactInboxProjection.$inferInsert {
   const parsed = inboxProjectionSchema.parse(record);
 
@@ -639,12 +645,12 @@ export function mapInboxProjectionToInsert(
     lastActivityAt: toDate(parsed.lastActivityAt),
     snippet: parsed.snippet,
     lastCanonicalEventId: parsed.lastCanonicalEventId,
-    lastEventType: parsed.lastEventType
+    lastEventType: parsed.lastEventType,
   };
 }
 
 export function mapTimelineProjectionRow(
-  row: TimelineProjectionRowDb
+  row: TimelineProjectionRowDb,
 ): TimelineProjectionRow {
   return timelineProjectionSchema.parse({
     id: row.id,
@@ -656,12 +662,12 @@ export function mapTimelineProjectionRow(
     summary: row.summary,
     channel: row.channel,
     primaryProvider: row.primaryProvider,
-    reviewState: row.reviewState
+    reviewState: row.reviewState,
   });
 }
 
 export function mapTimelineProjectionToInsert(
-  record: TimelineProjectionRow
+  record: TimelineProjectionRow,
 ): typeof contactTimelineProjection.$inferInsert {
   const parsed = timelineProjectionSchema.parse(record);
 
@@ -675,7 +681,7 @@ export function mapTimelineProjectionToInsert(
     summary: parsed.summary,
     channel: parsed.channel,
     primaryProvider: parsed.primaryProvider,
-    reviewState: parsed.reviewState
+    reviewState: parsed.reviewState,
   };
 }
 
@@ -694,12 +700,12 @@ export function mapSyncStateRow(row: SyncStateRow): SyncStateRecord {
     freshnessP95Seconds: row.freshnessP95Seconds,
     freshnessP99Seconds: row.freshnessP99Seconds,
     lastSuccessfulAt: fromDate(row.lastSuccessfulAt),
-    deadLetterCount: row.deadLetterCount
+    deadLetterCount: row.deadLetterCount,
   });
 }
 
 export function mapSyncStateToInsert(
-  record: SyncStateRecord
+  record: SyncStateRecord,
 ): typeof syncState.$inferInsert {
   const parsed = syncStateSchema.parse(record);
 
@@ -709,7 +715,8 @@ export function mapSyncStateToInsert(
     provider: parsed.provider,
     jobType: parsed.jobType,
     cursor: parsed.cursor,
-    windowStart: parsed.windowStart === null ? null : toDate(parsed.windowStart),
+    windowStart:
+      parsed.windowStart === null ? null : toDate(parsed.windowStart),
     windowEnd: parsed.windowEnd === null ? null : toDate(parsed.windowEnd),
     status: parsed.status,
     parityPercent:
@@ -718,11 +725,13 @@ export function mapSyncStateToInsert(
     freshnessP99Seconds: parsed.freshnessP99Seconds,
     lastSuccessfulAt:
       parsed.lastSuccessfulAt === null ? null : toDate(parsed.lastSuccessfulAt),
-    deadLetterCount: parsed.deadLetterCount
+    deadLetterCount: parsed.deadLetterCount,
   };
 }
 
-export function mapAuditEvidenceRow(row: AuditEvidenceRow): AuditEvidenceRecord {
+export function mapAuditEvidenceRow(
+  row: AuditEvidenceRow,
+): AuditEvidenceRecord {
   return auditEvidenceSchema.parse({
     id: row.id,
     actorType: row.actorType,
@@ -733,12 +742,12 @@ export function mapAuditEvidenceRow(row: AuditEvidenceRow): AuditEvidenceRecord 
     occurredAt: row.occurredAt.toISOString(),
     result: row.result,
     policyCode: row.policyCode,
-    metadataJson: row.metadataJson
+    metadataJson: row.metadataJson,
   });
 }
 
 export function mapAuditEvidenceToInsert(
-  record: AuditEvidenceRecord
+  record: AuditEvidenceRecord,
 ): typeof auditPolicyEvidence.$inferInsert {
   const parsed = auditEvidenceSchema.parse(record);
 
@@ -752,7 +761,7 @@ export function mapAuditEvidenceToInsert(
     occurredAt: toDate(parsed.occurredAt),
     result: parsed.result,
     policyCode: parsed.policyCode,
-    metadataJson: parsed.metadataJson
+    metadataJson: parsed.metadataJson,
   };
 }
 
@@ -766,13 +775,11 @@ export function mapUserRow(row: UserRow): UserRecord {
     role: row.role,
     deactivatedAt: row.deactivatedAt,
     createdAt: row.createdAt,
-    updatedAt: row.updatedAt
+    updatedAt: row.updatedAt,
   };
 }
 
-export function mapUserToInsert(
-  record: UserRecord
-): typeof users.$inferInsert {
+export function mapUserToInsert(record: UserRecord): typeof users.$inferInsert {
   return {
     id: record.id,
     name: record.name,
@@ -782,12 +789,12 @@ export function mapUserToInsert(
     role: record.role,
     deactivatedAt: record.deactivatedAt,
     createdAt: record.createdAt,
-    updatedAt: record.updatedAt
+    updatedAt: record.updatedAt,
   };
 }
 
 export function mapPendingComposerOutboundRow(
-  row: PendingComposerOutboundRow
+  row: PendingComposerOutboundRow,
 ): PendingComposerOutboundRecord {
   return {
     id: row.id,
@@ -810,12 +817,12 @@ export function mapPendingComposerOutboundRow(
     failedReason: row.failedReason,
     orphanedAt: fromDate(row.orphanedAt),
     createdAt: row.createdAt.toISOString(),
-    updatedAt: row.updatedAt.toISOString()
+    updatedAt: row.updatedAt.toISOString(),
   };
 }
 
 export function mapPendingComposerOutboundToInsert(
-  record: PendingComposerOutboundRecord
+  record: PendingComposerOutboundRecord,
 ): typeof pendingComposerOutbounds.$inferInsert {
   return {
     id: record.id,
@@ -839,7 +846,7 @@ export function mapPendingComposerOutboundToInsert(
     failedReason: record.failedReason,
     orphanedAt: record.orphanedAt === null ? null : toDate(record.orphanedAt),
     createdAt: toDate(record.createdAt),
-    updatedAt: toDate(record.updatedAt)
+    updatedAt: toDate(record.updatedAt),
   };
 }
 
@@ -852,12 +859,12 @@ export function mapProjectAliasRow(row: ProjectAliasRow): ProjectAliasRecord {
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
     createdBy: row.createdBy,
-    updatedBy: row.updatedBy
+    updatedBy: row.updatedBy,
   };
 }
 
 export function mapProjectAliasToInsert(
-  record: ProjectAliasRecord
+  record: ProjectAliasRecord,
 ): typeof projectAliases.$inferInsert {
   return {
     id: record.id,
@@ -867,6 +874,6 @@ export function mapProjectAliasToInsert(
     createdAt: record.createdAt,
     updatedAt: record.updatedAt,
     createdBy: record.createdBy,
-    updatedBy: record.updatedBy
+    updatedBy: record.updatedBy,
   };
 }

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -136,6 +136,7 @@ interface ManualNoteDetailRecord {
   readonly providerRecordId: string;
   readonly body: string;
   readonly authorDisplayName: string | null;
+  readonly authorId: string | null;
 }
 
 type SalesforceCommunicationDetailRow = SalesforceCommunicationDetailRecord;
@@ -244,6 +245,7 @@ function mapManualNoteDetailRowLocal(
     providerRecordId: row.providerRecordId,
     body: row.body,
     authorDisplayName: row.authorDisplayName,
+    authorId: row.authorId,
   };
 }
 
@@ -253,6 +255,7 @@ function mapManualNoteDetailToInsertLocal(record: ManualNoteDetailRecord) {
     providerRecordId: record.providerRecordId,
     body: record.body,
     authorDisplayName: record.authorDisplayName,
+    authorId: record.authorId,
   };
 }
 
@@ -803,13 +806,13 @@ function createStage1RepositoriesInternal(
           .where(
             or(
               sql`lower(${contacts.displayName}) like ${pattern}`,
-              sql`lower(coalesce(${contacts.primaryEmail}, '')) like ${pattern}`
-            )
+              sql`lower(coalesce(${contacts.primaryEmail}, '')) like ${pattern}`,
+            ),
           )
           .orderBy(
             sql`case when lower(${contacts.displayName}) like ${pattern} then 0 else 1 end`,
             asc(contacts.displayName),
-            asc(contacts.id)
+            asc(contacts.id),
           )
           .limit(limit);
 
@@ -1328,6 +1331,7 @@ function createStage1RepositoriesInternal(
               providerRecordId: values.providerRecordId,
               body: values.body,
               authorDisplayName: values.authorDisplayName,
+              authorId: values.authorId,
               updatedAt: new Date(),
             },
           })
@@ -1336,6 +1340,60 @@ function createStage1RepositoriesInternal(
         return mapManualNoteDetailRowLocal(
           requireRow(row, "Expected manual note detail row to be returned."),
         );
+      },
+
+      async updateBody(input) {
+        const [row] = (await db
+          .update(manualNoteDetails)
+          .set({
+            body: input.body,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(manualNoteDetails.sourceEvidenceId, input.sourceEvidenceId),
+              eq(manualNoteDetails.authorId, input.authorId),
+            ),
+          )
+          .returning()) as ManualNoteDetailRow[];
+
+        return row === undefined ? null : mapManualNoteDetailRowLocal(row);
+      },
+
+      async deleteByAuthor(input) {
+        return db.transaction(async (tx: Stage1Database) => {
+          const [matchingNote] = await tx
+            .select({
+              sourceEvidenceId: manualNoteDetails.sourceEvidenceId,
+            })
+            .from(manualNoteDetails)
+            .where(
+              and(
+                eq(manualNoteDetails.sourceEvidenceId, input.sourceEvidenceId),
+                eq(manualNoteDetails.authorId, input.authorId),
+              ),
+            )
+            .limit(1);
+
+          if (matchingNote === undefined) {
+            return 0;
+          }
+
+          await tx
+            .delete(canonicalEventLedger)
+            .where(
+              eq(canonicalEventLedger.sourceEvidenceId, input.sourceEvidenceId),
+            );
+
+          const deletedRows = await tx
+            .delete(sourceEvidenceLog)
+            .where(eq(sourceEvidenceLog.id, input.sourceEvidenceId))
+            .returning({
+              id: sourceEvidenceLog.id,
+            });
+
+          return deletedRows.length;
+        });
       },
     },
 
@@ -2160,7 +2218,7 @@ function createStage2RepositoriesInternal(
         id: aliasRow.id,
         address: aliasRow.alias,
         createdAt: aliasRow.createdAt,
-        signature: aliasRow.signature
+        signature: aliasRow.signature,
       });
       emailsByProjectId.set(aliasRow.projectId, projectEmails);
     }
@@ -2185,7 +2243,7 @@ function createStage2RepositoriesInternal(
           id: email.id,
           address: email.address,
           isPrimary: index === 0,
-          signature: email.signature
+          signature: email.signature,
         }));
 
       return {
@@ -2456,7 +2514,7 @@ function createStage2RepositoriesInternal(
             .from(projectAliases)
             .where(eq(projectAliases.projectId, input.projectId));
           const signatureByAlias = new Map(
-            existingRows.map((row) => [row.alias, row.signature] as const)
+            existingRows.map((row) => [row.alias, row.signature] as const),
           );
 
           await tx
@@ -2497,7 +2555,7 @@ function createStage2RepositoriesInternal(
           .set({
             signature: input.signature,
             updatedAt: new Date(),
-            updatedBy: input.actorId
+            updatedBy: input.actorId,
           })
           .where(eq(projectAliases.id, input.aliasId))
           .returning();

--- a/packages/db/src/schema/tables.ts
+++ b/packages/db/src/schema/tables.ts
@@ -2,7 +2,7 @@ import { sql } from "drizzle-orm";
 import type {
   CanonicalEventProvenance,
   IntegrationHealthCategory,
-  IntegrationHealthStatus
+  IntegrationHealthStatus,
 } from "@as-comms/contracts";
 import {
   boolean,
@@ -14,7 +14,7 @@ import {
   primaryKey,
   text,
   timestamp,
-  uniqueIndex
+  uniqueIndex,
 } from "drizzle-orm/pg-core";
 
 import {
@@ -34,19 +34,19 @@ import {
   syncScopeEnum,
   syncJobTypeEnum,
   syncStatusEnum,
-  userRoleEnum
+  userRoleEnum,
 } from "./enums.js";
 
 const createdAtColumn = timestamp("created_at", {
   mode: "date",
-  withTimezone: true
+  withTimezone: true,
 })
   .notNull()
   .defaultNow();
 
 const updatedAtColumn = timestamp("updated_at", {
   mode: "date",
-  withTimezone: true
+  withTimezone: true,
 })
   .notNull()
   .defaultNow();
@@ -66,29 +66,29 @@ export const sourceEvidenceLog = pgTable(
     providerRecordId: text("provider_record_id").notNull(),
     receivedAt: timestamp("received_at", {
       mode: "date",
-      withTimezone: true
+      withTimezone: true,
     }).notNull(),
     occurredAt: timestamp("occurred_at", {
       mode: "date",
-      withTimezone: true
+      withTimezone: true,
     }).notNull(),
     payloadRef: text("payload_ref").notNull(),
     idempotencyKey: text("idempotency_key").notNull(),
     checksum: text("checksum").notNull(),
-    createdAt: createdAtColumn
+    createdAt: createdAtColumn,
   },
   (table) => [
     index("source_evidence_log_provider_record_idx").on(
       table.provider,
       table.providerRecordType,
-      table.providerRecordId
+      table.providerRecordId,
     ),
     uniqueIndex("source_evidence_log_replay_unique").on(
       table.provider,
       table.idempotencyKey,
-      table.checksum
-    )
-  ]
+      table.checksum,
+    ),
+  ],
 );
 
 export const contacts = pgTable(
@@ -101,20 +101,20 @@ export const contacts = pgTable(
     primaryPhone: text("primary_phone"),
     createdAt: timestamp("created_at", {
       mode: "date",
-      withTimezone: true
+      withTimezone: true,
     }).notNull(),
     updatedAt: timestamp("updated_at", {
       mode: "date",
-      withTimezone: true
-    }).notNull()
+      withTimezone: true,
+    }).notNull(),
   },
   (table) => [
     uniqueIndex("contacts_salesforce_contact_id_unique").on(
-      table.salesforceContactId
+      table.salesforceContactId,
     ),
     index("contacts_primary_email_idx").on(table.primaryEmail),
-    index("contacts_primary_phone_idx").on(table.primaryPhone)
-  ]
+    index("contacts_primary_phone_idx").on(table.primaryPhone),
+  ],
 );
 
 export const contactIdentities = pgTable(
@@ -130,22 +130,22 @@ export const contactIdentities = pgTable(
     source: recordSourceEnum("source").notNull(),
     verifiedAt: timestamp("verified_at", {
       mode: "date",
-      withTimezone: true
+      withTimezone: true,
     }),
     createdAt: createdAtColumn,
-    updatedAt: updatedAtColumn
+    updatedAt: updatedAtColumn,
   },
   (table) => [
     uniqueIndex("contact_identities_contact_value_unique").on(
       table.contactId,
       table.kind,
-      table.normalizedValue
+      table.normalizedValue,
     ),
     index("contact_identities_kind_value_idx").on(
       table.kind,
-      table.normalizedValue
-    )
-  ]
+      table.normalizedValue,
+    ),
+  ],
 );
 
 export const contactMemberships = pgTable(
@@ -161,15 +161,15 @@ export const contactMemberships = pgTable(
     status: text("status"),
     source: recordSourceEnum("source").notNull(),
     createdAt: createdAtColumn,
-    updatedAt: updatedAtColumn
+    updatedAt: updatedAtColumn,
   },
   (table) => [
     index("contact_memberships_contact_idx").on(table.contactId),
     index("contact_memberships_context_idx").on(
       table.projectId,
-      table.expeditionId
-    )
-  ]
+      table.expeditionId,
+    ),
+  ],
 );
 
 export const projectDimensions = pgTable("project_dimensions", {
@@ -179,11 +179,11 @@ export const projectDimensions = pgTable("project_dimensions", {
   aiKnowledgeUrl: text("ai_knowledge_url"),
   aiKnowledgeSyncedAt: timestamp("ai_knowledge_synced_at", {
     mode: "date",
-    withTimezone: true
+    withTimezone: true,
   }),
   source: recordSourceEnum("source").notNull(),
   createdAt: createdAtColumn,
-  updatedAt: updatedAtColumn
+  updatedAt: updatedAtColumn,
 });
 
 export const expeditionDimensions = pgTable(
@@ -194,9 +194,9 @@ export const expeditionDimensions = pgTable(
     expeditionName: text("expedition_name").notNull(),
     source: recordSourceEnum("source").notNull(),
     createdAt: createdAtColumn,
-    updatedAt: updatedAtColumn
+    updatedAt: updatedAtColumn,
   },
-  (table) => [index("expedition_dimensions_project_idx").on(table.projectId)]
+  (table) => [index("expedition_dimensions_project_idx").on(table.projectId)],
 );
 
 export const gmailMessageDetails = pgTable(
@@ -215,12 +215,12 @@ export const gmailMessageDetails = pgTable(
     capturedMailbox: text("captured_mailbox"),
     projectInboxAlias: text("project_inbox_alias"),
     createdAt: createdAtColumn,
-    updatedAt: updatedAtColumn
+    updatedAt: updatedAtColumn,
   },
   (table) => [
     index("gmail_message_details_record_idx").on(table.providerRecordId),
-    index("gmail_message_details_thread_idx").on(table.gmailThreadId)
-  ]
+    index("gmail_message_details_thread_idx").on(table.gmailThreadId),
+  ],
 );
 
 export const salesforceEventContext = pgTable(
@@ -234,15 +234,15 @@ export const salesforceEventContext = pgTable(
     expeditionId: text("expedition_id"),
     sourceField: text("source_field"),
     createdAt: createdAtColumn,
-    updatedAt: updatedAtColumn
+    updatedAt: updatedAtColumn,
   },
   (table) => [
     index("salesforce_event_context_contact_idx").on(table.salesforceContactId),
     index("salesforce_event_context_context_idx").on(
       table.projectId,
-      table.expeditionId
-    )
-  ]
+      table.expeditionId,
+    ),
+  ],
 );
 
 export const salesforceCommunicationDetails = pgTable(
@@ -258,13 +258,13 @@ export const salesforceCommunicationDetails = pgTable(
     snippet: text("snippet").notNull().default(""),
     sourceLabel: text("source_label").notNull(),
     createdAt: createdAtColumn,
-    updatedAt: updatedAtColumn
+    updatedAt: updatedAtColumn,
   },
   (table) => [
     index("salesforce_communication_details_record_idx").on(
-      table.providerRecordId
-    )
-  ]
+      table.providerRecordId,
+    ),
+  ],
 );
 
 export const simpleTextingMessageDetails = pgTable(
@@ -283,13 +283,15 @@ export const simpleTextingMessageDetails = pgTable(
     providerThreadId: text("provider_thread_id"),
     threadKey: text("thread_key"),
     createdAt: createdAtColumn,
-    updatedAt: updatedAtColumn
+    updatedAt: updatedAtColumn,
   },
   (table) => [
-    index("simpletexting_message_details_record_idx").on(table.providerRecordId),
+    index("simpletexting_message_details_record_idx").on(
+      table.providerRecordId,
+    ),
     index("simpletexting_message_details_campaign_idx").on(table.campaignId),
-    index("simpletexting_message_details_thread_idx").on(table.threadKey)
-  ]
+    index("simpletexting_message_details_thread_idx").on(table.threadKey),
+  ],
 );
 
 export const mailchimpCampaignActivityDetails = pgTable(
@@ -306,14 +308,16 @@ export const mailchimpCampaignActivityDetails = pgTable(
     campaignName: text("campaign_name"),
     snippet: text("snippet").notNull().default(""),
     createdAt: createdAtColumn,
-    updatedAt: updatedAtColumn
+    updatedAt: updatedAtColumn,
   },
   (table) => [
     index("mailchimp_campaign_activity_details_record_idx").on(
-      table.providerRecordId
+      table.providerRecordId,
     ),
-    index("mailchimp_campaign_activity_details_campaign_idx").on(table.campaignId)
-  ]
+    index("mailchimp_campaign_activity_details_campaign_idx").on(
+      table.campaignId,
+    ),
+  ],
 );
 
 export const manualNoteDetails = pgTable(
@@ -325,12 +329,16 @@ export const manualNoteDetails = pgTable(
     providerRecordId: text("provider_record_id").notNull(),
     body: text("body").notNull(),
     authorDisplayName: text("author_display_name"),
+    authorId: text("author_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
     createdAt: createdAtColumn,
-    updatedAt: updatedAtColumn
+    updatedAt: updatedAtColumn,
   },
   (table) => [
-    index("manual_note_details_record_idx").on(table.providerRecordId)
-  ]
+    index("manual_note_details_record_idx").on(table.providerRecordId),
+    index("manual_note_details_author_idx").on(table.authorId),
+  ],
 );
 
 export const canonicalEventLedger = pgTable(
@@ -344,37 +352,35 @@ export const canonicalEventLedger = pgTable(
     channel: channelEnum("channel").notNull(),
     occurredAt: timestamp("occurred_at", {
       mode: "date",
-      withTimezone: true
+      withTimezone: true,
     }).notNull(),
     contentFingerprint: text("content_fingerprint"),
     sourceEvidenceId: text("source_evidence_id")
       .notNull()
       .references(() => sourceEvidenceLog.id, { onDelete: "restrict" }),
     idempotencyKey: text("idempotency_key").notNull(),
-    provenance: jsonb("provenance")
-      .$type<CanonicalEventProvenance>()
-      .notNull(),
+    provenance: jsonb("provenance").$type<CanonicalEventProvenance>().notNull(),
     reviewState: reviewStateEnum("review_state").notNull().default("clear"),
     createdAt: createdAtColumn,
-    updatedAt: updatedAtColumn
+    updatedAt: updatedAtColumn,
   },
   (table) => [
     uniqueIndex("canonical_event_ledger_idempotency_key_unique").on(
-      table.idempotencyKey
+      table.idempotencyKey,
     ),
     index("canonical_event_ledger_contact_occurred_idx").on(
       table.contactId,
-      table.occurredAt
+      table.occurredAt,
     ),
     index("canonical_event_ledger_contact_channel_fingerprint_idx").on(
       table.contactId,
       table.channel,
-      table.contentFingerprint
+      table.contentFingerprint,
     ),
     index("canonical_event_ledger_source_evidence_idx").on(
-      table.sourceEvidenceId
-    )
-  ]
+      table.sourceEvidenceId,
+    ),
+  ],
 );
 
 export const identityResolutionQueue = pgTable(
@@ -392,32 +398,35 @@ export const identityResolutionQueue = pgTable(
     status: reviewCaseStatusEnum("status").notNull().default("open"),
     openedAt: timestamp("opened_at", {
       mode: "date",
-      withTimezone: true
+      withTimezone: true,
     }).notNull(),
     resolvedAt: timestamp("resolved_at", {
       mode: "date",
-      withTimezone: true
+      withTimezone: true,
     }),
     normalizedIdentityValues: text("normalized_identity_values")
       .array()
       .notNull()
       .default([]),
-    anchoredContactId: text("anchored_contact_id").references(() => contacts.id, {
-      onDelete: "set null"
-    }),
+    anchoredContactId: text("anchored_contact_id").references(
+      () => contacts.id,
+      {
+        onDelete: "set null",
+      },
+    ),
     explanation: text("explanation").notNull(),
     createdAt: createdAtColumn,
-    updatedAt: updatedAtColumn
+    updatedAt: updatedAtColumn,
   },
   (table) => [
     index("identity_resolution_queue_source_evidence_idx").on(
-      table.sourceEvidenceId
+      table.sourceEvidenceId,
     ),
     index("identity_resolution_queue_status_idx").on(
       table.status,
-      table.reasonCode
-    )
-  ]
+      table.reasonCode,
+    ),
+  ],
 );
 
 export const routingReviewQueue = pgTable(
@@ -434,11 +443,11 @@ export const routingReviewQueue = pgTable(
     status: reviewCaseStatusEnum("status").notNull().default("open"),
     openedAt: timestamp("opened_at", {
       mode: "date",
-      withTimezone: true
+      withTimezone: true,
     }).notNull(),
     resolvedAt: timestamp("resolved_at", {
       mode: "date",
-      withTimezone: true
+      withTimezone: true,
     }),
     candidateMembershipIds: text("candidate_membership_ids")
       .array()
@@ -446,15 +455,12 @@ export const routingReviewQueue = pgTable(
       .default([]),
     explanation: text("explanation").notNull(),
     createdAt: createdAtColumn,
-    updatedAt: updatedAtColumn
+    updatedAt: updatedAtColumn,
   },
   (table) => [
     index("routing_review_queue_contact_idx").on(table.contactId),
-    index("routing_review_queue_status_idx").on(
-      table.status,
-      table.reasonCode
-    )
-  ]
+    index("routing_review_queue_status_idx").on(table.status, table.reasonCode),
+  ],
 );
 
 export const contactInboxProjection = pgTable(
@@ -468,33 +474,33 @@ export const contactInboxProjection = pgTable(
     hasUnresolved: boolean("has_unresolved").notNull().default(false),
     lastInboundAt: timestamp("last_inbound_at", {
       mode: "date",
-      withTimezone: true
+      withTimezone: true,
     }),
     lastOutboundAt: timestamp("last_outbound_at", {
       mode: "date",
-      withTimezone: true
+      withTimezone: true,
     }),
     lastActivityAt: timestamp("last_activity_at", {
       mode: "date",
-      withTimezone: true
+      withTimezone: true,
     }).notNull(),
     snippet: text("snippet").notNull().default(""),
     lastCanonicalEventId: text("last_canonical_event_id")
       .notNull()
       .references(() => canonicalEventLedger.id, { onDelete: "restrict" }),
     lastEventType: canonicalEventTypeEnum("last_event_type").notNull(),
-    updatedAt: updatedAtColumn
+    updatedAt: updatedAtColumn,
   },
   (table) => [
     index("contact_inbox_projection_bucket_idx").on(
       table.bucket,
-      table.lastActivityAt
+      table.lastActivityAt,
     ),
     index("contact_inbox_projection_unresolved_idx").on(
       table.hasUnresolved,
-      table.lastActivityAt
-    )
-  ]
+      table.lastActivityAt,
+    ),
+  ],
 );
 
 export const contactTimelineProjection = pgTable(
@@ -509,7 +515,7 @@ export const contactTimelineProjection = pgTable(
       .references(() => canonicalEventLedger.id, { onDelete: "cascade" }),
     occurredAt: timestamp("occurred_at", {
       mode: "date",
-      withTimezone: true
+      withTimezone: true,
     }).notNull(),
     // The spec intentionally leaves sortKey encoding open; Stage 1 stores it as
     // opaque text while requiring deterministic generation in projection code.
@@ -520,17 +526,17 @@ export const contactTimelineProjection = pgTable(
     primaryProvider: providerEnum("primary_provider").notNull(),
     reviewState: reviewStateEnum("review_state").notNull(),
     createdAt: createdAtColumn,
-    updatedAt: updatedAtColumn
+    updatedAt: updatedAtColumn,
   },
   (table) => [
     uniqueIndex("contact_timeline_projection_canonical_event_unique").on(
-      table.canonicalEventId
+      table.canonicalEventId,
     ),
     index("contact_timeline_projection_contact_sort_idx").on(
       table.contactId,
-      table.sortKey
-    )
-  ]
+      table.sortKey,
+    ),
+  ],
 );
 
 export const syncState = pgTable(
@@ -543,35 +549,35 @@ export const syncState = pgTable(
     cursor: text("cursor"),
     windowStart: timestamp("window_start", {
       mode: "date",
-      withTimezone: true
+      withTimezone: true,
     }),
     windowEnd: timestamp("window_end", {
       mode: "date",
-      withTimezone: true
+      withTimezone: true,
     }),
     status: syncStatusEnum("status").notNull(),
     parityPercent: numeric("parity_percent", {
       precision: 5,
-      scale: 2
+      scale: 2,
     }),
     freshnessP95Seconds: integer("freshness_p95_seconds"),
     freshnessP99Seconds: integer("freshness_p99_seconds"),
     lastSuccessfulAt: timestamp("last_successful_at", {
       mode: "date",
-      withTimezone: true
+      withTimezone: true,
     }),
     deadLetterCount: integer("dead_letter_count").notNull().default(0),
     createdAt: createdAtColumn,
-    updatedAt: updatedAtColumn
+    updatedAt: updatedAtColumn,
   },
   (table) => [
     index("sync_state_scope_provider_job_type_idx").on(
       table.scope,
       table.provider,
       table.jobType,
-      table.status
-    )
-  ]
+      table.status,
+    ),
+  ],
 );
 
 export const auditPolicyEvidence = pgTable(
@@ -585,7 +591,7 @@ export const auditPolicyEvidence = pgTable(
     entityId: text("entity_id").notNull(),
     occurredAt: timestamp("occurred_at", {
       mode: "date",
-      withTimezone: true
+      withTimezone: true,
     }).notNull(),
     result: auditResultEnum("result").notNull(),
     policyCode: text("policy_code").notNull(),
@@ -593,21 +599,16 @@ export const auditPolicyEvidence = pgTable(
       .$type<Record<string, unknown>>()
       .notNull()
       .default({}),
-    createdAt: createdAtColumn
+    createdAt: createdAtColumn,
   },
   (table) => [
     index("audit_policy_evidence_entity_idx").on(
       table.entityType,
-      table.entityId
+      table.entityId,
     ),
-    index("audit_policy_evidence_actor_idx").on(
-      table.actorType,
-      table.actorId
-    ),
-    index("audit_policy_evidence_occurred_at_idx").on(
-      table.occurredAt
-    )
-  ]
+    index("audit_policy_evidence_actor_idx").on(table.actorType, table.actorId),
+    index("audit_policy_evidence_occurred_at_idx").on(table.occurredAt),
+  ],
 );
 
 export const users = pgTable("users", {
@@ -616,16 +617,16 @@ export const users = pgTable("users", {
   email: text("email").notNull().unique(),
   emailVerified: timestamp("email_verified", {
     mode: "date",
-    withTimezone: true
+    withTimezone: true,
   }),
   image: text("image"),
   role: userRoleEnum("role").notNull().default("operator"),
   deactivatedAt: timestamp("deactivated_at", {
     mode: "date",
-    withTimezone: true
+    withTimezone: true,
   }),
   createdAt: createdAtColumn,
-  updatedAt: updatedAtColumn
+  updatedAt: updatedAtColumn,
 });
 
 export const accounts = pgTable(
@@ -643,15 +644,15 @@ export const accounts = pgTable(
     token_type: text("token_type"),
     scope: text("scope"),
     id_token: text("id_token"),
-    session_state: text("session_state")
+    session_state: text("session_state"),
   },
   (table) => [
     primaryKey({
       columns: [table.provider, table.providerAccountId],
-      name: "accounts_provider_provider_account_id_pk"
+      name: "accounts_provider_provider_account_id_pk",
     }),
-    index("accounts_user_id_idx").on(table.userId)
-  ]
+    index("accounts_user_id_idx").on(table.userId),
+  ],
 );
 
 export const sessions = pgTable(
@@ -663,10 +664,10 @@ export const sessions = pgTable(
       .references(() => users.id, { onDelete: "cascade" }),
     expires: timestamp("expires", {
       mode: "date",
-      withTimezone: true
-    }).notNull()
+      withTimezone: true,
+    }).notNull(),
   },
-  (table) => [index("sessions_user_id_idx").on(table.userId)]
+  (table) => [index("sessions_user_id_idx").on(table.userId)],
 );
 
 export const verificationTokens = pgTable(
@@ -676,15 +677,15 @@ export const verificationTokens = pgTable(
     token: text("token").notNull(),
     expires: timestamp("expires", {
       mode: "date",
-      withTimezone: true
-    }).notNull()
+      withTimezone: true,
+    }).notNull(),
   },
   (table) => [
     primaryKey({
       columns: [table.identifier, table.token],
-      name: "verification_tokens_identifier_token_pk"
-    })
-  ]
+      name: "verification_tokens_identifier_token_pk",
+    }),
+  ],
 );
 
 export const projectAliases = pgTable(
@@ -693,19 +694,22 @@ export const projectAliases = pgTable(
     id: text("id").primaryKey(),
     alias: text("alias").notNull().unique(),
     signature: text("signature").notNull().default(""),
-    projectId: text("project_id").references(() => projectDimensions.projectId, {
-      onDelete: "set null"
-    }),
+    projectId: text("project_id").references(
+      () => projectDimensions.projectId,
+      {
+        onDelete: "set null",
+      },
+    ),
     createdAt: createdAtColumn,
     updatedAt: updatedAtColumn,
     createdBy: text("created_by").references(() => users.id, {
-      onDelete: "set null"
+      onDelete: "set null",
     }),
     updatedBy: text("updated_by").references(() => users.id, {
-      onDelete: "set null"
-    })
+      onDelete: "set null",
+    }),
   },
-  (table) => [index("project_aliases_project_idx").on(table.projectId)]
+  (table) => [index("project_aliases_project_idx").on(table.projectId)],
 );
 
 export const pendingComposerOutbounds = pgTable(
@@ -720,9 +724,12 @@ export const pendingComposerOutbounds = pgTable(
     canonicalContactId: text("canonical_contact_id")
       .notNull()
       .references(() => contacts.id, { onDelete: "restrict" }),
-    projectId: text("project_id").references(() => projectDimensions.projectId, {
-      onDelete: "set null"
-    }),
+    projectId: text("project_id").references(
+      () => projectDimensions.projectId,
+      {
+        onDelete: "set null",
+      },
+    ),
     fromAlias: text("from_alias").notNull(),
     toEmailNormalized: text("to_email_normalized").notNull(),
     subject: text("subject").notNull(),
@@ -736,31 +743,31 @@ export const pendingComposerOutbounds = pgTable(
     inReplyToRfc822: text("in_reply_to_rfc822"),
     sentAt: timestamp("sent_at", {
       mode: "date",
-      withTimezone: true
+      withTimezone: true,
     }).notNull(),
     reconciledEventId: text("reconciled_event_id"),
     reconciledAt: timestamp("reconciled_at", {
       mode: "date",
-      withTimezone: true
+      withTimezone: true,
     }),
     failedReason: text("failed_reason"),
     orphanedAt: timestamp("orphaned_at", {
       mode: "date",
-      withTimezone: true
+      withTimezone: true,
     }),
     createdAt: createdAtColumn,
-    updatedAt: updatedAtColumn
+    updatedAt: updatedAtColumn,
   },
   (table) => [
     index("pending_composer_outbounds_fingerprint_idx").on(table.fingerprint),
     index("pending_composer_outbounds_contact_status_idx").on(
       table.canonicalContactId,
-      table.status
+      table.status,
     ),
     index("pending_composer_outbounds_pending_sweep_idx")
       .on(table.status, table.sentAt)
-      .where(sql`${table.status} = 'pending'`)
-  ]
+      .where(sql`${table.status} = 'pending'`),
+  ],
 );
 
 export const integrationHealth = pgTable(
@@ -775,7 +782,7 @@ export const integrationHealth = pgTable(
       .default("not_configured"),
     lastCheckedAt: timestamp("last_checked_at", {
       mode: "date",
-      withTimezone: true
+      withTimezone: true,
     }),
     detail: text("detail"),
     metadataJson: jsonb("metadata_json")
@@ -783,7 +790,7 @@ export const integrationHealth = pgTable(
       .notNull()
       .default({}),
     createdAt: createdAtColumn,
-    updatedAt: updatedAtColumn
+    updatedAt: updatedAtColumn,
   },
-  (table) => [index("integration_health_updated_at_idx").on(table.updatedAt)]
+  (table) => [index("integration_health_updated_at_idx").on(table.updatedAt)],
 );

--- a/packages/db/test/stage1-repositories.test.ts
+++ b/packages/db/test/stage1-repositories.test.ts
@@ -45,6 +45,7 @@ interface ManualNoteDetailRecord {
   readonly providerRecordId: string;
   readonly body: string;
   readonly authorDisplayName: string | null;
+  readonly authorId: string | null;
 }
 
 async function seedSharedInboxRecencyFixture(): Promise<{
@@ -172,7 +173,19 @@ async function seedSharedInboxRecencyFixture(): Promise<{
 
 describe("Stage 1 DB repositories", () => {
   it("persists and maps source evidence, contacts, identities, and memberships", async () => {
-    const { repositories } = await createTestStage1Context();
+    const { repositories, settings } = await createTestStage1Context();
+
+    await settings.users.upsert({
+      id: "user:stage-one",
+      name: "Stage One Operator",
+      email: "stage-one@example.org",
+      emailVerified: new Date("2026-01-01T00:00:00.000Z"),
+      image: null,
+      role: "operator",
+      deactivatedAt: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
 
     const sourceEvidence = await repositories.sourceEvidence.append({
       id: "sev_1",
@@ -327,6 +340,7 @@ describe("Stage 1 DB repositories", () => {
       providerRecordId: sourceEvidence.providerRecordId,
       body: "Follow up after the kickoff call.",
       authorDisplayName: "Stage One Operator",
+      authorId: "user:stage-one",
     })) as ManualNoteDetailRecord;
 
     await expect(

--- a/packages/db/test/stage3-note-author.test.ts
+++ b/packages/db/test/stage3-note-author.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "vitest";
+
+import { createTestStage1Context } from "./helpers.js";
+
+async function seedUser(
+  context: Awaited<ReturnType<typeof createTestStage1Context>>,
+  input: {
+    readonly id: string;
+    readonly email: string;
+    readonly name: string;
+  },
+): Promise<void> {
+  const now = new Date("2026-04-21T12:00:00.000Z");
+
+  await context.settings.users.upsert({
+    id: input.id,
+    name: input.name,
+    email: input.email,
+    emailVerified: now,
+    image: null,
+    role: "operator",
+    deactivatedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
+async function seedManualNote(
+  context: Awaited<ReturnType<typeof createTestStage1Context>>,
+  input: {
+    readonly noteId: string;
+    readonly contactId: string;
+    readonly authorId: string;
+    readonly body?: string;
+  },
+): Promise<{
+  readonly sourceEvidenceId: string;
+  readonly canonicalEventId: string;
+}> {
+  const occurredAt = "2026-04-21T12:00:00.000Z";
+  const sourceEvidenceId = `source-evidence:manual:note:${input.noteId}`;
+  const canonicalEventId = `canonical-event:manual:note:${input.noteId}`;
+
+  await context.repositories.contacts.upsert({
+    id: input.contactId,
+    salesforceContactId: null,
+    displayName: "Timeline Contact",
+    primaryEmail: "timeline@example.org",
+    primaryPhone: null,
+    createdAt: occurredAt,
+    updatedAt: occurredAt,
+  });
+
+  await context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "manual",
+    providerRecordType: "note",
+    providerRecordId: input.noteId,
+    receivedAt: occurredAt,
+    occurredAt,
+    payloadRef: `manual://note/${input.noteId}`,
+    idempotencyKey: `manual:note:${input.noteId}`,
+    checksum: `checksum:${input.noteId}`,
+  });
+
+  await context.repositories.canonicalEvents.upsert({
+    id: canonicalEventId,
+    contactId: input.contactId,
+    eventType: "note.internal.created",
+    channel: "note",
+    occurredAt,
+    contentFingerprint: null,
+    sourceEvidenceId,
+    idempotencyKey: `canonical-event:manual:note:${input.noteId}`,
+    provenance: {
+      primaryProvider: "manual",
+      primarySourceEvidenceId: sourceEvidenceId,
+      supportingSourceEvidenceIds: [],
+      winnerReason: "single_source",
+      sourceRecordType: "note",
+      sourceRecordId: input.noteId,
+      messageKind: null,
+      campaignRef: null,
+      threadRef: null,
+      direction: null,
+      notes: null,
+    },
+    reviewState: "clear",
+  });
+
+  await context.repositories.timelineProjection.upsert({
+    id: `timeline:${input.noteId}`,
+    contactId: input.contactId,
+    canonicalEventId,
+    occurredAt,
+    sortKey: `${occurredAt}::${canonicalEventId}`,
+    eventType: "note.internal.created",
+    summary: "Internal note added",
+    channel: "note",
+    primaryProvider: "manual",
+    reviewState: "clear",
+  });
+
+  await context.repositories.manualNoteDetails.upsert({
+    sourceEvidenceId,
+    providerRecordId: input.noteId,
+    body: input.body ?? "Original note body",
+    authorDisplayName: "Author",
+    authorId: input.authorId,
+  });
+
+  return {
+    sourceEvidenceId,
+    canonicalEventId,
+  };
+}
+
+describe("manual note author repository guards", () => {
+  it("persists authorId on upsert", async () => {
+    const context = await createTestStage1Context();
+    await seedUser(context, {
+      id: "user:author",
+      email: "author@example.org",
+      name: "Author",
+    });
+
+    const { sourceEvidenceId } = await seedManualNote(context, {
+      noteId: "note-1",
+      contactId: "contact:one",
+      authorId: "user:author",
+    });
+
+    await expect(
+      context.repositories.manualNoteDetails.listBySourceEvidenceIds([
+        sourceEvidenceId,
+      ]),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        sourceEvidenceId,
+        authorId: "user:author",
+      }),
+    ]);
+  });
+
+  it("updates the body only when the author id matches", async () => {
+    const context = await createTestStage1Context();
+    await seedUser(context, {
+      id: "user:author",
+      email: "author@example.org",
+      name: "Author",
+    });
+    await seedUser(context, {
+      id: "user:other",
+      email: "other@example.org",
+      name: "Other",
+    });
+
+    const { sourceEvidenceId } = await seedManualNote(context, {
+      noteId: "note-2",
+      contactId: "contact:two",
+      authorId: "user:author",
+    });
+
+    await expect(
+      context.repositories.manualNoteDetails.updateBody({
+        sourceEvidenceId,
+        authorId: "user:author",
+        body: "Updated note body",
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        sourceEvidenceId,
+        body: "Updated note body",
+      }),
+    );
+
+    await expect(
+      context.repositories.manualNoteDetails.updateBody({
+        sourceEvidenceId,
+        authorId: "user:other",
+        body: "Should not apply",
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("deletes authored notes only for the matching author and cascades note records", async () => {
+    const context = await createTestStage1Context();
+    await seedUser(context, {
+      id: "user:author",
+      email: "author@example.org",
+      name: "Author",
+    });
+    await seedUser(context, {
+      id: "user:other",
+      email: "other@example.org",
+      name: "Other",
+    });
+
+    const { sourceEvidenceId, canonicalEventId } = await seedManualNote(
+      context,
+      {
+        noteId: "note-3",
+        contactId: "contact:three",
+        authorId: "user:author",
+      },
+    );
+
+    await expect(
+      context.repositories.manualNoteDetails.deleteByAuthor({
+        sourceEvidenceId,
+        authorId: "user:other",
+      }),
+    ).resolves.toBe(0);
+
+    await expect(
+      context.repositories.manualNoteDetails.deleteByAuthor({
+        sourceEvidenceId,
+        authorId: "user:author",
+      }),
+    ).resolves.toBe(1);
+
+    await expect(
+      context.repositories.sourceEvidence.findById(sourceEvidenceId),
+    ).resolves.toBeNull();
+    await expect(
+      context.repositories.canonicalEvents.findById(canonicalEventId),
+    ).resolves.toBeNull();
+    await expect(
+      context.repositories.timelineProjection.findByCanonicalEventId(
+        canonicalEventId,
+      ),
+    ).resolves.toBeNull();
+  });
+});

--- a/packages/domain/src/notes.ts
+++ b/packages/domain/src/notes.ts
@@ -7,7 +7,7 @@ import {
   type InboxProjectionRow,
   type ManualNoteDetailRecord,
   type SourceEvidenceRecord,
-  type TimelineProjectionRow
+  type TimelineProjectionRow,
 } from "@as-comms/contracts";
 
 import type { Stage1NormalizationService } from "./normalization.js";
@@ -19,6 +19,7 @@ export interface Stage1InternalNoteCreateInput {
   readonly body: string;
   readonly occurredAt: string;
   readonly authorDisplayName?: string | null;
+  readonly authorId?: string | null;
 }
 
 export interface Stage1InternalNoteCreateResult {
@@ -32,8 +33,21 @@ export interface Stage1InternalNoteCreateResult {
 
 export interface Stage1InternalNoteService {
   createNote(
-    input: Stage1InternalNoteCreateInput
+    input: Stage1InternalNoteCreateInput,
   ): Promise<Stage1InternalNoteCreateResult>;
+  updateNote(input: {
+    readonly noteId: string;
+    readonly authorId: string;
+    readonly body: string;
+  }): Promise<{
+    readonly outcome: "applied" | "not_authorized" | "not_found";
+  }>;
+  deleteNote(input: {
+    readonly noteId: string;
+    readonly authorId: string;
+  }): Promise<{
+    readonly outcome: "applied" | "not_authorized" | "not_found";
+  }>;
 }
 
 function buildManualNoteChecksum(input: {
@@ -48,8 +62,8 @@ function buildManualNoteChecksum(input: {
         noteId: input.noteId,
         contactId: input.contactId,
         body: input.body,
-        occurredAt: input.occurredAt
-      })
+        occurredAt: input.occurredAt,
+      }),
     )
     .digest("hex");
 }
@@ -61,10 +75,44 @@ export function createStage1InternalNoteService(input: {
     "applyTimelineProjection" | "refreshInboxReviewOverlay"
   >;
 }): Stage1InternalNoteService {
+  async function loadExistingNote(inputValue: {
+    readonly noteId: string;
+  }): Promise<{
+    readonly sourceEvidence: SourceEvidenceRecord;
+    readonly noteDetail: ManualNoteDetailRecord;
+    readonly canonicalEvent: CanonicalEventRecord | null;
+  } | null> {
+    const sourceEvidenceId = `source-evidence:manual:note:${inputValue.noteId}`;
+    const canonicalEventId = `canonical-event:manual:note:${inputValue.noteId}`;
+    const [sourceEvidence, noteDetails, canonicalEvent] = await Promise.all([
+      input.persistence.repositories.sourceEvidence.findById(sourceEvidenceId),
+      input.persistence.repositories.manualNoteDetails.listBySourceEvidenceIds([
+        sourceEvidenceId,
+      ]),
+      input.persistence.repositories.canonicalEvents.findById(canonicalEventId),
+    ]);
+
+    if (sourceEvidence === null) {
+      return null;
+    }
+
+    const noteDetail = noteDetails[0] ?? null;
+
+    if (noteDetail === null) {
+      return null;
+    }
+
+    return {
+      sourceEvidence,
+      noteDetail,
+      canonicalEvent,
+    };
+  }
+
   return {
     async createNote(noteInput) {
       const contact = await input.persistence.repositories.contacts.findById(
-        noteInput.contactId
+        noteInput.contactId,
       );
 
       if (contact === null) {
@@ -81,16 +129,15 @@ export function createStage1InternalNoteService(input: {
         occurredAt: noteInput.occurredAt,
         payloadRef: `manual://note/${noteInput.noteId}`,
         idempotencyKey: `manual:note:${noteInput.noteId}`,
-        checksum: buildManualNoteChecksum(noteInput)
+        checksum: buildManualNoteChecksum(noteInput),
       };
 
-      const sourceEvidenceResult = await input.persistence.recordSourceEvidence(
-        sourceEvidence
-      );
+      const sourceEvidenceResult =
+        await input.persistence.recordSourceEvidence(sourceEvidence);
 
       if (sourceEvidenceResult.outcome === "conflict") {
         throw new Error(
-          `Manual note ${noteInput.noteId} conflicted with existing source evidence.`
+          `Manual note ${noteInput.noteId} conflicted with existing source evidence.`,
         );
       }
 
@@ -113,18 +160,17 @@ export function createStage1InternalNoteService(input: {
           campaignRef: null,
           threadRef: null,
           direction: null,
-          notes: null
+          notes: null,
         },
-        reviewState: "clear"
+        reviewState: "clear",
       });
 
-      const canonicalEventResult = await input.persistence.persistCanonicalEvent(
-        canonicalEvent
-      );
+      const canonicalEventResult =
+        await input.persistence.persistCanonicalEvent(canonicalEvent);
 
       if (canonicalEventResult.outcome === "conflict") {
         throw new Error(
-          `Manual note ${noteInput.noteId} conflicted with existing canonical event state.`
+          `Manual note ${noteInput.noteId} conflicted with existing canonical event state.`,
         );
       }
 
@@ -133,18 +179,21 @@ export function createStage1InternalNoteService(input: {
           sourceEvidenceId: sourceEvidenceResult.record.id,
           providerRecordId: noteInput.noteId,
           body: noteInput.body,
-          authorDisplayName: noteInput.authorDisplayName ?? null
-        })
+          authorDisplayName: noteInput.authorDisplayName ?? null,
+          authorId: noteInput.authorId ?? null,
+        }),
       );
 
       const persistedEvent = canonicalEventResult.record;
-      const timelineProjection = await input.normalization.applyTimelineProjection({
-        canonicalEvent: persistedEvent,
-        summary: "Internal note added"
-      });
-      const inboxProjection = await input.normalization.refreshInboxReviewOverlay({
-        contactId: noteInput.contactId
-      });
+      const timelineProjection =
+        await input.normalization.applyTimelineProjection({
+          canonicalEvent: persistedEvent,
+          summary: "Internal note added",
+        });
+      const inboxProjection =
+        await input.normalization.refreshInboxReviewOverlay({
+          contactId: noteInput.contactId,
+        });
 
       return {
         outcome:
@@ -156,8 +205,71 @@ export function createStage1InternalNoteService(input: {
         canonicalEvent: persistedEvent,
         timelineProjection,
         inboxProjection,
-        noteDetail
+        noteDetail,
       };
-    }
+    },
+
+    async updateNote(updateInput) {
+      const existing = await loadExistingNote({
+        noteId: updateInput.noteId,
+      });
+
+      if (existing === null) {
+        return {
+          outcome: "not_found",
+        };
+      }
+
+      const updated =
+        await input.persistence.repositories.manualNoteDetails.updateBody({
+          sourceEvidenceId: existing.sourceEvidence.id,
+          authorId: updateInput.authorId,
+          body: updateInput.body,
+        });
+
+      if (updated === null) {
+        return {
+          outcome: "not_authorized",
+        };
+      }
+
+      return {
+        outcome: "applied",
+      };
+    },
+
+    async deleteNote(deleteInput) {
+      const existing = await loadExistingNote({
+        noteId: deleteInput.noteId,
+      });
+
+      if (existing === null) {
+        return {
+          outcome: "not_found",
+        };
+      }
+
+      const deletedCount =
+        await input.persistence.repositories.manualNoteDetails.deleteByAuthor({
+          sourceEvidenceId: existing.sourceEvidence.id,
+          authorId: deleteInput.authorId,
+        });
+
+      if (deletedCount === 0) {
+        return {
+          outcome: "not_authorized",
+        };
+      }
+
+      if (existing.canonicalEvent !== null) {
+        await input.normalization.refreshInboxReviewOverlay({
+          contactId: existing.canonicalEvent.contactId,
+        });
+      }
+
+      return {
+        outcome: "applied",
+      };
+    },
   };
 }

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -160,6 +160,15 @@ export interface ManualNoteDetailRepository {
     sourceEvidenceIds: readonly string[],
   ): Promise<readonly ManualNoteDetailRecord[]>;
   upsert(record: ManualNoteDetailRecord): Promise<ManualNoteDetailRecord>;
+  updateBody(input: {
+    readonly sourceEvidenceId: string;
+    readonly authorId: string;
+    readonly body: string;
+  }): Promise<ManualNoteDetailRecord | null>;
+  deleteByAuthor(input: {
+    readonly sourceEvidenceId: string;
+    readonly authorId: string;
+  }): Promise<number>;
 }
 
 export interface PendingComposerOutboundRepository {

--- a/packages/domain/src/timeline.ts
+++ b/packages/domain/src/timeline.ts
@@ -6,7 +6,7 @@ import {
   type SalesforceEventContextRecord,
   type SourceEvidenceRecord,
   type TimelineItem,
-  type TimelineProjectionRow
+  type TimelineProjectionRow,
 } from "@as-comms/contracts";
 
 import type { Stage1RepositoryBundle } from "./repositories.js";
@@ -57,8 +57,10 @@ interface MailchimpCampaignActivityDetail {
 
 interface ManualNoteDetail {
   readonly sourceEvidenceId: string;
+  readonly providerRecordId: string;
   readonly body: string;
   readonly authorDisplayName: string | null;
+  readonly authorId: string | null;
 }
 
 interface TimelinePresentationContext {
@@ -83,14 +85,21 @@ interface TimelinePresentationContext {
     string,
     MailchimpCampaignActivityDetail
   >;
-  readonly manualNoteDetailBySourceEvidenceId: ReadonlyMap<string, ManualNoteDetail>;
+  readonly manualNoteDetailBySourceEvidenceId: ReadonlyMap<
+    string,
+    ManualNoteDetail
+  >;
   readonly projectNameById: ReadonlyMap<string, string>;
   readonly expeditionNameById: ReadonlyMap<string, string>;
 }
 
 function getLifecycleMilestone(
-  eventType: CanonicalEventRecord["eventType"]
-): "signed_up" | "received_training" | "completed_training" | "submitted_first_data" {
+  eventType: CanonicalEventRecord["eventType"],
+):
+  | "signed_up"
+  | "received_training"
+  | "completed_training"
+  | "submitted_first_data" {
   switch (eventType) {
     case "lifecycle.signed_up":
       return "signed_up";
@@ -165,12 +174,12 @@ function resolveFamily(event: CanonicalEventRecord): TimelineItem["family"] {
   }
 
   throw new Error(
-    `Canonical event ${event.id} (${event.eventType}) could not be resolved to a timeline family.`
+    `Canonical event ${event.id} (${event.eventType}) could not be resolved to a timeline family.`,
   );
 }
 
 function commonFields(
-  row: TimelineProjectionRow
+  row: TimelineProjectionRow,
 ): Omit<TimelineItem, "family"> & { family?: never } {
   return {
     id: row.id,
@@ -180,7 +189,7 @@ function commonFields(
     sortKey: row.sortKey,
     reviewState: row.reviewState,
     primaryProvider: row.primaryProvider,
-    summary: row.summary
+    summary: row.summary,
   } as Omit<TimelineItem, "family"> & { family?: never };
 }
 
@@ -189,7 +198,7 @@ function buildPendingTimelineSortKey(id: string, sentAt: string): string {
 }
 
 function buildPendingTimelineItems(
-  pendingRows: readonly PendingComposerOutboundRecord[]
+  pendingRows: readonly PendingComposerOutboundRecord[],
 ): readonly TimelineItem[] {
   return timelineItemListSchema.parse(
     pendingRows.map((row) => ({
@@ -218,7 +227,7 @@ function buildPendingTimelineItems(
           ? row.status
           : null,
       attachmentCount: row.attachmentMetadata.length,
-    }))
+    })),
   );
 }
 
@@ -227,20 +236,23 @@ function mergeTimelineItems(input: {
   readonly pendingRows: readonly PendingComposerOutboundRecord[];
 }): readonly TimelineItem[] {
   return timelineItemListSchema.parse(
-    [...input.canonicalItems, ...buildPendingTimelineItems(input.pendingRows)].sort(
-      (left, right) => left.sortKey.localeCompare(right.sortKey)
-    )
+    [
+      ...input.canonicalItems,
+      ...buildPendingTimelineItems(input.pendingRows),
+    ].sort((left, right) => left.sortKey.localeCompare(right.sortKey)),
   );
 }
 
 export interface Stage1TimelinePresentationService {
-  listTimelineItemsByContactId(contactId: string): Promise<readonly TimelineItem[]>;
+  listTimelineItemsByContactId(
+    contactId: string,
+  ): Promise<readonly TimelineItem[]>;
   listTimelineItemsPageByContactId(
     contactId: string,
     input: {
       readonly limit: number;
       readonly beforeSortKey: string | null;
-    }
+    },
   ): Promise<{
     readonly items: readonly TimelineItem[];
     readonly hasMore: boolean;
@@ -250,24 +262,27 @@ export interface Stage1TimelinePresentationService {
   findLastInboundAliasForContact(contactId: string): Promise<string | null>;
 }
 
-function uniqueStrings(values: readonly (string | null | undefined)[]): string[] {
+function uniqueStrings(
+  values: readonly (string | null | undefined)[],
+): string[] {
   return Array.from(
     new Set(
-      values.filter((value): value is string => typeof value === "string")
-    )
+      values.filter((value): value is string => typeof value === "string"),
+    ),
   );
 }
 
 async function loadTimelinePresentationContext(
   repositories: Stage1RepositoryBundle,
-  canonicalEvents: readonly CanonicalEventRecord[]
+  canonicalEvents: readonly CanonicalEventRecord[],
 ): Promise<TimelinePresentationContext> {
   const sourceEvidenceIds = uniqueStrings(
-    canonicalEvents.map((event) => event.sourceEvidenceId)
+    canonicalEvents.map((event) => event.sourceEvidenceId),
   );
-  const sourceEvidence = await repositories.sourceEvidence.listByIds(sourceEvidenceIds);
+  const sourceEvidence =
+    await repositories.sourceEvidence.listByIds(sourceEvidenceIds);
   const sourceEvidenceById = new Map(
-    sourceEvidence.map((record) => [record.id, record])
+    sourceEvidence.map((record) => [record.id, record]),
   );
   const [
     gmailDetails,
@@ -275,76 +290,81 @@ async function loadTimelinePresentationContext(
     salesforceCommunicationDetails,
     simpleTextingMessageDetails,
     mailchimpCampaignActivityDetails,
-    manualNoteDetails
+    manualNoteDetails,
   ] = (await Promise.all([
     repositories.gmailMessageDetails.listBySourceEvidenceIds(sourceEvidenceIds),
-    repositories.salesforceEventContext.listBySourceEvidenceIds(sourceEvidenceIds),
+    repositories.salesforceEventContext.listBySourceEvidenceIds(
+      sourceEvidenceIds,
+    ),
     repositories.salesforceCommunicationDetails.listBySourceEvidenceIds(
-      sourceEvidenceIds
+      sourceEvidenceIds,
     ),
     repositories.simpleTextingMessageDetails.listBySourceEvidenceIds(
-      sourceEvidenceIds
+      sourceEvidenceIds,
     ),
     repositories.mailchimpCampaignActivityDetails.listBySourceEvidenceIds(
-      sourceEvidenceIds
+      sourceEvidenceIds,
     ),
-    repositories.manualNoteDetails.listBySourceEvidenceIds(sourceEvidenceIds)
+    repositories.manualNoteDetails.listBySourceEvidenceIds(sourceEvidenceIds),
   ])) as [
     readonly GmailMessageDetailRecord[],
     readonly SalesforceEventContextDetail[],
     readonly SalesforceCommunicationDetail[],
     readonly SimpleTextingMessageDetail[],
     readonly MailchimpCampaignActivityDetail[],
-    readonly ManualNoteDetail[]
+    readonly ManualNoteDetail[],
   ];
 
   const [projectDimensions, expeditionDimensions] = await Promise.all([
     repositories.projectDimensions.listByIds(
-      uniqueStrings(salesforceContexts.map((context) => context.projectId))
+      uniqueStrings(salesforceContexts.map((context) => context.projectId)),
     ),
     repositories.expeditionDimensions.listByIds(
-      uniqueStrings(salesforceContexts.map((context) => context.expeditionId))
-    )
+      uniqueStrings(salesforceContexts.map((context) => context.expeditionId)),
+    ),
   ]);
 
   return {
     sourceEvidenceById,
     salesforceContextBySourceEvidenceId: new Map(
-      salesforceContexts.map((detail) => [detail.sourceEvidenceId, detail])
+      salesforceContexts.map((detail) => [detail.sourceEvidenceId, detail]),
     ),
     gmailDetailBySourceEvidenceId: new Map(
-      gmailDetails.map((detail) => [detail.sourceEvidenceId, detail])
+      gmailDetails.map((detail) => [detail.sourceEvidenceId, detail]),
     ),
     salesforceCommunicationBySourceEvidenceId: new Map(
       salesforceCommunicationDetails.map((detail) => [
         detail.sourceEvidenceId,
-        detail
-      ])
+        detail,
+      ]),
     ),
     simpleTextingDetailBySourceEvidenceId: new Map(
-      simpleTextingMessageDetails.map((detail) => [detail.sourceEvidenceId, detail])
+      simpleTextingMessageDetails.map((detail) => [
+        detail.sourceEvidenceId,
+        detail,
+      ]),
     ),
     mailchimpDetailBySourceEvidenceId: new Map(
       mailchimpCampaignActivityDetails.map((detail) => [
         detail.sourceEvidenceId,
-        detail
-      ])
+        detail,
+      ]),
     ),
     manualNoteDetailBySourceEvidenceId: new Map(
-      manualNoteDetails.map((detail) => [detail.sourceEvidenceId, detail])
+      manualNoteDetails.map((detail) => [detail.sourceEvidenceId, detail]),
     ),
     projectNameById: new Map(
       projectDimensions.map((dimension) => [
         dimension.projectId,
-        dimension.projectName
-      ])
+        dimension.projectName,
+      ]),
     ),
     expeditionNameById: new Map(
       expeditionDimensions.map((dimension) => [
         dimension.expeditionId,
-        dimension.expeditionName
-      ])
-    )
+        dimension.expeditionName,
+      ]),
+    ),
   };
 }
 
@@ -362,7 +382,9 @@ function buildTimelineItemsFromRows(input: {
       continue;
     }
 
-    const evidence = input.context.sourceEvidenceById.get(event.sourceEvidenceId);
+    const evidence = input.context.sourceEvidenceById.get(
+      event.sourceEvidenceId,
+    );
 
     if (evidence === undefined) {
       continue;
@@ -373,13 +395,16 @@ function buildTimelineItemsFromRows(input: {
     const provenance = event.provenance as TimelineProvenance;
     const salesforceContext =
       input.context.salesforceContextBySourceEvidenceId.get(evidence.id);
-    const gmailDetail = input.context.gmailDetailBySourceEvidenceId.get(evidence.id);
+    const gmailDetail = input.context.gmailDetailBySourceEvidenceId.get(
+      evidence.id,
+    );
     const salesforceCommunicationDetail =
       input.context.salesforceCommunicationBySourceEvidenceId.get(evidence.id);
     const simpleTextingDetail =
       input.context.simpleTextingDetailBySourceEvidenceId.get(evidence.id);
-    const mailchimpDetail =
-      input.context.mailchimpDetailBySourceEvidenceId.get(evidence.id);
+    const mailchimpDetail = input.context.mailchimpDetailBySourceEvidenceId.get(
+      evidence.id,
+    );
     const manualNoteDetail =
       input.context.manualNoteDetailBySourceEvidenceId.get(evidence.id);
 
@@ -393,16 +418,17 @@ function buildTimelineItemsFromRows(input: {
             salesforceContext?.projectId === null ||
             salesforceContext?.projectId === undefined
               ? null
-              : (input.context.projectNameById.get(salesforceContext.projectId) ??
-                null),
+              : (input.context.projectNameById.get(
+                  salesforceContext.projectId,
+                ) ?? null),
           expeditionName:
             salesforceContext?.expeditionId === null ||
             salesforceContext?.expeditionId === undefined
               ? null
               : (input.context.expeditionNameById.get(
-                  salesforceContext.expeditionId
+                  salesforceContext.expeditionId,
                 ) ?? null),
-          sourceField: salesforceContext?.sourceField ?? null
+          sourceField: salesforceContext?.sourceField ?? null,
         });
         break;
       case "auto_email":
@@ -413,7 +439,7 @@ function buildTimelineItemsFromRows(input: {
           subject: salesforceCommunicationDetail?.subject ?? null,
           snippet: salesforceCommunicationDetail?.snippet ?? "",
           sourceLabel:
-            salesforceCommunicationDetail?.sourceLabel ?? "Salesforce Flow"
+            salesforceCommunicationDetail?.sourceLabel ?? "Salesforce Flow",
         });
         break;
       case "auto_sms":
@@ -423,7 +449,7 @@ function buildTimelineItemsFromRows(input: {
           direction: "outbound",
           messageTextPreview: salesforceCommunicationDetail?.snippet ?? "",
           sourceLabel:
-            salesforceCommunicationDetail?.sourceLabel ?? "Salesforce Flow"
+            salesforceCommunicationDetail?.sourceLabel ?? "Salesforce Flow",
         });
         break;
       case "campaign_email":
@@ -434,12 +460,12 @@ function buildTimelineItemsFromRows(input: {
             mailchimpDetail?.activityType ??
             (event.eventType.replace(
               "campaign.email.",
-              ""
+              "",
             ) as CampaignEmailTimelineItem["activityType"]),
           campaignName: mailchimpDetail?.campaignName ?? null,
           campaignId: mailchimpDetail?.campaignId ?? null,
           audienceId: mailchimpDetail?.audienceId ?? null,
-          snippet: mailchimpDetail?.snippet ?? ""
+          snippet: mailchimpDetail?.snippet ?? "",
         });
         break;
       case "campaign_sms":
@@ -455,21 +481,28 @@ function buildTimelineItemsFromRows(input: {
           campaignId:
             simpleTextingDetail?.campaignId ??
             provenance.campaignRef?.providerCampaignId ??
-            null
+            null,
         });
         break;
       case "one_to_one_email":
         items.push({
           ...base,
           family,
-          direction: gmailDetail?.direction ?? provenance.direction ?? "outbound",
+          direction:
+            gmailDetail?.direction ?? provenance.direction ?? "outbound",
           subject:
-            gmailDetail?.subject ?? salesforceCommunicationDetail?.subject ?? null,
+            gmailDetail?.subject ??
+            salesforceCommunicationDetail?.subject ??
+            null,
           snippet:
-            gmailDetail?.snippetClean ?? salesforceCommunicationDetail?.snippet ?? "",
+            gmailDetail?.snippetClean ??
+            salesforceCommunicationDetail?.snippet ??
+            "",
           bodyPreview: gmailDetail?.bodyTextPreview ?? null,
           mailbox:
-            gmailDetail?.projectInboxAlias ?? gmailDetail?.capturedMailbox ?? null,
+            gmailDetail?.projectInboxAlias ??
+            gmailDetail?.capturedMailbox ??
+            null,
           threadId:
             gmailDetail?.gmailThreadId ??
             provenance.threadRef?.providerThreadId ??
@@ -477,7 +510,7 @@ function buildTimelineItemsFromRows(input: {
           rfc822MessageId: gmailDetail?.rfc822MessageId ?? null,
           inReplyToRfc822: null,
           sendStatus: null,
-          attachmentCount: 0
+          attachmentCount: 0,
         });
         break;
       case "one_to_one_sms":
@@ -485,7 +518,9 @@ function buildTimelineItemsFromRows(input: {
           ...base,
           family,
           direction:
-            simpleTextingDetail?.direction ?? provenance.direction ?? "outbound",
+            simpleTextingDetail?.direction ??
+            provenance.direction ??
+            "outbound",
           messageTextPreview:
             simpleTextingDetail?.messageTextPreview ??
             salesforceCommunicationDetail?.snippet ??
@@ -494,15 +529,18 @@ function buildTimelineItemsFromRows(input: {
           threadKey:
             simpleTextingDetail?.threadKey ??
             provenance.threadRef?.crossProviderCollapseKey ??
-            null
+            null,
         });
         break;
       case "internal_note":
         items.push({
           ...base,
           family,
+          noteId:
+            manualNoteDetail?.providerRecordId ?? evidence.providerRecordId,
           body: manualNoteDetail?.body ?? "",
-          authorDisplayName: manualNoteDetail?.authorDisplayName ?? null
+          authorDisplayName: manualNoteDetail?.authorDisplayName ?? null,
+          authorId: manualNoteDetail?.authorId ?? null,
         });
         break;
     }
@@ -512,7 +550,7 @@ function buildTimelineItemsFromRows(input: {
 }
 
 export function createStage1TimelinePresentationService(
-  repositories: Stage1RepositoryBundle
+  repositories: Stage1RepositoryBundle,
 ): Stage1TimelinePresentationService {
   return {
     async listTimelineItemsByContactId(contactId) {
@@ -520,24 +558,24 @@ export function createStage1TimelinePresentationService(
         repositories.canonicalEvents.listByContactId(contactId),
         repositories.timelineProjection.listByContactId(contactId),
         repositories.pendingOutbounds.findForContact(contactId, {
-          limit: Number.MAX_SAFE_INTEGER
-        })
+          limit: Number.MAX_SAFE_INTEGER,
+        }),
       ]);
       const canonicalEventById = new Map(
-        canonicalEvents.map((event) => [event.id, event])
+        canonicalEvents.map((event) => [event.id, event]),
       );
       const context = await loadTimelinePresentationContext(
         repositories,
-        canonicalEvents
+        canonicalEvents,
       );
 
       return mergeTimelineItems({
         canonicalItems: buildTimelineItemsFromRows({
           timelineRows,
           canonicalEventById,
-          context
+          context,
         }),
-        pendingRows
+        pendingRows,
       });
     },
 
@@ -546,23 +584,23 @@ export function createStage1TimelinePresentationService(
         repositories.canonicalEvents.listByContactId(contactId),
         repositories.timelineProjection.listByContactId(contactId),
         repositories.pendingOutbounds.findForContact(contactId, {
-          limit: Number.MAX_SAFE_INTEGER
-        })
+          limit: Number.MAX_SAFE_INTEGER,
+        }),
       ]);
       const canonicalEventById = new Map(
-        canonicalEvents.map((event) => [event.id, event])
+        canonicalEvents.map((event) => [event.id, event]),
       );
       const context = await loadTimelinePresentationContext(
         repositories,
-        canonicalEvents
+        canonicalEvents,
       );
       const mergedItems = mergeTimelineItems({
         canonicalItems: buildTimelineItemsFromRows({
           timelineRows: rows,
           canonicalEventById,
-          context
+          context,
         }),
-        pendingRows
+        pendingRows,
       });
       const beforeSortKey = input.beforeSortKey;
       const filteredItems =
@@ -581,7 +619,7 @@ export function createStage1TimelinePresentationService(
         hasMore,
         nextBeforeSortKey:
           pageItemsDescending[pageItemsDescending.length - 1]?.sortKey ?? null,
-        total: mergedItems.length
+        total: mergedItems.length,
       };
     },
 
@@ -599,14 +637,14 @@ export function createStage1TimelinePresentationService(
       const gmailDetails =
         await repositories.gmailMessageDetails.listBySourceEvidenceIds(
           uniqueStrings(
-            inboundEmailEvents.map((event) => event.sourceEvidenceId)
-          )
+            inboundEmailEvents.map((event) => event.sourceEvidenceId),
+          ),
         );
       const aliasBySourceEvidenceId = new Map(
         gmailDetails.map((detail) => [
           detail.sourceEvidenceId,
-          detail.projectInboxAlias
-        ])
+          detail.projectInboxAlias,
+        ]),
       );
 
       for (const event of inboundEmailEvents) {
@@ -618,6 +656,6 @@ export function createStage1TimelinePresentationService(
       }
 
       return null;
-    }
+    },
   };
 }

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -5,7 +5,7 @@ import type { ContactRecord } from "@as-comms/contracts";
 import {
   defineStage1RepositoryBundle,
   type PendingComposerOutboundRecord,
-  type Stage1RepositoryBundle
+  type Stage1RepositoryBundle,
 } from "../src/index.js";
 
 describe("defineStage1RepositoryBundle", () => {
@@ -17,7 +17,7 @@ describe("defineStage1RepositoryBundle", () => {
       primaryEmail: "volunteer@example.org",
       primaryPhone: null,
       createdAt: "2026-01-01T00:00:00.000Z",
-      updatedAt: "2026-01-01T00:00:00.000Z"
+      updatedAt: "2026-01-01T00:00:00.000Z",
     };
 
     const bundle: Stage1RepositoryBundle = defineStage1RepositoryBundle({
@@ -27,7 +27,7 @@ describe("defineStage1RepositoryBundle", () => {
         listByIds: () => Promise.resolve([]),
         findByIdempotencyKey: () => Promise.resolve(null),
         countByProvider: () => Promise.resolve(0),
-        listByProviderRecord: () => Promise.resolve([])
+        listByProviderRecord: () => Promise.resolve([]),
       },
       canonicalEvents: {
         findById: () => Promise.resolve(null),
@@ -38,7 +38,7 @@ describe("defineStage1RepositoryBundle", () => {
         countDistinctInboxContacts: () => Promise.resolve(0),
         listByIds: () => Promise.resolve([]),
         listByContactId: () => Promise.resolve([]),
-        upsert: (record) => Promise.resolve(record)
+        upsert: (record) => Promise.resolve(record),
       },
       contacts: {
         findById: () => Promise.resolve(contact),
@@ -46,51 +46,53 @@ describe("defineStage1RepositoryBundle", () => {
         listAll: () => Promise.resolve([contact]),
         listByIds: () => Promise.resolve([contact]),
         searchByQuery: () => Promise.resolve([contact]),
-        upsert: (record) => Promise.resolve(record)
+        upsert: (record) => Promise.resolve(record),
       },
       contactIdentities: {
         listByContactId: () => Promise.resolve([]),
         listByNormalizedValue: () => Promise.resolve([]),
-        upsert: (record) => Promise.resolve(record)
+        upsert: (record) => Promise.resolve(record),
       },
       contactMemberships: {
         listByContactId: () => Promise.resolve([]),
         listByContactIds: () => Promise.resolve([]),
-        upsert: (record) => Promise.resolve(record)
+        upsert: (record) => Promise.resolve(record),
       },
       projectDimensions: {
         listAll: () => Promise.resolve([]),
         listActive: () => Promise.resolve([]),
         listByIds: () => Promise.resolve([]),
-        upsert: (record) => Promise.resolve(record)
+        upsert: (record) => Promise.resolve(record),
       },
       expeditionDimensions: {
         listByIds: () => Promise.resolve([]),
-        upsert: (record) => Promise.resolve(record)
+        upsert: (record) => Promise.resolve(record),
       },
       gmailMessageDetails: {
         listBySourceEvidenceIds: () => Promise.resolve([]),
-        upsert: (record) => Promise.resolve(record)
+        upsert: (record) => Promise.resolve(record),
       },
       salesforceEventContext: {
         listBySourceEvidenceIds: () => Promise.resolve([]),
-        upsert: (record) => Promise.resolve(record)
+        upsert: (record) => Promise.resolve(record),
       },
       salesforceCommunicationDetails: {
         listBySourceEvidenceIds: () => Promise.resolve([]),
-        upsert: (record) => Promise.resolve(record)
+        upsert: (record) => Promise.resolve(record),
       },
       simpleTextingMessageDetails: {
         listBySourceEvidenceIds: () => Promise.resolve([]),
-        upsert: (record) => Promise.resolve(record)
+        upsert: (record) => Promise.resolve(record),
       },
       mailchimpCampaignActivityDetails: {
         listBySourceEvidenceIds: () => Promise.resolve([]),
-        upsert: (record) => Promise.resolve(record)
+        upsert: (record) => Promise.resolve(record),
       },
       manualNoteDetails: {
         listBySourceEvidenceIds: () => Promise.resolve([]),
-        upsert: (record) => Promise.resolve(record)
+        upsert: (record) => Promise.resolve(record),
+        updateBody: () => Promise.resolve(null),
+        deleteByAuthor: () => Promise.resolve(0),
       },
       pendingOutbounds: {
         insert: ({ id }) => Promise.resolve(id),
@@ -100,19 +102,19 @@ describe("defineStage1RepositoryBundle", () => {
         markFailed: () => Promise.resolve(),
         markSuperseded: () => Promise.resolve(),
         sweepOrphans: () => Promise.resolve(0),
-        findForContact: () => Promise.resolve([])
+        findForContact: () => Promise.resolve([]),
       },
       identityResolutionQueue: {
         findById: () => Promise.resolve(null),
         listOpenByContactId: () => Promise.resolve([]),
         listOpenByReasonCode: () => Promise.resolve([]),
-        upsert: (record) => Promise.resolve(record)
+        upsert: (record) => Promise.resolve(record),
       },
       routingReviewQueue: {
         findById: () => Promise.resolve(null),
         listOpenByContactId: () => Promise.resolve([]),
         listOpenByReasonCode: () => Promise.resolve([]),
-        upsert: (record) => Promise.resolve(record)
+        upsert: (record) => Promise.resolve(record),
       },
       inboxProjection: {
         countAll: () => Promise.resolve(0),
@@ -123,7 +125,7 @@ describe("defineStage1RepositoryBundle", () => {
         searchPageOrderedByRecency: () =>
           Promise.resolve({
             rows: [],
-            total: 0
+            total: 0,
           }),
         listPageOrderedByRecency: () => Promise.resolve([]),
         countByFilters: () =>
@@ -131,17 +133,17 @@ describe("defineStage1RepositoryBundle", () => {
             all: 0,
             unread: 0,
             followUp: 0,
-            unresolved: 0
+            unresolved: 0,
           }),
         getFreshness: () =>
           Promise.resolve({
             total: 0,
-            latestUpdatedAt: null
+            latestUpdatedAt: null,
           }),
         getFreshnessByContactId: () => Promise.resolve(null),
         deleteByContactId: () => Promise.resolve(),
         setNeedsFollowUp: () => Promise.resolve(null),
-        upsert: (record) => Promise.resolve(record)
+        upsert: (record) => Promise.resolve(record),
       },
       timelineProjection: {
         countAll: () => Promise.resolve(0),
@@ -154,22 +156,24 @@ describe("defineStage1RepositoryBundle", () => {
             contactId,
             total: 0,
             latestUpdatedAt: null,
-            latestSortKey: null
+            latestSortKey: null,
           }),
-        upsert: (record) => Promise.resolve(record)
+        upsert: (record) => Promise.resolve(record),
       },
       syncState: {
         findById: () => Promise.resolve(null),
         findLatest: () => Promise.resolve(null),
         listAll: () => Promise.resolve([]),
-        upsert: (record) => Promise.resolve(record)
+        upsert: (record) => Promise.resolve(record),
       },
       auditEvidence: {
         append: (record) => Promise.resolve(record),
-        listByEntity: () => Promise.resolve([])
-      }
+        listByEntity: () => Promise.resolve([]),
+      },
     });
 
-    await expect(bundle.contacts.findById("contact_1")).resolves.toEqual(contact);
+    await expect(bundle.contacts.findById("contact_1")).resolves.toEqual(
+      contact,
+    );
   });
 });

--- a/packages/domain/test/stage3-internal-note-service.test.ts
+++ b/packages/domain/test/stage3-internal-note-service.test.ts
@@ -58,7 +58,7 @@ describe("Stage1InternalNoteService", () => {
       } as never,
       normalization: {
         applyTimelineProjection: vi.fn(
-          () =>
+          async (_input: unknown): Promise<TimelineProjectionRow> =>
             ({
               id: "timeline:note-1",
               contactId: "contact:one",

--- a/packages/domain/test/stage3-internal-note-service.test.ts
+++ b/packages/domain/test/stage3-internal-note-service.test.ts
@@ -58,8 +58,9 @@ describe("Stage1InternalNoteService", () => {
       } as never,
       normalization: {
         applyTimelineProjection: vi.fn(
-          async (_input: unknown): Promise<TimelineProjectionRow> =>
-            ({
+          (...args: unknown[]): Promise<TimelineProjectionRow> => {
+            void args;
+            return Promise.resolve({
               id: "timeline:note-1",
               contactId: "contact:one",
               canonicalEventId: "canonical-event:manual:note:note-1",
@@ -71,7 +72,8 @@ describe("Stage1InternalNoteService", () => {
               channel: "note",
               primaryProvider: "manual",
               reviewState: "clear",
-            }) satisfies TimelineProjectionRow,
+            } satisfies TimelineProjectionRow);
+          },
         ),
         refreshInboxReviewOverlay: vi.fn(() =>
           Promise.resolve(null as InboxProjectionRow | null),

--- a/packages/domain/test/stage3-internal-note-service.test.ts
+++ b/packages/domain/test/stage3-internal-note-service.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  CanonicalEventRecord,
+  InboxProjectionRow,
+  ManualNoteDetailRecord,
+  SourceEvidenceRecord,
+  TimelineProjectionRow,
+} from "@as-comms/contracts";
+
+import { createStage1InternalNoteService } from "../src/notes.js";
+
+function buildContact() {
+  return {
+    id: "contact:one",
+    salesforceContactId: null,
+    displayName: "One Contact",
+    primaryEmail: "contact@example.org",
+    primaryPhone: null,
+    createdAt: "2026-04-21T12:00:00.000Z",
+    updatedAt: "2026-04-21T12:00:00.000Z",
+  };
+}
+
+describe("Stage1InternalNoteService", () => {
+  it("passes authorId through createNote", async () => {
+    const upsertManualNoteDetail = vi.fn((record: ManualNoteDetailRecord) =>
+      Promise.resolve(record),
+    );
+
+    const service = createStage1InternalNoteService({
+      persistence: {
+        repositories: {
+          contacts: {
+            findById: vi.fn(() => Promise.resolve(buildContact())),
+          },
+          sourceEvidence: {
+            findById: vi.fn(() => Promise.resolve(null)),
+          },
+          canonicalEvents: {
+            findById: vi.fn(() => Promise.resolve(null)),
+          },
+          manualNoteDetails: {
+            listBySourceEvidenceIds: vi.fn(() => Promise.resolve([])),
+            updateBody: vi.fn(() => Promise.resolve(null)),
+            deleteByAuthor: vi.fn(() => Promise.resolve(0)),
+          },
+        },
+        recordSourceEvidence: vi.fn(
+          (record: SourceEvidenceRecord) =>
+            ({ outcome: "inserted", record }) as const,
+        ),
+        persistCanonicalEvent: vi.fn(
+          (record: CanonicalEventRecord) =>
+            ({ outcome: "inserted", record }) as const,
+        ),
+        upsertManualNoteDetail,
+      } as never,
+      normalization: {
+        applyTimelineProjection: vi.fn(
+          () =>
+            ({
+              id: "timeline:note-1",
+              contactId: "contact:one",
+              canonicalEventId: "canonical-event:manual:note:note-1",
+              occurredAt: "2026-04-21T12:00:00.000Z",
+              sortKey:
+                "2026-04-21T12:00:00.000Z::canonical-event:manual:note:note-1",
+              eventType: "note.internal.created",
+              summary: "Internal note added",
+              channel: "note",
+              primaryProvider: "manual",
+              reviewState: "clear",
+            }) satisfies TimelineProjectionRow,
+        ),
+        refreshInboxReviewOverlay: vi.fn(() =>
+          Promise.resolve(null as InboxProjectionRow | null),
+        ),
+      },
+    });
+
+    await service.createNote({
+      noteId: "note-1",
+      contactId: "contact:one",
+      body: "Author-owned note",
+      occurredAt: "2026-04-21T12:00:00.000Z",
+      authorDisplayName: "Operator",
+      authorId: "user:author",
+    });
+
+    expect(upsertManualNoteDetail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authorId: "user:author",
+      }),
+    );
+  });
+
+  it("returns not_authorized when a non-author tries to update a note", async () => {
+    const service = createStage1InternalNoteService({
+      persistence: {
+        repositories: {
+          contacts: {
+            findById: vi.fn(() => Promise.resolve(buildContact())),
+          },
+          sourceEvidence: {
+            findById: vi.fn(
+              () =>
+                ({
+                  id: "source-evidence:manual:note:note-2",
+                  provider: "manual",
+                  providerRecordType: "note",
+                  providerRecordId: "note-2",
+                  receivedAt: "2026-04-21T12:00:00.000Z",
+                  occurredAt: "2026-04-21T12:00:00.000Z",
+                  payloadRef: "manual://note/note-2",
+                  idempotencyKey: "manual:note:note-2",
+                  checksum: "checksum-note-2",
+                }) satisfies SourceEvidenceRecord,
+            ),
+          },
+          canonicalEvents: {
+            findById: vi.fn(() => Promise.resolve(null)),
+          },
+          manualNoteDetails: {
+            listBySourceEvidenceIds: vi.fn(
+              () =>
+                [
+                  {
+                    sourceEvidenceId: "source-evidence:manual:note:note-2",
+                    providerRecordId: "note-2",
+                    body: "Original",
+                    authorDisplayName: "Author",
+                    authorId: "user:author",
+                  },
+                ] satisfies ManualNoteDetailRecord[],
+            ),
+            updateBody: vi.fn(() => Promise.resolve(null)),
+            deleteByAuthor: vi.fn(() => Promise.resolve(0)),
+          },
+        },
+      } as never,
+      normalization: {
+        applyTimelineProjection: vi.fn(),
+        refreshInboxReviewOverlay: vi.fn(() => Promise.resolve(null)),
+      },
+    });
+
+    await expect(
+      service.updateNote({
+        noteId: "note-2",
+        authorId: "user:other",
+        body: "Updated",
+      }),
+    ).resolves.toEqual({
+      outcome: "not_authorized",
+    });
+  });
+
+  it("returns not_authorized when a non-author tries to delete a note", async () => {
+    const service = createStage1InternalNoteService({
+      persistence: {
+        repositories: {
+          contacts: {
+            findById: vi.fn(() => Promise.resolve(buildContact())),
+          },
+          sourceEvidence: {
+            findById: vi.fn(
+              () =>
+                ({
+                  id: "source-evidence:manual:note:note-3",
+                  provider: "manual",
+                  providerRecordType: "note",
+                  providerRecordId: "note-3",
+                  receivedAt: "2026-04-21T12:00:00.000Z",
+                  occurredAt: "2026-04-21T12:00:00.000Z",
+                  payloadRef: "manual://note/note-3",
+                  idempotencyKey: "manual:note:note-3",
+                  checksum: "checksum-note-3",
+                }) satisfies SourceEvidenceRecord,
+            ),
+          },
+          canonicalEvents: {
+            findById: vi.fn(
+              () =>
+                ({
+                  id: "canonical-event:manual:note:note-3",
+                  contactId: "contact:one",
+                  eventType: "note.internal.created",
+                  channel: "note",
+                  occurredAt: "2026-04-21T12:00:00.000Z",
+                  sourceEvidenceId: "source-evidence:manual:note:note-3",
+                  idempotencyKey: "canonical-event:manual:note:note-3",
+                  contentFingerprint: null,
+                  provenance: {
+                    primaryProvider: "manual",
+                    primarySourceEvidenceId:
+                      "source-evidence:manual:note:note-3",
+                    supportingSourceEvidenceIds: [],
+                    winnerReason: "single_source",
+                    sourceRecordType: "note",
+                    sourceRecordId: "note-3",
+                    messageKind: null,
+                    campaignRef: null,
+                    threadRef: null,
+                    direction: null,
+                    notes: null,
+                  },
+                  reviewState: "clear",
+                }) satisfies CanonicalEventRecord,
+            ),
+          },
+          manualNoteDetails: {
+            listBySourceEvidenceIds: vi.fn(
+              () =>
+                [
+                  {
+                    sourceEvidenceId: "source-evidence:manual:note:note-3",
+                    providerRecordId: "note-3",
+                    body: "Original",
+                    authorDisplayName: "Author",
+                    authorId: "user:author",
+                  },
+                ] satisfies ManualNoteDetailRecord[],
+            ),
+            updateBody: vi.fn(() => Promise.resolve(null)),
+            deleteByAuthor: vi.fn(() => Promise.resolve(0)),
+          },
+        },
+      } as never,
+      normalization: {
+        applyTimelineProjection: vi.fn(),
+        refreshInboxReviewOverlay: vi.fn(() => Promise.resolve(null)),
+      },
+    });
+
+    await expect(
+      service.deleteNote({
+        noteId: "note-3",
+        authorId: "user:other",
+      }),
+    ).resolves.toEqual({
+      outcome: "not_authorized",
+    });
+  });
+});

--- a/packages/domain/test/stage3-last-inbound-alias.test.ts
+++ b/packages/domain/test/stage3-last-inbound-alias.test.ts
@@ -48,7 +48,9 @@ function buildRepositoryBundle(input: {
       listByIds: () => Promise.resolve(input.canonicalEvents),
       listByContactId: (contactId) =>
         Promise.resolve(
-          input.canonicalEvents.filter((event) => event.contactId === contactId)
+          input.canonicalEvents.filter(
+            (event) => event.contactId === contactId,
+          ),
         ),
       upsert: (record) => Promise.resolve(record),
     },
@@ -84,8 +86,8 @@ function buildRepositoryBundle(input: {
       listBySourceEvidenceIds: (sourceEvidenceIds) =>
         Promise.resolve(
           input.gmailDetails.filter((detail) =>
-            sourceEvidenceIds.includes(detail.sourceEvidenceId)
-          )
+            sourceEvidenceIds.includes(detail.sourceEvidenceId),
+          ),
         ),
       upsert: (record) => Promise.resolve(record),
     },
@@ -108,6 +110,8 @@ function buildRepositoryBundle(input: {
     manualNoteDetails: {
       listBySourceEvidenceIds: () => Promise.resolve([]),
       upsert: (record) => Promise.resolve(record),
+      updateBody: () => Promise.resolve(null),
+      deleteByAuthor: () => Promise.resolve(0),
     },
     pendingOutbounds: {
       insert: ({ id }) => Promise.resolve(id),
@@ -268,11 +272,11 @@ describe("findLastInboundAliasForContact", () => {
             alias: "latest-project@example.org",
           }),
         ],
-      })
+      }),
     );
 
     await expect(
-      presenter.findLastInboundAliasForContact("contact:volunteer")
+      presenter.findLastInboundAliasForContact("contact:volunteer"),
     ).resolves.toBe("latest-project@example.org");
   });
 
@@ -281,11 +285,11 @@ describe("findLastInboundAliasForContact", () => {
       buildRepositoryBundle({
         canonicalEvents: [],
         gmailDetails: [],
-      })
+      }),
     );
 
     await expect(
-      presenter.findLastInboundAliasForContact("contact:volunteer")
+      presenter.findLastInboundAliasForContact("contact:volunteer"),
     ).resolves.toBeNull();
   });
 });

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -7,12 +7,12 @@ import type {
   InboxProjectionRow,
   TimelineItem,
   SourceEvidenceRecord,
-  TimelineProjectionRow
+  TimelineProjectionRow,
 } from "@as-comms/contracts";
 
 import {
   type Stage1RepositoryBundle,
-  defineStage1RepositoryBundle
+  defineStage1RepositoryBundle,
 } from "../src/repositories.js";
 import type { PendingComposerOutboundRecord } from "../src/pending-outbounds.js";
 import { createStage1TimelinePresentationService } from "../src/timeline.js";
@@ -35,19 +35,19 @@ function createRepositoryBundle(input: {
   readonly pendingOutbounds?: readonly PendingComposerOutboundRecord[];
 }): Stage1RepositoryBundle {
   const canonicalEventsById = new Map(
-    input.canonicalEvents.map((event) => [event.id, event])
+    input.canonicalEvents.map((event) => [event.id, event]),
   );
   const sourceEvidenceById = new Map(
-    input.sourceEvidence.map((evidence) => [evidence.id, evidence])
+    input.sourceEvidence.map((evidence) => [evidence.id, evidence]),
   );
   const salesforceCommunicationDetailsBySourceEvidenceId = new Map(
     input.salesforceCommunicationDetails.map((detail) => [
       detail.sourceEvidenceId,
-      detail
-    ])
+      detail,
+    ]),
   );
   const timelineRowsByCanonicalEventId = new Map(
-    input.timelineRows.map((row) => [row.canonicalEventId, row])
+    input.timelineRows.map((row) => [row.canonicalEventId, row]),
   );
 
   const contact: ContactRecord = {
@@ -57,7 +57,7 @@ function createRepositoryBundle(input: {
     primaryEmail: "volunteer@example.org",
     primaryPhone: null,
     createdAt: "2026-01-01T00:00:00.000Z",
-    updatedAt: "2026-01-01T00:00:00.000Z"
+    updatedAt: "2026-01-01T00:00:00.000Z",
   };
 
   return defineStage1RepositoryBundle({
@@ -69,11 +69,11 @@ function createRepositoryBundle(input: {
           ids.flatMap((id) => {
             const evidence = sourceEvidenceById.get(id);
             return evidence === undefined ? [] : [evidence];
-          })
+          }),
         ),
       findByIdempotencyKey: () => Promise.resolve(null),
       countByProvider: () => Promise.resolve(0),
-      listByProviderRecord: () => Promise.resolve([])
+      listByProviderRecord: () => Promise.resolve([]),
     },
     canonicalEvents: {
       findById: (id) => Promise.resolve(canonicalEventsById.get(id) ?? null),
@@ -87,13 +87,15 @@ function createRepositoryBundle(input: {
           ids.flatMap((id) => {
             const event = canonicalEventsById.get(id);
             return event === undefined ? [] : [event];
-          })
+          }),
         ),
       listByContactId: (contactId) =>
         Promise.resolve(
-          input.canonicalEvents.filter((event) => event.contactId === contactId)
+          input.canonicalEvents.filter(
+            (event) => event.contactId === contactId,
+          ),
         ),
-      upsert: (record) => Promise.resolve(record)
+      upsert: (record) => Promise.resolve(record),
     },
     contacts: {
       findById: () => Promise.resolve(contact),
@@ -101,60 +103,66 @@ function createRepositoryBundle(input: {
       listAll: () => Promise.resolve([contact]),
       listByIds: () => Promise.resolve([contact]),
       searchByQuery: () => Promise.resolve([contact]),
-      upsert: (record) => Promise.resolve(record)
+      upsert: (record) => Promise.resolve(record),
     },
     contactIdentities: {
       listByContactId: () => Promise.resolve([]),
       listByNormalizedValue: () => Promise.resolve([]),
-      upsert: (record) => Promise.resolve(record)
+      upsert: (record) => Promise.resolve(record),
     },
     contactMemberships: {
       listByContactId: () => Promise.resolve([]),
       listByContactIds: () => Promise.resolve([]),
-      upsert: (record) => Promise.resolve(record)
+      upsert: (record) => Promise.resolve(record),
     },
     projectDimensions: {
       listAll: () => Promise.resolve([]),
       listActive: () => Promise.resolve([]),
       listByIds: () => Promise.resolve([]),
-      upsert: (record) => Promise.resolve(record)
+      upsert: (record) => Promise.resolve(record),
     },
     expeditionDimensions: {
       listByIds: () => Promise.resolve([]),
-      upsert: (record) => Promise.resolve(record)
+      upsert: (record) => Promise.resolve(record),
     },
     gmailMessageDetails: {
       listBySourceEvidenceIds: () => Promise.resolve([]),
-      upsert: (record) => Promise.resolve(record)
+      upsert: (record) => Promise.resolve(record),
     },
     salesforceEventContext: {
       listBySourceEvidenceIds: () => Promise.resolve([]),
-      upsert: (record) => Promise.resolve(record)
+      upsert: (record) => Promise.resolve(record),
     },
     salesforceCommunicationDetails: {
       listBySourceEvidenceIds: (sourceEvidenceIds) =>
         Promise.resolve(
           sourceEvidenceIds.flatMap(
-            (sourceEvidenceId): readonly SalesforceCommunicationDetailRecord[] => {
-            const detail =
-              salesforceCommunicationDetailsBySourceEvidenceId.get(sourceEvidenceId);
-            return detail === undefined ? [] : [detail];
-            }
-          )
+            (
+              sourceEvidenceId,
+            ): readonly SalesforceCommunicationDetailRecord[] => {
+              const detail =
+                salesforceCommunicationDetailsBySourceEvidenceId.get(
+                  sourceEvidenceId,
+                );
+              return detail === undefined ? [] : [detail];
+            },
+          ),
         ),
-      upsert: (record) => Promise.resolve(record)
+      upsert: (record) => Promise.resolve(record),
     },
     simpleTextingMessageDetails: {
       listBySourceEvidenceIds: () => Promise.resolve([]),
-      upsert: (record) => Promise.resolve(record)
+      upsert: (record) => Promise.resolve(record),
     },
     mailchimpCampaignActivityDetails: {
       listBySourceEvidenceIds: () => Promise.resolve([]),
-      upsert: (record) => Promise.resolve(record)
+      upsert: (record) => Promise.resolve(record),
     },
     manualNoteDetails: {
       listBySourceEvidenceIds: () => Promise.resolve([]),
-      upsert: (record) => Promise.resolve(record)
+      upsert: (record) => Promise.resolve(record),
+      updateBody: () => Promise.resolve(null),
+      deleteByAuthor: () => Promise.resolve(0),
     },
     pendingOutbounds: {
       insert: ({ id }) => Promise.resolve(id),
@@ -167,20 +175,20 @@ function createRepositoryBundle(input: {
         Promise.resolve(
           (input.pendingOutbounds ?? [])
             .filter((row) => row.canonicalContactId === contactId)
-            .slice(0, limit)
-        )
+            .slice(0, limit),
+        ),
     },
     identityResolutionQueue: {
       findById: () => Promise.resolve(null),
       listOpenByContactId: () => Promise.resolve([]),
       listOpenByReasonCode: () => Promise.resolve([]),
-      upsert: (record) => Promise.resolve(record)
+      upsert: (record) => Promise.resolve(record),
     },
     routingReviewQueue: {
       findById: () => Promise.resolve(null),
       listOpenByContactId: () => Promise.resolve([]),
       listOpenByReasonCode: () => Promise.resolve([]),
-      upsert: (record) => Promise.resolve(record)
+      upsert: (record) => Promise.resolve(record),
     },
     inboxProjection: {
       countAll: () => Promise.resolve(0),
@@ -191,7 +199,7 @@ function createRepositoryBundle(input: {
       searchPageOrderedByRecency: () =>
         Promise.resolve({
           rows: [],
-          total: 0
+          total: 0,
         }),
       listPageOrderedByRecency: () => Promise.resolve([]),
       countByFilters: () =>
@@ -199,25 +207,27 @@ function createRepositoryBundle(input: {
           all: 0,
           unread: 0,
           followUp: 0,
-          unresolved: 0
+          unresolved: 0,
         }),
-        getFreshness: () =>
-          Promise.resolve({
-            total: 0,
-            latestUpdatedAt: null
-          }),
-        getFreshnessByContactId: () => Promise.resolve(null),
-        deleteByContactId: () => Promise.resolve(),
-        setNeedsFollowUp: () => Promise.resolve(null),
-        upsert: (record: InboxProjectionRow) => Promise.resolve(record)
-      },
+      getFreshness: () =>
+        Promise.resolve({
+          total: 0,
+          latestUpdatedAt: null,
+        }),
+      getFreshnessByContactId: () => Promise.resolve(null),
+      deleteByContactId: () => Promise.resolve(),
+      setNeedsFollowUp: () => Promise.resolve(null),
+      upsert: (record: InboxProjectionRow) => Promise.resolve(record),
+    },
     timelineProjection: {
       countAll: () => Promise.resolve(input.timelineRows.length),
       findByCanonicalEventId: (canonicalEventId) =>
-        Promise.resolve(timelineRowsByCanonicalEventId.get(canonicalEventId) ?? null),
+        Promise.resolve(
+          timelineRowsByCanonicalEventId.get(canonicalEventId) ?? null,
+        ),
       listByContactId: (contactId) =>
         Promise.resolve(
-          input.timelineRows.filter((row) => row.contactId === contactId)
+          input.timelineRows.filter((row) => row.contactId === contactId),
         ),
       listRecentByContactId: ({ contactId, limit, beforeSortKey }) =>
         Promise.resolve(
@@ -225,42 +235,45 @@ function createRepositoryBundle(input: {
             .filter(
               (row) =>
                 row.contactId === contactId &&
-                (beforeSortKey === null || row.sortKey < beforeSortKey)
+                (beforeSortKey === null || row.sortKey < beforeSortKey),
             )
             .sort((left, right) => right.sortKey.localeCompare(left.sortKey))
-            .slice(0, limit)
+            .slice(0, limit),
         ),
       countByContactId: (contactId) =>
         Promise.resolve(
-          input.timelineRows.filter((row) => row.contactId === contactId).length
+          input.timelineRows.filter((row) => row.contactId === contactId)
+            .length,
         ),
       getFreshnessByContactId: (contactId) => {
-        const rows = input.timelineRows.filter((row) => row.contactId === contactId);
+        const rows = input.timelineRows.filter(
+          (row) => row.contactId === contactId,
+        );
         return Promise.resolve({
           contactId,
           total: rows.length,
           latestUpdatedAt: null,
-          latestSortKey: rows.at(-1)?.sortKey ?? null
+          latestSortKey: rows.at(-1)?.sortKey ?? null,
         });
       },
-      upsert: (record) => Promise.resolve(record)
+      upsert: (record) => Promise.resolve(record),
     },
     syncState: {
       findById: () => Promise.resolve(null),
       findLatest: () => Promise.resolve(null),
       listAll: () => Promise.resolve([]),
-      upsert: (record) => Promise.resolve(record)
+      upsert: (record) => Promise.resolve(record),
     },
     auditEvidence: {
       append: (record: AuditEvidenceRecord) => Promise.resolve(record),
-      listByEntity: () => Promise.resolve([])
-    }
+      listByEntity: () => Promise.resolve([]),
+    },
   });
 }
 
 function buildSourceEvidence(
   id: string,
-  providerRecordId: string
+  providerRecordId: string,
 ): SourceEvidenceRecord {
   return {
     id,
@@ -271,7 +284,7 @@ function buildSourceEvidence(
     occurredAt: "2026-01-01T00:00:00.000Z",
     payloadRef: `payloads/salesforce/${providerRecordId}.json`,
     idempotencyKey: `salesforce:${providerRecordId}`,
-    checksum: `checksum:${providerRecordId}`
+    checksum: `checksum:${providerRecordId}`,
   };
 }
 
@@ -308,9 +321,9 @@ function buildSalesforceOutboundEmailEvent(input: {
         campaignRef: null,
         threadRef: null,
         direction: "outbound",
-        notes: null
+        notes: null,
       } as CanonicalEventRecord["provenance"],
-      reviewState: "clear"
+      reviewState: "clear",
     },
     detail: {
       sourceEvidenceId: input.sourceEvidenceId,
@@ -321,7 +334,7 @@ function buildSalesforceOutboundEmailEvent(input: {
       messageKind: input.messageKind ?? "one_to_one",
       subject: input.subject,
       snippet: input.snippet,
-      sourceLabel: "Salesforce Logged Email"
+      sourceLabel: "Salesforce Logged Email",
     },
     timelineRow: {
       id: `timeline:${input.id}`,
@@ -333,8 +346,8 @@ function buildSalesforceOutboundEmailEvent(input: {
       summary: input.subject,
       channel: "email",
       primaryProvider: "salesforce",
-      reviewState: "clear"
-    }
+      reviewState: "clear",
+    },
   };
 }
 
@@ -346,7 +359,7 @@ describe("Stage 1 timeline presenter", () => {
       occurredAt: "2026-01-01T00:00:00.000Z",
       messageKind: null,
       subject: "Logged follow-up",
-      snippet: "Logged follow-up body"
+      snippet: "Logged follow-up body",
     });
     const explicitOneToOne = buildSalesforceOutboundEmailEvent({
       id: "evt_salesforce_one_to_one",
@@ -354,7 +367,7 @@ describe("Stage 1 timeline presenter", () => {
       occurredAt: "2026-01-01T00:01:00.000Z",
       messageKind: "one_to_one",
       subject: "Explicit one-to-one follow-up",
-      snippet: "Explicit one-to-one body"
+      snippet: "Explicit one-to-one body",
     });
     const explicitAuto = buildSalesforceOutboundEmailEvent({
       id: "evt_salesforce_auto",
@@ -362,33 +375,35 @@ describe("Stage 1 timeline presenter", () => {
       occurredAt: "2026-01-01T00:02:00.000Z",
       messageKind: "auto",
       subject: "Automation sent",
-      snippet: "Automation body"
+      snippet: "Automation body",
     });
 
     const repositories = createRepositoryBundle({
       canonicalEvents: [
         nullClassified.canonicalEvent,
         explicitOneToOne.canonicalEvent,
-        explicitAuto.canonicalEvent
+        explicitAuto.canonicalEvent,
       ],
       sourceEvidence: [
         buildSourceEvidence("sev_salesforce_null", "salesforce-null"),
-        buildSourceEvidence("sev_salesforce_one_to_one", "salesforce-one-to-one"),
-        buildSourceEvidence("sev_salesforce_auto", "salesforce-auto")
+        buildSourceEvidence(
+          "sev_salesforce_one_to_one",
+          "salesforce-one-to-one",
+        ),
+        buildSourceEvidence("sev_salesforce_auto", "salesforce-auto"),
       ],
       salesforceCommunicationDetails: [
         nullClassified.detail,
         explicitOneToOne.detail,
-        explicitAuto.detail
+        explicitAuto.detail,
       ],
       timelineRows: [
         nullClassified.timelineRow,
         explicitOneToOne.timelineRow,
-        explicitAuto.timelineRow
-      ]
+        explicitAuto.timelineRow,
+      ],
     });
-    const presenter =
-      createStage1TimelinePresentationService(repositories);
+    const presenter = createStage1TimelinePresentationService(repositories);
 
     const items: readonly TimelineItem[] =
       await presenter.listTimelineItemsByContactId("contact_1");
@@ -396,21 +411,21 @@ describe("Stage 1 timeline presenter", () => {
     expect(
       items.map((item) => ({
         canonicalEventId: item.canonicalEventId,
-        family: item.family
-      }))
+        family: item.family,
+      })),
     ).toEqual([
       {
         canonicalEventId: "evt_salesforce_null",
-        family: "one_to_one_email"
+        family: "one_to_one_email",
       },
       {
         canonicalEventId: "evt_salesforce_one_to_one",
-        family: "one_to_one_email"
+        family: "one_to_one_email",
       },
       {
         canonicalEventId: "evt_salesforce_auto",
-        family: "auto_email"
-      }
+        family: "auto_email",
+      },
     ]);
   });
 
@@ -421,12 +436,15 @@ describe("Stage 1 timeline presenter", () => {
       occurredAt: "2026-01-01T00:01:00.000Z",
       messageKind: "one_to_one",
       subject: "Existing outbound",
-      snippet: "Existing outbound body"
+      snippet: "Existing outbound body",
     });
     const repositories = createRepositoryBundle({
       canonicalEvents: [outbound.canonicalEvent],
       sourceEvidence: [
-        buildSourceEvidence("sev_salesforce_one_to_one", "salesforce-one-to-one")
+        buildSourceEvidence(
+          "sev_salesforce_one_to_one",
+          "salesforce-one-to-one",
+        ),
       ],
       salesforceCommunicationDetails: [outbound.detail],
       timelineRows: [outbound.timelineRow],
@@ -452,9 +470,9 @@ describe("Stage 1 timeline presenter", () => {
           failedReason: null,
           orphanedAt: null,
           createdAt: "2026-01-01T00:02:00.000Z",
-          updatedAt: "2026-01-01T00:02:00.000Z"
-        }
-      ]
+          updatedAt: "2026-01-01T00:02:00.000Z",
+        },
+      ],
     });
     const presenter = createStage1TimelinePresentationService(repositories);
 
@@ -462,7 +480,7 @@ describe("Stage 1 timeline presenter", () => {
 
     expect(items.map((item) => item.canonicalEventId)).toEqual([
       "evt_salesforce_one_to_one",
-      "pending-outbound:pending:1"
+      "pending-outbound:pending:1",
     ]);
     expect(items[1]).toMatchObject({
       family: "one_to_one_email",
@@ -470,7 +488,7 @@ describe("Stage 1 timeline presenter", () => {
       subject: "Pending outbound",
       bodyPreview: "Pending outbound body",
       sendStatus: "pending",
-      attachmentCount: 0
+      attachmentCount: 0,
     });
   });
 });


### PR DESCRIPTION
## Summary
Brief 5 — wires the Composer note tab to real persistence + adds author-only edit/delete affordances in the timeline. Notes flow through the existing \`Stage1InternalNoteService.createNote\` (no new write pipeline). Author enforcement lives on a new \`author_id\` FK on \`manual_note_details\`.

## Scope
- [x] Migration 0011: \`manual_note_details.author_id\` nullable FK → \`users(id)\`
- [x] Repo methods: authored \`upsert\`, \`updateBody\`, \`deleteByAuthor\` (all guarded by author_id in the WHERE)
- [x] \`Stage1InternalNoteService\`: authorId on createNote + new updateNote + deleteNote (outcome: applied | not_authorized | not_found)
- [x] Server Actions: \`createNoteAction\`, \`updateNoteAction\`, \`deleteNoteAction\` (auth, 60/min rate limit, plaintext HTML-tag rejection, audit trail)
- [x] Composer note tab enabled in reply context; Save note wired end-to-end
- [x] Timeline internal_note bubbles gain inline Edit + Delete affordances shown only to the author
- [x] Contracts: \`noteId\` + \`authorId\` carried through the internal_note timeline variant
- [x] Shared plaintext validation extracted to \`apps/web/src/lib\`

## D-029 alignment
- Notes remain team-visible (no private flag)
- Plaintext only, HTML tags rejected server-side
- Author-stamped; only the author sees edit/delete affordances; server also enforces via the author_id guard
- Legacy notes (author_id = null) remain visible but have no edit/delete controls

## Ops follow-up
- [ ] Run \`packages/db/drizzle/0011_manual_note_author.sql\` against Railway DB before the web deploy lands

## Test plan
- [ ] CI green (typecheck, lint, unit, boundaries, verify — all passing locally)
- [ ] Manual browser verification: open a contact, switch composer to Note mode, save → verify bubble; Edit + Delete flows work; note from another operator has no affordances

🤖 Generated with [Claude Code](https://claude.com/claude-code)