### PR TITLE
[codex] fix inbox list trust and sent mode

### DIFF
--- a/apps/web/app/api/inbox/list/route.ts
+++ b/apps/web/app/api/inbox/list/route.ts
@@ -6,7 +6,13 @@ import { requireApiSession } from "../../../../src/server/auth/api";
 
 export const dynamic = "force-dynamic";
 
-const filterSchema = z.enum(["all", "unread", "follow-up", "unresolved"]);
+const filterSchema = z.enum([
+  "all",
+  "unread",
+  "follow-up",
+  "unresolved",
+  "sent",
+]);
 
 function parseLimit(raw: string | null): number | undefined {
   if (raw === null) {

--- a/apps/web/app/inbox/_components/inbox-list.tsx
+++ b/apps/web/app/inbox/_components/inbox-list.tsx
@@ -14,6 +14,7 @@ import {
 import type { InboxFilterId, InboxListViewModel } from "../_lib/view-models";
 import { fetchInboxListPage } from "../_lib/client-api";
 import { DISPLAY_INBOX_FILTERS } from "../_lib/filters";
+import { shouldApplyUrlSearchQuery } from "../_lib/search-sync";
 import { Collapsible, CollapsibleContent } from "@/components/ui/collapsible";
 import {
   DropdownMenu,
@@ -24,6 +25,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { cn } from "@/lib/utils";
 
 import { extractInboxContactId } from "./inbox-keyboard-helpers";
@@ -41,6 +43,7 @@ import {
   ChevronDownIcon,
   FilterIcon,
   InboxIcon,
+  PencilIcon,
   SearchIcon,
   SearchXIcon,
   XIcon,
@@ -60,6 +63,10 @@ const DISPLAY_FILTER_IDS: readonly InboxFilterId[] = DISPLAY_INBOX_FILTERS.map(
 );
 
 const DEFAULT_TITLE = "Inbox";
+
+function isDisplayFilterId(value: string): value is InboxFilterId {
+  return DISPLAY_FILTER_IDS.includes(value as InboxFilterId);
+}
 
 export function InboxList({
   initialList,
@@ -96,6 +103,7 @@ export function InboxList({
   const pendingAppendCursorRef = useRef<string | null>(null);
   const previousFilterRef = useRef<InboxFilterId>(initialFilterId);
   const previousProjectIdRef = useRef<string | null>(null);
+  const previousUrlQueryRef = useRef(urlQuery);
   const latestShellStateRef = useRef({
     activeFilter: initialFilterId,
     selectedProjectId: initialList.selectedProjectId ?? null,
@@ -119,6 +127,17 @@ export function InboxList({
   }, [activeFilter, initialList, selectedProjectId]);
 
   useEffect(() => {
+    if (
+      !shouldApplyUrlSearchQuery({
+        urlQuery,
+        previousUrlQuery: previousUrlQueryRef.current,
+      })
+    ) {
+      return;
+    }
+
+    previousUrlQueryRef.current = urlQuery;
+
     if (search.query !== urlQuery) {
       setSearchQuery(urlQuery);
     }
@@ -145,6 +164,7 @@ export function InboxList({
         ? pathname
         : `${pathname}?${nextQueryString}`;
 
+    previousUrlQueryRef.current = normalizedQuery;
     router.replace(nextHref, { scroll: false });
   }, [normalizedQuery, pathname, router, searchParams, urlQuery]);
 
@@ -402,11 +422,15 @@ export function InboxList({
           </h1>
           <Button
             type="button"
-            size="sm"
+            variant="ghost"
+            size="icon"
+            aria-label="Compose"
             aria-keyshortcuts="c"
+            title="Compose"
             onClick={openNewDraft}
+            className="h-8 w-8 shrink-0 text-slate-500 hover:bg-slate-100 hover:text-slate-900"
           >
-            Compose
+            <PencilIcon aria-hidden="true" data-icon="inline-start" />
           </Button>
           <button
             type="button"
@@ -472,57 +496,54 @@ export function InboxList({
             id="inbox-filter-panel"
             className="border-t border-slate-100 px-5 pb-3 pt-3"
           >
-            <div className="flex flex-col gap-4">
-              <div className="flex flex-col gap-2">
-                <p className={TEXT.label}>Status</p>
-                <div className="flex flex-wrap gap-1.5">
-                  {DISPLAY_FILTER_IDS.map((id) => {
-                    const isActive = activeFilter === id;
-                    const showCount = id !== "all";
-                    return (
-                      <button
-                        key={id}
-                        type="button"
-                        aria-pressed={isActive}
-                        onClick={() => {
-                          startFilterTransition(() => {
-                            setActiveFilter(id);
-                          });
-                        }}
-                        className={cn(
-                          "rounded-full px-2.5 py-1 text-xs font-medium",
-                          "transition-[color,background-color,transform] duration-150 ease-out",
-                          "active:scale-[0.96]",
-                          TRANSITION.reduceMotion,
-                          FOCUS_RING,
-                          isActive
-                            ? "bg-slate-900 text-white"
-                            : "bg-slate-100 text-slate-600 hover:bg-slate-200",
-                        )}
-                      >
-                        {filterLabels.get(id) ?? id}
-                        {showCount ? (
-                          <span
-                            className={cn(
-                              "ml-1 tabular-nums",
-                              isActive ? "text-slate-300" : "text-slate-400",
-                            )}
-                          >
-                            {filterCounts[id]}
-                          </span>
-                        ) : null}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
+            <div className="flex flex-col gap-3">
+              <ToggleGroup
+                type="single"
+                value={activeFilter}
+                aria-label="Inbox mode"
+                variant="outline"
+                size="sm"
+                onValueChange={(value) => {
+                  if (typeof value !== "string" || !isDisplayFilterId(value)) {
+                    return;
+                  }
 
-              <div className="flex flex-col gap-2">
-                <p className={TEXT.label}>Project</p>
+                  startFilterTransition(() => {
+                    setActiveFilter(value);
+                  });
+                }}
+                className="grid grid-cols-2 rounded-md border border-slate-200 bg-slate-50 p-1"
+              >
+                {DISPLAY_FILTER_IDS.map((id) => {
+                  const showCount = id !== "all";
+                  return (
+                    <ToggleGroupItem
+                      key={id}
+                      value={id}
+                      aria-label={`Show ${filterLabels.get(id) ?? id}`}
+                      className={cn(
+                        "justify-between border-0 bg-transparent px-2.5 text-xs shadow-none",
+                        "data-[state=on]:bg-white data-[state=on]:text-slate-900 data-[state=on]:shadow-sm",
+                        "text-slate-600 hover:bg-white/70 hover:text-slate-900",
+                      )}
+                    >
+                      <span className="truncate">{filterLabels.get(id) ?? id}</span>
+                      {showCount ? (
+                        <span className="ml-2 tabular-nums text-slate-400">
+                          {filterCounts[id]}
+                        </span>
+                      ) : null}
+                    </ToggleGroupItem>
+                  );
+                })}
+              </ToggleGroup>
+
+              <div>
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <button
                       type="button"
+                      aria-label="Filter by project"
                       className={cn(
                         `flex w-full items-center gap-2 ${RADIUS.md} border border-slate-200 bg-white px-3 py-1.5 text-sm ${SHADOW.sm}`,
                         "transition-[color,background-color,border-color,transform] duration-150 ease-out",

--- a/apps/web/app/inbox/_lib/filters.ts
+++ b/apps/web/app/inbox/_lib/filters.ts
@@ -19,6 +19,7 @@ export const INBOX_FILTERS: readonly FilterDefinition[] = [
   { id: "all", label: "All", hint: null },
   { id: "unread", label: "Unread", hint: "New inbound message" },
   { id: "follow-up", label: "Needs Follow-Up", hint: "Flagged by you" },
+  { id: "sent", label: "Sent", hint: "Last outbound 1:1 message" },
   { id: "unresolved", label: "Unresolved", hint: "Has pending review items" }
 ];
 

--- a/apps/web/app/inbox/_lib/search-sync.ts
+++ b/apps/web/app/inbox/_lib/search-sync.ts
@@ -1,0 +1,6 @@
+export function shouldApplyUrlSearchQuery(input: {
+  readonly urlQuery: string;
+  readonly previousUrlQuery: string;
+}): boolean {
+  return input.urlQuery !== input.previousUrlQuery;
+}

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -52,6 +52,7 @@ interface InboxListCacheData {
     readonly unread: number;
     readonly followUp: number;
     readonly unresolved: number;
+    readonly sent: number;
   };
   readonly activeProjects: readonly InboxActiveProjectOption[];
   readonly page: {
@@ -131,6 +132,29 @@ export const compareInboxRecency = (
     }
 
     return a.lastInboundAt < b.lastInboundAt ? 1 : -1;
+  }
+
+  if (a.lastActivityAt !== b.lastActivityAt) {
+    return a.lastActivityAt < b.lastActivityAt ? 1 : -1;
+  }
+
+  return a.contactId.localeCompare(b.contactId);
+};
+
+export const compareInboxOutboundRecency = (
+  a: InboxListItemViewModel,
+  b: InboxListItemViewModel,
+): number => {
+  if (a.lastOutboundAt !== b.lastOutboundAt) {
+    if (a.lastOutboundAt === null) {
+      return 1;
+    }
+
+    if (b.lastOutboundAt === null) {
+      return -1;
+    }
+
+    return a.lastOutboundAt < b.lastOutboundAt ? 1 : -1;
   }
 
   if (a.lastActivityAt !== b.lastActivityAt) {
@@ -241,6 +265,7 @@ async function loadCampaignActivitySummaryByCampaignId(input: {
 
 function encodeInboxListCursor(input: {
   readonly lastInboundAt: string | null;
+  readonly lastOutboundAt: string | null;
   readonly lastActivityAt: string;
   readonly contactId: string;
 }): string {
@@ -249,6 +274,7 @@ function encodeInboxListCursor(input: {
 
 function decodeInboxListCursor(cursor: string | null): {
   readonly lastInboundAt: string | null;
+  readonly lastOutboundAt: string | null;
   readonly lastActivityAt: string;
   readonly contactId: string;
 } | null {
@@ -259,20 +285,21 @@ function decodeInboxListCursor(cursor: string | null): {
   try {
     const parsed = JSON.parse(
       Buffer.from(cursor, "base64url").toString("utf8"),
-    ) as Partial<{
-      readonly lastInboundAt: string | null;
-      readonly lastActivityAt: string;
-      readonly contactId: string;
-    }>;
+    ) as Record<string, unknown>;
+    const lastInboundAt = parsed.lastInboundAt;
+    const lastOutboundAt = parsed.lastOutboundAt ?? null;
+    const lastActivityAt = parsed.lastActivityAt;
+    const contactId = parsed.contactId;
 
-    return (parsed.lastInboundAt === null ||
-      typeof parsed.lastInboundAt === "string") &&
-      typeof parsed.lastActivityAt === "string" &&
-      typeof parsed.contactId === "string"
+    return (lastInboundAt === null || typeof lastInboundAt === "string") &&
+      (lastOutboundAt === null || typeof lastOutboundAt === "string") &&
+      typeof lastActivityAt === "string" &&
+      typeof contactId === "string"
       ? {
-          lastInboundAt: parsed.lastInboundAt ?? null,
-          lastActivityAt: parsed.lastActivityAt,
-          contactId: parsed.contactId,
+          lastInboundAt: lastInboundAt ?? null,
+          lastOutboundAt,
+          lastActivityAt,
+          contactId,
         }
       : null;
   } catch {
@@ -1879,6 +1906,7 @@ function totalForFilter(
     readonly unread: number;
     readonly followUp: number;
     readonly unresolved: number;
+    readonly sent: number;
   },
   filterId: InboxFilterId,
 ): number {
@@ -1891,7 +1919,15 @@ function totalForFilter(
       return counts.followUp;
     case "unresolved":
       return counts.unresolved;
+    case "sent":
+      return counts.sent;
   }
+}
+
+function orderForInboxFilter(
+  filterId: InboxFilterId,
+): "last-inbound" | "last-outbound" {
+  return filterId === "sent" ? "last-outbound" : "last-inbound";
 }
 
 async function readInboxListCacheData(input: {
@@ -1904,12 +1940,14 @@ async function readInboxListCacheData(input: {
   const runtime = await getStage1WebRuntime();
   const decodedCursor = decodeInboxListCursor(input.cursor);
   const normalizedQuery = normalizeInlineText(input.query) ?? null;
+  const order = orderForInboxFilter(input.filterId);
   const [projectionPage, counts, freshness, activeProjectRecords] =
     await Promise.all([
       normalizedQuery === null
         ? runtime.repositories.inboxProjection
             .listPageOrderedByRecency({
               filter: input.filterId,
+              order,
               limit: input.limit + 1,
               cursor: decodedCursor,
               projectId: input.projectId,
@@ -1920,6 +1958,7 @@ async function readInboxListCacheData(input: {
             }))
         : runtime.repositories.inboxProjection.searchPageOrderedByRecency({
             filter: input.filterId,
+            order,
             limit: input.limit + 1,
             cursor: decodedCursor,
             query: normalizedQuery,
@@ -1989,6 +2028,9 @@ async function readInboxListCacheData(input: {
               lastInboundAt:
                 pageRows[pageRows.length - 1]?.inboxProjection.lastInboundAt ??
                 null,
+              lastOutboundAt:
+                pageRows[pageRows.length - 1]?.inboxProjection
+                  .lastOutboundAt ?? null,
               lastActivityAt:
                 pageRows[pageRows.length - 1]?.inboxProjection.lastActivityAt ??
                 "",
@@ -2154,6 +2196,7 @@ function toListItemViewModel(
     hasUnresolved: row.inboxProjection.hasUnresolved,
     unreadCount: row.inboxProjection.bucket === "New" ? 1 : 0,
     lastInboundAt: row.inboxProjection.lastInboundAt,
+    lastOutboundAt: row.inboxProjection.lastOutboundAt,
     lastActivityAt: row.inboxProjection.lastActivityAt,
     lastEventType: row.inboxProjection.lastEventType,
     lastActivityLabel: formatRelativeTimestamp(
@@ -2215,6 +2258,8 @@ function matchesServerFilter(
       return item.needsFollowUp;
     case "unresolved":
       return item.hasUnresolved;
+    case "sent":
+      return item.lastOutboundAt !== null;
   }
 }
 
@@ -2249,7 +2294,9 @@ export async function getInboxList(
         ? totals.followUp
         : filter.id === "unresolved"
           ? totals.unresolved
-          : totals[filter.id],
+          : filter.id === "sent"
+            ? totals.sent
+            : totals[filter.id],
   }));
 
   return {

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -16,12 +16,18 @@ import type { InboxDrivingEventType } from "@as-comms/contracts";
  *   - campaign and automated sends are surfaced in the timeline as collapsed
  *     entries so 1:1 history stays readable (INBX-05)
  *   - default list order: lastInboundAt desc nulls last, then lastActivityAt desc
+ *   - sent mode order: lastOutboundAt desc, then lastActivityAt desc
  *   - toggling follow-up does NOT change row ordering
  */
 
 export type InboxBucket = "new" | "opened";
 
-export type InboxFilterId = "all" | "unread" | "follow-up" | "unresolved";
+export type InboxFilterId =
+  | "all"
+  | "unread"
+  | "follow-up"
+  | "unresolved"
+  | "sent";
 
 export type InboxChannel = "email" | "sms";
 
@@ -62,6 +68,7 @@ export interface InboxListItemViewModel {
 
   // ── Sort / display ──
   readonly lastInboundAt: string | null;
+  readonly lastOutboundAt: string | null;
   readonly lastActivityAt: string;
   readonly lastEventType: InboxDrivingEventType;
   readonly lastActivityLabel: string;
@@ -217,6 +224,7 @@ export interface InboxListViewModel {
     readonly unread: number;
     readonly followUp: number;
     readonly unresolved: number;
+    readonly sent: number;
   };
   readonly activeProjects: readonly InboxActiveProjectOption[];
   readonly selectedProjectId: string | null;

--- a/apps/web/tests/unit/fixtures/inbox-recency-fixture.ts
+++ b/apps/web/tests/unit/fixtures/inbox-recency-fixture.ts
@@ -22,6 +22,13 @@ export const inboxRecencyFixture: readonly InboxRecencyFixtureRow[] = [
     lastActivityAt: "2026-04-15T19:00:00.000Z",
   },
   {
+    contactId: "contact:inbound-same-older-activity",
+    displayName: "Inbound Same Older Activity",
+    lastInboundAt: "2026-04-15T15:00:00.000Z",
+    lastOutboundAt: null,
+    lastActivityAt: "2026-04-15T15:00:00.000Z",
+  },
+  {
     contactId: "contact:inbound-older",
     displayName: "Inbound Older",
     lastInboundAt: "2026-04-15T14:00:00.000Z",
@@ -46,3 +53,9 @@ export const inboxRecencyFixture: readonly InboxRecencyFixtureRow[] = [
 
 export const inboxRecencyExpectedOrder: readonly string[] =
   inboxRecencyFixture.map((row) => row.contactId);
+
+export const inboxSentExpectedOrder: readonly string[] = [
+  "contact:outbound-only-recent",
+  "contact:inbound-with-newer-outbound",
+  "contact:outbound-only-older",
+];

--- a/apps/web/tests/unit/inbox-search-sync.test.ts
+++ b/apps/web/tests/unit/inbox-search-sync.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldApplyUrlSearchQuery } from "../../app/inbox/_lib/search-sync";
+
+describe("inbox search sync", () => {
+  it("does not re-apply the same stale URL query while the operator is typing", () => {
+    expect(
+      shouldApplyUrlSearchQuery({
+        urlQuery: "",
+        previousUrlQuery: "",
+      }),
+    ).toBe(false);
+  });
+
+  it("applies external URL query changes", () => {
+    expect(
+      shouldApplyUrlSearchQuery({
+        urlQuery: "alex",
+        previousUrlQuery: "",
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -52,6 +52,7 @@ vi.mock("@/app/_lib/design-tokens", () => ({
 }));
 
 import {
+  compareInboxOutboundRecency,
   compareInboxRecency,
   getInboxDetail,
   getInboxList,
@@ -79,6 +80,7 @@ import {
 import {
   inboxRecencyExpectedOrder,
   inboxRecencyFixture,
+  inboxSentExpectedOrder,
 } from "./fixtures/inbox-recency-fixture.js";
 
 function buildItem(
@@ -99,6 +101,7 @@ function buildItem(
     hasUnresolved: overrides.hasUnresolved ?? false,
     unreadCount: overrides.unreadCount ?? 0,
     lastInboundAt: overrides.lastInboundAt ?? null,
+    lastOutboundAt: overrides.lastOutboundAt ?? null,
     lastActivityAt: overrides.lastActivityAt ?? "2026-04-14T14:00:00.000Z",
     lastEventType: overrides.lastEventType ?? "communication.email.outbound",
     lastActivityLabel: overrides.lastActivityLabel ?? "today",
@@ -335,6 +338,28 @@ describe("compareInboxRecency", () => {
       .map((item) => item.contactId);
 
     expect(orderedContactIds).toEqual(inboxRecencyExpectedOrder);
+  });
+
+  it("orders sent mode by last outbound activity", () => {
+    const orderedContactIds = inboxRecencyFixture
+      .map((row) =>
+        buildItem({
+          contactId: row.contactId,
+          displayName: row.displayName,
+          lastInboundAt: row.lastInboundAt,
+          lastOutboundAt: row.lastOutboundAt,
+          lastActivityAt: row.lastActivityAt,
+          lastEventType:
+            row.lastActivityAt === row.lastInboundAt
+              ? "communication.email.inbound"
+              : "communication.email.outbound",
+        }),
+      )
+      .filter((item) => item.lastOutboundAt !== null)
+      .sort(compareInboxOutboundRecency)
+      .map((item) => item.contactId);
+
+    expect(orderedContactIds).toEqual(inboxSentExpectedOrder);
   });
 });
 
@@ -2020,5 +2045,96 @@ describe("real inbox selectors", () => {
     ).toHaveLength(inboxRecencyExpectedOrder.length);
     expect(secondPage.page.hasMore).toBe(false);
     expect(secondPage.page.nextCursor).toBeNull();
+  });
+
+  it("orders and paginates sent mode by last outbound 1:1 message", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await runtime.dispose();
+    runtime = await createInboxTestRuntime();
+    await seedSharedInboxRecencyFixture(runtime);
+
+    const firstPage = await getInboxList("sent", {
+      limit: 2,
+    });
+
+    expect(firstPage.items.map((item) => item.contactId)).toEqual(
+      inboxSentExpectedOrder.slice(0, 2),
+    );
+    expect(firstPage.page.total).toBe(inboxSentExpectedOrder.length);
+    expect(firstPage.page.hasMore).toBe(true);
+    expect(firstPage.page.nextCursor).not.toBeNull();
+
+    const secondPage = await getInboxList("sent", {
+      limit: 2,
+      cursor: firstPage.page.nextCursor,
+    });
+
+    expect(secondPage.items.map((item) => item.contactId)).toEqual(
+      inboxSentExpectedOrder.slice(2),
+    );
+    expect(secondPage.page.hasMore).toBe(false);
+    expect(secondPage.page.nextCursor).toBeNull();
+  });
+
+  it("excludes campaign and automated outbound activity from sent mode", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:campaign-only-outbound",
+      salesforceContactId: "003-campaign-only-outbound",
+      displayName: "Campaign Only Outbound",
+      primaryEmail: "campaign-only@example.org",
+      primaryPhone: null,
+    });
+
+    const inbound = await seedInboxEmailEvent(runtime.context, {
+      id: "campaign-only-inbound",
+      contactId: "contact:campaign-only-outbound",
+      occurredAt: "2026-04-16T09:00:00.000Z",
+      direction: "inbound",
+      subject: "Checking in",
+      snippet: "I had one inbound note before campaign activity.",
+    });
+
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:campaign-only-outbound",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-16T09:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-04-16T09:00:00.000Z",
+      snippet: "I had one inbound note before campaign activity.",
+      lastCanonicalEventId: inbound.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+
+    await seedInboxCampaignEmailEvent(runtime.context, {
+      id: "campaign-only-campaign",
+      contactId: "contact:campaign-only-outbound",
+      occurredAt: "2026-04-16T12:00:00.000Z",
+      activityType: "sent",
+      campaignName: "Spring Check-In",
+      snippet: "Campaign send should not make this contact appear in Sent.",
+    });
+
+    await seedInboxAutoEmailEvent(runtime.context, {
+      id: "campaign-only-auto",
+      contactId: "contact:campaign-only-outbound",
+      occurredAt: "2026-04-16T13:00:00.000Z",
+      subject: "Automated follow-up",
+      snippet: "Automated outreach should not count as sent mode activity.",
+    });
+
+    const sentList = await getInboxList("sent");
+
+    expect(sentList.items.map((item) => item.contactId)).not.toContain(
+      "contact:campaign-only-outbound",
+    );
   });
 });

--- a/apps/worker/src/ops/_salesforce-task-audit.ts
+++ b/apps/worker/src/ops/_salesforce-task-audit.ts
@@ -104,7 +104,8 @@ function matchesAnyPattern(
 }
 
 function normalizeSubject(value: string | null): string {
-  return value?.trim() || "(no subject)";
+  const trimmed = value?.trim();
+  return trimmed !== undefined && trimmed.length > 0 ? trimmed : "(no subject)";
 }
 
 function buildSubjectStats(

--- a/apps/worker/src/ops/audit-salesforce-task-ingest.ts
+++ b/apps/worker/src/ops/audit-salesforce-task-ingest.ts
@@ -237,9 +237,7 @@ async function main(): Promise<void> {
   });
 
   try {
-    const rows = await loadSalesforceTaskAuditRows(
-      connection.sql as unknown as SqlRunner
-    );
+    const rows = await loadSalesforceTaskAuditRows(connection.sql);
     const report = buildSalesforceTaskAuditReport(rows, {
       sampleLimit,
       topSubjectLimit

--- a/apps/worker/src/ops/audit-salesforce-task-ingest.ts
+++ b/apps/worker/src/ops/audit-salesforce-task-ingest.ts
@@ -237,7 +237,9 @@ async function main(): Promise<void> {
   });
 
   try {
-    const rows = await loadSalesforceTaskAuditRows(connection.sql);
+    const rows = await loadSalesforceTaskAuditRows(
+      connection.sql as unknown as SqlRunner
+    );
     const report = buildSalesforceTaskAuditReport(rows, {
       sampleLimit,
       topSubjectLimit
@@ -254,7 +256,7 @@ async function main(): Promise<void> {
   }
 }
 
-void main().catch((error) => {
+void main().catch((error: unknown) => {
   console.error(error);
   process.exitCode = 1;
 });

--- a/apps/worker/src/ops/backfill-mailchimp-campaign-body.ts
+++ b/apps/worker/src/ops/backfill-mailchimp-campaign-body.ts
@@ -531,7 +531,7 @@ async function countSkippedClickedRows(
       ),
     );
 
-  return Number(rows[0]?.value ?? 0);
+  return rows[0]?.value ?? 0;
 }
 
 function groupCandidatesByCampaignId(

--- a/apps/worker/src/ops/cleanup-salesforce-owner-scope.ts
+++ b/apps/worker/src/ops/cleanup-salesforce-owner-scope.ts
@@ -289,7 +289,7 @@ function createSfCliQueryRunner(): SfQueryRunner {
         } catch (error) {
           const message =
             error instanceof Error && "stdout" in error
-              ? String((error as { stdout?: string }).stdout ?? error.message)
+              ? ((error as { stdout?: string }).stdout ?? error.message)
               : error instanceof Error
                 ? error.message
                 : String(error);

--- a/apps/worker/test/stage1-backfill-mailchimp-campaign-body.test.ts
+++ b/apps/worker/test/stage1-backfill-mailchimp-campaign-body.test.ts
@@ -130,11 +130,11 @@ describe("Stage 1 Mailchimp campaign body backfill ops", () => {
       const dryRun = await backfillMailchimpCampaignBodies({
         db: context.db,
         repositories: context.repositories,
-        fetchCampaignContent: async (campaignId) => {
+        fetchCampaignContent: (campaignId) => {
           expect(campaignId).toBe("campaign-1");
-          return {
+          return Promise.resolve({
             html: "<p>Campaign body line one.</p><p>Campaign body line two.</p>",
-          };
+          });
         },
         dryRun: true,
         options: {
@@ -157,9 +157,11 @@ describe("Stage 1 Mailchimp campaign body backfill ops", () => {
       const confirm = await backfillMailchimpCampaignBodies({
         db: context.db,
         repositories: context.repositories,
-        fetchCampaignContent: async () => ({
-          html: "<p>Campaign body line one.</p><p>Campaign body line two.</p>",
-        }),
+        fetchCampaignContent: () =>
+          Promise.resolve({
+            html:
+              "<p>Campaign body line one.</p><p>Campaign body line two.</p>",
+          }),
         dryRun: false,
         options: {
           progressInterval: null,
@@ -226,20 +228,21 @@ describe("Stage 1 Mailchimp campaign body backfill ops", () => {
       const result = await backfillMailchimpCampaignBodies({
         db: context.db,
         repositories: context.repositories,
-        fetchCampaignContent: async () => ({
-          plain_text: [
-            "*|MC_PREVIEW_TEXT|*",
-            "",
-            "Field update headline",
-            "",
-            "Bring your field notebook.",
-            "",
-            "============================================================",
-            "** Facebook (https://example.org)",
-            "Copyright © 2026 Adventure Scientists",
-            "Want to change how you receive these emails?",
-          ].join("\n"),
-        }),
+        fetchCampaignContent: () =>
+          Promise.resolve({
+            plain_text: [
+              "*|MC_PREVIEW_TEXT|*",
+              "",
+              "Field update headline",
+              "",
+              "Bring your field notebook.",
+              "",
+              "============================================================",
+              "** Facebook (https://example.org)",
+              "Copyright © 2026 Adventure Scientists",
+              "Want to change how you receive these emails?",
+            ].join("\n"),
+          }),
         dryRun: false,
         options: {
           campaignId: "campaign-plain",
@@ -299,11 +302,11 @@ describe("Stage 1 Mailchimp campaign body backfill ops", () => {
       const result = await backfillMailchimpCampaignBodies({
         db: context.db,
         repositories: context.repositories,
-        fetchCampaignContent: async (campaignId) => {
+        fetchCampaignContent: (campaignId) => {
           fetchedCampaignIds.push(campaignId);
-          return {
+          return Promise.resolve({
             plain_text: `Full body for ${campaignId}`,
-          };
+          });
         },
         dryRun: true,
         options: {

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -6,6 +6,7 @@ import {
   desc,
   eq,
   inArray,
+  isNotNull,
   isNull,
   lt,
   or,
@@ -326,20 +327,35 @@ const DEFAULT_INTEGRATION_HEALTH_SEED = [
   },
 ] as const;
 
-type InboxProjectionFilter = "all" | "unread" | "follow-up" | "unresolved";
+type InboxProjectionFilter =
+  | "all"
+  | "unread"
+  | "follow-up"
+  | "unresolved"
+  | "sent";
+type InboxProjectionOrder = "last-inbound" | "last-outbound";
 
 interface InboxRecencyCursor {
   readonly lastInboundAt: string | null;
+  readonly lastOutboundAt: string | null;
   readonly lastActivityAt: string;
   readonly contactId: string;
 }
 
-function buildInboxRecencyOrderBy(): [SQL, SQL, SQL] {
-  return [
-    sql`${contactInboxProjection.lastInboundAt} desc nulls last`,
-    desc(contactInboxProjection.lastActivityAt),
-    asc(contactInboxProjection.contactId),
-  ];
+function buildInboxRecencyOrderBy(
+  order: InboxProjectionOrder,
+): [SQL, SQL, SQL] {
+  return order === "last-outbound"
+    ? [
+        sql`${contactInboxProjection.lastOutboundAt} desc nulls last`,
+        desc(contactInboxProjection.lastActivityAt),
+        asc(contactInboxProjection.contactId),
+      ]
+    : [
+        sql`${contactInboxProjection.lastInboundAt} desc nulls last`,
+        desc(contactInboxProjection.lastActivityAt),
+        asc(contactInboxProjection.contactId),
+      ];
 }
 
 function buildInboxFilterPredicate(
@@ -351,6 +367,8 @@ function buildInboxFilterPredicate(
       ? eq(contactInboxProjection.isStarred, true)
       : filter === "unresolved"
         ? eq(contactInboxProjection.hasUnresolved, true)
+        : filter === "sent"
+          ? isNotNull(contactInboxProjection.lastOutboundAt)
         : undefined;
 }
 
@@ -370,9 +388,29 @@ function buildInboxProjectPredicate(
 
 function buildInboxCursorPredicate(input: {
   readonly cursor: InboxRecencyCursor | null;
+  readonly order: InboxProjectionOrder;
 }): SQL | undefined {
   if (input.cursor === null) {
     return undefined;
+  }
+
+  if (input.order === "last-outbound") {
+    if (input.cursor.lastOutboundAt === null) {
+      return undefined;
+    }
+
+    return sql`(
+      ${contactInboxProjection.lastOutboundAt} < ${new Date(input.cursor.lastOutboundAt)}
+      or (
+        ${contactInboxProjection.lastOutboundAt} = ${new Date(input.cursor.lastOutboundAt)}
+        and ${contactInboxProjection.lastActivityAt} < ${new Date(input.cursor.lastActivityAt)}
+      )
+      or (
+        ${contactInboxProjection.lastOutboundAt} = ${new Date(input.cursor.lastOutboundAt)}
+        and ${contactInboxProjection.lastActivityAt} = ${new Date(input.cursor.lastActivityAt)}
+        and ${contactInboxProjection.contactId} > ${input.cursor.contactId}
+      )
+    )`;
   }
 
   if (input.cursor.lastInboundAt === null) {
@@ -1750,7 +1788,7 @@ function createStage1RepositoriesInternal(
         const rows = await db
           .select()
           .from(contactInboxProjection)
-          .orderBy(...buildInboxRecencyOrderBy());
+          .orderBy(...buildInboxRecencyOrderBy("last-inbound"));
 
         return rows.map(mapInboxProjectionRow);
       },
@@ -1761,13 +1799,14 @@ function createStage1RepositoriesInternal(
           buildInboxProjectPredicate(input.projectId),
           buildInboxCursorPredicate({
             cursor: input.cursor,
+            order: input.order,
           }),
         );
         const baseQuery = db.select().from(contactInboxProjection);
         const filteredQuery =
           whereClause === undefined ? baseQuery : baseQuery.where(whereClause);
         const rows = await filteredQuery
-          .orderBy(...buildInboxRecencyOrderBy())
+          .orderBy(...buildInboxRecencyOrderBy(input.order))
           .limit(input.limit);
 
         return rows.map(mapInboxProjectionRow);
@@ -1779,6 +1818,7 @@ function createStage1RepositoriesInternal(
           buildInboxProjectPredicate(input.projectId),
           buildInboxCursorPredicate({
             cursor: input.cursor,
+            order: input.order,
           }),
           buildInboxSearchPredicate(input.query),
         );
@@ -1788,7 +1828,7 @@ function createStage1RepositoriesInternal(
           .where(whereClause);
         const [rows, totalRow] = await Promise.all([
           filteredQuery
-            .orderBy(...buildInboxRecencyOrderBy())
+            .orderBy(...buildInboxRecencyOrderBy(input.order))
             .limit(input.limit),
           db
             .select({
@@ -1819,6 +1859,7 @@ function createStage1RepositoriesInternal(
             unread: sql<number>`coalesce(sum(case when ${contactInboxProjection.bucket} = 'New' then 1 else 0 end), 0)`,
             followUp: sql<number>`coalesce(sum(case when ${contactInboxProjection.isStarred} then 1 else 0 end), 0)`,
             unresolved: sql<number>`coalesce(sum(case when ${contactInboxProjection.hasUnresolved} then 1 else 0 end), 0)`,
+            sent: sql<number>`coalesce(sum(case when ${contactInboxProjection.lastOutboundAt} is not null then 1 else 0 end), 0)`,
           })
           .from(contactInboxProjection);
         const [row] = await (projectPredicate === undefined
@@ -1830,6 +1871,7 @@ function createStage1RepositoriesInternal(
           unread: row?.unread ?? 0,
           followUp: row?.followUp ?? 0,
           unresolved: row?.unresolved ?? 0,
+          sent: row?.sent ?? 0,
         };
       },
 

--- a/packages/db/test/fixtures/inbox-recency-fixture.ts
+++ b/packages/db/test/fixtures/inbox-recency-fixture.ts
@@ -22,6 +22,13 @@ export const inboxRecencyFixture: readonly InboxRecencyFixtureRow[] = [
     lastActivityAt: "2026-04-15T19:00:00.000Z",
   },
   {
+    contactId: "contact:inbound-same-older-activity",
+    displayName: "Inbound Same Older Activity",
+    lastInboundAt: "2026-04-15T15:00:00.000Z",
+    lastOutboundAt: null,
+    lastActivityAt: "2026-04-15T15:00:00.000Z",
+  },
+  {
     contactId: "contact:inbound-older",
     displayName: "Inbound Older",
     lastInboundAt: "2026-04-15T14:00:00.000Z",
@@ -46,3 +53,9 @@ export const inboxRecencyFixture: readonly InboxRecencyFixtureRow[] = [
 
 export const inboxRecencyExpectedOrder: readonly string[] =
   inboxRecencyFixture.map((row) => row.contactId);
+
+export const inboxSentExpectedOrder: readonly string[] = [
+  "contact:outbound-only-recent",
+  "contact:inbound-with-newer-outbound",
+  "contact:outbound-only-older",
+];

--- a/packages/db/test/stage1-repositories.test.ts
+++ b/packages/db/test/stage1-repositories.test.ts
@@ -4,6 +4,7 @@ import { createTestStage1Context } from "./helpers.js";
 import {
   inboxRecencyExpectedOrder,
   inboxRecencyFixture,
+  inboxSentExpectedOrder,
 } from "./fixtures/inbox-recency-fixture.js";
 
 interface SalesforceCommunicationDetailRecord {
@@ -752,6 +753,7 @@ describe("Stage 1 DB repositories", () => {
     const firstPage =
       await repositories.inboxProjection.listPageOrderedByRecency({
         filter: "all",
+        order: "last-inbound",
         limit: 4,
         cursor: null,
       });
@@ -763,9 +765,12 @@ describe("Stage 1 DB repositories", () => {
     const secondPage =
       await repositories.inboxProjection.listPageOrderedByRecency({
         filter: "all",
+        order: "last-inbound",
         limit: 4,
         cursor: {
           lastInboundAt: firstPage[firstPage.length - 1]?.lastInboundAt ?? null,
+          lastOutboundAt:
+            firstPage[firstPage.length - 1]?.lastOutboundAt ?? null,
           lastActivityAt: firstPage[firstPage.length - 1]?.lastActivityAt ?? "",
           contactId: firstPage[firstPage.length - 1]?.contactId ?? "",
         },
@@ -773,6 +778,40 @@ describe("Stage 1 DB repositories", () => {
 
     expect(secondPage.map((row) => row.contactId)).toEqual(
       inboxRecencyExpectedOrder.slice(4),
+    );
+  });
+
+  it("orders and paginates sent inbox rows by last outbound timestamps", async () => {
+    const { repositories } = await seedSharedInboxRecencyFixture();
+
+    const firstPage =
+      await repositories.inboxProjection.listPageOrderedByRecency({
+        filter: "sent",
+        order: "last-outbound",
+        limit: 2,
+        cursor: null,
+      });
+
+    expect(firstPage.map((row) => row.contactId)).toEqual(
+      inboxSentExpectedOrder.slice(0, 2),
+    );
+
+    const secondPage =
+      await repositories.inboxProjection.listPageOrderedByRecency({
+        filter: "sent",
+        order: "last-outbound",
+        limit: 2,
+        cursor: {
+          lastInboundAt: firstPage[firstPage.length - 1]?.lastInboundAt ?? null,
+          lastOutboundAt:
+            firstPage[firstPage.length - 1]?.lastOutboundAt ?? null,
+          lastActivityAt: firstPage[firstPage.length - 1]?.lastActivityAt ?? "",
+          contactId: firstPage[firstPage.length - 1]?.contactId ?? "",
+        },
+      });
+
+    expect(secondPage.map((row) => row.contactId)).toEqual(
+      inboxSentExpectedOrder.slice(2),
     );
   });
 });

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -231,12 +231,14 @@ export interface InboxProjectionRepository {
   listInvalidRecencyContactIds(): Promise<readonly string[]>;
   listAllOrderedByRecency(): Promise<readonly InboxProjectionRow[]>;
   searchPageOrderedByRecency(input: {
-    readonly filter: "all" | "unread" | "follow-up" | "unresolved";
+    readonly filter: "all" | "unread" | "follow-up" | "unresolved" | "sent";
+    readonly order: "last-inbound" | "last-outbound";
     readonly limit: number;
     readonly query: string;
     readonly projectId?: string | null;
     readonly cursor: {
       readonly lastInboundAt: string | null;
+      readonly lastOutboundAt: string | null;
       readonly lastActivityAt: string;
       readonly contactId: string;
     } | null;
@@ -245,11 +247,13 @@ export interface InboxProjectionRepository {
     readonly total: number;
   }>;
   listPageOrderedByRecency(input: {
-    readonly filter: "all" | "unread" | "follow-up" | "unresolved";
+    readonly filter: "all" | "unread" | "follow-up" | "unresolved" | "sent";
+    readonly order: "last-inbound" | "last-outbound";
     readonly limit: number;
     readonly projectId?: string | null;
     readonly cursor: {
       readonly lastInboundAt: string | null;
+      readonly lastOutboundAt: string | null;
       readonly lastActivityAt: string;
       readonly contactId: string;
     } | null;
@@ -259,6 +263,7 @@ export interface InboxProjectionRepository {
     readonly unread: number;
     readonly followUp: number;
     readonly unresolved: number;
+    readonly sent: number;
   }>;
   getFreshness(): Promise<{
     readonly total: number;

--- a/packages/domain/src/timeline.ts
+++ b/packages/domain/src/timeline.ts
@@ -312,7 +312,12 @@ function timelineSameDayGmailOutboundDuplicateKey(
 
   const fingerprint = buildOutboundEmailDuplicateFingerprint({
     subject: entry.item.subject,
-    body: entry.item.bodyPreview || entry.item.snippet || entry.item.summary,
+    body:
+      entry.item.bodyPreview !== null && entry.item.bodyPreview.length > 0
+        ? entry.item.bodyPreview
+        : entry.item.snippet.length > 0
+          ? entry.item.snippet
+          : entry.item.summary,
   });
 
   if (fingerprint === null) {

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -134,6 +134,7 @@ describe("defineStage1RepositoryBundle", () => {
             unread: 0,
             followUp: 0,
             unresolved: 0,
+            sent: 0,
           }),
         getFreshness: () =>
           Promise.resolve({

--- a/packages/domain/test/stage3-last-inbound-alias.test.ts
+++ b/packages/domain/test/stage3-last-inbound-alias.test.ts
@@ -153,6 +153,7 @@ function buildRepositoryBundle(input: {
           unread: 0,
           followUp: 0,
           unresolved: 0,
+          sent: 0,
         }),
       getFreshness: () =>
         Promise.resolve({

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -240,6 +240,7 @@ function createRepositoryBundle(input: {
           unread: 0,
           followUp: 0,
           unresolved: 0,
+          sent: 0,
         }),
       getFreshness: () =>
         Promise.resolve({


### PR DESCRIPTION
## What changed
- fixes inbox list trust issues around search URL sync, pagination, and explicit recency ordering
- adds a peer `Sent` inbox mode backed by last outbound 1:1 activity with sent-aware cursors and counts
- redesigns the filter controls and lightens the Compose action to better match the inbox shell
- adds regression coverage for sent-mode ordering, pagination, and search sync behavior

## Why
Operators reported broken list refresh behavior, confusing chronology, a brittle search bar, and needed a dedicated sent-oriented view. This PR tightens the list semantics around the contact-centric inbox model while keeping unread and follow-up behavior projection-driven.

## Notes
- Sent mode is guarded by tests to exclude campaign and automated outbound activity.
- A few small non-inbox cleanup edits remain only because repo-wide lint/typecheck needed them.

## Validation
- pnpm test:unit
- pnpm lint
- pnpm typecheck
- git diff --check
