### PR TITLE
fix(sf-capture): include SF response body + SOQL in queryAll error

### DIFF
--- a/packages/integrations/src/capture-services/salesforce.ts
+++ b/packages/integrations/src/capture-services/salesforce.ts
@@ -662,8 +662,10 @@ export function createSalesforceApiClient(
         });
 
         if (!response.ok) {
+          const errorBodyText = await response.text();
+          const errorBodyPreview = errorBodyText.slice(0, 1000);
           throw new Error(
-            `Salesforce query failed with status ${String(response.status)}.`,
+            `Salesforce query failed with status ${String(response.status)}. Body: ${errorBodyPreview}. SOQL: ${soql.slice(0, 500)}`,
           );
         }
 


### PR DESCRIPTION
Follow-up to #111. PR #111 surfaced the structured error but only as 'status 400' — the actual Salesforce error body (which explains the 400) was discarded in the throw. This patch captures the first 1000 chars of the SF response body and the first 500 of the offending SOQL in the thrown error message, so the next poll will log the real SF complaint.

Diagnostic-only. No behavior change. Merge ASAP so we can read the real error within 5 min of Railway redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)