### PR TITLE
[codex] Debounce inbox search URL sync

### DIFF
--- a/apps/web/app/inbox/_components/inbox-list.tsx
+++ b/apps/web/app/inbox/_components/inbox-list.tsx
@@ -150,22 +150,28 @@ export function InboxList({
       return;
     }
 
-    const nextParams = new URLSearchParams(searchParams.toString());
+    const handle = window.setTimeout(() => {
+      const nextParams = new URLSearchParams(searchParams.toString());
 
-    if (normalizedQuery.length === 0) {
-      nextParams.delete("q");
-    } else {
-      nextParams.set("q", normalizedQuery);
-    }
+      if (normalizedQuery.length === 0) {
+        nextParams.delete("q");
+      } else {
+        nextParams.set("q", normalizedQuery);
+      }
 
-    const nextQueryString = nextParams.toString();
-    const nextHref =
-      nextQueryString.length === 0
-        ? pathname
-        : `${pathname}?${nextQueryString}`;
+      const nextQueryString = nextParams.toString();
+      const nextHref =
+        nextQueryString.length === 0
+          ? pathname
+          : `${pathname}?${nextQueryString}`;
 
-    previousUrlQueryRef.current = normalizedQuery;
-    router.replace(nextHref, { scroll: false });
+      previousUrlQueryRef.current = normalizedQuery;
+      router.replace(nextHref, { scroll: false });
+    }, 400);
+
+    return () => {
+      window.clearTimeout(handle);
+    };
   }, [normalizedQuery, pathname, router, searchParams, urlQuery]);
 
   const loadFilterPage = useCallback(


### PR DESCRIPTION
## Summary

- Debounces the `/inbox` search State->URL sync by 400ms so rapid typing no longer triggers `router.replace` on every deferred query change.
- Leaves the URL->State sync path unchanged for deep links and back/forward navigation.
- Adds no dependencies and keeps the change scoped to `apps/web/app/inbox/_components/inbox-list.tsx`.

## Root cause

`/inbox` is `force-dynamic` per D-040, so each search URL update caused a Server Component re-fetch and remounted the inbox list during typing. Search result loading already runs independently through `loadFilterPage`, so the URL update can safely wait for typing to settle.

## Brief

- Codex task brief: `fix/inbox-search-url-sync-debounce` inbox search URL sync debounce.

## Validation

- `pnpm install --prefer-offline`
- `pnpm --filter @as-comms/web typecheck`
- `pnpm --filter @as-comms/web lint`
- `pnpm --filter @as-comms/web test:unit`

## Manual verification

Architect/manual after merge: type `elise` rapidly into inbox search; verify no flash during typing, URL updates to `?q=elise` about 400ms after the last keystroke, and results still appear without delay.