### PR TITLE
fix(sf-capture): structured error logging on /live and sibling handlers

### DIFF
--- a/apps/salesforce-capture/src/index.ts
+++ b/apps/salesforce-capture/src/index.ts
@@ -253,6 +253,74 @@ function readServiceVersion(env: NodeJS.ProcessEnv): string | null {
   return trimmed && trimmed.length > 0 ? trimmed : null;
 }
 
+function parseRequestBodyForLogging(bodyText: string): unknown {
+  if (bodyText.trim().length === 0) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(bodyText) as unknown;
+  } catch {
+    return bodyText;
+  }
+}
+
+function getErrorDetails(error: unknown): {
+  readonly errorName: string;
+  readonly errorMessage: string;
+  readonly errorStack: string | null;
+} {
+  return {
+    errorName:
+      error instanceof Error ? error.constructor.name : typeof error,
+    errorMessage: error instanceof Error ? error.message : String(error),
+    errorStack: error instanceof Error ? (error.stack ?? null) : null
+  };
+}
+
+function getSalesforceCaptureErrorEvent(path: string): string {
+  switch (path) {
+    case "/live":
+      return "salesforce_capture.live.error";
+    case "/historical":
+      return "salesforce_capture.historical.error";
+    case "/health":
+      return "salesforce_capture.health.error";
+    default:
+      return "salesforce_capture.request.error";
+  }
+}
+
+function logSalesforceCaptureRequestError(input: {
+  readonly error: unknown;
+  readonly method: string;
+  readonly path: string;
+  readonly requestBody: unknown;
+}): {
+  readonly errorName: string;
+  readonly errorMessage: string;
+} {
+  const { errorName, errorMessage, errorStack } = getErrorDetails(input.error);
+
+  console.error(
+    JSON.stringify({
+      event: getSalesforceCaptureErrorEvent(input.path),
+      errorName,
+      errorMessage,
+      errorStack,
+      requestMethod: input.method,
+      requestPath: input.path,
+      requestBody: input.requestBody,
+      occurredAt: new Date().toISOString()
+    })
+  );
+
+  return {
+    errorName,
+    errorMessage
+  };
+}
+
 export async function handleSalesforceHealthRequest(
   config: SalesforceCaptureRuntimeConfig,
   input?: {
@@ -284,8 +352,11 @@ export async function startSalesforceCaptureServer(
     request: IncomingMessage,
     response: ServerResponse
   ): Promise<void> {
+    let path = "/";
+    let requestBody: unknown = null;
+
     try {
-      const path = new URL(
+      path = new URL(
         request.url ?? "/",
         "http://salesforce-capture.local"
       ).pathname;
@@ -303,20 +374,30 @@ export async function startSalesforceCaptureServer(
       }
 
       const bodyText = await readRequestBody(request);
+      requestBody = parseRequestBodyForLogging(bodyText);
       const serviceResponse = await service.handleHttpRequest(
         createHttpRequest(request, bodyText)
       );
       writeResponse(response, serviceResponse);
     } catch (error) {
-      console.error("Salesforce capture request failed.");
-      console.error(error instanceof Error ? error.message : String(error));
+      const { errorName, errorMessage } = logSalesforceCaptureRequestError({
+        error,
+        method: request.method ?? "GET",
+        path,
+        requestBody
+      });
+
       writeResponse(response, {
         status: 500,
         headers: {
           "content-type": "application/json; charset=utf-8"
         },
         body: JSON.stringify({
-          error: "internal_error"
+          ok: false,
+          error: {
+            name: errorName,
+            message: errorMessage
+          }
         })
       });
     }

--- a/apps/salesforce-capture/test/server.test.ts
+++ b/apps/salesforce-capture/test/server.test.ts
@@ -1,0 +1,155 @@
+import { createServer } from "node:net";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type * as IntegrationsModule from "@as-comms/integrations";
+
+const { createSalesforceCaptureServiceMock } = vi.hoisted(() => ({
+  createSalesforceCaptureServiceMock: vi.fn()
+}));
+
+vi.mock("@as-comms/integrations", async () => {
+  const actual =
+    await vi.importActual<typeof IntegrationsModule>(
+      "@as-comms/integrations"
+    );
+
+  return {
+    ...actual,
+    createSalesforceCaptureService: createSalesforceCaptureServiceMock
+  };
+});
+
+import {
+  readSalesforceCaptureRuntimeConfig,
+  startSalesforceCaptureServer
+} from "../src/index.js";
+
+function createConfig(port: number) {
+  return readSalesforceCaptureRuntimeConfig({
+    HOST: "127.0.0.1",
+    PORT: String(port),
+    SALESFORCE_CAPTURE_TOKEN: "salesforce-token",
+    SALESFORCE_LOGIN_URL: "https://test.salesforce.com",
+    SALESFORCE_CLIENT_ID: "salesforce-client-id",
+    SALESFORCE_USERNAME: "worker@example.org",
+    SALESFORCE_JWT_PRIVATE_KEY: `-----BEGIN PRIVATE KEY-----
+MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAOpC2YU1CUgOjNp+
+U8vch5eul83Qjq3IKkWWRQIfHualLi+CKRdYGpqZX+qis+rN3vA2VkY4ykKxtveQ
+nVl0lJVCb36QDDd96dTMZrcdrGvXHLP1dMfSZHRPmtGuysB5LYlF8viWMxvV7kiS
+a1xSTGS3KfikGuzLrEZpYYP/qGFxAgMBAAECgYA5sTT4xVL/1/WAadQhRLJv/KOO
+IGrDCaS/dn6QQzHNA6kYMioEgcIriNJCasd8cC8TYY5lxN6rBjFVTtwxh7B/iTGu
+xdsfUkWbmubU7le7KfDLe2kOYmm9qxH3aMCxhiTAnkTOrZ1hZfpjVrQYuR19aXU6
+IUMLF4Ph4t5K+4jPcQJBAPqidE+1FBO3A5rxeYBOL2BY8c1U8DG2Z3MMEpArJwRk
+tVeBftejaybo/T3bsylHk6Mw3YqHbIa6uGyqDpq72jsCQQDvRqoThKxOhZU6zyUK
+/YW3WinixUcsEPWgvCI9pXa09F7kJIB+m6IqO+Y+zvzjYnwUHx2pYxZGnAI864R3
+EoxDAkEA+DDbQPst0IAQ/+RTzyydWal6eTy9Rl08f/7aew1ga8dWlDrV4rAfMb7S
+1+ixuBT7LET9fWqxm5FXg7O7FpsjdQJABJXuHIGma7rTqVTe+N7y+RiZROdS/d01
+V+dDILtTExS73NN2QvbonLaZKwr8fb8dcaVHBEAJ5UCIKnK5Dy8j0QJBAKhVH0mU
+PZpRE1PvSL887gSHwWFelB7BlDbijc2M5fKrPC2KO/hJhg0wgnzVE1/UGwKWSSDX
+ZsMs9ff6x7BET58=
+-----END PRIVATE KEY-----`,
+    SALESFORCE_CONTACT_CAPTURE_MODE: "cdc_compatible",
+    SALESFORCE_MEMBERSHIP_CAPTURE_MODE: "delta_polling"
+  });
+}
+
+async function getAvailablePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+
+      if (address === null || typeof address === "string") {
+        reject(new Error("Failed to resolve an available port."));
+        return;
+      }
+
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve(address.port);
+      });
+    });
+  });
+}
+
+afterEach(() => {
+  createSalesforceCaptureServiceMock.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe("Salesforce capture server", () => {
+  it("logs structured details and returns diagnostic 500 bodies for live request failures", async () => {
+    const port = await getAvailablePort();
+    const serviceError = new TypeError("Salesforce live failure");
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    createSalesforceCaptureServiceMock.mockReturnValue({
+      handleHttpRequest: vi.fn(() => {
+        throw serviceError;
+      })
+    });
+
+    const server = await startSalesforceCaptureServer(createConfig(port));
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${String(port)}/live`, {
+        method: "POST",
+        headers: {
+          authorization: "Bearer salesforce-token",
+          "content-type": "application/json"
+        },
+        body: JSON.stringify({
+          jobId: "job:salesforce:live:1"
+        })
+      });
+
+      expect(response.status).toBe(500);
+      await expect(response.json()).resolves.toEqual({
+        ok: false,
+        error: {
+          name: "TypeError",
+          message: "Salesforce live failure"
+        }
+      });
+
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+
+      const loggedError = JSON.parse(
+        String(consoleErrorSpy.mock.calls[0]?.[0] ?? "")
+      ) as Record<string, unknown>;
+
+      expect(loggedError).toMatchObject({
+        event: "salesforce_capture.live.error",
+        errorName: "TypeError",
+        errorMessage: "Salesforce live failure",
+        requestMethod: "POST",
+        requestPath: "/live",
+        requestBody: {
+          jobId: "job:salesforce:live:1"
+        }
+      });
+      expect(loggedError.errorStack).toBe(serviceError.stack);
+      expect(typeof loggedError.occurredAt).toBe("string");
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      });
+    }
+  });
+});

--- a/packages/integrations/src/capture-services/salesforce.ts
+++ b/packages/integrations/src/capture-services/salesforce.ts
@@ -1657,9 +1657,7 @@ export function createSalesforceCaptureService(
           });
         }
 
-        return jsonResponse(500, {
-          error: "internal_error",
-        });
+        throw error;
       }
     },
   };

--- a/packages/integrations/test/stage1-salesforce-capture-service.test.ts
+++ b/packages/integrations/test/stage1-salesforce-capture-service.test.ts
@@ -268,6 +268,48 @@ describe("Salesforce capture service", () => {
     expect(queryCount).toBe(0);
   });
 
+  it("rethrows unknown live request failures for caller-level logging", async () => {
+    const service = createSalesforceCaptureService(
+      createSalesforceServiceConfig(),
+      {
+        apiClient: {
+          queryAll: () => {
+            throw new Error("Salesforce query failed");
+          },
+        },
+      },
+    );
+
+    await expect(
+      service.handleHttpRequest({
+        method: "POST",
+        path: "/live",
+        headers: {
+          authorization: "Bearer salesforce-token",
+        },
+        bodyText: JSON.stringify({
+          version: 1,
+          jobId: "job:salesforce:live:1",
+          correlationId: "corr:salesforce:live:1",
+          traceId: null,
+          batchId: "batch:salesforce:live:1",
+          syncStateId: "sync:salesforce:live:1",
+          attempt: 1,
+          maxAttempts: 3,
+          provider: "salesforce",
+          mode: "live",
+          jobType: "live_ingest",
+          cursor: null,
+          checkpoint: null,
+          windowStart: "2026-01-01T00:00:00.000Z",
+          windowEnd: "2026-01-06T00:00:00.000Z",
+          recordIds: [],
+          maxRecords: 25,
+        }),
+      }),
+    ).rejects.toThrow("Salesforce query failed");
+  });
+
   it("returns launch-scope Salesforce Contact, Expedition_Members__c, and Task records in the worker-facing provider-close shape", async () => {
     const queries: string[] = [];
     const baseApiClient = createFakeSalesforceApiClient();


### PR DESCRIPTION
## Summary

Diagnostic-only PR. Wraps Salesforce capture request handlers with structured error logging so the next 500 surfaces the actual exception in Railway logs. No behavior change.

## Why

Salesforce `/live` has been returning 500 on every worker poll since **2026-04-22 19:20 UTC** (360+ failed attempts). Railway logs from `salesforce-capture` only show startup output — the real exception is invisible. Before we can fix the regression we need to see what's actually throwing.

## Changes

- `apps/salesforce-capture/src/index.ts` — every request that 500s now emits:
  ```json
  {"event":"salesforce_capture.{path}.error","errorName":"...","errorMessage":"...","errorStack":"...","requestMethod":"POST","requestPath":"/live","requestBody":{...},"occurredAt":"..."}
  ```
  Response body on 500 is now `{ ok: false, error: { name, message } }` so the worker's `Provider capture request failed with status 500 for /live` log will include the message too.
- `packages/integrations/src/capture-services/salesforce.ts` — stop swallowing unknown `/live` / `/historical` failures as bare `internal_error`. 400 validation paths unchanged. Real exceptions now bubble to the app-level catch so the structured log fires.
- Tests for both surfaces.

## Test plan

- [x] `pnpm --filter @as-comms/salesforce-capture exec vitest run test/server.test.ts` passes (1/1)
- [x] `pnpm --filter @as-comms/integrations exec vitest run test/stage1-salesforce-capture-service.test.ts` passes (16/16)
- [x] `pnpm --filter @as-comms/salesforce-capture lint` clean
- [x] `pnpm --filter @as-comms/salesforce-capture typecheck` clean
- [ ] CI verify green
- [ ] After merge + Railway redeploy: `railway logs --service salesforce-capture` emits the structured JSON on next 500

## Post-merge handoff

1. Railway auto-redeploys on main merge
2. Within ~5 min the next `poll-salesforce-live` hits `/live` and 500s again with the new logged detail
3. Architect reads the JSON error line, dispatches targeted root-cause fix

## Out of scope

- Does NOT fix the 500 — diagnostic only
- Does NOT touch Gmail capture (separate regression, separate fix)

Related brief: `.codex-sf-live-debug-2026-04-24.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)