### PR TITLE
fix(gmail-capture): 10-min sliding poll window + dedup short-circuit

### DIFF
--- a/apps/worker/src/ingest/service.ts
+++ b/apps/worker/src/ingest/service.ts
@@ -310,6 +310,9 @@ export function createStage1IngestService(
         ingestMode: "live",
         mapper: mapGmailRecord,
         record,
+        options: {
+          overwriteDuplicateGmailMessageDetail: false,
+        },
       });
     },
 

--- a/apps/worker/src/orchestration/service.ts
+++ b/apps/worker/src/orchestration/service.ts
@@ -83,6 +83,7 @@ const gmailAndSimpleTextingP99ThresholdSeconds = 300;
 const salesforceLifecycleP95ThresholdSeconds = 600;
 const defaultGmailLivePollIntervalSeconds = 60;
 const defaultSalesforceLivePollIntervalSeconds = 300;
+export const gmailLiveWindowLookbackMs = 10 * 60 * 1000;
 const livePollMaxRecords = 1000;
 
 type CapturedProviderRecord =
@@ -863,8 +864,10 @@ export function createStage1WorkerOrchestrationService(input: {
   readonly revalidateInboxViews?: (input: {
     readonly contactIds: readonly string[];
   }) => Promise<void>;
+  readonly logger?: Pick<Console, "info">;
 }): Stage1WorkerOrchestrationService {
   const syncState = createStage1SyncStateService(input.persistence);
+  const logger = input.logger ?? console;
   const livePolling: Stage1LivePollingConfig = {
     gmailPollIntervalSeconds:
       input.livePolling?.gmailPollIntervalSeconds ??
@@ -888,13 +891,16 @@ export function createStage1WorkerOrchestrationService(input: {
     }
 
     const windowEnd = now.toISOString();
-    const windowStart = resolveLivePollCheckpoint({
+    const checkpoint = resolveLivePollCheckpoint({
       syncState: latestSyncState,
       fallbackWindowStart: subtractSeconds(
         now,
         livePolling.gmailPollIntervalSeconds
       )
     });
+    const windowStart = new Date(
+      now.getTime() - gmailLiveWindowLookbackMs
+    ).toISOString();
 
     return gmailLiveCaptureBatchPayloadSchema.parse({
       version: stage1JobVersion,
@@ -905,7 +911,7 @@ export function createStage1WorkerOrchestrationService(input: {
       provider: "gmail",
       mode: "live",
       jobType: "live_ingest",
-      checkpoint: windowStart,
+      checkpoint,
       windowStart,
       windowEnd,
       maxRecords: livePollMaxRecords
@@ -998,6 +1004,19 @@ export function createStage1WorkerOrchestrationService(input: {
       for (const { record, mapped } of prioritizedRecords) {
         const ingestResult = await params.ingestRecord(record);
         ingestResults.push(ingestResult);
+
+        if (
+          payload.provider === "gmail" &&
+          payload.jobType === "live_ingest" &&
+          ingestResult.outcome === "duplicate"
+        ) {
+          logger.info({
+            event: "gmail_live.duplicate_skip",
+            messageId: ingestResult.sourceRecordId,
+            windowStart: payload.windowStart,
+            windowEnd: payload.windowEnd
+          });
+        }
 
         if (
           ingestResult.outcome !== "deferred" &&

--- a/apps/worker/test/helpers.ts
+++ b/apps/worker/test/helpers.ts
@@ -119,6 +119,7 @@ export async function createTestWorkerContext(input?: {
   readonly revalidateInboxViews?: (input: {
     readonly contactIds: readonly string[];
   }) => Promise<void>;
+  readonly logger?: Pick<Console, "info">;
 }): Promise<TestWorkerContext> {
   const baseContext = await createTestStage1Context();
   const { normalization, persistence } = baseContext;
@@ -143,6 +144,11 @@ export async function createTestWorkerContext(input?: {
       ? {}
       : {
           revalidateInboxViews: input.revalidateInboxViews
+        }),
+    ...(input?.logger === undefined
+      ? {}
+      : {
+          logger: input.logger
         })
   });
 

--- a/apps/worker/test/stage1-live-polling.test.ts
+++ b/apps/worker/test/stage1-live-polling.test.ts
@@ -46,7 +46,7 @@ async function saveLiveSyncState(
 }
 
 describe("Stage 1 live polling scheduler tasks", () => {
-  it("enqueues a Gmail live capture batch from the latest checkpoint", async () => {
+  it("enqueues a Gmail live capture batch with a 10-minute sliding window", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-05T00:06:00.000Z"));
 
@@ -81,7 +81,7 @@ describe("Stage 1 live polling scheduler tasks", () => {
           mode: "live",
           jobType: "live_ingest",
           checkpoint: "2026-01-05T00:05:00.000Z",
-          windowStart: "2026-01-05T00:05:00.000Z",
+          windowStart: "2026-01-04T23:56:00.000Z",
           windowEnd: "2026-01-05T00:06:00.000Z",
           attempt: 1,
           maxAttempts: 3,

--- a/apps/worker/test/stage1-orchestration.test.ts
+++ b/apps/worker/test/stage1-orchestration.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   cutoverCheckpointBatchPayloadSchema,
@@ -795,6 +795,105 @@ Alias drift outbound message.
       expect(result.syncState.provider).toBe("gmail");
       expect(result.syncState.freshnessP95Seconds).toBe(60);
       expect(result.syncState.freshnessP99Seconds).toBe(60);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("skips already-ingested Gmail live messages without duplicating events or projections", async () => {
+    const gmailRecord = buildGmailMessageRecord({
+      recordId: "gmail-live-duplicate-1",
+      direction: "inbound",
+      occurredAt: "2026-01-02T00:00:30.000Z",
+      receivedAt: "2026-01-02T00:01:00.000Z",
+      payloadRef:
+        "gmail://volunteers@adventurescientists.org/messages/gmail-live-duplicate-1",
+      checksum: "checksum:gmail-live-duplicate-1",
+      snippet: "Live reply from volunteer",
+      snippetClean: "Live reply from volunteer",
+      bodyTextPreview: "Live reply from volunteer",
+      threadId: "thread-live-duplicate-1",
+      rfc822MessageId: "<gmail-live-duplicate-1@example.org>",
+      supportingRecords: [],
+      crossProviderCollapseKey: null
+    });
+    const capture = createEmptyCapturePorts();
+    capture.gmail.captureLiveBatch = () =>
+      Promise.resolve(buildCapturedBatch([gmailRecord]));
+    const logger = {
+      info: vi.fn()
+    };
+
+    const context = await createTestWorkerContext({ capture, logger });
+
+    try {
+      await seedContact(context);
+
+      const payload = {
+        version: 1 as const,
+        jobId: "job:gmail:live:duplicate",
+        correlationId: "corr:gmail:live:duplicate",
+        traceId: null,
+        batchId: "batch:gmail:live:duplicate",
+        syncStateId: "sync:gmail:live:duplicate:first",
+        attempt: 1,
+        maxAttempts: 3,
+        provider: "gmail" as const,
+        mode: "live" as const,
+        jobType: "live_ingest" as const,
+        cursor: null,
+        checkpoint: null,
+        windowStart: "2026-01-01T23:52:00.000Z",
+        windowEnd: "2026-01-02T00:02:00.000Z",
+        recordIds: ["gmail-live-duplicate-1"],
+        maxRecords: 10
+      };
+
+      const first = await context.orchestration.runGmailLiveCaptureBatch(payload);
+
+      expect(first.outcome).toBe("succeeded");
+      if (first.outcome !== "succeeded") {
+        throw new Error("Expected initial Gmail live batch to succeed.");
+      }
+      expect(first.summary.normalized).toBe(1);
+      expect(first.summary.duplicate).toBe(0);
+      await expect(context.repositories.canonicalEvents.countAll()).resolves.toBe(1);
+      await expect(context.repositories.timelineProjection.countAll()).resolves.toBe(1);
+      await expect(context.repositories.inboxProjection.countAll()).resolves.toBe(1);
+      await expect(
+        context.repositories.identityResolutionQueue.listOpenByContactId(contactId)
+      ).resolves.toEqual([]);
+      await expect(
+        context.repositories.routingReviewQueue.listOpenByContactId(contactId)
+      ).resolves.toEqual([]);
+
+      const second = await context.orchestration.runGmailLiveCaptureBatch({
+        ...payload,
+        syncStateId: "sync:gmail:live:duplicate:second"
+      });
+
+      expect(second.outcome).toBe("succeeded");
+      if (second.outcome !== "succeeded") {
+        throw new Error("Expected duplicate Gmail live batch to succeed.");
+      }
+      expect(second.summary.normalized).toBe(0);
+      expect(second.summary.duplicate).toBe(1);
+      await expect(context.repositories.canonicalEvents.countAll()).resolves.toBe(1);
+      await expect(context.repositories.timelineProjection.countAll()).resolves.toBe(1);
+      await expect(context.repositories.inboxProjection.countAll()).resolves.toBe(1);
+      await expect(
+        context.repositories.identityResolutionQueue.listOpenByContactId(contactId)
+      ).resolves.toEqual([]);
+      await expect(
+        context.repositories.routingReviewQueue.listOpenByContactId(contactId)
+      ).resolves.toEqual([]);
+      expect(logger.info).toHaveBeenCalledTimes(1);
+      expect(logger.info).toHaveBeenCalledWith({
+        event: "gmail_live.duplicate_skip",
+        messageId: "gmail-live-duplicate-1",
+        windowStart: "2026-01-01T23:52:00.000Z",
+        windowEnd: "2026-01-02T00:02:00.000Z"
+      });
     } finally {
       await context.dispose();
     }

--- a/packages/domain/src/normalization.ts
+++ b/packages/domain/src/normalization.ts
@@ -2176,6 +2176,55 @@ export function createStage1NormalizationService(
         };
       }
 
+      if (
+        sourceEvidenceResult.outcome === "duplicate" &&
+        options?.overwriteDuplicateGmailMessageDetail === false
+      ) {
+        const existingCanonicalEvent =
+          await persistence.findCanonicalEventByIdempotencyKey(
+            parsed.canonicalEvent.idempotencyKey
+          );
+
+        if (
+          existingCanonicalEvent !== null &&
+          findCanonicalEventForSourceEvidence(
+            [existingCanonicalEvent],
+            sourceEvidenceResult.record.id
+          ) !== null
+        ) {
+          const existingTimelineProjection =
+            await persistence.repositories.timelineProjection.findByCanonicalEventId(
+              existingCanonicalEvent.id
+            );
+          const timelineProjection =
+            existingTimelineProjection ??
+            (await service.applyTimelineProjection({
+              canonicalEvent: existingCanonicalEvent,
+              summary: parsed.canonicalEvent.summary
+            }));
+          const inboxProjection = isInboxDrivingCanonicalEvent(
+            existingCanonicalEvent
+          )
+            ? await persistence.repositories.inboxProjection.findByContactId(
+                existingCanonicalEvent.contactId
+              )
+            : await service.refreshInboxReviewOverlay({
+                contactId: existingCanonicalEvent.contactId
+              });
+
+          return {
+            outcome: "duplicate",
+            sourceEvidence: sourceEvidenceResult.record,
+            canonicalEvent: existingCanonicalEvent,
+            timelineProjection,
+            inboxProjection,
+            identityCase: null,
+            routingCase: null,
+            auditEvidence: null
+          };
+        }
+      }
+
       const nonVolunteerTaskDecision =
         await resolveNonVolunteerSalesforceTaskSkip(
           persistence,


### PR DESCRIPTION
## Summary

Gmail's `after:`/`before:` search index has minute-granularity rounding — 1-minute poll windows can miss messages that land near a boundary. Verified live: Ashley Schuyler reply at `internalDate=1777046731` (16:05:31 UTC) was missing from `after:1777046700 before:1777046760` while a 5-min/10-min wider window returned it.

## Fix

- Live Gmail poll uses **10-minute lookback** for `windowStart` (`worker/orchestration/service.ts: gmailLiveWindowLookbackMs = 10 * 60 * 1000`). Checkpoint metadata kept separately for observability.
- Live Gmail capture path **short-circuits** when `source_evidence` already exists for the message id (worker `ingest/service.ts` + domain `normalization.ts`) — dedup is silent and idempotent, no canonical / projection re-processing.
- Structured log on dedup skip: `{ event: \"gmail_live.duplicate_skip\", messageId, windowStart, windowEnd }`.

## Test plan

- [x] `pnpm --filter @as-comms/worker typecheck` clean
- [x] `pnpm --filter @as-comms/worker lint` clean
- [x] Tests in `stage1-live-polling.test.ts` + `stage1-orchestration.test.ts` cover window width + idempotency + duplicate-skip log
- [ ] CI verify green

## Out of scope

- Gmail history API migration (future)
- Cloud Pub/Sub push (future)
- SF poller (separate cadence + schema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)