### PR TITLE
[codex] fix inbox clipping and same-day Gmail dedupe

### DIFF
--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -641,8 +641,30 @@ const STRUCTURED_EMAIL_PARAGRAPH_STARTERS = [
 ] as const;
 const SIGNATURE_SEPARATOR_PATTERN = /^(?:---|--\s)$/;
 const SENT_WITH_SIGNATURE_PATTERN = /^Sent with\b/i;
-const SIGN_OFF_LINE_PATTERN =
-  /^(?:Best,|Thanks,|Warmly,|Cheers,|Sincerely,|Saludos,)(?:\s.*)?$/i;
+const SIGN_OFF_PREFIX_PATTERN =
+  /^(?:Best|Thanks|Warmly|Cheers|Sincerely|Saludos),/i;
+
+function isStandaloneSignOffLine(value: string): boolean {
+  const trimmed = value.trim();
+
+  if (!SIGN_OFF_PREFIX_PATTERN.test(trimmed)) {
+    return false;
+  }
+
+  const remainder = trimmed.replace(SIGN_OFF_PREFIX_PATTERN, "").trim();
+
+  if (remainder.length === 0) {
+    return true;
+  }
+
+  if (/[.!?]/.test(remainder)) {
+    return false;
+  }
+
+  return /^[A-ZÀ-Ý][A-Za-zÀ-ÿ'’.&-]*(?:\s+[A-ZÀ-Ý][A-Za-zÀ-ÿ'’.&-]*){0,4}$/u.test(
+    remainder,
+  );
+}
 
 function restoreStructuredEmailParagraphs(value: string): string {
   const normalized = value.trim();
@@ -883,7 +905,7 @@ export function stripSignature(body: string): string {
     const trimmed = (lines[index] ?? "").trim();
 
     if (
-      SIGN_OFF_LINE_PATTERN.test(trimmed) &&
+      isStandaloneSignOffLine(trimmed) &&
       signatureLooksLikeClosing(lines, index)
     ) {
       return lines.slice(0, index).join("\n").trim();
@@ -891,7 +913,7 @@ export function stripSignature(body: string): string {
   }
 
   const inlineClosingMatch =
-    /([.!?])\s*(?:Best,|Thanks,|Warmly,|Cheers,|Sincerely,|Saludos,).*/i.exec(
+    /([.!?])\s*(?:Best|Thanks|Warmly|Cheers|Sincerely|Saludos),\s*(?:[A-ZÀ-Ý][A-Za-zÀ-ÿ'’.&-]*(?:\s+[A-ZÀ-Ý][A-Za-zÀ-ÿ'’.&-]*){0,4})?\s*$/iu.exec(
       normalized,
     );
 
@@ -903,7 +925,7 @@ export function stripSignature(body: string): string {
   }
 
   const trailingSignatureMatch =
-    /\n+\s*(?:Best,|Thanks,|Warmly,|Cheers,|Sincerely,|Saludos,).*/i.exec(
+    /\n+\s*(?:Best|Thanks|Warmly|Cheers|Sincerely|Saludos),\s*(?:[A-ZÀ-Ý][A-Za-zÀ-ÿ'’.&-]*(?:\s+[A-ZÀ-Ý][A-Za-zÀ-ÿ'’.&-]*){0,4})?\s*$/iu.exec(
       normalized,
     );
 

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -1784,6 +1784,60 @@ describe("real inbox selectors", () => {
     });
   });
 
+  it("preserves inbound Salesforce bodies that begin with 'Thanks,'", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:shaina-dotson",
+      salesforceContactId: "003-shaina-dotson",
+      displayName: "Shaina Dotson",
+      primaryEmail: "shaina.dotson@gmail.com",
+      primaryPhone: null,
+    });
+    const latestSalesforceEvent = await seedInboxSalesforceOutboundEmailEvent(
+      runtime.context,
+      {
+        id: "shaina-thanks-body",
+        contactId: "contact:shaina-dotson",
+        occurredAt: "2026-04-21T00:38:00.000Z",
+        direction: "inbound",
+        subject: "Re: Update on Hex 43191",
+        snippet: [
+          "Thanks, Ricky & Samantha! I didn't realize that all ARUs need to be placed by the end of June! Glad I'll still be able to claim a hex to retrieve later this summer. Thanks for all your help!",
+          "",
+          "Shaina",
+        ].join("\n"),
+        messageKind: "one_to_one",
+      },
+    );
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:shaina-dotson",
+      bucket: "Opened",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-21T00:38:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-04-21T00:38:00.000Z",
+      snippet: "Shaina thanks-body preview",
+      lastCanonicalEventId: latestSalesforceEvent.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+
+    const detail = await getInboxDetail("contact:shaina-dotson");
+    const latestEntry = detail?.timeline.at(-1);
+
+    expect(latestEntry).toMatchObject({
+      kind: "inbound-email",
+      body: [
+        "Thanks, Ricky & Samantha! I didn't realize that all ARUs need to be placed by the end of June! Glad I'll still be able to claim a hex to retrieve later this summer. Thanks for all your help!",
+        "",
+        "Shaina",
+      ].join("\n"),
+    });
+  });
+
   it("strips signature fixtures without stripping inline closing phrases", () => {
     expect(
       stripSignature(
@@ -1845,6 +1899,22 @@ describe("real inbox selectors", () => {
       ),
     ).toBe(
       "Best regards, Samantha mentioned the confirmation timing in the paragraph above.",
+    );
+
+    expect(
+      stripSignature(
+        [
+          "Thanks, Ricky & Samantha! I didn't realize that all ARUs need to be placed by the end of June! Glad I'll still be able to claim a hex to retrieve later this summer. Thanks for all your help!",
+          "",
+          "Shaina",
+        ].join("\n"),
+      ),
+    ).toBe(
+      [
+        "Thanks, Ricky & Samantha! I didn't realize that all ARUs need to be placed by the end of June! Glad I'll still be able to claim a hex to retrieve later this summer. Thanks for all your help!",
+        "",
+        "Shaina",
+      ].join("\n"),
     );
   });
 

--- a/apps/web/tests/unit/inbox-stage1-helpers.ts
+++ b/apps/web/tests/unit/inbox-stage1-helpers.ts
@@ -384,6 +384,7 @@ export async function seedInboxSalesforceOutboundEmailEvent(
     readonly subject: string;
     readonly snippet: string;
     readonly messageKind: "one_to_one" | null;
+    readonly direction?: "inbound" | "outbound";
     readonly sourceRecordType?: string;
     readonly sourceLabel?: string;
   },
@@ -391,6 +392,7 @@ export async function seedInboxSalesforceOutboundEmailEvent(
   const sourceEvidenceId = `source:${input.id}`;
   const canonicalEventId = `event:${input.id}`;
   const sourceRecordType = input.sourceRecordType ?? "task_communication";
+  const direction = input.direction ?? "outbound";
 
   await context.repositories.sourceEvidence.append({
     id: sourceEvidenceId,
@@ -407,7 +409,7 @@ export async function seedInboxSalesforceOutboundEmailEvent(
   await context.repositories.canonicalEvents.upsert({
     id: canonicalEventId,
     contactId: input.contactId,
-    eventType: "communication.email.outbound",
+    eventType: `communication.email.${direction}`,
     channel: "email",
     occurredAt: input.occurredAt,
     sourceEvidenceId,
@@ -423,7 +425,7 @@ export async function seedInboxSalesforceOutboundEmailEvent(
       messageKind: input.messageKind,
       campaignRef: null,
       threadRef: null,
-      direction: "outbound",
+      direction,
       notes: null,
     },
     reviewState: "clear",
@@ -447,7 +449,7 @@ export async function seedInboxSalesforceOutboundEmailEvent(
     canonicalEventId,
     occurredAt: input.occurredAt,
     sortKey: `${input.occurredAt}::${canonicalEventId}`,
-    eventType: "communication.email.outbound",
+    eventType: `communication.email.${direction}`,
     summary: input.subject,
     channel: "email",
     primaryProvider: "salesforce",

--- a/packages/domain/src/timeline.ts
+++ b/packages/domain/src/timeline.ts
@@ -9,6 +9,7 @@ import {
   type TimelineProjectionRow,
 } from "@as-comms/contracts";
 
+import { buildOutboundEmailDuplicateFingerprint } from "./outbound-email-dedup.js";
 import type { Stage1RepositoryBundle } from "./repositories.js";
 import type { PendingComposerOutboundRecord } from "./pending-outbounds.js";
 
@@ -291,6 +292,43 @@ function timelineCampaignEmailDuplicateKey(
   return normalizeDuplicateText(item.campaignId);
 }
 
+function timelineSameDayGmailOutboundDuplicateKey(
+  entry: CanonicalTimelineItemWithEvent,
+): string | null {
+  if (
+    entry.item.family !== "one_to_one_email" ||
+    entry.item.direction !== "outbound" ||
+    entry.canonicalEvent.provenance.primaryProvider !== "gmail"
+  ) {
+    return null;
+  }
+
+  const threadId = normalizeDuplicateText(entry.item.threadId);
+  const mailbox = normalizeDuplicateText(entry.item.mailbox);
+
+  if (threadId === null || mailbox === null) {
+    return null;
+  }
+
+  const fingerprint = buildOutboundEmailDuplicateFingerprint({
+    subject: entry.item.subject,
+    body: entry.item.bodyPreview || entry.item.snippet || entry.item.summary,
+  });
+
+  if (fingerprint === null) {
+    return null;
+  }
+
+  return [
+    "gmail-same-day",
+    entry.canonicalEvent.contactId,
+    threadId,
+    mailbox,
+    entry.canonicalEvent.occurredAt.slice(0, 10),
+    fingerprint,
+  ].join(":");
+}
+
 function isSameCampaignEmailDuplicate(
   left: CanonicalTimelineItemWithEvent,
   right: CanonicalTimelineItemWithEvent,
@@ -358,18 +396,21 @@ function buildTimelineDuplicateSignature(item: TimelineItem): string | null {
   return parts.join("|");
 }
 
-function buildTimelineDuplicateKey(
+function buildTimelineDuplicateKeys(
   entry: CanonicalTimelineItemWithEvent,
-): string | null {
+): readonly string[] {
+  const keys: string[] = [];
   const campaignDuplicateKey = timelineCampaignEmailDuplicateKey(entry.item);
 
   if (campaignDuplicateKey !== null) {
-    return [
-      "campaign",
-      entry.canonicalEvent.contactId,
-      entry.canonicalEvent.channel,
-      campaignDuplicateKey,
-    ].join(":");
+    keys.push(
+      [
+        "campaign",
+        entry.canonicalEvent.contactId,
+        entry.canonicalEvent.channel,
+        campaignDuplicateKey,
+      ].join(":"),
+    );
   }
 
   const fingerprint = normalizeDuplicateText(
@@ -377,28 +418,32 @@ function buildTimelineDuplicateKey(
   );
 
   if (fingerprint !== null) {
-    return [
-      "fingerprint",
-      entry.canonicalEvent.contactId,
-      entry.canonicalEvent.eventType,
-      entry.canonicalEvent.channel,
-      fingerprint,
-    ].join(":");
+    keys.push(
+      [
+        "fingerprint",
+        entry.canonicalEvent.contactId,
+        entry.canonicalEvent.eventType,
+        entry.canonicalEvent.channel,
+        fingerprint,
+      ].join(":"),
+    );
   }
 
   const signature = buildTimelineDuplicateSignature(entry.item);
 
-  if (signature === null) {
-    return null;
+  if (signature !== null) {
+    keys.push(
+      [
+        "signature",
+        entry.canonicalEvent.contactId,
+        entry.canonicalEvent.eventType,
+        entry.canonicalEvent.channel,
+        signature,
+      ].join(":"),
+    );
   }
 
-  return [
-    "signature",
-    entry.canonicalEvent.contactId,
-    entry.canonicalEvent.eventType,
-    entry.canonicalEvent.channel,
-    signature,
-  ].join(":");
+  return keys;
 }
 
 function timelineOccurredAtMs(value: string): number {
@@ -418,6 +463,16 @@ function isTimelinePresentationDuplicate(
   }
 
   if (isSameCampaignEmailDuplicate(left, right)) {
+    return true;
+  }
+
+  const leftSameDayGmailKey = timelineSameDayGmailOutboundDuplicateKey(left);
+  const rightSameDayGmailKey = timelineSameDayGmailOutboundDuplicateKey(right);
+
+  if (
+    leftSameDayGmailKey !== null &&
+    leftSameDayGmailKey === rightSameDayGmailKey
+  ) {
     return true;
   }
 
@@ -505,6 +560,16 @@ function preferTimelineDuplicate(
   existing: CanonicalTimelineItemWithEvent,
   candidate: CanonicalTimelineItemWithEvent,
 ): CanonicalTimelineItemWithEvent {
+  const existingSameDayGmailKey =
+    timelineSameDayGmailOutboundDuplicateKey(existing);
+
+  if (
+    existingSameDayGmailKey !== null &&
+    existingSameDayGmailKey === timelineSameDayGmailOutboundDuplicateKey(candidate)
+  ) {
+    return existing;
+  }
+
   const familyDelta =
     timelineFamilyPriority(candidate.item) -
     timelineFamilyPriority(existing.item);
@@ -576,23 +641,24 @@ function collapseDuplicateTimelineItems(input: {
       item,
       canonicalEvent,
     } satisfies CanonicalTimelineItemWithEvent;
-    const key = buildTimelineDuplicateKey(candidate);
+    const keys = buildTimelineDuplicateKeys(candidate);
+    const existingIndex = keys
+      .map((key) => lastIndexByKey.get(key))
+      .find((value): value is number => value !== undefined);
 
-    if (key !== null) {
-      const existingIndex = lastIndexByKey.get(key);
+    if (existingIndex !== undefined) {
+      const existing = deduped[existingIndex];
 
-      if (existingIndex !== undefined) {
-        const existing = deduped[existingIndex];
-
-        if (
-          existing !== undefined &&
-          isTimelinePresentationDuplicate(existing, candidate)
-        ) {
-          deduped[existingIndex] = preferTimelineDuplicate(existing, candidate);
-          continue;
-        }
+      if (
+        existing !== undefined &&
+        isTimelinePresentationDuplicate(existing, candidate)
+      ) {
+        deduped[existingIndex] = preferTimelineDuplicate(existing, candidate);
+        continue;
       }
+    }
 
+    for (const key of keys) {
       lastIndexByKey.set(key, deduped.length);
     }
 

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -394,12 +394,18 @@ function buildGmailOutboundEmailEvent(input: {
   readonly subject: string;
   readonly snippet: string;
   readonly bodyPreview: string;
-  readonly contentFingerprint: string;
+  readonly contentFingerprint?: string | null;
+  readonly threadId?: string;
+  readonly capturedMailbox?: string;
+  readonly projectInboxAlias?: string;
 }): {
   readonly canonicalEvent: CanonicalEventRecord;
   readonly detail: GmailMessageDetailRecord;
   readonly timelineRow: TimelineProjectionRow;
 } {
+  const threadId = input.threadId ?? `thread:${input.id}`;
+  const capturedMailbox = input.capturedMailbox ?? "pnw@example.org";
+
   return {
     canonicalEvent: {
       id: input.id,
@@ -407,7 +413,7 @@ function buildGmailOutboundEmailEvent(input: {
       eventType: "communication.email.outbound",
       channel: "email",
       occurredAt: input.occurredAt,
-      contentFingerprint: input.contentFingerprint,
+      contentFingerprint: input.contentFingerprint ?? null,
       sourceEvidenceId: input.sourceEvidenceId,
       idempotencyKey: `canonical:${input.id}`,
       provenance: {
@@ -420,7 +426,7 @@ function buildGmailOutboundEmailEvent(input: {
         messageKind: "one_to_one",
         campaignRef: null,
         threadRef: {
-          providerThreadId: `thread:${input.id}`,
+          providerThreadId: threadId,
           crossProviderCollapseKey: null,
         },
         direction: "outbound",
@@ -431,14 +437,14 @@ function buildGmailOutboundEmailEvent(input: {
     detail: {
       sourceEvidenceId: input.sourceEvidenceId,
       providerRecordId: input.id,
-      gmailThreadId: `thread:${input.id}`,
+      gmailThreadId: threadId,
       rfc822MessageId: `<${input.id}@example.org>`,
       direction: "outbound",
       subject: input.subject,
       snippetClean: input.snippet,
       bodyTextPreview: input.bodyPreview,
-      capturedMailbox: "pnw@example.org",
-      projectInboxAlias: "pnw@example.org",
+      capturedMailbox,
+      projectInboxAlias: input.projectInboxAlias ?? capturedMailbox,
     },
     timelineRow: {
       id: `timeline:${input.id}`,
@@ -793,6 +799,73 @@ describe("Stage 1 timeline presenter", () => {
       primaryProvider: "gmail",
       subject: "Re: Confirmed: Hex 13174",
       bodyPreview: "No problem at all! I will plan to retrieve the ARUs.",
+    });
+  });
+
+  it("collapses same-day identical Gmail outbound resends on the same thread and keeps the first message", async () => {
+    const firstGmail = buildGmailOutboundEmailEvent({
+      id: "evt_gmail_same_day_first",
+      sourceEvidenceId: "sev_gmail_same_day_first",
+      occurredAt: "2026-04-20T18:02:51.000Z",
+      subject: "Re: Update on Hex 43191",
+      snippet:
+        "Hi Shaina,\n\nThanks so much for reaching out! Just to confirm you are planning to head out later in the summer, around 8/24?",
+      bodyPreview:
+        "Hi Shaina,\n\nThanks so much for reaching out! Just to confirm you are planning to head out later in the summer, around 8/24?",
+      contentFingerprint: "fp:gmail-same-day-first",
+      threadId: "thread:shaina-dotson",
+      capturedMailbox: "volunteers@adventurescientists.org",
+      projectInboxAlias: "pnwbio@adventurescientists.org",
+    });
+    const secondGmail = buildGmailOutboundEmailEvent({
+      id: "evt_gmail_same_day_second",
+      sourceEvidenceId: "sev_gmail_same_day_second",
+      occurredAt: "2026-04-20T21:26:25.000Z",
+      subject: "Re: Update on Hex 43191",
+      snippet:
+        "Hi Shaina,\n\nThanks so much for reaching out! Just to confirm you are planning to head out later in the summer, around 8/24?",
+      bodyPreview:
+        "Hi Shaina,\n\nThanks so much for reaching out! Just to confirm you are planning to head out later in the summer, around 8/24?",
+      contentFingerprint: "fp:gmail-same-day-second",
+      threadId: "thread:shaina-dotson",
+      capturedMailbox: "volunteers@adventurescientists.org",
+      projectInboxAlias: "pnwbio@adventurescientists.org",
+    });
+    const repositories = createRepositoryBundle({
+      canonicalEvents: [
+        firstGmail.canonicalEvent,
+        secondGmail.canonicalEvent,
+      ],
+      sourceEvidence: [
+        buildSourceEvidence({
+          id: "sev_gmail_same_day_first",
+          provider: "gmail",
+          providerRecordType: "gmail_message",
+          providerRecordId: "gmail-same-day-first",
+        }),
+        buildSourceEvidence({
+          id: "sev_gmail_same_day_second",
+          provider: "gmail",
+          providerRecordType: "gmail_message",
+          providerRecordId: "gmail-same-day-second",
+        }),
+      ],
+      salesforceCommunicationDetails: [],
+      gmailMessageDetails: [firstGmail.detail, secondGmail.detail],
+      timelineRows: [firstGmail.timelineRow, secondGmail.timelineRow],
+    });
+    const presenter = createStage1TimelinePresentationService(repositories);
+
+    const items = await presenter.listTimelineItemsByContactId("contact_1");
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      canonicalEventId: "evt_gmail_same_day_first",
+      family: "one_to_one_email",
+      primaryProvider: "gmail",
+      threadId: "thread:shaina-dotson",
+      mailbox: "pnwbio@adventurescientists.org",
+      subject: "Re: Update on Hex 43191",
     });
   });
 


### PR DESCRIPTION
## Summary
- stop stripping real message bodies when Salesforce inbound emails begin with a sentence like `Thanks, Ricky & Samantha!`
- collapse same-day identical Gmail outbound repeats on the same thread in the timeline while keeping the earliest send
- add focused regressions for the Shaina clipping case and same-day Gmail resend case

## Testing
- pnpm --filter @as-comms/web exec vitest run --config ../../vitest.config.ts tests/unit/inbox-selectors.test.ts
- pnpm --filter @as-comms/domain exec vitest run --config ../../vitest.config.ts test/timeline.test.ts