### PR TITLE
fix(db): normalize db.execute() shape across pglite/postgres-js

### DIFF
--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -1453,7 +1453,7 @@ function createStage1RepositoriesInternal(
           return new Map();
         }
 
-        const rows = (await db.execute(
+        const result = await db.execute(
           sql`
             select distinct on (${canonicalEventLedger.contactId})
               ${canonicalEventLedger.contactId} as "contactId",
@@ -1468,10 +1468,25 @@ function createStage1RepositoriesInternal(
               ${canonicalEventLedger.contactId},
               ${canonicalEventLedger.occurredAt} desc
           `,
-        )) as readonly {
+        );
+
+        // drizzle-orm/postgres-js returns rows as a top-level iterable;
+        // drizzle-orm/pglite (used in tests) returns { rows: [...] }.
+        // Normalize to a plain array of rows.
+        const rows: readonly {
           readonly contactId: string;
           readonly projectInboxAlias: string;
-        }[];
+        }[] = Array.isArray(result)
+          ? (result as readonly {
+              readonly contactId: string;
+              readonly projectInboxAlias: string;
+            }[])
+          : ((result as {
+              readonly rows?: readonly {
+                readonly contactId: string;
+                readonly projectInboxAlias: string;
+              }[];
+            }).rows ?? []);
 
         return new Map(
           rows.map((row) => [row.contactId, row.projectInboxAlias]),


### PR DESCRIPTION
## Summary

Follow-up to PR #137. The squash-merge picked up only the first commit on that branch (the prod-correct array fix) and dropped my second commit (the driver-shape normalization). As a result, main's CI is now broken: tests use the pglite driver which returns \`{ rows: [...] }\`, while prod's postgres-js driver returns the array directly. The merged code expects array shape only, so test-side execution throws \`TypeError: rows.map is not a function\`.

This PR ports the driver-shape normalization back onto main.

## Fix

\`packages/db/src/repositories.ts\` listLastInboundAliasByContactIds: defensive accessor that handles both shapes.

## Test plan

- [x] Identified test failure mode (pglite vs postgres-js shape mismatch)
- [ ] CI verify green
- [ ] Architect verifies inbox still loads in prod after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)