### PR TITLE
fix(inbox): rail sort + alias bubble tag + short project labels everywhere

### DIFF
--- a/.codex-last-message.txt
+++ b/.codex-last-message.txt
@@ -1,16 +1,8 @@
-Implemented and pushed branch `fix/readiness-admin-only`.
+Implemented the inbox/project surfacing fixes end to end.
 
-PR opened: https://github.com/nico-kneler-as/as-comms-platform/pull/125  
-Commit: `c122eb9`
+- `ContactMembershipRecord` now carries `createdAt`, and the DB mapper/repository path exposes it in both directions so memberships can be ordered deterministically and seeded in tests: [stage1-records.ts](/Users/nicolas/Downloads/AS%20Comms%20Platform/.codex-worktrees/contact-rail-sort-and-bubble-tag/packages/contracts/src/stage1-records.ts:140), [mappers.ts](/Users/nicolas/Downloads/AS%20Comms%20Platform/.codex-worktrees/contact-rail-sort-and-bubble-tag/packages/db/src/mappers.ts:418).
+- The inbox selectors now use `sortMembershipsByCreatedAt` for contact rail project ordering, resolve the list bubble tag from the last inbound Gmail alias with newest-membership fallback, and use short project labels in detail rail data: [selectors.ts](/Users/nicolas/Downloads/AS%20Comms%20Platform/.codex-worktrees/contact-rail-sort-and-bubble-tag/apps/web/app/inbox/_lib/selectors.ts:407), [selectors.ts](/Users/nicolas/Downloads/AS%20Comms%20Platform/.codex-worktrees/contact-rail-sort-and-bubble-tag/apps/web/app/inbox/_lib/selectors.ts:2119), [selectors.ts](/Users/nicolas/Downloads/AS%20Comms%20Platform/.codex-worktrees/contact-rail-sort-and-bubble-tag/apps/web/app/inbox/_lib/selectors.ts:2239), [selectors.ts](/Users/nicolas/Downloads/AS%20Comms%20Platform/.codex-worktrees/contact-rail-sort-and-bubble-tag/apps/web/app/inbox/_lib/selectors.ts:2343), [selectors.ts](/Users/nicolas/Downloads/AS%20Comms%20Platform/.codex-worktrees/contact-rail-sort-and-bubble-tag/apps/web/app/inbox/_lib/selectors.ts:2404).
+- Added the batch repository lookup for last inbound aliases and switched timeline lifecycle labels to prefer `projectAlias ?? projectName`: [repositories.ts](/Users/nicolas/Downloads/AS%20Comms%20Platform/.codex-worktrees/contact-rail-sort-and-bubble-tag/packages/db/src/repositories.ts:1451), [timeline.ts](/Users/nicolas/Downloads/AS%20Comms%20Platform/.codex-worktrees/contact-rail-sort-and-bubble-tag/packages/domain/src/timeline.ts:826).
+- Added helper/integration tests for createdAt sorting, alias-based primary membership resolution, newest-first rail ordering, and short lifecycle labels, and updated shared fixtures plus the Salesforce provider mapping for the new required membership field: [inbox-stage1-helpers.ts](/Users/nicolas/Downloads/AS%20Comms%20Platform/.codex-worktrees/contact-rail-sort-and-bubble-tag/apps/web/tests/unit/inbox-stage1-helpers.ts:25), [inbox-selectors.test.ts](/Users/nicolas/Downloads/AS%20Comms%20Platform/.codex-worktrees/contact-rail-sort-and-bubble-tag/apps/web/tests/unit/inbox-selectors.test.ts:553), [salesforce.ts](/Users/nicolas/Downloads/AS%20Comms%20Platform/.codex-worktrees/contact-rail-sort-and-bubble-tag/packages/integrations/src/providers/salesforce.ts:549).
 
-Changes:
-- `/api/readiness` now returns `{ ok: true }` for unauthenticated or non-admin callers.
-- Admin sessions still receive the full readiness posture.
-- Added unit coverage for unauthenticated, admin, and non-admin paths.
-
-Verification:
-- `pnpm --filter @as-comms/web test:unit` passed: 33 files, 185 tests.
-- `lint` and `typecheck` could not complete locally because this sandbox’s available dependency cache is missing TipTap packages used by existing `inbox-composer.tsx` imports.
-- I could not query remote PR checks after opening the PR because `gh pr checks` failed connecting to `api.github.com`.
-
-Unrelated existing worktree metadata changes remain uncommitted: `.codex-exec.log`, `.codex-last-message.txt`.
+Verification: `pnpm typecheck` passed, `pnpm lint` passed, and I also ran `pnpm install --prefer-offline`. `pnpm test:unit` is still blocked locally by the known Rollup `@rollup/rollup-darwin-arm64` native-module/code-signing failure after reinstall, so I could not get a local unit run past that environmental issue.

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -42,12 +42,14 @@ interface InboxListCacheRow {
     readonly subject: string | null;
     readonly body: string;
   } | null;
+  readonly lastInboundAlias: string | null;
 }
 
 interface InboxListCacheData {
   readonly rows: readonly InboxListCacheRow[];
   readonly projectNameById: Readonly<Record<string, string>>;
   readonly projectLabelById: Readonly<Record<string, string>>;
+  readonly aliasToProjectId: ReadonlyMap<string, string>;
   readonly counts: {
     readonly all: number;
     readonly unread: number;
@@ -402,6 +404,14 @@ function sortMemberships(
   });
 }
 
+export function sortMembershipsByCreatedAt(
+  memberships: readonly ContactMembershipRecord[],
+): readonly ContactMembershipRecord[] {
+  return [...memberships].sort((left, right) =>
+    right.createdAt.localeCompare(left.createdAt),
+  );
+}
+
 function mapVolunteerStage(
   memberships: readonly ContactMembershipRecord[],
 ): InboxVolunteerStage {
@@ -428,6 +438,29 @@ function mapVolunteerStage(
     default:
       return "non-volunteer";
   }
+}
+
+export function resolvePrimaryMembership(input: {
+  readonly memberships: readonly ContactMembershipRecord[];
+  readonly lastInboundAlias: string | null;
+  readonly aliasToProjectId: ReadonlyMap<string, string>;
+}): ContactMembershipRecord | null {
+  if (input.lastInboundAlias !== null) {
+    const projectId = input.aliasToProjectId.get(input.lastInboundAlias);
+
+    if (projectId !== undefined) {
+      const match =
+        sortMembershipsByCreatedAt(input.memberships).find(
+          (membership) => membership.projectId === projectId,
+        ) ?? null;
+
+      if (match !== null) {
+        return match;
+      }
+    }
+  }
+
+  return sortMembershipsByCreatedAt(input.memberships)[0] ?? null;
 }
 
 function mapProjectStatus(status: string | null): InboxProjectStatus {
@@ -2024,7 +2057,13 @@ async function readInboxListCacheData(input: {
   const decodedCursor = decodeInboxListCursor(input.cursor);
   const normalizedQuery = normalizeInlineText(input.query) ?? null;
   const order = orderForInboxFilter(input.filterId);
-  const [projectionPage, counts, freshness, activeProjectRecords] =
+  const [
+    projectionPage,
+    counts,
+    freshness,
+    activeProjectRecords,
+    projectAliasRecords,
+  ] =
     await Promise.all([
       normalizedQuery === null
         ? runtime.repositories.inboxProjection
@@ -2052,6 +2091,7 @@ async function readInboxListCacheData(input: {
       }),
       runtime.repositories.inboxProjection.getFreshness(),
       runtime.repositories.projectDimensions.listActive(),
+      runtime.settings.aliases.listAll(),
     ]);
   const activeProjects: readonly InboxActiveProjectOption[] =
     activeProjectRecords.map((record) => ({
@@ -2065,20 +2105,35 @@ async function readInboxListCacheData(input: {
   const candidateContactIds = pageProjections.map(
     (projection) => projection.contactId,
   );
-  const [contacts, memberships, latestMessagePreviewByCanonicalEventId] =
-    await Promise.all([
-      runtime.repositories.contacts.listByIds(candidateContactIds),
-      runtime.repositories.contactMemberships.listByContactIds(
-        candidateContactIds,
-      ),
-      loadLatestSubjectByCanonicalEventId(pageProjections),
-    ]);
+  const [
+    contacts,
+    memberships,
+    latestMessagePreviewByCanonicalEventId,
+    lastInboundAliasByContactId,
+  ] = await Promise.all([
+    runtime.repositories.contacts.listByIds(candidateContactIds),
+    runtime.repositories.contactMemberships.listByContactIds(
+      candidateContactIds,
+    ),
+    loadLatestSubjectByCanonicalEventId(pageProjections),
+    runtime.repositories.gmailMessageDetails.listLastInboundAliasByContactIds(
+      candidateContactIds,
+    ),
+  ]);
   const contactById = new Map(contacts.map((contact) => [contact.id, contact]));
   const membershipsByContactId = groupMembershipsByContactId(memberships);
   const [projectNameById, projectLabelById] = await Promise.all([
     loadProjectNameById(memberships),
     loadProjectLabelById(memberships),
   ]);
+  const aliasToProjectId = new Map<string, string>();
+
+  for (const aliasRecord of projectAliasRecords) {
+    if (aliasRecord.projectId !== null) {
+      aliasToProjectId.set(aliasRecord.alias, aliasRecord.projectId);
+    }
+  }
+
   const pageRows = pageProjections.flatMap((inboxProjection) => {
     const contact = contactById.get(inboxProjection.contactId);
 
@@ -2096,6 +2151,8 @@ async function readInboxListCacheData(input: {
           latestMessagePreviewByCanonicalEventId[
             inboxProjection.lastCanonicalEventId
           ] ?? null,
+        lastInboundAlias:
+          lastInboundAliasByContactId.get(inboxProjection.contactId) ?? null,
       } satisfies InboxListCacheRow,
     ];
   });
@@ -2104,6 +2161,7 @@ async function readInboxListCacheData(input: {
     rows: pageRows,
     projectNameById,
     projectLabelById,
+    aliasToProjectId,
     counts,
     activeProjects,
     page: {
@@ -2178,7 +2236,7 @@ async function readInboxDetailCacheData(
         runtime,
         canonicalEvents,
       }),
-    projectNameById: await loadProjectNameById(memberships),
+    projectNameById: await loadProjectLabelById(memberships),
     timelinePage: {
       hasMore: timelinePage.hasMore,
       nextCursor: timelinePage.hasMore ? timelinePage.nextBeforeSortKey : null,
@@ -2278,11 +2336,15 @@ function loadInboxWelcomeWorkloadCacheData() {
 
 function toListItemViewModel(
   row: InboxListCacheRow,
-  projectLabelById: Readonly<Record<string, string>>,
+  cacheData: Pick<InboxListCacheData, "projectLabelById" | "aliasToProjectId">,
   referenceNowIso: string,
 ): InboxListItemViewModel {
   const sortedMemberships = sortMemberships(row.memberships);
-  const primaryMembership = sortedMemberships[0] ?? null;
+  const primaryMembership = resolvePrimaryMembership({
+    memberships: row.memberships,
+    lastInboundAlias: row.lastInboundAlias,
+    aliasToProjectId: cacheData.aliasToProjectId,
+  });
   const preview = resolvePreferredMessagePreview({
     explicitSubjects: [row.latestMessagePreview?.subject],
     rawCandidates: [
@@ -2309,7 +2371,7 @@ function toListItemViewModel(
     projectLabel:
       primaryMembership === null
         ? null
-        : resolveProjectName(primaryMembership, projectLabelById),
+        : resolveProjectName(primaryMembership, cacheData.projectLabelById),
     volunteerStage: mapVolunteerStage(sortedMemberships),
     bucket: mapBucket(row.inboxProjection.bucket),
     needsFollowUp: row.inboxProjection.needsFollowUp,
@@ -2339,7 +2401,7 @@ function buildContactSummary(input: {
   readonly projectNameById: Readonly<Record<string, string>>;
   readonly referenceNowIso: string;
 }): InboxContactSummaryViewModel {
-  const memberships = sortMemberships(input.memberships);
+  const memberships = sortMembershipsByCreatedAt(input.memberships);
   const projectMemberships = memberships
     .map((membership) =>
       buildProjectMembershipViewModel(membership, input.projectNameById),
@@ -2407,7 +2469,14 @@ export async function getInboxList(
   });
   const referenceNowIso = new Date().toISOString();
   const items = cachedData.rows.map((row) =>
-    toListItemViewModel(row, cachedData.projectLabelById, referenceNowIso),
+    toListItemViewModel(
+      row,
+      {
+        projectLabelById: cachedData.projectLabelById,
+        aliasToProjectId: cachedData.aliasToProjectId,
+      },
+      referenceNowIso,
+    ),
   );
   const totals = cachedData.counts;
   const filters: InboxFilterViewModel[] = INBOX_FILTERS.map((filter) => ({

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import React, { createElement, type ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import type { ContactMembershipRecord } from "@as-comms/contracts";
 
 vi.mock("next/cache", () => ({
   unstable_cache: (loader: () => unknown) => loader,
@@ -59,6 +60,8 @@ import {
   getInboxTimelinePage,
   getInboxWelcomeWorkload,
   groupInboxTimelineSystemMessages,
+  resolvePrimaryMembership,
+  sortMembershipsByCreatedAt,
   stripSignature,
 } from "../../app/inbox/_lib/selectors";
 import { InboxContactRail } from "../../app/inbox/_components/inbox-contact-rail";
@@ -139,6 +142,25 @@ function buildTimelineEntry(
     attachmentCount: 0,
     campaignActivity: [],
     ...overrides,
+  };
+}
+
+function buildMembership(
+  overrides: Partial<ContactMembershipRecord> & {
+    readonly id: string;
+    readonly projectId: string | null;
+    readonly createdAt: string;
+  },
+): ContactMembershipRecord {
+  return {
+    id: overrides.id,
+    contactId: overrides.contactId ?? "contact:test",
+    projectId: overrides.projectId,
+    expeditionId: overrides.expeditionId ?? null,
+    role: overrides.role ?? "volunteer",
+    status: overrides.status ?? "active",
+    source: overrides.source ?? "salesforce",
+    createdAt: overrides.createdAt,
   };
 }
 
@@ -528,6 +550,97 @@ describe("groupInboxTimelineSystemMessages", () => {
   });
 });
 
+describe("sortMembershipsByCreatedAt", () => {
+  it("sorts memberships by createdAt descending", () => {
+    const memberships = [
+      buildMembership({
+        id: "membership:1",
+        projectId: "project:illegal-timber",
+        createdAt: "2026-04-04T23:52:53.343Z",
+      }),
+      buildMembership({
+        id: "membership:2",
+        projectId: "project:passive-acoustic",
+        createdAt: "2026-04-04T23:52:53.368Z",
+      }),
+      buildMembership({
+        id: "membership:3",
+        projectId: "project:whitebark-pine",
+        createdAt: "2026-04-04T23:52:53.349Z",
+      }),
+    ];
+
+    expect(sortMembershipsByCreatedAt(memberships).map((membership) => membership.id)).toEqual([
+      "membership:2",
+      "membership:3",
+      "membership:1",
+    ]);
+  });
+});
+
+describe("resolvePrimaryMembership", () => {
+  const memberships = [
+    buildMembership({
+      id: "membership:older",
+      projectId: "project:illegal-timber",
+      createdAt: "2026-04-01T10:00:00.000Z",
+      status: "lead",
+    }),
+    buildMembership({
+      id: "membership:newest",
+      projectId: "project:passive-acoustic",
+      createdAt: "2026-04-03T10:00:00.000Z",
+      status: "active",
+    }),
+  ];
+
+  it("returns the membership whose project matches the last-inbound alias", () => {
+    const primaryMembership = resolvePrimaryMembership({
+      memberships,
+      lastInboundAlias: "pnwbio@adventurescientists.org",
+      aliasToProjectId: new Map([
+        ["pnwbio@adventurescientists.org", "project:passive-acoustic"],
+      ]),
+    });
+
+    expect(primaryMembership?.id).toBe("membership:newest");
+  });
+
+  it("falls back to newest-by-createdAt when alias maps to a different project", () => {
+    const primaryMembership = resolvePrimaryMembership({
+      memberships,
+      lastInboundAlias: "whitebark@adventurescientists.org",
+      aliasToProjectId: new Map([
+        ["whitebark@adventurescientists.org", "project:whitebark-pine"],
+      ]),
+    });
+
+    expect(primaryMembership?.id).toBe("membership:newest");
+  });
+
+  it("falls back to newest-by-createdAt when no inbound alias exists", () => {
+    const primaryMembership = resolvePrimaryMembership({
+      memberships,
+      lastInboundAlias: null,
+      aliasToProjectId: new Map(),
+    });
+
+    expect(primaryMembership?.id).toBe("membership:newest");
+  });
+
+  it("returns null when memberships is empty", () => {
+    expect(
+      resolvePrimaryMembership({
+        memberships: [],
+        lastInboundAlias: "pnwbio@adventurescientists.org",
+        aliasToProjectId: new Map([
+          ["pnwbio@adventurescientists.org", "project:passive-acoustic"],
+        ]),
+      }),
+    ).toBeNull();
+  });
+});
+
 describe("real inbox selectors", () => {
   let runtime: InboxTestRuntime | null = null;
 
@@ -581,6 +694,77 @@ describe("real inbox selectors", () => {
       list.items.find((item) => item.contactId === "contact:sarah-martinez")
         ?.projectLabel,
     ).toBe("Amazon Basin");
+  });
+
+  it("uses the last inbound alias project for inbox row tags before rank sorting", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:steve-herman",
+      salesforceContactId: "003-steve",
+      displayName: "Steve Herman",
+      primaryEmail: "steve@example.org",
+      primaryPhone: null,
+      projectId: "project:illegal-timber",
+      projectName: "Illegal Timber Tracking",
+      projectAlias: "Illegal Timber",
+      membershipId: "membership:steve:illegal-timber",
+      membershipStatus: "lead",
+      membershipCreatedAt: "2026-04-01T10:00:00.000Z",
+    });
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:steve-herman",
+      salesforceContactId: "003-steve",
+      displayName: "Steve Herman",
+      primaryEmail: "steve@example.org",
+      primaryPhone: null,
+      projectId: "project:passive-acoustic",
+      projectName: "Passive Acoustic Monitoring of Pacific Northwest Forests",
+      projectAlias: "Passive Acoustic",
+      membershipId: "membership:steve:passive-acoustic",
+      membershipStatus: "active",
+      membershipCreatedAt: "2026-04-03T10:00:00.000Z",
+    });
+    await runtime.context.settings.aliases.create({
+      id: "alias:pnwbio",
+      alias: "pnwbio@adventurescientists.org",
+      signature: "",
+      projectId: "project:passive-acoustic",
+      createdAt: new Date("2026-04-20T12:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T12:00:00.000Z"),
+      createdBy: null,
+      updatedBy: null,
+    });
+    const latest = await seedInboxEmailEvent(runtime.context, {
+      id: "steve-inbound-1",
+      contactId: "contact:steve-herman",
+      occurredAt: "2026-04-20T12:30:00.000Z",
+      direction: "inbound",
+      subject: "Re: Field logistics",
+      snippet: "Replying from the PNW project alias.",
+      projectInboxAlias: "pnwbio@adventurescientists.org",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:steve-herman",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-20T12:30:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-04-20T12:30:00.000Z",
+      snippet: "Replying from the PNW project alias.",
+      lastCanonicalEventId: latest.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+
+    const list = await getInboxList();
+
+    expect(
+      list.items.find((item) => item.contactId === "contact:steve-herman")
+        ?.projectLabel,
+    ).toBe("Passive Acoustic");
   });
 
   it("uses bucket, needsFollowUp, and hasUnresolved for the secondary filters", async () => {
@@ -688,6 +872,7 @@ describe("real inbox selectors", () => {
       role: "volunteer",
       status: "trip_planning",
       source: "salesforce",
+      createdAt: "2026-04-14T12:00:00.000Z",
     });
 
     const workload = await getInboxWelcomeWorkload();
@@ -747,6 +932,91 @@ describe("real inbox selectors", () => {
       nextCursor: null,
       total: 2,
     });
+  });
+
+  it("orders contact rail active projects newest-first by membership createdAt and uses short aliases", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:steve-herman",
+      salesforceContactId: "003-steve",
+      displayName: "Steve Herman",
+      primaryEmail: "steve@example.org",
+      primaryPhone: null,
+      projectId: "project:illegal-timber",
+      projectName: "Illegal Timber Tracking",
+      projectAlias: "Illegal Timber",
+      membershipId: "membership:steve:illegal-timber",
+      membershipStatus: "lead",
+      membershipCreatedAt: "2026-04-01T10:00:00.000Z",
+    });
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:steve-herman",
+      salesforceContactId: "003-steve",
+      displayName: "Steve Herman",
+      primaryEmail: "steve@example.org",
+      primaryPhone: null,
+      projectId: "project:whitebark-pine",
+      projectName: "WPEF Tracking Whitebark Pine OR WA 2025-2026 2026",
+      projectAlias: "Whitebark Pine",
+      membershipId: "membership:steve:whitebark",
+      membershipStatus: "applied",
+      membershipCreatedAt: "2026-04-02T10:00:00.000Z",
+    });
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:steve-herman",
+      salesforceContactId: "003-steve",
+      displayName: "Steve Herman",
+      primaryEmail: "steve@example.org",
+      primaryPhone: null,
+      projectId: "project:passive-acoustic",
+      projectName: "Passive Acoustic Monitoring of Pacific Northwest Forests",
+      projectAlias: "Passive Acoustic",
+      membershipId: "membership:steve:passive-acoustic",
+      membershipStatus: "active",
+      membershipCreatedAt: "2026-04-03T10:00:00.000Z",
+    });
+    const latest = await seedInboxEmailEvent(runtime.context, {
+      id: "steve-detail-inbound-1",
+      contactId: "contact:steve-herman",
+      occurredAt: "2026-04-20T13:00:00.000Z",
+      direction: "inbound",
+      subject: "Re: Project recap",
+      snippet: "Here is the latest project update.",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:steve-herman",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-20T13:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-04-20T13:00:00.000Z",
+      snippet: "Here is the latest project update.",
+      lastCanonicalEventId: latest.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+
+    const detail = await getInboxDetail("contact:steve-herman");
+
+    if (detail === null) {
+      throw new Error("Expected inbox detail for Steve Herman");
+    }
+
+    expect(detail.contact.activeProjects.map((project) => project.projectName)).toEqual([
+      "Passive Acoustic",
+      "Whitebark Pine",
+      "Illegal Timber",
+    ]);
+    expect(
+      renderToStaticMarkup(
+        createElement(InboxContactRail, {
+          contact: detail.contact,
+        }),
+      ),
+    ).not.toContain("WPEF Tracking Whitebark Pine OR WA 2025-2026 2026");
   });
 
   it("threads Gmail From, To, and Cc headers into the timeline detail view model", async () => {
@@ -946,6 +1216,42 @@ describe("real inbox selectors", () => {
     expect(detail?.contact.recentActivity[0]?.occurredAtLabel).toEqual(
       expect.any(String),
     );
+  });
+
+  it("uses short project aliases in lifecycle timeline bodies and project activity labels", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await runtime.context.repositories.projectDimensions.upsert({
+      projectId: "project:amazon-basin",
+      projectName: "Amazon Basin Research",
+      projectAlias: "Amazon Basin",
+      source: "salesforce",
+    });
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "sarah-lifecycle-alias",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-09T09:00:00.000Z",
+      eventType: "lifecycle.received_training",
+      summary: "Received training materials",
+      projectId: "project:amazon-basin",
+    });
+
+    const detail = await getInboxDetail("contact:sarah-martinez");
+    const lifecycleEntry = detail?.timeline.find(
+      (entry) => entry.id === "timeline:sarah-lifecycle-alias",
+    );
+
+    expect(lifecycleEntry).toMatchObject({
+      kind: "system-event",
+      body: "Received training for Amazon Basin",
+    });
+    expect(detail?.contact.recentActivity).toMatchObject([
+      {
+        label: "Received training - Amazon Basin",
+      },
+    ]);
   });
 
   it("builds right-rail lifecycle activity for all four locked milestones in newest-first order", async () => {
@@ -2112,6 +2418,7 @@ describe("real inbox selectors", () => {
       role: "volunteer",
       status: "active",
       source: "salesforce",
+      createdAt: "2026-04-15T12:00:00.000Z",
     });
 
     const latest = await seedInboxEmailEvent(runtime.context, {

--- a/apps/web/tests/unit/inbox-stage1-helpers.ts
+++ b/apps/web/tests/unit/inbox-stage1-helpers.ts
@@ -22,6 +22,7 @@ export async function seedInboxContact(
     readonly projectAlias?: string | null;
     readonly membershipId?: string;
     readonly membershipStatus?: string | null;
+    readonly membershipCreatedAt?: string;
   },
 ): Promise<void> {
   await context.repositories.contacts.upsert({
@@ -52,6 +53,8 @@ export async function seedInboxContact(
       role: "volunteer",
       status: input.membershipStatus ?? null,
       source: "salesforce",
+      createdAt:
+        input.membershipCreatedAt ?? new Date().toISOString(),
     });
   }
 }
@@ -70,6 +73,7 @@ export async function seedInboxEmailEvent(
     readonly fromHeader?: string | null;
     readonly toHeader?: string | null;
     readonly ccHeader?: string | null;
+    readonly projectInboxAlias?: string | null;
   },
 ): Promise<{ readonly canonicalEventId: string }> {
   const sourceEvidenceId = `source:${input.id}`;
@@ -128,7 +132,7 @@ export async function seedInboxEmailEvent(
     snippetClean: input.snippetClean ?? input.snippet,
     bodyTextPreview: input.bodyTextPreview ?? input.snippet,
     capturedMailbox: "volunteers@example.org",
-    projectInboxAlias: "volunteers@example.org",
+    projectInboxAlias: input.projectInboxAlias ?? "volunteers@example.org",
   });
 
   await context.repositories.timelineProjection.upsert({

--- a/apps/web/tests/unit/settings-selectors.test.ts
+++ b/apps/web/tests/unit/settings-selectors.test.ts
@@ -108,7 +108,8 @@ async function seedProject(
       expeditionId: null,
       role: "volunteer",
       status: "active",
-      source: "salesforce"
+      source: "salesforce",
+      createdAt: `2026-04-20T15:${String(index).padStart(2, "0")}:00.000Z`,
     });
   }
 }

--- a/apps/worker/test/stage1-dedup-historical-ledger.test.ts
+++ b/apps/worker/test/stage1-dedup-historical-ledger.test.ts
@@ -85,7 +85,8 @@ async function seedContact(input: {
         expeditionId: "expedition_default",
         role: "volunteer",
         status: "active",
-        source: "salesforce"
+        source: "salesforce",
+        createdAt: "2026-01-01T00:00:00.000Z"
       }
     ]
   });

--- a/apps/worker/test/stage1-gmail-mbox-import.test.ts
+++ b/apps/worker/test/stage1-gmail-mbox-import.test.ts
@@ -165,7 +165,8 @@ async function seedContact(context: TestWorkerContext) {
         expeditionId: "expedition-stage1",
         role: "volunteer",
         status: "active",
-        source: "salesforce"
+        source: "salesforce",
+        createdAt: "2026-01-01T00:00:00.000Z"
       }
     ]
   });

--- a/apps/worker/test/stage1-inbox-revalidation.test.ts
+++ b/apps/worker/test/stage1-inbox-revalidation.test.ts
@@ -49,7 +49,8 @@ async function seedContact(context: TestWorkerContext): Promise<void> {
         expeditionId: "expedition-stage1",
         role: "volunteer",
         status: "active",
-        source: "salesforce"
+        source: "salesforce",
+        createdAt: "2026-01-01T00:00:00.000Z"
       }
     ]
   });

--- a/apps/worker/test/stage1-mailchimp-artifact-import.test.ts
+++ b/apps/worker/test/stage1-mailchimp-artifact-import.test.ts
@@ -50,7 +50,8 @@ async function seedContact(context: TestWorkerContext) {
         expeditionId: "expedition-stage1",
         role: "volunteer",
         status: "active",
-        source: "salesforce"
+        source: "salesforce",
+        createdAt: "2026-01-01T00:00:00.000Z"
       }
     ]
   });

--- a/apps/worker/test/stage1-ops.test.ts
+++ b/apps/worker/test/stage1-ops.test.ts
@@ -66,7 +66,8 @@ async function seedInspectableContact(context: TestWorkerContext): Promise<void>
         expeditionId: "expedition-stage1",
         role: "volunteer",
         status: "active",
-        source: "salesforce"
+        source: "salesforce",
+        createdAt: "2026-01-01T00:00:00.000Z"
       }
     ],
     projectDimensions: [

--- a/apps/worker/test/stage1-orchestration.test.ts
+++ b/apps/worker/test/stage1-orchestration.test.ts
@@ -69,7 +69,8 @@ async function seedContact(context: TestWorkerContext): Promise<void> {
         expeditionId: "expedition-stage1",
         role: "volunteer",
         status: "active",
-        source: "salesforce"
+        source: "salesforce",
+        createdAt: "2026-01-01T00:00:00.000Z"
       }
     ]
   });

--- a/apps/worker/test/stage1-runtime.test.ts
+++ b/apps/worker/test/stage1-runtime.test.ts
@@ -80,7 +80,8 @@ async function seedContact(context: TestWorkerContext): Promise<void> {
         expeditionId: "expedition-stage1",
         role: "volunteer",
         status: "active",
-        source: "salesforce"
+        source: "salesforce",
+        createdAt: "2026-01-01T00:00:00.000Z"
       }
     ]
   });

--- a/packages/contracts/src/stage1-records.ts
+++ b/packages/contracts/src/stage1-records.ts
@@ -145,6 +145,7 @@ export const contactMembershipSchema = z.object({
   role: z.string().min(1).nullable(),
   status: z.string().min(1).nullable(),
   source: recordSourceSchema,
+  createdAt: timestampSchema,
 });
 export type ContactMembershipRecord = z.infer<typeof contactMembershipSchema>;
 

--- a/packages/db/src/mappers.ts
+++ b/packages/db/src/mappers.ts
@@ -423,6 +423,7 @@ export function mapContactMembershipRow(
     role: row.role,
     status: row.status,
     source: row.source,
+    createdAt: row.createdAt.toISOString(),
   });
 }
 
@@ -439,6 +440,7 @@ export function mapContactMembershipToInsert(
     role: parsed.role,
     status: parsed.status,
     source: parsed.source,
+    createdAt: toDate(parsed.createdAt),
   };
 }
 

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -1448,6 +1448,35 @@ function createStage1RepositoriesInternal(
         return rows.map(mapGmailMessageDetailRow);
       },
 
+      async listLastInboundAliasByContactIds(contactIds) {
+        if (contactIds.length === 0) {
+          return new Map();
+        }
+
+        const result = (await db.execute(
+          sql`
+            select distinct on (${canonicalEventLedger.contactId})
+              ${canonicalEventLedger.contactId} as "contactId",
+              ${gmailMessageDetails.projectInboxAlias} as "projectInboxAlias"
+            from ${canonicalEventLedger}
+            inner join ${gmailMessageDetails}
+              on ${gmailMessageDetails.sourceEvidenceId} = ${canonicalEventLedger.sourceEvidenceId}
+            where ${inArray(canonicalEventLedger.contactId, [...contactIds])}
+              and ${gmailMessageDetails.direction} = 'inbound'
+              and ${gmailMessageDetails.projectInboxAlias} is not null
+            order by
+              ${canonicalEventLedger.contactId},
+              ${canonicalEventLedger.occurredAt} desc
+          `,
+        )) as {
+          rows: { contactId: string; projectInboxAlias: string }[];
+        };
+
+        return new Map(
+          result.rows.map((row) => [row.contactId, row.projectInboxAlias]),
+        );
+      },
+
       async upsert(record) {
         const values = mapGmailMessageDetailToInsert(record);
         const [row] = await db

--- a/packages/db/test/stage1-normalization.test.ts
+++ b/packages/db/test/stage1-normalization.test.ts
@@ -27,7 +27,8 @@ async function seedContactWithEmail(
             expeditionId: "expedition_default",
             role: "volunteer",
             status: "active",
-            source: "salesforce" as const
+            source: "salesforce" as const,
+            createdAt: "2026-01-01T00:00:00.000Z",
           }
         ];
 
@@ -50,7 +51,7 @@ async function seedContactWithEmail(
         isPrimary: true,
         source: "salesforce",
         verifiedAt: "2026-01-01T00:00:00.000Z"
-        }
+      }
       ],
     memberships
   });
@@ -292,7 +293,8 @@ describe("Stage 1 normalization service", () => {
           expeditionId: "expedition_1",
           role: "volunteer",
           status: "active",
-          source: "salesforce"
+          source: "salesforce",
+          createdAt: "2026-01-01T00:00:00.000Z"
         }
       ]
     });
@@ -1588,7 +1590,8 @@ describe("Stage 1 normalization service", () => {
           expeditionId: null,
           role: "volunteer",
           status: "active",
-          source: "salesforce"
+          source: "salesforce",
+          createdAt: "2026-01-01T00:00:00.000Z"
         },
         {
           id: "membership_2",
@@ -1597,7 +1600,8 @@ describe("Stage 1 normalization service", () => {
           expeditionId: null,
           role: "volunteer",
           status: "active",
-          source: "salesforce"
+          source: "salesforce",
+          createdAt: "2026-01-02T00:00:00.000Z"
         }
       ]
     });
@@ -1684,7 +1688,8 @@ describe("Stage 1 normalization service", () => {
           expeditionId: "expedition_anchor",
           role: "volunteer",
           status: "active",
-          source: "salesforce"
+          source: "salesforce",
+          createdAt: "2026-01-01T00:00:00.000Z"
         }
       ]
     });
@@ -1797,7 +1802,8 @@ describe("Stage 1 normalization service", () => {
           expeditionId: "expedition_cached",
           role: "volunteer",
           status: "active",
-          source: "salesforce"
+          source: "salesforce",
+          createdAt: "2026-01-01T00:00:00.000Z"
         }
       ]
     });

--- a/packages/db/test/stage1-repositories.test.ts
+++ b/packages/db/test/stage1-repositories.test.ts
@@ -254,6 +254,7 @@ describe("Stage 1 DB repositories", () => {
       role: "volunteer",
       status: "active",
       source: "salesforce",
+      createdAt: "2026-01-02T00:00:00.000Z",
     });
 
     await expect(

--- a/packages/db/test/stage1-timeline-and-notes.test.ts
+++ b/packages/db/test/stage1-timeline-and-notes.test.ts
@@ -66,7 +66,8 @@ async function seedVolunteerContact(input: {
         expeditionId: "expedition-stage1-seed",
         role: null,
         status: "applied",
-        source: "salesforce"
+        source: "salesforce",
+        createdAt: "2026-01-01T00:00:00.000Z"
       }
     ]
   });

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -179,6 +179,9 @@ export interface GmailMessageDetailRepository {
   listBySourceEvidenceIds(
     sourceEvidenceIds: readonly string[],
   ): Promise<readonly GmailMessageDetailRecord[]>;
+  listLastInboundAliasByContactIds(
+    contactIds: readonly string[],
+  ): Promise<ReadonlyMap<string, string>>;
   upsert(record: GmailMessageDetailRecord): Promise<GmailMessageDetailRecord>;
 }
 

--- a/packages/domain/src/timeline.ts
+++ b/packages/domain/src/timeline.ts
@@ -823,7 +823,7 @@ async function loadTimelinePresentationContext(
     projectNameById: new Map(
       projectDimensions.map((dimension) => [
         dimension.projectId,
-        dimension.projectName,
+        dimension.projectAlias ?? dimension.projectName,
       ]),
     ),
     expeditionNameById: new Map(

--- a/packages/domain/test/normalization.test.ts
+++ b/packages/domain/test/normalization.test.ts
@@ -340,6 +340,7 @@ function buildContext(input: {
               (record): record is GmailMessageDetailRecord => record !== undefined,
             ),
         ),
+      listLastInboundAliasByContactIds: () => Promise.resolve(new Map()),
       upsert: (record) => {
         gmailDetailsBySourceEvidenceId.set(record.sourceEvidenceId, record);
         return Promise.resolve(record);

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -92,6 +92,7 @@ describe("defineStage1RepositoryBundle", () => {
       },
       gmailMessageDetails: {
         listBySourceEvidenceIds: () => Promise.resolve([]),
+        listLastInboundAliasByContactIds: () => Promise.resolve(new Map()),
         upsert: (record) => Promise.resolve(record),
       },
       salesforceEventContext: {

--- a/packages/domain/test/stage3-last-inbound-alias.test.ts
+++ b/packages/domain/test/stage3-last-inbound-alias.test.ts
@@ -111,6 +111,7 @@ function buildRepositoryBundle(input: {
             sourceEvidenceIds.includes(detail.sourceEvidenceId),
           ),
         ),
+      listLastInboundAliasByContactIds: () => Promise.resolve(new Map()),
       upsert: (record) => Promise.resolve(record),
     },
     salesforceEventContext: {

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -172,6 +172,7 @@ function createRepositoryBundle(input: {
             return detail === undefined ? [] : [detail];
           }),
         ),
+      listLastInboundAliasByContactIds: () => Promise.resolve(new Map()),
       upsert: (record) => Promise.resolve(record),
     },
     salesforceEventContext: {

--- a/packages/integrations/src/providers/salesforce.ts
+++ b/packages/integrations/src/providers/salesforce.ts
@@ -559,6 +559,7 @@ function mapSalesforceContactSnapshot(
       role: membership.role,
       status: membership.status,
       source: "salesforce",
+      createdAt: record.createdAt,
     })),
     projectDimensions: Array.from(projectDimensionsById.values()),
     expeditionDimensions: Array.from(expeditionDimensionsById.values()),


### PR DESCRIPTION
## Summary

### 1. Contact rail — active projects sorted by createdAt DESC
`buildContactSummary` now uses a new `sortMembershipsByCreatedAt` helper instead of the status-rank sort. Active projects in the rail appear newest-first. `sortMemberships` (rank-based) is unchanged and still drives `mapVolunteerStage`.

Required: plumbed `createdAt` through `ContactMembershipRecord` (contracts schema → DB mapper → insert mapper). No DB migration — `contact_memberships.created_at` already exists.

### 2. Inbox list bubble tag — from last-inbound alias
`toListItemViewModel` now calls a new `resolvePrimaryMembership` helper that:
1. Looks up the project matching the contact's last inbound Gmail alias (`projectInboxAlias` field, already stored in `gmail_message_details`)
2. Falls back to the newest membership by `createdAt` when no alias match exists

A new `gmailMessageDetails.listLastInboundAliasByContactIds` batch query (single DISTINCT ON per page load) provides the per-contact alias. `aliasToProjectId` is loaded once per request via `runtime.settings.aliases.listAll()`.

### 3. Rail header + active-projects list — short alias labels
`readInboxDetailCacheData` now loads `loadProjectLabelById` (short alias when available, full name fallback) instead of `loadProjectNameById`. Affects the contact detail header and the active-projects list in the rail.

### 4. Timeline lifecycle events + PROJECT ACTIVITY — short alias labels
`packages/domain/src/timeline.ts` now uses `dimension.projectAlias ?? dimension.projectName` in the `projectNameById` map. Fixes both the main timeline ("Gary signed up for Whitebark Pine") and the PROJECT ACTIVITY rail section.

## Test plan
- [ ] New unit tests: `sortMembershipsByCreatedAt` DESC order, `resolvePrimaryMembership` alias-match + alias-miss + no-inbound fallback + empty memberships, contact rail active-projects newest-first via `getInboxDetail`
- [ ] CI typecheck + lint green
- [ ] Verify Steve Herman rail: Passive Acoustic first (created 23:52:53.368 — newest), then WPEF Whitebark Pine, then Illegal Timber
- [ ] Verify Steve Herman bubble tag: "Passive Acoustic" (last inbound alias `pnwbio@...`)
- [ ] Verify lifecycle events show short labels ("Whitebark Pine" not "WPEF Tracking Whitebark Pine OR WA 2025-2026")

No DB migration needed — `contact_memberships.created_at` already exists in production.

Ref: `.codex-contact-rail-sort-and-bubble-tag-2026-04-25.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)