### PR TITLE
[codex] collapse duplicate campaign email timeline rows

### DIFF
--- a/packages/domain/src/timeline.ts
+++ b/packages/domain/src/timeline.ts
@@ -281,6 +281,41 @@ function normalizeDuplicateText(value: string | null | undefined): string | null
   return normalized.length === 0 ? null : normalized;
 }
 
+function timelineCampaignEmailDuplicateKey(
+  item: TimelineItem,
+): string | null {
+  if (item.family !== "campaign_email") {
+    return null;
+  }
+
+  return normalizeDuplicateText(item.campaignId);
+}
+
+function isSameCampaignEmailDuplicate(
+  left: CanonicalTimelineItemWithEvent,
+  right: CanonicalTimelineItemWithEvent,
+): boolean {
+  const leftKey = timelineCampaignEmailDuplicateKey(left.item);
+  const rightKey = timelineCampaignEmailDuplicateKey(right.item);
+
+  return leftKey !== null && leftKey === rightKey;
+}
+
+function campaignEmailPresentationPriority(
+  item: Extract<TimelineItem, { family: "campaign_email" }>,
+): number {
+  switch (item.activityType) {
+    case "sent":
+      return 4;
+    case "opened":
+      return 3;
+    case "clicked":
+      return 2;
+    case "unsubscribed":
+      return 1;
+  }
+}
+
 function buildTimelineDuplicateSignature(item: TimelineItem): string | null {
   const parts = (() => {
     switch (item.family) {
@@ -326,6 +361,17 @@ function buildTimelineDuplicateSignature(item: TimelineItem): string | null {
 function buildTimelineDuplicateKey(
   entry: CanonicalTimelineItemWithEvent,
 ): string | null {
+  const campaignDuplicateKey = timelineCampaignEmailDuplicateKey(entry.item);
+
+  if (campaignDuplicateKey !== null) {
+    return [
+      "campaign",
+      entry.canonicalEvent.contactId,
+      entry.canonicalEvent.channel,
+      campaignDuplicateKey,
+    ].join(":");
+  }
+
   const fingerprint = normalizeDuplicateText(
     entry.canonicalEvent.contentFingerprint,
   );
@@ -366,9 +412,16 @@ function isTimelinePresentationDuplicate(
 ): boolean {
   if (
     left.canonicalEvent.contactId !== right.canonicalEvent.contactId ||
-    left.canonicalEvent.eventType !== right.canonicalEvent.eventType ||
     left.canonicalEvent.channel !== right.canonicalEvent.channel
   ) {
+    return false;
+  }
+
+  if (isSameCampaignEmailDuplicate(left, right)) {
+    return true;
+  }
+
+  if (left.canonicalEvent.eventType !== right.canonicalEvent.eventType) {
     return false;
   }
 
@@ -474,6 +527,24 @@ function preferTimelineDuplicate(
 
   if (providerDelta < 0) {
     return existing;
+  }
+
+  if (
+    existing.item.family === "campaign_email" &&
+    candidate.item.family === "campaign_email" &&
+    isSameCampaignEmailDuplicate(existing, candidate)
+  ) {
+    const activityDelta =
+      campaignEmailPresentationPriority(candidate.item) -
+      campaignEmailPresentationPriority(existing.item);
+
+    if (activityDelta > 0) {
+      return candidate;
+    }
+
+    if (activityDelta < 0) {
+      return existing;
+    }
   }
 
   const detailDelta =

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -861,4 +861,63 @@ describe("Stage 1 timeline presenter", () => {
       campaignName: "April Volunteer Update",
     });
   });
+
+  it("collapses sent and opened campaign activity variants into one representative email row", async () => {
+    const sentCampaign = buildMailchimpCampaignEmailEvent({
+      id: "evt_campaign_sent",
+      sourceEvidenceId: "sev_campaign_sent",
+      occurredAt: "2026-01-01T00:10:00.000Z",
+      activityType: "sent",
+      campaignName: "Trailhead Update",
+      snippet: "Subject: Trailhead Update\n\nBody:\nBring your field notebook.",
+      contentFingerprint: "fp:campaign-sent",
+    });
+    const openedCampaign = buildMailchimpCampaignEmailEvent({
+      id: "evt_campaign_opened",
+      sourceEvidenceId: "sev_campaign_opened",
+      occurredAt: "2026-01-02T04:45:00.000Z",
+      activityType: "opened",
+      campaignName: "Trailhead Update",
+      snippet: "Subject: Trailhead Update\n\nBody:\nBring your field notebook.",
+      contentFingerprint: "fp:campaign-opened",
+    });
+    const repositories = createRepositoryBundle({
+      canonicalEvents: [
+        sentCampaign.canonicalEvent,
+        openedCampaign.canonicalEvent,
+      ],
+      sourceEvidence: [
+        buildSourceEvidence({
+          id: "sev_campaign_sent",
+          provider: "mailchimp",
+          providerRecordType: "campaign_email_activity",
+          providerRecordId: "campaign-sent",
+        }),
+        buildSourceEvidence({
+          id: "sev_campaign_opened",
+          provider: "mailchimp",
+          providerRecordType: "campaign_email_activity",
+          providerRecordId: "campaign-opened",
+        }),
+      ],
+      salesforceCommunicationDetails: [],
+      mailchimpCampaignActivityDetails: [
+        sentCampaign.detail,
+        openedCampaign.detail,
+      ],
+      timelineRows: [sentCampaign.timelineRow, openedCampaign.timelineRow],
+    });
+    const presenter = createStage1TimelinePresentationService(repositories);
+
+    const items = await presenter.listTimelineItemsByContactId("contact_1");
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      canonicalEventId: "evt_campaign_sent",
+      family: "campaign_email",
+      activityType: "sent",
+      campaignName: "Trailhead Update",
+      snippet: "Subject: Trailhead Update\n\nBody:\nBring your field notebook.",
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- collapse Mailchimp campaign sent/opened/clicked variants into one timeline row when they share a campaign id
- prefer the sent row when multiple campaign activities exist so the timeline keeps the readable email content
- add a regression test covering sent/opened duplicates across different timestamps

## Testing
- pnpm --filter @as-comms/domain test:unit -- test/timeline.test.ts