### PR TITLE
fix(inbox-composer): show AI draft text in rich-text editor

### DIFF
--- a/apps/web/app/inbox/_components/composer-html.ts
+++ b/apps/web/app/inbox/_components/composer-html.ts
@@ -1,0 +1,24 @@
+export function escapeComposerHtmlSegment(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+export function plaintextToComposerHtml(value: string): string {
+  return value
+    .split(/\n\s*\n+/u)
+    .map((paragraph) => paragraph.trim())
+    .filter((paragraph) => paragraph.length > 0)
+    .map((paragraph) => {
+      const html = paragraph
+        .split("\n")
+        .map((segment) => escapeComposerHtmlSegment(segment))
+        .join("<br>");
+
+      return `<p>${html}</p>`;
+    })
+    .join("");
+}

--- a/apps/web/app/inbox/_components/inbox-composer.tsx
+++ b/apps/web/app/inbox/_components/inbox-composer.tsx
@@ -51,6 +51,7 @@ import {
   resolveDefaultAlias,
 } from "../_lib/composer-ui";
 import type { InboxComposerAliasOption } from "../_lib/view-models";
+import { plaintextToComposerHtml } from "./composer-html";
 import {
   ComposerToolbar,
   type ComposerToolbarCommand,
@@ -100,31 +101,6 @@ interface SenderPickerProps {
 }
 
 type ComposerFieldErrors = readonly ComposerValidationError[];
-
-function escapeComposerHtmlSegment(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
-}
-
-function plaintextToComposerHtml(value: string): string {
-  return value
-    .split(/\n\s*\n+/u)
-    .map((paragraph) => paragraph.trim())
-    .filter((paragraph) => paragraph.length > 0)
-    .map((paragraph) => {
-      const html = paragraph
-        .split("\n")
-        .map((segment) => escapeComposerHtmlSegment(segment))
-        .join("<br>");
-
-      return `<p>${html}</p>`;
-    })
-    .join("");
-}
 
 function formatBytes(bytes: number): string {
   if (bytes >= 1024 * 1024) {
@@ -1303,6 +1279,3 @@ export function InboxComposerDetailPane() {
   );
 }
 
-export const _test_only = {
-  plaintextToComposerHtml,
-};

--- a/apps/web/app/inbox/_components/inbox-composer.tsx
+++ b/apps/web/app/inbox/_components/inbox-composer.tsx
@@ -101,6 +101,31 @@ interface SenderPickerProps {
 
 type ComposerFieldErrors = readonly ComposerValidationError[];
 
+function escapeComposerHtmlSegment(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function plaintextToComposerHtml(value: string): string {
+  return value
+    .split(/\n\s*\n+/u)
+    .map((paragraph) => paragraph.trim())
+    .filter((paragraph) => paragraph.length > 0)
+    .map((paragraph) => {
+      const html = paragraph
+        .split("\n")
+        .map((segment) => escapeComposerHtmlSegment(segment))
+        .join("<br>");
+
+      return `<p>${html}</p>`;
+    })
+    .join("");
+}
+
 function formatBytes(bytes: number): string {
   if (bytes >= 1024 * 1024) {
     return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
@@ -318,8 +343,22 @@ function RichTextComposerEditor({
       return;
     }
 
-    if (bodyPlaintext.length === 0 && editor.getText().length > 0) {
+    const trimmedBodyPlaintext = bodyPlaintext.trim();
+    const trimmedEditorText = editor.getText().trim();
+
+    if (trimmedBodyPlaintext.length === 0 && trimmedEditorText.length > 0) {
       editor.commands.clearContent();
+      return;
+    }
+
+    if (
+      trimmedBodyPlaintext.length > 0 &&
+      trimmedBodyPlaintext !== trimmedEditorText
+    ) {
+      editor.commands.setContent(
+        plaintextToComposerHtml(bodyPlaintext),
+        { emitUpdate: false },
+      );
     }
   }, [bodyPlaintext, editor]);
 
@@ -769,6 +808,7 @@ export function InboxComposerDetailPane() {
       clearComposerErrors();
       setInlineError(null);
       setBody(result.data.draft);
+      setBodyHtml(plaintextToComposerHtml(result.data.draft));
       setRepromptText("");
       insertAiDraft({
         request,
@@ -1262,3 +1302,7 @@ export function InboxComposerDetailPane() {
     </TooltipProvider>
   );
 }
+
+export const _test_only = {
+  plaintextToComposerHtml,
+};

--- a/apps/web/tests/unit/stage3-composer-ui.test.tsx
+++ b/apps/web/tests/unit/stage3-composer-ui.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { InboxComposerReplyContext } from "../../app/inbox/_lib/view-models";
+import { _test_only } from "../../app/inbox/_components/inbox-composer";
 import {
   formatContactRecipientLabel,
   reduceComposerPane,
@@ -136,5 +137,15 @@ describe("stage3 composer ui helpers", () => {
         isSending: false
       })
     ).toBe(true);
+  });
+
+  it("converts AI draft plaintext into safe composer HTML paragraphs and line breaks", () => {
+    expect(
+      _test_only.plaintextToComposerHtml(
+        `Hi Lily,\n\nThanks for reaching out.\nSecond line\n\n<script>alert("xss")</script>\n`,
+      ),
+    ).toBe(
+      "<p>Hi Lily,</p><p>Thanks for reaching out.<br>Second line</p><p>&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;</p>",
+    );
   });
 });

--- a/apps/web/tests/unit/stage3-composer-ui.test.tsx
+++ b/apps/web/tests/unit/stage3-composer-ui.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { InboxComposerReplyContext } from "../../app/inbox/_lib/view-models";
-import { _test_only } from "../../app/inbox/_components/inbox-composer";
+import { plaintextToComposerHtml } from "../../app/inbox/_components/composer-html";
 import {
   formatContactRecipientLabel,
   reduceComposerPane,
@@ -141,7 +141,7 @@ describe("stage3 composer ui helpers", () => {
 
   it("converts AI draft plaintext into safe composer HTML paragraphs and line breaks", () => {
     expect(
-      _test_only.plaintextToComposerHtml(
+      plaintextToComposerHtml(
         `Hi Lily,\n\nThanks for reaching out.\nSecond line\n\n<script>alert("xss")</script>\n`,
       ),
     ).toBe(


### PR DESCRIPTION
## Why

The "Fill with AI" button in the inbox composer ran successfully and showed the reprompt UI, but the message body stayed empty. Reproduced live today on a Whitebark Pine thread (Lily Luo, "Re: Last Call: PNW Training") with `whitebarkpine@adventurescientists.org` alias.

Root cause: `RichTextComposerEditor` (tiptap, added in #118) only handled "external clear" — it never injected external content into the tiptap instance. The AI flow's `setBody(result.data.draft)` updated React state, but the editor stayed at its empty initial content.

## Changes

- New `plaintextToComposerHtml` helper: splits on blank lines into `<p>` paragraphs, single newlines become `<br>`, escapes HTML-unsafe chars
- Extended the `RichTextComposerEditor` sync effect to call `editor.commands.setContent(...)` with `emitUpdate: false` when `bodyPlaintext` is non-empty and differs from the editor's current text (trimmed comparison guards against the onUpdate feedback loop)
- AI draft callback now also calls `setBodyHtml(plaintextToComposerHtml(result.data.draft))` so Send doesn't ship an empty HTML body
- `_test_only` export of the helper for the regression test

## Test plan

- typecheck: pass (web package)
- lint: pass (web package)
- unit tests: pass on the new conversion helper. Full `pnpm test:unit` failed locally with the known macOS rollup-darwin-arm64 environmental issue; CI is authoritative
- Manual: click Fill with AI → expect the returned text to render in the editor

## Deviation from brief

Regression test is a narrow pure-unit test for `plaintextToComposerHtml`, not a live tiptap rerender. Vitest config runs in node, not jsdom — a stable DOM editor test would have needed extra harness work outside this fix's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via Codex