### PR TITLE
fix(composer): immediately confirm pending outbound on successful Gmail send

### DIFF
--- a/apps/web/app/inbox/actions.ts
+++ b/apps/web/app/inbox/actions.ts
@@ -1460,6 +1460,10 @@ export async function sendComposerAction(
     const sendResult = await sendComposerGmailMessage(sendParams);
 
     if (sendResult.kind === "success") {
+      await runtime.repositories.pendingOutbounds.markConfirmed(pendingOutboundId, {
+        reconciledEventId: null,
+      });
+
       await appendSecurityAudit({
         actorType: "user",
         actorId: currentUser.id,

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -1891,7 +1891,13 @@ function createStage1RepositoriesInternal(
           .where(
             and(
               eq(pendingComposerOutbounds.id, id),
-              eq(pendingComposerOutbounds.status, "pending"),
+              or(
+                eq(pendingComposerOutbounds.status, "pending"),
+                and(
+                  eq(pendingComposerOutbounds.status, "confirmed"),
+                  isNull(pendingComposerOutbounds.reconciledEventId),
+                ),
+              ),
             ),
           );
       },

--- a/packages/domain/src/normalization.ts
+++ b/packages/domain/src/normalization.ts
@@ -468,7 +468,12 @@ async function reconcilePendingComposerOutbound(
     fingerprint
   );
 
-  if (pending !== null && pending.status === "pending") {
+  if (
+    pending !== null &&
+    (pending.status === "pending" ||
+      (pending.status === "confirmed" && pending.reconciledEventId === null))
+  ) {
+    const via = pending.status === "pending" ? "fingerprint" : "event_link";
     await persistence.repositories.pendingOutbounds.markConfirmed(pending.id, {
       reconciledEventId: input.canonicalEvent.id
     });
@@ -479,7 +484,8 @@ async function reconcilePendingComposerOutbound(
         fingerprint,
         canonicalEventId: input.canonicalEvent.id,
         sourceEvidenceId: input.sourceEvidence.id,
-        providerRecordId: input.sourceEvidence.providerRecordId
+        providerRecordId: input.sourceEvidence.providerRecordId,
+        via
       }
     });
     return;

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -260,7 +260,7 @@ export interface PendingComposerOutboundRepository {
   ): Promise<PendingComposerOutboundRecord | null>;
   markConfirmed(
     id: string,
-    input: { readonly reconciledEventId: string },
+    input: { readonly reconciledEventId: string | null },
   ): Promise<void>;
   markFailed(id: string, input: { readonly reason: string }): Promise<void>;
   markSuperseded(id: string): Promise<void>;


### PR DESCRIPTION
## Summary

Closes the composer reconciliation gap: rows in `pending_composer_outbounds` were never transitioning `pending → confirmed` because reconciliation only fires when a canonical event is created for the matching Gmail message — but messages sent to internal `@adventurescientists.org` addresses are classified as `internal_only_message` and produce no canonical event. The 30-min orphan sweep then flipped them to `orphaned`.

## Fix

- Call `markConfirmed(id, { reconciledEventId: null })` immediately after the Gmail API returns success.
- The reconciler is extended to ALSO link the canonical event ID onto already-confirmed rows (status = `confirmed` AND `reconciledEventId IS NULL`) for external sends.
- No schema change — the column was already nullable with no FK constraint.

## Why this is a fresh PR (not a #136 update)

PR #136 was opened on a branch that was based on the now-closed #134 (CRM link work). It accidentally included 17 unrelated files that lint-failed and bloated the diff. This PR cherry-picks ONLY the reconciliation commit (`9e3ad49`) onto fresh main. 4 files, 20 insertions, 4 deletions. PR #136 will be closed.

## Verification

- Single-commit cherry-pick from a sub-architect's earlier work
- 4-file diff matches the brief scope precisely
- Pre-tested by the original sub-architect (the parent branch had the reconciliation logic working before it got bloated)
- CI on this PR is the source of truth

## Test plan

- [ ] CI verify green
- [ ] Architect signs off
- [ ] Post-merge: send a composer test email; verify `pending_composer_outbounds` row transitions `pending → confirmed` within ~1 second of send

🤖 Generated with [Claude Code](https://claude.com/claude-code)