### PR TITLE
[codex] fix campaign activity inbox deploy build

### DIFF
--- a/apps/web/app/inbox/_components/inbox-timeline.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline.tsx
@@ -398,7 +398,7 @@ function AutomatedRow({
             <p
               className={cn(
                 "text-[13px] leading-relaxed text-slate-600",
-                (headline || campaignActivity.length > 0) && "mt-1.5",
+                (headline !== null || campaignActivity.length > 0) && "mt-1.5",
                 isExpanded ? "whitespace-pre-wrap text-pretty" : "line-clamp-1",
               )}
             >

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -214,7 +214,12 @@ async function loadCampaignActivitySummaryByCampaignId(input: {
     }
 
     const detail = detailBySourceEvidenceId.get(event.sourceEvidenceId);
-    const campaignId = detail?.campaignId;
+
+    if (detail === undefined) {
+      continue;
+    }
+
+    const campaignId = detail.campaignId;
 
     if (typeof campaignId !== "string" || campaignId.trim().length === 0) {
       continue;


### PR DESCRIPTION
## Summary
- fix the campaign activity summary selector guard for TypeScript narrowing
- clean up the campaign bubble spacing condition so the Next.js lint step passes
- verify the full Railway-equivalent workspace build succeeds

## Testing
- pnpm --filter @as-comms/web test:unit -- tests/unit/inbox-selectors.test.ts tests/unit/inbox-timeline.test.ts tests/unit/stage3-timeline-pending.test.tsx
- pnpm --filter @as-comms/contracts build && pnpm --filter @as-comms/domain build && pnpm --filter @as-comms/db build && pnpm --filter @as-comms/ui build && pnpm --filter @as-comms/integrations build && pnpm --filter @as-comms/web build