### PR TITLE
fix(sf-capture): simplify launch-scope Task WHERE \u2014 unblocks /live 500s

### DIFF
--- a/packages/integrations/src/capture-services/salesforce.ts
+++ b/packages/integrations/src/capture-services/salesforce.ts
@@ -777,7 +777,7 @@ function buildEmailLikeTaskWhere(
   const emailChannelClauses = config.taskEmailChannelValues.map(
     (value) => `${config.taskChannelField} = ${quoteSoqlString(value)}`,
   );
-  const subjectDerivedEmailClause = `(${config.taskChannelField} = ${quoteSoqlString("Task")} AND Subject LIKE '%Email:%')`;
+  const subjectDerivedEmailClause = `${config.taskChannelField} = ${quoteSoqlString("Task")} AND Subject LIKE '%Email:%'`;
 
   return [...emailChannelClauses, subjectDerivedEmailClause]
     .map((clause) => `(${clause})`)
@@ -796,11 +796,16 @@ function buildLaunchScopedTaskWhere(
 ): string {
   const volunteerScopedWhere = buildVolunteerScopedTaskWhere(baseWhere, config);
   const emailLikeTaskWhere = buildEmailLikeTaskWhere(config);
+  const ownerIsLaunchScope = buildLaunchScopeEmailTaskOwnerWhere();
 
   // D-039: volunteer-linked Salesforce email Tasks are captured only when they
   // come from the Nim Admin automation owner. Non-email Task shapes keep the
-  // prior launch-scope behavior.
-  return `${volunteerScopedWhere} AND (NOT (${emailLikeTaskWhere}) OR ((${emailLikeTaskWhere}) AND ${buildLaunchScopeEmailTaskOwnerWhere()}))`;
+  // prior launch-scope behavior. Logic: include a Task if it is NOT
+  // email-like, OR it is email-like AND owned by an automation owner. That
+  // simplifies to `NOT emailLike OR ownerIsLaunchScope`, which avoids the
+  // redundant paren nesting that tripped SOQL's WHERE-clause depth limit
+  // (MALFORMED_QUERY observed 2026-04-22 onward).
+  return `${volunteerScopedWhere} AND (NOT (${emailLikeTaskWhere}) OR ${ownerIsLaunchScope})`;
 }
 
 function buildTaskWindowWhere(


### PR DESCRIPTION
## Summary

**Root-cause fix for SF live ingest.** `/live` has been returning 500 since **2026-04-22 19:20 UTC** (~400 failed poll attempts). PR #111 surfaced the error, PR #112 exposed the body, this fixes it.

## What SF said

```json
{
  "errorCode": "MALFORMED_QUERY",
  "message": "unexpected token: 'OR' at Row:1:Column:438"
}
```

The generated SOQL had this WHERE fragment:

```
AND (NOT ((TaskSubtype = 'Email') OR ((TaskSubtype = 'Task' AND Subject LIKE '%Email:%')))
     OR (((TaskSubtype = 'Email') OR ((TaskSubtype = 'Task' AND Subject LIKE '%Email:%'))) 
         AND Owner.Username IN (...)))
```

SOQL has a WHERE-clause nesting depth limit. The doubled-negation pattern `NOT X OR (X AND Y)` combined with extra parens from `buildEmailLikeTaskWhere` pre-wrapping an already-parenthesized subject clause hit the limit at column 438.

## Fix

Two small changes in `packages/integrations/src/capture-services/salesforce.ts`:

1. **`buildEmailLikeTaskWhere`** — stop pre-parenthesizing the `subjectDerivedEmailClause`. The `.map((clause) => \`(\${clause})\`)` already wraps each clause once; the inner pre-wrapping doubled it.

2. **`buildLaunchScopedTaskWhere`** — logically simplify `NOT (emailLike) OR (emailLike AND owner)` to `NOT (emailLike) OR owner`. Proof: `NOT X OR (X AND Y)` = `(NOT X OR X) AND (NOT X OR Y)` = `TRUE AND (NOT X OR Y)`. Both mean \"include non-email Tasks always, and email Tasks only when owned by a launch-scope automation account.\"

## Test plan

- [x] All 16 existing `stage1-salesforce-capture-service` tests still pass
- [x] `pnpm --filter @as-comms/integrations lint` clean
- [x] `pnpm --filter @as-comms/integrations typecheck` clean
- [ ] CI verify green
- [ ] After merge + Railway redeploy: SF live ingest resumes within 5 min

## Follow-up

After merge, the first successful SF poll will try to ingest **~32 hours of Task records** (window_start stuck at 2026-04-22T19:15Z since the breakage). If that single poll hits a row-count limit, the worker's retry logic should narrow the window automatically; if not, I'll reset the window manually.

Related: #111, #112 diagnostic PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)