### PR TITLE
fix(inbox): trust Salesforce detail message kinds

### DIFF
--- a/packages/domain/src/timeline.ts
+++ b/packages/domain/src/timeline.ts
@@ -31,6 +31,8 @@ type SalesforceEventContextDetail = SalesforceEventContextRecord & {
 
 interface SalesforceCommunicationDetail {
   readonly sourceEvidenceId: string;
+  readonly channel: "email" | "sms";
+  readonly messageKind: "auto" | "campaign" | "one_to_one";
   readonly subject: string | null;
   readonly snippet: string;
   readonly sourceLabel: string;
@@ -114,9 +116,41 @@ function getLifecycleMilestone(
   }
 }
 
-function resolveFamily(event: CanonicalEventRecord): TimelineItem["family"] {
+function resolveCommunicationMessageKind(input: {
+  readonly event: CanonicalEventRecord;
+  readonly salesforceCommunicationDetail: SalesforceCommunicationDetail | undefined;
+}): TimelineProvenance["messageKind"] {
+  const provenance = input.event.provenance as TimelineProvenance;
+  const eventType = input.event.eventType as string;
+
+  if (provenance.primaryProvider === "salesforce") {
+    const expectedChannel = eventType.includes(".sms.")
+      ? "sms"
+      : eventType.includes(".email.")
+        ? "email"
+        : null;
+
+    if (
+      expectedChannel !== null &&
+      input.salesforceCommunicationDetail?.channel === expectedChannel
+    ) {
+      return input.salesforceCommunicationDetail.messageKind;
+    }
+  }
+
+  return provenance.messageKind;
+}
+
+function resolveFamily(
+  event: CanonicalEventRecord,
+  salesforceCommunicationDetail: SalesforceCommunicationDetail | undefined,
+): TimelineItem["family"] {
   const eventType = event.eventType as string;
   const provenance = event.provenance as TimelineProvenance;
+  const messageKind = resolveCommunicationMessageKind({
+    event,
+    salesforceCommunicationDetail,
+  });
 
   if (eventType.startsWith("lifecycle.")) {
     return "salesforce_event";
@@ -132,21 +166,21 @@ function resolveFamily(event: CanonicalEventRecord): TimelineItem["family"] {
 
   if (
     eventType === "communication.email.outbound" &&
-    provenance.messageKind === "auto"
+    messageKind === "auto"
   ) {
     return "auto_email";
   }
 
   if (
     eventType === "communication.sms.outbound" &&
-    provenance.messageKind === "auto"
+    messageKind === "auto"
   ) {
     return "auto_sms";
   }
 
   if (
     eventType === "communication.sms.outbound" &&
-    provenance.messageKind === "campaign"
+    messageKind === "campaign"
   ) {
     return "campaign_sms";
   }
@@ -154,8 +188,8 @@ function resolveFamily(event: CanonicalEventRecord): TimelineItem["family"] {
   if (
     (eventType === "communication.email.inbound" ||
       eventType === "communication.email.outbound") &&
-    (provenance.messageKind === "one_to_one" ||
-      (provenance.messageKind === null &&
+    (messageKind === "one_to_one" ||
+      (messageKind === null &&
         (provenance.primaryProvider === "gmail" ||
           provenance.primaryProvider === "salesforce")))
   ) {
@@ -165,8 +199,8 @@ function resolveFamily(event: CanonicalEventRecord): TimelineItem["family"] {
   if (
     (eventType === "communication.sms.inbound" ||
       eventType === "communication.sms.outbound") &&
-    (provenance.messageKind === "one_to_one" ||
-      (provenance.messageKind === null &&
+    (messageKind === "one_to_one" ||
+      (messageKind === null &&
         (provenance.primaryProvider === "simpletexting" ||
           provenance.primaryProvider === "salesforce")))
   ) {
@@ -390,7 +424,9 @@ function buildTimelineItemsFromRows(input: {
       continue;
     }
 
-    const family = resolveFamily(event);
+    const salesforceCommunicationDetail =
+      input.context.salesforceCommunicationBySourceEvidenceId.get(evidence.id);
+    const family = resolveFamily(event, salesforceCommunicationDetail);
     const base = commonFields(row);
     const provenance = event.provenance as TimelineProvenance;
     const salesforceContext =
@@ -398,8 +434,6 @@ function buildTimelineItemsFromRows(input: {
     const gmailDetail = input.context.gmailDetailBySourceEvidenceId.get(
       evidence.id,
     );
-    const salesforceCommunicationDetail =
-      input.context.salesforceCommunicationBySourceEvidenceId.get(evidence.id);
     const simpleTextingDetail =
       input.context.simpleTextingDetailBySourceEvidenceId.get(evidence.id);
     const mailchimpDetail = input.context.mailchimpDetailBySourceEvidenceId.get(

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -288,11 +288,13 @@ function buildSourceEvidence(
   };
 }
 
-function buildSalesforceOutboundEmailEvent(input: {
+function buildSalesforceEmailEvent(input: {
   readonly id: string;
   readonly sourceEvidenceId: string;
   readonly occurredAt: string;
-  readonly messageKind: "one_to_one" | "auto" | null;
+  readonly direction: "inbound" | "outbound";
+  readonly canonicalMessageKind: "one_to_one" | "auto" | null;
+  readonly detailMessageKind?: "one_to_one" | "auto" | "campaign";
   readonly subject: string;
   readonly snippet: string;
 }): {
@@ -304,7 +306,7 @@ function buildSalesforceOutboundEmailEvent(input: {
     canonicalEvent: {
       id: input.id,
       contactId: "contact_1",
-      eventType: "communication.email.outbound",
+      eventType: `communication.email.${input.direction}`,
       channel: "email",
       occurredAt: input.occurredAt,
       contentFingerprint: null,
@@ -317,10 +319,10 @@ function buildSalesforceOutboundEmailEvent(input: {
         winnerReason: "single_source",
         sourceRecordType: "task_communication",
         sourceRecordId: input.id,
-        messageKind: input.messageKind,
+        messageKind: input.canonicalMessageKind,
         campaignRef: null,
         threadRef: null,
-        direction: "outbound",
+        direction: input.direction,
         notes: null,
       } as CanonicalEventRecord["provenance"],
       reviewState: "clear",
@@ -329,9 +331,8 @@ function buildSalesforceOutboundEmailEvent(input: {
       sourceEvidenceId: input.sourceEvidenceId,
       providerRecordId: input.id,
       channel: "email",
-      // The detail table stores a concrete message kind even when canonical
-      // provenance remains null for the classification regression case.
-      messageKind: input.messageKind ?? "one_to_one",
+      messageKind:
+        input.detailMessageKind ?? input.canonicalMessageKind ?? "one_to_one",
       subject: input.subject,
       snippet: input.snippet,
       sourceLabel: "Salesforce Logged Email",
@@ -342,7 +343,7 @@ function buildSalesforceOutboundEmailEvent(input: {
       canonicalEventId: input.id,
       occurredAt: input.occurredAt,
       sortKey: `${input.occurredAt}::${input.id}`,
-      eventType: "communication.email.outbound",
+      eventType: `communication.email.${input.direction}`,
       summary: input.subject,
       channel: "email",
       primaryProvider: "salesforce",
@@ -353,27 +354,30 @@ function buildSalesforceOutboundEmailEvent(input: {
 
 describe("Stage 1 timeline presenter", () => {
   it("keeps Salesforce outbound email in the 1:1 family unless canon explicitly marks it auto", async () => {
-    const nullClassified = buildSalesforceOutboundEmailEvent({
+    const nullClassified = buildSalesforceEmailEvent({
       id: "evt_salesforce_null",
       sourceEvidenceId: "sev_salesforce_null",
       occurredAt: "2026-01-01T00:00:00.000Z",
-      messageKind: null,
+      direction: "outbound",
+      canonicalMessageKind: null,
       subject: "Logged follow-up",
       snippet: "Logged follow-up body",
     });
-    const explicitOneToOne = buildSalesforceOutboundEmailEvent({
+    const explicitOneToOne = buildSalesforceEmailEvent({
       id: "evt_salesforce_one_to_one",
       sourceEvidenceId: "sev_salesforce_one_to_one",
       occurredAt: "2026-01-01T00:01:00.000Z",
-      messageKind: "one_to_one",
+      direction: "outbound",
+      canonicalMessageKind: "one_to_one",
       subject: "Explicit one-to-one follow-up",
       snippet: "Explicit one-to-one body",
     });
-    const explicitAuto = buildSalesforceOutboundEmailEvent({
+    const explicitAuto = buildSalesforceEmailEvent({
       id: "evt_salesforce_auto",
       sourceEvidenceId: "sev_salesforce_auto",
       occurredAt: "2026-01-01T00:02:00.000Z",
-      messageKind: "auto",
+      direction: "outbound",
+      canonicalMessageKind: "auto",
       subject: "Automation sent",
       snippet: "Automation body",
     });
@@ -429,12 +433,80 @@ describe("Stage 1 timeline presenter", () => {
     ]);
   });
 
+  it("prefers Salesforce communication detail message kinds when canonical metadata is stale", async () => {
+    const inboundAutoMismatch = buildSalesforceEmailEvent({
+      id: "evt_salesforce_inbound_auto_mismatch",
+      sourceEvidenceId: "sev_salesforce_inbound_auto_mismatch",
+      occurredAt: "2026-01-01T00:00:00.000Z",
+      direction: "inbound",
+      canonicalMessageKind: "auto",
+      detailMessageKind: "one_to_one",
+      subject: "Accepted: chat about orcas",
+      snippet: "Elise Newman has accepted this invitation.",
+    });
+    const outboundAutoMismatch = buildSalesforceEmailEvent({
+      id: "evt_salesforce_outbound_auto_mismatch",
+      sourceEvidenceId: "sev_salesforce_outbound_auto_mismatch",
+      occurredAt: "2026-01-01T00:01:00.000Z",
+      direction: "outbound",
+      canonicalMessageKind: "auto",
+      detailMessageKind: "one_to_one",
+      subject: "Manual follow-up",
+      snippet: "Operator follow-up sent from Salesforce.",
+    });
+
+    const repositories = createRepositoryBundle({
+      canonicalEvents: [
+        inboundAutoMismatch.canonicalEvent,
+        outboundAutoMismatch.canonicalEvent,
+      ],
+      sourceEvidence: [
+        buildSourceEvidence(
+          "sev_salesforce_inbound_auto_mismatch",
+          "salesforce-inbound-auto-mismatch",
+        ),
+        buildSourceEvidence(
+          "sev_salesforce_outbound_auto_mismatch",
+          "salesforce-outbound-auto-mismatch",
+        ),
+      ],
+      salesforceCommunicationDetails: [
+        inboundAutoMismatch.detail,
+        outboundAutoMismatch.detail,
+      ],
+      timelineRows: [
+        inboundAutoMismatch.timelineRow,
+        outboundAutoMismatch.timelineRow,
+      ],
+    });
+    const presenter = createStage1TimelinePresentationService(repositories);
+
+    const items = await presenter.listTimelineItemsByContactId("contact_1");
+
+    expect(
+      items.map((item) => ({
+        canonicalEventId: item.canonicalEventId,
+        family: item.family,
+      })),
+    ).toEqual([
+      {
+        canonicalEventId: "evt_salesforce_inbound_auto_mismatch",
+        family: "one_to_one_email",
+      },
+      {
+        canonicalEventId: "evt_salesforce_outbound_auto_mismatch",
+        family: "one_to_one_email",
+      },
+    ]);
+  });
+
   it("unions pending composer outbounds into the timeline read model", async () => {
-    const outbound = buildSalesforceOutboundEmailEvent({
+    const outbound = buildSalesforceEmailEvent({
       id: "evt_salesforce_one_to_one",
       sourceEvidenceId: "sev_salesforce_one_to_one",
       occurredAt: "2026-01-01T00:01:00.000Z",
-      messageKind: "one_to_one",
+      direction: "outbound",
+      canonicalMessageKind: "one_to_one",
       subject: "Existing outbound",
       snippet: "Existing outbound body",
     });


### PR DESCRIPTION
## Summary
- prefer Salesforce communication detail `messageKind` when classifying inbox timeline items
- keep the fallback scoped to matching communication channels so canonical metadata still wins elsewhere
- add regression coverage for stale Salesforce canonical metadata on inbound and outbound email rows

## Why
Production inbox detail rendering is failing for Salesforce-backed contacts when canonical `messageKind` is stale (`auto`) but the provider-specific communication detail row says `one_to_one`. This change uses the more specific detail record for timeline family resolution and keeps the inbox detail page from crashing on those contacts.

## Verification
- `packages/domain/test/timeline.test.ts`
- `packages/domain` lint
- `packages/domain` typecheck