### PR TITLE
fix(integrations): regression test + backfill ops for mbox-truncated bodies

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -13,6 +13,7 @@
     "ops:backfill-content-fingerprint": "tsx src/ops/backfill-content-fingerprint.ts",
     "ops:check-config": "tsx src/ops/cli.ts check-config",
     "ops:backfill-gmail-message-bodies": "tsx src/ops/backfill-gmail-message-bodies.ts",
+    "ops:backfill-gmail-mbox-bodies": "tsx src/ops/cli.ts backfill-gmail-mbox-bodies",
     "ops:cleanup-gmail-draft-events": "tsx src/ops/cleanup-gmail-draft-events.ts",
     "ops:backfill-mailchimp-campaign-body": "tsx src/ops/backfill-mailchimp-campaign-body.ts",
     "ops:backfill-salesforce-communication-details": "tsx src/ops/backfill-salesforce-communication-details.ts",

--- a/apps/worker/src/ops/backfill-gmail-mbox-bodies.ts
+++ b/apps/worker/src/ops/backfill-gmail-mbox-bodies.ts
@@ -1,0 +1,302 @@
+#!/usr/bin/env tsx
+import { readFile } from "node:fs/promises";
+
+import { asc, eq, inArray } from "drizzle-orm";
+
+import {
+  closeDatabaseConnection,
+  createDatabaseConnection,
+  gmailMessageDetails,
+  type Stage1Database
+} from "@as-comms/db";
+import {
+  buildLegacyMboxRecordIdCandidates,
+  importGmailMboxRecords,
+  type GmailRecord
+} from "@as-comms/integrations";
+
+import { readStage1LaunchScopeGmailConfig } from "./config.js";
+import {
+  parseCliFlags,
+  readOptionalIntegerFlag,
+  readRequiredFlag
+} from "./helpers.js";
+
+interface BackfillLogger {
+  info(message: string): void;
+}
+
+interface ExistingGmailBodyRow {
+  readonly sourceEvidenceId: string;
+  readonly providerRecordId: string;
+  readonly bodyTextPreview: string;
+  readonly snippetClean: string;
+}
+
+export interface GmailMboxBodyBackfillResult {
+  readonly dryRun: boolean;
+  readonly mboxPath: string;
+  readonly capturedMailbox: string;
+  readonly parsedRecords: number;
+  readonly matchedExisting: number;
+  readonly missingCount: number;
+  readonly unchangedCount: number;
+  readonly wouldUpdateCount: number;
+  readonly updatedCount: number;
+}
+
+function readConnectionString(env: NodeJS.ProcessEnv): string {
+  const connectionString = env.WORKER_DATABASE_URL ?? env.DATABASE_URL;
+
+  if (connectionString === undefined || connectionString.trim().length === 0) {
+    throw new Error(
+      "DATABASE_URL or WORKER_DATABASE_URL is required for Stage 1 ops commands."
+    );
+  }
+
+  return connectionString;
+}
+
+function normalizeLineEndings(value: string): string {
+  return value.replace(/\r\n/gu, "\n").replace(/\r/gu, "\n");
+}
+
+function splitMboxRawMessages(mboxText: string): string[] {
+  const normalized = normalizeLineEndings(mboxText);
+  const lines = normalized.split("\n");
+  const messages: string[] = [];
+  let currentLines: string[] = [];
+
+  for (const line of lines) {
+    if (line.startsWith("From ")) {
+      if (currentLines.length > 0) {
+        messages.push(currentLines.join("\n").trim());
+        currentLines = [];
+      }
+
+      continue;
+    }
+
+    currentLines.push(line);
+  }
+
+  if (currentLines.length > 0) {
+    messages.push(currentLines.join("\n").trim());
+  }
+
+  return messages.filter((message) => message.length > 0);
+}
+
+function isGmailMessageRecord(record: GmailRecord): record is Extract<GmailRecord, {
+  readonly recordType: "message";
+}> {
+  return record.recordType === "message";
+}
+
+async function findExistingGmailBodyRow(input: {
+  readonly db: Stage1Database;
+  readonly providerRecordIds: readonly string[];
+}): Promise<ExistingGmailBodyRow | null> {
+  const rows = await input.db
+    .select({
+      sourceEvidenceId: gmailMessageDetails.sourceEvidenceId,
+      providerRecordId: gmailMessageDetails.providerRecordId,
+      bodyTextPreview: gmailMessageDetails.bodyTextPreview,
+      snippetClean: gmailMessageDetails.snippetClean
+    })
+    .from(gmailMessageDetails)
+    .where(inArray(gmailMessageDetails.providerRecordId, [...input.providerRecordIds]))
+    .orderBy(asc(gmailMessageDetails.sourceEvidenceId));
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  const rowsByRecordId = new Map<string, ExistingGmailBodyRow>();
+
+  for (const row of rows) {
+    if (!rowsByRecordId.has(row.providerRecordId)) {
+      rowsByRecordId.set(row.providerRecordId, row);
+    }
+  }
+
+  for (const providerRecordId of input.providerRecordIds) {
+    const matchedRow = rowsByRecordId.get(providerRecordId);
+
+    if (matchedRow !== undefined) {
+      return matchedRow;
+    }
+  }
+
+  return rows[0] ?? null;
+}
+
+async function updateGmailBodyRow(input: {
+  readonly db: Stage1Database;
+  readonly sourceEvidenceId: string;
+  readonly bodyTextPreview: string;
+  readonly snippetClean: string;
+}): Promise<void> {
+  await input.db
+    .update(gmailMessageDetails)
+    .set({
+      bodyTextPreview: input.bodyTextPreview,
+      snippetClean: input.snippetClean,
+      updatedAt: new Date()
+    })
+    .where(eq(gmailMessageDetails.sourceEvidenceId, input.sourceEvidenceId));
+}
+
+export async function backfillGmailMboxBodies(input: {
+  readonly db: Stage1Database;
+  readonly mboxText: string;
+  readonly mboxPath: string;
+  readonly capturedMailbox: string;
+  readonly liveAccount: string;
+  readonly projectInboxAliases: readonly string[];
+  readonly projectInboxAliasOverride?: string | null;
+  readonly dryRun?: boolean;
+  readonly limit?: number | null;
+  readonly logger?: BackfillLogger;
+}): Promise<GmailMboxBodyBackfillResult> {
+  const dryRun = input.dryRun ?? true;
+  const logger = input.logger ?? {
+    info(message: string) {
+      console.info(message);
+    }
+  };
+  const parsedRecords = await importGmailMboxRecords({
+    mboxText: input.mboxText,
+    mboxPath: input.mboxPath,
+    capturedMailbox: input.capturedMailbox,
+    liveAccount: input.liveAccount,
+    projectInboxAliases: [...input.projectInboxAliases],
+    projectInboxAliasOverride: input.projectInboxAliasOverride ?? null,
+    receivedAt: new Date().toISOString(),
+    limit: input.limit ?? null
+  });
+  const rawMessages = splitMboxRawMessages(input.mboxText);
+  const selectedRawMessages =
+    input.limit === null || input.limit === undefined
+      ? rawMessages
+      : rawMessages.slice(0, input.limit);
+
+  let matchedExisting = 0;
+  let missingCount = 0;
+  let unchangedCount = 0;
+  let wouldUpdateCount = 0;
+  let updatedCount = 0;
+
+  for (const [index, record] of parsedRecords.entries()) {
+    if (!isGmailMessageRecord(record)) {
+      continue;
+    }
+
+    const rawMessage = selectedRawMessages[index];
+
+    if (rawMessage === undefined) {
+      throw new Error(
+        `Missing raw mbox message for parsed record ${String(index + 1)}.`
+      );
+    }
+
+    const providerRecordIds = [
+      record.recordId,
+      ...buildLegacyMboxRecordIdCandidates({
+        rawMessage,
+        capturedMailbox: input.capturedMailbox,
+        liveAccount: input.liveAccount,
+        projectInboxAliases: [...input.projectInboxAliases],
+        projectInboxAliasOverride: input.projectInboxAliasOverride ?? null
+      })
+    ];
+    const existing = await findExistingGmailBodyRow({
+      db: input.db,
+      providerRecordIds
+    });
+
+    if (existing === null) {
+      missingCount += 1;
+      continue;
+    }
+
+    matchedExisting += 1;
+
+    if (record.bodyTextPreview.length <= existing.bodyTextPreview.length) {
+      unchangedCount += 1;
+      continue;
+    }
+
+    wouldUpdateCount += 1;
+
+    if (dryRun) {
+      logger.info(
+        JSON.stringify({
+          sourceEvidenceId: existing.sourceEvidenceId,
+          oldLen: existing.bodyTextPreview.length,
+          newLen: record.bodyTextPreview.length,
+          oldFirst60: existing.bodyTextPreview.slice(0, 60),
+          newFirst60: record.bodyTextPreview.slice(0, 60)
+        })
+      );
+      continue;
+    }
+
+    await updateGmailBodyRow({
+      db: input.db,
+      sourceEvidenceId: existing.sourceEvidenceId,
+      bodyTextPreview: record.bodyTextPreview,
+      snippetClean: record.snippetClean
+    });
+    updatedCount += 1;
+  }
+
+  return {
+    dryRun,
+    mboxPath: input.mboxPath,
+    capturedMailbox: input.capturedMailbox,
+    parsedRecords: parsedRecords.length,
+    matchedExisting,
+    missingCount,
+    unchangedCount,
+    wouldUpdateCount,
+    updatedCount
+  };
+}
+
+export async function runBackfillGmailMboxBodiesCommand(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv
+): Promise<void> {
+  const flags = parseCliFlags(args);
+  const execute = Boolean(flags.execute);
+  const explicitDryRun = Boolean(flags["dry-run"]);
+
+  if (execute && explicitDryRun) {
+    throw new Error("Flags --execute and --dry-run are mutually exclusive.");
+  }
+
+  const connection = createDatabaseConnection({
+    connectionString: readConnectionString(env)
+  });
+
+  try {
+    const gmailConfig = readStage1LaunchScopeGmailConfig(env);
+    const mboxPath = readRequiredFlag(flags, "mbox-path");
+    const mboxText = await readFile(mboxPath, "utf8");
+    const result = await backfillGmailMboxBodies({
+      db: connection.db,
+      mboxText,
+      mboxPath,
+      capturedMailbox: readRequiredFlag(flags, "captured-mailbox"),
+      liveAccount: gmailConfig.liveAccount,
+      projectInboxAliases: [...gmailConfig.projectInboxAliases],
+      dryRun: execute ? false : true,
+      limit: readOptionalIntegerFlag(flags, "limit", 0) || null
+    });
+
+    console.info(JSON.stringify(result, null, 2));
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}

--- a/apps/worker/src/ops/cli.ts
+++ b/apps/worker/src/ops/cli.ts
@@ -29,6 +29,7 @@ import {
   inspectStage1Contact,
 } from "./inspect.js";
 import { runBackfillSalesforceCommunicationDetailsCommand } from "./backfill-salesforce-communication-details.js";
+import { runBackfillGmailMboxBodiesCommand } from "./backfill-gmail-mbox-bodies.js";
 import { runBackfillContentFingerprintCommand } from "./backfill-content-fingerprint.js";
 import { runBackfillMailchimpCampaignBodyCommand } from "./backfill-mailchimp-campaign-body.js";
 import { runCleanupGmailDraftEventsCommand } from "./cleanup-gmail-draft-events.js";
@@ -345,6 +346,9 @@ async function main(): Promise<void> {
     case "backfill-salesforce-communication-details":
       await runBackfillSalesforceCommunicationDetailsCommand(rest, process.env);
       return;
+    case "backfill-gmail-mbox-bodies":
+      await runBackfillGmailMboxBodiesCommand(rest, process.env);
+      return;
     case "backfill-content-fingerprint":
       await runBackfillContentFingerprintCommand(rest, process.env);
       return;
@@ -368,7 +372,7 @@ async function main(): Promise<void> {
       return;
     default:
       throw new Error(
-        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-content-fingerprint, backfill-mailchimp-campaign-body, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, dedup-historical-ledger, reconcile-identity-queue, reclassify-sf-direction.",
+        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-gmail-mbox-bodies, backfill-content-fingerprint, backfill-mailchimp-campaign-body, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, dedup-historical-ledger, reconcile-identity-queue, reclassify-sf-direction.",
       );
   }
 }

--- a/apps/worker/test/stage1-backfill-gmail-mbox-bodies.test.ts
+++ b/apps/worker/test/stage1-backfill-gmail-mbox-bodies.test.ts
@@ -1,0 +1,343 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildLegacyMboxRecordId,
+  buildSourceEvidenceId,
+  buildSourceEvidenceIdempotencyKey,
+  importGmailMboxRecords,
+  type GmailRecord
+} from "@as-comms/integrations";
+
+import {
+  backfillGmailMboxBodies
+} from "../src/ops/backfill-gmail-mbox-bodies.js";
+import { createTestWorkerContext } from "./helpers.js";
+
+const capturedMailbox = "pnw@example.org";
+const liveAccount = "volunteers@adventurescientists.org";
+const projectInboxAliases = [capturedMailbox];
+const mboxPath = "/tmp/spark-casual-on.mbox";
+const mboxText = `From MAILER-DAEMON Mon Apr 06 22:59:00 2026
+Date: Mon, 06 Apr 2026 22:59:00 +0000
+From: Volunteer <volunteer@example.org>
+To: PNW Forest Biodiversity <pnw@example.org>
+Subject: Re: Hex 31476: Were You Able to Pick Up Your ARU?
+Message-ID: <fixture-spark-casual-on-1@example.org>
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="69e45bb9_47b1b8c7_2c5"
+
+--69e45bb9_47b1b8c7_2c5
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+Content-Disposition: inline
+
+Hi Samantha,
+
+Thank you for these directions! I am planning on picking up my ARUs and =
+heading out on April 18-19. Have a great week!
+
+
+Be magnificent,
+
+
+Volunteer Name
+volunteer=40example.org
+On Mon, Apr 6, 2026 at 11:00=E2=80=AFAM PNW Forest Biodiversity <pnw=40e=
+xample.org>, wrote:
+> Hi Volunteer,
+>
+> Wonderful=21 Thank you so much.
+>
+
+--69e45bb9_47b1b8c7_2c5
+Content-Type: text/html; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+Content-Disposition: inline
+
+<div>Hi Samantha,</div>
+<div>Thank you for these directions=21 I am planning on picking up my AR=
+Us and heading out on April 18-19. Have a great week=21</div>
+
+--69e45bb9_47b1b8c7_2c5--
+`;
+
+function extractRawMessage(mboxMessage: string): string {
+  return mboxMessage
+    .replace(/\r\n/gu, "\n")
+    .replace(/\r/gu, "\n")
+    .split("\n")
+    .slice(1)
+    .join("\n")
+    .trim();
+}
+
+async function loadHistoricalMessageRecord(): Promise<Extract<GmailRecord, {
+  readonly recordType: "message";
+}>> {
+  const [record] = await importGmailMboxRecords({
+    mboxText,
+    mboxPath,
+    capturedMailbox,
+    liveAccount,
+    projectInboxAliases,
+    receivedAt: "2026-04-24T00:00:00.000Z"
+  });
+
+  if (record?.recordType !== "message") {
+    throw new Error("Expected a Gmail historical message record.");
+  }
+
+  return record as Extract<GmailRecord, { readonly recordType: "message" }>;
+}
+
+async function seedGmailMessageDetail(input: {
+  readonly context: Awaited<ReturnType<typeof createTestWorkerContext>>;
+  readonly providerRecordId: string;
+  readonly bodyTextPreview: string;
+  readonly snippetClean: string;
+}): Promise<string> {
+  const sourceEvidenceId = buildSourceEvidenceId(
+    "gmail",
+    "message",
+    input.providerRecordId
+  );
+
+  await input.context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "gmail",
+    providerRecordType: "message",
+    providerRecordId: input.providerRecordId,
+    receivedAt: "2026-04-24T00:00:00.000Z",
+    occurredAt: "2026-04-06T22:59:00.000Z",
+    payloadRef: `mbox://${encodeURIComponent(mboxPath)}#message=1`,
+    idempotencyKey: buildSourceEvidenceIdempotencyKey(
+      "gmail",
+      "message",
+      input.providerRecordId
+    ),
+    checksum: `checksum:${input.providerRecordId}`
+  });
+
+  await input.context.repositories.gmailMessageDetails.upsert({
+    sourceEvidenceId,
+    providerRecordId: input.providerRecordId,
+    gmailThreadId: null,
+    rfc822MessageId: "<fixture-spark-casual-on-1@example.org>",
+    direction: "inbound",
+    subject: "Re: Hex 31476: Were You Able to Pick Up Your ARU?",
+    fromHeader: "Volunteer <volunteer@example.org>",
+    toHeader: "PNW Forest Biodiversity <pnw@example.org>",
+    ccHeader: null,
+    labelIds: null,
+    snippetClean: input.snippetClean,
+    bodyTextPreview: input.bodyTextPreview,
+    capturedMailbox,
+    projectInboxAlias: capturedMailbox
+  });
+
+  return sourceEvidenceId;
+}
+
+describe("Stage 1 Gmail mbox body backfill ops", () => {
+  it("reports dry-run counts without mutating the stored row", async () => {
+    const context = await createTestWorkerContext();
+    const record = await loadHistoricalMessageRecord();
+    const sourceEvidenceId = await seedGmailMessageDetail({
+      context,
+      providerRecordId: record.recordId,
+      bodyTextPreview: "Hi Samantha,\n\nThank you for these directions! I am planning",
+      snippetClean: "Hi Samantha, Thank you for these directions! I am planning"
+    });
+    const logLines: string[] = [];
+
+    try {
+      const result = await backfillGmailMboxBodies({
+        db: context.db,
+        mboxText,
+        mboxPath,
+        capturedMailbox,
+        liveAccount,
+        projectInboxAliases,
+        dryRun: true,
+        logger: {
+          info(message) {
+            logLines.push(message);
+          }
+        }
+      });
+
+      expect(result).toMatchObject({
+        dryRun: true,
+        parsedRecords: 1,
+        matchedExisting: 1,
+        missingCount: 0,
+        unchangedCount: 0,
+        wouldUpdateCount: 1,
+        updatedCount: 0
+      });
+      expect(logLines).toHaveLength(1);
+
+      const [persisted] =
+        await context.repositories.gmailMessageDetails.listBySourceEvidenceIds([
+          sourceEvidenceId
+        ]);
+
+      expect(persisted?.bodyTextPreview).toBe(
+        "Hi Samantha,\n\nThank you for these directions! I am planning"
+      );
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("updates the row in execute mode when the reparsed body is longer", async () => {
+    const context = await createTestWorkerContext();
+    const record = await loadHistoricalMessageRecord();
+    const sourceEvidenceId = await seedGmailMessageDetail({
+      context,
+      providerRecordId: record.recordId,
+      bodyTextPreview: "Hi Samantha,\n\nThank you for these directions! I am planning",
+      snippetClean: "Hi Samantha, Thank you for these directions! I am planning"
+    });
+
+    try {
+      const result = await backfillGmailMboxBodies({
+        db: context.db,
+        mboxText,
+        mboxPath,
+        capturedMailbox,
+        liveAccount,
+        projectInboxAliases,
+        dryRun: false
+      });
+
+      expect(result).toMatchObject({
+        dryRun: false,
+        matchedExisting: 1,
+        wouldUpdateCount: 1,
+        updatedCount: 1
+      });
+
+      const [persisted] =
+        await context.repositories.gmailMessageDetails.listBySourceEvidenceIds([
+          sourceEvidenceId
+        ]);
+
+      expect(persisted?.bodyTextPreview).toBe(record.bodyTextPreview);
+      expect(persisted?.snippetClean).toBe(record.snippetClean);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("leaves rows alone when the current body is already complete", async () => {
+    const context = await createTestWorkerContext();
+    const record = await loadHistoricalMessageRecord();
+    const sourceEvidenceId = await seedGmailMessageDetail({
+      context,
+      providerRecordId: record.recordId,
+      bodyTextPreview: record.bodyTextPreview,
+      snippetClean: record.snippetClean
+    });
+
+    try {
+      const result = await backfillGmailMboxBodies({
+        db: context.db,
+        mboxText,
+        mboxPath,
+        capturedMailbox,
+        liveAccount,
+        projectInboxAliases,
+        dryRun: false
+      });
+
+      expect(result).toMatchObject({
+        matchedExisting: 1,
+        missingCount: 0,
+        unchangedCount: 1,
+        wouldUpdateCount: 0,
+        updatedCount: 0
+      });
+
+      const [persisted] =
+        await context.repositories.gmailMessageDetails.listBySourceEvidenceIds([
+          sourceEvidenceId
+        ]);
+
+      expect(persisted?.bodyTextPreview).toBe(record.bodyTextPreview);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("reports missing rows when no stored provider record matches", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      const result = await backfillGmailMboxBodies({
+        db: context.db,
+        mboxText,
+        mboxPath,
+        capturedMailbox,
+        liveAccount,
+        projectInboxAliases,
+        dryRun: true
+      });
+
+      expect(result).toMatchObject({
+        parsedRecords: 1,
+        matchedExisting: 0,
+        missingCount: 1,
+        unchangedCount: 0,
+        wouldUpdateCount: 0,
+        updatedCount: 0
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("matches and updates rows stored under the legacy mailbox-keyed provider id", async () => {
+    const context = await createTestWorkerContext();
+    const record = await loadHistoricalMessageRecord();
+    const legacyProviderRecordId = buildLegacyMboxRecordId({
+      rawMessage: extractRawMessage(mboxText),
+      capturedMailbox
+    });
+    const sourceEvidenceId = await seedGmailMessageDetail({
+      context,
+      providerRecordId: legacyProviderRecordId,
+      bodyTextPreview: "Hi Samantha,\n\nThank you for these directions! I am planning",
+      snippetClean: "Hi Samantha, Thank you for these directions! I am planning"
+    });
+
+    try {
+      const result = await backfillGmailMboxBodies({
+        db: context.db,
+        mboxText,
+        mboxPath,
+        capturedMailbox,
+        liveAccount,
+        projectInboxAliases,
+        dryRun: false
+      });
+
+      expect(result).toMatchObject({
+        matchedExisting: 1,
+        missingCount: 0,
+        wouldUpdateCount: 1,
+        updatedCount: 1
+      });
+
+      const [persisted] =
+        await context.repositories.gmailMessageDetails.listBySourceEvidenceIds([
+          sourceEvidenceId
+        ]);
+
+      expect(persisted?.providerRecordId).toBe(legacyProviderRecordId);
+      expect(persisted?.bodyTextPreview).toBe(record.bodyTextPreview);
+    } finally {
+      await context.dispose();
+    }
+  });
+});

--- a/packages/integrations/test/fixtures/gmail/spark-casual-on.mbox
+++ b/packages/integrations/test/fixtures/gmail/spark-casual-on.mbox
@@ -1,0 +1,42 @@
+From MAILER-DAEMON Mon Apr 06 22:59:00 2026
+Date: Mon, 06 Apr 2026 22:59:00 +0000
+From: Volunteer <volunteer@example.org>
+To: PNW Forest Biodiversity <pnw@example.org>
+Subject: Re: Hex 31476: Were You Able to Pick Up Your ARU?
+Message-ID: <fixture-spark-casual-on-1@example.org>
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="69e45bb9_47b1b8c7_2c5"
+
+--69e45bb9_47b1b8c7_2c5
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+Content-Disposition: inline
+
+Hi Samantha,
+
+Thank you for these directions! I am planning on picking up my ARUs and =
+heading out on April 18-19. Have a great week!
+
+
+Be magnificent,
+
+
+Volunteer Name
+volunteer=40example.org
+On Mon, Apr 6, 2026 at 11:00=E2=80=AFAM PNW Forest Biodiversity <pnw=40e=
+xample.org>, wrote:
+> Hi Volunteer,
+>
+> Wonderful=21 Thank you so much.
+>
+
+--69e45bb9_47b1b8c7_2c5
+Content-Type: text/html; charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+Content-Disposition: inline
+
+<div>Hi Samantha,</div>
+<div>Thank you for these directions=21 I am planning on picking up my AR=
+Us and heading out on April 18-19. Have a great week=21</div>
+
+--69e45bb9_47b1b8c7_2c5--

--- a/packages/integrations/test/gmail-body-extraction.test.ts
+++ b/packages/integrations/test/gmail-body-extraction.test.ts
@@ -150,6 +150,21 @@ describe("Gmail body extraction", () => {
     );
   });
 
+  it("does not truncate Spark-style replies at the casual word 'on' before the quoted-reply marker", async () => {
+    const mboxMessage = await readFixtureText("spark-casual-on.mbox");
+    const rawMessage = mboxMessage.replace(/^From .+\n/u, "");
+    const bodyPreview = await extractGmailBodyPreviewFromMimeMessage({
+      rawMessage
+    });
+
+    expect(bodyPreview).toContain("Thank you for these directions");
+    expect(bodyPreview).toContain("I am planning on picking up my ARUs");
+    expect(bodyPreview).toContain("Have a great week");
+    expect(bodyPreview).toContain("Volunteer Name");
+    expect(bodyPreview).not.toContain("On Mon, Apr 6, 2026");
+    expect(bodyPreview).not.toContain("> Hi Volunteer");
+  });
+
   it("preserves bodies longer than 2000 characters", () => {
     const longBody = `Hello Samantha,\n\n${"A".repeat(2_600)}`;
 


### PR DESCRIPTION
## Summary

- PR #74 already fixed the regex going forward. This PR adds a **regression test** pinning the casual-"on" loophole on the mbox parsing path, plus a **surgical backfill ops script** for the historical rows still stored with truncated bodies.
- No regex changes. No live-capture changes. The backfill writes only to `gmail_message_details.body_text_preview` + `snippet_clean`; nothing in `canonical_event_ledger`, `source_evidence_log`, or projections.

## Diagnosis (verified, no need to repeat)

The OLD regex `/(?:\bOn .+? wrote:)\s*>/isu` (pre-#74) matched the casual lowercase word "on" mid-sentence — case-insensitive `i`, word-boundary `\b` (NOT line-start), and `s` flag letting `.+?` cross newlines until the actual `On <date> ... wrote:\n>` quoted-reply marker. Replayed against `simpleParser` output of the four Tani Thomas Spark inbounds in `mbox files/pnwbio.mbox`:

| Tani message | DB body_len | OLD regex cuts to | NEW regex cuts to | Trigger |
|---|---|---|---|---|
| Apr 19 (`0fdac41d-…@Spark`) | 83  | **83**  | 210 | "...too much snow **on** the forest roads..." |
| Apr 6  (`83f3c7a3-…@Spark`) | 59  | **59**  | 186 | "...I am planning **on** picking up..." |
| Mar 29 (`0070c016-…@Spark`) | 64  | **64**  | 791 | "...sent an email **on** Friday..." |
| Mar 23 (`0d9d5eb3-…@Spark`) | 124 | 126 | 126 | proper "On Mon, Mar 23..." line — both regexes hit correctly |

PR #74's regex `/(?:\n|^)\s*On .+? wrote:\s*>/su` produces the right cut. Affected universe in prod: 860 mbox-imported inbound rows + 11 pre-#74 live-captured inbound rows. The 11 live rows are handled by the existing `backfill-gmail-message-bodies` script (out of scope here). The 860 mbox rows need this script.

## What's in this PR

1. **Regression test** in `packages/integrations`:
   - New fixture `test/fixtures/gmail/spark-casual-on.mbox` — sanitized version of the exact failing message structure (multipart/alternative, quoted-printable, `On <date> ... wrote:\n>` block, casual "on" earlier in the body).
   - New test `does not truncate Spark-style replies at the casual word 'on' before the quoted-reply marker` exercising `extractGmailBodyPreviewFromMimeMessage` end-to-end (the existing `trimQuotedReplyContent`-only test missed the mbox-path coupling).
2. **`apps/worker/src/ops/backfill-gmail-mbox-bodies.ts`** — new ops script:
   - `--mbox-path`, `--captured-mailbox` required.
   - `--dry-run` (default) prints stats + a one-line JSON per row that would change. `--execute` writes.
   - Re-parses via `importGmailMboxRecords`, matches DB rows by `provider_record_id` (preferred + legacy mailbox-keyed candidates), updates only when the re-parsed body is strictly longer.
3. CLI wiring in `apps/worker/src/ops/cli.ts` + script alias in `apps/worker/package.json`.
4. **Five unit tests** covering: dry-run no-write, execute updates, no-op when complete, missing-row reported, legacy mailbox-keyed record-id matched.

## How architect will use it

For each of the four mailboxes:

```bash
DATABASE_URL=… pnpm --filter @as-comms/worker ops:backfill-gmail-mbox-bodies \
  --mbox-path "/Users/nicolas/Downloads/AS Comms Platform/mbox files/pnwbio.mbox" \
  --captured-mailbox pnwbio@adventurescientists.org
# review wouldUpdateCount + sampled diffs, then re-run with --execute
```

Repeat for `volunteers.mbox`, `whitebark.mbox`, `orcas.mbox`. Total prod row count to update should land in the 200–500 range based on the 407 mbox rows under 200 chars (some are legitimately short).

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm --filter @as-comms/integrations test` passes (new regression test in there)
- [ ] CI runs `pnpm test:unit` for `@as-comms/worker` (local macOS hits the rollup-darwin-arm64 gotcha; CI is authoritative per `project_macos_rollup_gotcha.md`)
- [ ] Architect runs `--dry-run` against prod for all four mbox files and posts row counts before approving `--execute`

## Out of scope

- No regex changes; PR #74 already fixed the bug for live capture going forward.
- The 11 pre-#74 live-captured inbound rows handled separately by the existing `backfill-gmail-message-bodies` ops script.
- No canon changes (`docs/01-core`, `docs/02-bundles`).
- No changes to `canonical_event_ledger`, `source_evidence_log`, projections, or normalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)