### PR TITLE
fix(db): preserve project_dimensions.is_active across SF capture upserts

### DIFF
--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -1377,7 +1377,8 @@ function createStage1RepositoriesInternal(
             set: {
               projectName: values.projectName,
               projectAlias: values.projectAlias,
-              isActive: values.isActive,
+              // isActive intentionally NOT updated: admins manage it in Settings,
+              // and Salesforce capture must not overwrite that app-owned state.
               aiKnowledgeUrl: values.aiKnowledgeUrl,
               aiKnowledgeSyncedAt: values.aiKnowledgeSyncedAt,
               source: values.source,

--- a/packages/db/test/stage1-repositories.test.ts
+++ b/packages/db/test/stage1-repositories.test.ts
@@ -604,6 +604,41 @@ describe("Stage 1 DB repositories", () => {
     ).resolves.toEqual([timelineProjection]);
   });
 
+  it("preserves admin-managed project active state across project dimension upserts", async () => {
+    const { repositories, settings } = await createTestStage1Context();
+
+    await repositories.projectDimensions.upsert({
+      projectId: "project_1",
+      projectName: "Project Antarctica",
+      isActive: false,
+      source: "salesforce",
+    });
+
+    const activatedProject = await settings.projects.setActive("project_1", true);
+
+    expect(activatedProject).toMatchObject({
+      projectId: "project_1",
+      isActive: true,
+    });
+
+    await repositories.projectDimensions.upsert({
+      projectId: "project_1",
+      projectName: "Project Antarctica Resynced",
+      isActive: false,
+      source: "salesforce",
+    });
+
+    await expect(
+      repositories.projectDimensions.listByIds(["project_1"]),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        projectId: "project_1",
+        projectName: "Project Antarctica Resynced",
+        isActive: true,
+      }),
+    ]);
+  });
+
   it("persists sync state and audit evidence with contract-shaped results", async () => {
     const { repositories } = await createTestStage1Context();
 


### PR DESCRIPTION
## Summary

- preserve admin-managed `project_dimensions.is_active` during Salesforce capture upserts by omitting it from the conflict-update set
- add a regression test covering `setActive(true)` followed by a Salesforce-style re-upsert with `isActive: false`

## Why this matters

Production has 0 of 33 projects flagged active right now because every SF sync wipes the admin-set state. Anything that calls `projectDimensions.listActive()` (welcome workload, list project filter chips) returns empty.

## Verification

- `pnpm --filter @as-comms/db typecheck` ✅
- `pnpm --filter @as-comms/db lint` ✅
- `pnpm --filter @as-comms/db test:unit` blocked locally by macOS `@rollup/rollup-darwin-arm64` `ERR_DLOPEN_FAILED` (environmental, CI is authoritative — see memory `project_macos_rollup_gotcha.md`)

## One-off restoration SQL

Architect runs this **post-merge with sign-off** to restore admin-set state for projects with active memberships:

```sql
UPDATE project_dimensions pd
SET is_active = true, updated_at = now()
WHERE pd.project_id IN (
  SELECT DISTINCT cm.project_id
  FROM contact_memberships cm
  WHERE cm.project_id IS NOT NULL
    AND cm.status NOT IN ('Successful', 'Completed')
);
```

## Brief

`.codex-project-dimensions-preserve-is-active-2026-04-25.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)