### PR TITLE
fix(inbox): plumb SF membership Id for correct expedition CRM links

### DIFF
--- a/apps/web/app/inbox/_components/inbox-contact-rail.tsx
+++ b/apps/web/app/inbox/_components/inbox-contact-rail.tsx
@@ -152,14 +152,9 @@ function ProjectsSection({ title, projects, emptyLabel }: ProjectsSectionProps) 
         <p className="mt-2 text-[12px] text-slate-400">{emptyLabel}</p>
       ) : (
         <ul className="mt-2 space-y-1">
-          {projects.map((project) => (
-            <li key={project.membershipId}>
-              <a
-                href={project.crmUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="group flex items-center gap-2 rounded-lg px-2 py-1.5 transition hover:bg-white hover:ring-1 hover:ring-slate-200"
-              >
+          {projects.map((project) => {
+            const content = (
+              <>
                 <div className="min-w-0 flex-1">
                   <p className="truncate text-[13px] font-medium text-slate-800 group-hover:text-slate-900">
                     {project.projectName}
@@ -173,9 +168,28 @@ function ProjectsSection({ title, projects, emptyLabel }: ProjectsSectionProps) 
                   </p>
                 </div>
                 <ChevronRightIcon className="h-3.5 w-3.5 shrink-0 text-slate-300 group-hover:text-slate-500" />
-              </a>
-            </li>
-          ))}
+              </>
+            );
+
+            return (
+              <li key={project.membershipId}>
+                {project.crmUrl != null ? (
+                  <a
+                    href={project.crmUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="group flex items-center gap-2 rounded-lg px-2 py-1.5 transition hover:bg-white hover:ring-1 hover:ring-slate-200"
+                  >
+                    {content}
+                  </a>
+                ) : (
+                  <div className="group flex items-center gap-2 rounded-lg px-2 py-1.5">
+                    {content}
+                  </div>
+                )}
+              </li>
+            );
+          })}
         </ul>
       )}
     </section>

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -517,9 +517,12 @@ function buildProjectMembershipViewModel(
     status: mapProjectStatus(membership.status),
     // Right-rail links must target the volunteer's Salesforce membership
     // record for that specific project context.
-    crmUrl: `https://adventurescientists.lightning.force.com/lightning/r/Expedition_Members__c/${encodeURIComponent(
-      membership.id,
-    )}/view`,
+    crmUrl:
+      membership.salesforceMembershipId != null
+        ? `https://adventurescientists.lightning.force.com/lightning/r/Expedition_Members__c/${encodeURIComponent(
+            membership.salesforceMembershipId,
+          )}/view`
+        : null,
   };
 }
 

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -100,7 +100,7 @@ export interface InboxProjectMembershipViewModel {
   readonly projectName: string;
   readonly year: number;
   readonly status: InboxProjectStatus;
-  readonly crmUrl: string;
+  readonly crmUrl: string | null;
 }
 
 export interface InboxRecentActivityViewModel {

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -207,6 +207,7 @@ async function seedInboxFixture(runtime: InboxTestRuntime): Promise<void> {
     projectName: "Amazon Basin Research",
     membershipId: "membership:sarah",
     membershipStatus: "in_training",
+    salesforceMembershipId: "a15VK00000AUcRtYAL",
   });
   await seedInboxEmailEvent(runtime.context, {
     id: "sarah-outbound-1",
@@ -916,7 +917,7 @@ describe("real inbox selectors", () => {
       projectName: "Amazon Basin Research",
       status: "in-training",
       crmUrl:
-        "https://adventurescientists.lightning.force.com/lightning/r/Expedition_Members__c/membership%3Asarah/view",
+        "https://adventurescientists.lightning.force.com/lightning/r/Expedition_Members__c/a15VK00000AUcRtYAL/view",
     });
     expect(detail?.timeline.map((entry) => entry.kind)).toEqual([
       "outbound-email",
@@ -1017,6 +1018,73 @@ describe("real inbox selectors", () => {
         }),
       ),
     ).not.toContain("WPEF Tracking Whitebark Pine OR WA 2025-2026 2026");
+  });
+
+  describe("contact rail crmUrl", () => {
+    it("uses the Salesforce membership Id when present", async () => {
+      const detail = await getInboxDetail("contact:sarah-martinez");
+
+      expect(detail?.contact.activeProjects[0]?.crmUrl).toBe(
+        "https://adventurescientists.lightning.force.com/lightning/r/Expedition_Members__c/a15VK00000AUcRtYAL/view",
+      );
+    });
+
+    it("suppresses the CRM link for legacy memberships without a Salesforce Id", async () => {
+      if (runtime === null) {
+        throw new Error("Expected inbox test runtime");
+      }
+
+      await seedInboxContact(runtime.context, {
+        contactId: "contact:legacy-membership",
+        salesforceContactId: "003-legacy",
+        displayName: "Legacy Membership",
+        primaryEmail: "legacy@example.org",
+        primaryPhone: null,
+        projectId: "project:legacy",
+        projectName: "Legacy Project",
+        membershipId: "membership:legacy",
+        membershipStatus: "active",
+      });
+      const latest = await seedInboxEmailEvent(runtime.context, {
+        id: "legacy-membership-email-1",
+        contactId: "contact:legacy-membership",
+        occurredAt: "2026-04-16T13:00:00.000Z",
+        direction: "inbound",
+        subject: "Legacy membership",
+        snippet: "This membership predates the Salesforce backfill.",
+      });
+      await seedInboxProjection(runtime.context, {
+        contactId: "contact:legacy-membership",
+        bucket: "New",
+        needsFollowUp: false,
+        hasUnresolved: false,
+        lastInboundAt: "2026-04-16T13:00:00.000Z",
+        lastOutboundAt: null,
+        lastActivityAt: "2026-04-16T13:00:00.000Z",
+        snippet: "This membership predates the Salesforce backfill.",
+        lastCanonicalEventId: latest.canonicalEventId,
+        lastEventType: "communication.email.inbound",
+      });
+
+      const detail = await getInboxDetail("contact:legacy-membership");
+
+      if (detail === null) {
+        throw new Error("Expected inbox detail for legacy-membership contact");
+      }
+
+      expect(detail.contact.activeProjects[0]?.crmUrl).toBeNull();
+
+      const markup = renderToStaticMarkup(
+        createElement(InboxContactRail, {
+          contact: detail.contact,
+        }),
+      );
+
+      expect(markup).toContain("Legacy Project");
+      expect(markup).not.toContain(
+        "lightning/r/Expedition_Members__c/",
+      );
+    });
   });
 
   it("threads Gmail From, To, and Cc headers into the timeline detail view model", async () => {

--- a/apps/web/tests/unit/inbox-stage1-helpers.ts
+++ b/apps/web/tests/unit/inbox-stage1-helpers.ts
@@ -23,6 +23,7 @@ export async function seedInboxContact(
     readonly membershipId?: string;
     readonly membershipStatus?: string | null;
     readonly membershipCreatedAt?: string;
+    readonly salesforceMembershipId?: string;
   },
 ): Promise<void> {
   await context.repositories.contacts.upsert({
@@ -52,6 +53,7 @@ export async function seedInboxContact(
       expeditionId: null,
       role: "volunteer",
       status: input.membershipStatus ?? null,
+      salesforceMembershipId: input.salesforceMembershipId,
       source: "salesforce",
       createdAt:
         input.membershipCreatedAt ?? new Date().toISOString(),

--- a/apps/worker/src/ops/backfill-membership-sf-ids.ts
+++ b/apps/worker/src/ops/backfill-membership-sf-ids.ts
@@ -1,0 +1,434 @@
+#!/usr/bin/env tsx
+/**
+ * backfill-membership-sf-ids
+ *
+ * Usage:
+ *   pnpm --filter @as-comms/worker ops backfill-membership-sf-ids --dry-run
+ *   pnpm --filter @as-comms/worker ops backfill-membership-sf-ids
+ *
+ * Re-pulls Expedition_Members__c Salesforce record Ids for legacy
+ * contact_memberships rows where salesforce_membership_id is still null.
+ */
+import process from "node:process"
+
+import { and, eq, isNull } from "drizzle-orm"
+
+import {
+  closeDatabaseConnection,
+  contactMemberships,
+  contacts,
+  createDatabaseConnection,
+  type DatabaseConnection,
+} from "@as-comms/db"
+import {
+  buildContactMembershipId,
+  createSalesforceApiClient,
+  type SalesforceCaptureServiceConfig,
+} from "@as-comms/integrations"
+
+import { parseCliFlags, readOptionalBooleanFlag } from "./helpers.js"
+
+const membershipBatchSize = 200
+
+interface Logger {
+  log(...args: readonly unknown[]): void
+  error(...args: readonly unknown[]): void
+}
+
+interface MembershipBackfillCandidate {
+  readonly membershipId: string
+  readonly contactId: string
+  readonly salesforceContactId: string
+  readonly projectId: string | null
+  readonly expeditionId: string | null
+  readonly role: string | null
+}
+
+interface SalesforceMembershipMatch {
+  readonly membershipId: string
+  readonly salesforceMembershipId: string
+}
+
+interface BackfillMembershipSfIdsResult {
+  readonly dryRun: boolean
+  readonly candidateCount: number
+  readonly matchedCount: number
+  readonly updatedCount: number
+  readonly unmatchedCount: number
+  readonly ambiguousCount: number
+}
+
+function chunkValues<TValue>(
+  values: readonly TValue[],
+  chunkSize: number,
+): TValue[][] {
+  const chunks: TValue[][] = []
+
+  for (let index = 0; index < values.length; index += chunkSize) {
+    chunks.push(values.slice(index, index + chunkSize))
+  }
+
+  return chunks
+}
+
+function readConnectionString(env: NodeJS.ProcessEnv): string {
+  const connectionString = env.WORKER_DATABASE_URL ?? env.DATABASE_URL
+
+  if (connectionString === undefined || connectionString.trim().length === 0) {
+    throw new Error(
+      "DATABASE_URL or WORKER_DATABASE_URL is required for this ops command.",
+    )
+  }
+
+  return connectionString
+}
+
+function readRequiredEnv(env: NodeJS.ProcessEnv, key: string): string {
+  const value = env[key]?.trim()
+
+  if (value === undefined || value.length === 0) {
+    throw new Error(`${key} is required for this ops command.`)
+  }
+
+  return value
+}
+
+function readOptionalPositiveIntegerEnv(
+  env: NodeJS.ProcessEnv,
+  key: string,
+): number | undefined {
+  const rawValue = env[key]?.trim()
+
+  if (rawValue === undefined || rawValue.length === 0) {
+    return undefined
+  }
+
+  const parsed = Number.parseInt(rawValue, 10)
+
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${key} must be a positive integer.`)
+  }
+
+  return parsed
+}
+
+function readSalesforceConfig(
+  env: NodeJS.ProcessEnv,
+): SalesforceCaptureServiceConfig {
+  return {
+    bearerToken: readRequiredEnv(env, "SALESFORCE_CAPTURE_TOKEN"),
+    loginUrl: readRequiredEnv(env, "SALESFORCE_LOGIN_URL"),
+    clientId: readRequiredEnv(env, "SALESFORCE_CLIENT_ID"),
+    username: readRequiredEnv(env, "SALESFORCE_USERNAME"),
+    jwtPrivateKey: readRequiredEnv(env, "SALESFORCE_JWT_PRIVATE_KEY"),
+    jwtExpirationSeconds: readOptionalPositiveIntegerEnv(
+      env,
+      "SALESFORCE_JWT_EXPIRATION_SECONDS",
+    ),
+    apiVersion: env.SALESFORCE_API_VERSION?.trim(),
+    contactCaptureMode: readRequiredEnv(env, "SALESFORCE_CONTACT_CAPTURE_MODE") as "delta_polling" | "cdc_compatible",
+    membershipCaptureMode: readRequiredEnv(
+      env,
+      "SALESFORCE_MEMBERSHIP_CAPTURE_MODE",
+    ) as "delta_polling" | "cdc_compatible",
+    membershipObjectName:
+      env.SALESFORCE_EXPEDITION_MEMBER_OBJECT?.trim() ?? undefined,
+    membershipContactField:
+      env.SALESFORCE_EXPEDITION_MEMBER_CONTACT_FIELD?.trim() ?? undefined,
+    membershipProjectField:
+      env.SALESFORCE_EXPEDITION_MEMBER_PROJECT_FIELD?.trim() ?? undefined,
+    membershipExpeditionField:
+      env.SALESFORCE_EXPEDITION_MEMBER_EXPEDITION_FIELD?.trim() ?? undefined,
+    membershipRoleField:
+      env.SALESFORCE_EXPEDITION_MEMBER_ROLE_FIELD?.trim() ?? undefined,
+    membershipStatusField:
+      env.SALESFORCE_EXPEDITION_MEMBER_STATUS_FIELD?.trim() ?? undefined,
+    timeoutMs: readOptionalPositiveIntegerEnv(
+      env,
+      "SALESFORCE_CAPTURE_TIMEOUT_MS",
+    ),
+  }
+}
+
+function escapeSoqlLiteral(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll("'", "\\'")
+}
+
+function getOptionalStringField(
+  row: Record<string, unknown>,
+  fieldName: string | null,
+): string | null {
+  if (fieldName === null) {
+    return null
+  }
+
+  const value = row[fieldName]
+  return typeof value === "string" && value.trim().length > 0 ? value : null
+}
+
+async function loadCandidatesWithSalesforceContactIds(
+  connection: DatabaseConnection,
+): Promise<readonly MembershipBackfillCandidate[]> {
+  const rows = await connection.db
+    .select({
+      membershipId: contactMemberships.id,
+      contactId: contactMemberships.contactId,
+      salesforceContactId: contacts.salesforceContactId,
+      projectId: contactMemberships.projectId,
+      expeditionId: contactMemberships.expeditionId,
+      role: contactMemberships.role,
+    })
+    .from(contactMemberships)
+    .innerJoin(contacts, eq(contactMemberships.contactId, contacts.id))
+    .where(
+      and(
+        eq(contactMemberships.source, "salesforce"),
+        isNull(contactMemberships.salesforceMembershipId),
+      ),
+    )
+
+  return rows.filter(
+    (
+      row,
+    ): row is MembershipBackfillCandidate & { readonly salesforceContactId: string } =>
+      row.salesforceContactId !== null,
+  )
+}
+
+function buildMembershipSoql(input: {
+  readonly membershipObjectName: string
+  readonly membershipContactField: string
+  readonly membershipProjectField: string
+  readonly membershipExpeditionField: string
+  readonly membershipRoleField: string | null
+  readonly salesforceContactIds: readonly string[]
+}): string {
+  const fieldNames = [
+    "Id",
+    input.membershipContactField,
+    input.membershipProjectField,
+    input.membershipExpeditionField,
+    ...(input.membershipRoleField === null ? [] : [input.membershipRoleField]),
+  ]
+  const contactIds = input.salesforceContactIds
+    .map((value) => `'${escapeSoqlLiteral(value)}'`)
+    .join(", ")
+
+  return `SELECT ${fieldNames.join(", ")} FROM ${input.membershipObjectName} WHERE ${input.membershipContactField} IN (${contactIds})`
+}
+
+async function matchSalesforceMembershipIds(input: {
+  readonly candidates: readonly MembershipBackfillCandidate[]
+  readonly salesforceConfig: SalesforceCaptureServiceConfig
+  readonly logger: Logger
+}): Promise<{
+  readonly matches: readonly SalesforceMembershipMatch[]
+  readonly unmatchedCount: number
+  readonly ambiguousCount: number
+}> {
+  const client = createSalesforceApiClient(input.salesforceConfig)
+  const matches: SalesforceMembershipMatch[] = []
+  let unmatchedCount = 0
+  let ambiguousCount = 0
+
+  for (const batch of chunkValues(input.candidates, membershipBatchSize)) {
+    const uniqueSalesforceContactIds = Array.from(
+      new Set(batch.map((candidate) => candidate.salesforceContactId)),
+    )
+    const salesforceRows = await client.queryAll(
+      buildMembershipSoql({
+        membershipObjectName:
+          input.salesforceConfig.membershipObjectName ??
+          "Expedition_Members__c",
+        membershipContactField:
+          input.salesforceConfig.membershipContactField ?? "Contact__c",
+        membershipProjectField:
+          input.salesforceConfig.membershipProjectField ?? "Project__c",
+        membershipExpeditionField:
+          input.salesforceConfig.membershipExpeditionField ?? "Expedition__c",
+        membershipRoleField:
+          input.salesforceConfig.membershipRoleField ?? null,
+        salesforceContactIds: uniqueSalesforceContactIds,
+      }),
+    )
+
+    const contactIdBySalesforceContactId = new Map(
+      batch.map((candidate) => [
+        candidate.salesforceContactId,
+        candidate.contactId,
+      ]),
+    )
+    const candidateIds = new Set(batch.map((candidate) => candidate.membershipId))
+    const matchedSalesforceIdsByMembershipId = new Map<string, Set<string>>()
+    const membershipContactField =
+      input.salesforceConfig.membershipContactField ?? "Contact__c"
+    const membershipProjectField =
+      input.salesforceConfig.membershipProjectField ?? "Project__c"
+    const membershipExpeditionField =
+      input.salesforceConfig.membershipExpeditionField ?? "Expedition__c"
+    const membershipRoleField =
+      input.salesforceConfig.membershipRoleField ?? null
+
+    for (const row of salesforceRows) {
+      const salesforceContactId = getOptionalStringField(
+        row,
+        membershipContactField,
+      )
+      const salesforceMembershipId = getOptionalStringField(row, "Id")
+
+      if (salesforceContactId === null || salesforceMembershipId === null) {
+        continue
+      }
+
+      const contactId = contactIdBySalesforceContactId.get(salesforceContactId)
+
+      if (contactId === undefined) {
+        continue
+      }
+
+      const membershipId = buildContactMembershipId({
+        contactId,
+        projectId: getOptionalStringField(row, membershipProjectField),
+        expeditionId: getOptionalStringField(row, membershipExpeditionField),
+        role: getOptionalStringField(row, membershipRoleField),
+      })
+
+      if (!candidateIds.has(membershipId)) {
+        continue
+      }
+
+      const existing =
+        matchedSalesforceIdsByMembershipId.get(membershipId) ?? new Set<string>()
+      existing.add(salesforceMembershipId)
+      matchedSalesforceIdsByMembershipId.set(membershipId, existing)
+    }
+
+    for (const candidate of batch) {
+      const salesforceIds =
+        matchedSalesforceIdsByMembershipId.get(candidate.membershipId) ?? null
+
+      if (salesforceIds === null || salesforceIds.size === 0) {
+        unmatchedCount += 1
+        continue
+      }
+
+      if (salesforceIds.size > 1) {
+        ambiguousCount += 1
+        input.logger.error(
+          `Skipping ambiguous Salesforce membership match for ${candidate.membershipId}: ${Array.from(
+            salesforceIds,
+          ).join(", ")}`,
+        )
+        continue
+      }
+
+      const sfId = Array.from(salesforceIds)[0]
+      if (sfId === undefined) continue
+      matches.push({
+        membershipId: candidate.membershipId,
+        salesforceMembershipId: sfId,
+      })
+    }
+  }
+
+  return {
+    matches,
+    unmatchedCount,
+    ambiguousCount,
+  }
+}
+
+async function applyMatches(input: {
+  readonly connection: DatabaseConnection
+  readonly matches: readonly SalesforceMembershipMatch[]
+  readonly dryRun: boolean
+}): Promise<number> {
+  if (input.dryRun) {
+    return 0
+  }
+
+  let updatedCount = 0
+
+  for (const match of input.matches) {
+    const updatedRows = await input.connection.db
+      .update(contactMemberships)
+      .set({
+        salesforceMembershipId: match.salesforceMembershipId,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(contactMemberships.id, match.membershipId),
+          isNull(contactMemberships.salesforceMembershipId),
+        ),
+      )
+      .returning({
+        id: contactMemberships.id,
+      })
+
+    updatedCount += updatedRows.length
+  }
+
+  return updatedCount
+}
+
+export async function runBackfillMembershipSfIdsCommand(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv = process.env,
+  logger: Logger = console,
+): Promise<BackfillMembershipSfIdsResult> {
+  const flags = parseCliFlags(args)
+  const dryRun = readOptionalBooleanFlag(flags, "dry-run", false)
+  const connection = createDatabaseConnection({
+    connectionString: readConnectionString(env),
+  })
+
+  try {
+    const candidates = await loadCandidatesWithSalesforceContactIds(connection)
+    const salesforceConfig = readSalesforceConfig(env)
+    const { matches, unmatchedCount, ambiguousCount } =
+      await matchSalesforceMembershipIds({
+        candidates,
+        salesforceConfig,
+        logger,
+      })
+    const updatedCount = await applyMatches({
+      connection,
+      matches,
+      dryRun,
+    })
+
+    const result = {
+      dryRun,
+      candidateCount: candidates.length,
+      matchedCount: matches.length,
+      updatedCount,
+      unmatchedCount,
+      ambiguousCount,
+    } satisfies BackfillMembershipSfIdsResult
+
+    logger.log(
+      dryRun
+        ? `[dry-run] would update ${matches.length.toString()} rows`
+        : `updated ${updatedCount.toString()} rows`,
+    )
+    logger.log(JSON.stringify(result, null, 2))
+
+    return result
+  } finally {
+    await closeDatabaseConnection(connection)
+  }
+}
+
+if (import.meta.url === new URL(process.argv[1] ?? "", "file:").href) {
+  void runBackfillMembershipSfIdsCommand(process.argv.slice(2)).catch(
+    (error: unknown) => {
+      console.error(
+        error instanceof Error
+          ? error.message
+          : "Backfill membership Salesforce Ids failed.",
+      )
+      process.exitCode = 1
+    },
+  )
+}

--- a/apps/worker/src/ops/cli.ts
+++ b/apps/worker/src/ops/cli.ts
@@ -29,6 +29,7 @@ import {
   inspectStage1Contact,
 } from "./inspect.js";
 import { runBackfillSalesforceCommunicationDetailsCommand } from "./backfill-salesforce-communication-details.js";
+import { runBackfillMembershipSfIdsCommand } from "./backfill-membership-sf-ids.js";
 import { runBackfillGmailMboxBodiesCommand } from "./backfill-gmail-mbox-bodies.js";
 import { runBackfillContentFingerprintCommand } from "./backfill-content-fingerprint.js";
 import { runBackfillMailchimpCampaignBodyCommand } from "./backfill-mailchimp-campaign-body.js";
@@ -346,6 +347,9 @@ async function main(): Promise<void> {
     case "backfill-salesforce-communication-details":
       await runBackfillSalesforceCommunicationDetailsCommand(rest, process.env);
       return;
+    case "backfill-membership-sf-ids":
+      await runBackfillMembershipSfIdsCommand(rest, process.env);
+      return;
     case "backfill-gmail-mbox-bodies":
       await runBackfillGmailMboxBodiesCommand(rest, process.env);
       return;
@@ -372,7 +376,7 @@ async function main(): Promise<void> {
       return;
     default:
       throw new Error(
-        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-gmail-mbox-bodies, backfill-content-fingerprint, backfill-mailchimp-campaign-body, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, dedup-historical-ledger, reconcile-identity-queue, reclassify-sf-direction.",
+        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-membership-sf-ids, backfill-gmail-mbox-bodies, backfill-content-fingerprint, backfill-mailchimp-campaign-body, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, dedup-historical-ledger, reconcile-identity-queue, reclassify-sf-direction.",
       );
   }
 }

--- a/apps/worker/test/stage1-ingest.test.ts
+++ b/apps/worker/test/stage1-ingest.test.ts
@@ -198,7 +198,8 @@ describe("Stage 1 worker ingest service", () => {
           expeditionId: "expedition_1",
           expeditionName: "Expedition Antarctica",
           role: "volunteer",
-          status: "active"
+          status: "active",
+          salesforceId: "a15VK00000AUcRtYAL"
         }
       ]
     });

--- a/packages/contracts/src/stage1-records.ts
+++ b/packages/contracts/src/stage1-records.ts
@@ -144,6 +144,7 @@ export const contactMembershipSchema = z.object({
   expeditionId: z.string().min(1).nullable(),
   role: z.string().min(1).nullable(),
   status: z.string().min(1).nullable(),
+  salesforceMembershipId: nullableStringSchema.optional(),
   source: recordSourceSchema,
   createdAt: timestampSchema,
 });

--- a/packages/db/drizzle/0026_contact_memberships_salesforce_id.sql
+++ b/packages/db/drizzle/0026_contact_memberships_salesforce_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE contact_memberships ADD COLUMN salesforce_membership_id text;

--- a/packages/db/src/mappers.ts
+++ b/packages/db/src/mappers.ts
@@ -422,6 +422,7 @@ export function mapContactMembershipRow(
     expeditionId: row.expeditionId,
     role: row.role,
     status: row.status,
+    salesforceMembershipId: row.salesforceMembershipId ?? undefined,
     source: row.source,
     createdAt: row.createdAt.toISOString(),
   });
@@ -439,6 +440,7 @@ export function mapContactMembershipToInsert(
     expeditionId: parsed.expeditionId,
     role: parsed.role,
     status: parsed.status,
+    salesforceMembershipId: parsed.salesforceMembershipId ?? null,
     source: parsed.source,
     createdAt: toDate(parsed.createdAt),
   };

--- a/packages/db/src/schema/tables.ts
+++ b/packages/db/src/schema/tables.ts
@@ -159,6 +159,7 @@ export const contactMemberships = pgTable(
     expeditionId: text("expedition_id"),
     role: text("role"),
     status: text("status"),
+    salesforceMembershipId: text("salesforce_membership_id"),
     source: recordSourceEnum("source").notNull(),
     createdAt: createdAtColumn,
     updatedAt: updatedAtColumn,

--- a/packages/db/test/contact-membership-mappers.test.ts
+++ b/packages/db/test/contact-membership-mappers.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { mapContactMembershipRow } from "../src/mappers.js";
+
+describe("contact membership mappers", () => {
+  it("carries salesforceMembershipId when present", () => {
+    const row = {
+      id: "cm1",
+      contactId: "c1",
+      projectId: "p1",
+      expeditionId: null,
+      role: null,
+      status: "active",
+      salesforceMembershipId: "a15VK00000AUcRtYAL",
+      source: "salesforce" as const,
+      createdAt: new Date("2026-04-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+    };
+
+    const record = mapContactMembershipRow(row);
+
+    expect(record.salesforceMembershipId).toBe("a15VK00000AUcRtYAL");
+  });
+
+  it("omits salesforceMembershipId when null for legacy rows", () => {
+    const row = {
+      id: "cm1",
+      contactId: "c1",
+      projectId: "p1",
+      expeditionId: null,
+      role: null,
+      status: "active",
+      salesforceMembershipId: null,
+      source: "salesforce" as const,
+      createdAt: new Date("2026-04-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+    };
+
+    const record = mapContactMembershipRow(row);
+
+    expect(record.salesforceMembershipId).toBeUndefined();
+  });
+});

--- a/packages/integrations/src/capture-services/salesforce.ts
+++ b/packages/integrations/src/capture-services/salesforce.ts
@@ -908,6 +908,7 @@ function buildContactSnapshotRecordWithConfig(input: {
     createdAt,
     updatedAt,
     memberships: input.memberships.map((membership) => ({
+      salesforceId: getStringField(membership, "Id"),
       projectId: getStringField(
         membership,
         input.config.membershipProjectField,

--- a/packages/integrations/src/providers/salesforce.ts
+++ b/packages/integrations/src/providers/salesforce.ts
@@ -52,6 +52,7 @@ const salesforceRoutingContextSchema = z.object({
 });
 
 const salesforceMembershipSchema = z.object({
+  salesforceId: nullableStringSchema.default(null),
   projectId: nullableStringSchema.default(null),
   projectName: nullableStringSchema.default(null),
   expeditionId: nullableStringSchema.default(null),
@@ -558,6 +559,7 @@ function mapSalesforceContactSnapshot(
       expeditionId: membership.expeditionId,
       role: membership.role,
       status: membership.status,
+      salesforceMembershipId: membership.salesforceId ?? undefined,
       source: "salesforce",
       createdAt: record.createdAt,
     })),

--- a/packages/integrations/test/stage1-mappers.test.ts
+++ b/packages/integrations/test/stage1-mappers.test.ts
@@ -253,7 +253,8 @@ describe("Stage 1 provider-close mappers", () => {
           expeditionId: "expedition_1",
           expeditionName: "Expedition Antarctica",
           role: "volunteer",
-          status: "active"
+          status: "active",
+          salesforceId: "a15VK00000AUcRtYAL"
         }
       ]
     });


### PR DESCRIPTION
## Summary

- **Bug:** Active-project links in the contact rail opened 404 URLs because `buildProjectMembershipViewModel` used our internal composite membership key (`contact-membership:contact:salesforce:0031…`) instead of the actual `Expedition_Members__c` Salesforce record ID (e.g. `a15VK00000AUcRtYAL`). The SOQL query already fetched `Id` — the capture-service mapper just never extracted it.
- **Fix:** Plumbed the SF `Id` through the full stack: capture-service → intermediate schema → `ContactMembershipRecord` → DB column → URL builder. `crmUrl` is now `string | null`; the contact rail renders a non-link `<div>` for legacy rows until the backfill runs.
- **Backfill:** New ops script `backfill-membership-sf-ids.ts` re-pulls SF Ids for existing rows. **Architect runs this manually after merge with explicit sign-off.**

## Changes

| Layer | Change |
|---|---|
| `packages/db/drizzle/0026_…sql` | Migration: `ADD COLUMN salesforce_membership_id text` |
| `packages/db/src/schema/tables.ts` | Drizzle column |
| `packages/contracts/src/stage1-records.ts` | `salesforceMembershipId?: string \| null` in schema |
| `packages/db/src/mappers.ts` | Read + write in both membership mappers |
| `packages/integrations/src/capture-services/salesforce.ts` | Extract `getStringField(membership, "Id")` |
| `packages/integrations/src/providers/salesforce.ts` | Add `salesforceId` to intermediate schema; pass through to `ContactMembershipRecord` |
| `apps/web/app/inbox/_lib/selectors.ts` | `crmUrl` uses SF Id when present, `null` fallback |
| `apps/web/app/inbox/_lib/view-models.ts` | `crmUrl: string \| null` |
| `apps/web/app/inbox/_components/inbox-contact-rail.tsx` | Conditional `<a>` vs `<div>` on null crmUrl |
| `apps/worker/src/ops/backfill-membership-sf-ids.ts` | NEW — one-shot backfill ops script |

## Test plan

- [ ] `pnpm typecheck` — 14/14 ✅
- [ ] `pnpm lint` — 14/14 ✅
- [ ] `pnpm test:unit` — local rollup darwin error is environmental; CI is authoritative
- [ ] After merge: architect runs `pnpm --filter @as-comms/worker ops backfill-membership-sf-ids --dry-run` then without `--dry-run`
- [ ] Verify Steve Herman's "Passive Acoustic Monitoring" active-project link opens the correct SF record

Closes Change 3 deferred from PR #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)