### PR TITLE
fix(integrations): detect encrypted/binary email bodies, store placeholder

### DIFF
--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -1463,6 +1463,10 @@ function timelineActorLabel(
 const PARTICIPANT_HEADER_NAME_PATTERN = /^\s*"?([^"<]+?)"?\s*<[^>]+>\s*$/u;
 const PARTICIPANT_HEADER_EMAIL_PATTERN =
   /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/iu;
+const PLACEHOLDER_BODY_PREVIEWS = new Set([
+  "[Encrypted message — open in Gmail to read]",
+  "[Message body could not be extracted — open in Gmail]",
+]);
 
 function participantHeaderLabel(headerValue: string | null): string | null {
   if (headerValue === null) {
@@ -1822,12 +1826,16 @@ function buildComposerReplyContext(input: {
   readonly timelineItems: readonly TimelineItem[];
   readonly defaultAlias: string | null;
 }): InboxComposerReplyContext | null {
-  const latestInboundEmail = [...input.timelineItems]
+  const inboundEmails = [...input.timelineItems]
     .reverse()
-    .find(
+    .filter(
       (item): item is Extract<TimelineItem, { family: "one_to_one_email" }> =>
         item.family === "one_to_one_email" && item.direction === "inbound",
     );
+  const latestInboundEmail = inboundEmails[0];
+  const latestQuotableInboundEmail = inboundEmails.find(
+    (item) => !PLACEHOLDER_BODY_PREVIEWS.has((item.bodyPreview ?? "").trim()),
+  );
 
   if (latestInboundEmail === undefined) {
     return null;
@@ -1837,7 +1845,7 @@ function buildComposerReplyContext(input: {
     contactId: input.contact.id,
     contactDisplayName: input.contact.displayName,
     subject: buildReplySubject(latestInboundEmail.subject),
-    threadCursor: latestInboundEmail.canonicalEventId,
+    threadCursor: latestQuotableInboundEmail?.canonicalEventId ?? null,
     threadId: latestInboundEmail.threadId ?? null,
     inReplyToRfc822: latestInboundEmail.rfc822MessageId ?? null,
     defaultAlias: input.defaultAlias,

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -1783,6 +1783,64 @@ describe("real inbox selectors", () => {
     });
   });
 
+  it("skips encrypted placeholder bodies when deriving composer reply context", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:encrypted-reply",
+      salesforceContactId: "003-encrypted-reply",
+      displayName: "Steve Negri",
+      primaryEmail: "steve.negri@tetratech.com",
+      primaryPhone: null,
+    });
+
+    await seedInboxEmailEvent(runtime.context, {
+      id: "encrypted-reply-older",
+      contactId: "contact:encrypted-reply",
+      occurredAt: "2026-04-16T10:00:00.000Z",
+      direction: "inbound",
+      subject: "Re: Project check-in",
+      snippet: "Older plaintext inbound",
+      bodyTextPreview: "Here are the field updates you asked for.",
+    });
+    const latestEncryptedEvent = await seedInboxEmailEvent(runtime.context, {
+      id: "encrypted-reply-latest",
+      contactId: "contact:encrypted-reply",
+      occurredAt: "2026-04-16T11:00:00.000Z",
+      direction: "inbound",
+      subject: "Re: Project check-in",
+      snippet: "[Encrypted message — open in Gmail to read]",
+      bodyTextPreview: "[Encrypted message — open in Gmail to read]",
+      bodyKind: "encrypted_placeholder",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:encrypted-reply",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-16T11:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-04-16T11:00:00.000Z",
+      snippet: "[Encrypted message — open in Gmail to read]",
+      lastCanonicalEventId: latestEncryptedEvent.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+
+    const detail = await getInboxDetail("contact:encrypted-reply");
+
+    expect(detail?.timeline.at(-1)).toMatchObject({
+      kind: "inbound-email",
+      body: "[Encrypted message — open in Gmail to read]",
+    });
+    expect(detail?.composerReplyContext).toMatchObject({
+      subject: "Re: Project check-in",
+      threadCursor: "event:encrypted-reply-older",
+      inReplyToRfc822: "<encrypted-reply-latest@example.org>",
+    });
+  });
+
   it("falls back to provider communication details before projection snippets for Salesforce-backed latest rows", async () => {
     if (runtime === null) {
       throw new Error("Expected inbox test runtime");

--- a/apps/web/tests/unit/inbox-stage1-helpers.ts
+++ b/apps/web/tests/unit/inbox-stage1-helpers.ts
@@ -70,6 +70,10 @@ export async function seedInboxEmailEvent(
     readonly snippet: string;
     readonly snippetClean?: string;
     readonly bodyTextPreview?: string;
+    readonly bodyKind?:
+      | "plaintext"
+      | "encrypted_placeholder"
+      | "binary_fallback";
     readonly fromHeader?: string | null;
     readonly toHeader?: string | null;
     readonly ccHeader?: string | null;
@@ -131,6 +135,7 @@ export async function seedInboxEmailEvent(
     ccHeader: input.ccHeader ?? null,
     snippetClean: input.snippetClean ?? input.snippet,
     bodyTextPreview: input.bodyTextPreview ?? input.snippet,
+    bodyKind: input.bodyKind ?? "plaintext",
     capturedMailbox: "volunteers@example.org",
     projectInboxAlias: input.projectInboxAlias ?? "volunteers@example.org",
   });

--- a/packages/contracts/src/stage1-records.ts
+++ b/packages/contracts/src/stage1-records.ts
@@ -268,6 +268,13 @@ export type ExpeditionDimensionRecord = z.infer<
 export const gmailMessageDirectionSchema = z.enum(["inbound", "outbound"]);
 export type GmailMessageDirection = z.infer<typeof gmailMessageDirectionSchema>;
 
+export const gmailMessageBodyKindSchema = z.enum([
+  "plaintext",
+  "encrypted_placeholder",
+  "binary_fallback",
+]);
+export type GmailMessageBodyKind = z.infer<typeof gmailMessageBodyKindSchema>;
+
 export const gmailMessageDetailSchema = z.object({
   sourceEvidenceId: idSchema,
   providerRecordId: z.string().min(1),
@@ -281,6 +288,7 @@ export const gmailMessageDetailSchema = z.object({
   labelIds: stringArraySchema.nullable().optional(),
   snippetClean: z.string(),
   bodyTextPreview: z.string(),
+  bodyKind: gmailMessageBodyKindSchema.nullable().optional(),
   capturedMailbox: nullableStringSchema,
   projectInboxAlias: nullableStringSchema,
 });

--- a/packages/db/drizzle/0027_gmail_message_details_body_kind.sql
+++ b/packages/db/drizzle/0027_gmail_message_details_body_kind.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "gmail_message_details"
+ADD COLUMN "body_kind" text;

--- a/packages/db/src/mappers.ts
+++ b/packages/db/src/mappers.ts
@@ -559,6 +559,7 @@ export function mapGmailMessageDetailRow(
     labelIds: row.labelIds,
     snippetClean: row.snippetClean,
     bodyTextPreview: row.bodyTextPreview,
+    bodyKind: row.bodyKind,
     capturedMailbox: row.capturedMailbox,
     projectInboxAlias: row.projectInboxAlias,
   });
@@ -582,6 +583,7 @@ export function mapGmailMessageDetailToInsert(
     labelIds: parsed.labelIds,
     snippetClean: parsed.snippetClean,
     bodyTextPreview: parsed.bodyTextPreview,
+    bodyKind: parsed.bodyKind ?? null,
     capturedMailbox: parsed.capturedMailbox,
     projectInboxAlias: parsed.projectInboxAlias,
   };

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -1512,6 +1512,7 @@ function createStage1RepositoriesInternal(
               labelIds: values.labelIds,
               snippetClean: values.snippetClean,
               bodyTextPreview: values.bodyTextPreview,
+              bodyKind: values.bodyKind,
               capturedMailbox: values.capturedMailbox,
               projectInboxAlias: values.projectInboxAlias,
               updatedAt: new Date(),

--- a/packages/db/src/schema/tables.ts
+++ b/packages/db/src/schema/tables.ts
@@ -217,6 +217,7 @@ export const gmailMessageDetails = pgTable(
     labelIds: text("label_ids").array(),
     snippetClean: text("snippet_clean").notNull().default(""),
     bodyTextPreview: text("body_text_preview").notNull().default(""),
+    bodyKind: text("body_kind"),
     capturedMailbox: text("captured_mailbox"),
     projectInboxAlias: text("project_inbox_alias"),
     createdAt: createdAtColumn,

--- a/packages/integrations/src/capture-services/gmail.ts
+++ b/packages/integrations/src/capture-services/gmail.ts
@@ -20,7 +20,7 @@ import {
   type GmailProviderCloseMessageInput
 } from "../providers/gmail-record-builder.js";
 import {
-  extractGmailBodyPreviewFromPayload,
+  extractGmailBodyPreviewFromPayloadResult,
   type GmailApiMessagePart
 } from "../providers/gmail-body.js";
 import {
@@ -420,9 +420,7 @@ export async function mapLiveGmailMessageToRecord(input: {
     labelIds: input.message.labelIds,
     snippet: input.message.snippet,
     snippetClean: input.message.snippet,
-    bodyTextPreview: await extractGmailBodyPreviewFromPayload(
-      input.message.payload
-    ),
+    ...(await extractGmailBodyPreviewFromPayloadResult(input.message.payload)),
     internalDate: input.message.internalDate,
     headers,
     payloadRef: `gmail://${encodeURIComponent(input.capturedMailbox)}/messages/${encodeURIComponent(input.message.id)}`,

--- a/packages/integrations/src/providers/gmail-body.ts
+++ b/packages/integrations/src/providers/gmail-body.ts
@@ -32,6 +32,27 @@ interface CandidateBodyPart {
   readonly part: GmailApiMessagePart;
 }
 
+export type GmailBodyKind =
+  | "plaintext"
+  | "encrypted_placeholder"
+  | "binary_fallback";
+
+export interface GmailBodyPreviewResult {
+  readonly bodyTextPreview: string;
+  readonly bodyKind: GmailBodyKind;
+}
+
+const ENCRYPTED_MESSAGE_PLACEHOLDER =
+  "[Encrypted message — open in Gmail to read]";
+const BINARY_FALLBACK_PLACEHOLDER =
+  "[Message body could not be extracted — open in Gmail]";
+const ENCRYPTED_MIME_TYPES = new Set([
+  "application/pkcs7-mime",
+  "application/x-pkcs7-mime",
+  "multipart/encrypted",
+  "application/pgp-encrypted"
+]);
+
 function normalizeLineEndings(value: string): string {
   return value.replace(/\r\n/gu, "\n").replace(/\r/gu, "\n");
 }
@@ -202,6 +223,40 @@ function getPartHeader(
   return header?.value ?? null;
 }
 
+function normalizeMimeType(value: string | null | undefined): string {
+  return value?.split(";")[0]?.trim().toLowerCase() ?? "";
+}
+
+function buildBodyPreviewResult(
+  bodyTextPreview: string,
+  bodyKind: GmailBodyKind
+): GmailBodyPreviewResult {
+  return {
+    bodyTextPreview,
+    bodyKind
+  };
+}
+
+export function extractBodyKind(part: GmailApiMessagePart): GmailBodyKind {
+  const contentType = normalizeMimeType(
+    getPartHeader(part, "Content-Type") ?? part.mimeType ?? null
+  );
+
+  return ENCRYPTED_MIME_TYPES.has(contentType)
+    ? "encrypted_placeholder"
+    : "plaintext";
+}
+
+function containsEncryptedBodyPart(part: GmailApiMessagePart): boolean {
+  if (extractBodyKind(part) === "encrypted_placeholder") {
+    return true;
+  }
+
+  return (part.parts ?? []).some((childPart) =>
+    containsEncryptedBodyPart(childPart)
+  );
+}
+
 function isAttachmentPart(part: GmailApiMessagePart): boolean {
   if ((part.filename?.trim().length ?? 0) > 0) {
     return true;
@@ -293,9 +348,16 @@ async function extractTextFromMimePart(part: GmailApiMessagePart): Promise<strin
   }
 }
 
-export async function extractGmailBodyPreviewFromPayload(
+export async function extractGmailBodyPreviewFromPayloadResult(
   payload: GmailApiMessagePart
-): Promise<string> {
+): Promise<GmailBodyPreviewResult> {
+  if (containsEncryptedBodyPart(payload)) {
+    return buildBodyPreviewResult(
+      ENCRYPTED_MESSAGE_PLACEHOLDER,
+      "encrypted_placeholder"
+    );
+  }
+
   const candidates = collectCandidateBodyParts(payload);
 
   for (const kind of ["plain", "html"] as const) {
@@ -303,34 +365,78 @@ export async function extractGmailBodyPreviewFromPayload(
       const bodyPreview = await extractTextFromMimePart(candidate.part);
 
       if (bodyPreview.length > 0) {
-        return bodyPreview;
+        return buildBodyPreviewResult(bodyPreview, "plaintext");
       }
     }
+  }
+
+  if ((payload.parts?.length ?? 0) > 0) {
+    return buildBodyPreviewResult(
+      BINARY_FALLBACK_PLACEHOLDER,
+      "binary_fallback"
+    );
   }
 
   const fallbackBodyPreview = await extractTextFromMimePart(payload);
 
   return fallbackBodyPreview.length > 0
-    ? fallbackBodyPreview
-    : cleanGmailBodyPreviewText("");
+    ? buildBodyPreviewResult(fallbackBodyPreview, "plaintext")
+    : buildBodyPreviewResult(cleanGmailBodyPreviewText(""), "plaintext");
+}
+
+export async function extractGmailBodyPreviewFromPayload(
+  payload: GmailApiMessagePart
+): Promise<string> {
+  const result = await extractGmailBodyPreviewFromPayloadResult(payload);
+  return result.bodyTextPreview;
+}
+
+function extractTopLevelContentType(rawMessage: string): string {
+  const normalized = rawMessage.replace(/\r\n/gu, "\n");
+  const headerBlock = normalized.split(/\n\n/u, 1)[0] ?? "";
+  const match = /(?:^|\n)Content-Type:\s*([^\n]+)/iu.exec(headerBlock);
+
+  return normalizeMimeType(match?.[1] ?? null);
+}
+
+export async function extractGmailBodyPreviewFromMimeMessageResult(input: {
+  readonly rawMessage: string;
+  readonly fallbackBodyText?: string | null;
+}): Promise<GmailBodyPreviewResult> {
+  if (ENCRYPTED_MIME_TYPES.has(extractTopLevelContentType(input.rawMessage))) {
+    return buildBodyPreviewResult(
+      ENCRYPTED_MESSAGE_PLACEHOLDER,
+      "encrypted_placeholder"
+    );
+  }
+
+  try {
+    const extractedText = await extractTextFromMimeDocument(input.rawMessage);
+    const cleaned = cleanGmailBodyPreviewText(extractedText);
+
+    if (cleaned.length > 0) {
+      return buildBodyPreviewResult(cleaned, "plaintext");
+    }
+  } catch {
+    // Fall back to a conservative text clean-up below.
+  }
+
+  const fallbackBodyPreview = cleanGmailBodyPreviewText(
+    normalizeLineEndings(input.fallbackBodyText ?? "")
+  );
+
+  return fallbackBodyPreview.length > 0
+    ? buildBodyPreviewResult(fallbackBodyPreview, "plaintext")
+    : buildBodyPreviewResult(
+        BINARY_FALLBACK_PLACEHOLDER,
+        "binary_fallback"
+      );
 }
 
 export async function extractGmailBodyPreviewFromMimeMessage(input: {
   readonly rawMessage: string;
   readonly fallbackBodyText?: string | null;
 }): Promise<string> {
-  try {
-    const extractedText = await extractTextFromMimeDocument(input.rawMessage);
-    const cleaned = cleanGmailBodyPreviewText(extractedText);
-
-    if (cleaned.length > 0) {
-      return cleaned;
-    }
-  } catch {
-    // Fall back to a conservative text clean-up below.
-  }
-
-  return cleanGmailBodyPreviewText(
-    normalizeLineEndings(input.fallbackBodyText ?? "")
-  );
+  const result = await extractGmailBodyPreviewFromMimeMessageResult(input);
+  return result.bodyTextPreview;
 }

--- a/packages/integrations/src/providers/gmail-mbox.ts
+++ b/packages/integrations/src/providers/gmail-mbox.ts
@@ -6,7 +6,7 @@ import {
   type GmailProviderCloseMessageInput
 } from "./gmail-record-builder.js";
 import {
-  extractGmailBodyPreviewFromMimeMessage
+  extractGmailBodyPreviewFromMimeMessageResult
 } from "./gmail-body.js";
 import { gmailRecordSchema, type GmailRecord } from "./gmail.js";
 
@@ -269,10 +269,11 @@ export async function importGmailMboxRecords(
       })) ?? preferredRecordId;
     const internalDate =
       toSafeIsoTimestamp(message.headers.Date) ?? parsedInput.receivedAt;
-    const bodyTextPreview = await extractGmailBodyPreviewFromMimeMessage({
+    const extractedBody = await extractGmailBodyPreviewFromMimeMessageResult({
       rawMessage: message.rawMessage,
       fallbackBodyText: message.bodyText
     });
+    const bodyTextPreview = extractedBody.bodyTextPreview;
     const snippetClean = buildSnippet(bodyTextPreview, message.headers.Subject);
     const recordInput: GmailProviderCloseMessageInput = {
       recordId,
@@ -280,6 +281,7 @@ export async function importGmailMboxRecords(
       snippet: snippetClean,
       snippetClean,
       bodyTextPreview,
+      bodyKind: extractedBody.bodyKind,
       internalDate,
       headers: message.headers,
       payloadRef,

--- a/packages/integrations/src/providers/gmail-record-builder.ts
+++ b/packages/integrations/src/providers/gmail-record-builder.ts
@@ -14,6 +14,11 @@ export interface GmailProviderCloseMessageInput {
   readonly snippet: string;
   readonly snippetClean?: string;
   readonly bodyTextPreview?: string | null;
+  readonly bodyKind?:
+    | "plaintext"
+    | "encrypted_placeholder"
+    | "binary_fallback"
+    | null;
   readonly internalDate: string | null;
   readonly headers: Readonly<Record<string, string>>;
   readonly payloadRef: string;
@@ -251,6 +256,7 @@ export function buildGmailMessageRecord(
     labelIds,
     snippetClean,
     bodyTextPreview,
+    bodyKind: input.bodyKind ?? "plaintext",
     threadId: input.threadId,
     rfc822MessageId,
     capturedMailbox: input.capturedMailbox,

--- a/packages/integrations/src/providers/gmail.ts
+++ b/packages/integrations/src/providers/gmail.ts
@@ -42,6 +42,10 @@ export const gmailMessageRecordSchema = z.object({
   labelIds: nullableStringArraySchema.optional(),
   snippetClean: z.string().default(""),
   bodyTextPreview: z.string().default(""),
+  bodyKind: z
+    .enum(["plaintext", "encrypted_placeholder", "binary_fallback"])
+    .nullable()
+    .optional(),
   threadId: nullableStringSchema.default(null),
   rfc822MessageId: nullableStringSchema.default(null),
   capturedMailbox: nullableStringSchema.default(null),
@@ -175,6 +179,7 @@ function mapGmailMessageRecord(
       labelIds: record.labelIds,
       snippetClean: cleanSnippet,
       bodyTextPreview,
+      bodyKind: record.bodyKind ?? "plaintext",
       capturedMailbox: record.capturedMailbox,
       projectInboxAlias: record.projectInboxAlias
     }

--- a/packages/integrations/test/fixtures/gmail/binary-only-payload.json
+++ b/packages/integrations/test/fixtures/gmail/binary-only-payload.json
@@ -1,0 +1,51 @@
+{
+  "mimeType": "multipart/mixed",
+  "filename": "",
+  "headers": [
+    {
+      "name": "Content-Type",
+      "value": "multipart/mixed; boundary=\"binary-only-boundary\""
+    }
+  ],
+  "body": {
+    "size": 0
+  },
+  "parts": [
+    {
+      "mimeType": "image/png",
+      "filename": "logo.png",
+      "headers": [
+        {
+          "name": "Content-Type",
+          "value": "image/png; name=\"logo.png\""
+        },
+        {
+          "name": "Content-Disposition",
+          "value": "attachment; filename=\"logo.png\""
+        }
+      ],
+      "body": {
+        "data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAA"
+      },
+      "parts": []
+    },
+    {
+      "mimeType": "application/octet-stream",
+      "filename": "blob.bin",
+      "headers": [
+        {
+          "name": "Content-Type",
+          "value": "application/octet-stream; name=\"blob.bin\""
+        },
+        {
+          "name": "Content-Disposition",
+          "value": "attachment; filename=\"blob.bin\""
+        }
+      ],
+      "body": {
+        "data": "F8HCwxSxeWosLiFqd2FqLi4u"
+      },
+      "parts": []
+    }
+  ]
+}

--- a/packages/integrations/test/fixtures/gmail/encrypted-multipart.mbox
+++ b/packages/integrations/test/fixtures/gmail/encrypted-multipart.mbox
@@ -1,0 +1,18 @@
+From sender@example.org Fri Apr 17 10:00:00 2026
+MIME-Version: 1.0
+Date: Fri, 17 Apr 2026 10:00:00 +0000
+From: Steve Negri <steve.negri@tetratech.com>
+To: volunteers@example.org
+Subject: Secure message
+Content-Type: multipart/encrypted; protocol="application/pgp-encrypted"; boundary="encrypted-boundary"
+
+--encrypted-boundary
+Content-Type: application/pgp-encrypted
+
+Version: 1
+--encrypted-boundary
+Content-Type: application/octet-stream
+Content-Transfer-Encoding: base64
+
+hQEMA4a7T1I0L2YZAQf/X9n0mC8iN0V0V1BnaX5Xb1JXV1BTV1lBQUFBQUFBQUFB
+--encrypted-boundary--

--- a/packages/integrations/test/fixtures/gmail/encrypted-pkcs7-payload.json
+++ b/packages/integrations/test/fixtures/gmail/encrypted-pkcs7-payload.json
@@ -1,0 +1,18 @@
+{
+  "mimeType": "application/pkcs7-mime",
+  "filename": "smime.p7m",
+  "headers": [
+    {
+      "name": "Content-Type",
+      "value": "application/pkcs7-mime; smime-type=enveloped-data; name=\"smime.p7m\""
+    },
+    {
+      "name": "Content-Transfer-Encoding",
+      "value": "base64"
+    }
+  ],
+  "body": {
+    "data": "MIAGCSqGSIb3DQEHA6CAMIACAQAxggFfMIIBWwIBADBFMD0xCzAJBgNVBAYTAlVTMQ8wDQYDVQQKDAZUZXN0Q28xHTAbBgNVBAMMFFRlc3QgUy9NSU1FIFJlY2lwaWVudAIBADANBgkqhkiG9w0BAQEFAASCAQBm"
+  },
+  "parts": []
+}

--- a/packages/integrations/test/gmail-body-extraction.test.ts
+++ b/packages/integrations/test/gmail-body-extraction.test.ts
@@ -4,10 +4,13 @@ import { describe, expect, it } from "vitest";
 
 import {
   cleanGmailBodyPreviewText,
+  extractGmailBodyPreviewFromMimeMessageResult,
+  extractGmailBodyPreviewFromPayloadResult,
   extractGmailBodyPreviewFromMimeMessage,
   gmailMessageRecordSchema,
   gmailMessageFullResponseSchema,
   mapLiveGmailMessageToRecord,
+  type GmailApiMessagePart,
   trimQuotedReplyContent
 } from "../src/index.js";
 
@@ -15,6 +18,10 @@ const fixturesDirectory = new URL("./fixtures/gmail/", import.meta.url);
 
 async function readFixtureText(name: string): Promise<string> {
   return readFile(new URL(name, fixturesDirectory), "utf8");
+}
+
+async function readFixtureJson<T>(name: string): Promise<T> {
+  return JSON.parse(await readFixtureText(name)) as T;
 }
 
 describe("Gmail body extraction", () => {
@@ -49,6 +56,45 @@ describe("Gmail body extraction", () => {
         "Could you clarify why I need to do this again?",
         "I'm even accepted in Strava."
       ].join("\n")
+    );
+  });
+
+  it("stores an encrypted placeholder for application/pkcs7-mime payloads", async () => {
+    const payload = await readFixtureJson<GmailApiMessagePart>(
+      "encrypted-pkcs7-payload.json"
+    );
+
+    await expect(extractGmailBodyPreviewFromPayloadResult(payload)).resolves.toEqual(
+      {
+        bodyTextPreview: "[Encrypted message — open in Gmail to read]",
+        bodyKind: "encrypted_placeholder",
+      }
+    );
+  });
+
+  it("stores an encrypted placeholder for multipart/encrypted MIME messages", async () => {
+    const rawMessage = await readFixtureText("encrypted-multipart.mbox");
+    const parsed = await extractGmailBodyPreviewFromMimeMessageResult({
+      rawMessage: rawMessage.replace(/^From .+\n/u, ""),
+    });
+
+    expect(parsed).toEqual({
+      bodyTextPreview: "[Encrypted message — open in Gmail to read]",
+      bodyKind: "encrypted_placeholder",
+    });
+  });
+
+  it("stores a binary fallback placeholder when a multipart payload has no text parts", async () => {
+    const payload = await readFixtureJson<GmailApiMessagePart>(
+      "binary-only-payload.json"
+    );
+
+    await expect(extractGmailBodyPreviewFromPayloadResult(payload)).resolves.toEqual(
+      {
+        bodyTextPreview:
+          "[Message body could not be extracted — open in Gmail]",
+        bodyKind: "binary_fallback",
+      }
     );
   });
 


### PR DESCRIPTION
## Summary

- detect encrypted S/MIME and PGP Gmail bodies before text extraction and store placeholders instead of raw binary garbage
- persist `gmail_message_details.body_kind` so downstream reads can distinguish plaintext from encrypted/binary placeholders
- keep inbox timeline placeholders visible while excluding placeholder bodies from composer quoted-reply context

## Why this matters

Real prod issue: emails from Tetra Tech (Steve Negri) arrive S/MIME encrypted and our extractor stored ~700-1300 chars of pure binary garbage as the body, then rendered it as glyphs in the inbox. After this fix, those messages display as `[Encrypted message — open in Gmail to read]`.

## Notes

- Does NOT touch `trimQuotedReplyContent` or its boundary regex array — that's the parallel body-truncation sub-architect's scope
- Retroactively re-classifying existing garbled rows is OUT OF SCOPE; architect will handle via separate backfill ops after observing fresh inbound mail for ~24h

## New migration (architect runs post-merge)

```bash
psql -f packages/db/drizzle/0027_gmail_message_details_body_kind.sql "$DATABASE_URL"
```

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test:unit` blocked locally by macOS `@rollup/rollup-darwin-arm64` `ERR_DLOPEN_FAILED` — environmental, CI is authoritative (memory `project_macos_rollup_gotcha.md`)

## Brief

`.codex-gmail-body-encrypted-detection-2026-04-25.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)