### PR TITLE
fix(web): build integrations before Next build

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "build": "pnpm --dir ../.. --filter @as-comms/integrations build && next build",
+    "build": "next build",
     "start": "next start",
     "lint": "eslint app src tests next.config.ts tailwind.config.ts --max-warnings=0",
     "typecheck": "tsc -p tsconfig.typecheck.json --noEmit",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "pnpm --dir ../.. --filter @as-comms/integrations build && next build",
     "start": "next start",
     "lint": "eslint app src tests next.config.ts tailwind.config.ts --max-warnings=0",
     "typecheck": "tsc -p tsconfig.typecheck.json --noEmit",

--- a/apps/web/railway.json
+++ b/apps/web/railway.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "RAILPACK",
+    "buildCommand": "pnpm install --frozen-lockfile && pnpm --filter @as-comms/web... build"
+  },
+  "deploy": {
+    "startCommand": "pnpm --filter @as-comms/web start"
+  }
+}

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/integrations/src/index.ts
+++ b/packages/integrations/src/index.ts
@@ -1,3 +1,5 @@
+/// <reference path="./libmime.d.ts" />
+
 export * from "./provider-types.js";
 export * from "./shared.js";
 export {

--- a/packages/integrations/src/index.ts
+++ b/packages/integrations/src/index.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="./libmime.d.ts" />
 
 export * from "./provider-types.js";


### PR DESCRIPTION
## Summary
- build `@as-comms/integrations` inside the web package build path before running `next build`

## Why
Railway's latest web deployment for `main` failed immediately after `#83` merged because `apps/web/src/server/composer/gmail-send.ts` imports `@as-comms/integrations`, but the clean web build path did not ensure that workspace package had been built first.

## Verification
- Railway web deployment failure log for `6630db85-d2a6-4121-a8a1-f45537fbe7a9` shows `Module not found: Can't resolve '@as-comms/integrations'`
- this change makes the web build path explicitly build that workspace package before `next build`