### PR TITLE
feat(ui): pixel-perfect timeline bubbles + categorical system dividers (S1)

### DIFF
--- a/apps/web/app/inbox/_components/email-participant-header.tsx
+++ b/apps/web/app/inbox/_components/email-participant-header.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useId, useState } from "react";
+
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+import { FOCUS_RING, TONE_CLASSES, TRANSITION, TYPE } from "@/app/_lib/design-tokens-v2";
+
+import type { InboxTimelineEntryViewModel } from "../_lib/view-models";
+import {
+  ArrowRightIcon,
+  ChevronDownIcon,
+  MailIcon,
+} from "./icons";
+
+const WRAP_ANYWHERE = "break-words [overflow-wrap:anywhere]";
+const EXACT_TIMESTAMP_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+  timeZone: "UTC",
+  timeZoneName: "short",
+});
+
+function formatExactTimestamp(timestamp: string): string {
+  return EXACT_TIMESTAMP_FORMATTER.format(new Date(timestamp));
+}
+
+function extractDisplayName(value: string | null): string | null {
+  if (value === null) {
+    return null;
+  }
+
+  const stripped = value.replace(/\s*<[^>]+>\s*/g, "").trim();
+  return stripped.length === 0 ? value.trim() : stripped;
+}
+
+function RelativeTimestamp({
+  timestamp,
+  label,
+  className,
+}: {
+  readonly timestamp: string;
+  readonly label: string;
+  readonly className?: string;
+}) {
+  const exactLabel = formatExactTimestamp(timestamp);
+
+  return (
+    <time
+      dateTime={timestamp}
+      title={exactLabel}
+      className={cn(
+        "cursor-help rounded-sm decoration-dotted underline-offset-2 hover:underline",
+        FOCUS_RING,
+        className,
+      )}
+    >
+      {label}
+    </time>
+  );
+}
+
+export function EmailParticipantHeader({
+  entry,
+  tone = "slate",
+}: {
+  readonly entry: InboxTimelineEntryViewModel;
+  readonly tone?: "slate" | "sky";
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const contentId = useId();
+
+  if (
+    entry.channel !== "email" ||
+    (entry.fromHeader === null &&
+      entry.toHeader === null &&
+      entry.ccHeader === null)
+  ) {
+    return null;
+  }
+
+  const rows = [
+    { label: "From", value: entry.fromHeader },
+    { label: "To", value: entry.toHeader },
+    { label: "Cc", value: entry.ccHeader },
+  ].filter(
+    (
+      row,
+    ): row is {
+      readonly label: "From" | "To" | "Cc";
+      readonly value: string;
+    } => row.value !== null,
+  );
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  const sender = extractDisplayName(entry.fromHeader) ?? entry.actorLabel;
+  const recipient = extractDisplayName(entry.toHeader) ?? "Unknown recipient";
+  const hasCc = entry.ccHeader !== null && entry.ccHeader.trim().length > 0;
+  const dividerClass =
+    tone === "sky" ? "border-sky-100 bg-sky-50/40" : "border-slate-100 bg-slate-50/40";
+  const ccTone = tone === "sky" ? TONE_CLASSES.sky : TONE_CLASSES.slate;
+
+  return (
+    <Collapsible open={expanded} onOpenChange={setExpanded}>
+      <div className="mb-2.5">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <div className="flex min-w-0 items-center gap-1.5">
+              <MailIcon className="h-3.5 w-3.5 shrink-0 text-slate-400" />
+              <span className="min-w-0 truncate text-[12.5px] font-medium text-slate-700">
+                {sender}
+              </span>
+              <ArrowRightIcon className="h-3 w-3 shrink-0 text-slate-300" />
+              <span className="min-w-0 truncate text-[12.5px] text-slate-600">
+                {recipient}
+              </span>
+              {hasCc ? (
+                <span
+                  className={cn(
+                    "shrink-0 rounded-md px-1.5 py-0.5 text-[10px] font-medium",
+                    ccTone.subtle,
+                    "text-slate-500",
+                  )}
+                >
+                  +cc
+                </span>
+              ) : null}
+              <CollapsibleTrigger
+                type="button"
+                aria-controls={contentId}
+                aria-label={expanded ? "Hide full email headers" : "Show full email headers"}
+                className={cn(
+                  "inline-flex shrink-0 items-center justify-center rounded-sm text-slate-400 hover:text-slate-700",
+                  FOCUS_RING,
+                  TRANSITION.fast,
+                  TRANSITION.reduceMotion,
+                )}
+              >
+                <ChevronDownIcon
+                  className={cn(
+                    "h-3 w-3 transition-transform duration-150",
+                    expanded && "rotate-180",
+                    TRANSITION.reduceMotion,
+                  )}
+                />
+              </CollapsibleTrigger>
+            </div>
+          </div>
+
+          <RelativeTimestamp
+            timestamp={entry.occurredAt}
+            label={entry.occurredAtLabel}
+            className={cn(TYPE.micro, "shrink-0 text-slate-400")}
+          />
+        </div>
+
+        <CollapsibleContent
+          id={contentId}
+          className={cn("mt-2.5 rounded-xl border px-3 py-2", dividerClass)}
+        >
+          <dl className="space-y-1 text-[11.5px] leading-relaxed text-slate-600">
+            {rows.map((row) => (
+              <div
+                key={row.label}
+                className="grid grid-cols-[2rem_minmax(0,1fr)] gap-2"
+              >
+                <dt className="font-medium text-slate-400">{row.label}</dt>
+                <dd className={cn("min-w-0 text-slate-700", WRAP_ANYWHERE)}>
+                  {row.value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  );
+}

--- a/apps/web/app/inbox/_components/icons.tsx
+++ b/apps/web/app/inbox/_components/icons.tsx
@@ -29,6 +29,7 @@ export {
   PanelRightOpen as PanelRightOpenIcon,
   PanelRightClose as PanelRightCloseIcon,
   CornerUpLeft as CornerUpLeftIcon,
+  ArrowRight as ArrowRightIcon,
   X as XIcon,
   LogOut as LogOutIcon,
   Loader2 as LoaderIcon,
@@ -63,4 +64,5 @@ export {
   MailOpen as MailOpenIcon,
   ArrowUpRight as ArrowUpRightIcon,
   Quote as QuoteIcon,
+  Database as DatabaseIcon,
 } from "lucide-react";

--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -27,18 +27,22 @@ import {
 } from "../actions";
 import { plaintextToComposerHtml } from "@/src/lib/html-sanitizer";
 import { fetchInboxTimelinePage } from "../_lib/client-api";
-import type { InboxDetailViewModel } from "../_lib/view-models";
+import type {
+  InboxComposerReplyContext,
+  InboxDetailViewModel,
+  InboxTimelineEntryViewModel,
+} from "../_lib/view-models";
 import type { UiError, UiResult } from "@/src/server/ui-result";
 import { InboxFreshnessPoller } from "./inbox-freshness-poller";
 import { useInboxClient, type Reminder } from "./inbox-client-provider";
 import { SectionLabel } from "@/components/ui/section-label";
 import {
   LAYOUT,
-  TEXT,
-  TONE,
-  TRANSITION,
   SPACING,
-} from "@/app/_lib/design-tokens";
+  TONE_CLASSES,
+  TRANSITION,
+  TYPE,
+} from "@/app/_lib/design-tokens-v2";
 import { InboxComposerReplyBar } from "./inbox-composer";
 import {
   InboxContactRail,
@@ -63,6 +67,47 @@ interface DetailProps {
 }
 
 type ReminderUnit = "hours" | "days" | "weeks";
+
+const REPLY_SUBJECT_PREFIX_PATTERN = /^\s*(?:(?:re|fwd?)\s*:\s*)+/i;
+
+function buildReplySubject(subject: string | null): string {
+  const normalizedSubject = subject?.trim() ?? "";
+
+  if (normalizedSubject.length === 0) {
+    return "";
+  }
+
+  const trimmedSubject = normalizedSubject
+    .replace(REPLY_SUBJECT_PREFIX_PATTERN, "")
+    .trim();
+
+  return trimmedSubject.length === 0 ? "" : `Re: ${trimmedSubject}`;
+}
+
+function buildTimelineReplyContext(input: {
+  readonly contactId: string;
+  readonly contactDisplayName: string;
+  readonly entry: InboxTimelineEntryViewModel;
+  readonly defaultAlias: string | null;
+}): InboxComposerReplyContext | null {
+  if (input.entry.channel !== "email") {
+    return null;
+  }
+
+  return {
+    contactId: input.contactId,
+    contactDisplayName: input.contactDisplayName,
+    subject: buildReplySubject(input.entry.subject),
+    threadCursor:
+      input.entry.kind === "inbound-email" ? input.entry.id : null,
+    threadId: input.entry.threadId,
+    inReplyToRfc822:
+      input.entry.kind === "inbound-email"
+        ? input.entry.rfc822MessageId
+        : input.entry.inReplyToRfc822,
+    defaultAlias: input.defaultAlias,
+  };
+}
 
 export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
   const { contact } = detail;
@@ -234,6 +279,37 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
   const isFollowUp = followUpToggle.value;
   const existingReminder = reminders.get(contact.contactId) ?? null;
   const composerReplyContext = detail.composerReplyContext;
+  const handleReply = useCallback(
+    (entryId: string) => {
+      const entry = timelineEntries.find((item) => item.id === entryId);
+
+      if (entry === undefined) {
+        if (composerReplyContext !== null) {
+          openReplyDraft(composerReplyContext);
+        }
+        return;
+      }
+
+      const replyContext =
+        buildTimelineReplyContext({
+          contactId: contact.contactId,
+          contactDisplayName: contact.displayName,
+          entry,
+          defaultAlias: composerReplyContext?.defaultAlias ?? null,
+        }) ?? composerReplyContext;
+
+      if (replyContext !== null) {
+        openReplyDraft(replyContext);
+      }
+    },
+    [
+      composerReplyContext,
+      contact.contactId,
+      contact.displayName,
+      openReplyDraft,
+      timelineEntries,
+    ],
+  );
 
   const handleSetReminder = () => {
     const numeric = Number(reminderValue);
@@ -318,7 +394,7 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
           className={`flex ${LAYOUT.headerHeight} items-center justify-between gap-4 border-b border-slate-200 px-6`}
         >
           <div className="flex min-w-0 items-center gap-4">
-            <h1 className={`truncate ${TEXT.headingLg}`}>
+            <h1 className={`truncate ${TYPE.headingLg}`}>
               {contact.displayName}
             </h1>
             <div className="hidden h-5 w-px bg-slate-200 sm:block" />
@@ -432,7 +508,7 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
 
         <div
           ref={timelineScrollRef}
-          className={`min-h-0 flex-1 overflow-y-auto ${TONE.slate.subtle} ${SPACING.container}`}
+          className={`min-h-0 flex-1 overflow-y-auto ${TONE_CLASSES.slate.subtle} ${SPACING.container}`}
         >
           {isTimelineLoading && timelineEntries.length === 0 ? (
             <TimelineSkeleton />
@@ -445,6 +521,7 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
               isLoadingOlder={isTimelineLoading}
               retryingEntryId={isRetryPending ? retryingEntryId : null}
               onRetryPending={handleRetryPending}
+              onReply={handleReply}
               onLoadOlder={() => {
                 void loadOlderTimeline();
               }}
@@ -606,7 +683,7 @@ function useOptimisticBooleanToggle({
 function UnresolvedBanner() {
   return (
     <div
-      className={`flex items-center gap-2 border-b border-amber-200 px-6 py-2.5 ${TONE.amber.subtle}`}
+      className={`flex items-center gap-2 border-b border-amber-200 px-6 py-2.5 ${TONE_CLASSES.amber.subtle}`}
       role="status"
     >
       <AlertTriangleIcon className="h-4 w-4 shrink-0 text-amber-600" />

--- a/apps/web/app/inbox/_components/inbox-timeline-automated-row.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-automated-row.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+import type { ComponentType } from "react";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { TRANSITION } from "@/app/_lib/design-tokens-v2";
+
+import type {
+  InboxTimelineEntryKind,
+  InboxTimelineEntryViewModel,
+} from "../_lib/view-models";
+import { autolinkText } from "./_autolink";
+import {
+  CheckCircleIcon,
+  ChevronRightIcon,
+  EyeIcon,
+  MailIcon,
+  MegaphoneIcon,
+  MousePointerClickIcon,
+  PhoneIcon,
+  WandIcon,
+  XIcon,
+  ZapIcon,
+} from "./icons";
+
+const WRAP_ANYWHERE = "break-words [overflow-wrap:anywhere]";
+const EXACT_TIMESTAMP_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+  timeZone: "UTC",
+  timeZoneName: "short",
+});
+
+function formatExactTimestamp(timestamp: string): string {
+  return EXACT_TIMESTAMP_FORMATTER.format(new Date(timestamp));
+}
+
+function RelativeTimestamp({
+  timestamp,
+  label,
+  className,
+}: {
+  readonly timestamp: string;
+  readonly label: string;
+  readonly className?: string;
+}) {
+  return (
+    <time
+      dateTime={timestamp}
+      title={formatExactTimestamp(timestamp)}
+      className={className}
+    >
+      {label}
+    </time>
+  );
+}
+
+function bodyTextForEntry(entry: InboxTimelineEntryViewModel): string {
+  return entry.body.trim();
+}
+
+interface EventRowDescriptor {
+  readonly label: string;
+  readonly Icon: ComponentType<{ className?: string }>;
+  readonly shellClassName: string;
+  readonly iconClassName: string;
+  readonly labelClassName: string;
+}
+
+function describeEventRow(input: {
+  readonly role: "automated" | "campaign" | "activity";
+  readonly isEmail: boolean;
+}): EventRowDescriptor {
+  if (input.role === "campaign") {
+    return {
+      label: input.isEmail ? "Campaign" : "Campaign SMS",
+      Icon: MegaphoneIcon,
+      shellClassName:
+        "border-violet-200/70 bg-violet-50/30 hover:bg-violet-50/60",
+      iconClassName: "border-violet-100 bg-violet-100 text-violet-700",
+      labelClassName: "text-violet-700",
+    };
+  }
+
+  if (input.role === "activity") {
+    return {
+      label: input.isEmail ? "Activity" : "SMS Activity",
+      Icon: input.isEmail ? MailIcon : PhoneIcon,
+      shellClassName: "border-violet-200 bg-violet-50/75 hover:bg-violet-50",
+      iconClassName: "border-violet-200 text-violet-700",
+      labelClassName: "text-violet-700",
+    };
+  }
+
+  return {
+    label: input.isEmail ? "Automated" : "Automated SMS",
+    Icon: input.isEmail ? ZapIcon : WandIcon,
+    shellClassName: "border-slate-200 bg-slate-50/40 hover:bg-slate-100/60",
+    iconClassName: "border-slate-100 bg-slate-100 text-slate-600",
+    labelClassName: "text-slate-500",
+  };
+}
+
+function describeCampaignVisualState(
+  activities: readonly {
+    readonly activityType: "sent" | "opened" | "clicked" | "unsubscribed";
+  }[],
+): "sent" | "opened" | "clicked" | "unsubscribed" {
+  if (activities.some((activity) => activity.activityType === "unsubscribed")) {
+    return "unsubscribed";
+  }
+
+  if (activities.some((activity) => activity.activityType === "clicked")) {
+    return "clicked";
+  }
+
+  if (activities.some((activity) => activity.activityType === "opened")) {
+    return "opened";
+  }
+
+  return "sent";
+}
+
+function CampaignStateIcon({
+  state,
+}: {
+  readonly state: ReturnType<typeof describeCampaignVisualState>;
+}) {
+  const AccentIcon =
+    state === "clicked"
+      ? MousePointerClickIcon
+      : state === "opened"
+        ? EyeIcon
+        : state === "unsubscribed"
+          ? XIcon
+          : null;
+
+  return (
+    <span className="relative inline-flex">
+      <MegaphoneIcon className="size-4" />
+      {AccentIcon ? (
+        <span className="absolute -right-1 -top-1 inline-flex size-3.5 items-center justify-center rounded-full border border-violet-200 bg-white text-violet-700 shadow-sm">
+          <AccentIcon className="size-2" />
+        </span>
+      ) : (
+        <span className="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-violet-500 ring-2 ring-white" />
+      )}
+    </span>
+  );
+}
+
+function CampaignStateBadge({
+  state,
+}: {
+  readonly state: ReturnType<typeof describeCampaignVisualState>;
+}) {
+  const label =
+    state === "clicked"
+      ? "Clicked"
+      : state === "opened"
+        ? "Opened"
+        : state === "unsubscribed"
+          ? "Unsubscribed"
+          : "Sent";
+  const Icon =
+    state === "clicked"
+      ? MousePointerClickIcon
+      : state === "opened"
+        ? EyeIcon
+        : state === "unsubscribed"
+          ? XIcon
+          : CheckCircleIcon;
+  const className =
+    state === "clicked"
+      ? "bg-emerald-50 text-emerald-700"
+      : state === "opened"
+        ? "bg-indigo-50 text-indigo-700"
+        : state === "unsubscribed"
+          ? "bg-rose-50 text-rose-700"
+          : "bg-slate-50 text-slate-700";
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium",
+        className,
+      )}
+    >
+      <Icon className="size-2.5" />
+      {label}
+    </span>
+  );
+}
+
+export function shouldHideAutomatedRowBody(input: {
+  readonly isExpanded: boolean;
+  readonly kind: InboxTimelineEntryKind;
+  readonly headline: string | null;
+}): boolean {
+  return (
+    !input.isExpanded &&
+    ((input.kind === "outbound-auto-email" && input.headline !== null) ||
+      input.kind === "outbound-campaign-email")
+  );
+}
+
+export function TimelineAutomatedRow({
+  entry,
+  role,
+  isExpanded,
+  onToggle,
+}: {
+  readonly entry: InboxTimelineEntryViewModel;
+  readonly role: "automated" | "campaign" | "activity";
+  readonly isExpanded: boolean;
+  readonly onToggle: () => void;
+}) {
+  const isEmail = entry.channel === "email";
+  const campaignActivity =
+    entry.kind === "outbound-campaign-email" ? entry.campaignActivity : [];
+  const campaignState =
+    role === "campaign"
+      ? describeCampaignVisualState(campaignActivity)
+      : undefined;
+  const descriptor = describeEventRow({
+    role,
+    isEmail,
+  });
+  const headline = entry.subject;
+  const body = bodyTextForEntry(entry);
+  const hideCollapsedBody = shouldHideAutomatedRowBody({
+    isExpanded,
+    kind: entry.kind,
+    headline,
+  });
+
+  return (
+    <li className="flex w-full flex-col items-end pl-16">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-expanded={isExpanded}
+            title={formatExactTimestamp(entry.occurredAt)}
+            onClick={onToggle}
+            data-event-role={role}
+            data-campaign-state={campaignState}
+            className={cn(
+              "group flex w-full max-w-[560px] items-start gap-2.5 rounded-xl border px-4 py-2.5 text-left",
+              "transition-[color,background-color,transform] duration-150 ease-out",
+              "active:scale-[0.96]",
+              TRANSITION.reduceMotion,
+              descriptor.shellClassName,
+            )}
+          >
+            <div
+              className={cn(
+                "mt-0.5 inline-flex size-6 shrink-0 items-center justify-center rounded-md border bg-white/90",
+                descriptor.iconClassName,
+              )}
+            >
+              {role === "campaign" ? (
+                <CampaignStateIcon state={campaignState ?? "sent"} />
+              ) : (
+                <descriptor.Icon className="size-4" />
+              )}
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <span
+                  className={cn(
+                    "text-[9.5px] font-semibold uppercase tracking-wider",
+                    descriptor.labelClassName,
+                  )}
+                >
+                  {descriptor.label}
+                </span>
+                <RelativeTimestamp
+                  timestamp={entry.occurredAt}
+                  label={entry.occurredAtLabel}
+                  className="text-[11px] text-slate-500"
+                />
+              </div>
+              {headline ? (
+                <p
+                  className={cn(
+                    "mt-0.5 text-pretty text-[12.5px] font-medium leading-snug text-slate-800",
+                    WRAP_ANYWHERE,
+                  )}
+                >
+                  {headline}
+                </p>
+              ) : null}
+              {!hideCollapsedBody && body.length > 0 ? (
+                <p
+                  className={cn(
+                    "font-message-body text-[13.5px] leading-relaxed text-slate-700",
+                    WRAP_ANYWHERE,
+                    (headline !== null || role === "campaign") && "mt-1.5",
+                    isExpanded
+                      ? "whitespace-pre-wrap text-pretty"
+                      : "line-clamp-1",
+                  )}
+                >
+                  {isExpanded ? autolinkText(body, "text-sky-600") : body}
+                </p>
+              ) : null}
+            </div>
+            <div className="flex shrink-0 items-center gap-2 pt-1">
+              {role === "campaign" && campaignState !== undefined ? (
+                <CampaignStateBadge state={campaignState} />
+              ) : null}
+              <ChevronRightIcon
+                className={cn(
+                  "h-3.5 w-3.5 text-slate-500 transition-transform duration-150",
+                  isExpanded && "rotate-90",
+                )}
+              />
+            </div>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          <p>{formatExactTimestamp(entry.occurredAt)}</p>
+        </TooltipContent>
+      </Tooltip>
+    </li>
+  );
+}

--- a/apps/web/app/inbox/_components/inbox-timeline-bubble.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-bubble.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { SHADOW, TRANSITION, TYPE } from "@/app/_lib/design-tokens-v2";
+
+import type { InboxTimelineEntryViewModel } from "../_lib/view-models";
+import { autolinkText } from "./_autolink";
+import { EmailParticipantHeader } from "./email-participant-header";
+import { InboxAvatar } from "./inbox-avatar";
+import {
+  CornerUpLeftIcon,
+  LoaderIcon,
+  MailIcon,
+  PhoneIcon,
+  RefreshCwIcon,
+} from "./icons";
+
+const WRAP_ANYWHERE = "break-words [overflow-wrap:anywhere]";
+
+function initialsForLabel(label: string): string {
+  const parts = label.trim().split(/\s+/).filter(Boolean);
+
+  if (parts.length === 0) {
+    return "AS";
+  }
+
+  if (parts.length === 1) {
+    return (parts[0] ?? "AS").slice(0, 2).toUpperCase();
+  }
+
+  return `${parts[0]?.[0] ?? ""}${parts[1]?.[0] ?? ""}`.toUpperCase();
+}
+
+function bodyTextForEntry(entry: InboxTimelineEntryViewModel): string {
+  return entry.body.trim();
+}
+
+function ReplyButton({
+  entryId,
+  tone,
+  onReply,
+}: {
+  readonly entryId: string;
+  readonly tone: "slate" | "sky" | "sky-inverse";
+  readonly onReply?: (entryId: string) => void;
+}) {
+  if (onReply === undefined) {
+    return null;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        onReply(entryId);
+      }}
+      className={cn(
+        "mt-3 ml-auto inline-flex items-center gap-1 text-[11.5px]",
+        TRANSITION.fast,
+        TRANSITION.reduceMotion,
+        tone === "sky-inverse"
+          ? "text-sky-100 hover:text-white"
+          : tone === "sky"
+            ? "text-sky-700 hover:text-sky-900"
+            : "text-slate-500 hover:text-slate-900",
+      )}
+    >
+      <CornerUpLeftIcon className="h-3.5 w-3.5" />
+      <span>Reply</span>
+    </button>
+  );
+}
+
+function InboundMetadataRow({
+  entry,
+}: {
+  readonly entry: InboxTimelineEntryViewModel;
+}) {
+  const ChannelIcon = entry.channel === "email" ? MailIcon : PhoneIcon;
+
+  return (
+    <div className={cn("mt-1.5 flex items-center gap-1.5 px-1", TYPE.micro)}>
+      <ChannelIcon className="h-3 w-3" />
+      <span className="font-medium text-slate-500">{entry.actorLabel}</span>
+      {entry.isUnread ? (
+        <span
+          className="inline-flex h-1.5 w-1.5 rounded-full bg-sky-500"
+          aria-label="Unread"
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function OutboundSmsMetaRow({
+  entry,
+}: {
+  readonly entry: InboxTimelineEntryViewModel;
+}) {
+  return (
+    <div className="mb-1.5 flex items-center gap-1.5 pr-1 text-[11px] text-sky-600">
+      <PhoneIcon className="h-3 w-3" />
+      <span className="font-medium uppercase tracking-wide">SMS</span>
+      <span className="text-sky-300">·</span>
+      <time
+        dateTime={entry.occurredAt}
+        title={entry.occurredAt}
+        className="text-sky-700/80"
+      >
+        {entry.occurredAtLabel}
+      </time>
+    </div>
+  );
+}
+
+function OutboundStatusBanner({
+  entry,
+  isRetrying,
+  onRetryPending,
+}: {
+  readonly entry: InboxTimelineEntryViewModel;
+  readonly isRetrying: boolean;
+  readonly onRetryPending?: (entryId: string) => void;
+}) {
+  if (entry.sendStatus === "pending") {
+    return (
+      <div className="mb-2 inline-flex items-center gap-1.5 rounded-full border border-sky-200 bg-white px-2 py-1 text-[11px] font-medium text-sky-700">
+        <LoaderIcon className="size-3 animate-spin" />
+        Sending...
+      </div>
+    );
+  }
+
+  if (entry.sendStatus !== "failed" && entry.sendStatus !== "orphaned") {
+    return null;
+  }
+
+  const canRetry =
+    entry.attachmentCount === 0 && onRetryPending !== undefined;
+  const retryDisabledReason =
+    entry.attachmentCount > 0
+      ? "Re-attach files and send as a new message"
+      : null;
+
+  return (
+    <div className="mb-3 flex items-center justify-between gap-3 rounded-md border border-rose-300 bg-rose-50 px-3 py-2 text-xs text-rose-900">
+      <span>
+        {entry.sendStatus === "failed"
+          ? "Send failed."
+          : "Send stalled before confirmation."}
+      </span>
+      {retryDisabledReason ? (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                disabled
+                className="inline-flex items-center gap-1 rounded-md border border-rose-200 bg-white px-2 py-1 font-medium text-rose-500"
+              >
+                <RefreshCwIcon className="size-3" />
+                Retry
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>{retryDisabledReason}</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : (
+        <button
+          type="button"
+          disabled={!canRetry || isRetrying}
+          onClick={() => {
+            if (canRetry) {
+              onRetryPending(entry.id);
+            }
+          }}
+          className="inline-flex items-center gap-1 rounded-md border border-rose-200 bg-white px-2 py-1 font-medium text-rose-800 hover:bg-rose-100 disabled:cursor-not-allowed disabled:opacity-70"
+        >
+          {isRetrying ? (
+            <LoaderIcon className="size-3 animate-spin" />
+          ) : (
+            <RefreshCwIcon className="size-3" />
+          )}
+          Retry
+        </button>
+      )}
+    </div>
+  );
+}
+
+export function MessageBubble({
+  entry,
+  direction,
+  onReply,
+  isRetrying = false,
+  onRetryPending,
+}: {
+  readonly entry: InboxTimelineEntryViewModel;
+  readonly direction: "inbound" | "outbound";
+  readonly onReply?: (entryId: string) => void;
+  readonly isRetrying?: boolean;
+  readonly onRetryPending?: (entryId: string) => void;
+}) {
+  const isEmail = entry.channel === "email";
+  const isOutbound = direction === "outbound";
+  const body = bodyTextForEntry(entry);
+  const avatar = (
+    <InboxAvatar
+      initials={initialsForLabel(entry.actorLabel)}
+      tone="slate"
+      size="md"
+    />
+  );
+
+  const bubbleClassName = isEmail
+    ? isOutbound
+      ? "border border-sky-200 bg-sky-50/40 px-4 py-3"
+      : "border border-slate-200 bg-white px-4 py-3"
+    : isOutbound
+      ? "bg-sky-600 px-4 py-2.5 text-white"
+      : "bg-slate-100 px-4 py-2.5 text-slate-900";
+
+  return (
+    <li
+      className={cn(
+        "flex w-full flex-col",
+        isOutbound ? "items-end pl-16" : "items-start pr-16",
+      )}
+    >
+      {isOutbound && !isEmail ? <OutboundSmsMetaRow entry={entry} /> : null}
+
+      <div
+        className={cn(
+          "flex w-full items-start gap-2.5",
+          isOutbound ? "justify-end" : "justify-start",
+        )}
+      >
+        {!isOutbound ? <div className="shrink-0 pt-1">{avatar}</div> : null}
+
+        <div
+          className={cn(
+            "min-w-0 w-full max-w-[640px] rounded-2xl",
+            SHADOW.sm,
+            bubbleClassName,
+          )}
+        >
+          {isOutbound ? (
+            <OutboundStatusBanner
+              entry={entry}
+              isRetrying={isRetrying}
+              {...(onRetryPending === undefined
+                ? {}
+                : { onRetryPending })}
+            />
+          ) : null}
+
+          {isEmail ? (
+            <EmailParticipantHeader
+              entry={entry}
+              tone={isOutbound ? "sky" : "slate"}
+            />
+          ) : null}
+
+          {isEmail && entry.subject ? (
+            <p
+              className={cn(
+                "mb-1.5 mt-2 text-balance text-[13px] font-semibold text-slate-900",
+                WRAP_ANYWHERE,
+              )}
+            >
+              {entry.subject}
+            </p>
+          ) : null}
+
+          {body.length > 0 ? (
+            <p
+              className={cn(
+                isEmail
+                  ? `font-message-body whitespace-pre-wrap text-pretty ${TYPE.bodySerifSm}`
+                  : "whitespace-pre-wrap text-[13px] leading-relaxed",
+                isOutbound && !isEmail ? "text-white" : undefined,
+                WRAP_ANYWHERE,
+              )}
+            >
+              {autolinkText(
+                body,
+                isOutbound && !isEmail
+                  ? "text-white underline decoration-white/40"
+                  : isOutbound
+                    ? "text-sky-700"
+                    : "text-sky-600",
+              )}
+            </p>
+          ) : null}
+
+          <ReplyButton
+            entryId={entry.id}
+            tone={isOutbound ? (isEmail ? "sky" : "sky-inverse") : "slate"}
+            {...(onReply === undefined ? {} : { onReply })}
+          />
+        </div>
+
+        {isOutbound ? <div className="shrink-0 pt-1">{avatar}</div> : null}
+      </div>
+
+      {!isOutbound ? <InboundMetadataRow entry={entry} /> : null}
+    </li>
+  );
+}

--- a/apps/web/app/inbox/_components/inbox-timeline-note-entry.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-note-entry.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+import { deleteNoteAction, updateNoteAction } from "../actions";
+import type { InboxTimelineEntryViewModel } from "../_lib/view-models";
+import { getInternalNoteValidationError } from "@/src/lib/internal-note-validation";
+import { LoaderIcon, NoteIcon } from "./icons";
+
+const WRAP_ANYWHERE = "break-words [overflow-wrap:anywhere]";
+
+const EXACT_TIMESTAMP_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+  timeZone: "UTC",
+  timeZoneName: "short",
+});
+
+function formatExactTimestamp(timestamp: string): string {
+  return EXACT_TIMESTAMP_FORMATTER.format(new Date(timestamp));
+}
+
+export function TimelineNoteEntry({
+  entry,
+  currentOperatorUserId,
+}: {
+  readonly entry: InboxTimelineEntryViewModel;
+  readonly currentOperatorUserId: string;
+}) {
+  const router = useRouter();
+  const [isEditing, setIsEditing] = useState(false);
+  const [draftBody, setDraftBody] = useState(entry.body);
+  const [inlineError, setInlineError] = useState<string | null>(null);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [isSaving, startSaveTransition] = useTransition();
+  const [isDeleting, startDeleteTransition] = useTransition();
+  const canManageNote =
+    entry.noteId !== null &&
+    entry.noteId !== undefined &&
+    entry.authorId === currentOperatorUserId;
+
+  const saveEdit = () => {
+    const noteId = entry.noteId;
+
+    if (
+      typeof noteId !== "string" ||
+      entry.authorId !== currentOperatorUserId
+    ) {
+      return;
+    }
+
+    const validationError = getInternalNoteValidationError(draftBody);
+
+    if (validationError !== null) {
+      setInlineError(validationError);
+      return;
+    }
+
+    setInlineError(null);
+    startSaveTransition(async () => {
+      const result = await updateNoteAction({
+        noteId,
+        body: draftBody,
+      });
+
+      if (!result.ok) {
+        setInlineError(result.message);
+        return;
+      }
+
+      setIsEditing(false);
+      router.refresh();
+    });
+  };
+
+  const deleteNote = () => {
+    const noteId = entry.noteId;
+
+    if (
+      typeof noteId !== "string" ||
+      entry.authorId !== currentOperatorUserId
+    ) {
+      return;
+    }
+
+    setInlineError(null);
+    startDeleteTransition(async () => {
+      const result = await deleteNoteAction({
+        noteId,
+      });
+
+      if (!result.ok) {
+        setInlineError(result.message);
+        return;
+      }
+
+      setDeleteOpen(false);
+      router.refresh();
+    });
+  };
+
+  return (
+    <li className="flex w-full flex-col items-end pl-16">
+      <div className="w-full max-w-[640px] rounded-xl border border-amber-200 bg-amber-50/60 px-4 py-2.5 shadow-sm">
+        <div className="mb-1 flex items-center justify-between gap-3 text-[11px] text-amber-700">
+          <div className="flex items-center gap-1.5">
+            <NoteIcon className="h-3 w-3" />
+            <span className="font-medium">Note</span>
+            <span className="text-amber-300">·</span>
+            <span>{entry.actorLabel}</span>
+            <span className="text-amber-300">·</span>
+            <time dateTime={entry.occurredAt} title={formatExactTimestamp(entry.occurredAt)}>
+              {entry.occurredAtLabel}
+            </time>
+          </div>
+          {canManageNote ? (
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-auto px-2 py-1 text-[11px] text-amber-800 hover:bg-amber-100"
+                onClick={() => {
+                  setDraftBody(entry.body);
+                  setInlineError(null);
+                  setIsEditing(true);
+                }}
+              >
+                Edit
+              </Button>
+              <Popover open={deleteOpen} onOpenChange={setDeleteOpen}>
+                <PopoverTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-auto px-2 py-1 text-[11px] text-amber-800 hover:bg-amber-100"
+                  >
+                    Delete
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-64 space-y-3" align="end">
+                  <p className="text-sm font-medium text-slate-900">
+                    Delete this note?
+                  </p>
+                  <p className="text-xs text-slate-500">
+                    This removes the note from the shared timeline.
+                  </p>
+                  <div className="flex justify-end gap-2">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => {
+                        setDeleteOpen(false);
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      disabled={isDeleting}
+                      onClick={deleteNote}
+                    >
+                      {isDeleting ? (
+                        <>
+                          <LoaderIcon className="size-3 animate-spin" />
+                          Deleting...
+                        </>
+                      ) : (
+                        "Delete"
+                      )}
+                    </Button>
+                  </div>
+                </PopoverContent>
+              </Popover>
+            </div>
+          ) : null}
+        </div>
+        {isEditing ? (
+          <div className="space-y-3">
+            <textarea
+              rows={4}
+              value={draftBody}
+              onChange={(event) => {
+                setDraftBody(event.currentTarget.value);
+                if (inlineError !== null) {
+                  setInlineError(null);
+                }
+              }}
+              className="w-full resize-y rounded-md border border-amber-200 bg-white px-3 py-2 text-[13px] leading-relaxed text-slate-900 shadow-sm focus:outline-none focus:ring-1 focus:ring-amber-300"
+            />
+            {inlineError ? (
+              <p className="text-xs text-rose-700">{inlineError}</p>
+            ) : null}
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setDraftBody(entry.body);
+                  setInlineError(null);
+                  setIsEditing(false);
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                disabled={isSaving}
+                onClick={saveEdit}
+              >
+                {isSaving ? (
+                  <>
+                    <LoaderIcon className="size-3 animate-spin" />
+                    Saving...
+                  </>
+                ) : (
+                  "Save"
+                )}
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <p
+              className={cn(
+                "font-message-body whitespace-pre-wrap text-pretty text-[13.5px] leading-relaxed text-amber-900",
+                WRAP_ANYWHERE,
+              )}
+            >
+              {entry.body}
+            </p>
+            {inlineError ? (
+              <p className="mt-2 text-xs text-rose-700">{inlineError}</p>
+            ) : null}
+          </>
+        )}
+      </div>
+    </li>
+  );
+}

--- a/apps/web/app/inbox/_components/inbox-timeline-system-divider.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-system-divider.tsx
@@ -1,0 +1,152 @@
+import type { ComponentType } from "react";
+
+import { cn } from "@/lib/utils";
+import { SHADOW, TONE_CLASSES, TYPE, type ToneNameV2 } from "@/app/_lib/design-tokens-v2";
+
+import type { InboxTimelineEntryViewModel } from "../_lib/view-models";
+import {
+  CalendarIcon,
+  CheckCircleIcon,
+  DatabaseIcon,
+  MapPinIcon,
+  SparkleIcon,
+  WandIcon,
+} from "./icons";
+
+const EXACT_TIMESTAMP_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+  timeZone: "UTC",
+  timeZoneName: "short",
+});
+
+function formatExactTimestamp(timestamp: string): string {
+  return EXACT_TIMESTAMP_FORMATTER.format(new Date(timestamp));
+}
+
+function personalizeSystemBody(body: string, firstName: string): string {
+  if (body.length === 0) {
+    return firstName;
+  }
+
+  const head = body.charAt(0).toLowerCase();
+  const tail = body.slice(1);
+  return `${firstName} ${head}${tail}`;
+}
+
+export interface SystemDividerCategory {
+  readonly label:
+    | "LIFECYCLE"
+    | "APPLIED"
+    | "TRAINING"
+    | "TRIP PLANNING"
+    | "IN FIELD"
+    | "FIRST DATA"
+    | "COMPLETED";
+  readonly tone: ToneNameV2;
+  readonly Icon: ComponentType<{ className?: string }>;
+}
+
+export function classifySystemDivider(body: string): SystemDividerCategory {
+  const normalized = body.toLowerCase();
+
+  if (normalized.includes("applied")) {
+    return {
+      label: "APPLIED",
+      tone: "violet",
+      Icon: SparkleIcon,
+    };
+  }
+
+  if (normalized.includes("trip planning") || normalized.includes("moved to trip")) {
+    return {
+      label: "TRIP PLANNING",
+      tone: "amber",
+      Icon: CalendarIcon,
+    };
+  }
+
+  if (normalized.includes("training")) {
+    return {
+      label: "TRAINING",
+      tone: "sky",
+      Icon: WandIcon,
+    };
+  }
+
+  if (normalized.includes("first data") || normalized.includes("submitted first") || normalized.includes("batch")) {
+    return {
+      label: "FIRST DATA",
+      tone: "emerald",
+      Icon: DatabaseIcon,
+    };
+  }
+
+  if (normalized.includes("field") || normalized.includes("in the field")) {
+    return {
+      label: "IN FIELD",
+      tone: "emerald",
+      Icon: MapPinIcon,
+    };
+  }
+
+  if (normalized.includes("completed") || normalized.includes("successful") || normalized.includes("complete")) {
+    return {
+      label: "COMPLETED",
+      tone: "emerald",
+      Icon: CheckCircleIcon,
+    };
+  }
+
+  return {
+    label: "LIFECYCLE",
+    tone: "amber",
+    Icon: CalendarIcon,
+  };
+}
+
+export function SystemDivider({
+  entry,
+  volunteerFirstName,
+}: {
+  readonly entry: InboxTimelineEntryViewModel;
+  readonly volunteerFirstName: string;
+}) {
+  const body = personalizeSystemBody(entry.body, volunteerFirstName);
+  const category = classifySystemDivider(body);
+  const tone = TONE_CLASSES[category.tone];
+
+  return (
+    <li className="flex w-full items-center justify-center gap-3 py-1.5">
+      <div className="h-px flex-1 bg-slate-200" />
+      <div
+        className={cn(
+          "inline-flex max-w-[720px] items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1",
+          SHADOW.sm,
+        )}
+      >
+        <span
+          className={cn(
+            "inline-flex size-5 shrink-0 items-center justify-center rounded-full",
+            tone.subtle,
+          )}
+        >
+          <category.Icon className={cn("h-3 w-3", tone.text)} />
+        </span>
+        <span className={cn(TYPE.label, tone.text)}>{category.label}</span>
+        <span className="text-[11.5px] text-slate-600">{body}</span>
+        <time
+          dateTime={entry.occurredAt}
+          title={formatExactTimestamp(entry.occurredAt)}
+          className="cursor-help text-[11px] text-slate-400"
+        >
+          {entry.occurredAtLabel}
+        </time>
+      </div>
+      <div className="h-px flex-1 bg-slate-200" />
+    </li>
+  );
+}

--- a/apps/web/app/inbox/_components/inbox-timeline.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline.tsx
@@ -1,15 +1,6 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import type { ComponentType } from "react";
-import { useState, useTransition } from "react";
-
-import { Button } from "@/components/ui/button";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
+import { useState } from "react";
 import type {
   InboxTimelineEntryKind,
   InboxTimelinePresentationItem,
@@ -17,26 +8,10 @@ import type {
   InboxTimelineEntryViewModel,
 } from "../_lib/view-models";
 import { groupInboxTimelineSystemMessages } from "../_lib/view-models";
-import { autolinkText } from "./_autolink";
-import { deleteNoteAction, updateNoteAction } from "../actions";
-import { getInternalNoteValidationError } from "@/src/lib/internal-note-validation";
 import {
-  CalendarIcon,
-  CheckCircleIcon,
   ChevronRightIcon,
-  EyeIcon,
-  LoaderIcon,
-  MailIcon,
   MegaphoneIcon,
-  MousePointerClickIcon,
-  NoteIcon,
-  PhoneIcon,
-  RefreshCwIcon,
-  SparkleIcon,
-  WandIcon,
-  XIcon,
   ZapIcon,
-  MapPinIcon,
 } from "./icons";
 import {
   Tooltip,
@@ -45,13 +20,13 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import {
-  SHADOW,
-  TEXT,
-  TRANSITION,
-} from "@/app/_lib/design-tokens";
+import { TRANSITION } from "@/app/_lib/design-tokens-v2";
+import { TimelineAutomatedRow } from "./inbox-timeline-automated-row";
+import { MessageBubble } from "./inbox-timeline-bubble";
+import { TimelineNoteEntry } from "./inbox-timeline-note-entry";
+import { SystemDivider } from "./inbox-timeline-system-divider";
 
-const WRAP_ANYWHERE = "break-words [overflow-wrap:anywhere]";
+export { shouldHideAutomatedRowBody } from "./inbox-timeline-automated-row";
 const EXACT_TIMESTAMP_FORMATTER = new Intl.DateTimeFormat("en-US", {
   month: "short",
   day: "numeric",
@@ -71,6 +46,7 @@ interface TimelineProps {
   readonly onLoadOlder?: () => void;
   readonly retryingEntryId?: string | null;
   readonly onRetryPending?: (entryId: string) => void;
+  readonly onReply?: (entryId: string) => void;
 }
 
 export function InboxTimeline({
@@ -82,6 +58,7 @@ export function InboxTimeline({
   onLoadOlder,
   retryingEntryId = null,
   onRetryPending,
+  onReply,
 }: TimelineProps) {
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(
     () => new Set<string>(),
@@ -142,6 +119,7 @@ export function InboxTimeline({
               isExpanded={expanded.has(item.id)}
               retryingEntryId={retryingEntryId}
               onRetryPending={onRetryPending}
+              {...(onReply === undefined ? {} : { onReply })}
               onToggle={() => {
                 toggle(item.id);
               }}
@@ -162,6 +140,7 @@ interface PresentationItemProps {
   readonly isExpanded: boolean;
   readonly retryingEntryId: string | null;
   readonly onRetryPending: ((entryId: string) => void) | undefined;
+  readonly onReply?: (entryId: string) => void;
   readonly onToggle: () => void;
   readonly isChildExpanded: (entryId: string) => boolean;
   readonly onToggleChild: (entryId: string) => void;
@@ -174,6 +153,7 @@ function TimelinePresentationItem({
   isExpanded,
   retryingEntryId,
   onRetryPending,
+  onReply,
   onToggle,
   isChildExpanded,
   onToggleChild,
@@ -201,6 +181,7 @@ function TimelinePresentationItem({
       isExpanded={isExpanded}
       retryingEntryId={retryingEntryId}
       onRetryPending={onRetryPending}
+      {...(onReply === undefined ? {} : { onReply })}
       onToggle={onToggle}
     />
   );
@@ -260,25 +241,6 @@ function RelativeTimestamp({
   );
 }
 
-function TimelineTimestamp({
-  entry,
-  className,
-  asSpan = false,
-}: {
-  readonly entry: InboxTimelineEntryViewModel;
-  readonly className?: string;
-  readonly asSpan?: boolean;
-}) {
-  return (
-    <RelativeTimestamp
-      timestamp={entry.occurredAt}
-      label={entry.occurredAtLabel}
-      asSpan={asSpan}
-      {...(className === undefined ? {} : { className })}
-    />
-  );
-}
-
 interface EntryProps {
   readonly entry: InboxTimelineEntryViewModel;
   readonly volunteerFirstName: string;
@@ -286,6 +248,7 @@ interface EntryProps {
   readonly isExpanded: boolean;
   readonly retryingEntryId: string | null;
   readonly onRetryPending: ((entryId: string) => void) | undefined;
+  readonly onReply?: (entryId: string) => void;
   readonly onToggle: () => void;
 }
 
@@ -296,26 +259,35 @@ function TimelineEntry({
   isExpanded,
   retryingEntryId,
   onRetryPending,
+  onReply,
   onToggle,
 }: EntryProps) {
   const role = roleForKind(entry.kind);
 
   switch (role) {
     case "inbound":
-      return <InboundBubble entry={entry} />;
+      return (
+        <MessageBubble
+          entry={entry}
+          direction="inbound"
+          {...(onReply === undefined ? {} : { onReply })}
+        />
+      );
     case "outbound":
       return (
-        <OutboundBubble
+        <MessageBubble
           entry={entry}
+          direction="outbound"
           isRetrying={retryingEntryId === entry.id}
-          onRetryPending={onRetryPending}
+          {...(onReply === undefined ? {} : { onReply })}
+          {...(onRetryPending === undefined ? {} : { onRetryPending })}
         />
       );
     case "automated":
     case "campaign":
     case "activity":
       return (
-        <AutomatedRow
+        <TimelineAutomatedRow
           entry={entry}
           role={role}
           isExpanded={isExpanded}
@@ -324,7 +296,7 @@ function TimelineEntry({
       );
     case "note":
       return (
-        <NoteEntry
+        <TimelineNoteEntry
           entry={entry}
           currentOperatorUserId={currentOperatorUserId}
         />
@@ -450,832 +422,6 @@ function formatSystemGroupSummary(
   }
 
   return parts.join(" · ");
-}
-
-function InboundBubble({
-  entry,
-}: {
-  readonly entry: InboxTimelineEntryViewModel;
-}) {
-  const isEmail = entry.channel === "email";
-  const ChannelIcon = isEmail ? MailIcon : PhoneIcon;
-  const body = bodyTextForEntry(entry);
-
-  return (
-    <li className="flex w-full flex-col items-start pr-16">
-      <div
-        className={`min-w-0 w-full max-w-[640px] overflow-hidden rounded-xl border border-slate-200 bg-white px-4 py-3 ${SHADOW.sm}`}
-      >
-        <EmailParticipantHeaders entry={entry} tone="inbound" />
-        {isEmail && entry.subject ? (
-          <p
-            className={cn(
-              "mb-1.5 text-balance text-[13px] font-semibold leading-snug text-slate-900",
-              WRAP_ANYWHERE,
-            )}
-          >
-            {entry.subject}
-          </p>
-        ) : null}
-        {body.length > 0 ? (
-          <p
-            className={cn(
-              `font-message-body whitespace-pre-wrap text-pretty ${TEXT.bodySerifSm}`,
-              WRAP_ANYWHERE,
-            )}
-          >
-            {autolinkText(body, "text-sky-600")}
-          </p>
-        ) : null}
-      </div>
-      <div className={`mt-1.5 flex items-center gap-1.5 px-1 ${TEXT.micro}`}>
-        <ChannelIcon className="h-3 w-3" />
-        <span className="font-medium text-slate-500">{entry.actorLabel}</span>
-        <span>·</span>
-        <TimelineTimestamp entry={entry} />
-        {entry.isUnread ? (
-          <span
-            className="inline-flex h-1.5 w-1.5 rounded-full bg-sky-500"
-            aria-label="Unread"
-          />
-        ) : null}
-      </div>
-    </li>
-  );
-}
-
-function OutboundBubble({
-  entry,
-  isRetrying,
-  onRetryPending,
-}: {
-  readonly entry: InboxTimelineEntryViewModel;
-  readonly isRetrying: boolean;
-  readonly onRetryPending: ((entryId: string) => void) | undefined;
-}) {
-  const isEmail = entry.channel === "email";
-  const ChannelIcon = isEmail ? MailIcon : PhoneIcon;
-  const body = bodyTextForEntry(entry);
-  const canRetry =
-    (entry.sendStatus === "failed" || entry.sendStatus === "orphaned") &&
-    entry.attachmentCount === 0 &&
-    onRetryPending !== undefined;
-  const retryDisabledReason =
-    entry.attachmentCount > 0
-      ? "Re-attach files and send as a new message"
-      : null;
-
-  return (
-    <li className="flex w-full flex-col items-end pl-16">
-      <div
-        className={cn(
-          `min-w-0 w-full max-w-[640px] overflow-hidden rounded-xl border border-sky-200 bg-sky-50/40 px-4 py-3 ${SHADOW.sm}`,
-          "backdrop-blur-[1px]",
-        )}
-      >
-        {entry.sendStatus === "pending" ? (
-          <div className="mb-2 inline-flex items-center gap-1.5 rounded-full border border-sky-200 bg-white px-2 py-1 text-[11px] font-medium text-sky-700">
-            <LoaderIcon className="size-3 animate-spin" />
-            Sending...
-          </div>
-        ) : null}
-
-        {entry.sendStatus === "failed" || entry.sendStatus === "orphaned" ? (
-          <div className="mb-3 flex items-center justify-between gap-3 rounded-md border border-rose-300 bg-rose-50 px-3 py-2 text-xs text-rose-900">
-            <span>
-              {entry.sendStatus === "failed"
-                ? "Send failed."
-                : "Send stalled before confirmation."}
-            </span>
-            {retryDisabledReason ? (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      disabled
-                      className="inline-flex items-center gap-1 rounded-md border border-rose-200 bg-white px-2 py-1 font-medium text-rose-500"
-                    >
-                      <RefreshCwIcon className="size-3" />
-                      Retry
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent>{retryDisabledReason}</TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            ) : (
-              <button
-                type="button"
-                disabled={!canRetry || isRetrying}
-                onClick={() => {
-                  if (canRetry) {
-                    onRetryPending(entry.id);
-                  }
-                }}
-                className="inline-flex items-center gap-1 rounded-md border border-rose-200 bg-white px-2 py-1 font-medium text-rose-800 hover:bg-rose-100 disabled:cursor-not-allowed disabled:opacity-70"
-              >
-                {isRetrying ? (
-                  <LoaderIcon className="size-3 animate-spin" />
-                ) : (
-                  <RefreshCwIcon className="size-3" />
-                )}
-                Retry
-              </button>
-            )}
-          </div>
-        ) : null}
-
-        <EmailParticipantHeaders entry={entry} tone="outbound" />
-        {isEmail && entry.subject ? (
-          <p
-            className={cn(
-              "mb-1.5 text-balance text-[13px] font-semibold leading-snug text-slate-900",
-              WRAP_ANYWHERE,
-            )}
-          >
-            {entry.subject}
-          </p>
-        ) : null}
-        {body.length > 0 ? (
-          <p
-            className={cn(
-              "font-message-body whitespace-pre-wrap text-pretty text-[13.5px] leading-relaxed text-slate-700",
-              WRAP_ANYWHERE,
-            )}
-          >
-            {autolinkText(body, "text-sky-700")}
-          </p>
-        ) : null}
-      </div>
-      <div className={`mt-1.5 flex items-center gap-1.5 px-1 ${TEXT.micro}`}>
-        <TimelineTimestamp entry={entry} />
-        <span>·</span>
-        <ChannelIcon className="h-3 w-3" />
-      </div>
-    </li>
-  );
-}
-
-function EmailParticipantHeaders({
-  entry,
-  tone,
-}: {
-  readonly entry: InboxTimelineEntryViewModel;
-  readonly tone: "inbound" | "outbound";
-}) {
-  if (
-    entry.channel !== "email" ||
-    (entry.fromHeader === null &&
-      entry.toHeader === null &&
-      entry.ccHeader === null)
-  ) {
-    return null;
-  }
-
-  const borderClass =
-    tone === "inbound" ? "border-slate-200" : "border-sky-100";
-  const rows = [
-    { label: "From", value: entry.fromHeader },
-    { label: "To", value: entry.toHeader },
-    { label: "Cc", value: entry.ccHeader },
-  ].filter(
-    (
-      row,
-    ): row is {
-      readonly label: "From" | "To" | "Cc";
-      readonly value: string;
-    } => row.value !== null,
-  );
-
-  if (rows.length === 0) {
-    return null;
-  }
-
-  return (
-    <dl
-      className={`mb-2.5 space-y-1 border-b pb-2.5 text-[11.5px] leading-relaxed ${borderClass}`}
-    >
-      {rows.map((row) => (
-        <div
-          key={row.label}
-          className="grid grid-cols-[2rem_minmax(0,1fr)] gap-2"
-        >
-          <dt className="font-medium text-slate-400">{row.label}</dt>
-          <dd
-            className={cn(
-              "min-w-0 break-words text-slate-700",
-              WRAP_ANYWHERE,
-            )}
-          >
-            {row.value}
-          </dd>
-        </div>
-      ))}
-    </dl>
-  );
-}
-
-function AutomatedRow({
-  entry,
-  role,
-  isExpanded,
-  onToggle,
-}: {
-  readonly entry: InboxTimelineEntryViewModel;
-  readonly role: "automated" | "campaign" | "activity";
-  readonly isExpanded: boolean;
-  readonly onToggle: () => void;
-}) {
-  const isEmail = entry.channel === "email";
-  const campaignActivity =
-    entry.kind === "outbound-campaign-email" ? entry.campaignActivity : [];
-  const campaignState =
-    role === "campaign"
-      ? describeCampaignVisualState(campaignActivity)
-      : undefined;
-  const descriptor = describeEventRow({
-    role,
-    isEmail,
-  });
-  const headline = entry.subject;
-  const body = bodyTextForEntry(entry);
-  const hideCollapsedBody = shouldHideAutomatedRowBody({
-    isExpanded,
-    kind: entry.kind,
-    headline,
-  });
-
-  return (
-    <li className="flex w-full flex-col items-end pl-16">
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            aria-expanded={isExpanded}
-            title={formatExactTimestamp(entry.occurredAt)}
-            onClick={onToggle}
-            data-event-role={role}
-            data-campaign-state={campaignState}
-            className={cn(
-              "group flex w-full max-w-[560px] items-start gap-2.5 rounded-xl border px-4 py-2.5 text-left",
-              "transition-[color,background-color,transform] duration-150 ease-out",
-              "active:scale-[0.96]",
-              TRANSITION.reduceMotion,
-              descriptor.shellClassName,
-            )}
-          >
-            <div
-              className={cn(
-                "mt-0.5 inline-flex size-6 shrink-0 items-center justify-center rounded-md border bg-white/90",
-                descriptor.iconClassName,
-              )}
-            >
-              {role === "campaign" ? (
-                <CampaignStateIcon state={campaignState ?? "sent"} />
-              ) : (
-                <descriptor.Icon className="size-4" />
-              )}
-            </div>
-            <div className="min-w-0 flex-1">
-              <div className="flex flex-wrap items-center gap-2">
-                <span
-                  className={cn(
-                    "text-[9.5px] font-semibold uppercase tracking-wider",
-                    descriptor.labelClassName,
-                  )}
-                >
-                  {descriptor.label}
-                </span>
-                <RelativeTimestamp
-                  timestamp={entry.occurredAt}
-                  label={entry.occurredAtLabel}
-                  asSpan
-                  focusable={false}
-                  className="text-[11px] text-slate-500"
-                />
-              </div>
-              {headline ? (
-                <p
-                  className={cn(
-                    "mt-0.5 text-pretty text-[12.5px] font-medium leading-snug text-slate-800",
-                    WRAP_ANYWHERE,
-                  )}
-                >
-                  {headline}
-                </p>
-              ) : null}
-              {!hideCollapsedBody && body.length > 0 ? (
-                <p
-                  className={cn(
-                    "font-message-body text-[13.5px] leading-relaxed text-slate-700",
-                    WRAP_ANYWHERE,
-                    (headline !== null || role === "campaign") && "mt-1.5",
-                    isExpanded
-                      ? "whitespace-pre-wrap text-pretty"
-                      : "line-clamp-1",
-                  )}
-                >
-                  {isExpanded ? autolinkText(body, "text-sky-600") : body}
-                </p>
-              ) : null}
-            </div>
-            <div className="flex shrink-0 items-center gap-2 pt-1">
-              {role === "campaign" && campaignState !== undefined ? (
-                <CampaignStateBadge state={campaignState} />
-              ) : null}
-              <ChevronRightIcon
-                className={`h-3.5 w-3.5 text-slate-500 transition-transform duration-150 ${
-                  isExpanded ? "rotate-90" : ""
-                }`}
-              />
-            </div>
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="top">
-          <p>{formatExactTimestamp(entry.occurredAt)}</p>
-        </TooltipContent>
-      </Tooltip>
-    </li>
-  );
-}
-
-export function shouldHideAutomatedRowBody(input: {
-  readonly isExpanded: boolean;
-  readonly kind: InboxTimelineEntryKind;
-  readonly headline: string | null;
-}): boolean {
-  return (
-    !input.isExpanded &&
-    ((input.kind === "outbound-auto-email" && input.headline !== null) ||
-      input.kind === "outbound-campaign-email")
-  );
-}
-
-function NoteEntry({
-  entry,
-  currentOperatorUserId,
-}: {
-  readonly entry: InboxTimelineEntryViewModel;
-  readonly currentOperatorUserId: string;
-}) {
-  const router = useRouter();
-  const [isEditing, setIsEditing] = useState(false);
-  const [draftBody, setDraftBody] = useState(entry.body);
-  const [inlineError, setInlineError] = useState<string | null>(null);
-  const [deleteOpen, setDeleteOpen] = useState(false);
-  const [isSaving, startSaveTransition] = useTransition();
-  const [isDeleting, startDeleteTransition] = useTransition();
-  const canManageNote =
-    entry.noteId !== null &&
-    entry.noteId !== undefined &&
-    entry.authorId === currentOperatorUserId;
-
-  const saveEdit = () => {
-    const noteId = entry.noteId;
-
-    if (
-      typeof noteId !== "string" ||
-      entry.authorId !== currentOperatorUserId
-    ) {
-      return;
-    }
-
-    const validationError = getInternalNoteValidationError(draftBody);
-
-    if (validationError !== null) {
-      setInlineError(validationError);
-      return;
-    }
-
-    setInlineError(null);
-    startSaveTransition(async () => {
-      const result = await updateNoteAction({
-        noteId,
-        body: draftBody,
-      });
-
-      if (!result.ok) {
-        setInlineError(result.message);
-        return;
-      }
-
-      setIsEditing(false);
-      router.refresh();
-    });
-  };
-
-  const deleteNote = () => {
-    const noteId = entry.noteId;
-
-    if (
-      typeof noteId !== "string" ||
-      entry.authorId !== currentOperatorUserId
-    ) {
-      return;
-    }
-
-    setInlineError(null);
-    startDeleteTransition(async () => {
-      const result = await deleteNoteAction({
-        noteId,
-      });
-
-      if (!result.ok) {
-        setInlineError(result.message);
-        return;
-      }
-
-      setDeleteOpen(false);
-      router.refresh();
-    });
-  };
-
-  return (
-    <li className="flex w-full flex-col items-end pl-16">
-      <div
-        className="w-full max-w-[640px] rounded-xl border border-amber-200 bg-amber-50/60 px-4 py-2.5 shadow-sm"
-      >
-        <div className="mb-1 flex items-center justify-between gap-3 text-[11px] text-amber-700">
-          <div className="flex items-center gap-1.5">
-            <NoteIcon className="h-3 w-3" />
-            <span className="font-medium">Note</span>
-            <span className="text-amber-300">·</span>
-            <span>{entry.actorLabel}</span>
-            <span className="text-amber-300">·</span>
-            <TimelineTimestamp entry={entry} />
-          </div>
-          {canManageNote ? (
-            <div className="flex items-center gap-2">
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="h-auto px-2 py-1 text-[11px] text-amber-800 hover:bg-amber-100"
-                onClick={() => {
-                  setDraftBody(entry.body);
-                  setInlineError(null);
-                  setIsEditing(true);
-                }}
-              >
-                Edit
-              </Button>
-              <Popover open={deleteOpen} onOpenChange={setDeleteOpen}>
-                <PopoverTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="h-auto px-2 py-1 text-[11px] text-amber-800 hover:bg-amber-100"
-                  >
-                    Delete
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent className="w-64 space-y-3" align="end">
-                  <p className="text-sm font-medium text-slate-900">
-                    Delete this note?
-                  </p>
-                  <p className="text-xs text-slate-500">
-                    This removes the note from the shared timeline.
-                  </p>
-                  <div className="flex justify-end gap-2">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => {
-                        setDeleteOpen(false);
-                      }}
-                    >
-                      Cancel
-                    </Button>
-                    <Button
-                      type="button"
-                      size="sm"
-                      disabled={isDeleting}
-                      onClick={deleteNote}
-                    >
-                      {isDeleting ? (
-                        <>
-                          <LoaderIcon className="size-3 animate-spin" />
-                          Deleting...
-                        </>
-                      ) : (
-                        "Delete"
-                      )}
-                    </Button>
-                  </div>
-                </PopoverContent>
-              </Popover>
-            </div>
-          ) : null}
-        </div>
-        {isEditing ? (
-          <div className="space-y-3">
-            <textarea
-              rows={4}
-              value={draftBody}
-              onChange={(event) => {
-                setDraftBody(event.currentTarget.value);
-                if (inlineError !== null) {
-                  setInlineError(null);
-                }
-              }}
-              className="w-full resize-y rounded-md border border-amber-200 bg-white px-3 py-2 text-[13px] leading-relaxed text-slate-900 shadow-sm focus:outline-none focus:ring-1 focus:ring-amber-300"
-            />
-            {inlineError ? (
-              <p className="text-xs text-rose-700">{inlineError}</p>
-            ) : null}
-            <div className="flex justify-end gap-2">
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => {
-                  setDraftBody(entry.body);
-                  setInlineError(null);
-                  setIsEditing(false);
-                }}
-              >
-                Cancel
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                disabled={isSaving}
-                onClick={saveEdit}
-              >
-                {isSaving ? (
-                  <>
-                    <LoaderIcon className="size-3 animate-spin" />
-                    Saving...
-                  </>
-                ) : (
-                  "Save"
-                )}
-              </Button>
-            </div>
-          </div>
-        ) : (
-          <>
-            <p
-              className={cn(
-                "font-message-body whitespace-pre-wrap text-pretty text-[13.5px] leading-relaxed text-amber-900",
-                WRAP_ANYWHERE,
-              )}
-            >
-              {entry.body}
-            </p>
-            {inlineError ? (
-              <p className="mt-2 text-xs text-rose-700">{inlineError}</p>
-            ) : null}
-          </>
-        )}
-      </div>
-    </li>
-  );
-}
-
-function SystemDivider({
-  entry,
-  volunteerFirstName,
-}: {
-  readonly entry: InboxTimelineEntryViewModel;
-  readonly volunteerFirstName: string;
-}) {
-  const descriptor = describeLifecycleEvent(
-    personalizeSystemBody(entry.body, volunteerFirstName),
-  );
-
-  return (
-    <li className="flex w-full items-center justify-center gap-3 py-1.5">
-      <div className="h-px flex-1 bg-slate-200" />
-      <div
-        className={cn(
-          "inline-flex max-w-[720px] items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1 shadow-sm",
-        )}
-      >
-        <div
-          className={cn(
-            "inline-flex size-5 shrink-0 items-center justify-center rounded-full bg-white",
-            descriptor.iconClassName,
-          )}
-        >
-          <descriptor.Icon className="size-3" />
-        </div>
-        <span
-          className={cn(
-            "text-[10px] font-semibold uppercase tracking-wider",
-            descriptor.labelClassName,
-          )}
-        >
-          {descriptor.label}
-        </span>
-        <span className="text-[11.5px] text-slate-600">
-          {personalizeSystemBody(entry.body, volunteerFirstName)}
-        </span>
-        <TimelineTimestamp
-          entry={entry}
-          className="text-[11px] text-slate-400"
-          asSpan
-        />
-      </div>
-      <div className="h-px flex-1 bg-slate-200" />
-    </li>
-  );
-}
-
-interface EventRowDescriptor {
-  readonly label: string;
-  readonly Icon: ComponentType<{ className?: string }>;
-  readonly shellClassName: string;
-  readonly iconClassName: string;
-  readonly labelClassName: string;
-}
-
-function describeEventRow(input: {
-  readonly role: "automated" | "campaign" | "activity";
-  readonly isEmail: boolean;
-}): EventRowDescriptor {
-  if (input.role === "campaign") {
-    return {
-      label: input.isEmail ? "Campaign" : "Campaign SMS",
-      Icon: MegaphoneIcon,
-      shellClassName:
-        "border-violet-200/70 bg-violet-50/30 hover:bg-violet-50/60",
-      iconClassName: "border-violet-100 bg-violet-100 text-violet-700",
-      labelClassName: "text-violet-700",
-    };
-  }
-
-  if (input.role === "activity") {
-    return {
-      label: input.isEmail ? "Activity" : "SMS Activity",
-      Icon: input.isEmail ? MailIcon : PhoneIcon,
-      shellClassName: "border-violet-200 bg-violet-50/75 hover:bg-violet-50",
-      iconClassName: "border-violet-200 text-violet-700",
-      labelClassName: "text-violet-700",
-    };
-  }
-
-  return {
-    label: input.isEmail ? "Automated" : "Automated SMS",
-    Icon: input.isEmail ? ZapIcon : WandIcon,
-    shellClassName: "border-slate-200 bg-slate-50/40 hover:bg-slate-100/60",
-    iconClassName: "border-slate-100 bg-slate-100 text-slate-600",
-    labelClassName: "text-slate-500",
-  };
-}
-
-function describeCampaignVisualState(
-  activities: readonly {
-    readonly activityType: "sent" | "opened" | "clicked" | "unsubscribed";
-  }[],
-): "sent" | "opened" | "clicked" | "unsubscribed" {
-  if (activities.some((activity) => activity.activityType === "unsubscribed")) {
-    return "unsubscribed";
-  }
-
-  if (activities.some((activity) => activity.activityType === "clicked")) {
-    return "clicked";
-  }
-
-  if (activities.some((activity) => activity.activityType === "opened")) {
-    return "opened";
-  }
-
-  return "sent";
-}
-
-function CampaignStateIcon({
-  state,
-}: {
-  readonly state: ReturnType<typeof describeCampaignVisualState>;
-}) {
-  const AccentIcon =
-    state === "clicked"
-      ? MousePointerClickIcon
-      : state === "opened"
-        ? EyeIcon
-        : state === "unsubscribed"
-          ? XIcon
-          : null;
-
-  return (
-    <span className="relative inline-flex">
-      <MegaphoneIcon className="size-4" />
-      {AccentIcon ? (
-        <span className="absolute -right-1 -top-1 inline-flex size-3.5 items-center justify-center rounded-full border border-violet-200 bg-white text-violet-700 shadow-sm">
-          <AccentIcon className="size-2" />
-        </span>
-      ) : (
-        <span className="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-violet-500 ring-2 ring-white" />
-      )}
-    </span>
-  );
-}
-
-function CampaignStateBadge({
-  state,
-}: {
-  readonly state: ReturnType<typeof describeCampaignVisualState>;
-}) {
-  const label =
-    state === "clicked"
-      ? "Clicked"
-      : state === "opened"
-        ? "Opened"
-        : state === "unsubscribed"
-          ? "Unsubscribed"
-          : "Sent";
-  const Icon =
-    state === "clicked"
-      ? MousePointerClickIcon
-      : state === "opened"
-        ? EyeIcon
-        : state === "unsubscribed"
-          ? XIcon
-          : CheckCircleIcon;
-  const className =
-    state === "clicked"
-      ? "bg-emerald-50 text-emerald-700"
-      : state === "opened"
-        ? "bg-indigo-50 text-indigo-700"
-        : state === "unsubscribed"
-          ? "bg-rose-50 text-rose-700"
-          : "bg-slate-50 text-slate-700";
-
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium",
-        className,
-      )}
-    >
-      <Icon className="size-2.5" />
-      {label}
-    </span>
-  );
-}
-
-function describeLifecycleEvent(body: string): Omit<
-  EventRowDescriptor,
-  "shellClassName"
-> {
-  const normalized = body.toLowerCase();
-
-  if (normalized.includes("training")) {
-    return {
-      label: "Training",
-      Icon: WandIcon,
-      iconClassName: "border-sky-200 text-sky-700",
-      labelClassName: "text-sky-700",
-    };
-  }
-
-  if (normalized.includes("field")) {
-    return {
-      label: "In Field",
-      Icon: MapPinIcon,
-      iconClassName: "border-emerald-200 text-emerald-700",
-      labelClassName: "text-emerald-700",
-    };
-  }
-
-  if (normalized.includes("successful") || normalized.includes("complete")) {
-    return {
-      label: "Completed",
-      Icon: CheckCircleIcon,
-      iconClassName: "border-emerald-200 text-emerald-700",
-      labelClassName: "text-emerald-700",
-    };
-  }
-
-  if (normalized.includes("applied")) {
-    return {
-      label: "Applied",
-      Icon: SparkleIcon,
-      iconClassName: "border-violet-200 text-violet-700",
-      labelClassName: "text-violet-700",
-    };
-  }
-
-  return {
-    label: "Lifecycle",
-    Icon: CalendarIcon,
-    iconClassName: "border-amber-200 text-amber-700",
-    labelClassName: "text-amber-700",
-  };
-}
-
-function bodyTextForEntry(entry: InboxTimelineEntryViewModel): string {
-  return entry.body.trim();
-}
-
-function personalizeSystemBody(body: string, firstName: string): string {
-  if (body.length === 0) return firstName;
-  const head = body.charAt(0).toLowerCase();
-  const tail = body.slice(1);
-  return `${firstName} ${head}${tail}`;
 }
 
 type EntryRole =

--- a/apps/web/tests/unit/inbox-timeline.test.ts
+++ b/apps/web/tests/unit/inbox-timeline.test.ts
@@ -14,26 +14,40 @@ vi.mock("@/components/ui/divider-label", () => ({
     createElement("span", null, children),
 }));
 
-vi.mock("@/app/_lib/design-tokens", () => ({
-  RADIUS: {
-    bubble: "rounded-2xl",
-    md: "rounded-xl",
-  },
+vi.mock("@/app/_lib/design-tokens-v2", () => ({
   SHADOW: {
     sm: "shadow-sm",
   },
-  TEXT: {
-    bodySm: "text-sm",
+  TYPE: {
     bodySerifSm: "text-[13.5px]",
     micro: "text-xs",
-  },
-  TONE: {
-    amber: {
-      subtle: "bg-amber-50",
-    },
+    label: "text-[10px]",
   },
   TRANSITION: {
     fast: "transition-colors",
+    reduceMotion: "motion-reduce:transition-none",
+  },
+  TONE_CLASSES: {
+    amber: {
+      subtle: "bg-amber-50",
+      text: "text-amber-700",
+    },
+    emerald: {
+      subtle: "bg-emerald-50",
+      text: "text-emerald-700",
+    },
+    sky: {
+      subtle: "bg-sky-50",
+      text: "text-sky-700",
+    },
+    slate: {
+      subtle: "bg-slate-50",
+      text: "text-slate-700",
+    },
+    violet: {
+      subtle: "bg-violet-50",
+      text: "text-violet-700",
+    },
   },
 }));
 
@@ -41,6 +55,7 @@ import {
   InboxTimeline,
   shouldHideAutomatedRowBody,
 } from "../../app/inbox/_components/inbox-timeline";
+import { classifySystemDivider } from "../../app/inbox/_components/inbox-timeline-system-divider";
 
 const baseEntry = {
   id: "timeline:auto-email-1",
@@ -209,7 +224,7 @@ describe("InboxTimeline", () => {
       }),
     );
 
-    expect(markup).toContain("Applied");
+    expect(markup).toContain("APPLIED");
     expect(markup).toContain("Alice applied to the Pacific Northwest expedition.");
   });
 
@@ -277,7 +292,7 @@ describe("InboxTimeline", () => {
     expect(markup).toContain("[overflow-wrap:anywhere]");
   });
 
-  it("renders From, To, and Cc metadata for one-to-one email entries", () => {
+  it("renders the compact participant header for one-to-one email entries", () => {
     const markup = renderToStaticMarkup(
       createElement(InboxTimeline, {
         entries: [
@@ -299,17 +314,18 @@ describe("InboxTimeline", () => {
       }),
     );
 
-    expect(markup).toContain("From");
-    expect(markup).toContain(
-      "PNW Project &lt;pnwbio@adventurescientists.org&gt;",
-    );
-    expect(markup).toContain("To");
-    expect(markup).toContain(
-      "Shaina Dotson &lt;shaina.dotson@gmail.com&gt;",
-    );
-    expect(markup).toContain("Cc");
-    expect(markup).toContain(
-      "Samantha Doe &lt;samantha@adventurescientists.org&gt;",
-    );
+    expect(markup).toContain("PNW Project");
+    expect(markup).toContain("Shaina Dotson");
+    expect(markup).toContain("+cc");
+    expect(markup).toContain("Reply");
+  });
+
+  it("classifies first-data system dividers into the emerald data category", () => {
+    expect(
+      classifySystemDivider("Submitted first batch from the field."),
+    ).toMatchObject({
+      label: "FIRST DATA",
+      tone: "emerald",
+    });
   });
 });

--- a/apps/web/tests/unit/inbox-timeline.test.ts
+++ b/apps/web/tests/unit/inbox-timeline.test.ts
@@ -15,6 +15,17 @@ vi.mock("@/components/ui/divider-label", () => ({
 }));
 
 vi.mock("@/app/_lib/design-tokens-v2", () => ({
+  FOCUS_RING:
+    "focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-300",
+  RADIUS: {
+    sm: "rounded-sm",
+    md: "rounded-md",
+    lg: "rounded-lg",
+    xl: "rounded-xl",
+  },
+  SPACING: {
+    section: "px-5 py-4",
+  },
   SHADOW: {
     sm: "shadow-sm",
   },

--- a/apps/web/tests/unit/inbox-timeline.test.ts
+++ b/apps/web/tests/unit/inbox-timeline.test.ts
@@ -322,6 +322,9 @@ describe("InboxTimeline", () => {
         ],
         volunteerFirstName: "Shaina",
         currentOperatorUserId: "user:operator",
+        // Reply button only renders when onReply is provided; supply a no-op
+        // so the markup contains it for the assertion below.
+        onReply: () => {},
       }),
     );
 

--- a/apps/web/tests/unit/inbox-timeline.test.ts
+++ b/apps/web/tests/unit/inbox-timeline.test.ts
@@ -324,7 +324,7 @@ describe("InboxTimeline", () => {
         currentOperatorUserId: "user:operator",
         // Reply button only renders when onReply is provided; supply a no-op
         // so the markup contains it for the assertion below.
-        onReply: () => {},
+        onReply: vi.fn(),
       }),
     );
 

--- a/apps/web/tests/unit/stage3-timeline-pending.test.tsx
+++ b/apps/web/tests/unit/stage3-timeline-pending.test.tsx
@@ -17,6 +17,17 @@ vi.mock("@/components/ui/divider-label", () => ({
 }));
 
 vi.mock("@/app/_lib/design-tokens-v2", () => ({
+  FOCUS_RING:
+    "focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-300",
+  RADIUS: {
+    sm: "rounded-sm",
+    md: "rounded-md",
+    lg: "rounded-lg",
+    xl: "rounded-xl",
+  },
+  SPACING: {
+    section: "px-5 py-4",
+  },
   SHADOW: {
     sm: "shadow-sm",
   },

--- a/apps/web/tests/unit/stage3-timeline-pending.test.tsx
+++ b/apps/web/tests/unit/stage3-timeline-pending.test.tsx
@@ -16,26 +16,40 @@ vi.mock("@/components/ui/divider-label", () => ({
     createElement("span", null, children),
 }));
 
-vi.mock("@/app/_lib/design-tokens", () => ({
-  RADIUS: {
-    bubble: "rounded-2xl",
-    md: "rounded-xl",
-  },
+vi.mock("@/app/_lib/design-tokens-v2", () => ({
   SHADOW: {
     sm: "shadow-sm",
   },
-  TEXT: {
-    bodySm: "text-sm",
+  TYPE: {
     micro: "text-xs",
-  },
-  TONE: {
-    amber: {
-      subtle: "bg-amber-50",
-    },
+    bodySerifSm: "text-[13.5px]",
+    label: "text-[10px]",
   },
   TRANSITION: {
     fast: "transition-colors",
     reduceMotion: "motion-reduce:transition-none",
+  },
+  TONE_CLASSES: {
+    amber: {
+      subtle: "bg-amber-50",
+      text: "text-amber-700",
+    },
+    emerald: {
+      subtle: "bg-emerald-50",
+      text: "text-emerald-700",
+    },
+    sky: {
+      subtle: "bg-sky-50",
+      text: "text-sky-700",
+    },
+    slate: {
+      subtle: "bg-slate-50",
+      text: "text-slate-700",
+    },
+    violet: {
+      subtle: "bg-violet-50",
+      text: "text-violet-700",
+    },
   },
 }));
 


### PR DESCRIPTION
## Summary

Surface 1 of the pixel-perfect design v2 pass. Rebuilds the inbox timeline message bubbles + system dividers per the new design.

- Avatar OUTSIDE bubble (left/inbound, right/outbound)
- Compact `Sender → Recipient +cc ▾` one-liner header with arrow + chevron
- Subject bolded inside bubble; body in serif (preserved)
- Timestamp top-right of bubble header
- Inline `↩ Reply` button bottom-right wired to `openReplyDraft(...)`
- Inbound = white/slate; email outbound = sky-tinted; SMS outbound = filled sky
- System dividers: categorical pill labels (LIFECYCLE/TRAINING/TRIP PLANNING/FIRST DATA SUBMITTED) with icons + per-category tone

## Refactor (in same PR per Q6 in UI grill)

`inbox-timeline.tsx` split from a 1311-LOC monolith into 457 LOC + new files:
- `inbox-timeline-bubble.tsx`
- `inbox-timeline-system-divider.tsx`
- `email-participant-header.tsx`
- (additional automated/note row primitives)

## Verification

- `pnpm --filter @as-comms/web typecheck` ✅
- `pnpm --filter @as-comms/web lint` ✅
- Local unit tests blocked by macOS rollup-darwin-arm64 (memory `project_macos_rollup_gotcha.md`); CI is authoritative

## Brief

`.codex-s1-timeline-bubbles-2026-04-25.md` (wraps the UI sub-architect's `.codex-surface-1-timeline-bubbles-2026-04-25.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)