### PR TITLE
fix(inbox): show campaign name/subject in compressed campaign bubbles

### DIFF
--- a/apps/web/app/inbox/_components/inbox-timeline.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline.tsx
@@ -629,8 +629,8 @@ export function shouldHideAutomatedRowBody(input: {
 }): boolean {
   return (
     !input.isExpanded &&
-    input.kind === "outbound-auto-email" &&
-    input.headline !== null
+    ((input.kind === "outbound-auto-email" && input.headline !== null) ||
+      input.kind === "outbound-campaign-email")
   );
 }
 

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -1140,10 +1140,13 @@ function campaignHeadlineAndBody(
 } {
   if (item.family === "campaign_email") {
     const parsedPreview = parseCommunicationPreview(item.snippet);
+    const headline =
+      normalizeInlineText(item.campaignName) ??
+      resolveDisplayableOutboundSubject(parsedPreview.subject);
 
     if (parsedPreview.subject !== null) {
       return {
-        headline: parsedPreview.subject,
+        headline,
         body:
           resolveDisplayableOutboundSubject(parsedPreview.subject) === null
             ? parsedPreview.body
@@ -1159,13 +1162,8 @@ function campaignHeadlineAndBody(
         ? parsedPreview.body
         : (normalizeInlineText(item.summary) ?? "");
 
-    const split = splitHeadlineAndBody(cleaned);
-
     return {
-      headline:
-        split.headline ??
-        normalizeInlineText(item.campaignName) ??
-        normalizeInlineText(item.summary),
+      headline,
       body: cleaned,
     };
   }
@@ -1507,9 +1505,7 @@ function timelineSubject(item: TimelineItem): string | null {
     case "auto_sms":
       return null;
     case "campaign_email":
-      return resolveDisplayableOutboundSubject(
-        parseCommunicationPreview(item.snippet).subject,
-      );
+      return campaignHeadlineAndBody(item).headline;
     case "campaign_sms":
       return campaignHeadlineAndBody(item).headline;
     case "one_to_one_sms":

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -748,7 +748,7 @@ describe("real inbox selectors", () => {
     ]);
     expect(detail?.timeline[1]).toMatchObject({
       kind: "outbound-campaign-email",
-      subject: null,
+      subject: "Spring Kickoff",
       body: "Welcome to the new field season.",
     });
     expect(detail?.timeline[2]).toMatchObject({
@@ -1487,7 +1487,7 @@ describe("real inbox selectors", () => {
     });
   });
 
-  it("uses the best available current headline for campaign email rows and shows the sanitized body when expanded", async () => {
+  it("prefers campaign name for campaign email headlines while keeping the expanded body", async () => {
     if (runtime === null) {
       throw new Error("Expected inbox test runtime");
     }
@@ -1519,7 +1519,7 @@ describe("real inbox selectors", () => {
 
     expect(campaignEntry).toMatchObject({
       kind: "outbound-campaign-email",
-      subject: "April field update",
+      subject: "April Volunteer Update",
       body: "Hi Sarah,\nPlease bring your field notebook.",
       isPreview: true,
       campaignActivity: [],
@@ -1572,13 +1572,13 @@ describe("real inbox selectors", () => {
       detail?.timeline.filter(
         (entry) =>
           entry.kind === "outbound-campaign-email" &&
-          entry.subject === "April field update",
+          entry.subject === "April Volunteer Update",
       ) ?? [];
 
     expect(campaignEntries).toHaveLength(1);
     expect(campaignEntries[0]).toMatchObject({
       kind: "outbound-campaign-email",
-      subject: "April field update",
+      subject: "April Volunteer Update",
       body: "Hi Sarah,\nPlease bring your field notebook.",
     });
     expect(campaignEntries[0]?.campaignActivity.map((activity) => activity.activityType)).toEqual([
@@ -1587,7 +1587,7 @@ describe("real inbox selectors", () => {
     ]);
   });
 
-  it("strips outbound email prefixes from automated and campaign email subjects before display", async () => {
+  it("falls back to stripped campaign subjects when no campaign name exists", async () => {
     if (runtime === null) {
       throw new Error("Expected inbox test runtime");
     }
@@ -1604,7 +1604,7 @@ describe("real inbox selectors", () => {
       contactId: "contact:sarah-martinez",
       occurredAt: "2026-04-12T15:45:00.000Z",
       activityType: "sent",
-      campaignName: "PNW Training",
+      campaignName: null,
       snippet: [
         "From: volunteers@example.org",
         "To: sarah@example.org",
@@ -1619,7 +1619,7 @@ describe("real inbox selectors", () => {
       contactId: "contact:sarah-martinez",
       occurredAt: "2026-04-12T15:50:00.000Z",
       activityType: "sent",
-      campaignName: "Weekly Digest",
+      campaignName: null,
       snippet: [
         "From: volunteers@example.org",
         "To: sarah@example.org",
@@ -1670,7 +1670,7 @@ describe("real inbox selectors", () => {
     });
   });
 
-  it("hides unusable automated and campaign email subjects while keeping meaningful body and embedded URLs", async () => {
+  it("hides unusable automated and campaign email fallback subjects while keeping meaningful body and embedded URLs", async () => {
     if (runtime === null) {
       throw new Error("Expected inbox test runtime");
     }
@@ -1704,7 +1704,7 @@ describe("real inbox selectors", () => {
       contactId: "contact:sarah-martinez",
       occurredAt: "2026-04-12T16:20:00.000Z",
       activityType: "sent",
-      campaignName: "Webinar Push",
+      campaignName: null,
       snippet: [
         "From: volunteers@example.org",
         "To: sarah@example.org",
@@ -1719,7 +1719,7 @@ describe("real inbox selectors", () => {
       contactId: "contact:sarah-martinez",
       occurredAt: "2026-04-12T16:25:00.000Z",
       activityType: "sent",
-      campaignName: "Field Update",
+      campaignName: null,
       snippet: "Welcome to the new field season.",
     });
 
@@ -1792,9 +1792,35 @@ describe("real inbox selectors", () => {
 
     expect(campaignEntry).toMatchObject({
       kind: "outbound-campaign-email",
-      subject: "April field update",
+      subject: "April Volunteer Update",
       body: "",
       isPreview: true,
+    });
+  });
+
+  it("returns null for campaign email headlines when both campaign name and usable subject are missing", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxCampaignEmailEvent(runtime.context, {
+      id: "sarah-campaign-email-empty-fallback",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-12T16:30:00.000Z",
+      activityType: "sent",
+      campaignName: null,
+      snippet: "Body:\nNo explicit subject here, only body copy.",
+    });
+
+    const detail = await getInboxDetail("contact:sarah-martinez");
+    const campaignEntry = detail?.timeline.find(
+      (entry) => entry.id === "timeline:sarah-campaign-email-empty-fallback",
+    );
+
+    expect(campaignEntry).toMatchObject({
+      kind: "outbound-campaign-email",
+      subject: null,
+      body: "No explicit subject here, only body copy.",
     });
   });
 

--- a/apps/web/tests/unit/inbox-stage1-helpers.ts
+++ b/apps/web/tests/unit/inbox-stage1-helpers.ts
@@ -546,7 +546,7 @@ export async function seedInboxCampaignEmailEvent(
     readonly contactId: string;
     readonly occurredAt: string;
     readonly activityType: "sent" | "opened" | "clicked" | "unsubscribed";
-    readonly campaignName: string;
+    readonly campaignName: string | null;
     readonly campaignId?: string;
     readonly snippet: string;
   },
@@ -615,7 +615,7 @@ export async function seedInboxCampaignEmailEvent(
     occurredAt: input.occurredAt,
     sortKey: `${input.occurredAt}::${canonicalEventId}`,
     eventType,
-    summary: input.campaignName,
+    summary: input.campaignName ?? input.campaignId ?? "Campaign email",
     channel: "campaign_email",
     primaryProvider: "mailchimp",
     reviewState: "clear",

--- a/apps/web/tests/unit/inbox-timeline.test.ts
+++ b/apps/web/tests/unit/inbox-timeline.test.ts
@@ -84,7 +84,7 @@ describe("InboxTimeline", () => {
     );
   });
 
-  it("keeps campaign email body text visible when the row is collapsed", () => {
+  it("keeps campaign email rows collapsed to the resolved headline only", () => {
     const markup = renderToStaticMarkup(
       createElement(InboxTimeline, {
         entries: [
@@ -92,7 +92,7 @@ describe("InboxTimeline", () => {
             ...baseEntry,
             id: "timeline:campaign-email-1",
             kind: "outbound-campaign-email" as const,
-            subject: null,
+            subject: "Your Adventure Awaits",
             body: "Please review the latest field update.",
           },
         ],
@@ -102,7 +102,8 @@ describe("InboxTimeline", () => {
     );
 
     expect(markup).toContain("Campaign");
-    expect(markup).toContain("Please review the latest field update.");
+    expect(markup).toContain("Your Adventure Awaits");
+    expect(markup).not.toContain("Please review the latest field update.");
     expect(markup).not.toContain("rounded-full border px-2 py-1");
   });
 
@@ -189,7 +190,7 @@ describe("InboxTimeline", () => {
         kind: "outbound-campaign-email",
         headline: "April field update",
       }),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       shouldHideAutomatedRowBody({
         isExpanded: false,


### PR DESCRIPTION
## Summary

Compressed campaign-email bubbles were showing body copy (e.g. snippet text or the bot-prefixed preview) as the headline. This change resolves the compressed-state headline as:

1. `campaignName` if present
2. Stripped outbound subject if usable (handles the `→ Email:` prefix + pure-URL subject suppression)
3. Otherwise — no extra headline (falls back to the row's generic label)

The expanded state is unchanged — body still renders.

## Why

Per the architect diagnosis on 2026-04-23, the compressed form was leaking body copy where an operator expects a recognizable campaign identity. Tracked in \`.codex-campaign-bubble-headline-2026-04-23.md\`.

## Files

- \`apps/web/app/inbox/_lib/selectors.ts\` — \`campaignHeadlineAndBody\` + \`timelineSubject\`
- \`apps/web/app/inbox/_components/inbox-timeline.tsx\` — \`shouldHideAutomatedRowBody\` now collapses campaign body in the compressed state
- Unit tests in \`apps/web/tests/unit/inbox-selectors.test.ts\` and \`inbox-timeline.test.ts\`

## Test plan

- [x] Targeted vitest: \`pnpm --filter @as-comms/web exec vitest run --config ../../vitest.config.ts tests/unit/inbox-selectors.test.ts tests/unit/inbox-timeline.test.ts\` passes locally
- [ ] CI full suite passes
- [ ] Visual check: compressed campaign row shows campaign name (or stripped subject) — no body copy in the headline

🤖 Generated with [Claude Code](https://claude.com/claude-code)