### PR TITLE
fix(inbox): read-state, unanswered dot, label/sort match, follow-up refresh

### DIFF
--- a/apps/web/app/inbox/_components/icons.tsx
+++ b/apps/web/app/inbox/_components/icons.tsx
@@ -58,4 +58,6 @@ export {
   FileIcon as FileDocIcon,
   Eye as EyeIcon,
   MousePointerClick as MousePointerClickIcon,
+  Flag as FlagIcon,
+  MailOpen as MailOpenIcon,
 } from "lucide-react";

--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import {
   useCallback,
   useEffect,
@@ -20,6 +21,8 @@ import { cn } from "@/lib/utils";
 import {
   clearInboxNeedsFollowUpAction,
   markInboxNeedsFollowUpAction,
+  markInboxOpenedAction,
+  markInboxUnreadAction,
   sendComposerAction,
 } from "../actions";
 import { fetchInboxTimelinePage } from "../_lib/client-api";
@@ -47,7 +50,8 @@ import {
   ChevronDownIcon,
   ChevronUpIcon,
   ClockIcon,
-  CornerUpLeftIcon,
+  FlagIcon,
+  MailOpenIcon,
   PanelRightOpenIcon,
   XIcon,
 } from "./icons";
@@ -190,6 +194,40 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
       [contact.contactId],
     ),
   });
+  const router = useRouter();
+  const [isMarkUnreadPending, startMarkUnreadTransition] = useTransition();
+  const markOpenedRef = useRef(false);
+
+  // Flip bucket to "Opened" on first mount of a detail view whose server-
+  // state is still "New". The ref prevents re-firing if the effect re-runs
+  // (e.g., router.refresh swapping the detail prop). User-initiated
+  // "Mark as unread" goes through `handleMarkUnread` below, which also
+  // closes the detail, so we won't immediately re-mark as opened.
+  useEffect(() => {
+    if (markOpenedRef.current || detail.bucket !== "new") {
+      return;
+    }
+    markOpenedRef.current = true;
+    const formData = new FormData();
+    formData.set("contactId", contact.contactId);
+    void markInboxOpenedAction(formData).then((result) => {
+      if (result.ok) {
+        router.refresh();
+      }
+    });
+  }, [contact.contactId, detail.bucket, router]);
+
+  const handleMarkUnread = useCallback(() => {
+    startMarkUnreadTransition(async () => {
+      const formData = new FormData();
+      formData.set("contactId", contact.contactId);
+      const result = await markInboxUnreadAction(formData);
+      if (result.ok) {
+        router.push("/inbox");
+      }
+    });
+  }, [contact.contactId, router]);
+
   const activeProject = contact.activeProjects[0] ?? null;
   const firstName = contact.displayName.split(" ")[0] ?? contact.displayName;
   const isFollowUp = followUpToggle.value;
@@ -317,6 +355,20 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
               error={followUpToggle.error}
               onToggle={followUpToggle.toggle}
             />
+
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={isMarkUnreadPending}
+              onClick={handleMarkUnread}
+              aria-label="Mark as unread"
+              className="gap-1.5"
+              data-inbox-mark-unread="true"
+            >
+              <MailOpenIcon className="h-3.5 w-3.5" />
+              Mark as unread
+            </Button>
 
             <Popover open={reminderOpen} onOpenChange={setReminderOpen}>
               <PopoverTrigger asChild>
@@ -487,7 +539,7 @@ function FollowUpToggleButton({
           "border-rose-300 bg-rose-50 text-rose-800 hover:bg-rose-100 hover:text-rose-800",
       )}
     >
-      <CornerUpLeftIcon className="h-3.5 w-3.5" />
+      <FlagIcon className="h-3.5 w-3.5" />
       Needs Follow-Up
     </Button>
   );
@@ -502,6 +554,7 @@ function useOptimisticBooleanToggle({
   readonly value: boolean;
   readonly perform: (nextValue: boolean) => Promise<UiResult<unknown>>;
 }) {
+  const router = useRouter();
   const serverValueRef = useRef(value);
   const [committedValue, setCommittedValue] = useState(value);
   const [error, setError] = useState<UiError | null>(null);
@@ -528,13 +581,17 @@ function useOptimisticBooleanToggle({
       if (result.ok) {
         serverValueRef.current = nextValue;
         setCommittedValue(nextValue);
+        // Re-render the RSC tree so the inbox list row reflects the new
+        // value. Layout is `force-dynamic` (D-040), so this is a real
+        // refetch, not a cache hit.
+        router.refresh();
         return;
       }
 
       setCommittedValue(serverValueRef.current);
       setError(result);
     });
-  }, [optimisticValue, perform, setOptimisticValue]);
+  }, [optimisticValue, perform, router, setOptimisticValue]);
 
   return {
     value: optimisticValue,

--- a/apps/web/app/inbox/_components/inbox-row.tsx
+++ b/apps/web/app/inbox/_components/inbox-row.tsx
@@ -24,6 +24,10 @@ export function InboxRow({ item, isActive }: RowProps) {
   const router = useRouter();
   const prefetchedRef = useRef(false);
   const isUnread = item.bucket === "new";
+  // Dot appears when the thread needs operator attention: either unread
+  // (border line also appears) or opened-but-unanswered (only the dot).
+  // When both apply (fresh inbound, not yet opened), both show.
+  const showAttentionDot = isUnread || item.isUnanswered;
   const ChannelIcon = item.latestChannel === "email" ? MailIcon : PhoneIcon;
   const href = `/inbox/${encodeURIComponent(item.contactId)}`;
 
@@ -31,7 +35,7 @@ export function InboxRow({ item, isActive }: RowProps) {
     Boolean(item.projectLabel) ||
     item.needsFollowUp ||
     item.hasUnresolved ||
-    item.unreadCount > 0;
+    showAttentionDot;
 
   const prefetchDetail = useCallback(() => {
     if (prefetchedRef.current) {
@@ -125,10 +129,11 @@ export function InboxRow({ item, isActive }: RowProps) {
                   Review
                 </span>
               ) : null}
-              {item.unreadCount > 0 ? (
-                <span className="ml-auto inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-sky-600 px-1 text-[10px] font-semibold text-white tabular-nums">
-                  {item.unreadCount}
-                </span>
+              {showAttentionDot ? (
+                <span
+                  aria-label={isUnread ? "Unread" : "Unanswered"}
+                  className="ml-auto inline-block h-2 w-2 rounded-full bg-sky-600"
+                />
               ) : null}
             </div>
           ) : null}

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -2313,12 +2313,17 @@ function toListItemViewModel(
     needsFollowUp: row.inboxProjection.needsFollowUp,
     hasUnresolved: row.inboxProjection.hasUnresolved,
     unreadCount: row.inboxProjection.bucket === "New" ? 1 : 0,
+    isUnanswered:
+      row.inboxProjection.lastInboundAt !== null &&
+      (row.inboxProjection.lastOutboundAt === null ||
+        row.inboxProjection.lastInboundAt >
+          row.inboxProjection.lastOutboundAt),
     lastInboundAt: row.inboxProjection.lastInboundAt,
     lastOutboundAt: row.inboxProjection.lastOutboundAt,
     lastActivityAt: row.inboxProjection.lastActivityAt,
     lastEventType: row.inboxProjection.lastEventType,
     lastActivityLabel: formatRelativeTimestamp(
-      row.inboxProjection.lastActivityAt,
+      row.inboxProjection.lastInboundAt ?? row.inboxProjection.lastActivityAt,
       referenceNowIso,
     ),
   };

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -65,6 +65,12 @@ export interface InboxListItemViewModel {
   readonly needsFollowUp: boolean;
   readonly hasUnresolved: boolean;
   readonly unreadCount: number;
+  /**
+   * True when the last inbound is newer than the last outbound (or no outbound
+   * exists), regardless of bucket. Drives the "unanswered" dot indicator on
+   * the row: a thread the operator has opened but hasn't replied to yet.
+   */
+  readonly isUnanswered: boolean;
 
   // ── Sort / display ──
   readonly lastInboundAt: string | null;

--- a/apps/web/app/inbox/actions.ts
+++ b/apps/web/app/inbox/actions.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { computePendingComposerOutboundFingerprint } from "@as-comms/domain";
 import { requireSession } from "@/src/server/auth/session";
 import { sendComposerGmailMessage } from "@/src/server/composer/gmail-send";
+import { setInboxBucket } from "@/src/server/inbox/bucket";
 import { setInboxNeedsFollowUp } from "@/src/server/inbox/follow-up";
 import { revalidateInboxContact } from "@/src/server/inbox/revalidate";
 import {
@@ -66,6 +67,14 @@ export type FollowUpActionData = {
 export type FollowUpActionResult = UiResult<FollowUpActionData>;
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type InboxBucketActionData = {
+  readonly contactId: string;
+  readonly bucket: "New" | "Opened";
+};
+
+export type InboxBucketActionResult = UiResult<InboxBucketActionData>;
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type ComposerSendActionData = {
   readonly pendingOutboundId: string;
   readonly canonicalContactId: string;
@@ -118,6 +127,16 @@ function followUpRateLimitError(requestId: string): FollowUpActionResult {
     ok: false,
     code: "rate_limit_exceeded",
     message: "Too many follow-up updates. Please wait a minute and try again.",
+    requestId,
+    retryable: true,
+  };
+}
+
+function bucketRateLimitError(requestId: string): InboxBucketActionResult {
+  return {
+    ok: false,
+    code: "rate_limit_exceeded",
+    message: "Too many read-state changes. Please wait a minute and try again.",
     requestId,
     retryable: true,
   };
@@ -1214,4 +1233,85 @@ export async function clearInboxNeedsFollowUpAction(
   formData: FormData,
 ): Promise<FollowUpActionResult> {
   return updateNeedsFollowUp(formData, false);
+}
+
+async function updateInboxBucket(
+  formData: FormData,
+  bucket: "New" | "Opened",
+): Promise<InboxBucketActionResult> {
+  const requestId = randomUUID();
+  const contactId = readContactId(formData);
+
+  let currentUser;
+  try {
+    currentUser = await requireSession();
+  } catch (error) {
+    if (error instanceof Error && error.message === "UNAUTHORIZED") {
+      return unauthorizedError(requestId);
+    }
+    throw error;
+  }
+
+  if (contactId === null) {
+    return {
+      ok: false,
+      code: "validation_error",
+      message: "Missing contactId",
+      requestId,
+      fieldErrors: { contactId: "required" },
+    };
+  }
+
+  const decision = await enforceRateLimit({
+    scope: "server-action:inbox-bucket",
+    identifier: currentUser.id,
+    limit: 60,
+    audit: {
+      actorType: "user",
+      actorId: currentUser.id,
+      action: "inbox.bucket.rate_limited",
+      entityType: "server_action",
+      entityId: "inbox.bucket",
+      metadataJson: {
+        contactId,
+        bucket,
+      },
+    },
+  });
+
+  if (!decision.allowed) {
+    return bucketRateLimitError(requestId);
+  }
+
+  const result = await setInboxBucket({ contactId, bucket });
+
+  if (!result.ok) {
+    return {
+      ok: false,
+      code: "inbox_contact_not_found",
+      message: "No inbox row for that contact",
+      requestId,
+      retryable: false,
+    };
+  }
+
+  revalidateInboxContact(contactId);
+
+  return {
+    ok: true,
+    data: { contactId, bucket },
+    requestId,
+  };
+}
+
+export async function markInboxOpenedAction(
+  formData: FormData,
+): Promise<InboxBucketActionResult> {
+  return updateInboxBucket(formData, "Opened");
+}
+
+export async function markInboxUnreadAction(
+  formData: FormData,
+): Promise<InboxBucketActionResult> {
+  return updateInboxBucket(formData, "New");
 }

--- a/apps/web/src/server/inbox/bucket.ts
+++ b/apps/web/src/server/inbox/bucket.ts
@@ -1,0 +1,38 @@
+import type { InboxBucket } from "@as-comms/contracts";
+
+import { getStage1WebRuntime } from "../stage1-runtime";
+
+export interface InboxBucketUpdateResult {
+  readonly ok: true;
+  readonly contactId: string;
+  readonly bucket: InboxBucket;
+}
+
+export interface InboxBucketUpdateNotFound {
+  readonly ok: false;
+  readonly code: "inbox_contact_not_found";
+}
+
+export async function setInboxBucket(input: {
+  readonly contactId: string;
+  readonly bucket: InboxBucket;
+}): Promise<InboxBucketUpdateResult | InboxBucketUpdateNotFound> {
+  const runtime = await getStage1WebRuntime();
+  const updated = await runtime.repositories.inboxProjection.setBucket({
+    contactId: input.contactId,
+    bucket: input.bucket,
+  });
+
+  if (updated === null) {
+    return {
+      ok: false,
+      code: "inbox_contact_not_found",
+    };
+  }
+
+  return {
+    ok: true,
+    contactId: input.contactId,
+    bucket: input.bucket,
+  };
+}

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -101,6 +101,7 @@ function buildItem(
     needsFollowUp: overrides.needsFollowUp ?? false,
     hasUnresolved: overrides.hasUnresolved ?? false,
     unreadCount: overrides.unreadCount ?? 0,
+    isUnanswered: overrides.isUnanswered ?? false,
     lastInboundAt: overrides.lastInboundAt ?? null,
     lastOutboundAt: overrides.lastOutboundAt ?? null,
     lastActivityAt: overrides.lastActivityAt ?? "2026-04-14T14:00:00.000Z",

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -1938,6 +1938,19 @@ function createStage1RepositoriesInternal(
         return row === undefined ? null : mapInboxProjectionRow(row);
       },
 
+      async setBucket(input) {
+        const [row] = await db
+          .update(contactInboxProjection)
+          .set({
+            bucket: input.bucket,
+            updatedAt: new Date(),
+          })
+          .where(eq(contactInboxProjection.contactId, input.contactId))
+          .returning();
+
+        return row === undefined ? null : mapInboxProjectionRow(row);
+      },
+
       async upsert(record) {
         const values = mapInboxProjectionToInsert(record);
         const [row] = await db

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -9,6 +9,7 @@ import type {
   GmailMessageDetailRecord,
   IdentityResolutionCase,
   IdentityResolutionReasonCode,
+  InboxBucket,
   InboxProjectionRow,
   MailchimpCampaignActivityDetailRecord,
   ManualNoteDetailRecord,
@@ -277,6 +278,10 @@ export interface InboxProjectionRepository {
   setNeedsFollowUp(input: {
     readonly contactId: string;
     readonly needsFollowUp: boolean;
+  }): Promise<InboxProjectionRow | null>;
+  setBucket(input: {
+    readonly contactId: string;
+    readonly bucket: InboxBucket;
   }): Promise<InboxProjectionRow | null>;
   upsert(record: InboxProjectionRow): Promise<InboxProjectionRow>;
 }

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -144,6 +144,7 @@ describe("defineStage1RepositoryBundle", () => {
         getFreshnessByContactId: () => Promise.resolve(null),
         deleteByContactId: () => Promise.resolve(),
         setNeedsFollowUp: () => Promise.resolve(null),
+        setBucket: () => Promise.resolve(null),
         upsert: (record) => Promise.resolve(record),
       },
       timelineProjection: {

--- a/packages/domain/test/stage3-last-inbound-alias.test.ts
+++ b/packages/domain/test/stage3-last-inbound-alias.test.ts
@@ -163,6 +163,7 @@ function buildRepositoryBundle(input: {
       getFreshnessByContactId: () => Promise.resolve(null),
       deleteByContactId: () => Promise.resolve(),
       setNeedsFollowUp: () => Promise.resolve(null),
+      setBucket: () => Promise.resolve(null),
       upsert: (record) => Promise.resolve(record),
     },
     timelineProjection: {

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -250,6 +250,7 @@ function createRepositoryBundle(input: {
       getFreshnessByContactId: () => Promise.resolve(null),
       deleteByContactId: () => Promise.resolve(),
       setNeedsFollowUp: () => Promise.resolve(null),
+      setBucket: () => Promise.resolve(null),
       upsert: (record: InboxProjectionRow) => Promise.resolve(record),
     },
     timelineProjection: {


### PR DESCRIPTION
## Summary

Three inbox UX fixes flagged 2026-04-24, bundled for review.

### 1. Read state now sticks (Issue #1)

Opening a thread fires `markInboxOpenedAction` on mount (once per mount, bucket-guarded) and flips bucket `New → Opened`. A new **"Mark as unread"** button in the detail top bar (next to "Needs Follow-Up") calls `markInboxUnreadAction` and closes the detail pane. Shared across operators (single stored `bucket` column, no per-user read state).

**Product choice confirmed with architect**: (a) mark-on-open trigger, (b) shared-read semantics. Re-unread on new inbound is deferred to a follow-up PR against the normalization service (see Notes).

### 2. Row label now matches the sort key (Issue #2a)

The row's "X ago" label used `lastActivityAt` while the server sort uses `lastInboundAt DESC NULLS LAST`, making the list look non-monotonic when outbound was newer than inbound (e.g., a contact with inbound 2d ago + outbound yesterday displayed "yesterday" but sorted at the "2d ago" position, interleaving with true "yesterday" inbound rows). Switched `lastActivityLabel` derivation to `lastInboundAt ?? lastActivityAt` — label now matches sort, list is visually monotonic.

Issue #2b (cursor predicate) was investigated and closed as not-a-bug: over-inclusion in the `WHERE` clause is trimmed by `ORDER BY lastInboundAt DESC NULLS LAST + LIMIT`, so it produces correct output.

### 3. Follow-Up row state now updates without navigation (Issue #3)

Post-D-040 (#110), the server action's `revalidateInboxContact` is a no-op, so the list row stayed stale until the operator clicked another row or hard-refreshed. `useOptimisticBooleanToggle` now calls `router.refresh()` on success — the layout is `force-dynamic` so this is a real refetch, not a cache hit. Matches the `composer-send` and `timeline-retry` patterns already in the codebase.

## Visual changes

| State | Before | After |
|---|---|---|
| Unread (not opened) | sky border line + "1" badge | sky border line + blue dot (no number) |
| Opened, unanswered (reply pending) | — | blue dot |
| Answered | plain | plain |
| Needs follow-up | rose border line | rose border line (unchanged) |
| Follow-up button icon | CornerUpLeft | Flag |
| Mark-as-unread button | (new) | MailOpen |

`isUnanswered` derivation (new view-model field): `lastInboundAt !== null && (lastOutboundAt === null || lastInboundAt > lastOutboundAt)`.

## Files touched

- `packages/domain/src/repositories.ts` — `InboxProjectionRepository.setBucket` interface
- `packages/db/src/repositories.ts` — `setBucket` impl
- `apps/web/src/server/inbox/bucket.ts` — new helper (`setInboxBucket`)
- `apps/web/app/inbox/actions.ts` — `markInboxOpenedAction`, `markInboxUnreadAction` + shared `updateInboxBucket` (rate-limited, audited)
- `apps/web/app/inbox/_components/inbox-detail.tsx` — mark-opened-on-mount useEffect, Mark-as-unread button, follow-up icon → Flag, `router.refresh()` in optimistic toggle
- `apps/web/app/inbox/_components/inbox-row.tsx` — dot visual, number removed
- `apps/web/app/inbox/_lib/{view-models,selectors}.ts` — `isUnanswered` field, label derivation fix
- `apps/web/app/inbox/_components/icons.tsx` — FlagIcon, MailOpenIcon
- `packages/domain/test/*.test.ts` — 3 mock bundle updates for `setBucket`
- `apps/web/tests/unit/inbox-selectors.test.ts` — fixture helper updated for `isUnanswered`

## Deferred

- **Re-unread on new inbound** (user-confirmed requirement): requires updating `rebuildInboxProjectionForContact` in `packages/domain/src/normalization.ts` to flip bucket to `"New"` when a new inbound event arrives after the existing `lastInboundAt`. Will dispatch separately against the worker path.
- **Canon update** (`docs/02-bundles/inbox-bundle.md`): the bundle's "Acceptance" list says bucket is projection-driven; this PR adds operator-explicit overrides (read/unread). Architect doc pass to follow.

## Test plan

- [x] `pnpm --filter @as-comms/web typecheck` — clean
- [x] `pnpm --filter @as-comms/web test:unit` — 134/134
- [x] `pnpm --filter @as-comms/domain test:unit` — 23/23
- [x] `pnpm --filter @as-comms/db test:unit` — 50/50
- [x] `pnpm --filter @as-comms/web lint` — clean
- [ ] Manual: open a `"new"` thread → row bold goes away after mount (mark-opened fires) → `router.refresh()` updates list
- [ ] Manual: click "Mark as unread" → detail closes, thread returns to unread-style in list
- [ ] Manual: toggle Needs Follow-Up → both top bar AND row rose accent update without navigation
- [ ] Manual: verify row order is monotonic (no "yesterday after 2d ago" jumps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)