### PR TITLE
feat(integrations): degradation email alert + inbox banner (TSR-003)

### DIFF
--- a/apps/web/app/inbox/_components/inbox-shell.tsx
+++ b/apps/web/app/inbox/_components/inbox-shell.tsx
@@ -5,8 +5,10 @@ import type {
   InboxListViewModel,
   InboxComposerAliasOption
 } from "../_lib/view-models";
+import type { InboxIntegrationHealthBannerViewModel } from "../_lib/integration-health";
 import { PrimaryIconRail } from "@/app/_components/primary-icon-rail";
 
+import { IntegrationHealthBanner } from "./integration-health-banner";
 import { InboxClientProvider } from "./inbox-client-provider";
 import { InboxFreshnessPoller } from "./inbox-freshness-poller";
 import { InboxKeyboardProvider } from "./inbox-keyboard-provider";
@@ -17,6 +19,7 @@ interface ShellProps {
   readonly initialList: InboxListViewModel;
   readonly initialFilterId: InboxFilterId;
   readonly composerAliases: readonly InboxComposerAliasOption[];
+  readonly healthBanner: InboxIntegrationHealthBannerViewModel | null;
   readonly operator: {
     readonly initials: string;
     readonly displayName: string;
@@ -38,6 +41,7 @@ export function InboxShell({
   initialList,
   initialFilterId,
   composerAliases,
+  healthBanner,
   operator,
   children
 }: ShellProps) {
@@ -47,12 +51,18 @@ export function InboxShell({
         <InboxFreshnessPoller listFreshness={initialList.freshness} />
         <PrimaryIconRail operator={operator} />
 
-        <InboxList
-          initialList={initialList}
-          initialFilterId={initialFilterId}
-        />
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+          <IntegrationHealthBanner banner={healthBanner} />
 
-        <InboxWorkspace>{children}</InboxWorkspace>
+          <div className="flex min-h-0 flex-1">
+            <InboxList
+              initialList={initialList}
+              initialFilterId={initialFilterId}
+            />
+
+            <InboxWorkspace>{children}</InboxWorkspace>
+          </div>
+        </div>
       </InboxKeyboardProvider>
     </InboxClientProvider>
   );

--- a/apps/web/app/inbox/_components/integration-health-banner.tsx
+++ b/apps/web/app/inbox/_components/integration-health-banner.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+import { AlertTriangleIcon } from "lucide-react";
+
+import type { InboxIntegrationHealthBannerViewModel } from "../_lib/integration-health";
+import { TONE } from "@/app/_lib/design-tokens";
+
+function formatServiceList(services: readonly string[]): string {
+  if (services.length === 1) {
+    return services[0] ?? "Integration";
+  }
+
+  return services.join(", ");
+}
+
+export function IntegrationHealthBanner({
+  banner
+}: {
+  readonly banner: InboxIntegrationHealthBannerViewModel | null;
+}) {
+  if (banner === null) {
+    return null;
+  }
+
+  const serviceList = formatServiceList(banner.degradedServices);
+  const verb = banner.degradedServices.length === 1 ? "is" : "are";
+
+  return (
+    <div
+      role="alert"
+      className={`flex min-h-10 items-center gap-2 border-b px-4 py-2 ${TONE.amber.subtle} border-amber-200 text-amber-900`}
+    >
+      <AlertTriangleIcon className="h-4 w-4 shrink-0 text-amber-600" />
+      <p className="min-w-0 flex-1 text-sm font-medium">
+        {serviceList} integration {verb} degraded. Operators may not see new
+        messages until resolved.
+      </p>
+      <Link
+        href="/settings/integrations"
+        className="shrink-0 text-sm font-semibold text-amber-950 underline-offset-4 hover:underline"
+      >
+        View status →
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/app/inbox/_components/integration-health-banner.tsx
+++ b/apps/web/app/inbox/_components/integration-health-banner.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import Link from "next/link";
 import { AlertTriangleIcon } from "lucide-react";
 

--- a/apps/web/app/inbox/_lib/integration-health.ts
+++ b/apps/web/app/inbox/_lib/integration-health.ts
@@ -1,0 +1,45 @@
+import type { IntegrationHealthRecord } from "@as-comms/contracts";
+
+import { getStage1WebRuntime } from "@/src/server/stage1-runtime";
+
+const INBOX_HEALTH_SERVICE_IDS = ["gmail", "salesforce"] as const;
+
+export interface InboxIntegrationHealthBannerViewModel {
+  readonly degradedServices: readonly string[];
+}
+
+function isInboxHealthService(
+  value: string
+): value is (typeof INBOX_HEALTH_SERVICE_IDS)[number] {
+  return INBOX_HEALTH_SERVICE_IDS.includes(
+    value as (typeof INBOX_HEALTH_SERVICE_IDS)[number]
+  );
+}
+
+export function buildInboxIntegrationHealthBannerViewModel(
+  rows: readonly IntegrationHealthRecord[]
+): InboxIntegrationHealthBannerViewModel | null {
+  const degradedServices = rows
+    .filter(
+      (row) => isInboxHealthService(row.id) && row.status !== "healthy"
+    )
+    .map((row) => row.serviceName);
+
+  if (degradedServices.length === 0) {
+    return null;
+  }
+
+  return {
+    degradedServices
+  };
+}
+
+export async function getInboxIntegrationHealthBanner(): Promise<InboxIntegrationHealthBannerViewModel | null> {
+  const runtime = await getStage1WebRuntime();
+
+  await runtime.settings.integrationHealth.seedDefaults();
+  const rows = await runtime.settings.integrationHealth.listAll();
+
+  return buildInboxIntegrationHealthBannerViewModel(rows);
+}
+

--- a/apps/web/app/inbox/layout.tsx
+++ b/apps/web/app/inbox/layout.tsx
@@ -5,6 +5,7 @@ import { requireSession } from "@/src/server/auth/session";
 
 import { InboxShell } from "./_components/inbox-shell";
 import { getInboxComposerAliases } from "./_lib/composer-data";
+import { getInboxIntegrationHealthBanner } from "./_lib/integration-health";
 import { getInboxList } from "./_lib/selectors";
 
 export const metadata = {
@@ -43,9 +44,10 @@ export default async function InboxLayout({
     throw error;
   });
 
-  const [list, composerAliases] = await Promise.all([
+  const [list, composerAliases, healthBanner] = await Promise.all([
     getInboxList("all"),
     getInboxComposerAliases(),
+    getInboxIntegrationHealthBanner(),
   ]);
 
   return (
@@ -53,6 +55,7 @@ export default async function InboxLayout({
       initialList={list}
       initialFilterId="all"
       composerAliases={composerAliases}
+      healthBanner={healthBanner}
       operator={{
         initials: getInitials(currentUser.name ?? currentUser.email),
         displayName: currentUser.name ?? currentUser.email,

--- a/apps/web/tests/unit/inbox-integration-health-banner.test.tsx
+++ b/apps/web/tests/unit/inbox-integration-health-banner.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import React, { createElement, type AnchorHTMLAttributes } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: AnchorHTMLAttributes<HTMLAnchorElement> & {
+    readonly href: string;
+  }) => createElement("a", { ...props, href }, children)
+}));
+
+import { IntegrationHealthBanner } from "../../app/inbox/_components/integration-health-banner";
+import { buildInboxIntegrationHealthBannerViewModel } from "../../app/inbox/_lib/integration-health";
+import type { IntegrationHealthRecord } from "@as-comms/contracts";
+
+function buildHealthRecord(
+  overrides: Partial<IntegrationHealthRecord>
+): IntegrationHealthRecord {
+  return {
+    id: overrides.id ?? "gmail",
+    serviceName: overrides.serviceName ?? overrides.id ?? "gmail",
+    category: overrides.category ?? "messaging",
+    status: overrides.status ?? "healthy",
+    lastCheckedAt: overrides.lastCheckedAt ?? "2026-04-20T16:00:00.000Z",
+    degradedSinceAt: overrides.degradedSinceAt ?? null,
+    lastAlertSentAt: overrides.lastAlertSentAt ?? null,
+    detail: overrides.detail ?? null,
+    metadataJson: overrides.metadataJson ?? {},
+    createdAt: overrides.createdAt ?? "2026-04-20T15:00:00.000Z",
+    updatedAt: overrides.updatedAt ?? "2026-04-20T16:00:00.000Z"
+  };
+}
+
+describe("Inbox integration health banner", () => {
+  it("renders when an in-scope integration is degraded", () => {
+    const banner = buildInboxIntegrationHealthBannerViewModel([
+      buildHealthRecord({
+        id: "gmail",
+        serviceName: "gmail",
+        status: "needs_attention"
+      }),
+      buildHealthRecord({
+        id: "salesforce",
+        serviceName: "salesforce",
+        status: "healthy"
+      })
+    ]);
+
+    const html = renderToStaticMarkup(
+      <IntegrationHealthBanner banner={banner} />
+    );
+
+    expect(html).toContain("gmail integration is degraded");
+    expect(html).toContain("Operators may not see new messages until resolved.");
+    expect(html).toContain("href=\"/settings/integrations\"");
+  });
+
+  it("does not render when all in-scope integrations are healthy", () => {
+    const banner = buildInboxIntegrationHealthBannerViewModel([
+      buildHealthRecord({
+        id: "gmail",
+        serviceName: "gmail",
+        status: "healthy"
+      }),
+      buildHealthRecord({
+        id: "salesforce",
+        serviceName: "salesforce",
+        status: "healthy"
+      }),
+      buildHealthRecord({
+        id: "mailchimp",
+        serviceName: "mailchimp",
+        status: "needs_attention"
+      })
+    ]);
+
+    const html = renderToStaticMarkup(
+      <IntegrationHealthBanner banner={banner} />
+    );
+
+    expect(banner).toBeNull();
+    expect(html).toBe("");
+  });
+});

--- a/apps/web/tests/unit/settings-integration-health-action.test.ts
+++ b/apps/web/tests/unit/settings-integration-health-action.test.ts
@@ -70,6 +70,8 @@ describe("refreshIntegrationHealthAction", () => {
       category: "messaging",
       status: "healthy",
       lastCheckedAt: "2026-04-20T18:00:00.000Z",
+      degradedSinceAt: null,
+      lastAlertSentAt: null,
       detail: "Healthy",
       metadataJson: {},
       createdAt: "2026-04-20T18:00:00.000Z",

--- a/apps/worker/src/jobs/integration-health/email.ts
+++ b/apps/worker/src/jobs/integration-health/email.ts
@@ -1,0 +1,195 @@
+import { z } from "zod";
+
+import {
+  sendGmailMessage,
+  type GmailSendResult
+} from "@as-comms/integrations";
+import type {
+  IntegrationHealthRecord,
+  IntegrationHealthStatus
+} from "@as-comms/contracts";
+
+const DEFAULT_ALERT_RECIPIENT = "nico@adventurescientists.org";
+const DEFAULT_ALERT_FROM_ALIAS = "volunteers@adventurescientists.org";
+const SETTINGS_INTEGRATIONS_PATH = "/settings/integrations";
+
+const integrationHealthAlertConfigSchema = z.object({
+  liveAccount: z.string().email(),
+  oauthClientId: z.string().min(1),
+  oauthClientSecret: z.string().min(1),
+  oauthRefreshToken: z.string().min(1),
+  tokenUri: z.string().url().default("https://oauth2.googleapis.com/token"),
+  timeoutMs: z.number().int().positive().default(15_000),
+  recipient: z.string().email().default(DEFAULT_ALERT_RECIPIENT),
+  fromAlias: z.string().email().default(DEFAULT_ALERT_FROM_ALIAS),
+  settingsIntegrationsUrl: z.string().url()
+});
+
+export interface IntegrationHealthAlertInput {
+  readonly service: string;
+  readonly fromStatus: IntegrationHealthStatus;
+  readonly record: IntegrationHealthRecord;
+  readonly occurredAt: string;
+}
+
+export interface IntegrationHealthAlertSender {
+  send(input: IntegrationHealthAlertInput): Promise<GmailSendResult>;
+}
+
+function readOptionalEmailEnv(
+  env: NodeJS.ProcessEnv,
+  name: string,
+  fallback: string
+): string {
+  const value = env[name]?.trim();
+  return value && value.length > 0 ? value : fallback;
+}
+
+function readOptionalStringEnv(
+  env: NodeJS.ProcessEnv,
+  name: string
+): string | null {
+  const value = env[name]?.trim();
+  return value && value.length > 0 ? value : null;
+}
+
+function readSettingsIntegrationsUrl(env: NodeJS.ProcessEnv): string {
+  const explicit = env.INTEGRATION_HEALTH_ALERT_SETTINGS_URL?.trim();
+
+  if (explicit && explicit.length > 0) {
+    return explicit;
+  }
+
+  const baseUrl =
+    readOptionalStringEnv(env, "NEXT_PUBLIC_APP_URL") ??
+    readOptionalStringEnv(env, "APP_BASE_URL") ??
+    readOptionalStringEnv(env, "WEB_BASE_URL") ??
+    readOptionalStringEnv(env, "INBOX_REVALIDATE_BASE_URL") ??
+    "";
+
+  return new URL(SETTINGS_INTEGRATIONS_PATH, baseUrl).toString();
+}
+
+function readIntegrationHealthAlertConfig(env: NodeJS.ProcessEnv) {
+  return integrationHealthAlertConfigSchema.parse({
+    liveAccount: env.GMAIL_LIVE_ACCOUNT,
+    oauthClientId: env.GMAIL_GOOGLE_OAUTH_CLIENT_ID,
+    oauthClientSecret: env.GMAIL_GOOGLE_OAUTH_CLIENT_SECRET,
+    oauthRefreshToken: env.GMAIL_GOOGLE_OAUTH_REFRESH_TOKEN,
+    tokenUri:
+      env.GMAIL_GOOGLE_TOKEN_URI?.trim().length
+        ? env.GMAIL_GOOGLE_TOKEN_URI.trim()
+        : "https://oauth2.googleapis.com/token",
+    timeoutMs:
+      env.GMAIL_SEND_TIMEOUT_MS === undefined
+        ? 15_000
+        : Number.parseInt(env.GMAIL_SEND_TIMEOUT_MS, 10),
+    recipient: readOptionalEmailEnv(
+      env,
+      "INTEGRATION_HEALTH_ALERT_RECIPIENT",
+      DEFAULT_ALERT_RECIPIENT
+    ),
+    fromAlias: readOptionalEmailEnv(
+      env,
+      "INTEGRATION_HEALTH_ALERT_FROM_ALIAS",
+      DEFAULT_ALERT_FROM_ALIAS
+    ),
+    settingsIntegrationsUrl: readSettingsIntegrationsUrl(env)
+  });
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/gu, "&amp;")
+    .replace(/</gu, "&lt;")
+    .replace(/>/gu, "&gt;")
+    .replace(/"/gu, "&quot;");
+}
+
+function stringifyMetadata(record: IntegrationHealthRecord): string {
+  return JSON.stringify(record.metadataJson, null, 2);
+}
+
+export function buildIntegrationHealthAlertMessage(
+  input: IntegrationHealthAlertInput,
+  settingsIntegrationsUrl: string
+) {
+  const metadata = stringifyMetadata(input.record);
+  const subject = `[AS Comms] ${input.service} integration degraded — ${input.record.status}`;
+  const bodyPlaintext = [
+    `${input.service} status flipped from ${input.fromStatus} to ${input.record.status} at ${input.occurredAt}.`,
+    "",
+    "Last error metadata:",
+    metadata,
+    "",
+    `Settings → Integrations: ${settingsIntegrationsUrl}`,
+    "",
+    "This alert won't repeat for the same service for 1 hour."
+  ].join("\n");
+  const bodyHtml = [
+    `<p>${escapeHtml(input.service)} status flipped from ${escapeHtml(
+      input.fromStatus
+    )} to ${escapeHtml(input.record.status)} at ${escapeHtml(
+      input.occurredAt
+    )}.</p>`,
+    "<p>Last error metadata:</p>",
+    `<pre>${escapeHtml(metadata)}</pre>`,
+    `<p><a href="${escapeHtml(
+      settingsIntegrationsUrl
+    )}">Settings → Integrations</a></p>`,
+    "<p>This alert won't repeat for the same service for 1 hour.</p>"
+  ].join("");
+
+  return {
+    subject,
+    bodyPlaintext,
+    bodyHtml
+  };
+}
+
+export function createIntegrationHealthAlertSender(
+  env: NodeJS.ProcessEnv = process.env,
+  fetchImplementation: typeof fetch = fetch
+): IntegrationHealthAlertSender {
+  return {
+    async send(input) {
+      let config;
+
+      try {
+        config = readIntegrationHealthAlertConfig(env);
+      } catch {
+        return {
+          kind: "auth_error",
+          detail: "Integration health alert email is not configured."
+        };
+      }
+
+      const message = buildIntegrationHealthAlertMessage(
+        input,
+        config.settingsIntegrationsUrl
+      );
+
+      return sendGmailMessage(
+        {
+          fromAlias: config.fromAlias,
+          to: config.recipient,
+          subject: message.subject,
+          bodyPlaintext: message.bodyPlaintext,
+          bodyHtml: message.bodyHtml,
+          attachments: []
+        },
+        {
+          liveAccount: config.liveAccount,
+          oauthClient: {
+            clientId: config.oauthClientId,
+            clientSecret: config.oauthClientSecret,
+            tokenUri: config.tokenUri
+          },
+          oauthRefreshToken: config.oauthRefreshToken,
+          fetchImplementation,
+          timeoutMs: config.timeoutMs
+        }
+      );
+    }
+  };
+}

--- a/apps/worker/src/jobs/notion-knowledge-sync/sync.ts
+++ b/apps/worker/src/jobs/notion-knowledge-sync/sync.ts
@@ -306,6 +306,8 @@ function buildIntegrationHealthRecord(input: {
     category: "knowledge",
     status: input.status,
     lastCheckedAt: input.checkedAt,
+    degradedSinceAt: input.baseRecord?.degradedSinceAt ?? null,
+    lastAlertSentAt: input.baseRecord?.lastAlertSentAt ?? null,
     detail: input.detail,
     metadataJson,
     createdAt: input.baseRecord?.createdAt ?? input.checkedAt,

--- a/apps/worker/src/orchestration/tasks.ts
+++ b/apps/worker/src/orchestration/tasks.ts
@@ -30,6 +30,10 @@ import {
 } from "@as-comms/contracts";
 import type { IntegrationHealthRepository } from "@as-comms/domain";
 
+import {
+  createIntegrationHealthAlertSender,
+  type IntegrationHealthAlertSender
+} from "../jobs/integration-health/email.js";
 import type { Stage1WorkerOrchestrationService } from "./types.js";
 
 export const pollGmailLiveJobName = "poll-gmail-live" as const;
@@ -39,6 +43,7 @@ const polledIntegrationServices = [
   "salesforce",
   "gmail"
 ] as const satisfies readonly IntegrationHealthRecord["id"][];
+const integrationHealthAlertCooldownMs = 60 * 60 * 1000;
 
 export interface IntegrationHealthTaskDependencies {
   readonly integrationHealth: IntegrationHealthRepository;
@@ -47,7 +52,9 @@ export interface IntegrationHealthTaskDependencies {
     readonly salesforce: string;
   };
   readonly fetchImplementation?: typeof fetch;
-  readonly logger?: Pick<Console, "error" | "warn">;
+  readonly alertSender?: IntegrationHealthAlertSender;
+  readonly now?: () => Date;
+  readonly logger?: Pick<Console, "error" | "warn" | "info">;
 }
 
 function isFailedStage1TaskOutcome(
@@ -173,6 +180,74 @@ function buildUpdatedIntegrationHealthRecord(
   };
 }
 
+function isHealthyStatus(status: IntegrationHealthRecord["status"]): boolean {
+  return status === "healthy";
+}
+
+function shouldSendIntegrationHealthAlert(input: {
+  readonly previous: IntegrationHealthRecord;
+  readonly next: IntegrationHealthRecord;
+  readonly occurredAt: Date;
+}): boolean {
+  if (isHealthyStatus(input.next.status)) {
+    return false;
+  }
+
+  if (!isHealthyStatus(input.previous.status)) {
+    return (
+      input.previous.degradedSinceAt !== null &&
+      input.previous.lastAlertSentAt === null
+    );
+  }
+
+  if (input.previous.lastAlertSentAt === null) {
+    return true;
+  }
+
+  const lastAlertSentAt = Date.parse(input.previous.lastAlertSentAt);
+
+  return (
+    Number.isFinite(lastAlertSentAt) &&
+    input.occurredAt.getTime() - lastAlertSentAt >=
+      integrationHealthAlertCooldownMs
+  );
+}
+
+function applyIntegrationHealthAlertState(
+  previous: IntegrationHealthRecord,
+  next: IntegrationHealthRecord,
+  input: {
+    readonly occurredAt: string;
+    readonly alertSent: boolean;
+  }
+): IntegrationHealthRecord {
+  if (isHealthyStatus(next.status)) {
+    return {
+      ...next,
+      degradedSinceAt: null,
+      lastAlertSentAt: null
+    };
+  }
+
+  const degradedSinceAt = isHealthyStatus(previous.status)
+    ? input.occurredAt
+    : previous.degradedSinceAt ?? input.occurredAt;
+
+  return {
+    ...next,
+    degradedSinceAt,
+    lastAlertSentAt: input.alertSent
+      ? input.occurredAt
+      : previous.lastAlertSentAt
+  };
+}
+
+function isSuccessfulGmailSendResult(
+  result: Awaited<ReturnType<IntegrationHealthAlertSender["send"]>>
+): boolean {
+  return result.kind === "success";
+}
+
 async function pollIntegrationHealthRecord(
   record: IntegrationHealthRecord,
   input: {
@@ -244,6 +319,10 @@ function createPollIntegrationHealthTask(
   dependencies: IntegrationHealthTaskDependencies
 ): Task {
   const fetchImplementation = dependencies.fetchImplementation ?? globalThis.fetch;
+  const now = dependencies.now ?? (() => new Date());
+  const alertSender =
+    dependencies.alertSender ??
+    createIntegrationHealthAlertSender(process.env, fetchImplementation);
   const logger = dependencies.logger ?? console;
 
   return async () => {
@@ -295,9 +374,62 @@ function createPollIntegrationHealthTask(
         continue;
       }
 
-      const nextRecord = await pollIntegrationHealthRecord(record, {
+      const polledRecord = await pollIntegrationHealthRecord(record, {
         captureBaseUrls: dependencies.captureBaseUrls,
         fetchImplementation
+      });
+      const occurredAt = now();
+      const occurredAtIso = occurredAt.toISOString();
+      const shouldAlert = shouldSendIntegrationHealthAlert({
+        previous: record,
+        next: polledRecord,
+        occurredAt
+      });
+      let alertSent = false;
+
+      if (shouldAlert) {
+        try {
+          const sendResult = await alertSender.send({
+            service,
+            fromStatus: record.status,
+            record: polledRecord,
+            occurredAt: occurredAtIso
+          });
+
+          if (isSuccessfulGmailSendResult(sendResult)) {
+            alertSent = true;
+            const configuredRecipient =
+              process.env.INTEGRATION_HEALTH_ALERT_RECIPIENT?.trim();
+            logger.info(
+              JSON.stringify({
+                event: "integration_health.alert_sent",
+                service,
+                fromStatus: record.status,
+                toStatus: polledRecord.status,
+                recipient:
+                  configuredRecipient && configuredRecipient.length > 0
+                    ? configuredRecipient
+                    : "nico@adventurescientists.org",
+                occurredAt: occurredAtIso
+              })
+            );
+          } else {
+            logger.error(
+              `Integration health alert email failed for ${service}: ${sendResult.kind}`
+            );
+          }
+        } catch (error) {
+          logger.error(
+            `Integration health alert email failed for ${service}: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          );
+        }
+      }
+
+      const nextRecord = applyIntegrationHealthAlertState(record, polledRecord, {
+        occurredAt: occurredAtIso,
+        alertSent
       });
 
       try {

--- a/apps/worker/test/integration-health-alert-email.test.ts
+++ b/apps/worker/test/integration-health-alert-email.test.ts
@@ -1,0 +1,90 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
+import { describe, expect, it, vi } from "vitest";
+
+import type * as IntegrationsModule from "@as-comms/integrations";
+
+const sendGmailMessage = vi.hoisted(() => vi.fn());
+
+vi.mock("@as-comms/integrations", async (importOriginal) => {
+  const actual = await importOriginal<typeof IntegrationsModule>();
+
+  return {
+    ...actual,
+    sendGmailMessage,
+  };
+});
+
+import { createIntegrationHealthAlertSender } from "../src/jobs/integration-health/email.js";
+
+describe("integration health alert email", () => {
+  it("sends the configured alert email through the shared Gmail sender", async () => {
+    sendGmailMessage.mockResolvedValue({
+      kind: "success",
+      gmailMessageId: "gmail-message-id",
+      gmailThreadId: "gmail-thread-id",
+      rfc822MessageId: "<alert@example.test>"
+    });
+
+    const sender = createIntegrationHealthAlertSender(
+      {
+        GMAIL_LIVE_ACCOUNT: "volunteers@adventurescientists.org",
+        GMAIL_GOOGLE_OAUTH_CLIENT_ID: "client-id",
+        GMAIL_GOOGLE_OAUTH_CLIENT_SECRET: "client-secret",
+        GMAIL_GOOGLE_OAUTH_REFRESH_TOKEN: "refresh-token",
+        INTEGRATION_HEALTH_ALERT_RECIPIENT: "ops@example.test",
+        INTEGRATION_HEALTH_ALERT_FROM_ALIAS: "alerts@example.test",
+        INBOX_REVALIDATE_BASE_URL: "https://comms.example.test"
+      },
+      vi.fn() as unknown as typeof fetch
+    );
+
+    const result = await sender.send({
+      service: "gmail",
+      fromStatus: "healthy",
+      occurredAt: "2026-04-20T16:00:00.000Z",
+      record: {
+        id: "gmail",
+        serviceName: "gmail",
+        category: "messaging",
+        status: "needs_attention",
+        lastCheckedAt: "2026-04-20T16:00:00.000Z",
+        degradedSinceAt: null,
+        lastAlertSentAt: null,
+        detail: "OAuth token expired.",
+        metadataJson: {
+          checkedAt: "2026-04-20T16:00:00.000Z",
+          reason: "invalid_grant"
+        },
+        createdAt: "2026-04-20T15:00:00.000Z",
+        updatedAt: "2026-04-20T16:00:00.000Z"
+      }
+    });
+
+    expect(result).toMatchObject({ kind: "success" });
+    expect(sendGmailMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromAlias: "alerts@example.test",
+        to: "ops@example.test",
+        subject: "[AS Comms] gmail integration degraded — needs_attention",
+        bodyPlaintext: expect.stringContaining(
+          "gmail status flipped from healthy to needs_attention at 2026-04-20T16:00:00.000Z."
+        ),
+        bodyHtml: expect.stringContaining(
+          "https://comms.example.test/settings/integrations"
+        ),
+        attachments: []
+      }),
+      expect.objectContaining({
+        liveAccount: "volunteers@adventurescientists.org",
+        oauthClient: expect.objectContaining({
+          clientId: "client-id",
+          clientSecret: "client-secret"
+        }),
+        oauthRefreshToken: "refresh-token"
+      })
+    );
+    expect(sendGmailMessage.mock.calls[0]?.[0].bodyPlaintext).toContain(
+      '"reason": "invalid_grant"'
+    );
+  });
+});

--- a/apps/worker/test/integration-health-task.test.ts
+++ b/apps/worker/test/integration-health-task.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { describe, expect, it, vi } from "vitest";
 
 import { createTaskList } from "../src/tasks.js";
@@ -83,6 +84,8 @@ describe("integration health poller task", () => {
 
       expect(gmailRecord.id).toBe("gmail");
       expect(gmailRecord.status).toBe("healthy");
+      expect(gmailRecord.degradedSinceAt).toBeNull();
+      expect(gmailRecord.lastAlertSentAt).toBeNull();
       expect(gmailRecord.detail).toBeNull();
       expect(typeof gmailRecord.lastCheckedAt).toBe("string");
       expect(gmailRecord.metadataJson).toMatchObject({
@@ -99,9 +102,153 @@ describe("integration health poller task", () => {
 
       expect(salesforceRecord.id).toBe("salesforce");
       expect(salesforceRecord.status).toBe("needs_attention");
+      expect(typeof salesforceRecord.degradedSinceAt).toBe("string");
+      expect(salesforceRecord.lastAlertSentAt).toBeNull();
       expect(salesforceRecord.detail).toBe("Health endpoint returned status 503.");
       expect(typeof salesforceRecord.lastCheckedAt).toBe("string");
       expect(fetchImplementation).toHaveBeenCalledTimes(2);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("sends one degradation alert, applies cooldown, and clears state on recovery", async () => {
+    const fetchImplementation = vi.fn(
+      (input: string | URL | Request): Promise<Response> => {
+        const url = toRequestUrl(input);
+        const service = url.includes("gmail") ? "gmail" : "salesforce";
+
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              service,
+              status: service === "gmail" ? "needs_attention" : "healthy",
+              checkedAt: "2026-04-20T16:00:00.000Z",
+              detail: service === "gmail" ? "OAuth token expired." : null,
+              version: `${service}-sha`
+            }),
+            {
+              status: 200,
+              headers: {
+                "content-type": "application/json"
+              }
+            }
+          )
+        );
+      }
+    );
+    const alertSender = {
+      send: vi.fn().mockResolvedValue({
+        kind: "success",
+        gmailMessageId: "gmail-message-id",
+        gmailThreadId: "gmail-thread-id",
+        rfc822MessageId: "<alert@example.test>"
+      })
+    };
+    const logger = {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn()
+    };
+    const context = await createTestWorkerContext();
+
+    try {
+      await context.settings.integrationHealth.seedDefaults();
+      const gmailRecord = await context.settings.integrationHealth.findById("gmail");
+      if (gmailRecord === null) {
+        throw new Error("Expected Gmail integration health record to exist.");
+      }
+
+      await context.settings.integrationHealth.upsert({
+        ...gmailRecord,
+        status: "healthy",
+        updatedAt: "2026-04-20T15:55:00.000Z"
+      });
+
+      const taskList = createTaskList(context.orchestration, {
+        integrationHealth: {
+          integrationHealth: context.settings.integrationHealth,
+          captureBaseUrls: {
+            gmail: "https://gmail-capture.example.test",
+            salesforce: "https://salesforce-capture.example.test"
+          },
+          fetchImplementation,
+          alertSender,
+          now: () => new Date("2026-04-20T16:00:00.000Z"),
+          logger
+        }
+      });
+      const task = taskList[pollIntegrationHealthJobName];
+
+      if (task === undefined) {
+        throw new Error("Expected integration health poller task to be registered.");
+      }
+
+      await task(undefined, {} as never);
+      await task(undefined, {} as never);
+
+      const degradedRecord =
+        await context.settings.integrationHealth.findById("gmail");
+
+      expect(alertSender.send).toHaveBeenCalledTimes(1);
+      expect(alertSender.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          service: "gmail",
+          fromStatus: "healthy",
+          occurredAt: "2026-04-20T16:00:00.000Z",
+          record: expect.objectContaining({
+            status: "needs_attention",
+            detail: "OAuth token expired.",
+            metadataJson: expect.objectContaining({
+              checkedAt: "2026-04-20T16:00:00.000Z",
+              version: "gmail-sha"
+            })
+          })
+        })
+      );
+      expect(degradedRecord?.degradedSinceAt).toBe(
+        "2026-04-20T16:00:00.000Z"
+      );
+      expect(degradedRecord?.lastAlertSentAt).toBe(
+        "2026-04-20T16:00:00.000Z"
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('"event":"integration_health.alert_sent"')
+      );
+
+      fetchImplementation.mockImplementation(
+        (input: string | URL | Request): Promise<Response> => {
+          const url = toRequestUrl(input);
+          const service = url.includes("gmail") ? "gmail" : "salesforce";
+
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                service,
+                status: "healthy",
+                checkedAt: "2026-04-20T16:30:00.000Z",
+                detail: null,
+                version: `${service}-sha`
+              }),
+              {
+                status: 200,
+                headers: {
+                  "content-type": "application/json"
+                }
+              }
+            )
+          );
+        }
+      );
+
+      await task(undefined, {} as never);
+
+      const recoveredRecord =
+        await context.settings.integrationHealth.findById("gmail");
+
+      expect(recoveredRecord?.status).toBe("healthy");
+      expect(recoveredRecord?.degradedSinceAt).toBeNull();
+      expect(recoveredRecord?.lastAlertSentAt).toBeNull();
     } finally {
       await context.dispose();
     }

--- a/packages/contracts/src/settings-records.ts
+++ b/packages/contracts/src/settings-records.ts
@@ -39,6 +39,8 @@ export const integrationHealthSchema = z.object({
   category: integrationHealthCategorySchema,
   status: integrationHealthStatusSchema,
   lastCheckedAt: nullableTimestampSchema,
+  degradedSinceAt: nullableTimestampSchema,
+  lastAlertSentAt: nullableTimestampSchema,
   detail: nullableStringSchema,
   metadataJson: metadataJsonSchema.default({}),
   createdAt: timestampSchema,

--- a/packages/db/drizzle/0024_integration_health_alert_state.sql
+++ b/packages/db/drizzle/0024_integration_health_alert_state.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "integration_health"
+  ADD COLUMN "degraded_since_at" timestamp with time zone,
+  ADD COLUMN "last_alert_sent_at" timestamp with time zone;

--- a/packages/db/src/mappers.ts
+++ b/packages/db/src/mappers.ts
@@ -485,6 +485,8 @@ export function mapIntegrationHealthRow(
     category: row.category,
     status: row.status,
     lastCheckedAt: fromDate(row.lastCheckedAt),
+    degradedSinceAt: fromDate(row.degradedSinceAt),
+    lastAlertSentAt: fromDate(row.lastAlertSentAt),
     detail: row.detail,
     metadataJson: row.metadataJson,
     createdAt: row.createdAt.toISOString(),
@@ -504,6 +506,10 @@ export function mapIntegrationHealthToInsert(
     status: parsed.status,
     lastCheckedAt:
       parsed.lastCheckedAt === null ? null : toDate(parsed.lastCheckedAt),
+    degradedSinceAt:
+      parsed.degradedSinceAt === null ? null : toDate(parsed.degradedSinceAt),
+    lastAlertSentAt:
+      parsed.lastAlertSentAt === null ? null : toDate(parsed.lastAlertSentAt),
     detail: parsed.detail,
     metadataJson: parsed.metadataJson,
     createdAt: toDate(parsed.createdAt),

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -2708,6 +2708,8 @@ function createStage2RepositoriesInternal(
               category: values.category,
               status: values.status,
               lastCheckedAt: values.lastCheckedAt,
+              degradedSinceAt: values.degradedSinceAt,
+              lastAlertSentAt: values.lastAlertSentAt,
               detail: values.detail,
               metadataJson: values.metadataJson,
               updatedAt: new Date(),

--- a/packages/db/src/schema/tables.ts
+++ b/packages/db/src/schema/tables.ts
@@ -926,6 +926,14 @@ export const integrationHealth = pgTable(
       mode: "date",
       withTimezone: true,
     }),
+    degradedSinceAt: timestamp("degraded_since_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    lastAlertSentAt: timestamp("last_alert_sent_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
     detail: text("detail"),
     metadataJson: jsonb("metadata_json")
       .$type<Record<string, unknown>>()


### PR DESCRIPTION
## Summary

Closes TSR-003 from the 2026-04-24 security audit. When an integration's health flips from `healthy → not-healthy` for `gmail` or `salesforce`, we (a) email a single alert to the configured recipient and (b) show a banner at the top of `/inbox` until the integration recovers.

## Behavior

- **Email**: subject `[AS Comms] {service} integration degraded — {status}`. Body includes the transition timestamp, last error metadata, and a link to Settings → Integrations. Uses existing Gmail-send infra (multipart/alt, signature path).
- **Cooldown**: 1 hour per service. Sustained degradation does NOT spam.
- **Recovery**: status back to `healthy` resets the alert state — next degradation fires fresh. No \"all clear\" emails by design.
- **Banner**: rose tone at top of `/inbox`, server-rendered (page is `force-dynamic` per D-040), auto-hides when all in-scope services healthy.
- **In-scope**: gmail, salesforce. Other services (mailchimp, notion, openai, simpletexting) deliberately excluded for now; trivially extensible.

## Configuration

| Env var | Default |
|---|---|
| `INTEGRATION_HEALTH_ALERT_RECIPIENT` | `nico@adventurescientists.org` |
| `INTEGRATION_HEALTH_ALERT_FROM_ALIAS` | `volunteers@adventurescientists.org` |
| `INTEGRATION_HEALTH_ALERT_SETTINGS_URL` | (optional, for the email link) |

## Migration (architect runs post-merge)

```bash
psql -f packages/db/drizzle/0024_integration_health_alert_state.sql \"\$DATABASE_URL\"
```

Adds `degraded_since_at` and `last_alert_sent_at` to `integration_health`.

## Test plan

- [x] `pnpm --filter @as-comms/worker lint | typecheck` clean
- [x] `pnpm --filter @as-comms/web lint | typecheck` clean
- [ ] CI verify green
- [ ] Manual: stop the SF capture service to force a degradation; verify (a) email arrives at recipient, (b) banner shows on /inbox, (c) restoring service hides banner and resets cooldown

🤖 Generated with [Claude Code](https://claude.com/claude-code)