### PR TITLE
fix(composer): findForContact + test fixtures for #143 immediate-confirm

### DIFF
--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -806,12 +806,13 @@ describe("real inbox selectors", () => {
       source: "salesforce",
       isActive: true,
     });
-    await runtime.context.repositories.projectDimensions.upsert({
-      projectId: "project:killer-whales",
-      projectName: "Searching for Killer Whales",
-      source: "salesforce",
-      isActive: false,
-    });
+    // killer-whales was seeded by the fixture with isActive=true (default).
+    // Use the Settings projects repo to flip it — upsert no longer toggles
+    // isActive on conflict-update (PR #141 protects admin-managed state).
+    await runtime.context.settings.projects.setActive(
+      "project:killer-whales",
+      false,
+    );
 
     const workload = await getInboxWelcomeWorkload();
 
@@ -864,6 +865,13 @@ describe("real inbox selectors", () => {
       source: "salesforce",
       isActive: true,
     });
+    // killer-whales is seeded by the fixture with isActive=true (default) but
+    // this test only wants the two projects above as "active". Use setActive()
+    // since upsert no longer toggles isActive on conflict-update (PR #141).
+    await runtime.context.settings.projects.setActive(
+      "project:killer-whales",
+      false,
+    );
     await runtime.context.repositories.contactMemberships.upsert({
       id: "membership:sarah:whitebark",
       contactId: "contact:sarah-martinez",

--- a/apps/web/tests/unit/inbox-stage1-helpers.ts
+++ b/apps/web/tests/unit/inbox-stage1-helpers.ts
@@ -41,6 +41,11 @@ export async function seedInboxContact(
       projectName: input.projectName ?? input.projectId,
       projectAlias: input.projectAlias ?? null,
       source: "salesforce",
+      // Default fixture projects to active so tests don't have to opt in. Tests
+      // that need a specific project to be inactive should call setActive(id,false)
+      // explicitly — the upsert won't toggle isActive on conflict-update because
+      // PR #141 protects admin-managed state from being overwritten by SF capture.
+      isActive: true,
     });
   }
 

--- a/apps/web/tests/unit/stage3-send-action.test.ts
+++ b/apps/web/tests/unit/stage3-send-action.test.ts
@@ -160,7 +160,9 @@ describe("sendComposerAction", () => {
     });
     expect(pendingRows[0]).toMatchObject({
       id: result.data.pendingOutboundId,
-      status: "pending",
+      // PR #143 immediately confirms on successful Gmail send instead of waiting
+      // for inbound reconciliation to fire (which never fires for internal sends).
+      status: "confirmed",
       fromAlias: "antarctica@example.org",
       toEmailNormalized: "new-volunteer@example.org",
       subject: "Field logistics",

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -1957,6 +1957,10 @@ function createStage1RepositoriesInternal(
       },
 
       async findForContact(contactId, input) {
+        // Includes "confirmed" because PR #143 (immediate-confirm on Gmail send)
+        // transitions rows to confirmed immediately, and the UI still needs to
+        // surface them as recent outbound activity. "superseded" is excluded by
+        // design (replaced rows are not user-visible).
         const rows = (await db
           .select()
           .from(pendingComposerOutbounds)
@@ -1965,6 +1969,7 @@ function createStage1RepositoriesInternal(
               eq(pendingComposerOutbounds.canonicalContactId, contactId),
               inArray(pendingComposerOutbounds.status, [
                 "pending",
+                "confirmed",
                 "failed",
                 "orphaned",
               ]),


### PR DESCRIPTION
## Summary

#143 (composer immediate-confirm) cherry-picked only the implementation commit, not the matching test/fixture updates. Main has been failing CI on `stage3-send-action.test.ts` and two `inbox-selectors.test.ts` cases since #143 landed.

## Changes

- `packages/db/src/repositories.ts` — `findForContact` includes `confirmed` rows so the UI surfaces recently-sent outbound activity (since #143 immediately marks rows confirmed).
- `apps/web/tests/unit/inbox-stage1-helpers.ts` — fixture defaults projects to `isActive: true` (matches what most tests assume).
- `apps/web/tests/unit/inbox-selectors.test.ts` — two welcome-workload tests now use `settings.projects.setActive` to flip individual projects, since upsert no longer toggles `isActive` on conflict-update (PR #141 preserves admin-managed state).
- `apps/web/tests/unit/stage3-send-action.test.ts` — assert `status: "confirmed"` after successful send (was `"pending"`).

## Verification

- Locally: `pnpm --filter @as-comms/web test:unit -- inbox-selectors stage3-send-action` → 35/35 files, 202/202 tests pass
- CI: should be green now that main's regressions are addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)