### PR TITLE
fix(integrations): empty raw-message body returns plaintext, not binary fallback

### DIFF
--- a/packages/integrations/src/providers/gmail-body.ts
+++ b/packages/integrations/src/providers/gmail-body.ts
@@ -425,12 +425,11 @@ export async function extractGmailBodyPreviewFromMimeMessageResult(input: {
     normalizeLineEndings(input.fallbackBodyText ?? "")
   );
 
-  return fallbackBodyPreview.length > 0
-    ? buildBodyPreviewResult(fallbackBodyPreview, "plaintext")
-    : buildBodyPreviewResult(
-        BINARY_FALLBACK_PLACEHOLDER,
-        "binary_fallback"
-      );
+  // Raw-message extraction can legitimately return empty (e.g. mbox messages
+  // with subject + headers but no body). Treat that as empty plaintext, not
+  // a binary-extraction failure — the binary_fallback placeholder is reserved
+  // for the parts-based path where we can actually detect binary-only content.
+  return buildBodyPreviewResult(fallbackBodyPreview, "plaintext");
 }
 
 export async function extractGmailBodyPreviewFromMimeMessage(input: {


### PR DESCRIPTION
## Summary

Follow-up to #142. Main is currently broken: `pnpm --filter @as-comms/integrations test:unit` fails on `stage1-gmail-mbox.test.ts` because the new binary-detection logic treats an empty raw-message body as `binary_fallback` placeholder when it should be empty plaintext.

## Repro on current main

```bash
cd packages/integrations && pnpm test:unit -- stage1-gmail-mbox
# FAIL: expected snippet "Re: Training = ✅", actual "[Message body could not be extracted — open in Gmail]"
```

## Why this slipped through #142's CI

PR #143 auto-merged with this same failure visible (auto-merge fired despite the red check). The regression has been on main since #142 landed.

## Fix

`packages/integrations/src/providers/gmail-body.ts` — `extractGmailBodyPreviewFromMimeMessageResult` no longer maps an empty raw-message extraction to `binary_fallback`. The placeholder is reserved for the parts-based path where actual binary content is detectable. Mbox imports with subject + headers + empty body now produce empty plaintext, matching pre-#142 behavior.

## Test plan

- [x] `pnpm --filter @as-comms/integrations test:unit` passes locally (87/87)
- [ ] CI verify green
- [ ] Architect verifies prod inbox after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)