### PR TITLE
[codex] polish inbox composer controls

### DIFF
--- a/apps/web/app/inbox/_components/composer-recipient-picker.tsx
+++ b/apps/web/app/inbox/_components/composer-recipient-picker.tsx
@@ -1,13 +1,16 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Chip } from "@/components/ui/chip";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 
-import { resolveTypedEmailRecipient } from "../_lib/composer-ui";
+import {
+  formatContactRecipientLabel,
+  resolveTypedEmailRecipient,
+} from "../_lib/composer-ui";
 import {
   searchContactsAction,
   type ContactSearchResult
@@ -58,6 +61,7 @@ export function ComposerRecipientPicker({
   const [results, setResults] = useState<readonly ContactSearchResult[]>([]);
   const [isSearching, setIsSearching] = useState(false);
   const activeSearchIdRef = useRef(0);
+  const listboxId = useId();
 
   useEffect(() => {
     if (recipient !== null) {
@@ -119,10 +123,10 @@ export function ComposerRecipientPicker({
     (isSearching || results.length > 0 || query.trim().length >= 2);
 
   return (
-    <div className="space-y-2">
+    <div>
       <label className="flex items-start gap-3">
-        <span className="mt-2 w-10 text-sm font-medium text-slate-700">To:</span>
-        <div className="flex-1 space-y-2">
+        <span className="mt-3 w-10 text-sm font-medium text-slate-700">To:</span>
+        <div className="flex-1">
           {recipient ? (
             <RecipientChip
               recipient={recipient}
@@ -135,7 +139,7 @@ export function ComposerRecipientPicker({
             />
           ) : (
             <div className="relative">
-              <SearchIcon className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400" />
+              <SearchIcon className="pointer-events-none absolute left-4 top-4 size-4 text-slate-400" />
               <Input
                 value={query}
                 onChange={(event) => {
@@ -166,63 +170,67 @@ export function ComposerRecipientPicker({
                   onRecipientChange(typedEmailRecipient);
                 }}
                 placeholder="Search Salesforce contacts or type an email"
-                className="pl-9"
+                aria-expanded={shouldShowResults}
+                aria-controls={shouldShowResults ? listboxId : undefined}
+                aria-autocomplete="list"
+                className="h-11 rounded-xl border-slate-200 bg-white pl-11 shadow-sm"
               />
-            </div>
-          )}
-
-          {shouldShowResults ? (
-            <div className="rounded-md border border-slate-200 bg-white">
-              {isSearching ? (
-                <div className="px-3 py-2 text-sm text-slate-500">
-                  Searching contacts...
-                </div>
-              ) : results.length > 0 ? (
-                <ul className="divide-y divide-slate-100">
-                  {results.map((result) => (
-                    <li key={result.id}>
-                      <button
-                        type="button"
-                        onClick={() => {
-                          onRecipientChange(toContactRecipient(result));
-                        }}
-                        className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left hover:bg-slate-50"
-                      >
-                        <div className="min-w-0">
-                          <div className="flex items-center gap-2">
-                            <span className="truncate text-sm font-medium text-slate-900">
-                              {result.displayName}
-                            </span>
-                            {result.salesforceContactId ? (
-                              <Chip tone="neutral" className="uppercase">
-                                SF
-                              </Chip>
-                            ) : null}
-                          </div>
-                          <div className="mt-0.5 flex flex-wrap items-center gap-2 text-xs text-slate-500">
-                            {result.primaryEmail ? (
-                              <span className="font-mono text-[11px] text-slate-600">
-                                {result.primaryEmail}
-                              </span>
-                            ) : (
-                              <span>No primary email</span>
-                            )}
-                            {result.primaryProjectName ? (
-                              <span>{result.primaryProjectName}</span>
-                            ) : null}
-                          </div>
-                        </div>
-                      </button>
-                    </li>
-                  ))}
-                </ul>
-              ) : query.trim().length >= 2 ? (
-                <div className="px-3 py-2 text-sm text-slate-500">
-                  No matching contacts.
+              {shouldShowResults ? (
+                <div className="absolute inset-x-0 top-full z-20 mt-2 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-lg">
+                  {isSearching ? (
+                    <div className="px-4 py-3 text-sm text-slate-500">
+                      Searching contacts...
+                    </div>
+                  ) : results.length > 0 ? (
+                    <ul
+                      id={listboxId}
+                      role="listbox"
+                      className="max-h-72 divide-y divide-slate-100 overflow-y-auto"
+                    >
+                      {results.map((result) => (
+                        <li key={result.id}>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              onRecipientChange(toContactRecipient(result));
+                            }}
+                            className="flex w-full items-start justify-between gap-3 px-4 py-3 text-left transition-colors hover:bg-slate-50 focus-visible:bg-slate-50 focus-visible:outline-none"
+                          >
+                            <div className="min-w-0">
+                              <div className="flex items-center gap-2">
+                                <span className="truncate text-sm font-medium text-slate-900">
+                                  {formatContactRecipientLabel({
+                                    displayName: result.displayName,
+                                    primaryEmail: result.primaryEmail,
+                                  })}
+                                </span>
+                                {result.salesforceContactId ? (
+                                  <Chip tone="neutral" className="uppercase">
+                                    SF
+                                  </Chip>
+                                ) : null}
+                              </div>
+                              <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-slate-500">
+                                {result.primaryProjectName ? (
+                                  <span>{result.primaryProjectName}</span>
+                                ) : (
+                                  <span>Contact recipient</span>
+                                )}
+                              </div>
+                            </div>
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : query.trim().length >= 2 ? (
+                    <div className="px-4 py-3 text-sm text-slate-500">
+                      No matching contacts.
+                    </div>
+                  ) : null}
                 </div>
               ) : null}
             </div>
-          ) : null}
+          )}
         </div>
       </label>
     </div>
@@ -241,20 +249,16 @@ function RecipientChip({
   return (
     <span
       className={cn(
-        "inline-flex min-h-10 w-full items-center justify-between gap-3 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm"
+        "inline-flex min-h-11 w-full items-center justify-between gap-3 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm shadow-sm"
       )}
     >
-      <span className="min-w-0">
+      <span className="min-w-0 pr-2">
         {recipient.kind === "contact" ? (
-          <span className="flex min-w-0 items-center gap-2">
-            <span className="truncate font-medium text-slate-900">
-              {recipient.displayName}
-            </span>
-            {recipient.primaryEmail ? (
-              <span className="truncate font-mono text-[11px] text-slate-500">
-                {recipient.primaryEmail}
-              </span>
-            ) : null}
+          <span className="block truncate font-medium text-slate-900">
+            {formatContactRecipientLabel({
+              displayName: recipient.displayName,
+              primaryEmail: recipient.primaryEmail,
+            })}
           </span>
         ) : (
           <span className="flex min-w-0 items-center gap-2">
@@ -272,7 +276,7 @@ function RecipientChip({
           variant="ghost"
           size="icon"
           aria-label="Clear recipient"
-          className="size-7 text-slate-500 hover:bg-slate-200 hover:text-slate-900"
+          className="size-7 rounded-full text-slate-500 hover:bg-slate-100 hover:text-slate-900"
           onClick={onClear}
         >
           <XIcon className="size-4" />

--- a/apps/web/app/inbox/_components/inbox-composer.tsx
+++ b/apps/web/app/inbox/_components/inbox-composer.tsx
@@ -10,6 +10,15 @@ import {
 } from "react";
 
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import {
   Tooltip,
@@ -30,9 +39,11 @@ import {
   type ComposerSendActionInput,
 } from "../actions";
 import {
+  formatContactRecipientLabel,
   isComposerSendDisabled,
   resolveDefaultAlias,
 } from "../_lib/composer-ui";
+import type { InboxComposerAliasOption } from "../_lib/view-models";
 import {
   ComposerRecipientPicker,
   type ComposerContactRecipient,
@@ -44,6 +55,7 @@ import {
 } from "./inbox-client-provider";
 import {
   AlertCircleIcon,
+  ChevronDownIcon,
   ImageIcon,
   LoaderIcon,
   MailIcon,
@@ -68,6 +80,13 @@ interface InlineComposerError {
   readonly retryable: boolean;
 }
 
+interface SenderPickerProps {
+  readonly aliases: readonly InboxComposerAliasOption[];
+  readonly selectedAlias: string | null;
+  readonly errorMessage: string | undefined;
+  readonly onAliasChange: (alias: string | null) => void;
+}
+
 type ComposerFieldErrors = readonly ComposerValidationError[];
 
 function formatBytes(bytes: number): string {
@@ -84,7 +103,10 @@ function formatBytes(bytes: number): string {
 
 function resolveRecipientLabel(recipient: ComposerRecipientValue): string {
   return recipient.kind === "contact"
-    ? recipient.displayName
+    ? formatContactRecipientLabel({
+        displayName: recipient.displayName,
+        primaryEmail: recipient.primaryEmail,
+      })
     : recipient.emailAddress;
 }
 
@@ -126,6 +148,101 @@ function autoResizeTextarea(textarea: HTMLTextAreaElement): void {
   textarea.style.height = "auto";
   const lineHeight = 24;
   textarea.style.height = `${String(Math.min(textarea.scrollHeight, lineHeight * 20))}px`;
+}
+
+function SenderPicker({
+  aliases,
+  selectedAlias,
+  errorMessage,
+  onAliasChange,
+}: SenderPickerProps) {
+  const selectedOption =
+    aliases.find((alias) => alias.alias === selectedAlias) ?? null;
+
+  return (
+    <label className="flex items-start gap-3">
+      <span className="mt-3 w-10 text-sm font-medium text-slate-700">
+        From:
+      </span>
+      <div className="flex-1">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              aria-invalid={errorMessage ? true : undefined}
+              className={cn(
+                "flex min-h-11 w-full items-center justify-between gap-3 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-left shadow-sm transition-colors hover:border-slate-300 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-slate-300",
+                errorMessage ? "border-rose-300 ring-1 ring-rose-200" : "",
+              )}
+            >
+              <span className="min-w-0">
+                {selectedOption ? (
+                  <span className="block min-w-0">
+                    <span className="block truncate text-sm font-medium text-slate-900">
+                      {selectedOption.alias}
+                    </span>
+                    <span className="mt-0.5 block truncate text-xs text-slate-500">
+                      {selectedOption.projectName}
+                    </span>
+                  </span>
+                ) : (
+                  <span className="text-sm text-slate-500">
+                    Choose a sender alias
+                  </span>
+                )}
+              </span>
+              <ChevronDownIcon className="size-4 shrink-0 text-slate-400" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="start"
+            className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-[20rem] rounded-xl p-2"
+          >
+            <DropdownMenuLabel className="px-2 pb-2 pt-1 text-xs uppercase tracking-[0.16em] text-slate-500">
+              Send from
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <DropdownMenuRadioGroup
+              value={selectedAlias ?? ""}
+              onValueChange={(value) => {
+                onAliasChange(value.length > 0 ? value : null);
+              }}
+            >
+              <DropdownMenuRadioItem value="" className="rounded-lg">
+                <div className="flex min-w-0 flex-col">
+                  <span className="text-sm font-medium text-slate-700">
+                    No alias selected
+                  </span>
+                  <span className="text-xs text-slate-500">
+                    Pick a sender before sending
+                  </span>
+                </div>
+              </DropdownMenuRadioItem>
+              {aliases.map((alias) => (
+                <DropdownMenuRadioItem
+                  key={alias.id}
+                  value={alias.alias}
+                  className="rounded-lg"
+                >
+                  <div className="flex min-w-0 flex-col">
+                    <span className="truncate text-sm font-medium text-slate-900">
+                      {alias.alias}
+                    </span>
+                    <span className="truncate text-xs text-slate-500">
+                      {alias.projectName}
+                    </span>
+                  </div>
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        {errorMessage ? (
+          <p className="mt-1 text-xs text-rose-700">{errorMessage}</p>
+        ) : null}
+      </div>
+    </label>
+  );
 }
 
 async function readFileAsAttachment(file: File): Promise<AttachmentDraft> {
@@ -561,41 +678,15 @@ export function InboxComposerDetailPane() {
                   </p>
                 ) : null}
 
-                <label className="flex items-start gap-3">
-                  <span className="mt-2 w-10 text-sm font-medium text-slate-700">
-                    From:
-                  </span>
-                  <div className="flex-1">
-                    <select
-                      value={selectedAlias ?? ""}
-                      onChange={(event) => {
-                        const nextAlias = event.currentTarget.value;
-                        setSelectedAlias(
-                          nextAlias.length > 0 ? nextAlias : null,
-                        );
-                        clearComposerErrors();
-                      }}
-                      className={cn(
-                        "flex h-10 w-full rounded-md border border-slate-200 bg-white px-3 text-sm text-slate-900 shadow-sm focus:outline-none focus:ring-1 focus:ring-slate-300",
-                        aliasError
-                          ? "border-rose-300 ring-1 ring-rose-200"
-                          : "",
-                      )}
-                    >
-                      <option value="">Choose an alias</option>
-                      {composerAliases.map((alias) => (
-                        <option key={alias.id} value={alias.alias}>
-                          {alias.alias} · {alias.projectName}
-                        </option>
-                      ))}
-                    </select>
-                    {aliasError ? (
-                      <p className="mt-1 text-xs text-rose-700">
-                        {aliasError.message}
-                      </p>
-                    ) : null}
-                  </div>
-                </label>
+                <SenderPicker
+                  aliases={composerAliases}
+                  selectedAlias={selectedAlias}
+                  errorMessage={aliasError?.message}
+                  onAliasChange={(nextAlias) => {
+                    setSelectedAlias(nextAlias);
+                    clearComposerErrors();
+                  }}
+                />
 
                 <label className="flex items-start gap-3">
                   <span className="mt-2 w-10 text-sm font-medium text-slate-700">
@@ -716,10 +807,6 @@ export function InboxComposerDetailPane() {
 
               {activeTab === "email" ? (
                 <>
-                  <p className="text-xs text-slate-500">
-                    {formatBytes(attachmentBytes)} of{" "}
-                    {formatBytes(MAX_TOTAL_ATTACHMENT_BYTES)} used
-                  </p>
                   {attachmentError ? (
                     <p className="text-xs text-rose-700">
                       {attachmentError.message}

--- a/apps/web/app/inbox/_components/inbox-composer.tsx
+++ b/apps/web/app/inbox/_components/inbox-composer.tsx
@@ -161,8 +161,8 @@ function SenderPicker({
 
   return (
     <label className="flex items-start gap-3">
-      <span className="mt-3 w-10 text-sm font-medium text-slate-700">
-        From:
+      <span className="mt-3 w-20 text-sm font-medium text-slate-700">
+        Send from:
       </span>
       <div className="flex-1">
         <DropdownMenu>

--- a/apps/web/app/inbox/_lib/composer-ui.ts
+++ b/apps/web/app/inbox/_lib/composer-ui.ts
@@ -56,6 +56,17 @@ function normalizeEmail(value: string): string {
   return value.trim().toLowerCase();
 }
 
+export function formatContactRecipientLabel(input: {
+  readonly displayName: string;
+  readonly primaryEmail: string | null;
+}): string {
+  if (input.primaryEmail === null) {
+    return input.displayName;
+  }
+
+  return `${input.displayName} (${input.primaryEmail})`;
+}
+
 export function resolveTypedEmailRecipient(input: {
   readonly query: string;
   readonly results: readonly {

--- a/apps/web/tests/unit/stage3-composer-ui.test.tsx
+++ b/apps/web/tests/unit/stage3-composer-ui.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { InboxComposerReplyContext } from "../../app/inbox/_lib/view-models";
 import {
+  formatContactRecipientLabel,
   reduceComposerPane,
   resolveTypedEmailRecipient,
   isComposerSendDisabled,
@@ -74,6 +75,22 @@ describe("stage3 composer ui helpers", () => {
         ]
       })
     ).toBeNull();
+  });
+
+  it("formats contact recipients with their email when available", () => {
+    expect(
+      formatContactRecipientLabel({
+        displayName: "Alice Smith",
+        primaryEmail: "alice@example.com"
+      })
+    ).toBe("Alice Smith (alice@example.com)");
+
+    expect(
+      formatContactRecipientLabel({
+        displayName: "Alice Smith",
+        primaryEmail: null
+      })
+    ).toBe("Alice Smith");
   });
 
   it("defaults aliases from the contact project and disables send for missing input", () => {


### PR DESCRIPTION
## What changed
- aligns the composer recipient and sender controls visually using the existing shadcn-style patterns
- stops the `To:` search field from pushing the rest of the composer down
- removes the constant attachment size copy and only surfaces a warning when the limit is exceeded
- shows recipient email addresses next to names for email drafts
- polishes the sender options presentation

## Why
The composer controls felt mismatched and jumpy. This pass makes the sender/recipient surfaces feel like one system and removes low-signal copy that was adding noise.

## Validation
- targeted vitest: `tests/unit/stage3-composer-ui.test.tsx`
- `git diff --check`
