### PR TITLE
feat: autosave inbox composer drafts

### DIFF
--- a/apps/web/app/inbox/_components/inbox-client-provider.tsx
+++ b/apps/web/app/inbox/_components/inbox-client-provider.tsx
@@ -115,6 +115,7 @@ export interface InboxToastState {
 }
 
 interface InboxClientState {
+  readonly currentActorId: string;
   readonly reminders: ReadonlyMap<string, Reminder>;
   readonly setReminder: (contactId: string, reminder: Reminder) => void;
   readonly clearReminder: (contactId: string) => void;
@@ -173,10 +174,12 @@ const InboxClientContext = createContext<InboxClientState | null>(null);
 
 export function InboxClientProvider({
   children,
-  composerAliases
+  composerAliases,
+  currentActorId,
 }: {
   readonly children: ReactNode;
   readonly composerAliases: readonly InboxComposerAliasOption[];
+  readonly currentActorId: string;
 }) {
   const [reminders, setReminders] = useState<ReadonlyMap<string, Reminder>>(
     () => new Map<string, Reminder>()
@@ -392,6 +395,7 @@ export function InboxClientProvider({
 
   const value = useMemo<InboxClientState>(
     () => ({
+      currentActorId,
       reminders,
       setReminder,
       clearReminder,
@@ -426,6 +430,7 @@ export function InboxClientProvider({
       resetAiDraft
     }),
     [
+      currentActorId,
       reminders,
       setReminder,
       clearReminder,

--- a/apps/web/app/inbox/_components/inbox-composer.tsx
+++ b/apps/web/app/inbox/_components/inbox-composer.tsx
@@ -50,6 +50,11 @@ import {
   isComposerSendDisabled,
   resolveDefaultAlias,
 } from "../_lib/composer-ui";
+import {
+  clearDraft,
+  loadDraft,
+  saveDraft,
+} from "../_lib/composer-draft-storage";
 import type { InboxComposerAliasOption } from "../_lib/view-models";
 import { plaintextToComposerHtml } from "./composer-html";
 import {
@@ -85,7 +90,7 @@ interface AttachmentDraft {
   readonly filename: string;
   readonly size: number;
   readonly contentType: string;
-  readonly contentBase64: string;
+  readonly contentBase64: string | null;
 }
 
 interface InlineComposerError {
@@ -121,6 +126,29 @@ function resolveRecipientLabel(recipient: ComposerRecipientValue): string {
         primaryEmail: recipient.primaryEmail,
       })
     : recipient.emailAddress;
+}
+
+function normalizeEmail(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function resolveComposerDraftKey(input: {
+  readonly actorId: string;
+  readonly recipient: ComposerRecipientValue | null;
+}): string | null {
+  const recipient = input.recipient;
+
+  if (recipient === null) {
+    return null;
+  }
+
+  if (recipient.kind === "contact") {
+    return `composer-draft:v1:${input.actorId}:${recipient.contactId}:contact`;
+  }
+
+  return `composer-draft:v1:${input.actorId}:email:${normalizeEmail(
+    recipient.emailAddress,
+  )}`;
 }
 
 function mapFieldErrors(
@@ -510,6 +538,7 @@ export function InboxComposerReplyBar({
 export function InboxComposerDetailPane() {
   const router = useRouter();
   const {
+    currentActorId,
     composerAliases,
     composerPane,
     aiDraft,
@@ -546,12 +575,15 @@ export function InboxComposerDetailPane() {
   const [isGeneratingAi, startAiTransition] = useTransition();
   const bodyRef = useRef<HTMLTextAreaElement>(null);
   const attachmentInputRef = useRef<HTMLInputElement>(null);
+  const hydratedDraftKeyRef = useRef<string | null>(null);
 
   const replyContext =
     composerPane.mode === "replying" ? composerPane.replyContext : null;
+  const isReplying = composerPane.mode === "replying";
 
   useEffect(() => {
     if (composerPane.mode === "closed") {
+      hydratedDraftKeyRef.current = null;
       return;
     }
 
@@ -588,6 +620,124 @@ export function InboxComposerDetailPane() {
     setComposerStatus,
   ]);
 
+  const baselineSubject = replyContext?.subject ?? "";
+  const baselineAlias = isReplying
+    ? replyContext?.defaultAlias ?? null
+    : resolveDefaultAlias({
+        recipient,
+        aliases: composerAliases,
+      });
+  const draftKey = resolveComposerDraftKey({
+    actorId: currentActorId,
+    recipient,
+  });
+
+  useEffect(() => {
+    if (
+      composerPane.mode === "closed" ||
+      activeTab !== "email" ||
+      draftKey === null ||
+      hydratedDraftKeyRef.current === draftKey
+    ) {
+      return;
+    }
+
+    const isUntouchedComposer =
+      subject.trim() === baselineSubject.trim() &&
+      body.trim().length === 0 &&
+      bodyHtml.trim().length === 0 &&
+      attachments.length === 0 &&
+      selectedAlias === baselineAlias;
+
+    if (!isUntouchedComposer) {
+      hydratedDraftKeyRef.current = draftKey;
+      return;
+    }
+
+    const draft = loadDraft(draftKey);
+    hydratedDraftKeyRef.current = draftKey;
+
+    if (draft === null) {
+      return;
+    }
+
+    setSubject(draft.subject);
+    setBody(draft.bodyPlaintext);
+    setBodyHtml(draft.bodyHtml);
+    setSelectedAlias(draft.selectedAlias);
+    setAttachments(
+      draft.attachments.map((attachment, index) => ({
+        id: `draft:${attachment.filename}:${attachment.size.toString()}:${index.toString()}`,
+        filename: attachment.filename,
+        size: attachment.size,
+        contentType: attachment.contentType,
+        contentBase64: null,
+      })),
+    );
+  }, [
+    activeTab,
+    attachments.length,
+    baselineAlias,
+    body,
+    bodyHtml,
+    composerPane.mode,
+    draftKey,
+    replyContext,
+    selectedAlias,
+    subject,
+  ]);
+
+  useEffect(() => {
+    if (
+      composerPane.mode === "closed" ||
+      activeTab !== "email" ||
+      draftKey === null
+    ) {
+      return;
+    }
+
+    const hasPersistableContent =
+      subject.trim() !== baselineSubject.trim() ||
+      body.trim().length > 0 ||
+      bodyHtml.trim().length > 0 ||
+      selectedAlias !== baselineAlias ||
+      attachments.length > 0;
+
+    const timeoutId = window.setTimeout(() => {
+      if (!hasPersistableContent) {
+        clearDraft(draftKey);
+        return;
+      }
+
+      saveDraft(draftKey, {
+        subject,
+        bodyPlaintext: body,
+        bodyHtml,
+        selectedAlias,
+        attachments: attachments.map((attachment) => ({
+          filename: attachment.filename,
+          size: attachment.size,
+          contentType: attachment.contentType,
+        })),
+      });
+    }, 500);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [
+    activeTab,
+    attachments,
+    baselineAlias,
+    baselineSubject,
+    body,
+    bodyHtml,
+    composerPane.mode,
+    draftKey,
+    selectedAlias,
+    subject,
+  ]);
+
   useEffect(() => {
     if (activeTab !== "note" || !bodyRef.current) {
       return;
@@ -604,7 +754,6 @@ export function InboxComposerDetailPane() {
     (total, attachment) => total + attachment.size,
     0,
   );
-  const isReplying = composerPane.mode === "replying";
   const canUseNoteTab = isReplying && replyContext !== null;
   const selectedAliasRecord =
     selectedAlias === null
@@ -804,6 +953,32 @@ export function InboxComposerDetailPane() {
       return;
     }
 
+    if (attachments.some((attachment) => attachment.contentBase64 === null)) {
+      setInlineError({
+        message: "Please reattach files added before refresh before sending.",
+        retryable: false,
+      });
+      setComposerErrors([
+        {
+          field: "attachments",
+          message: "Please reattach files added before refresh before sending.",
+        },
+      ]);
+      return;
+    }
+
+    const serializedAttachments = attachments.flatMap((attachment) =>
+      attachment.contentBase64 === null
+        ? []
+        : [
+            {
+              filename: attachment.filename,
+              contentType: attachment.contentType,
+              contentBase64: attachment.contentBase64,
+            },
+          ],
+    );
+
     const payload: ComposerSendActionInput = {
       recipient:
         recipient.kind === "contact"
@@ -819,11 +994,7 @@ export function InboxComposerDetailPane() {
       subject: subject.trim(),
       bodyPlaintext: body.trim(),
       bodyHtml,
-      attachments: attachments.map((attachment) => ({
-        filename: attachment.filename,
-        contentType: attachment.contentType,
-        contentBase64: attachment.contentBase64,
-      })),
+      attachments: serializedAttachments,
       captureAsKnowledge,
       ...(replyContext?.threadId === null || replyContext === null
         ? {}
@@ -843,6 +1014,9 @@ export function InboxComposerDetailPane() {
       const result = await sendComposerAction(payload);
 
       if (result.ok) {
+        if (draftKey !== null) {
+          clearDraft(draftKey);
+        }
         setComposerStatus("sent-success");
         showToast(`Sent to ${resolveRecipientLabel(recipient)}`, "success");
         closeComposer();
@@ -911,6 +1085,14 @@ export function InboxComposerDetailPane() {
         retryable: result.retryable === true,
       });
     });
+  };
+
+  const handleCancel = () => {
+    if (draftKey !== null) {
+      clearDraft(draftKey);
+    }
+
+    closeComposer();
   };
 
   return (
@@ -1237,7 +1419,7 @@ export function InboxComposerDetailPane() {
           ) : null}
 
           <div className="flex items-center justify-between">
-            <Button type="button" variant="ghost" onClick={closeComposer}>
+            <Button type="button" variant="ghost" onClick={handleCancel}>
               Cancel
             </Button>
 
@@ -1278,4 +1460,3 @@ export function InboxComposerDetailPane() {
     </TooltipProvider>
   );
 }
-

--- a/apps/web/app/inbox/_components/inbox-shell.tsx
+++ b/apps/web/app/inbox/_components/inbox-shell.tsx
@@ -20,6 +20,7 @@ interface ShellProps {
   readonly initialFilterId: InboxFilterId;
   readonly composerAliases: readonly InboxComposerAliasOption[];
   readonly healthBanner: InboxIntegrationHealthBannerViewModel | null;
+  readonly currentActorId: string;
   readonly operator: {
     readonly initials: string;
     readonly displayName: string;
@@ -42,11 +43,15 @@ export function InboxShell({
   initialFilterId,
   composerAliases,
   healthBanner,
+  currentActorId,
   operator,
   children
 }: ShellProps) {
   return (
-    <InboxClientProvider composerAliases={composerAliases}>
+    <InboxClientProvider
+      composerAliases={composerAliases}
+      currentActorId={currentActorId}
+    >
       <InboxKeyboardProvider>
         <InboxFreshnessPoller listFreshness={initialList.freshness} />
         <PrimaryIconRail operator={operator} />

--- a/apps/web/app/inbox/_lib/composer-draft-storage.ts
+++ b/apps/web/app/inbox/_lib/composer-draft-storage.ts
@@ -1,0 +1,131 @@
+const MAX_LOCAL_STORAGE_BYTES = 4 * 1024 * 1024;
+const DRAFT_KEY_PREFIX = "composer-draft:v1:";
+
+export interface StoredComposerDraft {
+  readonly subject: string;
+  readonly bodyPlaintext: string;
+  readonly bodyHtml: string;
+  readonly selectedAlias: string | null;
+  readonly attachments: readonly {
+    readonly filename: string;
+    readonly size: number;
+    readonly contentType: string;
+  }[];
+  readonly updatedAt: number;
+}
+
+function getStorage(): Storage | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return window.localStorage;
+}
+
+function estimateStorageBytes(storage: Storage): number {
+  let total = 0;
+
+  for (let index = 0; index < storage.length; index += 1) {
+    const key = storage.key(index);
+
+    if (key === null) {
+      continue;
+    }
+
+    const value = storage.getItem(key) ?? "";
+    total += (key.length + value.length) * 2;
+  }
+
+  return total;
+}
+
+function pruneIfTooLarge(storage: Storage): void {
+  while (estimateStorageBytes(storage) > MAX_LOCAL_STORAGE_BYTES) {
+    let oldestKey: string | null = null;
+    let oldestUpdatedAt = Number.POSITIVE_INFINITY;
+
+    for (let index = 0; index < storage.length; index += 1) {
+      const key = storage.key(index);
+
+      if (!key?.startsWith(DRAFT_KEY_PREFIX)) {
+        continue;
+      }
+
+      const value = storage.getItem(key);
+      if (value === null) {
+        continue;
+      }
+
+      try {
+        const parsed = JSON.parse(value) as Partial<StoredComposerDraft>;
+        const updatedAt =
+          typeof parsed.updatedAt === "number" ? parsed.updatedAt : 0;
+
+        if (updatedAt < oldestUpdatedAt) {
+          oldestUpdatedAt = updatedAt;
+          oldestKey = key;
+        }
+      } catch {
+        oldestKey = key;
+        oldestUpdatedAt = Number.NEGATIVE_INFINITY;
+      }
+    }
+
+    if (oldestKey === null) {
+      return;
+    }
+
+    storage.removeItem(oldestKey);
+  }
+}
+
+export function saveDraft(
+  key: string,
+  draft: Omit<StoredComposerDraft, "updatedAt">,
+): void {
+  const storage = getStorage();
+
+  if (storage === null) {
+    return;
+  }
+
+  storage.setItem(
+    key,
+    JSON.stringify({
+      ...draft,
+      updatedAt: Date.now(),
+    } satisfies StoredComposerDraft),
+  );
+  pruneIfTooLarge(storage);
+}
+
+export function loadDraft(key: string): StoredComposerDraft | null {
+  const storage = getStorage();
+
+  if (storage === null) {
+    return null;
+  }
+
+  const value = storage.getItem(key);
+
+  if (value === null) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(value) as StoredComposerDraft;
+  } catch {
+    storage.removeItem(key);
+    return null;
+  }
+}
+
+export function clearDraft(key: string): void {
+  const storage = getStorage();
+
+  if (storage === null) {
+    return;
+  }
+
+  storage.removeItem(key);
+}

--- a/apps/web/app/inbox/layout.tsx
+++ b/apps/web/app/inbox/layout.tsx
@@ -56,6 +56,7 @@ export default async function InboxLayout({
       initialFilterId="all"
       composerAliases={composerAliases}
       healthBanner={healthBanner}
+      currentActorId={currentUser.id}
       operator={{
         initials: getInitials(currentUser.name ?? currentUser.email),
         displayName: currentUser.name ?? currentUser.email,

--- a/apps/web/tests/unit/composer-draft-storage.test.ts
+++ b/apps/web/tests/unit/composer-draft-storage.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  clearDraft,
+  loadDraft,
+  saveDraft,
+} from "../../app/inbox/_lib/composer-draft-storage";
+
+class MockStorage implements Storage {
+  private readonly store = new Map<string, string>();
+
+  get length(): number {
+    return this.store.size;
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.store.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+}
+
+describe("composer draft storage", () => {
+  let storage: MockStorage;
+
+  beforeEach(() => {
+    storage = new MockStorage();
+    vi.stubGlobal("window", {
+      localStorage: storage,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("saves and loads a draft payload", () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+
+    saveDraft("composer-draft:v1:actor-1:contact-1:contact", {
+      subject: "Re: Expedition dates",
+      bodyPlaintext: "Hello there",
+      bodyHtml: "<p>Hello there</p>",
+      selectedAlias: "field@adventuresci.org",
+      attachments: [
+        {
+          filename: "itinerary.pdf",
+          size: 1024,
+          contentType: "application/pdf",
+        },
+      ],
+    });
+
+    expect(
+      loadDraft("composer-draft:v1:actor-1:contact-1:contact"),
+    ).toMatchObject({
+      subject: "Re: Expedition dates",
+      bodyPlaintext: "Hello there",
+      bodyHtml: "<p>Hello there</p>",
+      selectedAlias: "field@adventuresci.org",
+      attachments: [
+        {
+          filename: "itinerary.pdf",
+          size: 1024,
+          contentType: "application/pdf",
+        },
+      ],
+      updatedAt: 1_700_000_000_000,
+    });
+  });
+
+  it("clears a saved draft", () => {
+    saveDraft("composer-draft:v1:actor-1:contact-1:contact", {
+      subject: "Hello",
+      bodyPlaintext: "Body",
+      bodyHtml: "<p>Body</p>",
+      selectedAlias: null,
+      attachments: [],
+    });
+
+    clearDraft("composer-draft:v1:actor-1:contact-1:contact");
+
+    expect(loadDraft("composer-draft:v1:actor-1:contact-1:contact")).toBeNull();
+  });
+
+  it("drops the oldest draft when total localStorage usage exceeds 4 MB", () => {
+    storage.setItem("non-draft", "x".repeat(2_085_000));
+    vi.spyOn(Date, "now")
+      .mockReturnValueOnce(100)
+      .mockReturnValueOnce(200);
+
+    saveDraft("composer-draft:v1:actor-1:contact-1:contact", {
+      subject: "Old draft",
+      bodyPlaintext: "a".repeat(5_000),
+      bodyHtml: `<p>${"a".repeat(5_000)}</p>`,
+      selectedAlias: null,
+      attachments: [],
+    });
+    saveDraft("composer-draft:v1:actor-1:contact-2:contact", {
+      subject: "New draft",
+      bodyPlaintext: "b".repeat(5_000),
+      bodyHtml: `<p>${"b".repeat(5_000)}</p>`,
+      selectedAlias: null,
+      attachments: [],
+    });
+
+    expect(loadDraft("composer-draft:v1:actor-1:contact-1:contact")).toBeNull();
+    expect(
+      loadDraft("composer-draft:v1:actor-1:contact-2:contact"),
+    ).not.toBeNull();
+    expect(storage.getItem("non-draft")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add localStorage-backed composer draft persistence scoped by actor and recipient
- hydrate untouched composers from saved drafts, clear drafts on successful send and explicit cancel, and preserve close-without-cancel recovery
- cover storage save/load/clear/prune behavior with unit tests

## Verification
- pnpm --filter @as-comms/web typecheck
- pnpm --filter @as-comms/web lint
- pnpm --filter @as-comms/web test:unit

## Brief
- Source brief: Codex task description for `feat/composer-draft-autosave` (no standalone URL or checked-in brief file was provided in the worktree to link here).