### PR TITLE
fix(sf-capture): push NOT to leaf predicates via De Morgan — unblocks /live

### DIFF
--- a/packages/integrations/src/capture-services/salesforce.ts
+++ b/packages/integrations/src/capture-services/salesforce.ts
@@ -771,17 +771,22 @@ function buildVolunteerScopedTaskWhere(
   return `${baseWhere} AND ${config.taskContactField} IN (SELECT ${config.membershipContactField} FROM ${config.membershipObjectName} WHERE ${config.membershipContactField} != null)`;
 }
 
-function buildEmailLikeTaskWhere(
+function buildNotEmailLikeTaskWhere(
   config: ResolvedSalesforceCaptureServiceConfig,
 ): string {
-  const emailChannelClauses = config.taskEmailChannelValues.map(
-    (value) => `${config.taskChannelField} = ${quoteSoqlString(value)}`,
+  // De Morgan's: NOT (subtype='Email' OR (subtype='Task' AND subject LIKE '%Email:%'))
+  // = (subtype != 'Email') AND (subtype != 'Task' OR NOT subject LIKE '%Email:%')
+  // Pushing NOT down to leaves avoids SOQL's rejection of NOT applied to a
+  // parenthesized OR group (MALFORMED_QUERY at runtime, confirmed via live
+  // probes 2026-04-24).
+  const notChannelEmailClauses = config.taskEmailChannelValues.map(
+    (value) => `${config.taskChannelField} != ${quoteSoqlString(value)}`,
   );
-  const subjectDerivedEmailClause = `${config.taskChannelField} = ${quoteSoqlString("Task")} AND Subject LIKE '%Email:%'`;
+  const notSubjectDerivedEmailClause = `(${config.taskChannelField} != ${quoteSoqlString("Task")} OR (NOT Subject LIKE '%Email:%'))`;
 
-  return [...emailChannelClauses, subjectDerivedEmailClause]
-    .map((clause) => `(${clause})`)
-    .join(" OR ");
+  return [...notChannelEmailClauses, notSubjectDerivedEmailClause].join(
+    " AND ",
+  );
 }
 
 function buildLaunchScopeEmailTaskOwnerWhere(): string {
@@ -795,17 +800,15 @@ function buildLaunchScopedTaskWhere(
   config: ResolvedSalesforceCaptureServiceConfig,
 ): string {
   const volunteerScopedWhere = buildVolunteerScopedTaskWhere(baseWhere, config);
-  const emailLikeTaskWhere = buildEmailLikeTaskWhere(config);
+  const notEmailLikeTaskWhere = buildNotEmailLikeTaskWhere(config);
   const ownerIsLaunchScope = buildLaunchScopeEmailTaskOwnerWhere();
 
   // D-039: volunteer-linked Salesforce email Tasks are captured only when they
   // come from the Nim Admin automation owner. Non-email Task shapes keep the
-  // prior launch-scope behavior. Logic: include a Task if it is NOT
-  // email-like, OR it is email-like AND owned by an automation owner. That
-  // simplifies to `NOT emailLike OR ownerIsLaunchScope`, which avoids the
-  // redundant paren nesting that tripped SOQL's WHERE-clause depth limit
-  // (MALFORMED_QUERY observed 2026-04-22 onward).
-  return `${volunteerScopedWhere} AND (NOT (${emailLikeTaskWhere}) OR ${ownerIsLaunchScope})`;
+  // prior launch-scope behavior. Expressed as (NOT emailLike) OR ownerMatch,
+  // with the NOT expanded via De Morgan into positive leaf predicates so
+  // SOQL accepts it.
+  return `${volunteerScopedWhere} AND ((${notEmailLikeTaskWhere}) OR ${ownerIsLaunchScope})`;
 }
 
 function buildTaskWindowWhere(


### PR DESCRIPTION
## Summary

Follow-up to #113. That PR simplified the WHERE to \`NOT (emailLike) OR owner\`, but SF's parser still rejected it with \`unexpected token: 'OR' at Column:436\`. SF's NOT apparently doesn't compose cleanly with an outer OR when applied to any parenthesized group.

## Live probe against SF proved the shape

With an API probe from the deployed capture service's creds:

| Probe | Shape | Result |
|---|---|---|
| A | `NOT (subtype='Email' OR (subtype='Task' AND subject LIKE '%Email:%')) OR owner` | **400 MALFORMED_QUERY** |
| B | De Morgan: `(subtype != 'Email' AND (subtype != 'Task' OR NOT subject LIKE '%Email:%')) OR owner` | **200 ✓** |
| C | Positive enumeration (`subtype = 'Call' OR ...`) | 200 ✓ but wrong semantic |
| D | `NOT subtype = 'Email' OR owner` | **400** |

So NOT must live on leaf predicates, not on any OR'd group.

## Fix

Replace \`buildEmailLikeTaskWhere\` with \`buildNotEmailLikeTaskWhere\` which pre-expands the negation via De Morgan:

\`\`\`
NOT (subtype='Email' OR (subtype='Task' AND subject LIKE '%Email:%'))
= (subtype != 'Email') AND (subtype != 'Task' OR NOT subject LIKE '%Email:%')
\`\`\`

Emitted SOQL:
\`\`\`
... AND ((TaskSubtype != 'Email' AND (TaskSubtype != 'Task' OR (NOT Subject LIKE '%Email:%'))) OR Owner.Username IN (...))
\`\`\`

Semantic equivalent to D-039: include non-email-like Tasks always; include email-like Tasks only when owned by a launch-scope automation.

## Test plan

- [x] All 16 \`stage1-salesforce-capture-service\` tests still pass
- [x] Live SF probe with the new shape returns records (tested as probe B above)
- [x] \`pnpm --filter @as-comms/integrations lint\` clean
- [x] \`pnpm --filter @as-comms/integrations typecheck\` clean
- [ ] CI verify green
- [ ] After merge + Railway redeploy: SF \`/live\` returns records, \`sync_state\` row transitions to \`succeeded\`, 32h backlog clears

Related: #111, #112, #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)