### PR TITLE
[codex] polish inbox campaign timeline rows

### DIFF
--- a/apps/web/app/inbox/_components/inbox-timeline.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline.tsx
@@ -521,14 +521,6 @@ function AutomatedRow({
                   focusable={false}
                   className="text-[11px] text-slate-500"
                 />
-                {role === "campaign" ? (
-                  <>
-                    <span className="text-slate-300">·</span>
-                    <span className="text-[11px] font-medium text-violet-700/80">
-                      {campaignStateLabel(campaignState ?? "sent")}
-                    </span>
-                  </>
-                ) : null}
               </div>
               {headline ? (
                 <p
@@ -919,21 +911,6 @@ function describeCampaignVisualState(
   }
 
   return "sent";
-}
-
-function campaignStateLabel(
-  state: ReturnType<typeof describeCampaignVisualState>,
-): string {
-  switch (state) {
-    case "opened":
-      return "Opened";
-    case "clicked":
-      return "Clicked";
-    case "unsubscribed":
-      return "Unsubscribed";
-    case "sent":
-      return "Sent";
-  }
 }
 
 function CampaignStateIcon({

--- a/apps/web/app/inbox/_components/inbox-timeline.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline.tsx
@@ -30,7 +30,6 @@ import {
   NoteIcon,
   PhoneIcon,
   RefreshCwIcon,
-  SendIcon,
   SparkleIcon,
   WandIcon,
   XIcon,
@@ -465,7 +464,6 @@ function AutomatedRow({
   const descriptor = describeEventRow({
     role,
     isEmail,
-    campaignActivity,
   });
   const headline = entry.subject;
   const body = bodyTextForEntry(entry);
@@ -500,21 +498,37 @@ function AutomatedRow({
                 descriptor.iconClassName,
               )}
             >
-              <descriptor.Icon className="size-4" />
+              {role === "campaign" ? (
+                <CampaignStateIcon state={campaignState ?? "sent"} />
+              ) : (
+                <descriptor.Icon className="size-4" />
+              )}
             </div>
             <div className="min-w-0 flex-1">
               <div className="flex flex-wrap items-center gap-2">
                 <span
                   className={cn(
-                    "inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em]",
-                    descriptor.badgeClassName,
+                    "text-[11px] font-semibold uppercase tracking-[0.18em]",
+                    descriptor.labelClassName,
                   )}
                 >
                   {descriptor.label}
                 </span>
-                <span className="text-[11px] text-slate-500">
-                  {entry.occurredAtLabel}
-                </span>
+                <RelativeTimestamp
+                  timestamp={entry.occurredAt}
+                  label={entry.occurredAtLabel}
+                  asSpan
+                  focusable={false}
+                  className="text-[11px] text-slate-500"
+                />
+                {role === "campaign" ? (
+                  <>
+                    <span className="text-slate-300">·</span>
+                    <span className="text-[11px] font-medium text-violet-700/80">
+                      {campaignStateLabel(campaignState ?? "sent")}
+                    </span>
+                  </>
+                ) : null}
               </div>
               {headline ? (
                 <p
@@ -526,17 +540,12 @@ function AutomatedRow({
                   {headline}
                 </p>
               ) : null}
-              <EventStateChips
-                entry={entry}
-                role={role}
-                campaignActivity={campaignActivity}
-              />
               {!hideCollapsedBody && body.length > 0 ? (
                 <p
                   className={cn(
                     "text-[13px] leading-relaxed text-slate-700",
                     WRAP_ANYWHERE,
-                    (headline !== null || campaignActivity.length > 0) && "mt-1.5",
+                    (headline !== null || role === "campaign") && "mt-1.5",
                     isExpanded
                       ? "whitespace-pre-wrap text-pretty"
                       : "line-clamp-1",
@@ -830,8 +839,8 @@ function SystemDivider({
           <div className="flex flex-wrap items-center gap-2">
             <span
               className={cn(
-                "inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em]",
-                descriptor.badgeClassName,
+                "text-[11px] font-semibold uppercase tracking-[0.18em]",
+                descriptor.labelClassName,
               )}
             >
               {descriptor.label}
@@ -855,52 +864,21 @@ interface EventRowDescriptor {
   readonly label: string;
   readonly Icon: ComponentType<{ className?: string }>;
   readonly shellClassName: string;
-  readonly badgeClassName: string;
   readonly iconClassName: string;
+  readonly labelClassName: string;
 }
 
 function describeEventRow(input: {
   readonly role: "automated" | "campaign" | "activity";
   readonly isEmail: boolean;
-  readonly campaignActivity: readonly {
-    readonly activityType: "sent" | "opened" | "clicked" | "unsubscribed";
-  }[];
 }): EventRowDescriptor {
   if (input.role === "campaign") {
-    const state = describeCampaignVisualState(input.campaignActivity);
-
     return {
       label: input.isEmail ? "Campaign" : "Campaign SMS",
-      ...(state === "clicked"
-        ? {
-            Icon: MousePointerClickIcon,
-            shellClassName:
-              "border-violet-200 bg-violet-50/75 hover:bg-violet-50",
-            badgeClassName: "border-violet-200 bg-white text-violet-700",
-            iconClassName: "border-violet-200 text-violet-700",
-          }
-        : state === "opened"
-          ? {
-              Icon: EyeIcon,
-              shellClassName: "border-sky-200 bg-sky-50/75 hover:bg-sky-50",
-              badgeClassName: "border-sky-200 bg-white text-sky-700",
-              iconClassName: "border-sky-200 text-sky-700",
-            }
-          : state === "unsubscribed"
-            ? {
-                Icon: XIcon,
-                shellClassName:
-                  "border-rose-200 bg-rose-50/75 hover:bg-rose-50",
-                badgeClassName: "border-rose-200 bg-white text-rose-700",
-                iconClassName: "border-rose-200 text-rose-700",
-              }
-            : {
-                Icon: MegaphoneIcon,
-                shellClassName:
-                  "border-emerald-200 bg-emerald-50/75 hover:bg-emerald-50",
-                badgeClassName: "border-emerald-200 bg-white text-emerald-700",
-                iconClassName: "border-emerald-200 text-emerald-700",
-              }),
+      Icon: MegaphoneIcon,
+      shellClassName: "border-violet-200 bg-violet-50/75 hover:bg-violet-50",
+      iconClassName: "border-violet-200 text-violet-700",
+      labelClassName: "text-violet-700",
     };
   }
 
@@ -909,8 +887,8 @@ function describeEventRow(input: {
       label: input.isEmail ? "Activity" : "SMS Activity",
       Icon: input.isEmail ? MailIcon : PhoneIcon,
       shellClassName: "border-violet-200 bg-violet-50/75 hover:bg-violet-50",
-      badgeClassName: "border-violet-200 bg-white text-violet-700",
       iconClassName: "border-violet-200 text-violet-700",
+      labelClassName: "text-violet-700",
     };
   }
 
@@ -918,92 +896,9 @@ function describeEventRow(input: {
     label: input.isEmail ? "Automated" : "Automated SMS",
     Icon: input.isEmail ? BotIcon : WandIcon,
     shellClassName: "border-sky-200 bg-sky-50/75 hover:bg-sky-50",
-    badgeClassName: "border-sky-200 bg-white text-sky-700",
     iconClassName: "border-sky-200 text-sky-700",
+    labelClassName: "text-sky-700",
   };
-}
-
-function EventStateChips({
-  entry,
-  role,
-  campaignActivity,
-}: {
-  readonly entry: InboxTimelineEntryViewModel;
-  readonly role: "automated" | "campaign" | "activity";
-  readonly campaignActivity: readonly {
-    readonly activityType: "sent" | "opened" | "clicked" | "unsubscribed";
-    readonly occurredAt: string;
-    readonly occurredAtLabel: string;
-    readonly label: string;
-  }[];
-}) {
-  const states = [
-    ...(role === "activity"
-      ? []
-      : [
-          {
-            key: `sent:${entry.occurredAt}`,
-            label: "Sent",
-            occurredAt: entry.occurredAt,
-            occurredAtLabel: entry.occurredAtLabel,
-            Icon: SendIcon,
-            className: "border-slate-200 bg-white text-slate-600",
-          },
-        ]),
-    ...(role !== "campaign"
-      ? []
-      : campaignActivity.map((activity) => ({
-          key: `${activity.activityType}:${activity.occurredAt}`,
-          label:
-            activity.activityType === "opened"
-              ? "Opened"
-              : activity.activityType === "clicked"
-                ? "Clicked"
-                : "Unsubscribed",
-          occurredAt: activity.occurredAt,
-          occurredAtLabel: activity.occurredAtLabel,
-          Icon:
-            activity.activityType === "opened"
-              ? EyeIcon
-              : activity.activityType === "clicked"
-                ? MousePointerClickIcon
-                : XIcon,
-          className:
-            activity.activityType === "opened"
-              ? "border-sky-200 bg-sky-100/80 text-sky-700"
-              : activity.activityType === "clicked"
-                ? "border-violet-200 bg-violet-100/80 text-violet-700"
-                : "border-rose-200 bg-rose-100/80 text-rose-700",
-        }))),
-  ];
-
-  if (states.length === 0) {
-    return null;
-  }
-
-  return (
-    <div className="mt-2 flex flex-wrap gap-1.5">
-      {states.map((state) => (
-        <span
-          key={state.key}
-          className={cn(
-            "inline-flex items-center gap-1 rounded-full border px-2 py-1 text-[11px] font-medium leading-none",
-            state.className,
-          )}
-        >
-          <state.Icon className="size-3" />
-          <span>{state.label}</span>
-          <span className="text-current/60">·</span>
-          <RelativeTimestamp
-            timestamp={state.occurredAt}
-            label={state.occurredAtLabel}
-            asSpan
-            focusable={false}
-          />
-        </span>
-      ))}
-    </div>
-  );
 }
 
 function describeCampaignVisualState(
@@ -1026,6 +921,49 @@ function describeCampaignVisualState(
   return "sent";
 }
 
+function campaignStateLabel(
+  state: ReturnType<typeof describeCampaignVisualState>,
+): string {
+  switch (state) {
+    case "opened":
+      return "Opened";
+    case "clicked":
+      return "Clicked";
+    case "unsubscribed":
+      return "Unsubscribed";
+    case "sent":
+      return "Sent";
+  }
+}
+
+function CampaignStateIcon({
+  state,
+}: {
+  readonly state: ReturnType<typeof describeCampaignVisualState>;
+}) {
+  const AccentIcon =
+    state === "clicked"
+      ? MousePointerClickIcon
+      : state === "opened"
+        ? EyeIcon
+        : state === "unsubscribed"
+          ? XIcon
+          : null;
+
+  return (
+    <span className="relative inline-flex">
+      <MegaphoneIcon className="size-4" />
+      {AccentIcon ? (
+        <span className="absolute -right-1 -top-1 inline-flex size-3.5 items-center justify-center rounded-full border border-violet-200 bg-white text-violet-700 shadow-sm">
+          <AccentIcon className="size-2" />
+        </span>
+      ) : (
+        <span className="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-violet-500 ring-2 ring-white" />
+      )}
+    </span>
+  );
+}
+
 function describeLifecycleEvent(body: string): Omit<
   EventRowDescriptor,
   "shellClassName"
@@ -1036,8 +974,8 @@ function describeLifecycleEvent(body: string): Omit<
     return {
       label: "Training",
       Icon: WandIcon,
-      badgeClassName: "border-sky-200 bg-white text-sky-700",
       iconClassName: "border-sky-200 text-sky-700",
+      labelClassName: "text-sky-700",
     };
   }
 
@@ -1045,8 +983,8 @@ function describeLifecycleEvent(body: string): Omit<
     return {
       label: "In Field",
       Icon: MapPinIcon,
-      badgeClassName: "border-emerald-200 bg-white text-emerald-700",
       iconClassName: "border-emerald-200 text-emerald-700",
+      labelClassName: "text-emerald-700",
     };
   }
 
@@ -1054,8 +992,8 @@ function describeLifecycleEvent(body: string): Omit<
     return {
       label: "Completed",
       Icon: CheckCircleIcon,
-      badgeClassName: "border-emerald-200 bg-white text-emerald-700",
       iconClassName: "border-emerald-200 text-emerald-700",
+      labelClassName: "text-emerald-700",
     };
   }
 
@@ -1063,16 +1001,16 @@ function describeLifecycleEvent(body: string): Omit<
     return {
       label: "Applied",
       Icon: SparkleIcon,
-      badgeClassName: "border-violet-200 bg-white text-violet-700",
       iconClassName: "border-violet-200 text-violet-700",
+      labelClassName: "text-violet-700",
     };
   }
 
   return {
     label: "Lifecycle",
     Icon: CalendarIcon,
-    badgeClassName: "border-amber-200 bg-white text-amber-700",
     iconClassName: "border-amber-200 text-amber-700",
+    labelClassName: "text-amber-700",
   };
 }
 

--- a/apps/web/tests/unit/inbox-timeline.test.ts
+++ b/apps/web/tests/unit/inbox-timeline.test.ts
@@ -99,7 +99,6 @@ describe("InboxTimeline", () => {
     );
 
     expect(markup).toContain("Campaign");
-    expect(markup).toContain("Sent");
     expect(markup).toContain("Please review the latest field update.");
     expect(markup).not.toContain("rounded-full border px-2 py-1");
   });
@@ -136,10 +135,11 @@ describe("InboxTimeline", () => {
     );
 
     expect(markup).toContain('data-campaign-state="clicked"');
-    expect(markup).toContain("Clicked");
     expect(markup).toContain("border-violet-200 bg-violet-50/75");
     expect(markup).not.toContain("Opened 1h ago");
     expect(markup).not.toContain("45m ago");
+    expect(markup).not.toContain(">Sent<");
+    expect(markup).not.toContain(">Clicked<");
   });
 
   it("renders lifecycle events as volunteer-side context rows with an icon-led label", () => {

--- a/apps/web/tests/unit/inbox-timeline.test.ts
+++ b/apps/web/tests/unit/inbox-timeline.test.ts
@@ -101,9 +101,10 @@ describe("InboxTimeline", () => {
     expect(markup).toContain("Campaign");
     expect(markup).toContain("Sent");
     expect(markup).toContain("Please review the latest field update.");
+    expect(markup).not.toContain("rounded-full border px-2 py-1");
   });
 
-  it("shows consolidated campaign activity state inside the bubble and on the row shell", () => {
+  it("shows one consolidated campaign state while keeping the row in the purple campaign treatment", () => {
     const markup = renderToStaticMarkup(
       createElement(InboxTimeline, {
         entries: [
@@ -135,11 +136,10 @@ describe("InboxTimeline", () => {
     );
 
     expect(markup).toContain('data-campaign-state="clicked"');
-    expect(markup).toContain("Sent");
-    expect(markup).toContain("Opened");
-    expect(markup).toContain(">1h ago<");
     expect(markup).toContain("Clicked");
-    expect(markup).toContain(">45m ago<");
+    expect(markup).toContain("border-violet-200 bg-violet-50/75");
+    expect(markup).not.toContain("Opened 1h ago");
+    expect(markup).not.toContain("45m ago");
   });
 
   it("renders lifecycle events as volunteer-side context rows with an icon-led label", () => {


### PR DESCRIPTION
## What changed
- polishes campaign and automated timeline rows to match the requested icon-led treatment
- removes the extra AUTOMATED/CAMPAIGN pill treatment and keeps a single quieter state signal per row
- keeps campaign rows on one consistent color treatment and aligns the icon language with the campaign rail icon
- leaves the expedition-member link format intact while refining the row shell and test expectations

## Why
The campaign/automated timeline rows were still carrying too much label noise and too many competing state cues. This pass makes them scan more like part of the product and less like raw event metadata.

## Validation
- targeted vitest: `tests/unit/inbox-timeline.test.ts`
- `git diff --check`
