### PR TITLE
fix(composer): From display name + config-failure logging

### DIFF
--- a/apps/web/src/server/composer/gmail-send.ts
+++ b/apps/web/src/server/composer/gmail-send.ts
@@ -44,7 +44,8 @@ export async function sendComposerGmailMessage(
 
   try {
     config = readComposerGmailSendConfig(process.env);
-  } catch {
+  } catch (error) {
+    console.error("[composer/gmail-send] Config parse failed — check GMAIL_* env vars on web service.", error);
     return {
       kind: "auth_error",
       detail: "Composer Gmail send is not configured."

--- a/docs/03-reference/reference-security-response.md
+++ b/docs/03-reference/reference-security-response.md
@@ -25,10 +25,14 @@
 | `MAILCHIMP_CAPTURE_TOKEN`  | future `worker` + Mailchimp capture service | Railway service variables           | Deferred until Mailchimp capture resumes.                                 |
 | `SENDGRID_API_KEY`         | future campaigns service                    | Railway service variables           | Deferred until Campaigns Email lands.                                     |
 | `ANTHROPIC_API_KEY`        | `web`                                       | Railway service variables           | Powers Stage 4 AI drafting in the web service only.                       |
+| `GMAIL_LIVE_ACCOUNT`       | `web`, `worker`, `gmail-capture`            | Railway service variables           | `web` uses it for composer sends; `worker`/`gmail-capture` for ingestion. |
+| `GMAIL_GOOGLE_OAUTH_CLIENT_ID` | `web`, `worker`, `gmail-capture`        | Railway service variables           | Same OAuth app; rotate the client ID across all three services together.  |
+| `GMAIL_GOOGLE_OAUTH_CLIENT_SECRET` | `web`, `worker`, `gmail-capture`    | Railway service variables           | Same OAuth app; rotate the client secret across all three services.       |
+| `GMAIL_GOOGLE_OAUTH_REFRESH_TOKEN` | `web`, `worker`, `gmail-capture`    | Railway service variables           | If revoked, re-mint via the Google OAuth flow and update all three.       |
 
 Current provider-facing secrets that also need the same treatment:
 
-- Gmail capture OAuth credentials in `gmail-capture`: `GMAIL_GOOGLE_OAUTH_CLIENT_SECRET`, `GMAIL_GOOGLE_OAUTH_REFRESH_TOKEN`
+- Gmail OAuth credentials (`GMAIL_GOOGLE_OAUTH_CLIENT_SECRET`, `GMAIL_GOOGLE_OAUTH_REFRESH_TOKEN`): required on **`web`** (composer sends), **`worker`**, and **`gmail-capture`**
 - Salesforce capture credentials in `salesforce-capture`: `SALESFORCE_CLIENT_ID`, `SALESFORCE_JWT_PRIVATE_KEY`
 
 ## Railway Rotation Commands

--- a/packages/integrations/src/providers/gmail-send.ts
+++ b/packages/integrations/src/providers/gmail-send.ts
@@ -235,7 +235,7 @@ function buildMimeMessage(
   const rfc822MessageId = buildMessageId(params.fromAlias, now);
   const headers = [
     `Date: ${now.toUTCString()}`,
-    `From: <${params.fromAlias}>`,
+    `From: "Adventure Scientists" <${params.fromAlias}>`,
     `To: <${params.to}>`,
     `Subject: ${encodeHeaderWordUtf8(params.subject)}`,
     `Message-ID: ${rfc822MessageId}`,

--- a/packages/integrations/test/stage3-gmail-send.test.ts
+++ b/packages/integrations/test/stage3-gmail-send.test.ts
@@ -157,7 +157,9 @@ describe("Stage 3 Gmail send client", () => {
 
     const rawMessage = decodeRawMessage(String(requestBody.raw));
 
-    expect(rawMessage).toContain("From: <pnwbio@adventurescientists.org>");
+    expect(rawMessage).toContain(
+      "From: \"Adventure Scientists\" <pnwbio@adventurescientists.org>"
+    );
     expect(rawMessage).toContain("To: <volunteer@example.org>");
     expect(rawMessage).toContain("Subject: Re: Field update");
     expect(rawMessage).toContain("In-Reply-To: <parent-message@example.org>");


### PR DESCRIPTION
## Summary

Two small composer-send fixes pulled out of yesterday's diagnosis session into a reviewable PR.

- **From display name**: MIME builder now emits `From: Adventure Scientists <alias@…>` instead of a bare email. One-line change in `gmail-send.ts`. Recipients were seeing the bare address.
- **Config-parse logging**: `sendComposerGmailMessage` was silently catching Zod parse failures and returning generic `auth_error`. Now adds `console.error` so Railway logs surface the missing env var. This is the change that would have shortened today's "Email sending unavailable" diagnosis from ~30 min to ~5.
- **Secret inventory doc**: documents `GMAIL_LIVE_ACCOUNT` + the 3 OAuth vars as required on all three Railway services, closing the gap that caused the outage.

## Test plan

- [x] Already deployed effectively — these were committed direct to local main yesterday during the composer-send-fix session, this PR is just bringing them through normal CI/PR gate.
- [ ] CI verify green
- [ ] Architect review

🤖 Generated with [Claude Code](https://claude.com/claude-code)