### PR TITLE
fix(welcome): derive friendly first name from email when user.name is empty

### DIFF
--- a/apps/web/app/inbox/page.tsx
+++ b/apps/web/app/inbox/page.tsx
@@ -3,14 +3,40 @@ import { requireSession } from "@/src/server/auth/session";
 import { InboxWelcomeWorkload } from "./_components/inbox-welcome-workload";
 import { getInboxWelcomeWorkload } from "./_lib/selectors";
 
+function deriveFirstName(name: string | null, email: string): string {
+  // Prefer the user's display name's first whitespace-delimited token.
+  if (name !== null) {
+    const trimmed = name.trim();
+    if (trimmed.length > 0) {
+      const token = trimmed.split(/\s+/u)[0] ?? "";
+      if (token.length > 0) {
+        return token;
+      }
+    }
+  }
+
+  // Fall back to the email's local part, capitalized — e.g.
+  // "nico@adventurescientists.org" → "Nico". Reading "Welcome back,
+  // nico@adventurescientists.org" looks like an error to operators.
+  const local = (email.split("@")[0] ?? "").trim();
+  if (local.length === 0) {
+    return "there";
+  }
+  // Strip dots/dashes/underscores so first.last → "First".
+  const cleanedToken = local.split(/[.\-_]+/u)[0] ?? local;
+  if (cleanedToken.length === 0) {
+    return "there";
+  }
+  return cleanedToken.charAt(0).toUpperCase() + cleanedToken.slice(1);
+}
+
 export default async function InboxListPage() {
   const [workload, currentUser] = await Promise.all([
     getInboxWelcomeWorkload(),
     requireSession(),
   ]);
 
-  const displayName = currentUser.name ?? currentUser.email;
-  const firstName = displayName.trim().split(/\s+/)[0] ?? "there";
+  const firstName = deriveFirstName(currentUser.name, currentUser.email);
 
   return <InboxWelcomeWorkload workload={workload} firstName={firstName} />;
 }


### PR DESCRIPTION
## Summary

QA finding from the inbox welcome screen. Users with `name=null` saw `Welcome back, nico@adventurescientists.org` — looks like a rendering error.

## Fix

`apps/web/app/inbox/page.tsx` — `deriveFirstName(name, email)`:
1. Prefer first whitespace-delimited token of `user.name` if non-empty
2. Fall back to email local part, capitalized (`nico@adventurescientists.org` → `Nico`)
3. Handle dotted locals: `first.last@example.org` → `First`
4. Final guard: `there`

## Test plan

- [x] Local QA: dev server now renders `Welcome back, Nico` instead of full email
- [x] `pnpm --filter @as-comms/web typecheck` clean
- [ ] CI verify green

🤖 Generated with [Claude Code](https://claude.com/claude-code)