### PR TITLE
[codex] add inbox welcome workload surface

### DIFF
--- a/apps/web/app/inbox/_components/inbox-welcome-workload.tsx
+++ b/apps/web/app/inbox/_components/inbox-welcome-workload.tsx
@@ -1,0 +1,147 @@
+import { EmptyState } from "@/components/ui/empty-state";
+import { SectionLabel } from "@/components/ui/section-label";
+import {
+  LAYOUT,
+  RADIUS,
+  SHADOW,
+  TEXT,
+} from "@/app/_lib/design-tokens";
+
+import type { InboxWelcomeWorkloadViewModel } from "../_lib/view-models";
+import { CheckCircleIcon, InboxIcon } from "./icons";
+
+interface InboxWelcomeWorkloadProps {
+  readonly workload: InboxWelcomeWorkloadViewModel;
+}
+
+function formatCount(value: number): string {
+  return value.toLocaleString("en-US");
+}
+
+function formatWorkSummary(workload: InboxWelcomeWorkloadViewModel): string {
+  if (workload.totals.activeProjects === 0) {
+    return "No active projects are currently enabled.";
+  }
+
+  if (workload.totals.unread === 0 && workload.totals.needsFollowUp === 0) {
+    return "No unread or follow-up work across active projects.";
+  }
+
+  const unread =
+    workload.totals.unread === 1
+      ? "1 unread conversation"
+      : `${formatCount(workload.totals.unread)} unread conversations`;
+  const followUp =
+    workload.totals.needsFollowUp === 1
+      ? "1 needs follow-up"
+      : `${formatCount(workload.totals.needsFollowUp)} need follow-up`;
+
+  return `${unread}; ${followUp}.`;
+}
+
+export function InboxWelcomeWorkload({
+  workload,
+}: InboxWelcomeWorkloadProps) {
+  return (
+    <section className="flex min-h-0 flex-1 flex-col bg-slate-50">
+      <header
+        className={`flex ${LAYOUT.headerHeight} items-center border-b border-slate-200 bg-white px-6`}
+      >
+        <div className="min-w-0">
+          <h1 className={TEXT.headingLg}>Welcome Sam!</h1>
+          <p className="mt-0.5 text-xs text-slate-500">
+            Active project workload from inbox projections.
+          </p>
+        </div>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-5 px-6 py-8">
+          <div className="flex flex-col gap-1">
+            <SectionLabel as="h2">Today</SectionLabel>
+            <p className={TEXT.bodySm}>{formatWorkSummary(workload)}</p>
+          </div>
+
+          {workload.projects.length === 0 ? (
+            <div
+              className={`${RADIUS.md} border border-slate-200 bg-white ${SHADOW.sm}`}
+            >
+              <EmptyState
+                icon={<InboxIcon className="h-6 w-6" />}
+                title="No active project workload"
+                description="Activate projects in Settings to show unread and follow-up counts here."
+              />
+            </div>
+          ) : (
+            <div
+              className={`overflow-hidden ${RADIUS.md} border border-slate-200 bg-white ${SHADOW.sm}`}
+            >
+              <div className="flex items-center gap-2 border-b border-slate-100 bg-slate-50 px-4 py-3">
+                <CheckCircleIcon className="h-4 w-4 text-emerald-600" />
+                <p className="text-xs font-medium text-slate-600">
+                  Active projects only
+                </p>
+              </div>
+
+              <table className="w-full table-fixed text-left text-sm">
+                <thead>
+                  <tr className="border-b border-slate-100">
+                    <th
+                      scope="col"
+                      className="px-4 py-2.5 text-xs font-medium text-slate-500"
+                    >
+                      Project
+                    </th>
+                    <th
+                      scope="col"
+                      className="w-24 px-4 py-2.5 text-right text-xs font-medium text-slate-500"
+                    >
+                      Unread
+                    </th>
+                    <th
+                      scope="col"
+                      className="w-36 px-4 py-2.5 text-right text-xs font-medium text-slate-500"
+                    >
+                      Needs Follow-Up
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100">
+                  {workload.projects.map((project) => {
+                    const hasWork =
+                      project.unreadCount > 0 ||
+                      project.needsFollowUpCount > 0;
+
+                    return (
+                      <tr key={project.projectId}>
+                        <th
+                          scope="row"
+                          className="min-w-0 px-4 py-3 text-sm font-medium text-slate-900"
+                        >
+                          <span className="block truncate">
+                            {project.projectName}
+                          </span>
+                          {!hasWork ? (
+                            <span className="mt-0.5 block text-xs font-normal text-slate-400">
+                              No active queue items
+                            </span>
+                          ) : null}
+                        </th>
+                        <td className="px-4 py-3 text-right text-sm tabular-nums text-slate-700">
+                          {formatCount(project.unreadCount)}
+                        </td>
+                        <td className="px-4 py-3 text-right text-sm tabular-nums text-slate-700">
+                          {formatCount(project.needsFollowUpCount)}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -32,6 +32,7 @@ import type {
   InboxTimelineEntryKind,
   InboxTimelineEntryViewModel,
   InboxVolunteerStage,
+  InboxWelcomeWorkloadViewModel,
 } from "./view-models";
 
 interface InboxListCacheRow {
@@ -86,6 +87,11 @@ interface InboxDetailCacheData {
     readonly timelineUpdatedAt: string | null;
     readonly timelineCount: number;
   };
+}
+
+interface InboxWelcomeWorkloadCacheData {
+  readonly projects: InboxWelcomeWorkloadViewModel["projects"];
+  readonly totals: InboxWelcomeWorkloadViewModel["totals"];
 }
 
 const DEFAULT_INBOX_LIST_PAGE_SIZE = 50;
@@ -2156,6 +2162,77 @@ function loadInboxDetailCacheData(
   )();
 }
 
+async function readInboxWelcomeWorkloadCacheData(): Promise<InboxWelcomeWorkloadCacheData> {
+  const runtime = await getStage1WebRuntime();
+  const activeProjects = await runtime.repositories.projectDimensions.listActive();
+  const activeProjectIds = new Set(
+    activeProjects.map((project) => project.projectId),
+  );
+  const projectCounts = await Promise.all(
+    activeProjects.map((project) =>
+      runtime.repositories.inboxProjection.countByFilters({
+        projectId: project.projectId,
+      }),
+    ),
+  );
+  const allInboxRows =
+    activeProjectIds.size === 0
+      ? []
+      : await runtime.repositories.inboxProjection.listAllOrderedByRecency();
+  const memberships =
+    allInboxRows.length === 0
+      ? []
+      : await runtime.repositories.contactMemberships.listByContactIds(
+          allInboxRows.map((row) => row.contactId),
+        );
+  const membershipsByContactId = groupMembershipsByContactId(memberships);
+  const activeWorkloadRows = allInboxRows.filter((row) =>
+    (membershipsByContactId.get(row.contactId) ?? []).some(
+      (membership) =>
+        membership.projectId !== null &&
+        activeProjectIds.has(membership.projectId),
+    ),
+  );
+
+  return {
+    projects: activeProjects.map((project, index) => {
+      const counts = projectCounts[index] ?? {
+        all: 0,
+        unread: 0,
+        followUp: 0,
+        unresolved: 0,
+      };
+
+      return {
+        projectId: project.projectId,
+        projectName: project.projectName,
+        unreadCount: counts.unread,
+        needsFollowUpCount: counts.followUp,
+      };
+    }),
+    totals: {
+      activeProjects: activeProjects.length,
+      unread: activeWorkloadRows.filter((row) => row.bucket === "New").length,
+      needsFollowUp: activeWorkloadRows.filter((row) => row.needsFollowUp)
+        .length,
+    },
+  };
+}
+
+function loadInboxWelcomeWorkloadCacheData() {
+  if (process.env.NODE_ENV !== "production") {
+    return readInboxWelcomeWorkloadCacheData();
+  }
+
+  return unstable_cache(
+    () => readInboxWelcomeWorkloadCacheData(),
+    ["inbox:welcome-workload"],
+    {
+      tags: ["inbox", "settings:projects"],
+    },
+  )();
+}
+
 function toListItemViewModel(
   row: InboxListCacheRow,
   projectNameById: Readonly<Record<string, string>>,
@@ -2307,6 +2384,15 @@ export async function getInboxList(
     selectedProjectId: projectId,
     page: cachedData.page,
     freshness: cachedData.freshness,
+  };
+}
+
+export async function getInboxWelcomeWorkload(): Promise<InboxWelcomeWorkloadViewModel> {
+  const cachedData = await loadInboxWelcomeWorkloadCacheData();
+
+  return {
+    projects: cachedData.projects,
+    totals: cachedData.totals,
   };
 }
 

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -216,6 +216,22 @@ export interface InboxActiveProjectOption {
   readonly name: string;
 }
 
+export interface InboxWelcomeProjectWorkloadViewModel {
+  readonly projectId: string;
+  readonly projectName: string;
+  readonly unreadCount: number;
+  readonly needsFollowUpCount: number;
+}
+
+export interface InboxWelcomeWorkloadViewModel {
+  readonly projects: readonly InboxWelcomeProjectWorkloadViewModel[];
+  readonly totals: {
+    readonly activeProjects: number;
+    readonly unread: number;
+    readonly needsFollowUp: number;
+  };
+}
+
 export interface InboxListViewModel {
   readonly items: readonly InboxListItemViewModel[];
   readonly filters: readonly InboxFilterViewModel[];

--- a/apps/web/app/inbox/page.tsx
+++ b/apps/web/app/inbox/page.tsx
@@ -1,5 +1,8 @@
-import { InboxEmptyState } from "./_components/inbox-empty-state";
+import { InboxWelcomeWorkload } from "./_components/inbox-welcome-workload";
+import { getInboxWelcomeWorkload } from "./_lib/selectors";
 
-export default function InboxListPage() {
-  return <InboxEmptyState />;
+export default async function InboxListPage() {
+  const workload = await getInboxWelcomeWorkload();
+
+  return <InboxWelcomeWorkload workload={workload} />;
 }

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -57,6 +57,7 @@ import {
   getInboxDetail,
   getInboxList,
   getInboxTimelinePage,
+  getInboxWelcomeWorkload,
   stripSignature,
 } from "../../app/inbox/_lib/selectors";
 import { InboxContactRail } from "../../app/inbox/_components/inbox-contact-rail";
@@ -411,6 +412,120 @@ describe("real inbox selectors", () => {
     expect(unresolved.items.map((item) => item.contactId)).toEqual([
       "contact:alex-thompson",
     ]);
+  });
+
+  it("builds welcome workload counts from active project projections only", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await runtime.context.repositories.projectDimensions.upsert({
+      projectId: "project:amazon-basin",
+      projectName: "Amazon Basin Research",
+      source: "salesforce",
+      isActive: true,
+    });
+    await runtime.context.repositories.projectDimensions.upsert({
+      projectId: "project:whitebark-pine",
+      projectName: "Tracking Whitebark Pine",
+      source: "salesforce",
+      isActive: true,
+    });
+    await runtime.context.repositories.projectDimensions.upsert({
+      projectId: "project:river-cleanup",
+      projectName: "River Cleanup",
+      source: "salesforce",
+      isActive: true,
+    });
+    await runtime.context.repositories.projectDimensions.upsert({
+      projectId: "project:killer-whales",
+      projectName: "Searching for Killer Whales",
+      source: "salesforce",
+      isActive: false,
+    });
+
+    const workload = await getInboxWelcomeWorkload();
+
+    expect(workload.projects).toEqual([
+      {
+        projectId: "project:amazon-basin",
+        projectName: "Amazon Basin Research",
+        unreadCount: 1,
+        needsFollowUpCount: 1,
+      },
+      {
+        projectId: "project:river-cleanup",
+        projectName: "River Cleanup",
+        unreadCount: 0,
+        needsFollowUpCount: 0,
+      },
+      {
+        projectId: "project:whitebark-pine",
+        projectName: "Tracking Whitebark Pine",
+        unreadCount: 0,
+        needsFollowUpCount: 0,
+      },
+    ]);
+    expect(
+      workload.projects.some(
+        (project) => project.projectId === "project:killer-whales",
+      ),
+    ).toBe(false);
+    expect(workload.totals).toEqual({
+      activeProjects: 3,
+      unread: 1,
+      needsFollowUp: 1,
+    });
+  });
+
+  it("keeps per-project welcome counts while deduplicating top-level totals across active projects", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await runtime.context.repositories.projectDimensions.upsert({
+      projectId: "project:amazon-basin",
+      projectName: "Amazon Basin Research",
+      source: "salesforce",
+      isActive: true,
+    });
+    await runtime.context.repositories.projectDimensions.upsert({
+      projectId: "project:whitebark-pine",
+      projectName: "Tracking Whitebark Pine",
+      source: "salesforce",
+      isActive: true,
+    });
+    await runtime.context.repositories.contactMemberships.upsert({
+      id: "membership:sarah:whitebark",
+      contactId: "contact:sarah-martinez",
+      projectId: "project:whitebark-pine",
+      expeditionId: null,
+      role: "volunteer",
+      status: "trip_planning",
+      source: "salesforce",
+    });
+
+    const workload = await getInboxWelcomeWorkload();
+
+    expect(workload.projects).toEqual([
+      {
+        projectId: "project:amazon-basin",
+        projectName: "Amazon Basin Research",
+        unreadCount: 1,
+        needsFollowUpCount: 1,
+      },
+      {
+        projectId: "project:whitebark-pine",
+        projectName: "Tracking Whitebark Pine",
+        unreadCount: 1,
+        needsFollowUpCount: 1,
+      },
+    ]);
+    expect(workload.totals).toEqual({
+      activeProjects: 2,
+      unread: 1,
+      needsFollowUp: 1,
+    });
   });
 
   it("assembles selected-contact detail from real contact, membership, timeline, and projection data", async () => {

--- a/apps/worker/src/ops/_salesforce-task-audit.ts
+++ b/apps/worker/src/ops/_salesforce-task-audit.ts
@@ -104,8 +104,8 @@ function matchesAnyPattern(
 }
 
 function normalizeSubject(value: string | null): string {
-  const trimmed = value?.trim();
-  return trimmed !== undefined && trimmed.length > 0 ? trimmed : "(no subject)";
+  const trimmed = value?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed : "(no subject)";
 }
 
 function buildSubjectStats(

--- a/apps/worker/src/ops/audit-salesforce-task-ingest.ts
+++ b/apps/worker/src/ops/audit-salesforce-task-ingest.ts
@@ -237,9 +237,7 @@ async function main(): Promise<void> {
   });
 
   try {
-    const rows = await loadSalesforceTaskAuditRows(
-      connection.sql as unknown as SqlRunner
-    );
+    const rows = await loadSalesforceTaskAuditRows(connection.sql);
     const report = buildSalesforceTaskAuditReport(rows, {
       sampleLimit,
       topSubjectLimit

--- a/apps/worker/src/ops/audit-salesforce-task-ingest.ts
+++ b/apps/worker/src/ops/audit-salesforce-task-ingest.ts
@@ -237,7 +237,9 @@ async function main(): Promise<void> {
   });
 
   try {
-    const rows = await loadSalesforceTaskAuditRows(connection.sql);
+    const rows = await loadSalesforceTaskAuditRows(
+      connection.sql as unknown as SqlRunner
+    );
     const report = buildSalesforceTaskAuditReport(rows, {
       sampleLimit,
       topSubjectLimit

--- a/packages/domain/src/timeline.ts
+++ b/packages/domain/src/timeline.ts
@@ -282,6 +282,18 @@ function normalizeDuplicateText(value: string | null | undefined): string | null
   return normalized.length === 0 ? null : normalized;
 }
 
+function firstNonEmptyDuplicateText(
+  values: readonly (string | null | undefined)[]
+): string {
+  for (const value of values) {
+    if (typeof value === "string" && normalizeDuplicateText(value) !== null) {
+      return value;
+    }
+  }
+
+  return "";
+}
+
 function timelineCampaignEmailDuplicateKey(
   item: TimelineItem,
 ): string | null {
@@ -312,12 +324,11 @@ function timelineSameDayGmailOutboundDuplicateKey(
 
   const fingerprint = buildOutboundEmailDuplicateFingerprint({
     subject: entry.item.subject,
-    body:
-      entry.item.bodyPreview !== null && entry.item.bodyPreview.length > 0
-        ? entry.item.bodyPreview
-        : entry.item.snippet.length > 0
-          ? entry.item.snippet
-          : entry.item.summary,
+    body: firstNonEmptyDuplicateText([
+      entry.item.bodyPreview,
+      entry.item.snippet,
+      entry.item.summary,
+    ]),
   });
 
   if (fingerprint === null) {


### PR DESCRIPTION
## What changed
- replaces the empty inbox detail pane with a `Welcome Sam!` workload surface
- shows active-project-only unread and needs-follow-up counts using projection-backed inbox data
- fixes welcome-surface cache invalidation so project activation changes in Settings refresh `/inbox`
- fixes top-level totals to deduplicate contacts across multiple active project memberships
- adds regression coverage for active-project-only behavior and multi-membership deduplication

## Why
The previous empty state was too instructional and not useful as an operator landing view. This PR turns it into a real workload surface without changing inbox truth semantics.

## Notes
- Per-project counts remain project-scoped.
- Top-level totals are now distinct-contact totals across active projects.
- This branch overlaps inbox selectors/tests with the list-trust branch and should be rebased after that PR lands.
- A few small non-inbox cleanup edits remain only because repo-wide lint/typecheck needed them.

## Validation
- pnpm test:unit
- pnpm lint
- pnpm typecheck
- git diff --check
