### PR TITLE
[codex] show consolidated campaign activity in inbox

### DIFF
--- a/apps/web/app/inbox/_components/inbox-timeline.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline.tsx
@@ -350,6 +350,9 @@ function AutomatedRow({
           : "Campaign SMS";
   const headline = entry.subject;
   const body = bodyTextForEntry(entry);
+  const campaignActivity = entry.kind === "outbound-campaign-email"
+    ? entry.campaignActivity
+    : [];
   const hideCollapsedBody = shouldHideAutomatedRowBody({
     isExpanded,
     kind: entry.kind,
@@ -379,11 +382,23 @@ function AutomatedRow({
               {headline}
             </p>
           ) : null}
+          {campaignActivity.length > 0 ? (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {campaignActivity.map((activity) => (
+                <span
+                  key={`${activity.activityType}:${activity.occurredAt}`}
+                  className="inline-flex items-center rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-medium leading-none text-emerald-700"
+                >
+                  {activity.label}
+                </span>
+              ))}
+            </div>
+          ) : null}
           {!hideCollapsedBody && body.length > 0 ? (
             <p
               className={cn(
                 "text-[13px] leading-relaxed text-slate-600",
-                headline && "mt-1.5",
+                (headline || campaignActivity.length > 0) && "mt-1.5",
                 isExpanded ? "whitespace-pre-wrap text-pretty" : "line-clamp-1",
               )}
             >

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -1,6 +1,7 @@
 import { unstable_cache } from "next/cache";
 
 import type {
+  CanonicalEventRecord,
   ContactMembershipRecord,
   ContactRecord,
   InboxDrivingEventType,
@@ -27,6 +28,7 @@ import type {
   InboxProjectMembershipViewModel,
   InboxProjectStatus,
   InboxRecentActivityViewModel,
+  InboxTimelineCampaignActivityViewModel,
   InboxTimelineEntryKind,
   InboxTimelineEntryViewModel,
   InboxVolunteerStage,
@@ -69,6 +71,9 @@ interface InboxDetailCacheData {
   readonly memberships: readonly ContactMembershipRecord[];
   readonly activityTimelineItems: readonly TimelineItem[];
   readonly timelineItems: readonly TimelineItem[];
+  readonly campaignActivitySummaryByCampaignId: Readonly<
+    Record<string, CampaignActivitySummary>
+  >;
   readonly projectNameById: Readonly<Record<string, string>>;
   readonly timelinePage: {
     readonly hasMore: boolean;
@@ -84,6 +89,18 @@ interface InboxDetailCacheData {
 
 const DEFAULT_INBOX_LIST_PAGE_SIZE = 50;
 const DEFAULT_INBOX_TIMELINE_PAGE_SIZE = 40;
+
+type CampaignActivityType = Extract<
+  TimelineItem,
+  { family: "campaign_email" }
+>["activityType"];
+
+interface CampaignActivitySummary {
+  sentAt: string | null;
+  openedAt: string | null;
+  clickedAt: string | null;
+  unsubscribedAt: string | null;
+}
 
 const AVATAR_TONES: readonly InboxAvatarTone[] = [
   "indigo",
@@ -131,6 +148,90 @@ function uniqueStrings(
       values.filter((value): value is string => typeof value === "string"),
     ),
   );
+}
+
+function emptyCampaignActivitySummary(): CampaignActivitySummary {
+  return {
+    sentAt: null,
+    openedAt: null,
+    clickedAt: null,
+    unsubscribedAt: null,
+  };
+}
+
+function campaignActivitySummaryKey(
+  activityType: CampaignActivityType,
+): keyof CampaignActivitySummary {
+  switch (activityType) {
+    case "sent":
+      return "sentAt";
+    case "opened":
+      return "openedAt";
+    case "clicked":
+      return "clickedAt";
+    case "unsubscribed":
+      return "unsubscribedAt";
+  }
+}
+
+function keepMostRecentTimestamp(
+  current: string | null,
+  candidate: string,
+): string {
+  if (current === null) {
+    return candidate;
+  }
+
+  return current >= candidate ? current : candidate;
+}
+
+async function loadCampaignActivitySummaryByCampaignId(input: {
+  readonly runtime: Awaited<ReturnType<typeof getStage1WebRuntime>>;
+  readonly canonicalEvents: readonly CanonicalEventRecord[];
+}): Promise<Readonly<Record<string, CampaignActivitySummary>>> {
+  const campaignSourceEvidenceIds = uniqueStrings(
+    input.canonicalEvents
+      .filter((event) => event.channel === "campaign_email")
+      .map((event) => event.sourceEvidenceId),
+  );
+
+  if (campaignSourceEvidenceIds.length === 0) {
+    return {};
+  }
+
+  const details =
+    await input.runtime.repositories.mailchimpCampaignActivityDetails.listBySourceEvidenceIds(
+      campaignSourceEvidenceIds,
+    );
+  const detailBySourceEvidenceId = new Map(
+    details.map((detail) => [detail.sourceEvidenceId, detail]),
+  );
+  const summaryByCampaignId: Record<string, CampaignActivitySummary> = {};
+
+  for (const event of input.canonicalEvents) {
+    if (event.channel !== "campaign_email") {
+      continue;
+    }
+
+    const detail = detailBySourceEvidenceId.get(event.sourceEvidenceId);
+    const campaignId = detail?.campaignId;
+
+    if (typeof campaignId !== "string" || campaignId.trim().length === 0) {
+      continue;
+    }
+
+    const key = campaignId.trim();
+    const summary =
+      summaryByCampaignId[key] ?? (summaryByCampaignId[key] = emptyCampaignActivitySummary());
+    const summaryKey = campaignActivitySummaryKey(detail.activityType);
+
+    summary[summaryKey] = keepMostRecentTimestamp(
+      summary[summaryKey],
+      event.occurredAt,
+    );
+  }
+
+  return summaryByCampaignId;
 }
 
 function encodeInboxListCursor(input: {
@@ -1357,6 +1458,73 @@ function timelineBody(item: TimelineItem): string {
   }
 }
 
+function formatCampaignActivityLabel(
+  activityType: Exclude<CampaignActivityType, "sent">,
+  occurredAtLabel: string,
+): string {
+  switch (activityType) {
+    case "opened":
+      return `Opened ${occurredAtLabel}`;
+    case "clicked":
+      return `Clicked ${occurredAtLabel}`;
+    case "unsubscribed":
+      return `Unsubscribed ${occurredAtLabel}`;
+  }
+}
+
+function buildCampaignActivityViewModels(input: {
+  readonly item: Extract<TimelineItem, { family: "campaign_email" }>;
+  readonly campaignActivitySummaryByCampaignId: Readonly<
+    Record<string, CampaignActivitySummary>
+  >;
+  readonly referenceNowIso: string;
+}): readonly InboxTimelineCampaignActivityViewModel[] {
+  const campaignId = input.item.campaignId;
+
+  if (campaignId === null) {
+    return [];
+  }
+
+  const summary = input.campaignActivitySummaryByCampaignId[campaignId];
+
+  if (summary === undefined) {
+    return [];
+  }
+
+  const activities: readonly Exclude<CampaignActivityType, "sent">[] = [
+    "opened",
+    "clicked",
+    "unsubscribed",
+  ];
+
+  return activities.flatMap((activityType) => {
+    const occurredAt =
+      activityType === "opened"
+        ? summary.openedAt
+        : activityType === "clicked"
+          ? summary.clickedAt
+          : summary.unsubscribedAt;
+
+    if (occurredAt === null || activityType === input.item.activityType) {
+      return [];
+    }
+
+    const occurredAtLabel = formatRelativeTimestamp(
+      occurredAt,
+      input.referenceNowIso,
+    );
+
+    return [
+      {
+        activityType,
+        occurredAt,
+        occurredAtLabel,
+        label: formatCampaignActivityLabel(activityType, occurredAtLabel),
+      } satisfies InboxTimelineCampaignActivityViewModel,
+    ];
+  });
+}
+
 function isPreviewTimelineItem(item: TimelineItem): boolean {
   switch (item.family) {
     case "salesforce_event":
@@ -1377,6 +1545,9 @@ function buildTimelineEntry(input: {
   readonly contactPrimaryEmail: string | null;
   readonly inboxProjection: InboxProjectionRow;
   readonly item: TimelineItem;
+  readonly campaignActivitySummaryByCampaignId: Readonly<
+    Record<string, CampaignActivitySummary>
+  >;
   readonly referenceNowIso: string;
 }): InboxTimelineEntryViewModel {
   const latestProjectionSnippet =
@@ -1438,6 +1609,15 @@ function buildTimelineEntry(input: {
     !hasRenderableEmailContent && input.item.family === "one_to_one_email"
       ? "email-activity"
       : kind;
+  const campaignActivity =
+    input.item.family === "campaign_email"
+      ? buildCampaignActivityViewModels({
+          item: input.item,
+          campaignActivitySummaryByCampaignId:
+            input.campaignActivitySummaryByCampaignId,
+          referenceNowIso: input.referenceNowIso,
+        })
+      : [];
   const isUnread =
     input.inboxProjection.bucket === "New" &&
     input.item.canonicalEventId ===
@@ -1486,6 +1666,7 @@ function buildTimelineEntry(input: {
       input.item.family === "one_to_one_email"
         ? (input.item.attachmentCount ?? 0)
         : 0,
+    campaignActivity,
     noteId: input.item.family === "internal_note" ? input.item.noteId : null,
     authorId:
       input.item.family === "internal_note" ? input.item.authorId : null,
@@ -1811,6 +1992,7 @@ async function readInboxDetailCacheData(
     timelinePage,
     inboxFreshness,
     timelineFreshness,
+    canonicalEvents,
   ] = await Promise.all([
     runtime.repositories.contacts.findById(contactId),
     runtime.repositories.inboxProjection.findByContactId(contactId),
@@ -1822,6 +2004,7 @@ async function readInboxDetailCacheData(
     }),
     runtime.repositories.inboxProjection.getFreshnessByContactId(contactId),
     runtime.repositories.timelineProjection.getFreshnessByContactId(contactId),
+    runtime.repositories.canonicalEvents.listByContactId(contactId),
   ]);
 
   if (contact === null || inboxProjection === null) {
@@ -1834,6 +2017,11 @@ async function readInboxDetailCacheData(
     memberships,
     activityTimelineItems,
     timelineItems: timelinePage.items,
+    campaignActivitySummaryByCampaignId:
+      await loadCampaignActivitySummaryByCampaignId({
+        runtime,
+        canonicalEvents,
+      }),
     projectNameById: await loadProjectNameById(memberships),
     timelinePage: {
       hasMore: timelinePage.hasMore,
@@ -2080,6 +2268,8 @@ export async function getInboxTimelinePage(
         contactPrimaryEmail: cachedData.contact.primaryEmail,
         inboxProjection: cachedData.inboxProjection,
         item,
+        campaignActivitySummaryByCampaignId:
+          cachedData.campaignActivitySummaryByCampaignId,
         referenceNowIso,
       }),
     ),
@@ -2174,6 +2364,8 @@ export async function getInboxDetail(
         contactPrimaryEmail: cachedData.contact.primaryEmail,
         inboxProjection: cachedData.inboxProjection,
         item,
+        campaignActivitySummaryByCampaignId:
+          cachedData.campaignActivitySummaryByCampaignId,
         referenceNowIso,
       }),
     ),

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -133,6 +133,13 @@ export type InboxTimelineEntrySendStatus =
   | "orphaned"
   | null;
 
+export interface InboxTimelineCampaignActivityViewModel {
+  readonly activityType: "sent" | "opened" | "clicked" | "unsubscribed";
+  readonly occurredAt: string;
+  readonly occurredAtLabel: string;
+  readonly label: string;
+}
+
 export interface InboxTimelineEntryViewModel {
   readonly id: string;
   readonly kind: InboxTimelineEntryKind;
@@ -150,6 +157,7 @@ export interface InboxTimelineEntryViewModel {
   readonly inReplyToRfc822: string | null;
   readonly sendStatus: InboxTimelineEntrySendStatus;
   readonly attachmentCount: number;
+  readonly campaignActivity: readonly InboxTimelineCampaignActivityViewModel[];
   readonly noteId?: string | null;
   readonly authorId?: string | null;
 }

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -1260,7 +1260,69 @@ describe("real inbox selectors", () => {
       subject: "April field update",
       body: "Hi Sarah,\nPlease bring your field notebook.",
       isPreview: true,
+      campaignActivity: [],
     });
+  });
+
+  it("surfaces opened and clicked metadata on consolidated campaign email rows while keeping the sent body", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxCampaignEmailEvent(runtime.context, {
+      id: "sarah-campaign-email-consolidated-sent",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-12T15:00:00.000Z",
+      activityType: "sent",
+      campaignId: "campaign:april-field-update",
+      campaignName: "April Volunteer Update",
+      snippet: [
+        "From: volunteers@example.org",
+        "To: sarah@example.org",
+        "",
+        "Subject: April field update",
+        "Body:",
+        "Hi Sarah,",
+        "Please bring your field notebook.",
+      ].join("\n"),
+    });
+    await seedInboxCampaignEmailEvent(runtime.context, {
+      id: "sarah-campaign-email-consolidated-opened",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-12T16:00:00.000Z",
+      activityType: "opened",
+      campaignId: "campaign:april-field-update",
+      campaignName: "April Volunteer Update",
+      snippet: "Campaign opened",
+    });
+    await seedInboxCampaignEmailEvent(runtime.context, {
+      id: "sarah-campaign-email-consolidated-clicked",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-12T16:30:00.000Z",
+      activityType: "clicked",
+      campaignId: "campaign:april-field-update",
+      campaignName: "April Volunteer Update",
+      snippet: "https://example.org/register",
+    });
+
+    const detail = await getInboxDetail("contact:sarah-martinez");
+    const campaignEntries =
+      detail?.timeline.filter(
+        (entry) =>
+          entry.kind === "outbound-campaign-email" &&
+          entry.subject === "April field update",
+      ) ?? [];
+
+    expect(campaignEntries).toHaveLength(1);
+    expect(campaignEntries[0]).toMatchObject({
+      kind: "outbound-campaign-email",
+      subject: "April field update",
+      body: "Hi Sarah,\nPlease bring your field notebook.",
+    });
+    expect(campaignEntries[0]?.campaignActivity.map((activity) => activity.activityType)).toEqual([
+      "opened",
+      "clicked",
+    ]);
   });
 
   it("strips outbound email prefixes from automated and campaign email subjects before display", async () => {

--- a/apps/web/tests/unit/inbox-stage1-helpers.ts
+++ b/apps/web/tests/unit/inbox-stage1-helpers.ts
@@ -537,12 +537,14 @@ export async function seedInboxCampaignEmailEvent(
     readonly occurredAt: string;
     readonly activityType: "sent" | "opened" | "clicked" | "unsubscribed";
     readonly campaignName: string;
+    readonly campaignId?: string;
     readonly snippet: string;
   },
 ): Promise<{ readonly canonicalEventId: string }> {
   const sourceEvidenceId = `source:${input.id}`;
   const canonicalEventId = `event:${input.id}`;
   const eventType = `campaign.email.${input.activityType}` as const;
+  const campaignId = input.campaignId ?? `campaign:${input.id}`;
 
   await context.repositories.sourceEvidence.append({
     id: sourceEvidenceId,
@@ -574,7 +576,7 @@ export async function seedInboxCampaignEmailEvent(
       sourceRecordId: input.id,
       messageKind: "campaign",
       campaignRef: {
-        providerCampaignId: "campaign_email_1",
+        providerCampaignId: campaignId,
         providerAudienceId: "audience_1",
         providerMessageName: input.campaignName,
       },
@@ -589,7 +591,7 @@ export async function seedInboxCampaignEmailEvent(
     sourceEvidenceId,
     providerRecordId: input.id,
     activityType: input.activityType,
-    campaignId: "campaign_email_1",
+    campaignId,
     audienceId: "audience_1",
     memberId: "member_1",
     campaignName: input.campaignName,

--- a/apps/web/tests/unit/inbox-timeline.test.ts
+++ b/apps/web/tests/unit/inbox-timeline.test.ts
@@ -58,6 +58,7 @@ const baseEntry = {
   inReplyToRfc822: null,
   sendStatus: null,
   attachmentCount: 0,
+  campaignActivity: [],
 };
 
 describe("InboxTimeline", () => {
@@ -99,6 +100,41 @@ describe("InboxTimeline", () => {
 
     expect(markup).toContain("Campaign Email");
     expect(markup).toContain("Please review the latest field update.");
+  });
+
+  it("shows consolidated campaign activity badges inside the bubble", () => {
+    const markup = renderToStaticMarkup(
+      createElement(InboxTimeline, {
+        entries: [
+          {
+            ...baseEntry,
+            id: "timeline:campaign-email-activity",
+            kind: "outbound-campaign-email" as const,
+            subject: "April field update",
+            body: "Please bring your field notebook.",
+            campaignActivity: [
+              {
+                activityType: "opened" as const,
+                occurredAt: "2026-04-16T13:30:00.000Z",
+                occurredAtLabel: "1h ago",
+                label: "Opened 1h ago",
+              },
+              {
+                activityType: "clicked" as const,
+                occurredAt: "2026-04-16T13:45:00.000Z",
+                occurredAtLabel: "45m ago",
+                label: "Clicked 45m ago",
+              },
+            ],
+          },
+        ],
+        volunteerFirstName: "Alice",
+        currentOperatorUserId: "user:operator",
+      }),
+    );
+
+    expect(markup).toContain("Opened 1h ago");
+    expect(markup).toContain("Clicked 45m ago");
   });
 
   it("only hides automated email body text while a subject-bearing row is collapsed", () => {

--- a/apps/web/tests/unit/stage3-timeline-pending.test.tsx
+++ b/apps/web/tests/unit/stage3-timeline-pending.test.tsx
@@ -61,6 +61,7 @@ function buildEntry(
     inReplyToRfc822: "parent-message-id",
     sendStatus: "pending",
     attachmentCount: 0,
+    campaignActivity: [],
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary
- carry consolidated Mailchimp opened/clicked metadata into the inbox timeline entry view model
- render campaign activity badges inside the collapsed/expanded campaign bubble
- keep inbox campaign test helpers realistic by defaulting each seeded campaign email to its own campaign id

## Testing
- pnpm --filter @as-comms/web test:unit -- tests/unit/inbox-selectors.test.ts tests/unit/inbox-timeline.test.ts tests/unit/stage3-timeline-pending.test.tsx