### PR TITLE
fix(contact-rail): plumb salesforceMembershipId for correct expedition CRM links

### DIFF
--- a/apps/web/app/inbox/_components/inbox-contact-rail.tsx
+++ b/apps/web/app/inbox/_components/inbox-contact-rail.tsx
@@ -154,26 +154,43 @@ function ProjectsSection({ title, projects, emptyLabel }: ProjectsSectionProps) 
         <ul className="mt-2 space-y-1">
           {projects.map((project) => (
             <li key={project.membershipId}>
-              <a
-                href={project.crmUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="group flex items-center gap-2 rounded-lg px-2 py-1.5 transition hover:bg-white hover:ring-1 hover:ring-slate-200"
-              >
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-[13px] font-medium text-slate-800 group-hover:text-slate-900">
-                    {project.projectName}
-                  </p>
-                  <p className="mt-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
-                    <span className="tabular-nums">
-                      {project.year.toString()}
-                    </span>
-                    <span className="text-slate-300">·</span>
-                    <InboxProjectStatusBadge status={project.status} />
-                  </p>
+              {project.crmUrl != null ? (
+                <a
+                  href={project.crmUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="group flex items-center gap-2 rounded-lg px-2 py-1.5 transition hover:bg-white hover:ring-1 hover:ring-slate-200"
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-[13px] font-medium text-slate-800 group-hover:text-slate-900">
+                      {project.projectName}
+                    </p>
+                    <p className="mt-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
+                      <span className="tabular-nums">
+                        {project.year.toString()}
+                      </span>
+                      <span className="text-slate-300">·</span>
+                      <InboxProjectStatusBadge status={project.status} />
+                    </p>
+                  </div>
+                  <ChevronRightIcon className="h-3.5 w-3.5 shrink-0 text-slate-300 group-hover:text-slate-500" />
+                </a>
+              ) : (
+                <div className="flex items-center gap-2 rounded-lg px-2 py-1.5">
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-[13px] font-medium text-slate-800">
+                      {project.projectName}
+                    </p>
+                    <p className="mt-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
+                      <span className="tabular-nums">
+                        {project.year.toString()}
+                      </span>
+                      <span className="text-slate-300">·</span>
+                      <InboxProjectStatusBadge status={project.status} />
+                    </p>
+                  </div>
                 </div>
-                <ChevronRightIcon className="h-3.5 w-3.5 shrink-0 text-slate-300 group-hover:text-slate-500" />
-              </a>
+              )}
             </li>
           ))}
         </ul>

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -515,11 +515,10 @@ function buildProjectMembershipViewModel(
     // shell keeps its existing contract with a selector-derived current year.
     year: new Date().getUTCFullYear(),
     status: mapProjectStatus(membership.status),
-    // Right-rail links must target the volunteer's Salesforce membership
-    // record for that specific project context.
-    crmUrl: `https://adventurescientists.lightning.force.com/lightning/r/Expedition_Members__c/${encodeURIComponent(
-      membership.id,
-    )}/view`,
+    crmUrl:
+      membership.salesforceMembershipId != null
+        ? `https://adventurescientists.lightning.force.com/lightning/r/Expedition_Members__c/${membership.salesforceMembershipId}/view`
+        : null,
   };
 }
 

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -100,7 +100,7 @@ export interface InboxProjectMembershipViewModel {
   readonly projectName: string;
   readonly year: number;
   readonly status: InboxProjectStatus;
-  readonly crmUrl: string;
+  readonly crmUrl: string | null;
 }
 
 export interface InboxRecentActivityViewModel {

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -207,6 +207,7 @@ async function seedInboxFixture(runtime: InboxTestRuntime): Promise<void> {
     projectName: "Amazon Basin Research",
     membershipId: "membership:sarah",
     membershipStatus: "in_training",
+    salesforceMembershipId: "a15VK00000AUcRtYAL",
   });
   await seedInboxEmailEvent(runtime.context, {
     id: "sarah-outbound-1",
@@ -916,7 +917,7 @@ describe("real inbox selectors", () => {
       projectName: "Amazon Basin Research",
       status: "in-training",
       crmUrl:
-        "https://adventurescientists.lightning.force.com/lightning/r/Expedition_Members__c/membership%3Asarah/view",
+        "https://adventurescientists.lightning.force.com/lightning/r/Expedition_Members__c/a15VK00000AUcRtYAL/view",
     });
     expect(detail?.timeline.map((entry) => entry.kind)).toEqual([
       "outbound-email",

--- a/apps/web/tests/unit/inbox-stage1-helpers.ts
+++ b/apps/web/tests/unit/inbox-stage1-helpers.ts
@@ -23,6 +23,7 @@ export async function seedInboxContact(
     readonly membershipId?: string;
     readonly membershipStatus?: string | null;
     readonly membershipCreatedAt?: string;
+    readonly salesforceMembershipId?: string | null;
   },
 ): Promise<void> {
   await context.repositories.contacts.upsert({
@@ -55,6 +56,7 @@ export async function seedInboxContact(
       source: "salesforce",
       createdAt:
         input.membershipCreatedAt ?? new Date().toISOString(),
+      salesforceMembershipId: input.salesforceMembershipId ?? null,
     });
   }
 }

--- a/apps/worker/src/ops/backfill-membership-sf-ids.ts
+++ b/apps/worker/src/ops/backfill-membership-sf-ids.ts
@@ -1,0 +1,291 @@
+#!/usr/bin/env tsx
+/**
+ * backfill-membership-sf-ids
+ *
+ * Re-pulls Expedition_Members__c.Id from Salesforce for every contact_membership
+ * row that has source = 'salesforce' but salesforce_membership_id IS NULL.
+ * Run once after migration 0025 to fill legacy rows.
+ *
+ * Usage (dry-run by default):
+ *   pnpm --filter @as-comms/worker ops backfill-membership-sf-ids
+ *   pnpm --filter @as-comms/worker ops backfill-membership-sf-ids --execute
+ *   pnpm --filter @as-comms/worker ops backfill-membership-sf-ids --execute --limit=500
+ *
+ * Required env vars (same as salesforce-capture service):
+ *   DATABASE_URL or WORKER_DATABASE_URL
+ *   SALESFORCE_LOGIN_URL
+ *   SALESFORCE_CLIENT_ID
+ *   SALESFORCE_USERNAME
+ *   SALESFORCE_JWT_PRIVATE_KEY
+ * Optional:
+ *   SALESFORCE_JWT_EXPIRATION_SECONDS  (default 180)
+ *   SALESFORCE_API_VERSION             (default 61.0)
+ */
+import process from "node:process";
+
+import { and, eq, isNull, sql } from "drizzle-orm";
+
+import {
+  closeDatabaseConnection,
+  contactMemberships,
+  contacts,
+  createDatabaseConnection,
+  type Stage1Database,
+} from "@as-comms/db";
+import {
+  createSalesforceApiClient,
+  type SalesforceApiClient,
+} from "@as-comms/integrations";
+
+import { parseCliFlags, readOptionalIntegerFlag } from "./helpers.js";
+
+const soqlBatchSize = 200;
+const updateChunkSize = 500;
+
+interface Logger {
+  log(...args: readonly unknown[]): void;
+  error(...args: readonly unknown[]): void;
+}
+
+interface MembershipCandidate {
+  readonly membershipId: string;
+  readonly salesforceContactId: string;
+  readonly projectId: string | null;
+  readonly expeditionId: string | null;
+}
+
+interface SalesforceIdMatch {
+  readonly membershipId: string;
+  readonly salesforceMembershipId: string;
+}
+
+export interface BackfillMembershipSfIdsResult {
+  readonly dryRun: boolean;
+  readonly candidateCount: number;
+  readonly matchedCount: number;
+  readonly unmatchedCount: number;
+  readonly updatedCount: number;
+  readonly sample: readonly SalesforceIdMatch[];
+}
+
+function readConnectionString(env: NodeJS.ProcessEnv): string {
+  const connectionString = env.WORKER_DATABASE_URL ?? env.DATABASE_URL;
+
+  if (connectionString === undefined || connectionString.trim().length === 0) {
+    throw new Error(
+      "DATABASE_URL or WORKER_DATABASE_URL is required for this ops command.",
+    );
+  }
+
+  return connectionString;
+}
+
+function readRequiredEnv(env: NodeJS.ProcessEnv, key: string): string {
+  const value = env[key]?.trim();
+
+  if (value === undefined || value.length === 0) {
+    throw new Error(`${key} is required for this ops command.`);
+  }
+
+  return value;
+}
+
+function chunkValues<TValue>(
+  values: readonly TValue[],
+  chunkSize: number,
+): TValue[][] {
+  const chunks: TValue[][] = [];
+
+  for (let i = 0; i < values.length; i += chunkSize) {
+    chunks.push(values.slice(i, i + chunkSize));
+  }
+
+  return chunks;
+}
+
+async function loadCandidates(input: {
+  readonly db: Stage1Database;
+  readonly limit: number | null;
+}): Promise<readonly MembershipCandidate[]> {
+  const rows = await input.db
+    .select({
+      membershipId: contactMemberships.id,
+      salesforceContactId: contacts.salesforceContactId,
+      projectId: contactMemberships.projectId,
+      expeditionId: contactMemberships.expeditionId,
+    })
+    .from(contactMemberships)
+    .innerJoin(contacts, eq(contactMemberships.contactId, contacts.id))
+    .where(
+      and(
+        eq(contactMemberships.source, "salesforce"),
+        isNull(contactMemberships.salesforceMembershipId),
+      ),
+    )
+    .orderBy(contactMemberships.id);
+
+  const candidates = rows.filter(
+    (row): row is MembershipCandidate & { salesforceContactId: string } =>
+      row.salesforceContactId !== null,
+  );
+
+  return input.limit === null ? candidates : candidates.slice(0, input.limit);
+}
+
+async function fetchSfIds(
+  sfClient: SalesforceApiClient,
+  contactIds: readonly string[],
+): Promise<readonly { Id: string; Contact__c: string; Project__c: string; Expedition__c: string }[]> {
+  const quoted = contactIds.map((id) => `'${id}'`).join(",");
+  const soql = `SELECT Id, Contact__c, Project__c, Expedition__c FROM Expedition_Members__c WHERE Contact__c IN (${quoted})`;
+  const rows = await sfClient.queryAll(soql);
+
+  return rows as {
+    Id: string;
+    Contact__c: string;
+    Project__c: string;
+    Expedition__c: string;
+  }[];
+}
+
+export async function backfillMembershipSfIds(input: {
+  readonly db: Stage1Database;
+  readonly sfClient: SalesforceApiClient;
+  readonly dryRun?: boolean;
+  readonly limit?: number | null;
+  readonly logger?: Logger;
+}): Promise<BackfillMembershipSfIdsResult> {
+  const dryRun = input.dryRun ?? true;
+  const logger = input.logger ?? console;
+
+  const candidates = await loadCandidates({
+    db: input.db,
+    limit: input.limit ?? null,
+  });
+
+  logger.log(`Found ${candidates.length} memberships needing SF ID backfill.`);
+
+  const uniqueContactIds = Array.from(
+    new Set(candidates.map((c) => c.salesforceContactId)),
+  );
+
+  logger.log(`Querying Salesforce for ${uniqueContactIds.length} contact IDs across ${Math.ceil(uniqueContactIds.length / soqlBatchSize)} batch(es).`);
+
+  const sfRows: {
+    Id: string;
+    Contact__c: string;
+    Project__c: string;
+    Expedition__c: string;
+  }[] = [];
+
+  for (const batch of chunkValues(uniqueContactIds, soqlBatchSize)) {
+    const rows = await fetchSfIds(input.sfClient, batch);
+    sfRows.push(...rows);
+  }
+
+  logger.log(`Salesforce returned ${sfRows.length} Expedition_Members__c rows.`);
+
+  // Build lookup: (contactId, projectId, expeditionId) → SF record Id
+  const sfLookup = new Map<string, string>();
+  for (const row of sfRows) {
+    const key = `${row.Contact__c}|${row.Project__c ?? ""}|${row.Expedition__c ?? ""}`;
+    sfLookup.set(key, row.Id);
+  }
+
+  const matches: SalesforceIdMatch[] = [];
+  let unmatchedCount = 0;
+
+  for (const candidate of candidates) {
+    const key = `${candidate.salesforceContactId}|${candidate.projectId ?? ""}|${candidate.expeditionId ?? ""}`;
+    const sfId = sfLookup.get(key);
+
+    if (sfId === undefined) {
+      unmatchedCount += 1;
+      continue;
+    }
+
+    matches.push({ membershipId: candidate.membershipId, salesforceMembershipId: sfId });
+  }
+
+  logger.log(
+    `Matched: ${matches.length}, Unmatched: ${unmatchedCount}. dryRun=${String(dryRun)}`,
+  );
+
+  if (!dryRun && matches.length > 0) {
+    for (const chunk of chunkValues(matches, updateChunkSize)) {
+      for (const match of chunk) {
+        await input.db
+          .update(contactMemberships)
+          .set({ salesforceMembershipId: match.salesforceMembershipId })
+          .where(eq(contactMemberships.id, match.membershipId));
+      }
+    }
+  }
+
+  const result: BackfillMembershipSfIdsResult = {
+    dryRun,
+    candidateCount: candidates.length,
+    matchedCount: matches.length,
+    unmatchedCount,
+    updatedCount: dryRun ? 0 : matches.length,
+    sample: matches.slice(0, 10),
+  };
+
+  logger.log(JSON.stringify(result, null, 2));
+
+  return result;
+}
+
+export async function runBackfillMembershipSfIdsCommand(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+): Promise<void> {
+  const flags = parseCliFlags(args);
+  const connection = createDatabaseConnection({
+    connectionString: readConnectionString(env),
+  });
+
+  const sfClient = createSalesforceApiClient({
+    bearerToken: "ops-backfill-membership-sf-ids",
+    loginUrl: readRequiredEnv(env, "SALESFORCE_LOGIN_URL"),
+    clientId: readRequiredEnv(env, "SALESFORCE_CLIENT_ID"),
+    username: readRequiredEnv(env, "SALESFORCE_USERNAME"),
+    jwtPrivateKey: readRequiredEnv(env, "SALESFORCE_JWT_PRIVATE_KEY"),
+    jwtExpirationSeconds: env.SALESFORCE_JWT_EXPIRATION_SECONDS !== undefined
+      ? Number.parseInt(env.SALESFORCE_JWT_EXPIRATION_SECONDS, 10)
+      : 180,
+    apiVersion: env.SALESFORCE_API_VERSION ?? "61.0",
+    contactCaptureMode: "delta_polling",
+    membershipCaptureMode: "delta_polling",
+  });
+
+  try {
+    await backfillMembershipSfIds({
+      db: connection.db,
+      sfClient,
+      dryRun: !args.includes("--execute"),
+      limit: readOptionalIntegerFlag(flags, "limit", 0) || null,
+    });
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}
+
+const entrypointPath = process.argv[1];
+
+if (
+  entrypointPath !== undefined &&
+  import.meta.url === `file://${entrypointPath}`
+) {
+  void runBackfillMembershipSfIdsCommand(
+    process.argv.slice(2),
+    process.env,
+  ).catch((error: unknown) => {
+    console.error(
+      error instanceof Error
+        ? error.message
+        : "backfill-membership-sf-ids failed.",
+    );
+    process.exitCode = 1;
+  });
+}

--- a/apps/worker/src/ops/cli.ts
+++ b/apps/worker/src/ops/cli.ts
@@ -37,6 +37,7 @@ import { runCleanupSalesforceOwnerScopeCommand } from "./cleanup-salesforce-owne
 import { reconcileIdentityQueue } from "./reconcile-identity-queue.js";
 import { runDedupHistoricalLedgerCommand } from "./dedup-historical-ledger.js";
 import { runReclassifySfDirectionCommand } from "./reclassify-sf-direction.js";
+import { runBackfillMembershipSfIdsCommand } from "./backfill-membership-sf-ids.js";
 import {
   buildOperationId,
   parseCliFlags,
@@ -370,9 +371,12 @@ async function main(): Promise<void> {
     case "reclassify-sf-direction":
       await runReclassifySfDirectionCommand(rest, process.env);
       return;
+    case "backfill-membership-sf-ids":
+      await runBackfillMembershipSfIdsCommand(rest, process.env);
+      return;
     default:
       throw new Error(
-        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-gmail-mbox-bodies, backfill-content-fingerprint, backfill-mailchimp-campaign-body, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, dedup-historical-ledger, reconcile-identity-queue, reclassify-sf-direction.",
+        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-gmail-mbox-bodies, backfill-content-fingerprint, backfill-mailchimp-campaign-body, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, dedup-historical-ledger, reconcile-identity-queue, reclassify-sf-direction, backfill-membership-sf-ids.",
       );
   }
 }

--- a/apps/worker/test/stage1-ingest.test.ts
+++ b/apps/worker/test/stage1-ingest.test.ts
@@ -193,6 +193,7 @@ describe("Stage 1 worker ingest service", () => {
       updatedAt: "2026-01-02T00:00:00.000Z",
       memberships: [
         {
+          salesforceId: "a15VK00000AUcRtYAL",
           projectId: "project_1",
           projectName: "Project Antarctica",
           expeditionId: "expedition_1",

--- a/packages/contracts/src/stage1-records.ts
+++ b/packages/contracts/src/stage1-records.ts
@@ -146,6 +146,7 @@ export const contactMembershipSchema = z.object({
   status: z.string().min(1).nullable(),
   source: recordSourceSchema,
   createdAt: timestampSchema,
+  salesforceMembershipId: nullableStringSchema.optional(),
 });
 export type ContactMembershipRecord = z.infer<typeof contactMembershipSchema>;
 

--- a/packages/db/drizzle/0026_contact_memberships_salesforce_id.sql
+++ b/packages/db/drizzle/0026_contact_memberships_salesforce_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "contact_memberships" ADD COLUMN "salesforce_membership_id" text;

--- a/packages/db/src/mappers.ts
+++ b/packages/db/src/mappers.ts
@@ -424,6 +424,7 @@ export function mapContactMembershipRow(
     status: row.status,
     source: row.source,
     createdAt: row.createdAt.toISOString(),
+    salesforceMembershipId: row.salesforceMembershipId ?? null,
   });
 }
 
@@ -440,6 +441,7 @@ export function mapContactMembershipToInsert(
     role: parsed.role,
     status: parsed.status,
     source: parsed.source,
+    salesforceMembershipId: parsed.salesforceMembershipId ?? null,
     createdAt: toDate(parsed.createdAt),
   };
 }

--- a/packages/db/src/schema/tables.ts
+++ b/packages/db/src/schema/tables.ts
@@ -160,6 +160,7 @@ export const contactMemberships = pgTable(
     role: text("role"),
     status: text("status"),
     source: recordSourceEnum("source").notNull(),
+    salesforceMembershipId: text("salesforce_membership_id"),
     createdAt: createdAtColumn,
     updatedAt: updatedAtColumn,
   },

--- a/packages/integrations/src/capture-services/salesforce.ts
+++ b/packages/integrations/src/capture-services/salesforce.ts
@@ -908,6 +908,7 @@ function buildContactSnapshotRecordWithConfig(input: {
     createdAt,
     updatedAt,
     memberships: input.memberships.map((membership) => ({
+      salesforceId: getStringField(membership, "Id"),
       projectId: getStringField(
         membership,
         input.config.membershipProjectField,

--- a/packages/integrations/src/providers/salesforce.ts
+++ b/packages/integrations/src/providers/salesforce.ts
@@ -52,6 +52,7 @@ const salesforceRoutingContextSchema = z.object({
 });
 
 const salesforceMembershipSchema = z.object({
+  salesforceId: nullableStringSchema.default(null),
   projectId: nullableStringSchema.default(null),
   projectName: nullableStringSchema.default(null),
   expeditionId: nullableStringSchema.default(null),
@@ -560,6 +561,7 @@ function mapSalesforceContactSnapshot(
       status: membership.status,
       source: "salesforce",
       createdAt: record.createdAt,
+      salesforceMembershipId: membership.salesforceId ?? null,
     })),
     projectDimensions: Array.from(projectDimensionsById.values()),
     expeditionDimensions: Array.from(expeditionDimensionsById.values()),

--- a/packages/integrations/test/stage1-mappers.test.ts
+++ b/packages/integrations/test/stage1-mappers.test.ts
@@ -248,6 +248,7 @@ describe("Stage 1 provider-close mappers", () => {
       updatedAt: "2026-01-02T00:00:00.000Z",
       memberships: [
         {
+          salesforceId: "a15VK00000AUcRtYAL",
           projectId: "project_1",
           projectName: "Project Antarctica",
           expeditionId: "expedition_1",


### PR DESCRIPTION
## Summary

- **Bug**: Active Projects links in the contact rail 404 in Salesforce because the URL used the internal composite membership ID (`contact-membership:contact%3Asalesforce%3A0031...`) instead of the real `Expedition_Members__c` record ID (a 15-char SF ID like `a15VK00000AUcRtYAL`)
- **Root cause**: SOQL already fetched `Id`, but the capture-service mapper never extracted it — 6 consecutive gaps from mapper → schema → contract → DB → selector
- **Fix**: plumb `salesforceMembershipId` end-to-end; build `crmUrl` from the new field; `null` when absent (legacy rows pre-backfill render as non-link)

## Files changed

| Layer | File | Change |
|-------|------|--------|
| Capture | `packages/integrations/src/capture-services/salesforce.ts` | Extract `salesforceId: getStringField(membership, "Id")` |
| Provider schema | `packages/integrations/src/providers/salesforce.ts` | Add `salesforceId` to `salesforceMembershipSchema`; map to `salesforceMembershipId` on `ContactMembershipRecord` |
| Contract | `packages/contracts/src/stage1-records.ts` | Add `salesforceMembershipId: nullableStringSchema.optional()` |
| DB schema | `packages/db/src/schema/tables.ts` | Add `salesforce_membership_id` column |
| Migration | `packages/db/drizzle/0026_contact_memberships_salesforce_id.sql` | `ALTER TABLE contact_memberships ADD COLUMN salesforce_membership_id text` |
| DB mapper | `packages/db/src/mappers.ts` | Carry field through row→record and record→insert |
| Selector | `apps/web/app/inbox/_lib/selectors.ts` | Use `salesforceMembershipId` for `crmUrl`; `null` when absent |
| View model | `apps/web/app/inbox/_lib/view-models.ts` | Widen `crmUrl: string → string \| null` |
| UI | `apps/web/app/inbox/_components/inbox-contact-rail.tsx` | Render `<a>` only when `crmUrl` non-null; else bare `<div>` |
| Worker ops | `apps/worker/src/ops/backfill-membership-sf-ids.ts` + `cli.ts` | Register pre-written backfill script in CLI |

## Backfill

The new `salesforce_membership_id` column is null for all existing rows. After merging and running the migration, the backfill script fills them from SF:

```bash
# Dry run first
pnpm --filter @as-comms/worker ops backfill-membership-sf-ids

# Execute with architect sign-off
pnpm --filter @as-comms/worker ops backfill-membership-sf-ids --execute
```

**Architect must explicitly run this after merge — do not run automatically.**

Until backfill completes, legacy rows render project names as text (no link), not 404s.

## Test plan

- [x] `pnpm typecheck` — 13/14 packages clean; web fails on pre-existing tiptap missing-module errors unrelated to this change (confirmed present on main before this PR)
- [x] `pnpm test:unit` — 503/503 tests passing across 8 packages
- [x] `inbox-selectors.test.ts` updated: Sarah's fixture now seeds `salesforceMembershipId: "a15VK00000AUcRtYAL"` and asserts the correct URL (no `%3A` encoding, clean 15-char SF ID)
- [x] Manual verification: URL shape `…/Expedition_Members__c/a15VK00000AUcRtYAL/view` matches known-good SF pattern from architect's bug report

🤖 Generated with [Claude Code](https://claude.com/claude-code)