### PR TITLE
fix(inbox): restore Gmail sender labels and widen SF owner cleanup

### DIFF
--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -1452,7 +1452,7 @@ function participantHeaderLabel(headerValue: string | null): string | null {
     return name;
   }
 
-  const emailMatch = trimmed.match(PARTICIPANT_HEADER_EMAIL_PATTERN)?.[0]?.trim();
+  const emailMatch = PARTICIPANT_HEADER_EMAIL_PATTERN.exec(trimmed)?.[0]?.trim();
 
   if (emailMatch !== undefined && emailMatch.length > 0) {
     return emailMatch;

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -1389,7 +1389,19 @@ function timelineActorLabel(
   contactDisplayName: string,
   kind: InboxTimelineEntryKind,
 ): string {
-  if (kind === "inbound-email" || kind === "inbound-sms") {
+  if (kind === "inbound-email") {
+    if (item.family === "one_to_one_email") {
+      const senderLabel = participantHeaderLabel(item.fromHeader ?? null);
+
+      if (senderLabel !== null) {
+        return senderLabel;
+      }
+    }
+
+    return contactDisplayName;
+  }
+
+  if (kind === "inbound-sms") {
     return contactDisplayName;
   }
 
@@ -1416,6 +1428,37 @@ function timelineActorLabel(
     case "salesforce_event":
       return "System";
   }
+}
+
+const PARTICIPANT_HEADER_NAME_PATTERN = /^\s*"?([^"<]+?)"?\s*<[^>]+>\s*$/u;
+const PARTICIPANT_HEADER_EMAIL_PATTERN =
+  /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/iu;
+
+function participantHeaderLabel(headerValue: string | null): string | null {
+  if (headerValue === null) {
+    return null;
+  }
+
+  const trimmed = headerValue.trim();
+
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const nameMatch = PARTICIPANT_HEADER_NAME_PATTERN.exec(trimmed);
+  const name = nameMatch?.[1]?.trim();
+
+  if (name !== undefined && name.length > 0) {
+    return name;
+  }
+
+  const emailMatch = trimmed.match(PARTICIPANT_HEADER_EMAIL_PATTERN)?.[0]?.trim();
+
+  if (emailMatch !== undefined && emailMatch.length > 0) {
+    return emailMatch;
+  }
+
+  return trimmed;
 }
 
 const OUTBOUND_SUBJECT_PREFIX_PATTERN =

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -635,6 +635,55 @@ describe("real inbox selectors", () => {
     });
   });
 
+  it("uses the Gmail From header as the inbound actor label when present", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:shaina-ricky",
+      salesforceContactId: "003-shaina-ricky",
+      displayName: "Shaina Dotson",
+      primaryEmail: "shaina.dotson@gmail.com",
+      primaryPhone: null,
+    });
+    const latestEvent = await seedInboxEmailEvent(runtime.context, {
+      id: "shaina-ricky-latest",
+      contactId: "contact:shaina-ricky",
+      occurredAt: "2026-04-21T15:47:27.000Z",
+      direction: "inbound",
+      subject: "Re: Update on Hex 43191",
+      snippet: "Hi Shaina, Sorry for the delay.",
+      bodyTextPreview: "Hi Shaina, Sorry for the delay.",
+      fromHeader: "Ricky Jones <ricky@adventurescientists.org>",
+      toHeader: "Shaina Dotson <shaina.dotson@gmail.com>",
+      ccHeader: "PNW Forest Biodiversity <pnwbio@adventurescientists.org>",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:shaina-ricky",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-21T15:47:27.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-04-21T15:47:27.000Z",
+      snippet: "Hi Shaina, Sorry for the delay.",
+      lastCanonicalEventId: latestEvent.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+
+    const detail = await getInboxDetail("contact:shaina-ricky");
+    const latestEntry = detail?.timeline.at(-1);
+
+    expect(latestEntry).toMatchObject({
+      kind: "inbound-email",
+      actorLabel: "Ricky Jones",
+      fromHeader: "Ricky Jones <ricky@adventurescientists.org>",
+      toHeader: "Shaina Dotson <shaina.dotson@gmail.com>",
+      ccHeader: "PNW Forest Biodiversity <pnwbio@adventurescientists.org>",
+    });
+  });
+
   it("preserves Stage 1 timeline families instead of flattening them into generic system events", async () => {
     if (runtime === null) {
       throw new Error("Expected inbox test runtime");

--- a/apps/worker/src/ops/cleanup-salesforce-owner-scope.ts
+++ b/apps/worker/src/ops/cleanup-salesforce-owner-scope.ts
@@ -7,9 +7,9 @@
  *   pnpm --filter @as-comms/worker ops cleanup-salesforce-owner-scope --execute
  *
  * Dry-run by default. Looks up the current Salesforce Task owner for every
- * Salesforce outbound email canonical event in the DB and removes the rows
- * whose Task owner is explicitly not Nim Admin. Tasks that Salesforce does not
- * currently resolve are skipped and reported rather than deleted.
+ * Salesforce email canonical event in the DB and removes the rows whose Task
+ * owner is explicitly not Nim Admin. Tasks that Salesforce does not currently
+ * resolve are skipped and reported rather than deleted.
  */
 import { execFile } from "node:child_process";
 import process from "node:process";
@@ -330,7 +330,10 @@ async function loadCleanupCandidates(
       on source_evidence_log.id = canonical_event_ledger.source_evidence_id
     left join salesforce_communication_details
       on salesforce_communication_details.source_evidence_id = canonical_event_ledger.source_evidence_id
-    where canonical_event_ledger.event_type = 'communication.email.outbound'
+    where canonical_event_ledger.event_type in (
+      'communication.email.inbound',
+      'communication.email.outbound'
+    )
       and canonical_event_ledger.provenance ->> 'primaryProvider' = 'salesforce'
       and source_evidence_log.provider = 'salesforce'
       and source_evidence_log.provider_record_type = 'task_communication'
@@ -450,9 +453,7 @@ function printPlanSummary(
   console.log("cleanup-salesforce-owner-scope");
   console.log(`Mode: ${input.dryRun ? "dry-run" : "execute"}`);
   console.log(`- Salesforce target org: ${input.targetOrg}`);
-  console.log(
-    `- scanned Salesforce outbound email rows: ${String(plan.scannedCount)}`,
-  );
+  console.log(`- scanned Salesforce email rows: ${String(plan.scannedCount)}`);
   console.log(`- owner-resolved Task ids: ${String(plan.resolvedCount)}`);
   console.log(`- Nim Admin rows kept: ${String(plan.keepCount)}`);
   console.log(`- non-Nim Admin rows to remove: ${String(plan.removeCount)}`);


### PR DESCRIPTION
## Summary
- show inbound Gmail timeline actor labels from the From header when present
- widen the Salesforce owner-scope cleanup to include inbound and outbound task emails
- add selector coverage for Ricky-style third-party senders

## Testing
- pnpm exec vitest run --config ../../vitest.config.ts tests/unit/inbox-selectors.test.ts
- pnpm exec vitest run --config ../../vitest.config.ts test/stage1-cleanup-salesforce-owner-scope.test.ts