### PR TITLE
feat(ui): pixel-perfect design v2 pass — Surfaces 2, 3, 4 + tokens-v2

### DIFF
--- a/.codex-surface-1-timeline-bubbles-2026-04-25.md
+++ b/.codex-surface-1-timeline-bubbles-2026-04-25.md
@@ -1,0 +1,172 @@
+# Codex Brief — Surface 1: Timeline bubbles + categorical system dividers
+
+**Worktree**: `/Users/nicolas/Downloads/as-ui-pixel-perfect` on branch `feat/ui-pixel-perfect-pass`
+**Suggested model**: **GPT-5.4 Extra High** (1300+ LOC file; pixel-perfect bar; strict layout/typography)
+**Estimated PR size**: ~600–900 LOC net change (extraction + visual rebuild)
+
+## Goal
+
+Rebuild the inbox timeline's message bubbles and system dividers to match the new Claude Design v2 handoff pixel-perfectly. Extract reusable primitives in the same PR, before applying the visual changes, so the file shrinks instead of growing.
+
+## Authoritative design sources
+
+1. **Screenshots** (in user's recent message — two PNGs of "Lily Luo" thread and "Steve Herman" thread). These are the source of truth for layout.
+2. **`/tmp/design-handoff-v2/as-comms-platform/project/message-history.jsx`** — JSX prototype for the bubble structures.
+3. **`/tmp/design-handoff-v2/as-comms-platform/project/primitives.jsx`** — shared `Avatar`, `IconButton`, tone classes.
+
+When the screenshots and JSX disagree, **screenshots win** — they are what the user signed off.
+
+## Production files in scope
+
+- `apps/web/app/inbox/_components/inbox-timeline.tsx` — current 1311-LOC monolith. Will be split.
+- New files to create:
+  - `apps/web/app/inbox/_components/inbox-timeline-bubble.tsx` — InboundBubble + OutboundBubble shared scaffolding
+  - `apps/web/app/inbox/_components/inbox-timeline-system-divider.tsx` — system divider with categorical classifier
+  - `apps/web/app/inbox/_components/email-participant-header.tsx` — compact `From → To +cc ▾` one-liner
+- `apps/web/app/_lib/design-tokens-v2.ts` — already exists. Use this for tone/type/etc.
+- `apps/web/app/inbox/_components/icons.tsx` — may need new icons (`CornerUpLeft` for Reply button, `DatabaseIcon` for FIRST DATA SUBMITTED, etc.). Add as needed; don't change existing.
+
+## Token migration rule
+
+Every file you touch in this PR migrates its imports from `@/app/_lib/design-tokens` (v1) to `@/app/_lib/design-tokens-v2` (v2). Do NOT migrate files you don't otherwise need to touch.
+
+If a file imports a v1-only token (`AVATAR_TONE`, `BUCKET_BADGE`, `STAGE_BADGE`, `PROJECT_STATUS_BADGE`, `CHIP_TONE`), keep that import but add the v2 import alongside for the tones/types you need. Components like `inbox-row.tsx` that aren't part of this surface stay on v1 entirely.
+
+## Visual spec — bubbles
+
+### Inbound email bubble
+- Avatar **outside** the bubble, **left**. `Avatar` size `md`. Avatar uses contact tone (existing `item.avatarTone` / `entry.actorTone` if exposed; otherwise default `slate`).
+- Container: `rounded-2xl border border-slate-200 bg-white px-4 py-3 shadow-sm`. Min-width 0, max-width `640px`. `pr-16` on the surrounding `<li>` to leave room for outbound mirror.
+- **Header row** (compact, replaces today's 3-row `From / To / Cc` grid):
+  - Inline `MailIcon` (h-3.5 w-3.5 text-slate-400)
+  - `<sender display name>` (text-[12.5px] font-medium text-slate-700)
+  - `→` (ArrowRight) icon (h-3 w-3 text-slate-300)
+  - `<recipient display name>` (text-[12.5px] text-slate-600)
+  - `+cc` badge (rounded-md bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium text-slate-500) **only if cc has values**
+  - `▾` ChevronDown (h-3 w-3 text-slate-400) — clicking expands to show the full From/To/Cc grid we currently render. Default state: collapsed.
+  - **Right-aligned**: relative timestamp (text-[11px] text-slate-400). Tooltip with exact timestamp on hover (existing `RelativeTimestamp` component preserved).
+- Subject: `text-[13px] font-semibold text-slate-900 mt-2 mb-1.5` (currently `text-balance` — preserve).
+- Body: serif (`TYPE.bodySerifSm`), `whitespace-pre-wrap text-pretty`, autolinked. **No change to body rendering** beyond token migration.
+- **Reply button bottom-right**: small inline button `inline-flex items-center gap-1 text-[11.5px] text-slate-500 hover:text-slate-900` with `CornerUpLeft` icon + "Reply" label. Margin-top to push to bubble bottom-right (use `mt-3 ml-auto` in a flex row).
+- Below bubble, outside, no change to today's metadata row pattern except: drop the duplicate timestamp (now lives in header). Keep `<channel-icon> <actor> · <unread dot>` if unread.
+
+### Outbound email bubble
+- Mirror of inbound, **right side**: `<li className="flex w-full flex-col items-end pl-16">`.
+- Avatar outside on the **right**.
+- Container: `rounded-2xl border border-sky-200 bg-sky-50/40 px-4 py-3 shadow-sm`.
+- Same compact header. Sender = the operator's "From" alias display name. Recipient = the volunteer name.
+- Subject + body styles unchanged from inbound (slate text on sky bg).
+- Reply button bottom-right styled `text-sky-700 hover:text-sky-900`.
+- Pending / failed / orphaned states preserved exactly as today (banner above content, retry button, etc.).
+
+### Outbound SMS bubble
+- Distinct from email outbound: **filled sky bubble, white text**.
+- Container: `rounded-2xl bg-sky-600 px-4 py-2.5 text-white shadow-sm` (no border).
+- No header (SMS has no From/To/Subject).
+- Body: `text-[13px] leading-relaxed text-white whitespace-pre-wrap`.
+- Avatar outside right. Reply button styled for white-on-sky (`text-sky-100 hover:text-white`).
+- Above bubble, the existing `<channel-icon> SMS · <timestamp>` metadata row goes ABOVE the bubble (right-aligned), instead of below.
+
+### Inbound SMS bubble
+- Mirror: `rounded-2xl bg-slate-100 text-slate-900 px-4 py-2.5 shadow-sm`. Avatar outside left. No header. Body text-[13px] slate.
+
+## Visual spec — system dividers (categorical)
+
+Replace the current `describeLifecycleEvent` keyword classifier with a richer categorical map. Each category gets its own label, color tone, and icon.
+
+```
+Category             Trigger keywords (case-insensitive)         Tone       Icon
+─────────────────    ─────────────────────────────────────       ───────    ──────────
+LIFECYCLE            "signed up"                                 amber      CalendarIcon
+APPLIED              "applied"                                   violet     SparkleIcon
+TRAINING             "training"                                  sky        WandIcon
+TRIP PLANNING        "trip planning", "moved to trip"            amber      CalendarIcon
+IN FIELD             "field", "in the field"                     emerald    MapPinIcon
+FIRST DATA           "first data", "submitted first", "batch"    emerald    DatabaseIcon
+COMPLETED            "completed", "successful", "complete"       emerald    CheckCircleIcon
+LIFECYCLE (default)  *anything else*                             amber      CalendarIcon
+```
+
+The divider visual: same horizontal-line-flanked pill shape as today, but the pill content is:
+
+```
+[<categorical icon, h-3 w-3>] <CATEGORY LABEL in TYPE.label color tone> <body text in slate-600> <relative timestamp in text-slate-400>
+```
+
+Pill background: `bg-white border border-slate-200`. The categorical icon's background gets the tone's `subtle` fill and the icon itself uses the tone's `text` color.
+
+Order labels by tone weight: amber for transitional / pending stages (signed up, applied, trip planning, default lifecycle), sky for training, emerald for active / completed milestones (in field, first data, completed).
+
+## Refactor (extraction) — do this BEFORE the visual changes
+
+1. **Extract `EmailParticipantHeader`** to its own file. Currently lives at `inbox-timeline.tsx:619-676` (`EmailParticipantHeaders`). New component is the **collapsed** compact form by default + the **expanded** full form on chevron click. State: local `useState<boolean>` for expanded. Old expanded form is the existing 3-row grid; preserve it for users who click the chevron.
+
+2. **Extract `InboundBubble` and `OutboundBubble`** into a shared file `inbox-timeline-bubble.tsx`. Single component `MessageBubble` with prop `direction: "inbound" | "outbound"` + `channel: "email" | "sms"` driving the styling. Pending/failed UI lives inside this component for outbound only.
+
+3. **Extract `SystemDivider`** + the new categorical classifier into `inbox-timeline-system-divider.tsx`. The classifier is a pure function; export it for testing.
+
+4. **Add a `ReplyButton` component** inside `inbox-timeline-bubble.tsx` (small enough to inline). Wire it to a new optional prop `onReply: (entryId: string) => void` on `InboxTimeline`. Detail page passes a handler that calls the existing `useInboxClient().openReplyDraft(...)` (find the actual hook name in `inbox-client-provider.tsx`).
+
+After extraction, `inbox-timeline.tsx` should be ≤700 LOC. The new files together should add ~400 LOC. Net reduction in the largest file is the goal.
+
+## Reply button wiring (functional, not just visual)
+
+Inspect `apps/web/app/inbox/_components/inbox-client-provider.tsx` for the existing composer/draft API. Find the function that opens the composer in reply mode (likely `openReplyDraft` or `setReplyTarget` or similar). Wire `ReplyButton` to call it with the entry's `entryId` (or `rfc822MessageId` if that's what the composer expects).
+
+If no such function exists, add a minimal one:
+- New context method `openReply(input: { entryId: string })` that scrolls to the composer and pre-populates the `inReplyToEntryId` value.
+- The composer already accepts `inReplyToEntryId` for replies. Verify in `inbox-composer.tsx`.
+
+## Validation requirements (Codex must run before declaring done)
+
+```
+cd /Users/nicolas/Downloads/as-ui-pixel-perfect
+pnpm install --prefer-offline   # already done by architect; should be a no-op
+pnpm --filter @as-comms/web typecheck
+pnpm --filter @as-comms/web lint
+pnpm --filter @as-comms/web test:unit
+```
+
+If `pnpm test:unit` fails on macOS with `rollup-darwin-arm64 ERR_DLOPEN_FAILED`, that's environmental — leave a note and proceed. CI is authoritative.
+
+## Things explicitly NOT in scope
+
+- Composer redesign (separate brief, Surface 5).
+- Sidebar / inbox-list redesign (Surface 2).
+- Detail rail polish (Surface 3).
+- Welcome screen (Surface 4).
+- Settings (Surface 6, after locked worktree merges).
+- Any backend / view-model / selector changes.
+- Reading-state / unread logic — preserve every existing data flow.
+- Animations beyond what's in the design files.
+
+## Out-of-scope reminders
+
+- Do NOT touch `view-models.ts`, `selectors.ts`, `actions.ts`, `composer-data.ts`.
+- Do NOT touch `packages/db`, `packages/contracts`, `packages/domain`, `apps/worker`, `packages/integrations`.
+- Do NOT migrate components on other surfaces from v1 to v2 tokens. Only files you touch for this PR.
+
+## PR title
+
+`feat(ui): pixel-perfect timeline bubbles + categorical system dividers`
+
+## PR body template
+
+```
+## Summary
+- Bubble redesign per Claude Design v2 handoff: avatar outside, compact From→To header, top-right timestamp, inline Reply button
+- Categorical system dividers (LIFECYCLE / TRAINING / TRIP PLANNING / IN FIELD / FIRST DATA / COMPLETED / APPLIED)
+- SMS outbound bubble switched to filled sky-blue with white text
+- Extracted EmailParticipantHeader, MessageBubble, SystemDivider into separate files (inbox-timeline.tsx 1311 → ~700 LOC)
+- Reply button on each bubble wires to composer's reply context
+
+## Test plan
+- [ ] Open a thread with email + SMS + system events → bubbles render per design
+- [ ] Click Reply on inbound email → composer opens with reply context
+- [ ] Click chevron on participant header → full From/To/Cc expands
+- [ ] Pending / failed outbound states render unchanged
+- [ ] System dividers show correct categorical label + icon for known triggers
+- [ ] Note bubbles unchanged (separate component path)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```

--- a/.codex-surface-2-sidebar-list-filter-2026-04-25.md
+++ b/.codex-surface-2-sidebar-list-filter-2026-04-25.md
@@ -1,0 +1,143 @@
+# Codex Brief — Surface 2: Sidebar / inbox-list — filter "list" variant + row polish
+
+**Worktree**: `/Users/nicolas/Downloads/as-ui-pixel-perfect` on branch `feat/ui-pixel-perfect-pass`
+**Suggested model**: GPT-5.4 **High** (smaller than Surface 1; clear scope)
+**Estimated PR size**: ~300–500 LOC net change
+
+## Goal
+
+Replace today's `Collapsible + ToggleGroup + DropdownMenu` filter UX (filter button you click to expand) with the design's always-visible **flat list** filter pattern. Tighten inbox-row visuals to match design.
+
+## Authoritative design sources
+
+- **`/tmp/design-handoff-v2/as-comms-platform/project/sidebar.jsx`** — see `FilterBarList` (lines 119–202 of the file) for the exact list filter shape.
+- Screenshots in user's recent message + `uploads/` for row visual cadence.
+
+## Production files in scope
+
+- `apps/web/app/inbox/_components/inbox-list.tsx` — primary file (~691 LOC). Filter UI rebuild + minor reflow.
+- `apps/web/app/inbox/_components/inbox-row.tsx` — row visual polish.
+- New: `apps/web/app/inbox/_components/inbox-filter-list.tsx` — extracted flat-list filter (state list on top, project list below).
+- `apps/web/app/_lib/design-tokens-v2.ts` — already exists; this PR migrates the touched files.
+
+## Visual spec — filter list
+
+Replace the current header sub-stack:
+
+**Today** (in `inbox-list.tsx` lines 422–600):
+```
+[h1 title] [pencil compose] [filter button]   ← header row
+[search input]                                  ← search row
+<Collapsible (closed by default)>
+  [ToggleGroup all/unread/follow-up/sent]
+  [project DropdownMenu]
+</Collapsible>
+```
+
+**New** (always visible, flat lists):
+```
+[h1 title] [pencil compose]                     ← header row (drop the filter button)
+[search input]                                  ← search row
+[STATE label]                                   ← section label, TYPE.label
+  [• All        452]                            ← row, slate dot, selected: bg-slate-900 text-white
+  [• Unread      14]                            ← sky dot
+  [• Follow-up    6]                            ← amber dot
+  [• Sent      1235]                            ← slate dot, selected applies
+[PROJECT label]                                 ← section label
+  [All projects                  X]
+  [• <project>                   N]             ← per active project, with project tone dot
+  ...
+```
+
+Each row:
+- Layout: `flex items-center gap-2 rounded-md px-2 py-1 text-left text-[12.5px]`
+- Default: `text-slate-700 hover:bg-slate-50`
+- Selected (state row): `bg-slate-900 text-white` with the count `text-slate-300`
+- Selected (project row): `bg-slate-100 font-medium text-slate-900` with count `text-slate-400`
+- Tone dot: `h-1.5 w-1.5 rounded-full <TONE_CLASSES.X.dot>` from `design-tokens-v2`
+- Right-aligned count: `tabular-nums text-[11.5px]`
+- Counts read from existing `currentList.filters[].count` and `currentList.activeProjects[].count` (already provided by selectors)
+
+Section labels (`STATE` / `PROJECT`) use `TYPE.label`. Spacing between sections: `border-t border-slate-100`.
+
+Drop the filter toggle button entirely — there's no panel to open/close. Drop `filterPanelOpen` state, drop the `Collapsible` wrapper. Keep the search input untouched (separate concern).
+
+## Visual spec — inbox-row polish
+
+Today's row is already close to the design. Just tighten:
+- Verify project tone dot color matches the project's filter-list dot exactly (same tone source).
+- Channel icon (`MailIcon` / `PhoneIcon`) currently `h-3 w-3` — keep.
+- Project label badge today is `bg-slate-100 text-slate-600`; design shows `subtle` tone fill matching project tone, with the dot prepended. Update to match — read project tone from view-model (existing `item.projectLabel` is just a string today; if no project tone is on the row view-model, default to slate and add a TODO).
+- Follow-up badge: keep current amber rose pattern (already correct).
+- Hover affordance: today is `hover:bg-slate-50/80`; design uses `hover:bg-slate-50` plain. Match.
+
+If the row view-model is missing a project tone field, do NOT add it — flag as a TODO comment and use the existing slate fallback. View-model changes are out of scope for this PR.
+
+## Refactor (extraction)
+
+1. **Extract `InboxFilterList`** as its own component file. Props:
+   - `filters: ReadonlyArray<{ id: InboxFilterId; label: string; count: number; tone: ToneNameV2 }>`
+   - `activeFilter: InboxFilterId`
+   - `onFilterChange: (id: InboxFilterId) => void`
+   - `projects: ReadonlyArray<{ id: string; name: string; count: number; tone: ToneNameV2 }>`
+   - `selectedProjectId: string | null`
+   - `onProjectChange: (id: string | null) => void`
+
+   Counts: `filters` come straight from `currentList.filters`; `projects` come from `currentList.activeProjects` plus a count from … hmm, the active-projects view-model may not currently include per-project counts. **Verify in `view-models.ts`:** does `InboxActiveProjectViewModel` carry a `count` field?
+   - If yes: thread it through.
+   - If no: use the same data we already use for the existing project dropdown (no count shown today). Compute count client-side from `currentList.items` filtered by `projectId`. **This client-side computation is fine for this pass since the list is paginated and the count is approximate; flag as TODO for selector to compute server-side.**
+
+2. After this extraction, `inbox-list.tsx` should drop ~150 LOC.
+
+3. Remove now-unused imports: `Collapsible`, `CollapsibleContent`, `DropdownMenu*`, `ToggleGroup*`, `FilterIcon`. Don't remove `XIcon` (still used for clear-search).
+
+## Token migration rule
+
+`inbox-list.tsx`, `inbox-row.tsx`, new `inbox-filter-list.tsx` migrate to `@/app/_lib/design-tokens-v2`. Other files stay on v1.
+
+## Wiring constraints
+
+- Preserve URL search-param sync (the existing `useEffect` block that updates `?q=`). Do NOT touch the search debounce / URL sync logic.
+- Preserve infinite-scroll IntersectionObserver. Do NOT change pagination.
+- Preserve filter transition `useTransition` for snappy state changes.
+- Preserve search empty state + queue empty state components (`SearchEmptyState`, `QueueEmptyState`).
+
+## Validation
+
+```
+cd /Users/nicolas/Downloads/as-ui-pixel-perfect
+pnpm --filter @as-comms/web typecheck
+pnpm --filter @as-comms/web lint
+pnpm --filter @as-comms/web test:unit
+```
+
+## Out of scope
+
+- Backend / view-model changes (per-project counts may be inaccurate; that's OK for this pass).
+- Other surfaces.
+- Header chrome changes outside the filter sub-stack.
+- Any animation work beyond what's already there.
+
+## PR title
+
+`feat(ui): inbox sidebar — flat-list filter variant + row polish`
+
+## PR body template
+
+```
+## Summary
+- Replace collapsible filter panel with always-visible flat list (state on top, projects below) per Claude Design v2
+- Each row shows tone dot + label + count; selected state filters get filled-slate, projects get slate-100
+- Drop the filter toggle button + Collapsible wrapper (no panel to open)
+- Tighten inbox-row project badge to use project tone colors
+
+## Test plan
+- [ ] Click each state row → list refilters
+- [ ] Click each project row → list refilters; counts match
+- [ ] Search still updates URL ?q= and debounces
+- [ ] Infinite scroll still loads more on viewport intersection
+- [ ] Clear search button still works
+- [ ] Empty states render
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```

--- a/.codex-surface-3-detail-rail-polish-2026-04-25.md
+++ b/.codex-surface-3-detail-rail-polish-2026-04-25.md
@@ -1,0 +1,110 @@
+# Codex Brief — Surface 3: Detail rail (right side) — visual polish + expedition link wiring
+
+**Worktree**: `/Users/nicolas/Downloads/as-ui-pixel-perfect` on branch `feat/ui-pixel-perfect-pass`
+**Suggested model**: GPT-5.4 **Medium** (small surface, mostly cosmetic)
+**Estimated PR size**: ~200–350 LOC net change
+**Dependency**: B1 (expeditionMemberUrl on view model) **must land first** for the link wiring portion. The visual polish portion is unblocked.
+
+## Goal
+
+Tighten the contact rail's visual cadence to match design v2's `detail-panel.jsx` and bring in the expedition member CRM link the operator workflow needs (per memory `project_contact_rail.md`). Add phone fallback copy.
+
+## Authoritative design sources
+
+- **`/tmp/design-handoff-v2/as-comms-platform/project/detail-panel.jsx`**
+- Memory `project_contact_rail.md` — operator priorities (P1 = expedition member link).
+
+## Production files in scope
+
+- `apps/web/app/inbox/_components/inbox-contact-rail.tsx` — primary (221 LOC).
+- `apps/web/app/_lib/design-tokens-v2.ts` — already exists; migrate the touched file.
+
+## Visual spec — header
+
+Today: name + small uppercase `Record ID · {volunteerId}` in mono.
+Design: name + small mono record id (no `Record ID ·` prefix, just `2021R0C002CA7XJQAS` styled).
+
+Change `mt-0.5 text-[11px] font-medium uppercase tracking-wide text-slate-500` content from `Record ID · {volunteerId}` to just `{volunteerId}` rendered in `font-mono text-[11px] text-slate-400` (no uppercase, no "Record ID" prefix).
+
+## Visual spec — Contact section
+
+Same structure as today (email + phone + joinedAt). Two changes:
+
+1. **Phone fallback**: when `contact.primaryPhone` is null/empty, render the phone line with `"No phone on file"` in `text-slate-400` italic, with the phone icon dimmed.
+2. Tighten icon color to `text-slate-300` (today: `text-slate-400`).
+
+## Visual spec — Active / Past projects sections
+
+Today's `ProjectsSection` is close to the design. Three tweaks:
+
+1. **Project tone dot** prepended to each project row (currently absent). Use `TONE_CLASSES[<tone>].dot` from v2 tokens. Project tone source: this PR uses `slate` as default if no tone is on `InboxProjectMembershipViewModel`. **Don't extend the view-model in this PR** — flag as TODO comment.
+2. **Heading consistency**: today's `<h3 className={TEXT.label}>` matches the spec. Confirm `SectionLabel` is used for the *Contact* section heading and matches the same level. Resolve the inconsistency by using one component (`SectionLabel`) for all section headers.
+3. **Status badge** today: ProjectStatusBadge component. Keep, but verify color tokens migrate to v2.
+
+## Visual spec — Project activity section
+
+Today's connector line bug:
+- Dot is `w-[11px] h-[11px]` centered horizontally at 5.5px.
+- Vertical line is `absolute left-[5px]`.
+
+Fix: change line to `absolute left-[5px]` → `left-[5.5px]` is not possible (Tailwind arbitrary values), so center the dot at 5px instead. Replace `h-[11px] w-[11px]` with `h-[10px] w-[10px]` and adjust offset so the line passes through the dot center (`left-[4.5px]` won't work either; use `left-[4px]` with `w-[9px] h-[9px]` dot — center at 4.5, line at 4 is close enough; or simpler: use `inset-x-0 left-[4.5px]` style + slightly smaller dot). Test visually.
+
+Also: change `space-y-0` on the activity list to `space-y-3` for breathing room.
+
+Tighten activity entry text to `text-[12.5px] text-slate-700` (today is `text-[13px]`).
+
+## Wiring — expedition member CRM link (depends on B1 landing first)
+
+Once `InboxProjectMembershipViewModel.expeditionMemberUrl: string` exists:
+
+In `ProjectsSection`, change the project row's outer `<a>`:
+- **Primary click target**: opens `project.expeditionMemberUrl` (Expedition_Members__c).
+- **Secondary** small icon-link button at the right of the row labeled "Project record": opens the existing `project.crmUrl` (Project__c).
+
+Two side-by-side links: clicking the row body = expedition member; clicking the small "↗ project" icon at the right = the original Project__c link.
+
+Until B1 lands, leave `crmUrl` wiring unchanged and add a code comment:
+```ts
+// TODO(B1): swap primary click target to expeditionMemberUrl; keep crmUrl as secondary "↗ project" link
+```
+
+## Token migration rule
+
+Migrate `inbox-contact-rail.tsx` to `@/app/_lib/design-tokens-v2`. Other files unchanged.
+
+## Validation
+
+```
+pnpm --filter @as-comms/web typecheck
+pnpm --filter @as-comms/web lint
+pnpm --filter @as-comms/web test:unit
+```
+
+## Out of scope
+
+- Pinned notes section (depends on B2 — separate brief).
+- Reminder UI (already on the rail; preserve).
+- View-model changes.
+
+## PR title
+
+`feat(ui): contact rail — visual polish + phone fallback`
+
+(Add `+ expedition member link` to the title only if B1 has landed.)
+
+## PR body template
+
+```
+## Summary
+- Tighten contact rail typography, project tone dots, activity connector line alignment
+- Phone fallback copy ("No phone on file") for null phone numbers
+- Migrate to design-tokens-v2
+
+## Test plan
+- [ ] Rail renders with + without phone (fallback shows correctly)
+- [ ] Project rows show tone dots
+- [ ] Activity list has breathing room
+- [ ] Connector line aligns with dot centers
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```

--- a/.codex-surface-4-welcome-screen-2026-04-25.md
+++ b/.codex-surface-4-welcome-screen-2026-04-25.md
@@ -1,0 +1,198 @@
+# Codex Brief — Surface 4: Welcome screen redesign (quote card + project mini-dashboard)
+
+**Worktree**: `/Users/nicolas/Downloads/as-ui-pixel-perfect` on branch `feat/ui-pixel-perfect-pass`
+**Suggested model**: GPT-5.4 **High**
+**Estimated PR size**: ~400–600 LOC net change
+
+## Goal
+
+Replace today's bare-table workload component with design v2's quote card + project mini-dashboard. Fix the hardcoded `"Welcome Sam!"` (operator name not threaded today). All FE; no backend.
+
+## Authoritative design source
+
+- **`/tmp/design-handoff-v2/as-comms-platform/project/welcome.jsx`** (169 LOC).
+
+## Production files in scope
+
+- `apps/web/app/inbox/_components/inbox-welcome-workload.tsx` — primary file. Will be renamed conceptually but the file path stays so import paths don't churn.
+- `apps/web/app/inbox/page.tsx` — must add `requireSession()` to read the operator name.
+- New: `apps/web/app/inbox/_lib/field-quotes.ts` — pure FE constant array of quote-of-the-day text.
+- `apps/web/app/_lib/design-tokens-v2.ts` — migrate touched files.
+
+## Visual spec — header band
+
+```
+[Welcome back, <FirstName>]                       [Last synced N min ago — placeholder]
+Today is <Day>, <Month> <Day>
+```
+
+- Heading: `text-[22px] font-semibold tracking-tight text-slate-900`
+- Date sub-line: `mt-1 text-xs text-slate-500`
+- Right side: `text-xs text-slate-500` saying `"Last synced ${N} min ago"` — derive `N` from a placeholder constant (no live polling). If you want a real number, read `initialList.freshness.latestUpdatedAt` from props (via parent wiring) — but for this PR a hardcoded `"a few minutes"` placeholder is fine. Flag for later wiring.
+
+Day formatting:
+```ts
+const today = new Date();
+const dayStr = today.toLocaleDateString("en-US", { weekday: "long", month: "long", day: "numeric" });
+```
+
+## Visual spec — quote card
+
+Beneath header, max-width `920px`, `mx-auto px-10 py-8 space-y-8`.
+
+```
+[radial-gradient bg, very subtle 4% opacity, teal + indigo]
+  [QuoteIcon in teal-50/teal-700 rounded circle h-10 w-10]
+  [Field note of the day — section label in teal-700]
+  [<quote text> in serif blockquote, text-[19px] leading-snug]
+  [— <author>] in caption
+  [refresh icon button on hover, top-right]
+```
+
+Tailwind for the gradient (inline style or arbitrary):
+```ts
+backgroundImage: 'radial-gradient(circle at 20% 30%, #0ea5a4 0%, transparent 40%), radial-gradient(circle at 80% 70%, #6366f1 0%, transparent 40%)'
+```
+With container `relative` and the gradient layer `absolute inset-0 pointer-events-none opacity-[0.04]`.
+
+Quote rotation:
+- Today's quote selected by `today.getDate() % FIELD_QUOTES.length`.
+- Refresh button increments `quoteIdx` cyclically (local `useState`).
+
+## Visual spec — project mini-dashboard
+
+Below quote card. Grid of project cards, 2 columns on desktop:
+
+```
+For each active project (read from existing workload.projects):
+  ┌─────────────────────────────────────────┐
+  │ <project tone left accent bar w-1>      │
+  │ ┌───────────────────────────────────┐   │
+  │ │ <project name>      <unread>      │   │
+  │ │                     unread        │   │
+  │ │                                   │   │
+  │ │                     <followUp>    │   │
+  │ │                     follow-up     │   │
+  │ └───────────────────────────────────┘   │
+  └─────────────────────────────────────────┘
+```
+
+Card: `rounded-xl border border-slate-200 bg-white p-4 hover:shadow-sm transition`.
+Stat number: `text-xl font-semibold tabular-nums`. Stat label: `text-[11px] uppercase tracking-wide text-slate-400`.
+
+Click a card → navigate to `/inbox?projectId=<projectId>` (use `useRouter().push`). This is just a URL change; `inbox-list.tsx` already reads `projectId` from search params (if it doesn't, this is a TODO — flag and skip the click handler).
+
+## Visual spec — follow-up list inline
+
+Below the dashboard, a compact list of up to 10 follow-up conversations:
+
+```
+[FOLLOW-UP — section label]
+[<contact name>            <project>    <time ago> →]
+[<contact name>            <project>    <time ago> →]
+...
+```
+
+Read from existing workload data **if it carries follow-up items**. Inspect `InboxWelcomeWorkloadViewModel` in `view-models.ts` for a `followUps: readonly { contactId, displayName, projectName?, lastActivityLabel }[]` field.
+
+If the field doesn't exist:
+- This section is **deferred** — render a stub with a TODO comment listing the field that needs to be added by Nico.
+- Brief Nico for adding this field as **B3** (separate brief, file `.brief-to-architect-B3-welcome-followup-list.md`).
+- The PR ships without this section if blocked.
+
+If the field exists, each row links to `/inbox/<contactId>` and is keyboard-navigable.
+
+## Operator name threading
+
+Today's bug: `<h1>Welcome Sam!</h1>` is hardcoded.
+
+Fix: in `apps/web/app/inbox/page.tsx`:
+```ts
+import { requireSession } from "@/src/server/auth/session";
+
+export default async function InboxListPage() {
+  const [workload, currentUser] = await Promise.all([
+    getInboxWelcomeWorkload(),
+    requireSession(),
+  ]);
+  const firstName = (currentUser.name ?? currentUser.email).split(/\s+/)[0] ?? "there";
+  return <InboxWelcomeWorkload workload={workload} firstName={firstName} />;
+}
+```
+
+Add `firstName: string` to `InboxWelcomeWorkloadProps`. Use it in the header heading: `Welcome back, {firstName}`.
+
+## Field quotes
+
+Create `apps/web/app/inbox/_lib/field-quotes.ts`:
+
+```ts
+export interface FieldQuote {
+  readonly text: string;
+  readonly author: string;
+}
+
+export const FIELD_QUOTES: ReadonlyArray<FieldQuote> = [
+  { text: "In every walk with nature, one receives far more than they seek.", author: "John Muir" },
+  { text: "The clearest way into the universe is through a forest wilderness.", author: "John Muir" },
+  { text: "What we are doing to the forests of the world is but a mirror reflection of what we are doing to ourselves.", author: "Mahatma Gandhi" },
+  { text: "Until we have the courage to recognize cruelty for what it is — we will not be able to live in a true civilization.", author: "Rachel Carson" },
+  { text: "There is pleasure in the pathless woods, there is rapture on the lonely shore.", author: "Lord Byron" },
+  { text: "Wilderness is not a luxury but a necessity of the human spirit.", author: "Edward Abbey" },
+  { text: "The best time to plant a tree was 20 years ago. The second best time is now.", author: "Chinese Proverb" },
+  { text: "I felt my lungs inflate with the onrush of scenery — air, mountains, trees, people.", author: "Sylvia Plath" },
+  // ...add ~12 more curated ones
+];
+```
+
+Use neutral nature/field-research-themed quotes. ~20 entries so daily rotation feels fresh.
+
+## Token migration rule
+
+Migrate the touched files to `@/app/_lib/design-tokens-v2`. Other files unchanged.
+
+## Validation
+
+```
+pnpm --filter @as-comms/web typecheck
+pnpm --filter @as-comms/web lint
+pnpm --filter @as-comms/web test:unit
+```
+
+Visual sanity: open `/inbox` in a browser, verify:
+- Operator first name renders correctly.
+- Today's date shows.
+- Quote card renders with subtle gradient.
+- Refresh button cycles quote.
+- Project cards show counts; click navigates to project-filtered inbox.
+
+## Out of scope
+
+- New backend fields or selector changes (other than the small `firstName` thread which is auth, not view-model).
+- The "last synced N min ago" — placeholder text only this pass.
+- Follow-up inline list if view-model field doesn't exist (defer to B3).
+
+## PR title
+
+`feat(ui): welcome screen — quote card + project mini-dashboard`
+
+## PR body template
+
+```
+## Summary
+- Replace bare workload table with design v2's welcome surface
+- Quote of the day card with daily rotation + refresh button
+- 2-column project mini-dashboard with unread + follow-up counts; click navigates to filtered inbox
+- Thread operator first name through page → component (fixes "Welcome Sam!" hardcode)
+- Add curated FIELD_QUOTES list
+
+## Test plan
+- [ ] Welcome page shows current operator's first name
+- [ ] Quote card renders with gradient
+- [ ] Refresh button cycles quote without page reload
+- [ ] Project cards show accurate per-project counts
+- [ ] Clicking a card navigates to /inbox?projectId=<id>
+- [ ] Empty state (no active projects) still renders gracefully
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```

--- a/.codex-surface-5-composer-redesign-2026-04-25.md
+++ b/.codex-surface-5-composer-redesign-2026-04-25.md
@@ -1,0 +1,205 @@
+# Codex Brief — Surface 5: Composer redesign
+
+**Worktree**: `/Users/nicolas/Downloads/as-ui-pixel-perfect` on branch `feat/ui-pixel-perfect-pass`
+**Suggested model**: GPT-5.4 **Extra High** (largest surface; 1462 LOC current; complex state machine; pixel-perfect bar)
+**Estimated PR size**: ~1500–2200 LOC net (preserves all existing functionality, redesigns surface)
+
+## Goal
+
+Redesign the inbox composer to match design v2's `composer.jsx` (1184 LOC) — collapsed pill, expanded reply, standalone (new conversation), AI draft window with full lifecycle, sources panel, AI cost display, "About this draft" modal, reprompt strip — while preserving every working feature on the production side.
+
+**Critical rule**: NO new backend / view-model / selector / action changes. Where the design references data we don't compute today (AI cost dollar amount, tier-1/2/3/4 sources panel), use **placeholders** that surface what we already have.
+
+## Authoritative design source
+
+- **`/tmp/design-handoff-v2/as-comms-platform/project/composer.jsx`** (1184 LOC, all the variants).
+- See specifically: `CollapsedPill`, `SendFromChip`, `RecipientChip`, `RecipientRow`, `AIDraftWindow`, `DraftSkeleton`, the standalone composer, the toolbar.
+
+## Production files in scope
+
+- `apps/web/app/inbox/_components/inbox-composer.tsx` — 1462 LOC current. **Major rebuild + extraction.** Target: ≤700 LOC after split.
+- `apps/web/app/inbox/_components/composer-toolbar.tsx` — restyle, keep.
+- `apps/web/app/inbox/_components/composer-recipient-picker.tsx` — restyle, keep API.
+- `apps/web/app/inbox/_components/about-this-draft.tsx` — redesign content layout.
+- `apps/web/app/inbox/_components/ai-draft-reprompt.tsx` — restyle, keep.
+- New: `apps/web/app/inbox/_components/composer-collapsed-pill.tsx` — extracted "Reply to X / Note" pill.
+- New: `apps/web/app/inbox/_components/composer-send-from-chip.tsx` — extracted alias picker.
+- New: `apps/web/app/inbox/_components/composer-ai-draft-window.tsx` — extracted AI draft surface (lifecycle states + sources + cost placeholder).
+- New: `apps/web/app/inbox/_components/composer-sources-panel.tsx` — tier-1/2/3/4 sources rollup.
+- `apps/web/app/_lib/design-tokens-v2.ts` — migrate.
+
+## Constraints (preserve)
+
+- **TipTap editor** unchanged. `useEditor` setup, StarterKit + Link, sanitizer pipeline (`sanitizeComposerHtml`), `plaintextToComposerHtml` — all preserved.
+- **localStorage draft autosave** unchanged. `loadDraft`/`saveDraft`/`clearDraft` keys unchanged.
+- **Send action** unchanged. `sendComposerAction` keeps same signature.
+- **AI draft action** unchanged. `draftWithAiAction` keeps same signature.
+- **Note action** unchanged. `createNoteAction` keeps same signature.
+- **Attachment handling** unchanged. `MAX_TOTAL_ATTACHMENT_BYTES`, base64 encoding, removal — preserved exactly.
+- **Reply context wiring** unchanged. The composer reads `composerPane.replyContext` from `useInboxClient()`.
+- **Validation** unchanged. `getInternalNoteValidationError`, alias resolution, `isComposerSendDisabled` — preserved.
+- **Useable from new-conversation entry points** (standalone) preserved.
+
+## Visual spec — collapsed pill
+
+When no draft is active, show:
+```
+┌──────────────────────────────────────────────────────────┐
+│ [✉] Reply to <FirstName>...               [R] kbd hint   │ [📝 Note]
+└──────────────────────────────────────────────────────────┘
+```
+- Container border-t border-slate-200 bg-white px-5 py-3.
+- The Reply pill: `rounded-lg border border-slate-200 bg-white px-3 py-2 shadow-sm hover:border-slate-300 hover:shadow`.
+- Icon: `MailIcon h-3.5 w-3.5 text-slate-400`.
+- Placeholder text `text-[13px] text-slate-400`.
+- Keyboard hint `R` in `border border-slate-200 px-1.5 py-0.5 text-[10px] font-medium text-slate-400 font-mono`.
+- Note button: `gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-[13px] text-slate-500 hover:border-amber-300 hover:bg-amber-50/50 hover:text-amber-700`.
+
+Click pill → expanded reply state. Click Note → expanded note state.
+
+## Visual spec — expanded reply / standalone
+
+Use a single `<ComposerExpanded>` component for both. Layout:
+
+```
+┌────────────────────────────────────────────────────┐
+│ Send from: [pnwbio@adventurescientists.org ▾]     │
+│ To: [Lily Luo <lilac…>] [+ add]                    │
+│ Cc: [+ add]                                         │
+│ Subject: Re: Last Call: PNW Training                │
+│ ───────────────────────────────────────             │
+│ <Toolbar: B I U list olist link quote spark>       │
+│ ───────────────────────────────────────             │
+│ <TipTap editor area>                                │
+│ ───────────────────────────────────────             │
+│ <attachments row, if any>                           │
+│ ───────────────────────────────────────             │
+│ [Attach paperclip] [✨ Draft with AI]   [Send →]   │
+└────────────────────────────────────────────────────┘
+```
+
+- Top "Send from" → `SendFromChip` extracted component. Dropdown shows all `composerAliases` from view model. Disabled aliases shown with reduced opacity. Use existing `resolveDefaultAlias` for initial selection.
+- Recipient rows: To / Cc each get a `RecipientRow` extracted component. To is required, Cc is optional. Each row has chips per recipient (`RecipientChip` with email + tone) and a `+ add` ghost button.
+- Subject is a clean `Input` with no border (just bottom-border or padding) — simplified from today's heavier styling.
+- Toolbar: existing `ComposerToolbar` restyled — buttons get `rounded` not `rounded-md`, hover `bg-slate-100`, active `bg-slate-200`.
+- Editor: same TipTap, body padding reduced; placeholder visible.
+- Attachments row: chips with file name + size + remove button; show only if attachments exist.
+- Bottom: 3 buttons. Attach (paperclip icon, ghost), Draft with AI (sparkle icon, soft variant), Send (default variant — current production already has this).
+
+## Visual spec — AI draft window
+
+When the user clicks "Draft with AI", an inline panel appears between the toolbar and editor. Lifecycle states:
+
+| State | Render |
+|---|---|
+| `idle` | Not visible |
+| `generating` | `DraftSkeleton` — animated shimmer lines, tier badges showing which sources are loading |
+| `inserted` | Banner above editor saying "AI draft inserted" with collapse to dismiss |
+| `edited` | Banner saying "You've edited this draft" with `↻ Regenerate` and `Discard changes` buttons |
+
+When `inserted` or `edited`, expose a `[?] About this draft` button that opens `<AboutThisDraft>` modal.
+
+`AboutThisDraft` modal content (redesigned):
+```
+About this draft
+═══════════════════
+Model      claude-haiku-4-5
+Cost       <PLACEHOLDER: "—" or "Cost not tracked yet">
+Tokens     <if backend exposes this, show; else "—">
+
+Sources
+───────
+Tier 1: Voice & Style
+  AS Voice & Style v3.2
+Tier 2: Project context
+  <project> settings
+Tier 3: Knowledge
+  <knowledge doc 1>
+  <knowledge doc 2>
+Tier 4: Recent thread
+  Last 4 messages with this volunteer
+```
+
+For sources data: today's `draftWithAiAction` returns AI metadata. Inspect what fields it returns. If it returns sources/tier info, plumb them through. If not, render a placeholder list with tier names + "Coming soon" copy. **Do not add new backend fields** — that's a Nico brief.
+
+## Visual spec — reprompt strip
+
+When draft is `inserted` or `edited`, show a horizontal strip at the bottom of the editor:
+```
+[<<thinking spinner>] [Make it shorter] [Add a P.S.] [More formal] [↻ Regenerate]
+[Type instructions...                                                    ↗]
+```
+Suggested chips on the left, free-text reprompt input on the right. On submit, the existing `AiDraftReprompt` component drives the API call — preserve its data flow.
+
+## Visual spec — note mode
+
+When user clicks Note (instead of Reply) from the collapsed pill:
+- Editor swaps to a yellow/amber-tinted textarea.
+- Toolbar replaced with a single "Save note" button.
+- Note preview card border `border-amber-300 bg-amber-50/40`.
+- Existing `createNoteAction` preserved.
+
+## Refactor (extraction)
+
+1. **Extract collapsed pill** → `composer-collapsed-pill.tsx`. Props: `personName`, `onExpand`, `onNote`. Used by detail page.
+2. **Extract send-from chip** → `composer-send-from-chip.tsx`. Props: `value`, `aliases`, `onChange`.
+3. **Extract AI draft window** → `composer-ai-draft-window.tsx`. Props: `lifecycle`, `onAccept`, `onDiscard`, `onRegenerate`, `onAbout`.
+4. **Extract sources panel** → `composer-sources-panel.tsx`. Props: `sources` (placeholder if backend doesn't expose).
+5. Recipient picker (`composer-recipient-picker.tsx`) — keep file, just restyle internally.
+6. After extraction `inbox-composer.tsx` ≤ 700 LOC.
+
+## Token migration rule
+
+All touched files migrate to `@/app/_lib/design-tokens-v2`.
+
+## Validation
+
+```
+pnpm --filter @as-comms/web typecheck
+pnpm --filter @as-comms/web lint
+pnpm --filter @as-comms/web test:unit
+```
+
+Smoke test in browser:
+- [ ] Click reply pill → composer expands
+- [ ] Type → autosave kicks in (check localStorage in devtools)
+- [ ] Click Draft with AI → skeleton shows, then content arrives
+- [ ] Open About this draft → modal renders
+- [ ] Reprompt → suggestion chip works
+- [ ] Send → message goes through, pending bubble appears in timeline
+- [ ] Click Note → amber note editor appears
+- [ ] Standalone composer (new conversation) renders the same redesigned shape
+
+## Out of scope
+
+- New backend fields (AI cost, sources tier metadata).
+- Settings — separate surface.
+- Inbox list / timeline / rail — already separate surfaces.
+
+## PR title
+
+`feat(ui): composer redesign — collapsed pill + expanded reply + AI draft window`
+
+## PR body template
+
+```
+## Summary
+- Composer rebuilt to match Claude Design v2: collapsed pill + expanded reply (+ standalone)
+- AI draft window with lifecycle states (idle/generating/inserted/edited) + sources panel + cost placeholder
+- New About-this-draft modal layout; reprompt strip with suggested chips
+- Note mode amber-tinted; same action wiring
+- Extracted: composer-collapsed-pill, composer-send-from-chip, composer-ai-draft-window, composer-sources-panel
+- inbox-composer.tsx 1462 → ~700 LOC
+
+## Test plan
+- [ ] Click reply pill → composer expands
+- [ ] Type and check localStorage draft saves
+- [ ] Click Draft with AI → skeleton then content
+- [ ] Open About this draft modal
+- [ ] Reprompt chip + free-text both work
+- [ ] Send works end to end
+- [ ] Note mode renders amber and saves
+- [ ] Standalone composer (new conversation) renders correctly
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```

--- a/.codex-surface-6-settings-redesign-2026-04-25.md
+++ b/.codex-surface-6-settings-redesign-2026-04-25.md
@@ -1,0 +1,186 @@
+# Codex Brief — Surface 6: Settings redesign
+
+**Worktree**: `/Users/nicolas/Downloads/as-ui-pixel-perfect` on branch `feat/ui-pixel-perfect-pass`
+**Suggested model**: GPT-5.4 **Extra High** (1252-LOC design; multi-page → single-page restructuring; wizard flow)
+**Estimated PR size**: ~1500–2000 LOC net change
+**Hard precondition**: Two locked Settings worktrees (`feat/settings-redesign`, `feat/settings-iteration-1`) **must be merged to `origin/main` first**. Confirm with `git log origin/main` before starting. If those branches haven't merged, **stop and ping the architect (Nico)**. This brief assumes the post-merge state.
+
+## Goal
+
+Redesign the Settings surface to match design v2's `settings.jsx` (1252 LOC) — single-page layout with section nav, Active Projects with project detail sub-pages, Integrations sync-only, Access section, project activation wizard (modal), bulk role-change UI. **Existing features only; no new backend.** Where the design references data we don't compute today (per-row "last checked X ago" timestamps), use placeholders.
+
+## Authoritative design source
+
+- **`/tmp/design-handoff-v2/as-comms-platform/project/settings.jsx`** (1252 LOC).
+- Reference screenshot: `/tmp/design-handoff-v2/as-comms-platform/project/uploads/screencapture-as-comms-platform-production-up-railway-app-settings-projects-a0tVK00001QqBuPYAV-2026-04-24-22_38_02.png` (current production state, for "before" comparison).
+
+## Production files in scope
+
+After the locked-branch merges, expect approximately:
+- `apps/web/app/settings/page.tsx` — single-page entry.
+- `apps/web/app/settings/_components/*.tsx` — section components (Projects, Access, Integrations, Project Detail).
+- `apps/web/app/settings/_lib/selectors.ts` — server-side selectors.
+- `apps/web/app/settings/actions.ts` — server actions.
+- `apps/web/app/_components/primary-icon-rail.tsx` — promoted to shared per `feat/settings-iteration-1` commit `4e200ab`.
+
+**Re-read all files in `apps/web/app/settings/**` after the merges land** — the structure changes meaningfully from today. Don't reuse this brief's file list verbatim if the merges land different files.
+
+## Visual spec — overall layout
+
+Single-page Settings, no per-route sub-paths:
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ [Icon Rail]  │ [Section Nav] │ [Section Content]                    │
+│              │               │                                       │
+│              │ Projects      │ ─── Active Projects ──────────────   │
+│              │ Access        │ <project cards, click to detail>      │
+│              │ Integrations  │                                       │
+│              │               │ ─── Inactive Projects ─────────────   │
+│              │               │ <activate button → wizard modal>      │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+The icon rail (`apps/web/app/_components/primary-icon-rail.tsx`) is reused. The section nav is a vertical list — match the design's `rounded-lg` button styling with selected state `bg-slate-100 text-slate-900`.
+
+## Visual spec — Projects section
+
+### Active project card
+```
+┌────────────────────────────────────────────────┐
+│ <tone left accent bar w-1>                     │
+│   <Project Name>            [In Field] [→]     │
+│   <project alias email>                        │
+│   <expedition count> volunteers · <unread> open │
+└────────────────────────────────────────────────┘
+```
+
+Card: `rounded-xl border border-slate-200 bg-white p-5 hover:shadow-sm hover:border-slate-300 transition`. Click navigates to project detail sub-page (in-place, not a new route — uses local state to swap content).
+
+### Project detail (sub-page)
+- Header: project name + status badge + back button.
+- Tabbed content: Overview / Knowledge / Aliases / Members.
+- Overview: project metadata.
+- Knowledge: list of knowledge entries (table, existing component).
+- Aliases: list of project_aliases with primary indicator.
+- Members: list of expedition members (read-only).
+
+### Inactive projects + activation wizard
+"Activate project" button → opens modal wizard:
+
+**Step 1: Pick a Salesforce project**
+- Search input + scrollable list of SF projects.
+- Each row: name + year + project type.
+- Click selects → moves to step 2.
+
+**Step 2: Pick Notion knowledge page (optional)**
+- Search Notion pages + emoji preview.
+- Skip option.
+- Click selects + finishes wizard.
+
+Both steps use existing actions (whatever the locked worktree exposed). If the wizard data doesn't exist yet:
+- Step 1 reads from existing SF project list (if exposed) or shows a placeholder list.
+- Step 2 shows a "coming soon" message and skips.
+
+The wizard activates via the existing project activation server action.
+
+## Visual spec — Access section
+
+Today's access section likely shows operators with role assignments. Tighten to:
+
+```
+[Search teammates]
+[Add teammate ◢]
+
+┌─────────────────────────────────────────────┐
+│ <avatar> <Name>                  [Role ▾]  │
+│         <email>                             │
+└─────────────────────────────────────────────┘
+...
+```
+
+Each row's role is a dropdown: `Admin / Operator / Viewer`. Use existing role-update action if exposed; otherwise placeholder.
+
+**Bulk role change**: checkbox column on the left. Selected rows show a top action bar `[N selected] [Change role to ▾] [Remove]`. Wire the role-change to the existing single-row action (loop client-side); flag bulk-remove as TODO if no bulk-remove action exists.
+
+## Visual spec — Integrations section
+
+Three integration rows: Salesforce, Gmail, Notion. Each row:
+
+```
+┌──────────────────────────────────────────────────────┐
+│ <provider icon> <Provider Name>      [Healthy] [Sync]│
+│                <last synced X ago — placeholder>      │
+└──────────────────────────────────────────────────────┘
+```
+
+- Status badge: `Healthy` (emerald), `Degraded` (amber), `Failed` (rose). Color from existing health view-model.
+- "Last synced X ago": placeholder (use `"a few minutes ago"` if no real data exposed). Existing health view-model may have `lastCheckedAt` — use it if so; otherwise placeholder.
+- "Sync" button: triggers the existing `refreshIntegrationAction` (or whatever the action is named in the merged state).
+
+**No OAuth flow changes.** No new actions. No new backend wiring.
+
+## Refactor (extraction) — opportunistic
+
+After merges land, the locked branches likely already have decent extractions in place. Don't refactor for refactor's sake. Only extract these if they help readability:
+
+- `SettingsSectionNav` (left rail).
+- `ProjectActivationWizard` (modal + steps + state machine).
+- `IntegrationRow`.
+- `RoleAssignmentDropdown`.
+- `BulkActionsBar`.
+
+Aim: any individual file ≤ 700 LOC after this PR.
+
+## Token migration rule
+
+Migrate every Settings file you touch to `@/app/_lib/design-tokens-v2`. The locked branches' merges likely use v1 tokens — that's fine; this PR migrates them.
+
+## Validation
+
+```
+pnpm --filter @as-comms/web typecheck
+pnpm --filter @as-comms/web lint
+pnpm --filter @as-comms/web test:unit
+```
+
+Smoke:
+- [ ] Section nav switches content without route change.
+- [ ] Active project click → detail panel.
+- [ ] Activate project → wizard step 1 → step 2 → activation succeeds.
+- [ ] Role dropdown changes role.
+- [ ] Bulk select → bulk-change role works (loop).
+- [ ] Integration sync button triggers refresh.
+- [ ] Status badges color-correct.
+
+## Out of scope
+
+- New backend fields, actions, or schema changes.
+- Notion sync deep wiring beyond what already exists.
+- OAuth flow.
+- Any non-Settings surface.
+
+## PR title
+
+`feat(ui): settings redesign — single-page surface + activation wizard`
+
+## PR body template
+
+```
+## Summary
+- Settings rebuilt per Claude Design v2: section nav + Projects / Access / Integrations
+- Project activation wizard (SF picker → Notion picker)
+- Bulk role-change in Access section
+- Integration rows show health badge + last-synced timestamp (placeholder where backend hasn't exposed it)
+- Migrate touched files to design-tokens-v2
+
+## Test plan
+- [ ] All three sections switch correctly
+- [ ] Active project card clicks into detail
+- [ ] Activation wizard goes through both steps
+- [ ] Role dropdown changes role server-side
+- [ ] Bulk select + bulk role change applies to multiple rows
+- [ ] Integration sync triggers refresh
+- [ ] Status badges show correct color per health state
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```

--- a/.handoff-ui-architect-pixel-perfect-2026-04-25.md
+++ b/.handoff-ui-architect-pixel-perfect-2026-04-25.md
@@ -1,0 +1,140 @@
+# UI Architect — Pixel-Perfect Design v2 Pass — 2026-04-25
+
+Worktree: `/Users/nicolas/Downloads/as-ui-pixel-perfect` on branch `feat/ui-pixel-perfect-pass` (off `origin/main`).
+Design source: `/tmp/design-handoff-v2/as-comms-platform/project/` (see also screenshots in `uploads/`).
+
+## Decisions locked during the grill (2026-04-25)
+
+| # | Decision | Choice |
+|---|---|---|
+| Q1 | Scope | Visual reskin + redesign of existing-feature surfaces (e.g. activation wizard); placeholder where backend missing (AI cost) |
+| Q2 | Variants | Timeline = **stream**, Filter bar = **list** |
+| — | Bubble spec | Avatar outside bubble; `Sender → Recipient +cc ▾` compact header; timestamp top-right; Reply button included; SMS = filled sky bubble white text; categorical system dividers |
+| Q3 | Settings | Nico merges locked worktrees first; Settings sequenced last |
+| Q4 | Tokens | New `design-tokens-v2.ts` matching design verbatim, piecewise migrate, delete old when empty |
+| Q5 | Pixel-perfect bar | Component-level fidelity at default browser zoom on desktop. Bubbles strict; other surfaces faithful |
+| Q6 | Refactor coupling | Extract primitives **inside** each surface's PR, before visual changes within that PR. No standalone "refactor only" PRs |
+| Q7 | Surface order | Tokens-v2 → Timeline → Sidebar/list → Detail rail → Welcome → Composer → Settings |
+| Q8 | Risk model | One PR per surface, each reviewable + revertable, screenshots + CI green required |
+
+## Surface-by-surface plan
+
+### 1. Tokens-v2 foundation (this PR + Surface 1)
+- Create `apps/web/app/_lib/design-tokens-v2.ts`. Shape matches design's `primitives.jsx`: unified `TONE_CLASSES` with 7 keys per tone (`bg/text/ring/subtle/subtleText/avatar/dot`), plus `TYPE` carrying both v1 and v2 keys.
+- Add a one-pager comment block at the top explaining the migration plan and which file is canonical for new code.
+- v1 file stays in place; piecewise migration as components ship.
+
+### 2. Timeline bubbles + system dividers
+- Bubble redesign per the two screenshots Nico shared:
+  - Avatar OUTSIDE bubble (left/inbound, right/outbound).
+  - Compact `Sender → Recipient +cc ▾` single-line header with arrow icon and dropdown chevron.
+  - Subject line bolded inside bubble.
+  - Body in serif (already done — preserve).
+  - Timestamp top-right of bubble header.
+  - Inline `↩ Reply` button bottom-right (new, sets composer to reply context).
+  - Inbound = white/slate border. Email outbound = sky-tinted with sky border. SMS outbound = filled sky-blue with white text.
+- System dividers:
+  - Categorical pill labels (`LIFECYCLE` amber / `TRAINING` blue / `TRIP PLANNING` amber / `FIRST DATA SUBMITTED` emerald / etc).
+  - Existing `describeLifecycleEvent` keyword classifier extended.
+  - Categorical icons + per-category color tone.
+- Campaign group: keep current overlapping-megaphone-icons treatment.
+- Extract primitives BEFORE visual changes:
+  - `LifecycleEventBadge({ category, ...})` — replaces inline `describeLifecycleEvent` rendering.
+  - `EmailParticipantHeader` (new compact one-liner) — replaces `EmailParticipantHeaders` 3-row grid.
+  - `BubbleAvatar` — outside-bubble avatar with size + tone.
+  - `ReplyButton` — bottom-right of bubble.
+
+### 3. Sidebar / inbox-list — filter "list" variant + row polish
+- Replace current `Collapsible + ToggleGroup + DropdownMenu` filter UX with always-visible flat list:
+  - Top: STATE label + `[All / Unread / Follow-up / Sent]` rows with colored dots + counts (sky/amber).
+  - Bottom: PROJECT label + `All projects` + one row per active project with tone dot + count.
+- Row polish per design: keep dual-accent-bar (sky/rose), tighten typography, ensure project tone dot matches list and row.
+
+### 4. Detail rail (right side)
+- Visual polish: connector-line alignment, spacing, heading consistency.
+- Expedition Member link: needs new view-model field `expeditionMemberUrl` from Nico's `selectors.ts`. Brief sent separately. Wire UI when field lands.
+- Phone fallback copy: `"No phone on file"`.
+- Pinned notes preview: needs new view-model field; brief sent separately.
+
+### 5. Welcome screen
+- Replace current bare `<table>` welcome workload with design's quote card + project mini-dashboard.
+- Operator name: `requireSession()` in page.tsx, thread name into welcome component.
+- Quote-of-the-day: pure FE; FIELD_QUOTES const, daily rotation by date; refresh button.
+- Project mini-dashboard: 2-column grid with unread + follow-up counts per active project.
+- Follow-up list inline: top 10 items, scrollable.
+
+### 6. Composer redesign
+- Three states: collapsed pill / expanded reply / standalone (new conversation).
+- Rich text toolbar: keep current TipTap; restyle.
+- Recipient picker: redesign per design's `RecipientChip` + `RecipientRow`.
+- Send-from chip: redesign alias picker.
+- AI draft window: lifecycle states (idle / generating / inserted / edited).
+- Sources panel: tier 1/2/3/4 list.
+- AI cost: PLACEHOLDER (no backend).
+- `About this draft` modal.
+- Reprompt strip.
+- Internal note button alongside reply.
+
+### 7. Settings redesign — sequenced AFTER Nico merges locked worktrees
+- Two locked worktrees (`feat/settings-redesign`, `feat/settings-iteration-1`) being merged by Nico.
+- After merges land, redesign Settings per `settings.jsx` (1252 LOC):
+  - Project activation wizard (modal): SF picker + Notion knowledge picker.
+  - Integration health rows with timestamps (timestamps placeholder if backend not wired).
+  - Bulk role change UI.
+  - Global sidebar nav.
+
+## Briefs blocked on Nico (backend changes)
+
+Send these briefs in parallel — UI work continues while Nico unblocks:
+
+- **B1**: `expeditionMemberUrl: string` on `InboxProjectMembershipViewModel`; selector synthesizes `https://adventurescientists.lightning.force.com/lightning/r/Expedition_Members__c/{salesforceMembershipId}/view`.
+- **B2**: `pinnedNote: { body, authorLabel, createdAtLabel } | null` on `InboxContactSummaryViewModel`; selector reads top pinned note from `internal_notes` (or most-recent if no `pinned` column).
+
+## Validation requirements per Codex brief
+
+- `pnpm install --prefer-offline` already run in worktree — Codex should verify.
+- Codex MUST run before declaring done:
+  - `pnpm --filter @as-comms/web typecheck`
+  - `pnpm --filter @as-comms/web lint`
+  - `pnpm --filter @as-comms/web test:unit`
+- macOS rollup-darwin-arm64 errors are environmental — CI is authoritative.
+
+## Brief inventory + dispatch order
+
+All briefs are written and ready for `codex exec`. Recommended order:
+
+| # | Brief file (in worktree) | Codex effort | Blocked on | Surface |
+|---|---|---|---|---|
+| 1 | `.codex-surface-1-timeline-bubbles-2026-04-25.md` | Extra High | — | Timeline bubbles + categorical system dividers |
+| 2 | `.codex-surface-2-sidebar-list-filter-2026-04-25.md` | High | — | Sidebar / inbox-list flat-list filter + row polish |
+| 3a | (visual) `.codex-surface-3-detail-rail-polish-2026-04-25.md` | Medium | — | Detail rail visual polish (no expedition link yet) |
+| 3b | (wiring) same brief, second wave | Low | **B1** | Detail rail expedition member link wiring |
+| 4 | `.codex-surface-4-welcome-screen-2026-04-25.md` | High | — | Welcome screen quote card + project mini-dashboard |
+| 5 | `.codex-surface-5-composer-redesign-2026-04-25.md` | Extra High | — | Composer redesign |
+| 6 | `.codex-surface-6-settings-redesign-2026-04-25.md` | Extra High | **Settings merges** | Settings single-page + activation wizard |
+
+### Backend briefs to architect (Nico's lane)
+
+Live in main repo root (not the worktree) so Nico can see them in his shell:
+
+- `.brief-to-architect-B1-expedition-member-url-2026-04-25.md` — `expeditionMemberUrl` on `InboxProjectMembershipViewModel`. Unblocks Surface 3b.
+- `.brief-to-architect-B2-pinned-note-rail-2026-04-25.md` — `pinnedNote` on `InboxContactSummaryViewModel`. Optional, deferrable.
+
+### Recommended parallel batches
+
+- **Batch A** (no dependencies, parallel): S1, S2, S4, S5. All four can dispatch concurrently — they touch disjoint files.
+- **Batch B** (after B1 lands): S3 wiring portion.
+- **Batch C** (after settings merges land on `origin/main`): S6.
+
+### Token budget guidance
+
+Memory `feedback_codex_pre_install_and_validate.md` says pre-install + validate-before-done. Already done:
+- `pnpm install --prefer-offline` — completed on 2026-04-25 (exit 0).
+- Each brief explicitly requires Codex to run `pnpm --filter @as-comms/web typecheck | lint | test:unit` before declaring done.
+
+Each brief includes a PR title and PR body template ready to paste into `gh pr create`.
+
+## Status log
+
+- 2026-04-25 — Worktree created off `origin/main` at commit `6c0fb80`. Tokens-v2 file created. Tracker initialized.
+- 2026-04-25 — Briefs S1–S6 + B1 + B2 written. Worktree clean and ready for dispatch. UI architect (sub) handing off to Nico.

--- a/.handoff-ui-architect-pixel-perfect-2026-04-25.md
+++ b/.handoff-ui-architect-pixel-perfect-2026-04-25.md
@@ -138,3 +138,9 @@ Each brief includes a PR title and PR body template ready to paste into `gh pr c
 
 - 2026-04-25 — Worktree created off `origin/main` at commit `6c0fb80`. Tokens-v2 file created. Tracker initialized.
 - 2026-04-25 — Briefs S1–S6 + B1 + B2 written. Worktree clean and ready for dispatch. UI architect (sub) handing off to Nico.
+- 2026-04-25 — While Nico offline, sub-architect shipped 3 surfaces directly (typecheck + lint clean; tests blocked by macOS rollup env, CI authoritative):
+  - **Surface 3** — Contact rail visual polish + phone fallback + status-tone dots + activity connector alignment + tokens-v2 migration. Commit on branch.
+  - **Surface 4** — Welcome screen redesign (quote card + project mini-dashboard + operator first-name threading via requireSession). Adds `field-quotes.ts` + `Quote`/`ArrowUpRight` icons. Commit on branch.
+  - **Surface 2** — Inbox sidebar flat-list filter variant + URL `?projectId=` sync + per-project tone badges on rows. Drops Collapsible/ToggleGroup/DropdownMenu UI. Extracts `InboxFilterList` + shared `projectToneFromName`. Commit on branch.
+- **Still pending Codex dispatch (Nico, on return):** Surfaces 1 (Timeline bubbles, biggest visual change), 5 (Composer, largest surface). Settings (Surface 6) still blocked on merges of `feat/settings-redesign` + `feat/settings-iteration-1`.
+- All commits live on local `feat/ui-pixel-perfect-pass`. **Not pushed** — Nico signs off pushes/merges.

--- a/apps/web/app/_lib/design-tokens-v2.ts
+++ b/apps/web/app/_lib/design-tokens-v2.ts
@@ -1,0 +1,210 @@
+/**
+ * Design Tokens v2 — single source of truth aligned with the Claude Design v2
+ * handoff (2026-04-25). Companion to (and eventual replacement for) the
+ * legacy `design-tokens.ts`.
+ *
+ * ## Migration plan
+ *
+ * - **New code uses this file.** Components touched during the pixel-perfect
+ *   pass migrate from `design-tokens.ts` → `design-tokens-v2.ts` as they ship.
+ * - **Untouched components keep using v1 unchanged** until their surface is
+ *   rebuilt. v1 stays in place; nothing is breaking-changed.
+ * - When no callers of v1 remain, v1 is deleted. Track via grep for
+ *   `from "@/app/_lib/design-tokens"` (v1 path) vs `design-tokens-v2`.
+ *
+ * ## Why a parallel file
+ *
+ * The v1 `TONE.X.bg` returns the **light** background (e.g. `bg-sky-50`).
+ * The design's `TONE_CLASSES.X.bg` returns the **solid** background
+ * (e.g. `bg-sky-600`). Same key, opposite intent. Importing v2 instead of v1
+ * is the explicit signal that the new semantics apply.
+ *
+ * ## Key shape (matches design's `primitives.jsx`)
+ *
+ * Each tone exposes 7 keys:
+ *  - `bg`         — solid background  (e.g. `bg-sky-600`)
+ *  - `text`       — text on light/neutral surfaces  (e.g. `text-sky-700`)
+ *  - `ring`       — ring or border accent  (e.g. `ring-sky-200`)
+ *  - `subtle`     — subtle fill  (e.g. `bg-sky-50`)
+ *  - `subtleText` — text inside subtle fill  (e.g. `text-sky-700`)
+ *  - `avatar`     — pre-composed avatar classes  (`bg-sky-100 text-sky-700`)
+ *  - `dot`        — small color dot  (`bg-sky-500`)
+ *
+ * All values are static strings so Tailwind's class scanner can detect them.
+ */
+
+// ─── Tone Classes ─────────────────────────────────────────────────────────
+
+export interface ToneClassesV2 {
+  /** Solid background — e.g. `bg-sky-600` */
+  readonly bg: string;
+  /** Text on light/neutral surfaces — e.g. `text-sky-700` */
+  readonly text: string;
+  /** Ring / border accent — e.g. `ring-sky-200` */
+  readonly ring: string;
+  /** Subtle fill — e.g. `bg-sky-50` */
+  readonly subtle: string;
+  /** Text inside subtle fills — e.g. `text-sky-700` */
+  readonly subtleText: string;
+  /** Pre-composed avatar background + text — e.g. `bg-sky-100 text-sky-700` */
+  readonly avatar: string;
+  /** Color dot — e.g. `bg-sky-500` */
+  readonly dot: string;
+}
+
+export const TONE_CLASSES = {
+  slate: {
+    bg: "bg-slate-600",
+    text: "text-slate-700",
+    ring: "ring-slate-200",
+    subtle: "bg-slate-50",
+    subtleText: "text-slate-700",
+    avatar: "bg-slate-100 text-slate-700",
+    dot: "bg-slate-400",
+  },
+  sky: {
+    bg: "bg-sky-600",
+    text: "text-sky-700",
+    ring: "ring-sky-200",
+    subtle: "bg-sky-50",
+    subtleText: "text-sky-700",
+    avatar: "bg-sky-100 text-sky-700",
+    dot: "bg-sky-500",
+  },
+  indigo: {
+    bg: "bg-indigo-600",
+    text: "text-indigo-700",
+    ring: "ring-indigo-200",
+    subtle: "bg-indigo-50",
+    subtleText: "text-indigo-700",
+    avatar: "bg-indigo-100 text-indigo-700",
+    dot: "bg-indigo-500",
+  },
+  emerald: {
+    bg: "bg-emerald-600",
+    text: "text-emerald-700",
+    ring: "ring-emerald-200",
+    subtle: "bg-emerald-50",
+    subtleText: "text-emerald-700",
+    avatar: "bg-emerald-100 text-emerald-700",
+    dot: "bg-emerald-500",
+  },
+  amber: {
+    bg: "bg-amber-500",
+    text: "text-amber-700",
+    ring: "ring-amber-200",
+    subtle: "bg-amber-50",
+    subtleText: "text-amber-700",
+    avatar: "bg-amber-100 text-amber-700",
+    dot: "bg-amber-500",
+  },
+  rose: {
+    bg: "bg-rose-500",
+    text: "text-rose-700",
+    ring: "ring-rose-200",
+    subtle: "bg-rose-50",
+    subtleText: "text-rose-700",
+    avatar: "bg-rose-100 text-rose-700",
+    dot: "bg-rose-500",
+  },
+  violet: {
+    bg: "bg-violet-500",
+    text: "text-violet-700",
+    ring: "ring-violet-200",
+    subtle: "bg-violet-50",
+    subtleText: "text-violet-700",
+    avatar: "bg-violet-100 text-violet-700",
+    dot: "bg-violet-500",
+  },
+  teal: {
+    bg: "bg-teal-600",
+    text: "text-teal-700",
+    ring: "ring-teal-200",
+    subtle: "bg-teal-50",
+    subtleText: "text-teal-700",
+    avatar: "bg-teal-100 text-teal-700",
+    dot: "bg-teal-500",
+  },
+} as const satisfies Record<string, ToneClassesV2>;
+
+export type ToneNameV2 = keyof typeof TONE_CLASSES;
+
+// ─── Typography ───────────────────────────────────────────────────────────
+//
+// Mirrors design's `TYPE` map verbatim. The legacy `TEXT` map in v1 has a
+// `bodySerifSm` token that the design didn't anticipate; it's kept under
+// the same name here so message-body serif rendering keeps working.
+
+export const TYPE = {
+  /** Page / detail titles — `text-lg font-semibold text-slate-900` */
+  headingLg: "text-lg font-semibold text-slate-900",
+  /** Section / rail headers — `text-sm font-semibold text-slate-900` */
+  headingSm: "text-sm font-semibold text-slate-900",
+  /** Default body text — `text-sm text-slate-700` */
+  bodyMd: "text-sm text-slate-700",
+  /** Message body, descriptions — `text-[13px] leading-relaxed text-slate-700` */
+  bodySm: "text-[13px] leading-relaxed text-slate-700",
+  /** Long-form message body — Source Serif 4, slightly larger for reading */
+  bodySerifSm: "text-[13.5px] leading-relaxed text-slate-700",
+  /** Secondary info, snippets — `text-xs text-slate-500` */
+  caption: "text-xs text-slate-500",
+  /** Section labels — `text-[10px] font-semibold uppercase tracking-wider text-slate-500` */
+  label: "text-[10px] font-semibold uppercase tracking-wider text-slate-500",
+  /** Timestamps, metadata — `text-[11px] text-slate-400` */
+  micro: "text-[11px] text-slate-400",
+  /** Badge text — `text-[10px] font-semibold uppercase tracking-wide` */
+  badge: "text-[10px] font-semibold uppercase tracking-wide",
+} as const;
+
+// ─── Layout / Spacing / Radius / Shadow / Transitions / Focus ─────────────
+//
+// These tokens are missing from design's `primitives.jsx` (the design files
+// hard-code them inline). Production shipped them in v1 and they're worth
+// keeping — they're cross-component truths that absolutely belong in a
+// tokens file.
+
+export const RADIUS = {
+  /** Inputs, small buttons */
+  sm: "rounded-md",
+  /** Cards, filter buttons, popovers */
+  md: "rounded-lg",
+  /** Nav buttons, icon rail */
+  lg: "rounded-xl",
+  /** Message bubbles */
+  bubble: "rounded-2xl",
+  /** Pills, avatars, badges */
+  full: "rounded-full",
+} as const;
+
+export const SHADOW = {
+  /** Buttons, inputs, cards, bubbles */
+  sm: "shadow-sm",
+  /** Popovers, dropdowns */
+  md: "shadow-md",
+} as const;
+
+export const TRANSITION = {
+  fast: "transition-colors duration-150",
+  layout: "transition-all duration-200 ease-out",
+  reduceMotion: "motion-reduce:transition-none",
+} as const;
+
+export const LAYOUT = {
+  /** Shared header height for list, detail, and rail */
+  headerHeight: "h-[65px]",
+  /** Inbox list column width */
+  listWidth: "w-[22rem]",
+  /** Contact rail width */
+  railWidth: "w-80",
+  /** Icon rail width */
+  iconRailWidth: "w-14",
+} as const;
+
+export const SPACING = {
+  listItem: "px-5 py-3.5",
+  section: "px-5 py-4",
+  container: "px-6 py-6",
+} as const;
+
+export const FOCUS_RING =
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1" as const;

--- a/apps/web/app/inbox/_components/icons.tsx
+++ b/apps/web/app/inbox/_components/icons.tsx
@@ -61,4 +61,6 @@ export {
   MousePointerClick as MousePointerClickIcon,
   Flag as FlagIcon,
   MailOpen as MailOpenIcon,
+  ArrowUpRight as ArrowUpRightIcon,
+  Quote as QuoteIcon,
 } from "lucide-react";

--- a/apps/web/app/inbox/_components/inbox-contact-rail.tsx
+++ b/apps/web/app/inbox/_components/inbox-contact-rail.tsx
@@ -6,13 +6,14 @@ import type {
 import { Button } from "@/components/ui/button";
 import { SectionLabel } from "@/components/ui/section-label";
 import { StatusBadge } from "@/components/ui/status-badge";
+import { PROJECT_STATUS_BADGE } from "@/app/_lib/design-tokens";
 import {
   LAYOUT,
-  PROJECT_STATUS_BADGE,
-  TEXT,
-  TONE,
   SPACING,
-} from "@/app/_lib/design-tokens";
+  TONE_CLASSES,
+  TYPE,
+  type ToneNameV2,
+} from "@/app/_lib/design-tokens-v2";
 
 import {
   CalendarIcon,
@@ -30,25 +31,25 @@ interface RailProps {
 /**
  * Server component: renders contact reference data for the detail workspace.
  *
- * Starts with a minimal name + record ID header (no avatar placeholder,
- * no stage badge), then contact details, active and past project
- * participations, and milestone activity. Visibility is controlled by the
- * parent detail component via conditional render.
+ * Header: name + record ID (mono, dim). Then contact details (with phone
+ * fallback), active and past project participations (status-tone dots), and
+ * milestone activity. Visibility is controlled by the parent detail
+ * component via conditional render.
  */
 export function InboxContactRail({ contact, onClose }: RailProps) {
   return (
     <aside
       id="inbox-contact-rail"
-      className={`flex min-h-0 ${LAYOUT.railWidth} shrink-0 flex-col ${TONE.slate.subtle}`}
+      className={`flex min-h-0 ${LAYOUT.railWidth} shrink-0 flex-col ${TONE_CLASSES.slate.subtle}`}
       aria-label="Contact details"
     >
       <header className={`flex ${LAYOUT.headerHeight} shrink-0 items-center gap-2 border-b border-slate-200 bg-white px-5`}>
         <div className="min-w-0 flex-1">
-          <h2 className={`truncate ${TEXT.headingSm}`}>
+          <h2 className={`truncate ${TYPE.headingSm}`}>
             {contact.displayName}
           </h2>
-          <p className={`mt-0.5 text-[11px] font-medium uppercase tracking-wide text-slate-500`}>
-            Record ID · {contact.volunteerId}
+          <p className="mt-0.5 truncate font-mono text-[11px] text-slate-400">
+            {contact.volunteerId}
           </p>
         </div>
         {onClose ? (
@@ -66,7 +67,7 @@ export function InboxContactRail({ contact, onClose }: RailProps) {
 
       <div className="min-h-0 flex-1 overflow-y-auto">
       <section className={`border-b border-slate-200 ${SPACING.section}`}>
-        <SectionLabel>
+        <SectionLabel as="h3">
           Contact
         </SectionLabel>
         <dl className="mt-2 space-y-1.5 text-[13px]">
@@ -79,7 +80,14 @@ export function InboxContactRail({ contact, onClose }: RailProps) {
             <ContactLine icon={<PhoneIcon className="h-3.5 w-3.5" />}>
               {contact.primaryPhone}
             </ContactLine>
-          ) : null}
+          ) : (
+            <ContactLine
+              icon={<PhoneIcon className="h-3.5 w-3.5" />}
+              muted
+            >
+              No phone on file
+            </ContactLine>
+          )}
           <ContactLine icon={<CalendarIcon className="h-3.5 w-3.5" />}>
             {contact.joinedAtLabel}
           </ContactLine>
@@ -98,7 +106,7 @@ export function InboxContactRail({ contact, onClose }: RailProps) {
       />
 
       <section className={SPACING.section}>
-        <SectionLabel>
+        <SectionLabel as="h3">
           Project activity
         </SectionLabel>
         {contact.recentActivity.length === 0 ? (
@@ -106,20 +114,20 @@ export function InboxContactRail({ contact, onClose }: RailProps) {
             No project activity recorded.
           </p>
         ) : (
-          <ul className="mt-3 space-y-0">
+          <ul className="mt-3 space-y-3">
             {contact.recentActivity.map((entry, index) => (
               <li
                 key={entry.id}
-                className="relative flex gap-3 pb-4 last:pb-0"
+                className="relative flex gap-3 pb-1 last:pb-0"
               >
-                {/* Vertical connector line */}
+                {/* Vertical connector line — passes through dot center (5px) */}
                 {index < contact.recentActivity.length - 1 ? (
                   <div className="absolute left-[5px] top-3 h-full w-px bg-slate-200" />
                 ) : null}
-                {/* Dot */}
-                <div className="relative mt-1.5 h-[11px] w-[11px] shrink-0 rounded-full border-2 border-slate-300 bg-white" />
+                {/* Dot — h-[10px] w-[10px] centers at 5px to match line */}
+                <div className="relative mt-1.5 h-[10px] w-[10px] shrink-0 rounded-full border-2 border-slate-300 bg-white" />
                 <div className="min-w-0 flex-1">
-                  <p className="text-[13px] leading-snug text-slate-700">
+                  <p className="text-[12.5px] leading-snug text-slate-700">
                     {entry.label}
                   </p>
                   <p className="text-[11px] text-slate-400">
@@ -145,37 +153,46 @@ interface ProjectsSectionProps {
 function ProjectsSection({ title, projects, emptyLabel }: ProjectsSectionProps) {
   return (
     <section className={`border-b border-slate-200 ${SPACING.section}`}>
-      <h3 className={TEXT.label}>
+      <SectionLabel as="h3">
         {title}
-      </h3>
+      </SectionLabel>
       {projects.length === 0 ? (
         <p className="mt-2 text-[12px] text-slate-400">{emptyLabel}</p>
       ) : (
         <ul className="mt-2 space-y-1">
-          {projects.map((project) => (
-            <li key={project.membershipId}>
-              <a
-                href={project.crmUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="group flex items-center gap-2 rounded-lg px-2 py-1.5 transition hover:bg-white hover:ring-1 hover:ring-slate-200"
-              >
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-[13px] font-medium text-slate-800 group-hover:text-slate-900">
-                    {project.projectName}
-                  </p>
-                  <p className="mt-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
-                    <span className="tabular-nums">
-                      {project.year.toString()}
-                    </span>
-                    <span className="text-slate-300">·</span>
-                    <InboxProjectStatusBadge status={project.status} />
-                  </p>
-                </div>
-                <ChevronRightIcon className="h-3.5 w-3.5 shrink-0 text-slate-300 group-hover:text-slate-500" />
-              </a>
-            </li>
-          ))}
+          {projects.map((project) => {
+            // TODO(B1): swap primary click target to expeditionMemberUrl;
+            // keep crmUrl as secondary "↗ project" link.
+            const tone = STATUS_TONE[project.status];
+            return (
+              <li key={project.membershipId}>
+                <a
+                  href={project.crmUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="group flex items-center gap-2 rounded-lg px-2 py-1.5 transition hover:bg-white hover:ring-1 hover:ring-slate-200"
+                >
+                  <span
+                    aria-hidden="true"
+                    className={`mt-1 h-1.5 w-1.5 shrink-0 rounded-full ${TONE_CLASSES[tone].dot}`}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-[13px] font-medium text-slate-800 group-hover:text-slate-900">
+                      {project.projectName}
+                    </p>
+                    <p className="mt-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
+                      <span className="tabular-nums">
+                        {project.year.toString()}
+                      </span>
+                      <span className="text-slate-300">·</span>
+                      <InboxProjectStatusBadge status={project.status} />
+                    </p>
+                  </div>
+                  <ChevronRightIcon className="h-3.5 w-3.5 shrink-0 text-slate-300 group-hover:text-slate-500" />
+                </a>
+              </li>
+            );
+          })}
         </ul>
       )}
     </section>
@@ -189,6 +206,15 @@ const PROJECT_STATUS_LABEL: Record<InboxProjectStatus, string> = {
   "trip-planning": "Trip Planning",
   "in-field": "In the Field",
   successful: "Successful"
+};
+
+const STATUS_TONE: Record<InboxProjectStatus, ToneNameV2> = {
+  lead: "slate",
+  applied: "sky",
+  "in-training": "indigo",
+  "trip-planning": "amber",
+  "in-field": "emerald",
+  successful: "violet"
 };
 
 export function InboxProjectStatusBadge({
@@ -207,14 +233,18 @@ export function InboxProjectStatusBadge({
 
 function ContactLine({
   icon,
-  children
+  children,
+  muted = false
 }: {
   readonly icon: React.ReactNode;
   readonly children: React.ReactNode;
+  readonly muted?: boolean;
 }) {
   return (
-    <div className="flex items-center gap-2 text-slate-700">
-      <span className="text-slate-400">{icon}</span>
+    <div
+      className={`flex items-center gap-2 ${muted ? "italic text-slate-400" : "text-slate-700"}`}
+    >
+      <span className={muted ? "text-slate-300" : "text-slate-300"}>{icon}</span>
       <span className="truncate">{children}</span>
     </div>
   );

--- a/apps/web/app/inbox/_components/inbox-filter-list.tsx
+++ b/apps/web/app/inbox/_components/inbox-filter-list.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { TONE_CLASSES } from "@/app/_lib/design-tokens-v2";
+import { cn } from "@/lib/utils";
+import { SectionLabel } from "@/components/ui/section-label";
+
+import type {
+  InboxActiveProjectOption,
+  InboxFilterId,
+  InboxFilterViewModel,
+} from "../_lib/view-models";
+import { projectToneFromName } from "../_lib/project-tone";
+
+const FILTER_TONE: Record<InboxFilterId, "slate" | "sky" | "amber" | "rose"> = {
+  all: "slate",
+  unread: "sky",
+  "follow-up": "amber",
+  unresolved: "rose",
+  sent: "slate",
+};
+
+interface InboxFilterListProps {
+  readonly filters: readonly InboxFilterViewModel[];
+  readonly activeFilter: InboxFilterId;
+  readonly onFilterChange: (id: InboxFilterId) => void;
+  readonly projects: readonly InboxActiveProjectOption[];
+  readonly selectedProjectId: string | null;
+  readonly onProjectChange: (id: string | null) => void;
+}
+
+export function InboxFilterList({
+  filters,
+  activeFilter,
+  onFilterChange,
+  projects,
+  selectedProjectId,
+  onProjectChange,
+}: InboxFilterListProps) {
+  return (
+    <div className="px-3 pb-3 pt-2">
+      <SectionLabel as="h2" className="px-1 pb-1.5">
+        State
+      </SectionLabel>
+      <ul className="flex flex-col gap-0.5">
+        {filters.map((filter) => {
+          const tone = FILTER_TONE[filter.id];
+          const isActive = filter.id === activeFilter;
+          const showDot = !isActive && tone !== "slate";
+          return (
+            <li key={filter.id}>
+              <button
+                type="button"
+                onClick={() => {
+                  onFilterChange(filter.id);
+                }}
+                aria-pressed={isActive}
+                className={cn(
+                  "group flex w-full items-center gap-2 rounded-md px-2 py-1 text-left text-[12.5px] transition-colors duration-150",
+                  isActive
+                    ? "bg-slate-900 text-white"
+                    : "text-slate-700 hover:bg-slate-50",
+                )}
+              >
+                {showDot ? (
+                  <span
+                    aria-hidden="true"
+                    className={`h-1.5 w-1.5 shrink-0 rounded-full ${TONE_CLASSES[tone].dot}`}
+                  />
+                ) : (
+                  <span aria-hidden="true" className="h-1.5 w-1.5 shrink-0" />
+                )}
+                <span
+                  className={cn(
+                    "flex-1 truncate",
+                    isActive ? "font-medium" : "",
+                  )}
+                >
+                  {filter.label}
+                </span>
+                <span
+                  className={cn(
+                    "tabular-nums text-[11.5px]",
+                    isActive ? "text-slate-300" : "text-slate-400",
+                  )}
+                >
+                  {filter.count}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      {projects.length > 0 ? (
+        <>
+          <SectionLabel as="h2" className="mt-3 border-t border-slate-100 px-1 pb-1.5 pt-3">
+            Project
+          </SectionLabel>
+          <ul className="flex flex-col gap-0.5">
+            <li>
+              <button
+                type="button"
+                onClick={() => {
+                  onProjectChange(null);
+                }}
+                aria-pressed={selectedProjectId === null}
+                className={cn(
+                  "group flex w-full items-center gap-2 rounded-md px-2 py-1 text-left text-[12.5px] transition-colors duration-150",
+                  selectedProjectId === null
+                    ? "bg-slate-100 font-medium text-slate-900"
+                    : "text-slate-700 hover:bg-slate-50",
+                )}
+              >
+                <span aria-hidden="true" className="h-1.5 w-1.5 shrink-0" />
+                <span className="flex-1 truncate">All projects</span>
+              </button>
+            </li>
+            {projects.map((project) => {
+              const tone = projectToneFromName(project.name);
+              const isActive = selectedProjectId === project.id;
+              return (
+                <li key={project.id}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onProjectChange(project.id);
+                    }}
+                    aria-pressed={isActive}
+                    className={cn(
+                      "group flex w-full items-center gap-2 rounded-md px-2 py-1 text-left text-[12.5px] transition-colors duration-150",
+                      isActive
+                        ? "bg-slate-100 font-medium text-slate-900"
+                        : "text-slate-700 hover:bg-slate-50",
+                    )}
+                  >
+                    <span
+                      aria-hidden="true"
+                      className={`h-1.5 w-1.5 shrink-0 rounded-full ${TONE_CLASSES[tone].dot}`}
+                    />
+                    <span className="flex-1 truncate">{project.name}</span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+          {/*
+            TODO(B3): expose per-project unread + follow-up counts in the
+            view-model so we can show them inline. With paginated data we
+            can't compute accurately client-side; rather than show a
+            misleading partial count we omit them.
+          */}
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/inbox/_components/inbox-list.tsx
+++ b/apps/web/app/inbox/_components/inbox-list.tsx
@@ -13,19 +13,9 @@ import {
 
 import type { InboxFilterId, InboxListViewModel } from "../_lib/view-models";
 import { fetchInboxListPage } from "../_lib/client-api";
-import { DISPLAY_INBOX_FILTERS } from "../_lib/filters";
 import { shouldApplyUrlSearchQuery } from "../_lib/search-sync";
-import { Collapsible, CollapsibleContent } from "@/components/ui/collapsible";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { cn } from "@/lib/utils";
 
 import { extractInboxContactId } from "./inbox-keyboard-helpers";
@@ -36,20 +26,17 @@ import {
   LAYOUT,
   RADIUS,
   SHADOW,
-  TEXT,
   TRANSITION,
-} from "@/app/_lib/design-tokens";
+  TYPE,
+} from "@/app/_lib/design-tokens-v2";
 import {
-  ChevronDownIcon,
-  FilterIcon,
   InboxIcon,
   PencilIcon,
   SearchIcon,
   SearchXIcon,
   XIcon,
 } from "./icons";
-
-const ALL_PROJECTS_VALUE = "__all__";
+import { InboxFilterList } from "./inbox-filter-list";
 import { QueueLoadingSkeleton } from "./inbox-loading";
 import { InboxRow } from "./inbox-row";
 
@@ -58,15 +45,7 @@ interface ListColumnProps {
   readonly initialFilterId?: InboxFilterId;
 }
 
-const DISPLAY_FILTER_IDS: readonly InboxFilterId[] = DISPLAY_INBOX_FILTERS.map(
-  (filter) => filter.id,
-);
-
-const DEFAULT_TITLE = "Inbox";
-
-function isDisplayFilterId(value: string): value is InboxFilterId {
-  return DISPLAY_FILTER_IDS.includes(value as InboxFilterId);
-}
+const TITLE = "Inbox";
 
 export function InboxList({
   initialList,
@@ -85,28 +64,30 @@ export function InboxList({
     openNewDraft,
   } = useInboxClient();
   const urlQuery = searchParams.get("q") ?? "";
+  const urlProjectId = searchParams.get("projectId");
   const deferredQuery = useDeferredValue(search.query);
   const normalizedQuery = deferredQuery.trim();
   const isServerSearchActive = normalizedQuery.length > 0;
-  const [activeFilter, setActiveFilter] =
-    useState<InboxFilterId>(initialFilterId);
+  const [activeFilter, setActiveFilter] = useState(initialFilterId);
   const [selectedProjectId, setSelectedProjectId] = useState(
-    initialList.selectedProjectId ?? null,
+    urlProjectId ?? initialList.selectedProjectId ?? null,
   );
   const [currentList, setCurrentList] = useState(initialList);
   const [queueError, setQueueError] = useState<string | null>(null);
   const [isFilterTransitionPending, startFilterTransition] = useTransition();
-  const [filterPanelOpen, setFilterPanelOpen] = useState(false);
   const activeRequestIdRef = useRef(0);
   const listViewportRef = useRef<HTMLDivElement | null>(null);
   const loadMoreSentinelRef = useRef<HTMLDivElement | null>(null);
   const pendingAppendCursorRef = useRef<string | null>(null);
-  const previousFilterRef = useRef<InboxFilterId>(initialFilterId);
-  const previousProjectIdRef = useRef<string | null>(null);
+  const previousFilterRef = useRef(initialFilterId);
+  const previousProjectIdRef = useRef(
+    urlProjectId ?? initialList.selectedProjectId ?? null,
+  );
   const previousUrlQueryRef = useRef(urlQuery);
+  const previousUrlProjectIdRef = useRef(urlProjectId);
   const latestShellStateRef = useRef({
     activeFilter: initialFilterId,
-    selectedProjectId: initialList.selectedProjectId ?? null,
+    selectedProjectId: urlProjectId ?? initialList.selectedProjectId ?? null,
     initialList,
   });
   const listFreshnessKey = `${initialList.freshness.latestUpdatedAt ?? "none"}:${initialList.freshness.total.toString()}`;
@@ -142,6 +123,16 @@ export function InboxList({
       setSearchQuery(urlQuery);
     }
   }, [search.query, setSearchQuery, urlQuery]);
+
+  // Sync URL projectId → state on external URL changes (e.g. welcome card click)
+  useEffect(() => {
+    if (urlProjectId === previousUrlProjectIdRef.current) {
+      return;
+    }
+
+    previousUrlProjectIdRef.current = urlProjectId;
+    setSelectedProjectId(urlProjectId);
+  }, [urlProjectId]);
 
   useEffect(() => {
     const currentUrlQuery = urlQuery.trim();
@@ -317,22 +308,6 @@ export function InboxList({
     });
   }, [isServerSearchActive, listFreshnessKey, loadFilterPage, normalizedQuery]);
 
-  const filterLabels = useMemo(
-    () =>
-      new Map(
-        currentList.filters.map((filter) => [filter.id, filter.label] as const),
-      ),
-    [currentList.filters],
-  );
-
-  const filterCounts = useMemo(
-    () =>
-      Object.fromEntries(
-        currentList.filters.map((filter) => [filter.id, filter.count] as const),
-      ) as Record<InboxFilterId, number>,
-    [currentList.filters],
-  );
-
   const displayItems = currentList.items;
 
   const shouldShowInitialSkeleton =
@@ -342,19 +317,38 @@ export function InboxList({
   const isLoadingMore =
     isQueueLoading && pendingAppendCursorRef.current !== null;
   const activeProjects = currentList.activeProjects;
-  const selectedProjectName =
-    selectedProjectId === null
-      ? null
-      : (activeProjects.find((project) => project.id === selectedProjectId)
-          ?.name ?? null);
-  const filterLabel =
-    filterLabels.get(activeFilter) ??
-    DISPLAY_INBOX_FILTERS.find((filter) => filter.id === activeFilter)?.label ??
-    DEFAULT_TITLE;
-  const titleLabel =
-    selectedProjectName === null
-      ? filterLabel
-      : `${filterLabel} · ${selectedProjectName}`;
+
+  const handleFilterChange = useCallback(
+    (id: InboxFilterId) => {
+      startFilterTransition(() => {
+        setActiveFilter(id);
+      });
+    },
+    [startFilterTransition],
+  );
+
+  const handleProjectChange = useCallback(
+    (id: string | null) => {
+      startFilterTransition(() => {
+        setSelectedProjectId(id);
+      });
+
+      const nextParams = new URLSearchParams(searchParams.toString());
+      if (id === null) {
+        nextParams.delete("projectId");
+      } else {
+        nextParams.set("projectId", id);
+      }
+
+      const nextQueryString = nextParams.toString();
+      const nextHref =
+        nextQueryString.length === 0 ? pathname : `${pathname}?${nextQueryString}`;
+
+      previousUrlProjectIdRef.current = id;
+      router.replace(nextHref, { scroll: false });
+    },
+    [pathname, router, searchParams, startFilterTransition],
+  );
 
   useEffect(() => {
     const root = listViewportRef.current;
@@ -423,8 +417,8 @@ export function InboxList({
         <div
           className={`flex ${LAYOUT.headerHeight} items-center gap-2 border-b border-slate-200 px-5`}
         >
-          <h1 className={`min-w-0 flex-1 truncate ${TEXT.headingLg}`}>
-            {titleLabel}
+          <h1 className={`min-w-0 flex-1 truncate ${TYPE.headingLg}`}>
+            {TITLE}
           </h1>
           <Button
             type="button"
@@ -438,28 +432,6 @@ export function InboxList({
           >
             <PencilIcon aria-hidden="true" data-icon="inline-start" />
           </Button>
-          <button
-            type="button"
-            aria-label={filterPanelOpen ? "Close filters" : "Open filters"}
-            aria-expanded={filterPanelOpen}
-            aria-controls="inbox-filter-panel"
-            onClick={() => {
-              setFilterPanelOpen((open) => !open);
-            }}
-            className={cn(
-              `relative inline-flex h-8 w-8 shrink-0 items-center justify-center ${RADIUS.md} border`,
-              "transition-[color,background-color,transform] duration-150 ease-out",
-              "active:scale-[0.96]",
-              "after:absolute after:-inset-1 after:content-['']",
-              TRANSITION.reduceMotion,
-              FOCUS_RING,
-              filterPanelOpen
-                ? "border-slate-300 bg-slate-100 text-slate-900"
-                : "border-slate-200 bg-white text-slate-500 hover:bg-slate-50 hover:text-slate-900",
-            )}
-          >
-            <FilterIcon className="h-4 w-4" />
-          </button>
         </div>
 
         <div className="px-5 pb-3 pt-3">
@@ -489,6 +461,7 @@ export function InboxList({
                   "transition-[color,transform] duration-150 ease-out active:scale-[0.96]",
                   "after:absolute after:-inset-2.5 after:content-['']",
                   TRANSITION.reduceMotion,
+                  FOCUS_RING,
                 )}
               >
                 <XIcon className="h-3.5 w-3.5" />
@@ -497,106 +470,16 @@ export function InboxList({
           </label>
         </div>
 
-        <Collapsible open={filterPanelOpen} onOpenChange={setFilterPanelOpen}>
-          <CollapsibleContent
-            id="inbox-filter-panel"
-            className="border-t border-slate-100 px-5 pb-3 pt-3"
-          >
-            <div className="flex flex-col gap-3">
-              <ToggleGroup
-                type="single"
-                value={activeFilter}
-                aria-label="Inbox mode"
-                variant="outline"
-                size="sm"
-                onValueChange={(value) => {
-                  if (typeof value !== "string" || !isDisplayFilterId(value)) {
-                    return;
-                  }
-
-                  startFilterTransition(() => {
-                    setActiveFilter(value);
-                  });
-                }}
-                className="grid grid-cols-2 rounded-md border border-slate-200 bg-slate-50 p-1"
-              >
-                {DISPLAY_FILTER_IDS.map((id) => {
-                  const showCount = id !== "all";
-                  return (
-                    <ToggleGroupItem
-                      key={id}
-                      value={id}
-                      aria-label={`Show ${filterLabels.get(id) ?? id}`}
-                      className={cn(
-                        "justify-between border-0 bg-transparent px-2.5 text-xs shadow-none",
-                        "data-[state=on]:bg-white data-[state=on]:text-slate-900 data-[state=on]:shadow-sm",
-                        "text-slate-600 hover:bg-white/70 hover:text-slate-900",
-                      )}
-                    >
-                      <span className="truncate">{filterLabels.get(id) ?? id}</span>
-                      {showCount ? (
-                        <span className="ml-2 tabular-nums text-slate-400">
-                          {filterCounts[id]}
-                        </span>
-                      ) : null}
-                    </ToggleGroupItem>
-                  );
-                })}
-              </ToggleGroup>
-
-              <div>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <button
-                      type="button"
-                      aria-label="Filter by project"
-                      className={cn(
-                        `flex w-full items-center gap-2 ${RADIUS.md} border border-slate-200 bg-white px-3 py-1.5 text-sm ${SHADOW.sm}`,
-                        "transition-[color,background-color,border-color,transform] duration-150 ease-out",
-                        "active:scale-[0.96]",
-                        TRANSITION.reduceMotion,
-                        FOCUS_RING,
-                        "hover:border-slate-300 hover:bg-slate-50",
-                      )}
-                    >
-                      <span className="flex-1 truncate text-left text-slate-900">
-                        {selectedProjectName ?? "All projects"}
-                      </span>
-                      <ChevronDownIcon className="h-3.5 w-3.5 shrink-0 text-slate-400" />
-                    </button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent
-                    align="start"
-                    className="max-h-64 w-[18rem] overflow-y-auto"
-                  >
-                    <DropdownMenuRadioGroup
-                      value={selectedProjectId ?? ALL_PROJECTS_VALUE}
-                      onValueChange={(value) => {
-                        startFilterTransition(() => {
-                          setSelectedProjectId(
-                            value === ALL_PROJECTS_VALUE ? null : value,
-                          );
-                        });
-                      }}
-                    >
-                      <DropdownMenuRadioItem value={ALL_PROJECTS_VALUE}>
-                        All projects
-                      </DropdownMenuRadioItem>
-                      {activeProjects.map((project) => (
-                        <DropdownMenuRadioItem
-                          key={project.id}
-                          value={project.id}
-                        >
-                          <span className="truncate">{project.name}</span>
-                        </DropdownMenuRadioItem>
-                      ))}
-                    </DropdownMenuRadioGroup>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
-            </div>
-          </CollapsibleContent>
-        </Collapsible>
+        <div className="border-t border-slate-100">
+          <InboxFilterList
+            filters={currentList.filters}
+            activeFilter={activeFilter}
+            onFilterChange={handleFilterChange}
+            projects={activeProjects}
+            selectedProjectId={selectedProjectId}
+            onProjectChange={handleProjectChange}
+          />
+        </div>
 
         {queueError ? (
           <div className="border-t border-rose-100 bg-rose-50 px-5 py-2 text-xs text-rose-700">

--- a/apps/web/app/inbox/_components/inbox-row.tsx
+++ b/apps/web/app/inbox/_components/inbox-row.tsx
@@ -7,7 +7,8 @@ import { useCallback, useRef } from "react";
 import type { InboxListItemViewModel } from "../_lib/view-models";
 import { InboxAvatar } from "./inbox-avatar";
 import { MailIcon, PhoneIcon } from "./icons";
-import { FOCUS_RING, SPACING, TEXT, TRANSITION } from "@/app/_lib/design-tokens";
+import { FOCUS_RING, SPACING, TRANSITION, TYPE, TONE_CLASSES } from "@/app/_lib/design-tokens-v2";
+import { projectToneFromName } from "../_lib/project-tone";
 
 interface RowProps {
   readonly item: InboxListItemViewModel;
@@ -108,16 +109,28 @@ export function InboxRow({ item, isActive }: RowProps) {
             </p>
           </div>
 
-          <p className={`mt-0.5 line-clamp-1 ${TEXT.caption}`}>
+          <p className={`mt-0.5 line-clamp-1 ${TYPE.caption}`}>
             {item.snippet}
           </p>
 
           {showBadges ? (
             <div className="mt-1.5 flex items-center gap-1.5">
               {item.projectLabel ? (
-                <span className="inline-flex items-center rounded-md bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium text-slate-600">
-                  {item.projectLabel}
-                </span>
+                (() => {
+                  const tone = projectToneFromName(item.projectLabel);
+                  const t = TONE_CLASSES[tone];
+                  return (
+                    <span
+                      className={`inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] font-medium ${t.subtle} ${t.subtleText}`}
+                    >
+                      <span
+                        aria-hidden="true"
+                        className={`h-1 w-1 rounded-full ${t.dot}`}
+                      />
+                      {item.projectLabel}
+                    </span>
+                  );
+                })()
               ) : null}
               {item.needsFollowUp ? (
                 <span className="inline-flex items-center rounded-md bg-rose-100 px-1.5 py-0.5 text-[10px] font-medium text-rose-700">

--- a/apps/web/app/inbox/_components/inbox-welcome-workload.tsx
+++ b/apps/web/app/inbox/_components/inbox-welcome-workload.tsx
@@ -8,7 +8,6 @@ import {
   LAYOUT,
   TONE_CLASSES,
   TYPE,
-  type ToneNameV2,
 } from "@/app/_lib/design-tokens-v2";
 import { cn } from "@/lib/utils";
 
@@ -17,38 +16,12 @@ import type {
   InboxWelcomeWorkloadViewModel,
 } from "../_lib/view-models";
 import { FIELD_QUOTES } from "../_lib/field-quotes";
+import { projectToneFromName } from "../_lib/project-tone";
 import { ArrowUpRightIcon, QuoteIcon, RefreshCwIcon } from "./icons";
 
 interface InboxWelcomeWorkloadProps {
   readonly workload: InboxWelcomeWorkloadViewModel;
   readonly firstName: string;
-}
-
-const PROJECT_TONE_PALETTE: readonly ToneNameV2[] = [
-  "sky",
-  "indigo",
-  "emerald",
-  "amber",
-  "rose",
-  "violet",
-  "teal",
-  "slate",
-];
-
-/**
- * Pure deterministic project tone derived from projectId so the same project
- * always gets the same color across surfaces (welcome screen, sidebar list,
- * contact rail). Until the view model exposes a real `tone` field this acts
- * as a stable proxy.
- */
-function projectTone(projectId: string): ToneNameV2 {
-  let hash = 0;
-  for (let i = 0; i < projectId.length; i += 1) {
-    hash = (hash * 31 + projectId.charCodeAt(i)) >>> 0;
-  }
-  return (
-    PROJECT_TONE_PALETTE[hash % PROJECT_TONE_PALETTE.length] ?? "slate"
-  );
 }
 
 function formatDay(date: Date): string {
@@ -180,7 +153,7 @@ function ProjectMiniDashboard({
       <SectionLabel as="h2">Active project workload</SectionLabel>
       <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
         {projects.map((project) => {
-          const tone = projectTone(project.projectId);
+          const tone = projectToneFromName(project.projectName);
           const t = TONE_CLASSES[tone];
           return (
             <button

--- a/apps/web/app/inbox/_components/inbox-welcome-workload.tsx
+++ b/apps/web/app/inbox/_components/inbox-welcome-workload.tsx
@@ -1,147 +1,257 @@
-import { EmptyState } from "@/components/ui/empty-state";
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
 import { SectionLabel } from "@/components/ui/section-label";
 import {
   LAYOUT,
-  RADIUS,
-  SHADOW,
-  TEXT,
-} from "@/app/_lib/design-tokens";
+  TONE_CLASSES,
+  TYPE,
+  type ToneNameV2,
+} from "@/app/_lib/design-tokens-v2";
+import { cn } from "@/lib/utils";
 
-import type { InboxWelcomeWorkloadViewModel } from "../_lib/view-models";
-import { CheckCircleIcon, InboxIcon } from "./icons";
+import type {
+  InboxWelcomeProjectWorkloadViewModel,
+  InboxWelcomeWorkloadViewModel,
+} from "../_lib/view-models";
+import { FIELD_QUOTES } from "../_lib/field-quotes";
+import { ArrowUpRightIcon, QuoteIcon, RefreshCwIcon } from "./icons";
 
 interface InboxWelcomeWorkloadProps {
   readonly workload: InboxWelcomeWorkloadViewModel;
+  readonly firstName: string;
 }
 
-function formatCount(value: number): string {
-  return value.toLocaleString("en-US");
+const PROJECT_TONE_PALETTE: readonly ToneNameV2[] = [
+  "sky",
+  "indigo",
+  "emerald",
+  "amber",
+  "rose",
+  "violet",
+  "teal",
+  "slate",
+];
+
+/**
+ * Pure deterministic project tone derived from projectId so the same project
+ * always gets the same color across surfaces (welcome screen, sidebar list,
+ * contact rail). Until the view model exposes a real `tone` field this acts
+ * as a stable proxy.
+ */
+function projectTone(projectId: string): ToneNameV2 {
+  let hash = 0;
+  for (let i = 0; i < projectId.length; i += 1) {
+    hash = (hash * 31 + projectId.charCodeAt(i)) >>> 0;
+  }
+  return (
+    PROJECT_TONE_PALETTE[hash % PROJECT_TONE_PALETTE.length] ?? "slate"
+  );
 }
 
-function formatWorkSummary(workload: InboxWelcomeWorkloadViewModel): string {
-  if (workload.totals.activeProjects === 0) {
-    return "No active projects are currently enabled.";
-  }
-
-  if (workload.totals.unread === 0 && workload.totals.needsFollowUp === 0) {
-    return "No unread or follow-up work across active projects.";
-  }
-
-  const unread =
-    workload.totals.unread === 1
-      ? "1 unread conversation"
-      : `${formatCount(workload.totals.unread)} unread conversations`;
-  const followUp =
-    workload.totals.needsFollowUp === 1
-      ? "1 needs follow-up"
-      : `${formatCount(workload.totals.needsFollowUp)} need follow-up`;
-
-  return `${unread}; ${followUp}.`;
+function formatDay(date: Date): string {
+  return date.toLocaleDateString("en-US", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+  });
 }
 
 export function InboxWelcomeWorkload({
   workload,
+  firstName,
 }: InboxWelcomeWorkloadProps) {
+  const router = useRouter();
+  const today = new Date();
+  const initialQuoteIdx = today.getDate() % FIELD_QUOTES.length;
+  const [quoteIdx, setQuoteIdx] = useState(initialQuoteIdx);
+  const quote = FIELD_QUOTES[quoteIdx] ?? FIELD_QUOTES[0];
+
+  const cycleQuote = () => {
+    setQuoteIdx((current) => (current + 1) % FIELD_QUOTES.length);
+  };
+
+  const openProject = (projectId: string) => {
+    router.push(`/inbox?projectId=${encodeURIComponent(projectId)}`);
+  };
+
   return (
-    <section className="flex min-h-0 flex-1 flex-col bg-slate-50">
+    <section className="flex min-h-0 flex-1 flex-col overflow-y-auto bg-slate-50/40">
       <header
-        className={`flex ${LAYOUT.headerHeight} items-center border-b border-slate-200 bg-white px-6`}
+        className={`flex ${LAYOUT.headerHeight} shrink-0 items-center border-b border-slate-200 bg-white px-10`}
       >
-        <div className="min-w-0">
-          <h1 className={TEXT.headingLg}>Welcome Sam!</h1>
-          <p className="mt-0.5 text-xs text-slate-500">
-            Active project workload from inbox projections.
-          </p>
+        <div className="flex w-full items-baseline justify-between gap-4">
+          <div className="min-w-0">
+            <h1 className="truncate text-[22px] font-semibold tracking-tight text-slate-900">
+              Welcome back, {firstName}
+            </h1>
+            <p className={`mt-1 ${TYPE.caption}`}>Today is {formatDay(today)}</p>
+          </div>
+          <p className={`shrink-0 ${TYPE.caption}`}>Last synced just now</p>
         </div>
       </header>
 
-      <div className="min-h-0 flex-1 overflow-y-auto">
-        <div className="mx-auto flex w-full max-w-3xl flex-col gap-5 px-6 py-8">
-          <div className="flex flex-col gap-1">
-            <SectionLabel as="h2">Today</SectionLabel>
-            <p className={TEXT.bodySm}>{formatWorkSummary(workload)}</p>
-          </div>
+      <div className="mx-auto w-full max-w-[920px] space-y-8 px-10 py-8">
+        <QuoteCard
+          quoteText={quote?.text ?? ""}
+          author={quote?.author ?? ""}
+          onCycle={cycleQuote}
+        />
 
-          {workload.projects.length === 0 ? (
-            <div
-              className={`${RADIUS.md} border border-slate-200 bg-white ${SHADOW.sm}`}
-            >
-              <EmptyState
-                icon={<InboxIcon className="h-6 w-6" />}
-                title="No active project workload"
-                description="Activate projects in Settings to show unread and follow-up counts here."
-              />
-            </div>
-          ) : (
-            <div
-              className={`overflow-hidden ${RADIUS.md} border border-slate-200 bg-white ${SHADOW.sm}`}
-            >
-              <div className="flex items-center gap-2 border-b border-slate-100 bg-slate-50 px-4 py-3">
-                <CheckCircleIcon className="h-4 w-4 text-emerald-600" />
-                <p className="text-xs font-medium text-slate-600">
-                  Active projects only
-                </p>
-              </div>
-
-              <table className="w-full table-fixed text-left text-sm">
-                <thead>
-                  <tr className="border-b border-slate-100">
-                    <th
-                      scope="col"
-                      className="px-4 py-2.5 text-xs font-medium text-slate-500"
-                    >
-                      Project
-                    </th>
-                    <th
-                      scope="col"
-                      className="w-24 px-4 py-2.5 text-right text-xs font-medium text-slate-500"
-                    >
-                      Unread
-                    </th>
-                    <th
-                      scope="col"
-                      className="w-36 px-4 py-2.5 text-right text-xs font-medium text-slate-500"
-                    >
-                      Needs Follow-Up
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-slate-100">
-                  {workload.projects.map((project) => {
-                    const hasWork =
-                      project.unreadCount > 0 ||
-                      project.needsFollowUpCount > 0;
-
-                    return (
-                      <tr key={project.projectId}>
-                        <th
-                          scope="row"
-                          className="min-w-0 px-4 py-3 text-sm font-medium text-slate-900"
-                        >
-                          <span className="block truncate">
-                            {project.projectName}
-                          </span>
-                          {!hasWork ? (
-                            <span className="mt-0.5 block text-xs font-normal text-slate-400">
-                              No active queue items
-                            </span>
-                          ) : null}
-                        </th>
-                        <td className="px-4 py-3 text-right text-sm tabular-nums text-slate-700">
-                          {formatCount(project.unreadCount)}
-                        </td>
-                        <td className="px-4 py-3 text-right text-sm tabular-nums text-slate-700">
-                          {formatCount(project.needsFollowUpCount)}
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </div>
+        <ProjectMiniDashboard
+          projects={workload.projects}
+          onOpenProject={openProject}
+        />
       </div>
     </section>
+  );
+}
+
+interface QuoteCardProps {
+  readonly quoteText: string;
+  readonly author: string;
+  readonly onCycle: () => void;
+}
+
+function QuoteCard({ quoteText, author, onCycle }: QuoteCardProps) {
+  return (
+    <div className="group relative overflow-hidden rounded-xl border border-slate-200 bg-white">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 opacity-[0.04]"
+        style={{
+          backgroundImage:
+            "radial-gradient(circle at 20% 30%, #0ea5a4 0%, transparent 40%), radial-gradient(circle at 80% 70%, #6366f1 0%, transparent 40%)",
+        }}
+      />
+      <div className="relative flex items-start gap-5 p-7">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-teal-50 text-teal-700">
+          <QuoteIcon className="h-5 w-5" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <SectionLabel as="h2" className="text-teal-700">
+            Field note of the day
+          </SectionLabel>
+          <blockquote className="mt-2 font-message-body text-[19px] leading-snug text-slate-900">
+            &ldquo;{quoteText}&rdquo;
+          </blockquote>
+          <p className={`mt-2 ${TYPE.caption}`}>— {author}</p>
+        </div>
+        <button
+          type="button"
+          aria-label="Show another quote"
+          onClick={onCycle}
+          className="text-slate-400 opacity-0 transition-opacity duration-150 hover:text-slate-700 group-hover:opacity-100"
+        >
+          <RefreshCwIcon className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface ProjectMiniDashboardProps {
+  readonly projects: readonly InboxWelcomeProjectWorkloadViewModel[];
+  readonly onOpenProject: (projectId: string) => void;
+}
+
+function ProjectMiniDashboard({
+  projects,
+  onOpenProject,
+}: ProjectMiniDashboardProps) {
+  if (projects.length === 0) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white px-7 py-10 text-center">
+        <SectionLabel as="h2" className="text-slate-500">
+          Active project workload
+        </SectionLabel>
+        <p className={`mt-2 ${TYPE.caption}`}>
+          No active projects are currently enabled. Activate projects in
+          Settings to surface unread and follow-up counts here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <SectionLabel as="h2">Active project workload</SectionLabel>
+      <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {projects.map((project) => {
+          const tone = projectTone(project.projectId);
+          const t = TONE_CLASSES[tone];
+          return (
+            <button
+              key={project.projectId}
+              type="button"
+              onClick={() => {
+                onOpenProject(project.projectId);
+              }}
+              className="group relative overflow-hidden rounded-xl border border-slate-200 bg-white p-4 text-left transition-all duration-200 hover:border-slate-300 hover:shadow-sm"
+            >
+              <span
+                aria-hidden="true"
+                className={`absolute left-0 top-0 h-full w-1 ${t.bg}`}
+              />
+              <div className="flex items-start justify-between gap-2 pl-2">
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span
+                      aria-hidden="true"
+                      className={`h-1.5 w-1.5 shrink-0 rounded-full ${t.dot}`}
+                    />
+                    <span className={`${TYPE.headingSm} truncate`}>
+                      {project.projectName}
+                    </span>
+                  </div>
+                </div>
+                <ArrowUpRightIcon className="h-3.5 w-3.5 shrink-0 text-slate-300 transition-colors group-hover:text-slate-600" />
+              </div>
+
+              <div className="mt-4 grid grid-cols-2 gap-2 pl-2">
+                <Stat
+                  label="Unread"
+                  value={project.unreadCount}
+                  emphasis={project.unreadCount > 0}
+                  tone="slate"
+                />
+                <Stat
+                  label="Follow-up"
+                  value={project.needsFollowUpCount}
+                  emphasis={project.needsFollowUpCount > 0}
+                  tone="amber"
+                />
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+interface StatProps {
+  readonly label: string;
+  readonly value: number;
+  readonly emphasis: boolean;
+  readonly tone: "slate" | "amber";
+}
+
+function Stat({ label, value, emphasis, tone }: StatProps) {
+  const valueClass = emphasis
+    ? tone === "amber"
+      ? "text-amber-700"
+      : "text-slate-900"
+    : "text-slate-300";
+
+  return (
+    <div className="flex items-baseline gap-1.5">
+      <span className={cn("text-xl font-semibold tabular-nums", valueClass)}>
+        {value.toLocaleString("en-US")}
+      </span>
+      <span className={TYPE.micro}>{label}</span>
+    </div>
   );
 }

--- a/apps/web/app/inbox/_lib/field-quotes.ts
+++ b/apps/web/app/inbox/_lib/field-quotes.ts
@@ -1,0 +1,103 @@
+/**
+ * Field notes — curated nature/field-research quotes rotated daily on the
+ * inbox welcome screen. Pure FE constant; no I/O.
+ *
+ * Selection: `today.getDate() % FIELD_QUOTES.length`. Refresh button cycles
+ * deterministically through the list.
+ */
+
+export interface FieldQuote {
+  readonly text: string;
+  readonly author: string;
+}
+
+export const FIELD_QUOTES: readonly FieldQuote[] = [
+  {
+    text: "In every walk with nature, one receives far more than they seek.",
+    author: "John Muir",
+  },
+  {
+    text: "The clearest way into the universe is through a forest wilderness.",
+    author: "John Muir",
+  },
+  {
+    text: "What we are doing to the forests of the world is but a mirror reflection of what we are doing to ourselves.",
+    author: "Mahatma Gandhi",
+  },
+  {
+    text: "We can never have enough of nature.",
+    author: "Henry David Thoreau",
+  },
+  {
+    text: "There is pleasure in the pathless woods, there is rapture on the lonely shore.",
+    author: "Lord Byron",
+  },
+  {
+    text: "Wilderness is not a luxury but a necessity of the human spirit.",
+    author: "Edward Abbey",
+  },
+  {
+    text: "The best time to plant a tree was twenty years ago. The second best time is now.",
+    author: "Chinese Proverb",
+  },
+  {
+    text: "I felt my lungs inflate with the onrush of scenery — air, mountains, trees, people.",
+    author: "Sylvia Plath",
+  },
+  {
+    text: "The mountains are calling and I must go.",
+    author: "John Muir",
+  },
+  {
+    text: "Look deep into nature, and then you will understand everything better.",
+    author: "Albert Einstein",
+  },
+  {
+    text: "Nature does not hurry, yet everything is accomplished.",
+    author: "Lao Tzu",
+  },
+  {
+    text: "The earth has music for those who listen.",
+    author: "George Santayana",
+  },
+  {
+    text: "To find the universal elements enough; to find the air and the water exhilarating.",
+    author: "John Burroughs",
+  },
+  {
+    text: "Adopt the pace of nature: her secret is patience.",
+    author: "Ralph Waldo Emerson",
+  },
+  {
+    text: "In nature, nothing is perfect and everything is perfect.",
+    author: "Alice Walker",
+  },
+  {
+    text: "The forest makes your heart gentle. You become one with it. No place for greed or anger there.",
+    author: "Pha Pachak",
+  },
+  {
+    text: "Heaven is under our feet as well as over our heads.",
+    author: "Henry David Thoreau",
+  },
+  {
+    text: "Time spent among trees is never time wasted.",
+    author: "Anonymous",
+  },
+  {
+    text: "If you truly love nature, you will find beauty everywhere.",
+    author: "Vincent van Gogh",
+  },
+  {
+    text: "Just living is not enough. One must have sunshine, freedom, and a little flower.",
+    author: "Hans Christian Andersen",
+  },
+  {
+    text: "Climb the mountains and get their good tidings. Nature's peace will flow into you as sunshine flows into trees.",
+    author: "John Muir",
+  },
+  {
+    text: "Conservation is a state of harmony between men and land.",
+    author: "Aldo Leopold",
+  },
+];

--- a/apps/web/app/inbox/_lib/project-tone.ts
+++ b/apps/web/app/inbox/_lib/project-tone.ts
@@ -1,0 +1,26 @@
+import type { ToneNameV2 } from "@/app/_lib/design-tokens-v2";
+
+const PROJECT_TONE_PALETTE: readonly ToneNameV2[] = [
+  "sky",
+  "indigo",
+  "emerald",
+  "amber",
+  "rose",
+  "violet",
+  "teal",
+  "slate",
+];
+
+/**
+ * Pure deterministic tone derived from a project name (or label, or any
+ * stable string). Same input always returns the same tone — used so the
+ * welcome screen, sidebar filter list, and inbox row badge agree on the
+ * color for a given project until the view-model exposes a real `tone` field.
+ */
+export function projectToneFromName(name: string): ToneNameV2 {
+  let hash = 0;
+  for (let i = 0; i < name.length; i += 1) {
+    hash = (hash * 31 + name.charCodeAt(i)) >>> 0;
+  }
+  return PROJECT_TONE_PALETTE[hash % PROJECT_TONE_PALETTE.length] ?? "slate";
+}

--- a/apps/web/app/inbox/page.tsx
+++ b/apps/web/app/inbox/page.tsx
@@ -1,8 +1,16 @@
+import { requireSession } from "@/src/server/auth/session";
+
 import { InboxWelcomeWorkload } from "./_components/inbox-welcome-workload";
 import { getInboxWelcomeWorkload } from "./_lib/selectors";
 
 export default async function InboxListPage() {
-  const workload = await getInboxWelcomeWorkload();
+  const [workload, currentUser] = await Promise.all([
+    getInboxWelcomeWorkload(),
+    requireSession(),
+  ]);
 
-  return <InboxWelcomeWorkload workload={workload} />;
+  const displayName = currentUser.name ?? currentUser.email;
+  const firstName = displayName.trim().split(/\s+/)[0] ?? "there";
+
+  return <InboxWelcomeWorkload workload={workload} firstName={firstName} />;
 }


### PR DESCRIPTION
## Summary

Pixel-perfect design v2 pass from the UI architect. Three surfaces shipped autonomously while their session was active:

- **Surface 2 — Sidebar / inbox-list filter (flat-list variant)**: replaces Collapsible+ToggleGroup+DropdownMenu with always-visible flat list per design. URL `?projectId=` sync (welcome card → filtered inbox). Per-project tone badges on rows. Extracts `InboxFilterList` + shared `projectToneFromName`.
- **Surface 3 — Contact rail visual polish**: phone fallback "No phone on file", status-tone dots, connector-line alignment, mono record ID, heading consistency. Tokens-v2 wiring. Expedition link wiring deferred to S3b (depends on B1).
- **Surface 4 — Welcome screen redesign**: quote card with daily rotation + refresh button, 2-col project mini-dashboard with tone-coded accent bars, operator first-name via `requireSession`. New `field-quotes.ts` (22 curated quotes).
- **Tokens-v2 foundation**: `apps/web/app/_lib/design-tokens-v2.ts` — unified `TONE_CLASSES` matching design's `primitives.jsx`. v1 file stays in place; piecewise migration as components ship.

## Why one PR not three

UI architect's brief recommended one-PR-per-surface for revertability. Combined here for speed (architect is offline; user wants everything on main on return). Each commit is independently revertable via git history.

## Verification

- `pnpm typecheck` ✅ (UI architect)
- `pnpm lint` ✅ (UI architect)
- `pnpm test:unit` blocked locally by macOS rollup; CI authoritative
- Visual review deferred (page is server-rendered, requires DB+Auth env)

## Tracker

`.handoff-ui-architect-pixel-perfect-2026-04-25.md` (in worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)