### PR TITLE
[codex] polish settings integrations and operator menu

### DIFF
--- a/apps/web/app/_components/operator-menu-actions.ts
+++ b/apps/web/app/_components/operator-menu-actions.ts
@@ -1,0 +1,9 @@
+"use server";
+
+import { signOut } from "@/src/server/auth";
+
+export async function signOutOperatorAction() {
+  await signOut({
+    redirectTo: "/auth/sign-in"
+  });
+}

--- a/apps/web/app/_components/primary-icon-rail.tsx
+++ b/apps/web/app/_components/primary-icon-rail.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useState } from "react";
 import type { LucideIcon } from "lucide-react";
 import {
   Inbox as InboxIcon,
@@ -13,7 +14,6 @@ import {
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger
@@ -31,27 +31,25 @@ import {
   SHADOW,
   TRANSITION
 } from "@/app/_lib/design-tokens";
+import { cn } from "@/lib/utils";
 
 import { AdventureScientistsLogo } from "./adventure-scientists-logo";
+import { signOutOperatorAction } from "./operator-menu-actions";
 
 interface RailItem {
   readonly id: string;
   readonly label: string;
   readonly Icon: LucideIcon;
-  /** Route the item links to, or `null` for not-yet-implemented destinations. */
   readonly href: string | null;
-  /** Pathname prefixes that mark this item active, e.g. ["/inbox"]. */
   readonly activePrefixes: readonly string[];
 }
 
-/**
- * Prototype left nav shared between `/inbox` and `/settings`. Kept to three
- * destinations per product brief — Inbox, Campaigns, Settings — so the icon
- * strip doesn't drift into speculative sections. The active state is driven
- * by `usePathname()` so the same component renders correctly on either
- * surface. The bottom slot hosts a user circle that reveals the operator's
- * name and a Log out affordance on hover.
- */
+export interface PrimaryRailOperator {
+  readonly initials: string;
+  readonly displayName: string;
+  readonly email: string;
+}
+
 const ITEMS: readonly RailItem[] = [
   {
     id: "inbox",
@@ -61,9 +59,6 @@ const ITEMS: readonly RailItem[] = [
     activePrefixes: ["/inbox"]
   },
   {
-    // Campaigns is deferred (see `project_campaigns_deferred` memory); rendered
-    // as a non-interactive disc so operators can see the future destination
-    // without being able to route to a stub route.
     id: "campaigns",
     label: "Campaigns",
     Icon: MegaphoneIcon,
@@ -79,19 +74,17 @@ const ITEMS: readonly RailItem[] = [
   }
 ];
 
-const OPERATOR = {
-  initials: "JC",
-  displayName: "Jordan Cole",
-  email: "jordan@adventurescientists.org"
-};
-
 function isActive(pathname: string, prefixes: readonly string[]): boolean {
   return prefixes.some(
     (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
   );
 }
 
-export function PrimaryIconRail() {
+export function PrimaryIconRail({
+  operator
+}: {
+  readonly operator: PrimaryRailOperator;
+}) {
   const pathname = usePathname();
 
   return (
@@ -153,45 +146,78 @@ export function PrimaryIconRail() {
           })}
         </div>
 
-        <OperatorMenu />
+        <OperatorMenu operator={operator} />
       </nav>
     </TooltipProvider>
   );
 }
 
-function OperatorMenu() {
+function OperatorMenu({
+  operator
+}: {
+  readonly operator: PrimaryRailOperator;
+}) {
+  const [open, setOpen] = useState(false);
+
   return (
-    <DropdownMenu>
+    <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>
         <button
           type="button"
-          aria-label={`${OPERATOR.displayName} · account menu`}
-          className={`mt-2 flex h-9 w-9 items-center justify-center ${RADIUS.full} bg-slate-900 text-[11px] font-semibold text-white ${SHADOW.sm} ${TRANSITION.fast} hover:bg-slate-800 ${FOCUS_RING}`}
+          aria-label={`${operator.displayName} · account menu`}
+          className={cn(
+            "group mt-2 flex h-10 items-center gap-2 overflow-hidden border border-slate-200 bg-white pl-0.5 pr-2 text-left text-slate-700",
+            RADIUS.full,
+            SHADOW.sm,
+            TRANSITION.layout,
+            TRANSITION.reduceMotion,
+            FOCUS_RING,
+            open
+              ? "w-44 border-slate-300 shadow-md"
+              : "w-10 hover:w-44 hover:border-slate-300 hover:shadow-md focus-visible:w-44"
+          )}
         >
-          {OPERATOR.initials}
+          <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-slate-900 text-[11px] font-semibold text-white">
+            {operator.initials}
+          </span>
+          <span
+            className={cn(
+              "min-w-0 overflow-hidden whitespace-nowrap text-xs font-medium transition-all duration-200 ease-out motion-reduce:transition-none",
+              open
+                ? "max-w-24 opacity-100"
+                : "max-w-0 opacity-0 group-hover:max-w-24 group-hover:opacity-100 group-focus-visible:max-w-24 group-focus-visible:opacity-100"
+            )}
+          >
+            {operator.displayName}
+          </span>
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent side="right" align="end" className="w-56">
         <DropdownMenuLabel className="font-normal">
           <div className="flex items-center gap-3">
             <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-slate-900 text-[11px] font-semibold text-white">
-              {OPERATOR.initials}
+              {operator.initials}
             </div>
             <div className="min-w-0">
               <p className="truncate text-sm font-semibold text-slate-900">
-                {OPERATOR.displayName}
+                {operator.displayName}
               </p>
               <p className="truncate text-[11px] text-slate-500">
-                {OPERATOR.email}
+                {operator.email}
               </p>
             </div>
           </div>
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
-        <DropdownMenuItem className="gap-2 text-xs font-medium">
-          <LogOutIcon className="h-3.5 w-3.5" />
-          Log out
-        </DropdownMenuItem>
+        <form action={signOutOperatorAction}>
+          <button
+            type="submit"
+            className="relative flex w-full select-none items-center gap-2 rounded-sm px-2 py-1.5 text-xs font-medium outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+          >
+            <LogOutIcon className="h-3.5 w-3.5" />
+            Log out
+          </button>
+        </form>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/web/app/inbox/_components/inbox-shell.tsx
+++ b/apps/web/app/inbox/_components/inbox-shell.tsx
@@ -17,6 +17,11 @@ interface ShellProps {
   readonly initialList: InboxListViewModel;
   readonly initialFilterId: InboxFilterId;
   readonly composerAliases: readonly InboxComposerAliasOption[];
+  readonly operator: {
+    readonly initials: string;
+    readonly displayName: string;
+    readonly email: string;
+  };
   readonly children: ReactNode;
 }
 
@@ -33,13 +38,14 @@ export function InboxShell({
   initialList,
   initialFilterId,
   composerAliases,
+  operator,
   children
 }: ShellProps) {
   return (
     <InboxClientProvider composerAliases={composerAliases}>
       <InboxKeyboardProvider>
         <InboxFreshnessPoller listFreshness={initialList.freshness} />
-        <PrimaryIconRail />
+        <PrimaryIconRail operator={operator} />
 
         <InboxList
           initialList={initialList}

--- a/apps/web/app/inbox/layout.tsx
+++ b/apps/web/app/inbox/layout.tsx
@@ -36,14 +36,12 @@ export default async function InboxLayout({
 }: {
   readonly children: ReactNode;
 }) {
-  try {
-    await requireSession();
-  } catch (error) {
+  const currentUser = await requireSession().catch((error: unknown) => {
     if (error instanceof Error && error.message === "UNAUTHORIZED") {
       redirect("/auth/sign-in");
     }
     throw error;
-  }
+  });
 
   const [list, composerAliases] = await Promise.all([
     getInboxList("all"),
@@ -55,8 +53,29 @@ export default async function InboxLayout({
       initialList={list}
       initialFilterId="all"
       composerAliases={composerAliases}
+      operator={{
+        initials: getInitials(currentUser.name ?? currentUser.email),
+        displayName: currentUser.name ?? currentUser.email,
+        email: currentUser.email
+      }}
     >
       {children}
     </InboxShell>
   );
+}
+
+function getInitials(value: string): string {
+  const parts = value
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+
+  if (parts.length === 0) {
+    return "?";
+  }
+
+  return parts
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("");
 }

--- a/apps/web/app/settings/_components/integrations-section.tsx
+++ b/apps/web/app/settings/_components/integrations-section.tsx
@@ -7,11 +7,12 @@ import {
   RADIUS,
   SHADOW,
   TEXT,
+  TONE,
   TRANSITION
 } from "@/app/_lib/design-tokens";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { StatusBadge } from "@/components/ui/status-badge";
-import { ToneAvatar } from "@/components/ui/tone-avatar";
 import {
   Tooltip,
   TooltipContent,
@@ -145,6 +146,7 @@ export function IntegrationsSection({ viewModel }: IntegrationsSectionProps) {
         <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
           {items.map((integration) => {
             const statusMeta = STATUS_META[integration.status];
+            const categoryTone = TONE[CATEGORY_TONE[integration.category]];
             const isRowPending =
               pending && pendingId === integration.serviceName;
             const isSyncDisabled =
@@ -154,50 +156,70 @@ export function IntegrationsSection({ viewModel }: IntegrationsSectionProps) {
               <li
                 key={integration.serviceName}
                 className={cn(
-                  "flex min-h-full flex-col gap-4 p-5",
+                  "flex min-h-full flex-col gap-4 border border-slate-200 bg-white p-4",
                   RADIUS.md,
-                  "border border-slate-200 bg-white",
                   SHADOW.sm,
-                  TRANSITION.fast,
+                  TRANSITION.layout,
+                  TRANSITION.reduceMotion,
+                  "hover:-translate-y-0.5 hover:border-slate-300",
                   isRowPending && "opacity-60"
                 )}
               >
-                <div className="flex items-start gap-3">
-                  <ToneAvatar
-                    initials={integration.logo}
-                    tone={CATEGORY_TONE[integration.category]}
-                    size="md"
-                  />
-                  <div className="min-w-0 flex-1">
-                    <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                      <p className="truncate text-sm font-semibold text-slate-900">
-                        {integration.displayName}
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex min-w-0 items-center gap-3">
+                    <IntegrationLogoMark integration={integration} />
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                        <p className="truncate text-sm font-semibold text-slate-900">
+                          {integration.displayName}
+                        </p>
+                        <span
+                          className={cn(
+                            "inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em]",
+                            categoryTone.subtle,
+                            categoryTone.text
+                          )}
+                        >
+                          {CATEGORY_LABEL[integration.category]}
+                        </span>
+                      </div>
+                      <p className={cn("mt-1", TEXT.caption, "text-slate-600")}>
+                        {integration.description}
                       </p>
-                      <span className={cn(TEXT.caption, "text-slate-500")}>
-                        {CATEGORY_LABEL[integration.category]}
-                      </span>
                     </div>
-                    <p
-                      className={cn(
-                        "mt-1 line-clamp-2",
-                        TEXT.bodySm,
-                        "text-slate-600"
-                      )}
-                    >
-                      {integration.detail ?? integration.description}
-                    </p>
                   </div>
+
+                  <StatusBadge
+                    label={statusMeta.label}
+                    colorClasses={statusMeta.colorClasses}
+                    variant="soft"
+                    className="shrink-0"
+                  />
+                </div>
+
+                <div
+                  className={cn(
+                    "flex min-h-16 items-center rounded-xl px-3 py-2.5",
+                    categoryTone.subtle
+                  )}
+                >
+                  <p
+                    className={cn(
+                      "line-clamp-2",
+                      TEXT.bodySm,
+                      integration.detail ? "text-slate-700" : "text-slate-500"
+                    )}
+                  >
+                    {integration.detail ?? "Waiting for the next health check."}
+                  </p>
                 </div>
 
                 <div className="flex items-center justify-between gap-3 border-t border-slate-100 pt-3">
                   <div className="flex min-w-0 flex-col gap-1">
-                    <StatusBadge
-                      label={statusMeta.label}
-                      colorClasses={statusMeta.colorClasses}
-                      variant="soft"
-                      className="self-start"
-                    />
-                    <span className={cn(TEXT.micro, "tabular-nums")}>
+                    <span className={cn(TEXT.label, "text-slate-400")}>
+                      Last checked
+                    </span>
+                    <span className={cn(TEXT.micro, "tabular-nums text-slate-500")}>
                       {formatRelative(integration.lastCheckedAt)}
                     </span>
                   </div>
@@ -221,6 +243,178 @@ export function IntegrationsSection({ viewModel }: IntegrationsSectionProps) {
       </SettingsSection>
     </TooltipProvider>
   );
+}
+
+function IntegrationLogoMark({
+  integration
+}: {
+  readonly integration: IntegrationHealthViewModel;
+}) {
+  return (
+    <Avatar className="size-11 rounded-2xl border border-slate-200 bg-transparent">
+      <AvatarFallback
+        delayMs={0}
+        className="rounded-2xl bg-transparent text-slate-900"
+      >
+        <span className="sr-only">{integration.displayName}</span>
+        <BrandMark serviceName={integration.serviceName} />
+      </AvatarFallback>
+    </Avatar>
+  );
+}
+
+function BrandMark({
+  serviceName
+}: {
+  readonly serviceName: IntegrationHealthViewModel["serviceName"];
+}) {
+  switch (serviceName) {
+    case "salesforce":
+      return (
+        <svg viewBox="0 0 48 48" className="size-8" aria-hidden="true">
+          <path
+            d="M16.6 31.9c-4.1 0-7.4-3-7.4-6.8 0-3.5 2.8-6.4 6.5-6.8.8-4.1 4.6-7.2 9.2-7.2 5.1 0 9.3 3.9 9.5 8.8 3 .8 5.2 3.4 5.2 6.5 0 3.8-3.2 6.8-7.2 6.8H16.6Z"
+            fill="#00A1E0"
+          />
+          <text
+            x="24"
+            y="29"
+            textAnchor="middle"
+            className="fill-white text-[11px] font-bold"
+          >
+            sf
+          </text>
+        </svg>
+      );
+    case "gmail":
+      return (
+        <svg viewBox="0 0 48 48" className="size-8" aria-hidden="true">
+          <path
+            d="M9 14.5 24 26l15-11.5"
+            fill="none"
+            stroke="#EA4335"
+            strokeWidth="4"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M9 14.5v19h8.5V22.3L24 27l6.5-4.7v11.2H39v-19"
+            fill="none"
+            stroke="#34A853"
+            strokeWidth="4"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M9 14.5 24 26l15-11.5"
+            fill="none"
+            stroke="#4285F4"
+            strokeWidth="2"
+            opacity="0.65"
+          />
+          <path
+            d="M9 14.5v19"
+            fill="none"
+            stroke="#FBBC05"
+            strokeWidth="4"
+            strokeLinecap="round"
+          />
+        </svg>
+      );
+    case "simpletexting":
+      return (
+        <svg viewBox="0 0 48 48" className="size-8" aria-hidden="true">
+          <rect x="8" y="10" width="25" height="18" rx="8" fill="#1D4ED8" />
+          <path d="M18 28h8l6 8v-8" fill="#1D4ED8" />
+          <rect x="16" y="16" width="10" height="3" rx="1.5" fill="white" />
+          <rect
+            x="16"
+            y="22"
+            width="14"
+            height="3"
+            rx="1.5"
+            fill="white"
+            opacity="0.78"
+          />
+        </svg>
+      );
+    case "mailchimp":
+      return (
+        <svg viewBox="0 0 48 48" className="size-8" aria-hidden="true">
+          <circle cx="24" cy="24" r="12" fill="#FACC15" />
+          <path
+            d="M18 28c1.8 2.3 4 3.5 6 3.5s4.2-1.2 6-3.5"
+            fill="none"
+            stroke="#111827"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+          />
+          <circle cx="20" cy="21" r="1.8" fill="#111827" />
+          <circle cx="28" cy="21" r="1.8" fill="#111827" />
+          <path
+            d="M30.8 15.3c2.4-.4 4.7.9 5.8 3"
+            fill="none"
+            stroke="#111827"
+            strokeWidth="2"
+            strokeLinecap="round"
+          />
+        </svg>
+      );
+    case "notion":
+      return (
+        <svg viewBox="0 0 48 48" className="size-8" aria-hidden="true">
+          <rect
+            x="11"
+            y="11"
+            width="26"
+            height="26"
+            rx="3"
+            fill="white"
+            stroke="#111827"
+            strokeWidth="2.5"
+          />
+          <path
+            d="M18 31V18l12 13V18"
+            fill="none"
+            stroke="#111827"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      );
+    case "openai":
+      return (
+        <svg viewBox="0 0 48 48" className="size-8" aria-hidden="true">
+          <g
+            fill="none"
+            stroke="#111827"
+            strokeWidth="2.6"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M24 11c3.6 0 6.6 2.9 6.6 6.5v2.1" />
+            <path d="M35.1 18.7c1.8 3.2.8 7.3-2.3 9.1L31 28.9" />
+            <path d="M33 31.5c-1.8 3.2-5.9 4.3-9.1 2.5L22 32.9" />
+            <path d="M18 34c-3.6 0-6.6-2.9-6.6-6.5v-2.1" />
+            <path d="M12.9 29.3c-1.8-3.2-.8-7.3 2.3-9.1L17 19.1" />
+            <path d="M15 16.5c1.8-3.2 5.9-4.3 9.1-2.5L26 15.1" />
+          </g>
+          <path
+            d="M18.5 18.5 29.5 29.5"
+            stroke="#D97706"
+            strokeWidth="2.2"
+            strokeLinecap="round"
+          />
+        </svg>
+      );
+    default:
+      return (
+        <span className="text-xs font-semibold">
+          {serviceName.slice(0, 2).toUpperCase()}
+        </span>
+      );
+  }
 }
 
 interface SyncButtonProps {

--- a/apps/web/app/settings/layout.tsx
+++ b/apps/web/app/settings/layout.tsx
@@ -31,22 +31,42 @@ export default async function SettingsLayout({
 }: {
   readonly children: ReactNode;
 }) {
-  try {
-    await requireSession();
-  } catch (error) {
+  const currentUser = await requireSession().catch((error: unknown) => {
     if (error instanceof Error && error.message === "UNAUTHORIZED") {
       redirect("/auth/sign-in");
     }
     throw error;
-  }
+  });
 
   return (
     <div className="flex min-h-screen w-full bg-slate-100 text-slate-900 antialiased">
-      <PrimaryIconRail />
+      <PrimaryIconRail
+        operator={{
+          initials: getInitials(currentUser.name ?? currentUser.email),
+          displayName: currentUser.name ?? currentUser.email,
+          email: currentUser.email
+        }}
+      />
       <SettingsSectionNav />
       <main className="flex min-w-0 flex-1 flex-col overflow-y-auto">
         {children}
       </main>
     </div>
   );
+}
+
+function getInitials(value: string): string {
+  const parts = value
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+
+  if (parts.length === 0) {
+    return "?";
+  }
+
+  return parts
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("");
 }

--- a/apps/web/src/server/settings/selectors.ts
+++ b/apps/web/src/server/settings/selectors.ts
@@ -65,7 +65,6 @@ export interface IntegrationHealthViewModel {
   readonly serviceName: string;
   readonly displayName: string;
   readonly description: string;
-  readonly logo: string;
   readonly category: IntegrationHealthCategory;
   readonly status: IntegrationHealthStatus;
   readonly lastCheckedAt: string | null;
@@ -90,44 +89,32 @@ const INTEGRATION_ORDER = [
 const INTEGRATION_META = {
   salesforce: {
     displayName: "Salesforce",
-    description:
-      "Source of truth for volunteer contacts, projects, and participation history.",
-    logo: "SF",
+    description: "Contacts and project records",
     supportsRefresh: true
   },
   gmail: {
     displayName: "Gmail",
-    description:
-      "Routes incoming mail to project inboxes and sends replies on behalf of operators.",
-    logo: "G",
+    description: "Inbound and outbound email",
     supportsRefresh: true
   },
   simpletexting: {
     displayName: "SimpleTexting",
-    description:
-      "Two-way SMS channel for volunteer check-ins and field-support threads.",
-    logo: "ST",
+    description: "Volunteer SMS delivery",
     supportsRefresh: false
   },
   mailchimp: {
     displayName: "Mailchimp",
-    description:
-      "Legacy campaign-delivery provider kept for historical compatibility.",
-    logo: "MC",
+    description: "Historical campaign records",
     supportsRefresh: false
   },
   notion: {
     displayName: "Notion",
-    description:
-      "Knowledge source backing grounded AI context once Stage 4 sync lands.",
-    logo: "N",
+    description: "Knowledge sync source",
     supportsRefresh: false
   },
   openai: {
-    displayName: "OpenAI",
-    description:
-      "Draft-generation model provider used by the future AI assistant stage.",
-    logo: "OA",
+    displayName: "Anthropic",
+    description: "AI draft provider",
     supportsRefresh: false
   }
 } as const satisfies Record<
@@ -135,7 +122,6 @@ const INTEGRATION_META = {
   {
     readonly displayName: string;
     readonly description: string;
-    readonly logo: string;
     readonly supportsRefresh: boolean;
   }
 >;
@@ -354,7 +340,6 @@ async function readIntegrationHealth() {
         serviceName: record.serviceName,
         displayName: meta.displayName,
         description: meta.description,
-        logo: meta.logo,
         category: record.category,
         status: record.status,
         lastCheckedAt: record.lastCheckedAt,


### PR DESCRIPTION
## What changed
- replaces the old integrations card treatment with denser cards that fit the available space better
- swaps the Settings copy from OpenAI to Anthropic and adds transparent integration logos
- trims the long explanatory copy inside integration cards
- updates the lower-left operator control so initials stay in the rail, the name appears on hover, and logout uses a dedicated action

## Why
The previous integrations/settings shell was too copy-heavy and the lower-left operator affordance was not behaving like a real operator control. This keeps the surface closer to the design system and makes the settings shell feel like the rest of the app.

## Validation
- targeted vitest: `tests/unit/settings-selectors.test.ts`
- `git diff --check`

## Notes
- this branch was rebased on top of the merged settings-admin alias work before PR creation
