### PR TITLE
[codex] fix inbox timeline detail correctness

### DIFF
--- a/apps/web/app/inbox/[contactId]/loading.tsx
+++ b/apps/web/app/inbox/[contactId]/loading.tsx
@@ -1,0 +1,5 @@
+import { InboxDetailLoading } from "../_components/inbox-loading";
+
+export default function InboxContactLoading() {
+  return <InboxDetailLoading />;
+}

--- a/apps/web/app/inbox/_components/_autolink.tsx
+++ b/apps/web/app/inbox/_components/_autolink.tsx
@@ -1,8 +1,45 @@
-import type { ReactNode } from "react";
+import { Fragment, type ReactNode } from "react";
 
 import { cn } from "@/lib/utils";
 
 const URL_PATTERN = /(https?:\/\/[^\s<>"]+)/g;
+const TRAILING_PUNCTUATION_PATTERN = /[.,!?;:)]/;
+
+function splitTrailingPunctuation(segment: string): {
+  readonly href: string;
+  readonly trailingText: string;
+} {
+  let href = segment;
+  let trailingText = "";
+
+  while (href.length > 0) {
+    const trailingCharacter = href.at(-1);
+
+    if (
+      trailingCharacter === undefined ||
+      !TRAILING_PUNCTUATION_PATTERN.test(trailingCharacter)
+    ) {
+      break;
+    }
+
+    if (trailingCharacter === ")") {
+      const openParentheses = href.match(/\(/g)?.length ?? 0;
+      const closeParentheses = href.match(/\)/g)?.length ?? 0;
+
+      if (closeParentheses <= openParentheses) {
+        break;
+      }
+    }
+
+    trailingText = `${trailingCharacter}${trailingText}`;
+    href = href.slice(0, -1);
+  }
+
+  return {
+    href,
+    trailingText,
+  };
+}
 
 export function autolinkText(
   body: string,
@@ -13,16 +50,27 @@ export function autolinkText(
       return segment;
     }
 
+    const { href, trailingText } = splitTrailingPunctuation(segment);
+
+    if (href.length === 0) {
+      return segment;
+    }
+
     return (
-      <a
-        key={`${segment}-${String(index)}`}
-        href={segment}
-        target="_blank"
-        rel="noopener noreferrer"
-        className={cn("underline-offset-2 hover:underline", linkClassName)}
-      >
-        {segment}
-      </a>
+      <Fragment key={`${segment}-${String(index)}`}>
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={cn(
+            "font-medium underline decoration-current/70 underline-offset-2 transition-[text-decoration-color] hover:decoration-current focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 [overflow-wrap:anywhere]",
+            linkClassName,
+          )}
+        >
+          {href}
+        </a>
+        {trailingText}
+      </Fragment>
     );
   });
 }

--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -63,6 +63,8 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
   const { contact } = detail;
   const timelineScrollRef = useRef<HTMLDivElement>(null);
   const activeTimelineRequestIdRef = useRef(0);
+  const shouldScrollToLatestRef = useRef(true);
+  const previousContactIdRef = useRef(detail.contact.contactId);
   const {
     reminders,
     setReminder,
@@ -87,6 +89,11 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
     setTimelineLoading(false);
     setTimelineEntries(detail.timeline);
     setTimelinePage(detail.timelinePage);
+
+    if (previousContactIdRef.current !== detail.contact.contactId) {
+      shouldScrollToLatestRef.current = true;
+      previousContactIdRef.current = detail.contact.contactId;
+    }
   }, [
     detail.contact.contactId,
     detail.freshness.inboxUpdatedAt,
@@ -96,6 +103,27 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
     detail.timelinePage,
     setTimelineLoading,
   ]);
+
+  useEffect(() => {
+    if (!shouldScrollToLatestRef.current) {
+      return;
+    }
+
+    const frame = window.requestAnimationFrame(() => {
+      const container = timelineScrollRef.current;
+
+      if (!container) {
+        return;
+      }
+
+      container.scrollTop = container.scrollHeight;
+      shouldScrollToLatestRef.current = false;
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
+  }, [detail.contact.contactId, timelineEntries]);
 
   const loadOlderTimeline = useCallback(async () => {
     if (!timelinePage.hasMore || timelinePage.nextCursor === null) {

--- a/apps/web/app/inbox/_components/inbox-loading.tsx
+++ b/apps/web/app/inbox/_components/inbox-loading.tsx
@@ -62,6 +62,33 @@ export function InboxAppLoading() {
 }
 
 /**
+ * Detail-pane loading state for contact route transitions. Keeps the inbox
+ * shell stable and only placeholders the message-history workspace.
+ */
+export function InboxDetailLoading() {
+  return (
+    <div className="flex min-h-0 flex-1" role="status" aria-label="Loading conversation history">
+      <section className="flex min-w-0 flex-1 flex-col border-r border-slate-200 bg-white">
+        <header className={`flex ${LAYOUT.headerHeight} items-center gap-4 border-b border-slate-200 px-6`}>
+          <div className="min-w-0 flex-1">
+            <Skeleton className="h-5 w-40" />
+            <Skeleton className="mt-2 h-3.5 w-56" />
+          </div>
+          <Skeleton className="h-8 w-28 rounded-md" />
+          <Skeleton className="h-8 w-8 rounded-md" />
+        </header>
+        <div className={`min-h-0 flex-1 overflow-y-auto ${TONE.slate.subtle} ${SPACING.container}`}>
+          <TimelineSkeleton />
+        </div>
+        <div className="border-t border-slate-200 px-5 py-4">
+          <Skeleton className="h-16 w-full rounded-lg" />
+        </div>
+      </section>
+    </div>
+  );
+}
+
+/**
  * Skeleton for a single queue row — avatar + 3 text lines.
  * Used inside both the full app loading state and the queue-only reload.
  */

--- a/apps/web/app/inbox/_components/inbox-timeline.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline.tsx
@@ -40,6 +40,17 @@ import {
   TRANSITION,
 } from "@/app/_lib/design-tokens";
 
+const WRAP_ANYWHERE = "break-words [overflow-wrap:anywhere]";
+const EXACT_TIMESTAMP_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+  timeZone: "UTC",
+  timeZoneName: "short",
+});
+
 interface TimelineProps {
   readonly entries: readonly InboxTimelineEntryViewModel[];
   readonly volunteerFirstName: string;
@@ -86,45 +97,153 @@ export function InboxTimeline({
   };
 
   return (
-    <div className="flex flex-col gap-4">
-      {hasMore && onLoadOlder ? (
-        <div className="flex justify-center">
-          <button
-            type="button"
-            disabled={isLoadingOlder}
-            onClick={onLoadOlder}
-            className={cn(
-              "rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600",
-              "transition-[color,background-color,transform] duration-150 ease-out",
-              "active:scale-[0.96] disabled:active:scale-100",
-              TRANSITION.reduceMotion,
-              "hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60",
-            )}
-          >
-            {isLoadingOlder
-              ? "Loading older activity..."
-              : "Load older activity"}
-          </button>
-        </div>
-      ) : null}
+    <TooltipProvider>
+      <div className="flex flex-col gap-4">
+        {hasMore && onLoadOlder ? (
+          <div className="flex justify-center">
+            <button
+              type="button"
+              disabled={isLoadingOlder}
+              onClick={onLoadOlder}
+              className={cn(
+                "rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600",
+                "transition-[color,background-color,transform] duration-150 ease-out",
+                "active:scale-[0.96] disabled:active:scale-100",
+                TRANSITION.reduceMotion,
+                "hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60",
+              )}
+            >
+              {isLoadingOlder
+                ? "Loading older activity..."
+                : "Load older activity"}
+            </button>
+          </div>
+        ) : null}
 
-      <ol className="flex flex-col gap-4">
-        {entries.map((entry) => (
-          <TimelineEntry
-            key={entry.id}
-            entry={entry}
-            volunteerFirstName={volunteerFirstName}
-            currentOperatorUserId={currentOperatorUserId}
-            isExpanded={expanded.has(entry.id)}
-            retryingEntryId={retryingEntryId}
-            onRetryPending={onRetryPending}
-            onToggle={() => {
-              toggle(entry.id);
-            }}
-          />
-        ))}
-      </ol>
-    </div>
+        <ol className="flex flex-col gap-4">
+          {entries.map((entry) => (
+            <TimelineEntry
+              key={entry.id}
+              entry={entry}
+              volunteerFirstName={volunteerFirstName}
+              currentOperatorUserId={currentOperatorUserId}
+              isExpanded={expanded.has(entry.id)}
+              retryingEntryId={retryingEntryId}
+              onRetryPending={onRetryPending}
+              onToggle={() => {
+                toggle(entry.id);
+              }}
+            />
+          ))}
+        </ol>
+      </div>
+    </TooltipProvider>
+  );
+}
+
+function formatExactTimestamp(timestamp: string): string {
+  return EXACT_TIMESTAMP_FORMATTER.format(new Date(timestamp));
+}
+
+function RelativeTimestamp({
+  timestamp,
+  label,
+  className,
+  asSpan = false,
+  focusable = true,
+}: {
+  readonly timestamp: string;
+  readonly label: string;
+  readonly className?: string;
+  readonly asSpan?: boolean;
+  readonly focusable?: boolean;
+}) {
+  const exactLabel = formatExactTimestamp(timestamp);
+
+  const content = asSpan ? (
+    <span
+      title={exactLabel}
+      tabIndex={focusable ? 0 : undefined}
+      className={cn(
+        "cursor-help rounded-sm decoration-dotted underline-offset-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 hover:underline",
+        className,
+      )}
+    >
+      {label}
+    </span>
+  ) : (
+    <time
+      dateTime={timestamp}
+      title={exactLabel}
+      tabIndex={focusable ? 0 : undefined}
+      className={cn(
+        "cursor-help rounded-sm decoration-dotted underline-offset-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 hover:underline",
+        className,
+      )}
+    >
+      {label}
+    </time>
+  );
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{content}</TooltipTrigger>
+      <TooltipContent side="top">
+        <p>{exactLabel}</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function CampaignActivityTimestamp({
+  label,
+  occurredAt,
+}: {
+  readonly label: string;
+  readonly occurredAt: string;
+}) {
+  const [activityLabel, relativeLabel] = label.split(/ (?=\S+ ago$|yesterday$)/);
+
+  if (relativeLabel === undefined) {
+    return (
+      <RelativeTimestamp
+        timestamp={occurredAt}
+        label={label}
+        asSpan
+        focusable={false}
+      />
+    );
+  }
+
+  return (
+    <>
+      {activityLabel}{" "}
+      <RelativeTimestamp
+        timestamp={occurredAt}
+        label={relativeLabel}
+        asSpan
+        focusable={false}
+      />
+    </>
+  );
+}
+
+function TimelineTimestamp({
+  entry,
+  className,
+  asSpan = false,
+}: {
+  readonly entry: InboxTimelineEntryViewModel;
+  readonly className?: string;
+  readonly asSpan?: boolean;
+}) {
+  return (
+    <RelativeTimestamp
+      timestamp={entry.occurredAt}
+      label={entry.occurredAtLabel}
+      asSpan={asSpan}
+      {...(className === undefined ? {} : { className })}
+    />
   );
 }
 
@@ -197,15 +316,25 @@ function InboundBubble({
   return (
     <li className="flex w-full flex-col items-start">
       <div
-        className={`w-full max-w-2xl ${RADIUS.bubble} rounded-bl-sm border border-slate-200 bg-white px-4 py-3 ${SHADOW.sm}`}
+        className={`min-w-0 w-full max-w-2xl ${RADIUS.bubble} rounded-bl-sm border border-slate-200 bg-white px-4 py-3 ${SHADOW.sm}`}
       >
         {isEmail && entry.subject ? (
-          <p className="mb-1.5 text-balance text-[13px] font-semibold leading-snug text-slate-900">
+          <p
+            className={cn(
+              "mb-1.5 text-balance text-[13px] font-semibold leading-snug text-slate-900",
+              WRAP_ANYWHERE,
+            )}
+          >
             {entry.subject}
           </p>
         ) : null}
         {body.length > 0 ? (
-          <p className={`whitespace-pre-wrap text-pretty ${TEXT.bodySm}`}>
+          <p
+            className={cn(
+              `whitespace-pre-wrap text-pretty ${TEXT.bodySm}`,
+              WRAP_ANYWHERE,
+            )}
+          >
             {autolinkText(body, "text-sky-600")}
           </p>
         ) : null}
@@ -214,7 +343,7 @@ function InboundBubble({
         <ChannelIcon className="h-3 w-3" />
         <span className="font-medium text-slate-500">{entry.actorLabel}</span>
         <span>·</span>
-        <span>{entry.occurredAtLabel}</span>
+        <TimelineTimestamp entry={entry} />
         {entry.isUnread ? (
           <span
             className="inline-flex h-1.5 w-1.5 rounded-full bg-sky-500"
@@ -250,7 +379,7 @@ function OutboundBubble({
   return (
     <li className="flex w-full flex-col items-end">
       <div
-        className={`w-full max-w-2xl ${RADIUS.bubble} rounded-br-sm bg-slate-800 px-4 py-3 ${SHADOW.sm}`}
+        className={`min-w-0 w-full max-w-2xl ${RADIUS.bubble} rounded-br-sm bg-slate-800 px-4 py-3 ${SHADOW.sm}`}
       >
         {entry.sendStatus === "pending" ? (
           <div className="mb-2 inline-flex items-center gap-1.5 rounded-full bg-white/10 px-2 py-1 text-[11px] font-medium text-slate-100">
@@ -305,18 +434,28 @@ function OutboundBubble({
         ) : null}
 
         {isEmail && entry.subject ? (
-          <p className="mb-1.5 text-balance text-[13px] font-semibold leading-snug text-slate-100">
+          <p
+            className={cn(
+              "mb-1.5 text-balance text-[13px] font-semibold leading-snug text-slate-100",
+              WRAP_ANYWHERE,
+            )}
+          >
             {entry.subject}
           </p>
         ) : null}
         {body.length > 0 ? (
-          <p className="whitespace-pre-wrap text-pretty text-[13px] leading-relaxed text-slate-200">
+          <p
+            className={cn(
+              "whitespace-pre-wrap text-pretty text-[13px] leading-relaxed text-slate-200",
+              WRAP_ANYWHERE,
+            )}
+          >
             {autolinkText(body, "text-sky-300")}
           </p>
         ) : null}
       </div>
       <div className={`mt-1.5 flex items-center gap-1.5 px-1 ${TEXT.micro}`}>
-        <span>{entry.occurredAtLabel}</span>
+        <TimelineTimestamp entry={entry} />
         <span>·</span>
         <ChannelIcon className="h-3 w-3" />
       </div>
@@ -364,59 +503,79 @@ function AutomatedRow({
       <div className="mb-1 flex w-full max-w-2xl items-center justify-between px-1">
         <span className={TEXT.micro}>{label}</span>
       </div>
-      <button
-        type="button"
-        aria-expanded={isExpanded}
-        onClick={onToggle}
-        className={cn(
-          `group flex w-full max-w-2xl items-center gap-3 ${RADIUS.md} border border-dashed border-slate-300 bg-white px-4 py-2.5 text-left`,
-          "transition-[color,background-color,transform] duration-150 ease-out",
-          "active:scale-[0.96]",
-          TRANSITION.reduceMotion,
-          "hover:bg-slate-50",
-        )}
-      >
-        <div className="min-w-0 flex-1">
-          {headline ? (
-            <p className="text-pretty text-[13px] font-medium leading-snug text-slate-700">
-              {headline}
-            </p>
-          ) : null}
-          {campaignActivity.length > 0 ? (
-            <div className="mt-2 flex flex-wrap gap-1.5">
-              {campaignActivity.map((activity) => (
-                <span
-                  key={`${activity.activityType}:${activity.occurredAt}`}
-                  className="inline-flex items-center rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-medium leading-none text-emerald-700"
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-expanded={isExpanded}
+            title={formatExactTimestamp(entry.occurredAt)}
+            onClick={onToggle}
+            className={cn(
+              `group flex w-full max-w-2xl items-center gap-3 ${RADIUS.md} border border-dashed border-slate-300 bg-white px-4 py-2.5 text-left`,
+              "transition-[color,background-color,transform] duration-150 ease-out",
+              "active:scale-[0.96]",
+              TRANSITION.reduceMotion,
+              "hover:bg-slate-50",
+            )}
+          >
+            <div className="min-w-0 flex-1">
+              {headline ? (
+                <p
+                  className={cn(
+                    "text-pretty text-[13px] font-medium leading-snug text-slate-700",
+                    WRAP_ANYWHERE,
+                  )}
                 >
-                  {activity.label}
-                </span>
-              ))}
+                  {headline}
+                </p>
+              ) : null}
+              {campaignActivity.length > 0 ? (
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  {campaignActivity.map((activity) => (
+                    <span
+                      key={`${activity.activityType}:${activity.occurredAt}`}
+                      className="inline-flex items-center rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-medium leading-none text-emerald-700"
+                    >
+                      <CampaignActivityTimestamp
+                        label={activity.label}
+                        occurredAt={activity.occurredAt}
+                      />
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+              {!hideCollapsedBody && body.length > 0 ? (
+                <p
+                  className={cn(
+                    "text-[13px] leading-relaxed text-slate-600",
+                    WRAP_ANYWHERE,
+                    (headline !== null || campaignActivity.length > 0) &&
+                      "mt-1.5",
+                    isExpanded
+                      ? "whitespace-pre-wrap text-pretty"
+                      : "line-clamp-1",
+                  )}
+                >
+                  {isExpanded ? autolinkText(body, "text-sky-600") : body}
+                </p>
+              ) : null}
             </div>
-          ) : null}
-          {!hideCollapsedBody && body.length > 0 ? (
-            <p
-              className={cn(
-                "text-[13px] leading-relaxed text-slate-600",
-                (headline !== null || campaignActivity.length > 0) && "mt-1.5",
-                isExpanded ? "whitespace-pre-wrap text-pretty" : "line-clamp-1",
-              )}
-            >
-              {isExpanded ? autolinkText(body, "text-sky-600") : body}
-            </p>
-          ) : null}
-        </div>
-        <div className="flex shrink-0 items-center gap-2">
-          <span className="text-[11px] text-slate-400">
-            {entry.occurredAtLabel}
-          </span>
-          <ChevronRightIcon
-            className={`h-3.5 w-3.5 text-slate-400 transition-transform duration-150 ${
-              isExpanded ? "rotate-90" : ""
-            }`}
-          />
-        </div>
-      </button>
+            <div className="flex shrink-0 items-center gap-2">
+              <span className="text-[11px] text-slate-400">
+                {entry.occurredAtLabel}
+              </span>
+              <ChevronRightIcon
+                className={`h-3.5 w-3.5 text-slate-400 transition-transform duration-150 ${
+                  isExpanded ? "rotate-90" : ""
+                }`}
+              />
+            </div>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          <p>{formatExactTimestamp(entry.occurredAt)}</p>
+        </TooltipContent>
+      </Tooltip>
     </li>
   );
 }
@@ -524,7 +683,7 @@ function NoteEntry({
             <span className="text-amber-300">·</span>
             <span>{entry.actorLabel}</span>
             <span className="text-amber-300">·</span>
-            <span>{entry.occurredAtLabel}</span>
+            <TimelineTimestamp entry={entry} />
           </div>
           {canManageNote ? (
             <div className="flex items-center gap-2">
@@ -639,7 +798,12 @@ function NoteEntry({
           </div>
         ) : (
           <>
-            <p className="whitespace-pre-wrap text-pretty text-[13px] leading-relaxed text-amber-900">
+            <p
+              className={cn(
+                "whitespace-pre-wrap text-pretty text-[13px] leading-relaxed text-amber-900",
+                WRAP_ANYWHERE,
+              )}
+            >
               {entry.body}
             </p>
             {inlineError ? (

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -482,10 +482,10 @@ function buildProjectMembershipViewModel(
     // shell keeps its existing contract with a selector-derived current year.
     year: new Date().getUTCFullYear(),
     status: mapProjectStatus(membership.status),
-    // Gap: the canonical project URL is not stored yet, so the shell uses a
-    // stable best-effort CRM path derived from the project identifier.
-    crmUrl: `https://adventurescientists.lightning.force.com/lightning/r/Project__c/${encodeURIComponent(
-      membership.projectId,
+    // Right-rail links must target the volunteer's Salesforce membership
+    // record for that specific project context.
+    crmUrl: `https://adventurescientists.lightning.force.com/lightning/r/Expedition_Members__c/${encodeURIComponent(
+      membership.id,
     )}/view`,
   };
 }

--- a/apps/web/tests/unit/inbox-autolink.test.ts
+++ b/apps/web/tests/unit/inbox-autolink.test.ts
@@ -58,4 +58,21 @@ describe("autolinkText", () => {
       'href="https://docuseal.com/e/abc123?review=true#signature"',
     );
   });
+
+  it("keeps trailing punctuation outside the linked URL", () => {
+    const markup = renderToStaticMarkup(
+      createElement(
+        "p",
+        null,
+        autolinkText(
+          "Review https://example.org/forms). before you reply.",
+          "text-sky-600",
+        ),
+      ),
+    );
+
+    expect(markup).toContain('href="https://example.org/forms"');
+    expect(markup).toContain(">https://example.org/forms<");
+    expect(markup).toContain("</a>). before you reply.");
+  });
 });

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -545,6 +545,8 @@ describe("real inbox selectors", () => {
     expect(detail?.contact.activeProjects[0]).toMatchObject({
       projectName: "Amazon Basin Research",
       status: "in-training",
+      crmUrl:
+        "https://adventurescientists.lightning.force.com/lightning/r/Expedition_Members__c/membership%3Asarah/view",
     });
     expect(detail?.timeline.map((entry) => entry.kind)).toEqual([
       "outbound-email",

--- a/apps/web/tests/unit/inbox-timeline.test.ts
+++ b/apps/web/tests/unit/inbox-timeline.test.ts
@@ -133,8 +133,10 @@ describe("InboxTimeline", () => {
       }),
     );
 
-    expect(markup).toContain("Opened 1h ago");
-    expect(markup).toContain("Clicked 45m ago");
+    expect(markup).toContain("Opened");
+    expect(markup).toContain(">1h ago<");
+    expect(markup).toContain("Clicked");
+    expect(markup).toContain(">45m ago<");
   });
 
   it("only hides automated email body text while a subject-bearing row is collapsed", () => {
@@ -166,5 +168,38 @@ describe("InboxTimeline", () => {
         headline: null,
       }),
     ).toBe(false);
+  });
+
+  it("reveals an exact timestamp while keeping the relative label visible", () => {
+    const markup = renderToStaticMarkup(
+      createElement(InboxTimeline, {
+        entries: [baseEntry],
+        volunteerFirstName: "Alice",
+        currentOperatorUserId: "user:operator",
+      }),
+    );
+
+    expect(markup).toContain(">2h ago<");
+    expect(markup).toContain('title="Apr 16, 2026, 12:30 PM UTC"');
+  });
+
+  it("adds wrap-anywhere behavior to expanded timeline copy", () => {
+    const markup = renderToStaticMarkup(
+      createElement(InboxTimeline, {
+        entries: [
+          {
+            ...baseEntry,
+            kind: "outbound-email" as const,
+            body: "https://example.org/really-long-link-without-natural-breakpoints",
+            sendStatus: null,
+            mailbox: "volunteers@example.org",
+          },
+        ],
+        volunteerFirstName: "Alice",
+        currentOperatorUserId: "user:operator",
+      }),
+    );
+
+    expect(markup).toContain("[overflow-wrap:anywhere]");
   });
 });


### PR DESCRIPTION
## Summary
- anchor newly opened contacts to the latest timeline content
- scope loading to the detail pane and improve timeline link wrapping/affordance
- show exact timestamps on hover/focus and point project links at Expedition Member records

## Verification
- pnpm test:unit
- pnpm typecheck
- git diff --check

## Notes
- pnpm lint is currently blocked by a pre-existing inherited lint error in packages/domain/src/timeline.ts:315 on main (@typescript-eslint/prefer-nullish-coalescing); this branch does not touch that file