### PR TITLE
[codex] add Salesforce email cleanup and audit ops

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -14,6 +14,8 @@
     "ops:check-config": "tsx src/ops/cli.ts check-config",
     "ops:backfill-gmail-message-bodies": "tsx src/ops/backfill-gmail-message-bodies.ts",
     "ops:backfill-salesforce-communication-details": "tsx src/ops/backfill-salesforce-communication-details.ts",
+    "ops:audit-salesforce-task-ingest": "tsx src/ops/audit-salesforce-task-ingest.ts",
+    "ops:cleanup-salesforce-owner-scope": "tsx src/ops/cleanup-salesforce-owner-scope.ts",
     "ops:dedup-historical-ledger": "tsx src/ops/dedup-historical-ledger.ts",
     "ops:enqueue": "tsx src/ops/cli.ts enqueue",
     "ops:import-gmail-mbox": "tsx src/ops/cli.ts import-gmail-mbox",

--- a/apps/worker/src/ops/_reconcile-from-stored-evidence.ts
+++ b/apps/worker/src/ops/_reconcile-from-stored-evidence.ts
@@ -238,7 +238,9 @@ function parseSubjectDirection(rawSubject: string | null): {
 
   return {
     direction: "outbound",
-    cleanSubject: trimmed
+    cleanSubject: normalizeCleanSubject(
+      trimmed.replace(/^Email:\s*/iu, "")
+    )
   };
 }
 

--- a/apps/worker/src/ops/_salesforce-task-audit.ts
+++ b/apps/worker/src/ops/_salesforce-task-audit.ts
@@ -1,0 +1,371 @@
+export interface SalesforceTaskAuditRow {
+  readonly canonicalEventId: string;
+  readonly sourceEvidenceId: string;
+  readonly providerRecordId: string;
+  readonly payloadRef: string;
+  readonly contactId: string;
+  readonly displayName: string;
+  readonly salesforceContactId: string | null;
+  readonly membershipCount: number;
+  readonly projects: string | null;
+  readonly messageKind: "auto" | "one_to_one" | "campaign";
+  readonly subject: string | null;
+  readonly snippet: string;
+  readonly sourceLabel: string;
+  readonly occurredAt: string;
+  readonly subjectEventCount: number;
+  readonly subjectContactCount: number;
+}
+
+export interface SalesforceTaskAuditSignals {
+  readonly subjectPrefix: "reply" | "forward" | "none";
+  readonly hasStructuredEnvelope: boolean;
+  readonly hasQuotedReply: boolean;
+  readonly hasHtmlMarkup: boolean;
+  readonly hasVolunteerAutomationKeyword: boolean;
+  readonly hasBatchLikeSubject: boolean;
+  readonly hasConversationSignal: boolean;
+  readonly hasAutomationSignal: boolean;
+}
+
+export type SalesforceTaskInferredShape =
+  | "probable_human_conversation"
+  | "probable_automation"
+  | "mixed"
+  | "unclear";
+
+export interface SalesforceTaskAuditAnnotatedRow extends SalesforceTaskAuditRow {
+  readonly signals: SalesforceTaskAuditSignals;
+  readonly inferredShape: SalesforceTaskInferredShape;
+}
+
+export interface SalesforceTaskAuditTopSubject {
+  readonly subject: string;
+  readonly eventCount: number;
+  readonly contactCount: number;
+}
+
+export interface SalesforceTaskAuditReport {
+  readonly totalRows: number;
+  readonly distinctContacts: number;
+  readonly rowsWithoutMembership: number;
+  readonly messageKindCounts: Readonly<Record<string, number>>;
+  readonly inferredShapeCounts: Readonly<Record<string, number>>;
+  readonly signalCounts: Readonly<Record<string, number>>;
+  readonly mismatchCounts: Readonly<Record<string, number>>;
+  readonly topSubjects: readonly SalesforceTaskAuditTopSubject[];
+  readonly samples: {
+    readonly autoWithConversationSignal: readonly SalesforceTaskAuditAnnotatedRow[];
+    readonly autoButProbablyHuman: readonly SalesforceTaskAuditAnnotatedRow[];
+    readonly oneToOneButProbablyAutomation: readonly SalesforceTaskAuditAnnotatedRow[];
+    readonly probableHumanConversation: readonly SalesforceTaskAuditAnnotatedRow[];
+    readonly probableAutomation: readonly SalesforceTaskAuditAnnotatedRow[];
+  };
+}
+
+const replyPrefixPattern = /^\s*re\s*:/iu;
+const forwardPrefixPattern = /^\s*(?:fw|fwd)\s*:/iu;
+const structuredEnvelopePatterns = [
+  /^from:/imu,
+  /^recipients?:/imu,
+  /^subject:/imu,
+  /^body:/imu
+] as const;
+const quotedReplyPatterns = [
+  /\bon .+ wrote:/iu,
+  /forwarded message/iu,
+  /original message/iu
+] as const;
+const volunteerAutomationKeywordPatterns = [
+  /\btraining\b/iu,
+  /\bapplication\b/iu,
+  /\bapply(?:ing|)?\b/iu,
+  /\bcapacit/iu,
+  /\bnext step\b/iu,
+  /\bwaitlist\b/iu,
+  /\breminder\b/iu,
+  /\bvolunteer gathering\b/iu,
+  /\bpints for pines\b/iu,
+  /\bstart your training\b/iu,
+  /\bcomplete(?:d)? your training\b/iu,
+  /\byour [a-z0-9' -]+ application\b/iu,
+  /\bready\. set\. go\./iu
+] as const;
+
+function matchesAnyPattern(
+  value: string | null | undefined,
+  patterns: readonly RegExp[]
+): boolean {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return false;
+  }
+
+  return patterns.some((pattern) => pattern.test(value));
+}
+
+function normalizeSubject(value: string | null): string {
+  return value?.trim() || "(no subject)";
+}
+
+function buildSubjectStats(
+  rows: readonly SalesforceTaskAuditRow[]
+): readonly SalesforceTaskAuditTopSubject[] {
+  const stats = new Map<
+    string,
+    {
+      eventCount: number;
+      contactIds: Set<string>;
+    }
+  >();
+
+  for (const row of rows) {
+    const subject = normalizeSubject(row.subject);
+    const current = stats.get(subject) ?? {
+      eventCount: 0,
+      contactIds: new Set<string>()
+    };
+    current.eventCount += 1;
+    current.contactIds.add(row.contactId);
+    stats.set(subject, current);
+  }
+
+  return Array.from(stats.entries())
+    .map(([subject, value]) => ({
+      subject,
+      eventCount: value.eventCount,
+      contactCount: value.contactIds.size
+    }))
+    .sort((left, right) => {
+      if (left.eventCount !== right.eventCount) {
+        return right.eventCount - left.eventCount;
+      }
+
+      return left.subject.localeCompare(right.subject);
+    });
+}
+
+export function deriveSalesforceTaskAuditSignals(
+  row: Pick<
+    SalesforceTaskAuditRow,
+    "subject" | "snippet" | "subjectContactCount"
+  >
+): SalesforceTaskAuditSignals {
+  const subject = row.subject?.trim() ?? null;
+  const snippet = row.snippet;
+  const subjectPrefix = replyPrefixPattern.test(subject ?? "")
+    ? "reply"
+    : forwardPrefixPattern.test(subject ?? "")
+      ? "forward"
+      : "none";
+  const hasStructuredEnvelope =
+    structuredEnvelopePatterns.every((pattern) => pattern.test(snippet));
+  const hasQuotedReply = matchesAnyPattern(snippet, quotedReplyPatterns);
+  const hasHtmlMarkup = /<\/?[a-z][^>]*>/iu.test(snippet);
+  const hasVolunteerAutomationKeyword =
+    matchesAnyPattern(subject, volunteerAutomationKeywordPatterns) ||
+    matchesAnyPattern(snippet, volunteerAutomationKeywordPatterns);
+  const hasBatchLikeSubject = row.subjectContactCount >= 5;
+  const hasConversationSignal =
+    subjectPrefix !== "none" || hasStructuredEnvelope || hasQuotedReply;
+  const hasAutomationSignal =
+    hasVolunteerAutomationKeyword || hasBatchLikeSubject || hasHtmlMarkup;
+
+  return {
+    subjectPrefix,
+    hasStructuredEnvelope,
+    hasQuotedReply,
+    hasHtmlMarkup,
+    hasVolunteerAutomationKeyword,
+    hasBatchLikeSubject,
+    hasConversationSignal,
+    hasAutomationSignal
+  };
+}
+
+export function inferSalesforceTaskShape(
+  signals: SalesforceTaskAuditSignals
+): SalesforceTaskInferredShape {
+  if (signals.hasConversationSignal && !signals.hasAutomationSignal) {
+    return "probable_human_conversation";
+  }
+
+  if (!signals.hasConversationSignal && signals.hasAutomationSignal) {
+    return "probable_automation";
+  }
+
+  if (signals.hasConversationSignal && signals.hasAutomationSignal) {
+    return "mixed";
+  }
+
+  return "unclear";
+}
+
+export function annotateSalesforceTaskAuditRows(
+  rows: readonly SalesforceTaskAuditRow[]
+): readonly SalesforceTaskAuditAnnotatedRow[] {
+  return rows.map((row) => {
+    const signals = deriveSalesforceTaskAuditSignals(row);
+
+    return {
+      ...row,
+      signals,
+      inferredShape: inferSalesforceTaskShape(signals)
+    };
+  });
+}
+
+function incrementCounter(
+  counters: Map<string, number>,
+  key: string
+): void {
+  counters.set(key, (counters.get(key) ?? 0) + 1);
+}
+
+function toRecord(counters: Map<string, number>): Readonly<Record<string, number>> {
+  return Object.fromEntries(
+    Array.from(counters.entries()).sort(([left], [right]) =>
+      left.localeCompare(right)
+    )
+  );
+}
+
+function buildVariedSample(
+  rows: readonly SalesforceTaskAuditAnnotatedRow[],
+  limit: number
+): readonly SalesforceTaskAuditAnnotatedRow[] {
+  const sample: SalesforceTaskAuditAnnotatedRow[] = [];
+  const seenSubjects = new Set<string>();
+
+  for (const row of rows) {
+    const subjectKey = normalizeSubject(row.subject);
+    if (seenSubjects.has(subjectKey)) {
+      continue;
+    }
+
+    sample.push(row);
+    seenSubjects.add(subjectKey);
+    if (sample.length >= limit) {
+      return sample;
+    }
+  }
+
+  for (const row of rows) {
+    if (sample.length >= limit) {
+      break;
+    }
+
+    if (sample.some((existing) => existing.providerRecordId === row.providerRecordId)) {
+      continue;
+    }
+
+    sample.push(row);
+  }
+
+  return sample;
+}
+
+export function buildSalesforceTaskAuditReport(
+  rows: readonly SalesforceTaskAuditRow[],
+  input?: {
+    readonly sampleLimit?: number;
+    readonly topSubjectLimit?: number;
+  }
+): SalesforceTaskAuditReport {
+  const sampleLimit = input?.sampleLimit ?? 8;
+  const topSubjectLimit = input?.topSubjectLimit ?? 20;
+  const annotatedRows = annotateSalesforceTaskAuditRows(rows);
+  const distinctContacts = new Set(rows.map((row) => row.contactId)).size;
+  const messageKindCounts = new Map<string, number>();
+  const inferredShapeCounts = new Map<string, number>();
+  const signalCounts = new Map<string, number>();
+  const mismatchCounts = new Map<string, number>();
+
+  for (const row of annotatedRows) {
+    incrementCounter(messageKindCounts, row.messageKind);
+    incrementCounter(inferredShapeCounts, row.inferredShape);
+    if (row.signals.hasConversationSignal) {
+      incrementCounter(signalCounts, "conversation_signal");
+    }
+    if (row.signals.hasAutomationSignal) {
+      incrementCounter(signalCounts, "automation_signal");
+    }
+    if (row.messageKind === "auto" && row.signals.hasConversationSignal) {
+      incrementCounter(mismatchCounts, "auto_with_conversation_signal");
+    }
+    if (row.messageKind === "one_to_one" && row.signals.hasAutomationSignal) {
+      incrementCounter(mismatchCounts, "one_to_one_with_automation_signal");
+    }
+
+    if (
+      row.messageKind === "auto" &&
+      row.inferredShape === "probable_human_conversation"
+    ) {
+      incrementCounter(mismatchCounts, "auto_but_probably_human");
+    }
+
+    if (
+      row.messageKind === "one_to_one" &&
+      row.inferredShape === "probable_automation"
+    ) {
+      incrementCounter(mismatchCounts, "one_to_one_but_probably_automation");
+    }
+  }
+
+  const probableHumanConversation = annotatedRows.filter(
+    (row) => row.inferredShape === "probable_human_conversation"
+  );
+  const probableAutomation = annotatedRows.filter(
+    (row) => row.inferredShape === "probable_automation"
+  );
+  const autoWithConversationSignal = annotatedRows.filter(
+    (row) => row.messageKind === "auto" && row.signals.hasConversationSignal
+  );
+  const autoButProbablyHuman = probableHumanConversation.filter(
+    (row) => row.messageKind === "auto"
+  );
+  const oneToOneButProbablyAutomation = probableAutomation.filter(
+    (row) => row.messageKind === "one_to_one"
+  );
+
+  return {
+    totalRows: rows.length,
+    distinctContacts,
+    rowsWithoutMembership: rows.filter((row) => row.membershipCount === 0).length,
+    messageKindCounts: toRecord(messageKindCounts),
+    inferredShapeCounts: toRecord(inferredShapeCounts),
+    signalCounts: toRecord(signalCounts),
+    mismatchCounts: toRecord(mismatchCounts),
+    topSubjects: buildSubjectStats(rows).slice(0, topSubjectLimit),
+    samples: {
+      autoWithConversationSignal: buildVariedSample(
+        autoWithConversationSignal,
+        sampleLimit
+      ),
+      autoButProbablyHuman: buildVariedSample(
+        autoButProbablyHuman,
+        sampleLimit
+      ),
+      oneToOneButProbablyAutomation: buildVariedSample(
+        oneToOneButProbablyAutomation,
+        sampleLimit
+      ),
+      probableHumanConversation: buildVariedSample(
+        probableHumanConversation,
+        sampleLimit
+      ),
+      probableAutomation: buildVariedSample(probableAutomation, sampleLimit)
+    }
+  };
+}
+
+export function formatSnippetPreview(
+  snippet: string,
+  maxLength = 240
+): string {
+  const normalized = snippet.replaceAll(/\s+/gu, " ").trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
+}

--- a/apps/worker/src/ops/audit-salesforce-task-ingest.ts
+++ b/apps/worker/src/ops/audit-salesforce-task-ingest.ts
@@ -1,0 +1,263 @@
+#!/usr/bin/env tsx
+import process from "node:process";
+
+import {
+  closeDatabaseConnection,
+  createDatabaseConnection
+} from "@as-comms/db";
+
+import {
+  buildSalesforceTaskAuditReport,
+  formatSnippetPreview,
+  type SalesforceTaskAuditRow
+} from "./_salesforce-task-audit.js";
+import {
+  parseCliFlags,
+  readOptionalBooleanFlag,
+  readOptionalIntegerFlag
+} from "./helpers.js";
+
+interface SqlRunner {
+  unsafe<T extends readonly object[]>(query: string): Promise<T>;
+}
+
+interface SalesforceTaskAuditRowRaw {
+  readonly canonical_event_id: string;
+  readonly source_evidence_id: string;
+  readonly provider_record_id: string;
+  readonly payload_ref: string;
+  readonly contact_id: string;
+  readonly display_name: string;
+  readonly salesforce_contact_id: string | null;
+  readonly membership_count: number;
+  readonly projects: string | null;
+  readonly message_kind: "auto" | "one_to_one" | "campaign";
+  readonly subject: string | null;
+  readonly snippet: string;
+  readonly source_label: string;
+  readonly occurred_at: string;
+  readonly subject_event_count: number;
+  readonly subject_contact_count: number;
+}
+
+function readConnectionString(env: NodeJS.ProcessEnv): string {
+  const connectionString = env.WORKER_DATABASE_URL ?? env.DATABASE_URL;
+
+  if (connectionString === undefined || connectionString.trim().length === 0) {
+    throw new Error(
+      "DATABASE_URL or WORKER_DATABASE_URL is required for this ops command."
+    );
+  }
+
+  return connectionString;
+}
+
+async function loadSalesforceTaskAuditRows(
+  sql: SqlRunner
+): Promise<readonly SalesforceTaskAuditRow[]> {
+  const rows = await sql.unsafe<readonly SalesforceTaskAuditRowRaw[]>(`
+    with membership_projects as (
+      select
+        cm.contact_id,
+        count(*)::int as membership_count,
+        string_agg(
+          distinct coalesce(pd.project_name, cm.project_id, '[unknown project]'),
+          ' | '
+          order by coalesce(pd.project_name, cm.project_id, '[unknown project]')
+        ) as projects
+      from contact_memberships cm
+      left join project_dimensions pd
+        on pd.project_id = cm.project_id
+      group by cm.contact_id
+    ),
+    subject_stats as (
+      select
+        scd.subject,
+        count(*)::int as subject_event_count,
+        count(distinct cel.contact_id)::int as subject_contact_count
+      from canonical_event_ledger cel
+      join salesforce_communication_details scd
+        on scd.source_evidence_id = cel.source_evidence_id
+      where cel.event_type = 'communication.email.outbound'
+        and cel.provenance ->> 'primaryProvider' = 'salesforce'
+      group by scd.subject
+    )
+    select
+      cel.id as canonical_event_id,
+      cel.source_evidence_id,
+      se.provider_record_id,
+      se.payload_ref,
+      cel.contact_id,
+      c.display_name,
+      c.salesforce_contact_id,
+      coalesce(mp.membership_count, 0)::int as membership_count,
+      mp.projects,
+      scd.message_kind,
+      scd.subject,
+      scd.snippet,
+      scd.source_label,
+      cel.occurred_at,
+      ss.subject_event_count,
+      ss.subject_contact_count
+    from canonical_event_ledger cel
+    join source_evidence_log se
+      on se.id = cel.source_evidence_id
+    join salesforce_communication_details scd
+      on scd.source_evidence_id = cel.source_evidence_id
+    join contacts c
+      on c.id = cel.contact_id
+    left join membership_projects mp
+      on mp.contact_id = cel.contact_id
+    left join subject_stats ss
+      on ss.subject is not distinct from scd.subject
+    where cel.event_type = 'communication.email.outbound'
+      and cel.provenance ->> 'primaryProvider' = 'salesforce'
+    order by cel.occurred_at desc, cel.id desc
+  `);
+
+  return rows.map((row) => ({
+    canonicalEventId: row.canonical_event_id,
+    sourceEvidenceId: row.source_evidence_id,
+    providerRecordId: row.provider_record_id,
+    payloadRef: row.payload_ref,
+    contactId: row.contact_id,
+    displayName: row.display_name,
+    salesforceContactId: row.salesforce_contact_id,
+    membershipCount: row.membership_count,
+    projects: row.projects,
+    messageKind: row.message_kind,
+    subject: row.subject,
+    snippet: row.snippet,
+    sourceLabel: row.source_label,
+    occurredAt: row.occurred_at,
+    subjectEventCount: row.subject_event_count,
+    subjectContactCount: row.subject_contact_count
+  }));
+}
+
+function buildSampleLine(
+  row: ReturnType<typeof buildSalesforceTaskAuditReport>["samples"][keyof ReturnType<typeof buildSalesforceTaskAuditReport>["samples"]][number]
+): string {
+  return JSON.stringify({
+    occurredAt: row.occurredAt,
+    messageKind: row.messageKind,
+    inferredShape: row.inferredShape,
+    subject: row.subject,
+    displayName: row.displayName,
+    projects: row.projects,
+    providerRecordId: row.providerRecordId,
+    subjectEventCount: row.subjectEventCount,
+    subjectContactCount: row.subjectContactCount,
+    signals: row.signals,
+    snippetPreview: formatSnippetPreview(row.snippet)
+  });
+}
+
+function printHumanReadableReport(
+  report: ReturnType<typeof buildSalesforceTaskAuditReport>
+): void {
+  console.log("audit-salesforce-task-ingest");
+  console.log(`- total Salesforce outbound email rows: ${String(report.totalRows)}`);
+  console.log(`- distinct contacts: ${String(report.distinctContacts)}`);
+  console.log(`- rows without memberships: ${String(report.rowsWithoutMembership)}`);
+
+  console.log("Message-kind counts:");
+  for (const [messageKind, count] of Object.entries(report.messageKindCounts)) {
+    console.log(`- ${messageKind}: ${String(count)}`);
+  }
+
+  console.log("Inferred-shape counts:");
+  for (const [shape, count] of Object.entries(report.inferredShapeCounts)) {
+    console.log(`- ${shape}: ${String(count)}`);
+  }
+
+  console.log("Signal counts:");
+  for (const [signal, count] of Object.entries(report.signalCounts)) {
+    console.log(`- ${signal}: ${String(count)}`);
+  }
+
+  if (Object.keys(report.mismatchCounts).length > 0) {
+    console.log("Mismatch buckets:");
+    for (const [label, count] of Object.entries(report.mismatchCounts)) {
+      console.log(`- ${label}: ${String(count)}`);
+    }
+  }
+
+  console.log("Top subjects:");
+  for (const subject of report.topSubjects) {
+    console.log(
+      `- ${JSON.stringify({
+        subject: subject.subject,
+        eventCount: subject.eventCount,
+        contactCount: subject.contactCount
+      })}`
+    );
+  }
+
+  const sections = [
+    [
+      "Sample rows: current auto + conversation signal",
+      report.samples.autoWithConversationSignal
+    ] as const,
+    [
+      "Sample rows: current auto + probable human conversation",
+      report.samples.autoButProbablyHuman
+    ] as const,
+    [
+      "Sample rows: current one_to_one + probable automation",
+      report.samples.oneToOneButProbablyAutomation
+    ] as const,
+    [
+      "Sample rows: probable human conversation",
+      report.samples.probableHumanConversation
+    ] as const,
+    [
+      "Sample rows: probable automation",
+      report.samples.probableAutomation
+    ] as const
+  ];
+
+  for (const [label, rows] of sections) {
+    console.log(label);
+    if (rows.length === 0) {
+      console.log("- none");
+      continue;
+    }
+
+    for (const row of rows) {
+      console.log(`- ${buildSampleLine(row)}`);
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const flags = parseCliFlags(process.argv.slice(2));
+  const sampleLimit = readOptionalIntegerFlag(flags, "limit", 8);
+  const topSubjectLimit = readOptionalIntegerFlag(flags, "subject-limit", 20);
+  const asJson = readOptionalBooleanFlag(flags, "json", false);
+  const connection = createDatabaseConnection({
+    connectionString: readConnectionString(process.env)
+  });
+
+  try {
+    const rows = await loadSalesforceTaskAuditRows(connection.sql);
+    const report = buildSalesforceTaskAuditReport(rows, {
+      sampleLimit,
+      topSubjectLimit
+    });
+
+    if (asJson) {
+      console.log(JSON.stringify(report, null, 2));
+      return;
+    }
+
+    printHumanReadableReport(report);
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/worker/src/ops/cleanup-salesforce-owner-scope.ts
+++ b/apps/worker/src/ops/cleanup-salesforce-owner-scope.ts
@@ -1,0 +1,825 @@
+#!/usr/bin/env tsx
+/**
+ * cleanup-salesforce-owner-scope
+ *
+ * Usage:
+ *   pnpm --filter @as-comms/worker ops cleanup-salesforce-owner-scope
+ *   pnpm --filter @as-comms/worker ops cleanup-salesforce-owner-scope --execute
+ *
+ * Dry-run by default. Looks up the current Salesforce Task owner for every
+ * Salesforce outbound email canonical event in the DB and removes the rows
+ * whose Task owner is explicitly not Nim Admin. Tasks that Salesforce does not
+ * currently resolve are skipped and reported rather than deleted.
+ */
+import { execFile } from "node:child_process";
+import process from "node:process";
+import { promisify } from "node:util";
+
+import { inArray } from "drizzle-orm";
+import { z } from "zod";
+
+import {
+  projectionRebuildBatchPayloadSchema,
+  stage1JobVersion,
+} from "@as-comms/contracts";
+import {
+  canonicalEventLedger,
+  closeDatabaseConnection,
+  contactInboxProjection,
+  createDatabaseConnection,
+  createStage1RepositoryBundleFromConnection,
+  identityResolutionQueue,
+  routingReviewQueue,
+  sourceEvidenceLog,
+  type DatabaseConnection,
+} from "@as-comms/db";
+import {
+  createStage1NormalizationService,
+  createStage1PersistenceService,
+} from "@as-comms/domain";
+
+import { createStage1IngestService } from "../ingest/index.js";
+import {
+  createStage1WorkerOrchestrationService,
+  type Stage1WorkerOrchestrationService,
+} from "../orchestration/index.js";
+import {
+  buildOperationId,
+  parseCliFlags,
+  readOptionalBooleanFlag,
+  readOptionalIntegerFlag,
+  readOptionalStringFlag,
+} from "./helpers.js";
+
+const execFileAsync = promisify(execFile);
+
+const defaultTargetOrg = "as-production";
+const nimAdminUsername = "admin+1@adventurescientists.org";
+const queryChunkSize = 200;
+const deleteChunkSize = 500;
+const projectionChunkSize = 250;
+const sampleLimit = 10;
+
+interface Logger {
+  log(...args: readonly unknown[]): void;
+  error(...args: readonly unknown[]): void;
+}
+
+interface SqlRunner {
+  unsafe<T extends readonly object[]>(query: string): Promise<T>;
+}
+
+interface CleanupCandidateRow {
+  readonly canonical_event_id: string;
+  readonly contact_id: string;
+  readonly source_evidence_id: string;
+  readonly provider_record_id: string;
+  readonly subject: string | null;
+}
+
+export interface SalesforceOwnerScopeCleanupCandidate {
+  readonly canonicalEventId: string;
+  readonly contactId: string;
+  readonly sourceEvidenceId: string;
+  readonly providerRecordId: string;
+  readonly subject: string | null;
+}
+
+export interface SalesforceOwnerScopeCleanupChange {
+  readonly canonicalEventId: string;
+  readonly contactId: string;
+  readonly sourceEvidenceId: string;
+  readonly providerRecordId: string;
+  readonly subject: string | null;
+  readonly ownerUsername: string | null;
+  readonly removalReason: "non_nim_admin_owner" | "unresolved_owner";
+}
+
+export interface SalesforceOwnerScopeCleanupPlan {
+  readonly scannedCount: number;
+  readonly resolvedCount: number;
+  readonly keepCount: number;
+  readonly removeCount: number;
+  readonly unresolvedCount: number;
+  readonly affectedContactIds: readonly string[];
+  readonly changes: readonly SalesforceOwnerScopeCleanupChange[];
+  readonly unresolvedProviderRecordIds: readonly string[];
+}
+
+export interface CleanupSalesforceOwnerScopeResult {
+  readonly dryRun: boolean;
+  readonly targetOrg: string;
+  readonly scannedCount: number;
+  readonly resolvedCount: number;
+  readonly keepCount: number;
+  readonly removeCount: number;
+  readonly unresolvedCount: number;
+  readonly affectedContactIds: readonly string[];
+  readonly unresolvedProviderRecordIds: readonly string[];
+  readonly deletedCanonicalCount: number;
+  readonly deletedSourceEvidenceCount: number;
+  readonly deletedInboxProjectionCount: number;
+  readonly deletedIdentityReviewCount: number;
+  readonly deletedRoutingReviewCount: number;
+  readonly rebuiltContactCount: number;
+  readonly missingProjectionSeeds: readonly string[];
+}
+
+interface DeleteCounts {
+  readonly deletedCanonicalCount: number;
+  readonly deletedSourceEvidenceCount: number;
+  readonly deletedInboxProjectionCount: number;
+  readonly deletedIdentityReviewCount: number;
+  readonly deletedRoutingReviewCount: number;
+}
+
+interface SfQueryRunner {
+  queryTaskOwnerUsernames(input: {
+    readonly targetOrg: string;
+    readonly taskIds: readonly string[];
+  }): Promise<ReadonlyMap<string, string | null>>;
+}
+
+const sfTaskOwnerQueryResultSchema = z.object({
+  status: z.number().int(),
+  result: z.object({
+    records: z.array(
+      z.object({
+        Id: z.string().min(1),
+        Owner: z
+          .object({
+            Username: z.string().min(1).nullable().optional(),
+          })
+          .nullable()
+          .optional(),
+      }),
+    ),
+  }),
+});
+
+function readConnectionString(env: NodeJS.ProcessEnv): string {
+  const connectionString = env.WORKER_DATABASE_URL ?? env.DATABASE_URL;
+
+  if (connectionString === undefined || connectionString.trim().length === 0) {
+    throw new Error(
+      "DATABASE_URL or WORKER_DATABASE_URL is required for this ops command.",
+    );
+  }
+
+  return connectionString;
+}
+
+function chunkValues<TValue>(
+  values: readonly TValue[],
+  chunkSize: number,
+): TValue[][] {
+  const chunks: TValue[][] = [];
+
+  for (let index = 0; index < values.length; index += chunkSize) {
+    chunks.push(values.slice(index, index + chunkSize));
+  }
+
+  return chunks;
+}
+
+function uniqueSortedStrings(values: readonly string[]): string[] {
+  return Array.from(new Set(values)).sort((left, right) =>
+    left.localeCompare(right),
+  );
+}
+
+function quoteSoqlString(value: string): string {
+  return `'${value.replaceAll("\\", "\\\\").replaceAll("'", "\\'")}'`;
+}
+
+function normalizeOwnerUsername(
+  value: string | null | undefined,
+): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim().toLowerCase();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+function buildSalesforceTaskOwnerQuery(taskIds: readonly string[]): string {
+  return `SELECT Id, Owner.Username FROM Task WHERE Id IN (${taskIds.map((taskId) => quoteSoqlString(taskId)).join(", ")})`;
+}
+
+function buildUnexpectedCapturePorts() {
+  const unexpectedUse = (): Promise<never> => {
+    return Promise.reject(
+      new Error(
+        "This ops runtime only supports projection rebuilds after owner-scoped cleanup.",
+      ),
+    );
+  };
+
+  return {
+    gmail: {
+      captureHistoricalBatch: unexpectedUse,
+      captureLiveBatch: unexpectedUse,
+    },
+    salesforce: {
+      captureHistoricalBatch: unexpectedUse,
+      captureLiveBatch: unexpectedUse,
+    },
+    simpleTexting: {
+      captureHistoricalBatch: unexpectedUse,
+      captureLiveBatch: unexpectedUse,
+    },
+    mailchimp: {
+      captureHistoricalBatch: unexpectedUse,
+      captureTransitionBatch: unexpectedUse,
+    },
+  };
+}
+
+function createProjectionRebuildOrchestration(
+  connection: DatabaseConnection,
+): Pick<Stage1WorkerOrchestrationService, "runProjectionRebuildBatch"> {
+  const repositories = createStage1RepositoryBundleFromConnection(connection);
+  const persistence = createStage1PersistenceService(repositories);
+  const normalization = createStage1NormalizationService(persistence);
+  const ingest = createStage1IngestService(normalization);
+
+  return createStage1WorkerOrchestrationService({
+    capture: buildUnexpectedCapturePorts(),
+    ingest,
+    normalization,
+    persistence,
+    gmailHistoricalReplay: {
+      liveAccount: "unused@example.org",
+      projectInboxAliases: [],
+    },
+  });
+}
+
+function createSfCliQueryRunner(): SfQueryRunner {
+  return {
+    async queryTaskOwnerUsernames(input) {
+      const ownerUsernameByTaskId = new Map<string, string | null>();
+
+      for (const chunk of chunkValues(
+        uniqueSortedStrings(input.taskIds),
+        queryChunkSize,
+      )) {
+        const query = buildSalesforceTaskOwnerQuery(chunk);
+
+        let stdout: string;
+
+        try {
+          ({ stdout } = await execFileAsync(
+            "sf",
+            [
+              "data",
+              "query",
+              "--target-org",
+              input.targetOrg,
+              "--query",
+              query,
+              "--json",
+            ],
+            {
+              cwd: process.cwd(),
+              maxBuffer: 10 * 1024 * 1024,
+            },
+          ));
+        } catch (error) {
+          const message =
+            error instanceof Error && "stdout" in error
+              ? String((error as { stdout?: string }).stdout ?? error.message)
+              : error instanceof Error
+                ? error.message
+                : String(error);
+
+          throw new Error(
+            `Salesforce CLI owner lookup failed for ${String(chunk.length)} Task ids: ${message}`,
+          );
+        }
+
+        const parsed = sfTaskOwnerQueryResultSchema.parse(JSON.parse(stdout));
+
+        for (const record of parsed.result.records) {
+          ownerUsernameByTaskId.set(
+            record.Id,
+            normalizeOwnerUsername(record.Owner?.Username ?? null),
+          );
+        }
+      }
+
+      return ownerUsernameByTaskId;
+    },
+  };
+}
+
+async function loadCleanupCandidates(
+  sql: SqlRunner,
+  input?: { readonly limit?: number | null },
+): Promise<readonly SalesforceOwnerScopeCleanupCandidate[]> {
+  const rows = await sql.unsafe<readonly CleanupCandidateRow[]>(`
+    select
+      canonical_event_ledger.id as canonical_event_id,
+      canonical_event_ledger.contact_id,
+      canonical_event_ledger.source_evidence_id,
+      source_evidence_log.provider_record_id,
+      salesforce_communication_details.subject
+    from canonical_event_ledger
+    join source_evidence_log
+      on source_evidence_log.id = canonical_event_ledger.source_evidence_id
+    left join salesforce_communication_details
+      on salesforce_communication_details.source_evidence_id = canonical_event_ledger.source_evidence_id
+    where canonical_event_ledger.event_type = 'communication.email.outbound'
+      and canonical_event_ledger.provenance ->> 'primaryProvider' = 'salesforce'
+      and source_evidence_log.provider = 'salesforce'
+      and source_evidence_log.provider_record_type = 'task_communication'
+    order by canonical_event_ledger.occurred_at asc, canonical_event_ledger.id asc
+  `);
+
+  const candidates = rows.map((row) => ({
+    canonicalEventId: row.canonical_event_id,
+    contactId: row.contact_id,
+    sourceEvidenceId: row.source_evidence_id,
+    providerRecordId: row.provider_record_id,
+    subject: row.subject,
+  }));
+
+  return input?.limit === null || input?.limit === undefined
+    ? candidates
+    : candidates.slice(0, input.limit);
+}
+
+export function planSalesforceOwnerScopeCleanup(input: {
+  readonly candidates: readonly SalesforceOwnerScopeCleanupCandidate[];
+  readonly ownerUsernameByTaskId: ReadonlyMap<string, string | null>;
+  readonly includeUnresolved?: boolean;
+}): SalesforceOwnerScopeCleanupPlan {
+  const includeUnresolved = input.includeUnresolved ?? false;
+  const changes: SalesforceOwnerScopeCleanupChange[] = [];
+  const affectedContactIds = new Set<string>();
+  const unresolvedProviderRecordIds = new Set<string>();
+  let resolvedCount = 0;
+  let keepCount = 0;
+
+  for (const candidate of input.candidates) {
+    if (!input.ownerUsernameByTaskId.has(candidate.providerRecordId)) {
+      unresolvedProviderRecordIds.add(candidate.providerRecordId);
+
+      if (includeUnresolved) {
+        affectedContactIds.add(candidate.contactId);
+        changes.push({
+          canonicalEventId: candidate.canonicalEventId,
+          contactId: candidate.contactId,
+          sourceEvidenceId: candidate.sourceEvidenceId,
+          providerRecordId: candidate.providerRecordId,
+          subject: candidate.subject,
+          ownerUsername: null,
+          removalReason: "unresolved_owner",
+        });
+      }
+
+      continue;
+    }
+
+    const ownerUsername =
+      input.ownerUsernameByTaskId.get(candidate.providerRecordId) ?? null;
+
+    if (ownerUsername === null) {
+      unresolvedProviderRecordIds.add(candidate.providerRecordId);
+
+      if (includeUnresolved) {
+        affectedContactIds.add(candidate.contactId);
+        changes.push({
+          canonicalEventId: candidate.canonicalEventId,
+          contactId: candidate.contactId,
+          sourceEvidenceId: candidate.sourceEvidenceId,
+          providerRecordId: candidate.providerRecordId,
+          subject: candidate.subject,
+          ownerUsername: null,
+          removalReason: "unresolved_owner",
+        });
+      }
+
+      continue;
+    }
+
+    resolvedCount += 1;
+
+    if (ownerUsername === nimAdminUsername) {
+      keepCount += 1;
+      continue;
+    }
+
+    affectedContactIds.add(candidate.contactId);
+    changes.push({
+      canonicalEventId: candidate.canonicalEventId,
+      contactId: candidate.contactId,
+      sourceEvidenceId: candidate.sourceEvidenceId,
+      providerRecordId: candidate.providerRecordId,
+      subject: candidate.subject,
+      ownerUsername,
+      removalReason: "non_nim_admin_owner",
+    });
+  }
+
+  return {
+    scannedCount: input.candidates.length,
+    resolvedCount,
+    keepCount,
+    removeCount: changes.length,
+    unresolvedCount: unresolvedProviderRecordIds.size,
+    affectedContactIds: Array.from(affectedContactIds).sort((left, right) =>
+      left.localeCompare(right),
+    ),
+    changes,
+    unresolvedProviderRecordIds: Array.from(unresolvedProviderRecordIds).sort(
+      (left, right) => left.localeCompare(right),
+    ),
+  };
+}
+
+function printPlanSummary(
+  plan: SalesforceOwnerScopeCleanupPlan,
+  input: {
+    readonly dryRun: boolean;
+    readonly targetOrg: string;
+    readonly includeUnresolved: boolean;
+  },
+): void {
+  console.log("cleanup-salesforce-owner-scope");
+  console.log(`Mode: ${input.dryRun ? "dry-run" : "execute"}`);
+  console.log(`- Salesforce target org: ${input.targetOrg}`);
+  console.log(
+    `- scanned Salesforce outbound email rows: ${String(plan.scannedCount)}`,
+  );
+  console.log(`- owner-resolved Task ids: ${String(plan.resolvedCount)}`);
+  console.log(`- Nim Admin rows kept: ${String(plan.keepCount)}`);
+  console.log(`- non-Nim Admin rows to remove: ${String(plan.removeCount)}`);
+  console.log(
+    `- unresolved Task ids ${input.includeUnresolved ? "to remove" : "skipped"}: ${String(plan.unresolvedCount)}`,
+  );
+  console.log(
+    `- affected contacts for projection rebuild: ${String(plan.affectedContactIds.length)}`,
+  );
+}
+
+function printSampleChanges(
+  changes: readonly SalesforceOwnerScopeCleanupChange[],
+): void {
+  if (changes.length === 0) {
+    console.log(
+      "No non-Nim Admin Salesforce email rows are currently in scope.",
+    );
+    return;
+  }
+
+  console.log("Sample removals (first 10):");
+  for (const change of changes.slice(0, sampleLimit)) {
+    console.log(
+      `- ${JSON.stringify({
+        canonicalEventId: change.canonicalEventId,
+        contactId: change.contactId,
+        providerRecordId: change.providerRecordId,
+        ownerUsername: change.ownerUsername,
+        removalReason: change.removalReason,
+        subject: change.subject,
+      })}`,
+    );
+  }
+}
+
+function printSampleUnresolved(providerRecordIds: readonly string[]): void {
+  if (providerRecordIds.length === 0) {
+    return;
+  }
+
+  console.log("Sample unresolved Task ids (first 10):");
+  for (const providerRecordId of providerRecordIds.slice(0, sampleLimit)) {
+    console.log(`- ${providerRecordId}`);
+  }
+}
+
+async function deleteRowsForPlan(input: {
+  readonly connection: DatabaseConnection;
+  readonly plan: SalesforceOwnerScopeCleanupPlan;
+}): Promise<DeleteCounts> {
+  const affectedContactIds = input.plan.affectedContactIds;
+  const canonicalEventIds = input.plan.changes.map(
+    (change) => change.canonicalEventId,
+  );
+  const sourceEvidenceIds = input.plan.changes.map(
+    (change) => change.sourceEvidenceId,
+  );
+
+  let deletedInboxProjectionCount = 0;
+  let deletedIdentityReviewCount = 0;
+  let deletedRoutingReviewCount = 0;
+  let deletedCanonicalCount = 0;
+  let deletedSourceEvidenceCount = 0;
+
+  await input.connection.db.transaction(async (tx) => {
+    for (const chunk of chunkValues(affectedContactIds, deleteChunkSize)) {
+      if (chunk.length === 0) {
+        continue;
+      }
+
+      const deletedInboxRows = await tx
+        .delete(contactInboxProjection)
+        .where(inArray(contactInboxProjection.contactId, chunk))
+        .returning({
+          contactId: contactInboxProjection.contactId,
+        });
+
+      deletedInboxProjectionCount += deletedInboxRows.length;
+    }
+
+    for (const chunk of chunkValues(sourceEvidenceIds, deleteChunkSize)) {
+      if (chunk.length === 0) {
+        continue;
+      }
+
+      const deletedIdentityRows = await tx
+        .delete(identityResolutionQueue)
+        .where(inArray(identityResolutionQueue.sourceEvidenceId, chunk))
+        .returning({
+          id: identityResolutionQueue.id,
+        });
+      deletedIdentityReviewCount += deletedIdentityRows.length;
+
+      const deletedRoutingRows = await tx
+        .delete(routingReviewQueue)
+        .where(inArray(routingReviewQueue.sourceEvidenceId, chunk))
+        .returning({
+          id: routingReviewQueue.id,
+        });
+      deletedRoutingReviewCount += deletedRoutingRows.length;
+    }
+
+    for (const chunk of chunkValues(canonicalEventIds, deleteChunkSize)) {
+      if (chunk.length === 0) {
+        continue;
+      }
+
+      const deletedCanonicalRows = await tx
+        .delete(canonicalEventLedger)
+        .where(inArray(canonicalEventLedger.id, chunk))
+        .returning({
+          id: canonicalEventLedger.id,
+        });
+
+      deletedCanonicalCount += deletedCanonicalRows.length;
+    }
+
+    for (const chunk of chunkValues(sourceEvidenceIds, deleteChunkSize)) {
+      if (chunk.length === 0) {
+        continue;
+      }
+
+      const deletedSourceEvidenceRows = await tx
+        .delete(sourceEvidenceLog)
+        .where(inArray(sourceEvidenceLog.id, chunk))
+        .returning({
+          id: sourceEvidenceLog.id,
+        });
+
+      deletedSourceEvidenceCount += deletedSourceEvidenceRows.length;
+    }
+  });
+
+  return {
+    deletedCanonicalCount,
+    deletedSourceEvidenceCount,
+    deletedInboxProjectionCount,
+    deletedIdentityReviewCount,
+    deletedRoutingReviewCount,
+  };
+}
+
+async function rebuildProjectionsForContacts(
+  orchestration: Pick<
+    Stage1WorkerOrchestrationService,
+    "runProjectionRebuildBatch"
+  >,
+  contactIds: readonly string[],
+  logger: Logger,
+): Promise<{
+  readonly rebuiltContactCount: number;
+  readonly missingProjectionSeeds: readonly string[];
+}> {
+  const sortedContactIds = uniqueSortedStrings(contactIds);
+  const missingProjectionSeeds = new Set<string>();
+  let rebuiltContactCount = 0;
+
+  for (const [index, chunk] of chunkValues(
+    sortedContactIds,
+    projectionChunkSize,
+  ).entries()) {
+    const result = await orchestration.runProjectionRebuildBatch(
+      projectionRebuildBatchPayloadSchema.parse({
+        version: stage1JobVersion,
+        jobId: buildOperationId("stage1:projection-rebuild:job"),
+        correlationId: buildOperationId(
+          "stage1:projection-rebuild:correlation",
+        ),
+        traceId: null,
+        batchId: buildOperationId("stage1:projection-rebuild:batch"),
+        syncStateId: buildOperationId("stage1:projection-rebuild:sync-state"),
+        attempt: 1,
+        maxAttempts: 1,
+        jobType: "projection_rebuild",
+        projection: "all",
+        contactIds: chunk,
+        includeReviewOverlayRefresh: true,
+      }),
+    );
+
+    if (result.outcome !== "succeeded") {
+      const failureMessage = result.failure?.message ?? "unknown failure";
+      throw new Error(
+        `Projection rebuild batch ${String(index + 1)} failed: ${failureMessage}`,
+      );
+    }
+
+    rebuiltContactCount += result.rebuiltContactIds.length;
+    for (const canonicalEventId of result.missingProjectionSeeds) {
+      missingProjectionSeeds.add(canonicalEventId);
+    }
+
+    logger.log(
+      `- rebuilt projections for ${String(rebuiltContactCount)} / ${String(sortedContactIds.length)} contacts`,
+    );
+  }
+
+  return {
+    rebuiltContactCount,
+    missingProjectionSeeds: Array.from(missingProjectionSeeds).sort(
+      (left, right) => left.localeCompare(right),
+    ),
+  };
+}
+
+export async function runCleanupSalesforceOwnerScope(input: {
+  readonly connectionString: string;
+  readonly targetOrg: string;
+  readonly dryRun: boolean;
+  readonly includeUnresolved?: boolean;
+  readonly limit?: number | null;
+  readonly logger?: Logger;
+  readonly queryRunner?: SfQueryRunner;
+}): Promise<CleanupSalesforceOwnerScopeResult> {
+  const logger = input.logger ?? console;
+  const connection = createDatabaseConnection({
+    connectionString: input.connectionString,
+  });
+
+  try {
+    const sql = connection.sql as unknown as SqlRunner;
+    const candidates = await loadCleanupCandidates(sql, {
+      limit: input.limit ?? null,
+    });
+    const queryRunner = input.queryRunner ?? createSfCliQueryRunner();
+    const ownerUsernameByTaskId = await queryRunner.queryTaskOwnerUsernames({
+      targetOrg: input.targetOrg,
+      taskIds: candidates.map((candidate) => candidate.providerRecordId),
+    });
+    const plan = planSalesforceOwnerScopeCleanup({
+      candidates,
+      ownerUsernameByTaskId,
+      includeUnresolved: input.includeUnresolved ?? false,
+    });
+
+    printPlanSummary(plan, {
+      dryRun: input.dryRun,
+      targetOrg: input.targetOrg,
+      includeUnresolved: input.includeUnresolved ?? false,
+    });
+    printSampleChanges(plan.changes);
+    printSampleUnresolved(plan.unresolvedProviderRecordIds);
+
+    if (input.dryRun) {
+      logger.log(
+        `Dry run complete. Re-run with --execute${input.includeUnresolved ? " --delete-unresolved" : ""} to delete the current in-scope rows.`,
+      );
+      return {
+        dryRun: true,
+        targetOrg: input.targetOrg,
+        scannedCount: plan.scannedCount,
+        resolvedCount: plan.resolvedCount,
+        keepCount: plan.keepCount,
+        removeCount: plan.removeCount,
+        unresolvedCount: plan.unresolvedCount,
+        affectedContactIds: plan.affectedContactIds,
+        unresolvedProviderRecordIds: plan.unresolvedProviderRecordIds,
+        deletedCanonicalCount: 0,
+        deletedSourceEvidenceCount: 0,
+        deletedInboxProjectionCount: 0,
+        deletedIdentityReviewCount: 0,
+        deletedRoutingReviewCount: 0,
+        rebuiltContactCount: 0,
+        missingProjectionSeeds: [],
+      };
+    }
+
+    if (plan.changes.length === 0) {
+      logger.log("No Salesforce rows matched the current cleanup scope.");
+      return {
+        dryRun: false,
+        targetOrg: input.targetOrg,
+        scannedCount: plan.scannedCount,
+        resolvedCount: plan.resolvedCount,
+        keepCount: plan.keepCount,
+        removeCount: 0,
+        unresolvedCount: plan.unresolvedCount,
+        affectedContactIds: [],
+        unresolvedProviderRecordIds: plan.unresolvedProviderRecordIds,
+        deletedCanonicalCount: 0,
+        deletedSourceEvidenceCount: 0,
+        deletedInboxProjectionCount: 0,
+        deletedIdentityReviewCount: 0,
+        deletedRoutingReviewCount: 0,
+        rebuiltContactCount: 0,
+        missingProjectionSeeds: [],
+      };
+    }
+
+    const deleteCounts = await deleteRowsForPlan({
+      connection,
+      plan,
+    });
+    logger.log(
+      `- deleted canonical events: ${String(deleteCounts.deletedCanonicalCount)}`,
+    );
+    logger.log(
+      `- deleted source evidence rows: ${String(deleteCounts.deletedSourceEvidenceCount)}`,
+    );
+    logger.log(
+      `- deleted inbox projection rows: ${String(deleteCounts.deletedInboxProjectionCount)}`,
+    );
+
+    const orchestration = createProjectionRebuildOrchestration(connection);
+    const rebuildResult = await rebuildProjectionsForContacts(
+      orchestration,
+      plan.affectedContactIds,
+      logger,
+    );
+
+    return {
+      dryRun: false,
+      targetOrg: input.targetOrg,
+      scannedCount: plan.scannedCount,
+      resolvedCount: plan.resolvedCount,
+      keepCount: plan.keepCount,
+      removeCount: plan.removeCount,
+      unresolvedCount: plan.unresolvedCount,
+      affectedContactIds: plan.affectedContactIds,
+      unresolvedProviderRecordIds: plan.unresolvedProviderRecordIds,
+      deletedCanonicalCount: deleteCounts.deletedCanonicalCount,
+      deletedSourceEvidenceCount: deleteCounts.deletedSourceEvidenceCount,
+      deletedInboxProjectionCount: deleteCounts.deletedInboxProjectionCount,
+      deletedIdentityReviewCount: deleteCounts.deletedIdentityReviewCount,
+      deletedRoutingReviewCount: deleteCounts.deletedRoutingReviewCount,
+      rebuiltContactCount: rebuildResult.rebuiltContactCount,
+      missingProjectionSeeds: rebuildResult.missingProjectionSeeds,
+    };
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}
+
+export async function runCleanupSalesforceOwnerScopeCommand(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<CleanupSalesforceOwnerScopeResult> {
+  const flags = parseCliFlags(args);
+  const targetOrg =
+    readOptionalStringFlag(flags, "target-org") ?? defaultTargetOrg;
+  const limit = readOptionalIntegerFlag(flags, "limit", 0);
+  const includeUnresolved = readOptionalBooleanFlag(
+    flags,
+    "delete-unresolved",
+    false,
+  );
+
+  return runCleanupSalesforceOwnerScope({
+    connectionString: readConnectionString(env),
+    targetOrg,
+    dryRun: !readOptionalBooleanFlag(flags, "execute", false),
+    includeUnresolved,
+    limit: limit === 0 ? null : limit,
+  });
+}
+
+if (import.meta.url === `file://${process.argv[1] ?? ""}`) {
+  void runCleanupSalesforceOwnerScopeCommand(process.argv.slice(2)).catch(
+    (error: unknown) => {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "cleanup-salesforce-owner-scope failed.";
+
+      console.error(message);
+      process.exitCode = 1;
+    },
+  );
+}

--- a/apps/worker/src/ops/cli.ts
+++ b/apps/worker/src/ops/cli.ts
@@ -4,56 +4,43 @@ import process from "node:process";
 import {
   closeDatabaseConnection,
   createDatabaseConnection,
-  createStage1RepositoryBundleFromConnection
+  createStage1RepositoryBundleFromConnection,
 } from "@as-comms/db";
 import {
   createStage1NormalizationService,
-  createStage1PersistenceService
+  createStage1PersistenceService,
 } from "@as-comms/domain";
 import {
   createGmailCapturePort,
   createMailchimpCapturePort,
   createSalesforceCapturePort,
-  createSimpleTextingCapturePort
+  createSimpleTextingCapturePort,
 } from "@as-comms/integrations";
 
-import {
-  buildSafeRuntimeConfigSummary,
-  readWorkerConfig
-} from "../runtime.js";
+import { buildSafeRuntimeConfigSummary, readWorkerConfig } from "../runtime.js";
 import { createStage1IngestService } from "../ingest/index.js";
 import { createStage1SyncStateService } from "../orchestration/index.js";
-import {
-  buildStage1EnqueueRequest,
-  enqueueStage1Job
-} from "./enqueue.js";
+import { buildStage1EnqueueRequest, enqueueStage1Job } from "./enqueue.js";
 import { createStage1GmailMboxImportService } from "./gmail-mbox.js";
 import {
   inspectAuditEvidence,
   inspectLatestSyncState,
   inspectSourceEvidenceForProviderRecord,
-  inspectStage1Contact
+  inspectStage1Contact,
 } from "./inspect.js";
-import {
-  runBackfillSalesforceCommunicationDetailsCommand
-} from "./backfill-salesforce-communication-details.js";
-import {
-  runBackfillContentFingerprintCommand
-} from "./backfill-content-fingerprint.js";
+import { runBackfillSalesforceCommunicationDetailsCommand } from "./backfill-salesforce-communication-details.js";
+import { runBackfillContentFingerprintCommand } from "./backfill-content-fingerprint.js";
+import { runCleanupSalesforceOwnerScopeCommand } from "./cleanup-salesforce-owner-scope.js";
 import { reconcileIdentityQueue } from "./reconcile-identity-queue.js";
-import {
-  runDedupHistoricalLedgerCommand
-} from "./dedup-historical-ledger.js";
-import {
-  runReclassifySfDirectionCommand
-} from "./reclassify-sf-direction.js";
+import { runDedupHistoricalLedgerCommand } from "./dedup-historical-ledger.js";
+import { runReclassifySfDirectionCommand } from "./reclassify-sf-direction.js";
 import {
   buildOperationId,
   parseCliFlags,
   readOptionalBooleanFlag,
   readOptionalIntegerFlag,
   readOptionalStringFlag,
-  readRequiredFlag
+  readRequiredFlag,
 } from "./helpers.js";
 import { readStage1LaunchScopeGmailConfig } from "./config.js";
 
@@ -62,7 +49,7 @@ function readConnectionString(env: NodeJS.ProcessEnv): string {
 
   if (connectionString === undefined || connectionString.trim().length === 0) {
     throw new Error(
-      "DATABASE_URL or WORKER_DATABASE_URL is required for Stage 1 ops commands."
+      "DATABASE_URL or WORKER_DATABASE_URL is required for Stage 1 ops commands.",
     );
   }
 
@@ -71,7 +58,9 @@ function readConnectionString(env: NodeJS.ProcessEnv): string {
 
 function rejectUnconfiguredProvider(providerLabel: string): Promise<never> {
   return Promise.reject(
-    new Error(`${providerLabel} capture is not configured for this worker runtime.`)
+    new Error(
+      `${providerLabel} capture is not configured for this worker runtime.`,
+    ),
   );
 }
 
@@ -96,7 +85,7 @@ function readOptionalLimitArg(args: readonly string[]): number | undefined {
 function runCheckConfig(): void {
   const config = readWorkerConfig({
     ...process.env,
-    WORKER_BOOT_MODE: "run"
+    WORKER_BOOT_MODE: "run",
   });
 
   if (config === null) {
@@ -120,7 +109,7 @@ async function runEnqueue(args: readonly string[]): Promise<void> {
     job !== "cutover-checkpoint"
   ) {
     throw new Error(
-      "Unknown enqueue job. Use one of: gmail-historical, gmail-live, salesforce-historical, salesforce-live, replay, projection-rebuild, parity-check, cutover-checkpoint."
+      "Unknown enqueue job. Use one of: gmail-historical, gmail-live, salesforce-historical, salesforce-live, replay, projection-rebuild, parity-check, cutover-checkpoint.",
     );
   }
 
@@ -128,7 +117,7 @@ async function runEnqueue(args: readonly string[]): Promise<void> {
   const request = buildStage1EnqueueRequest(job, flags);
   const result = await enqueueStage1Job({
     connectionString: readConnectionString(process.env),
-    request
+    request,
   });
 
   console.info(JSON.stringify(result, null, 2));
@@ -137,7 +126,7 @@ async function runEnqueue(args: readonly string[]): Promise<void> {
 async function runImportGmailMbox(args: readonly string[]): Promise<void> {
   const flags = parseCliFlags(args);
   const connection = createDatabaseConnection({
-    connectionString: readConnectionString(process.env)
+    connectionString: readConnectionString(process.env),
   });
 
   try {
@@ -150,7 +139,7 @@ async function runImportGmailMbox(args: readonly string[]): Promise<void> {
     const importer = createStage1GmailMboxImportService({
       ingest,
       persistence,
-      syncState
+      syncState,
     });
     const mboxPath = readRequiredFlag(flags, "mbox-path");
     const mboxText = await readFile(mboxPath, "utf8");
@@ -160,7 +149,7 @@ async function runImportGmailMbox(args: readonly string[]): Promise<void> {
       capturedMailbox: readRequiredFlag(flags, "captured-mailbox"),
       projectInboxAliasOverride: readOptionalStringFlag(
         flags,
-        "project-inbox-alias"
+        "project-inbox-alias",
       ),
       liveAccount: gmailConfig.liveAccount,
       projectInboxAliases: [...gmailConfig.projectInboxAliases],
@@ -173,7 +162,11 @@ async function runImportGmailMbox(args: readonly string[]): Promise<void> {
       traceId: readOptionalStringFlag(flags, "trace-id"),
       receivedAt: readOptionalStringFlag(flags, "received-at"),
       limit: readOptionalIntegerFlag(flags, "limit", 0) || null,
-      overwriteBodies: readOptionalBooleanFlag(flags, "overwrite-bodies", false)
+      overwriteBodies: readOptionalBooleanFlag(
+        flags,
+        "overwrite-bodies",
+        false,
+      ),
     });
 
     console.info(JSON.stringify(result, null, 2));
@@ -186,7 +179,7 @@ async function runInspect(args: readonly string[]): Promise<void> {
   const subcommand = args[0];
   const flags = parseCliFlags(args.slice(1));
   const connection = createDatabaseConnection({
-    connectionString: readConnectionString(process.env)
+    connectionString: readConnectionString(process.env),
   });
 
   try {
@@ -197,28 +190,31 @@ async function runInspect(args: readonly string[]): Promise<void> {
         const contactId = readOptionalStringFlag(flags, "contact-id");
         const salesforceContactId = readOptionalStringFlag(
           flags,
-          "salesforce-contact-id"
+          "salesforce-contact-id",
         );
         const email = readOptionalStringFlag(flags, "email");
         const result = await inspectStage1Contact(repositories, {
           ...(contactId === null ? {} : { contactId }),
           ...(salesforceContactId === null ? {} : { salesforceContactId }),
-          ...(email === null ? {} : { email })
+          ...(email === null ? {} : { email }),
         });
 
         console.info(JSON.stringify(result, null, 2));
         return;
       }
       case "source-evidence": {
-        const result = await inspectSourceEvidenceForProviderRecord(repositories, {
-          provider: readRequiredFlag(flags, "provider") as
-            | "gmail"
-            | "salesforce"
-            | "simpletexting"
-            | "mailchimp",
-          providerRecordType: readRequiredFlag(flags, "provider-record-type"),
-          providerRecordId: readRequiredFlag(flags, "provider-record-id")
-        });
+        const result = await inspectSourceEvidenceForProviderRecord(
+          repositories,
+          {
+            provider: readRequiredFlag(flags, "provider") as
+              | "gmail"
+              | "salesforce"
+              | "simpletexting"
+              | "mailchimp",
+            providerRecordType: readRequiredFlag(flags, "provider-record-type"),
+            providerRecordId: readRequiredFlag(flags, "provider-record-id"),
+          },
+        );
 
         console.info(JSON.stringify(result, null, 2));
         return;
@@ -229,10 +225,8 @@ async function runInspect(args: readonly string[]): Promise<void> {
           syncStateId !== null
             ? await inspectLatestSyncState(repositories, { syncStateId })
             : await inspectLatestSyncState(repositories, {
-                scope:
-                  (readOptionalStringFlag(flags, "scope") ?? "provider") as
-                    | "provider"
-                    | "orchestration",
+                scope: (readOptionalStringFlag(flags, "scope") ??
+                  "provider") as "provider" | "orchestration",
                 provider:
                   (readOptionalStringFlag(flags, "provider") as
                     | "gmail"
@@ -246,7 +240,7 @@ async function runInspect(args: readonly string[]): Promise<void> {
                   | "projection_rebuild"
                   | "parity_snapshot"
                   | "final_delta_sync"
-                  | "dead_letter_reprocess"
+                  | "dead_letter_reprocess",
               });
 
         console.info(JSON.stringify(result, null, 2));
@@ -255,7 +249,7 @@ async function runInspect(args: readonly string[]): Promise<void> {
       case "audit": {
         const result = await inspectAuditEvidence(repositories, {
           entityType: readRequiredFlag(flags, "entity-type"),
-          entityId: readRequiredFlag(flags, "entity-id")
+          entityId: readRequiredFlag(flags, "entity-id"),
         });
 
         console.info(JSON.stringify(result, null, 2));
@@ -263,7 +257,7 @@ async function runInspect(args: readonly string[]): Promise<void> {
       }
       default:
         throw new Error(
-          "Unknown inspect command. Use one of: contact, source-evidence, sync, audit."
+          "Unknown inspect command. Use one of: contact, source-evidence, sync, audit.",
         );
     }
   } finally {
@@ -271,12 +265,14 @@ async function runInspect(args: readonly string[]): Promise<void> {
   }
 }
 
-async function runReconcileIdentityQueue(args: readonly string[]): Promise<void> {
+async function runReconcileIdentityQueue(
+  args: readonly string[],
+): Promise<void> {
   const dryRun = !args.includes("--execute");
   const limit = readOptionalLimitArg(args);
   const config = readWorkerConfig({
     ...process.env,
-    WORKER_BOOT_MODE: "run"
+    WORKER_BOOT_MODE: "run",
   });
 
   if (config === null) {
@@ -284,7 +280,7 @@ async function runReconcileIdentityQueue(args: readonly string[]): Promise<void>
   }
 
   const connection = createDatabaseConnection({
-    connectionString: readConnectionString(process.env)
+    connectionString: readConnectionString(process.env),
   });
 
   try {
@@ -301,7 +297,7 @@ async function runReconcileIdentityQueue(args: readonly string[]): Promise<void>
                 captureHistoricalBatch: () =>
                   rejectUnconfiguredProvider("SimpleTexting"),
                 captureLiveBatch: () =>
-                  rejectUnconfiguredProvider("SimpleTexting")
+                  rejectUnconfiguredProvider("SimpleTexting"),
               }
             : createSimpleTextingCapturePort(config.capture.simpleTexting),
         mailchimp:
@@ -310,16 +306,16 @@ async function runReconcileIdentityQueue(args: readonly string[]): Promise<void>
                 captureHistoricalBatch: () =>
                   rejectUnconfiguredProvider("Mailchimp"),
                 captureTransitionBatch: () =>
-                  rejectUnconfiguredProvider("Mailchimp")
+                  rejectUnconfiguredProvider("Mailchimp"),
               }
-            : createMailchimpCapturePort(config.capture.mailchimp)
+            : createMailchimpCapturePort(config.capture.mailchimp),
       },
       gmailHistoricalReplay: {
         liveAccount: config.launchScope.gmail.liveAccount,
-        projectInboxAliases: [...config.launchScope.gmail.projectInboxAliases]
+        projectInboxAliases: [...config.launchScope.gmail.projectInboxAliases],
       },
       dryRun,
-      ...(limit === undefined ? {} : { limit })
+      ...(limit === undefined ? {} : { limit }),
     });
 
     console.log("Final report:", report);
@@ -350,6 +346,9 @@ async function main(): Promise<void> {
     case "backfill-content-fingerprint":
       await runBackfillContentFingerprintCommand(rest, process.env);
       return;
+    case "cleanup-salesforce-owner-scope":
+      await runCleanupSalesforceOwnerScopeCommand(rest, process.env);
+      return;
     case "dedup-historical-ledger":
       await runDedupHistoricalLedgerCommand(rest, process.env);
       return;
@@ -361,14 +360,14 @@ async function main(): Promise<void> {
       return;
     default:
       throw new Error(
-        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-content-fingerprint, dedup-historical-ledger, reconcile-identity-queue, reclassify-sf-direction."
+        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-content-fingerprint, cleanup-salesforce-owner-scope, dedup-historical-ledger, reconcile-identity-queue, reclassify-sf-direction.",
       );
   }
 }
 
 void main().catch((error: unknown) => {
   console.error(
-    error instanceof Error ? error.message : "Stage 1 ops command failed."
+    error instanceof Error ? error.message : "Stage 1 ops command failed.",
   );
   process.exitCode = 1;
 });

--- a/apps/worker/src/ops/reclassify-sf-direction.ts
+++ b/apps/worker/src/ops/reclassify-sf-direction.ts
@@ -130,7 +130,7 @@ async function loadCandidates(
     where canonical_event_ledger.provenance ->> 'primaryProvider' = 'salesforce'
       and salesforce_communication_details.channel = 'email'
       and salesforce_communication_details.subject is not null
-      and salesforce_communication_details.subject ~ '^[[:space:]]*[←⇐→⇒]'
+      and salesforce_communication_details.subject ~* '^[[:space:]]*(?:[←⇐→⇒]|Email:)'
     order by canonical_event_ledger.occurred_at asc, canonical_event_ledger.id asc
     limit ${String(limit)}
   `);

--- a/apps/worker/test/stage1-audit-salesforce-task-ingest.test.ts
+++ b/apps/worker/test/stage1-audit-salesforce-task-ingest.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSalesforceTaskAuditReport,
+  deriveSalesforceTaskAuditSignals,
+  inferSalesforceTaskShape,
+  type SalesforceTaskAuditRow
+} from "../src/ops/_salesforce-task-audit.js";
+
+function buildRow(
+  overrides: Partial<SalesforceTaskAuditRow>
+): SalesforceTaskAuditRow {
+  return {
+    canonicalEventId: overrides.canonicalEventId ?? "evt:1",
+    sourceEvidenceId: overrides.sourceEvidenceId ?? "sev:1",
+    providerRecordId: overrides.providerRecordId ?? "task:1",
+    payloadRef: overrides.payloadRef ?? "salesforce://Task/task:1",
+    contactId: overrides.contactId ?? "contact:1",
+    displayName: overrides.displayName ?? "Sample Contact",
+    salesforceContactId: overrides.salesforceContactId ?? "003-sample",
+    membershipCount: overrides.membershipCount ?? 1,
+    projects: overrides.projects ?? "Sample Project",
+    messageKind: overrides.messageKind ?? "auto",
+    subject: overrides.subject ?? "Subject",
+    snippet: overrides.snippet ?? "Snippet",
+    sourceLabel: overrides.sourceLabel ?? "Salesforce Flow",
+    occurredAt: overrides.occurredAt ?? "2026-04-22T00:00:00.000Z",
+    subjectEventCount: overrides.subjectEventCount ?? 1,
+    subjectContactCount: overrides.subjectContactCount ?? 1
+  };
+}
+
+describe("salesforce task audit helpers", () => {
+  it("detects human-conversation signals from reply-like snippets", () => {
+    const signals = deriveSalesforceTaskAuditSignals(
+      buildRow({
+        subject: "Re: Update on Hex 43191",
+        snippet:
+          "From: teammate@adventurescientists.org\nRecipients: volunteer@example.org\nSubject: Re: Update on Hex 43191\nBody:\nHi there!\n\nOn Mon, Apr 20, 2026 at 1:00 PM Volunteer wrote:"
+      })
+    );
+
+    expect(signals).toMatchObject({
+      subjectPrefix: "reply",
+      hasStructuredEnvelope: true,
+      hasQuotedReply: true,
+      hasConversationSignal: true
+    });
+    expect(inferSalesforceTaskShape(signals)).toBe(
+      "probable_human_conversation"
+    );
+  });
+
+  it("detects probable automation from repeated training templates", () => {
+    const signals = deriveSalesforceTaskAuditSignals(
+      buildRow({
+        subject: "Last Call: PNW Training",
+        snippet: "<p>Hi volunteer, start your training today.</p>",
+        subjectContactCount: 117
+      })
+    );
+
+    expect(signals).toMatchObject({
+      hasHtmlMarkup: true,
+      hasVolunteerAutomationKeyword: true,
+      hasBatchLikeSubject: true,
+      hasAutomationSignal: true
+    });
+    expect(inferSalesforceTaskShape(signals)).toBe("probable_automation");
+  });
+
+  it("summarizes mismatch buckets for current labels vs inferred shape", () => {
+    const report = buildSalesforceTaskAuditReport(
+      [
+        buildRow({
+          messageKind: "auto",
+          subject: "Re: Hex 21178 delay",
+          snippet:
+            "From: pnwbio@adventurescientists.org\nRecipients: planetrelations@gmail.com\nSubject: Re: Hex 21178 delay\nBody:\nOn Sat, Apr 18, 2026 at 10:36 PM Jeff wrote:"
+        }),
+        buildRow({
+          canonicalEventId: "evt:2",
+          sourceEvidenceId: "sev:2",
+          providerRecordId: "task:2",
+          contactId: "contact:2",
+          messageKind: "one_to_one",
+          subject: "Gracias por Aplicar - Siguiente paso: Capacitacion en Linea",
+          snippet: "<p>Hola! Gracias por aplicar. Start your training today.</p>",
+          subjectEventCount: 40,
+          subjectContactCount: 40
+        }),
+        buildRow({
+          canonicalEventId: "evt:3",
+          sourceEvidenceId: "sev:3",
+          providerRecordId: "task:3",
+          contactId: "contact:3",
+          subject: "Last Call: PNW Training",
+          snippet: "<p>Start your training today.</p>",
+          subjectEventCount: 117,
+          subjectContactCount: 117
+        })
+      ],
+      {
+        sampleLimit: 2,
+        topSubjectLimit: 5
+      }
+    );
+
+    expect(report.totalRows).toBe(3);
+    expect(report.distinctContacts).toBe(3);
+    expect(report.signalCounts).toEqual({
+      automation_signal: 2,
+      conversation_signal: 1
+    });
+    expect(report.mismatchCounts).toEqual({
+      auto_with_conversation_signal: 1,
+      auto_but_probably_human: 1,
+      one_to_one_but_probably_automation: 1,
+      one_to_one_with_automation_signal: 1
+    });
+    expect(report.samples.autoWithConversationSignal).toHaveLength(1);
+    expect(report.samples.autoButProbablyHuman).toHaveLength(1);
+    expect(report.samples.oneToOneButProbablyAutomation).toHaveLength(1);
+  });
+});

--- a/apps/worker/test/stage1-cleanup-salesforce-owner-scope.test.ts
+++ b/apps/worker/test/stage1-cleanup-salesforce-owner-scope.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  planSalesforceOwnerScopeCleanup,
+  type SalesforceOwnerScopeCleanupCandidate,
+} from "../src/ops/cleanup-salesforce-owner-scope.js";
+
+describe("cleanup-salesforce-owner-scope planning", () => {
+  it("removes only positively resolved non-Nim Admin Salesforce email rows", () => {
+    const candidates: SalesforceOwnerScopeCleanupCandidate[] = [
+      {
+        canonicalEventId: "evt:nim-admin",
+        contactId: "contact:1",
+        sourceEvidenceId: "sev:nim-admin",
+        providerRecordId: "00T-nim-admin",
+        subject: "Application received",
+      },
+      {
+        canonicalEventId: "evt:human-owner",
+        contactId: "contact:2",
+        sourceEvidenceId: "sev:human-owner",
+        providerRecordId: "00T-human-owner",
+        subject: "Re: Let’s meet!",
+      },
+      {
+        canonicalEventId: "evt:unresolved",
+        contactId: "contact:3",
+        sourceEvidenceId: "sev:unresolved",
+        providerRecordId: "00T-unresolved",
+        subject: "Historical task",
+      },
+    ];
+
+    const plan = planSalesforceOwnerScopeCleanup({
+      candidates,
+      ownerUsernameByTaskId: new Map([
+        ["00T-nim-admin", "admin+1@adventurescientists.org"],
+        ["00T-human-owner", "ricky@adventurescientists.org"],
+      ]),
+    });
+
+    expect(plan).toMatchObject({
+      scannedCount: 3,
+      resolvedCount: 2,
+      keepCount: 1,
+      removeCount: 1,
+      unresolvedCount: 1,
+      affectedContactIds: ["contact:2"],
+      unresolvedProviderRecordIds: ["00T-unresolved"],
+    });
+    expect(plan.changes).toEqual([
+      expect.objectContaining({
+        canonicalEventId: "evt:human-owner",
+        contactId: "contact:2",
+        providerRecordId: "00T-human-owner",
+        ownerUsername: "ricky@adventurescientists.org",
+        removalReason: "non_nim_admin_owner",
+      }),
+    ]);
+  });
+
+  it("can explicitly include unresolved Salesforce email rows for removal", () => {
+    const candidates: SalesforceOwnerScopeCleanupCandidate[] = [
+      {
+        canonicalEventId: "evt:nim-admin",
+        contactId: "contact:1",
+        sourceEvidenceId: "sev:nim-admin",
+        providerRecordId: "00T-nim-admin",
+        subject: "Application received",
+      },
+      {
+        canonicalEventId: "evt:unresolved",
+        contactId: "contact:3",
+        sourceEvidenceId: "sev:unresolved",
+        providerRecordId: "00T-unresolved",
+        subject: "Historical task",
+      },
+    ];
+
+    const plan = planSalesforceOwnerScopeCleanup({
+      candidates,
+      ownerUsernameByTaskId: new Map([
+        ["00T-nim-admin", "admin+1@adventurescientists.org"],
+      ]),
+      includeUnresolved: true,
+    });
+
+    expect(plan).toMatchObject({
+      scannedCount: 2,
+      resolvedCount: 1,
+      keepCount: 1,
+      removeCount: 1,
+      unresolvedCount: 1,
+      affectedContactIds: ["contact:3"],
+      unresolvedProviderRecordIds: ["00T-unresolved"],
+    });
+    expect(plan.changes).toEqual([
+      expect.objectContaining({
+        canonicalEventId: "evt:unresolved",
+        contactId: "contact:3",
+        providerRecordId: "00T-unresolved",
+        ownerUsername: null,
+        removalReason: "unresolved_owner",
+      }),
+    ]);
+  });
+});

--- a/apps/worker/test/stage1-reclassify-sf-direction.test.ts
+++ b/apps/worker/test/stage1-reclassify-sf-direction.test.ts
@@ -74,4 +74,31 @@ describe("reclassify-sf-direction planning", () => {
       })
     );
   });
+
+  it('cleans bare Salesforce "Email:" subjects without reclassifying direction', () => {
+    const plan = planSfDirectionReclassifications([
+      buildCandidate({
+        index: 1,
+        subject: "Email: Aplicacion en Revision: Monitoreo y Restauracion de Arrecifes de Coral"
+      })
+    ]);
+
+    expect(plan.scannedCount).toBe(1);
+    expect(plan.reclassifiedCount).toBe(0);
+    expect(plan.cleanedSubjectCount).toBe(1);
+    expect(plan.skippedCrossProviderRows).toEqual([]);
+    expect(plan.changes).toEqual([
+      expect.objectContaining({
+        canonicalEventId: "evt:1",
+        previousEventType: "communication.email.outbound",
+        nextEventType: "communication.email.outbound",
+        previousSubject:
+          "Email: Aplicacion en Revision: Monitoreo y Restauracion de Arrecifes de Coral",
+        nextSubject:
+          "Aplicacion en Revision: Monitoreo y Restauracion de Arrecifes de Coral",
+        direction: "outbound",
+        reclassifiesEventType: false
+      })
+    ]);
+  });
 });


### PR DESCRIPTION
## What changed
- add reusable Salesforce task audit tooling for inspecting current DB/task patterns
- add a safe owner-scope cleanup op for removing non-`Nim Admin` Salesforce email rows
- extend the historical subject cleanup/reclassify tooling to also handle bare `Email:` prefixes

## Why
We already used these ops to audit the Salesforce data and clean production safely. This PR commits the operator tooling so the cleanup and verification are reproducible.

## Impact
- the production cleanup path is now codified in repo
- historical Salesforce subject cleanup can strip bare `Email:` prefixes
- future operator audits of Salesforce task ingest patterns are repeatable

## Validation
- `pnpm --filter @as-comms/worker exec vitest run test/stage1-cleanup-salesforce-owner-scope.test.ts test/stage1-audit-salesforce-task-ingest.test.ts test/stage1-reclassify-sf-direction.test.ts test/stage1-reclassify-salesforce-tasks.test.ts`
