### PR TITLE
[codex] fix project alias worker test expectation

### DIFF
--- a/apps/worker/test/stage1-orchestration.test.ts
+++ b/apps/worker/test/stage1-orchestration.test.ts
@@ -457,6 +457,7 @@ Alias drift outbound message.
         {
           projectId: "project-stage1",
           projectName: "Project Stage 1",
+          projectAlias: null,
           source: "salesforce",
           isActive: false,
           aiKnowledgeUrl: null,


### PR DESCRIPTION
## What changed
- updates the Stage 1 worker orchestration test to expect the new `projectAlias` field on `project_dimensions`

## Why
The project-alias schema change merged in #99, but one worker test was still asserting the old record shape. This follow-up gets `main` back to green without widening the surface.

## Validation
- narrow test expectation update only
- full validation deferred to GitHub CI because local worker vitest in this tmp clone is missing shared package links
