### PR TITLE
fix(inbox): unbreak inbox detail+list pages (P0 from #130)

### DIFF
--- a/packages/contracts/src/stage1-records.ts
+++ b/packages/contracts/src/stage1-records.ts
@@ -419,12 +419,12 @@ export const inboxProjectionSchema = z
     if (
       value.lastInboundAt === null &&
       value.lastOutboundAt !== null &&
-      value.lastActivityAt !== value.lastOutboundAt
+      value.lastActivityAt < value.lastOutboundAt
     ) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
         message:
-          "outbound-only inbox rows must set lastActivityAt to lastOutboundAt",
+          "outbound-only inbox rows must set lastActivityAt at or after lastOutboundAt",
       });
     }
 
@@ -450,12 +450,12 @@ export const inboxProjectionSchema = z
 
     if (
       expectedLastActivityAt !== null &&
-      value.lastActivityAt !== expectedLastActivityAt
+      value.lastActivityAt < expectedLastActivityAt
     ) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
         message:
-          "lastActivityAt must equal the newest inbound or outbound timestamp",
+          "lastActivityAt must be at least as recent as the newest inbound or outbound timestamp",
       });
     }
   });

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -1453,7 +1453,7 @@ function createStage1RepositoriesInternal(
           return new Map();
         }
 
-        const result = (await db.execute(
+        const rows = (await db.execute(
           sql`
             select distinct on (${canonicalEventLedger.contactId})
               ${canonicalEventLedger.contactId} as "contactId",
@@ -1468,12 +1468,13 @@ function createStage1RepositoriesInternal(
               ${canonicalEventLedger.contactId},
               ${canonicalEventLedger.occurredAt} desc
           `,
-        )) as {
-          rows: { contactId: string; projectInboxAlias: string }[];
-        };
+        )) as readonly {
+          readonly contactId: string;
+          readonly projectInboxAlias: string;
+        }[];
 
         return new Map(
-          result.rows.map((row) => [row.contactId, row.projectInboxAlias]),
+          rows.map((row) => [row.contactId, row.projectInboxAlias]),
         );
       },
 


### PR DESCRIPTION
## Summary

P0 hotfix. Two distinct bugs introduced by PR #130 are crashing the inbox in production. Both visible in Railway logs immediately after deploy. The user reports the inbox throws "Application error: a server-side exception has occurred" on every page load.

## Bugs

### 1. `listLastInboundAliasByContactIds` — `result.rows` undefined
The new repo method (`packages/db/src/repositories.ts:1451`) casts `db.execute(sql)` result to `{ rows: ... }` but the `drizzle-orm/postgres-js` driver returns rows directly as a top-level array, not nested under `.rows`. Runtime: `TypeError: Cannot read properties of undefined (reading 'map')` on every inbox list/detail load.

Fix: drop the `.rows` indirection — use the returned array directly.

### 2. `inboxProjectionSchema` — strict-equality refinement on `lastActivityAt`
The schema requires `lastActivityAt === max(lastInboundAt, lastOutboundAt)`. But `lastInboundAt` / `lastOutboundAt` are email-only timestamps, while `lastActivityAt` legitimately advances on any channel including SMS. **2 prod rows** where the latest activity is an SMS inbound have `lastActivityAt > both email timestamps`, causing `ZodError: lastActivityAt must equal the newest inbound or outbound timestamp` on inbox list load.

Fix: relax both the outbound-only refinement and the both-set refinement from `!==` strict equality to `<` (i.e., accept `lastActivityAt >= max(...)`). Updated error messages to match.

## Verification

```sql
SELECT count(*) FROM contact_inbox_projection
WHERE last_activity_at != GREATEST(
  COALESCE(last_inbound_at, '-infinity'::timestamptz),
  COALESCE(last_outbound_at, '-infinity'::timestamptz)
);
-- 2 rows; both have last_event_type='communication.sms.inbound'
```

Both rows are semantically correct (SMS legitimately advances activity); the schema was over-strict.

## Test plan

- [x] Identified both root causes from Railway prod logs (digest 1634501881 + 1977789826)
- [ ] CI verify green
- [ ] Architect verifies inbox loads after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)