### PR TITLE
fix(integrations): detect Gmail DSN bounces, mark pending outbound failed (D3)

### DIFF
--- a/apps/web/app/inbox/_components/inbox-timeline-bubble.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-bubble.tsx
@@ -144,12 +144,14 @@ function OutboundStatusBanner({
       : null;
 
   return (
-    <div className="mb-3 flex items-center justify-between gap-3 rounded-md border border-rose-300 bg-rose-50 px-3 py-2 text-xs text-rose-900">
-      <span>
-        {entry.sendStatus === "failed"
-          ? "Send failed."
-          : "Send stalled before confirmation."}
-      </span>
+      <div className="mb-3 flex items-center justify-between gap-3 rounded-md border border-rose-300 bg-rose-50 px-3 py-2 text-xs text-rose-900">
+        <span>
+          {entry.failedReason === "bounce"
+            ? "Your last reply to this contact bounced — recipient address may be invalid."
+            : entry.sendStatus === "failed"
+              ? "Send failed."
+              : "Send stalled before confirmation."}
+        </span>
       {retryDisabledReason ? (
         <TooltipProvider>
           <Tooltip>

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -1819,6 +1819,14 @@ function buildTimelineEntry(input: {
       input.item.family === "one_to_one_email"
         ? (input.item.sendStatus ?? null)
         : null,
+    failedReason:
+      input.item.family === "one_to_one_email"
+        ? (input.item.failedReason ?? null)
+        : null,
+    failedDetail:
+      input.item.family === "one_to_one_email"
+        ? (input.item.failedDetail ?? null)
+        : null,
     attachmentCount:
       input.item.family === "one_to_one_email"
         ? (input.item.attachmentCount ?? 0)

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -178,6 +178,8 @@ export interface InboxTimelineEntryViewModel {
   readonly rfc822MessageId: string | null;
   readonly inReplyToRfc822: string | null;
   readonly sendStatus: InboxTimelineEntrySendStatus;
+  readonly failedReason: string | null;
+  readonly failedDetail: string | null;
   readonly attachmentCount: number;
   readonly campaignActivity: readonly InboxTimelineCampaignActivityViewModel[];
   readonly noteId?: string | null;

--- a/apps/web/app/inbox/actions.ts
+++ b/apps/web/app/inbox/actions.ts
@@ -1481,6 +1481,11 @@ export async function sendComposerAction(
         },
       });
 
+      await runtime.repositories.pendingOutbounds.markSentRfc822(
+        pendingOutboundId,
+        sendResult.rfc822MessageId,
+      );
+
       if (parsedInput.data.supersedesPendingId !== undefined) {
         await runtime.repositories.pendingOutbounds.markSuperseded(
           parsedInput.data.supersedesPendingId,

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -139,6 +139,8 @@ function buildTimelineEntry(
     rfc822MessageId: null,
     inReplyToRfc822: null,
     sendStatus: null,
+    failedReason: null,
+    failedDetail: null,
     attachmentCount: 0,
     campaignActivity: [],
     ...overrides,

--- a/apps/web/tests/unit/inbox-timeline.test.ts
+++ b/apps/web/tests/unit/inbox-timeline.test.ts
@@ -87,6 +87,8 @@ const baseEntry = {
   rfc822MessageId: null,
   inReplyToRfc822: null,
   sendStatus: null,
+  failedReason: null,
+  failedDetail: null,
   attachmentCount: 0,
   campaignActivity: [],
 };

--- a/apps/web/tests/unit/stage3-send-action.test.ts
+++ b/apps/web/tests/unit/stage3-send-action.test.ts
@@ -122,6 +122,14 @@ describe("sendComposerAction", () => {
   });
 
   it("writes a durable pending row first, creates a contact for a naked email, and returns the FP-07 success envelope", async () => {
+    if (!runtime) {
+      throw new Error("Expected runtime.");
+    }
+
+    const markSentRfc822Spy = vi.spyOn(
+      runtime.context.repositories.pendingOutbounds,
+      "markSentRfc822",
+    );
     sendComposerGmailMessage.mockResolvedValue({
       kind: "success",
       gmailMessageId: "gmail-message-1",
@@ -138,8 +146,8 @@ describe("sendComposerAction", () => {
       },
     });
 
-    if (!runtime || !result.ok) {
-      throw new Error("Expected runtime and success result.");
+    if (!result.ok) {
+      throw new Error("Expected success result.");
     }
 
     const contact = await runtime.context.repositories.contacts.findById(
@@ -174,6 +182,7 @@ describe("sendComposerAction", () => {
           contentType: "text/plain",
         },
       ],
+      sentRfc822MessageId: "<gmail-message-1@example.org>",
     });
     expect(audits.map((audit) => audit.action)).toEqual([
       "composer.send_attempted",
@@ -184,6 +193,10 @@ describe("sendComposerAction", () => {
         bodyPlaintext: "Thanks again for confirming the field logistics.",
         bodyHtml: "<p>Thanks again for confirming the field logistics.</p>",
       }),
+    );
+    expect(markSentRfc822Spy).toHaveBeenCalledWith(
+      result.data.pendingOutboundId,
+      "<gmail-message-1@example.org>",
     );
   });
 

--- a/apps/web/tests/unit/stage3-timeline-pending.test.tsx
+++ b/apps/web/tests/unit/stage3-timeline-pending.test.tsx
@@ -88,6 +88,8 @@ function buildEntry(
     rfc822MessageId: null,
     inReplyToRfc822: "parent-message-id",
     sendStatus: "pending",
+    failedReason: null,
+    failedDetail: null,
     attachmentCount: 0,
     campaignActivity: [],
     ...overrides,
@@ -124,6 +126,27 @@ describe("stage3 pending timeline rendering", () => {
 
     expect(markup).toContain("Send failed.");
     expect(markup).toContain("Retry");
+  });
+
+  it("renders the bounce-specific failure banner for bounced replies", () => {
+    const markup = renderToStaticMarkup(
+      createElement(InboxTimeline, {
+        entries: [
+          buildEntry({
+            sendStatus: "failed",
+            failedReason: "bounce",
+            failedDetail: "550 5.1.1 user unknown",
+          }),
+        ],
+        volunteerFirstName: "Alice",
+        currentOperatorUserId: "user:operator",
+        onRetryPending: vi.fn(),
+      }),
+    );
+
+    expect(markup).toContain(
+      "Your last reply to this contact bounced"
+    );
   });
 
   it("disables retry when the failed row had attachments", () => {

--- a/apps/worker/src/ingest/types.ts
+++ b/apps/worker/src/ingest/types.ts
@@ -69,7 +69,8 @@ export interface Stage1DeferredIngestResult extends Stage1IngestResultBase {
   readonly reason:
     | "unsupported_record_type"
     | "deferred_record_family"
-    | "skipped_by_policy";
+    | "skipped_by_policy"
+    | "gmail_dsn";
   readonly detail: string;
 }
 

--- a/apps/worker/src/orchestration/service.ts
+++ b/apps/worker/src/orchestration/service.ts
@@ -31,6 +31,7 @@ import {
 } from "@as-comms/contracts";
 import {
   ProviderCaptureError,
+  gmailMessageRecordSchema,
   importGmailMboxRecords,
   mapGmailRecord,
   mapMailchimpRecord,
@@ -1016,6 +1017,67 @@ export function createStage1WorkerOrchestrationService(input: {
             windowStart: payload.windowStart,
             windowEnd: payload.windowEnd
           });
+        }
+
+        if (
+          payload.provider === "gmail" &&
+          ingestResult.outcome === "deferred" &&
+          ingestResult.reason === "gmail_dsn"
+        ) {
+          const gmailRecord = gmailMessageRecordSchema.safeParse(record);
+
+          if (gmailRecord.success) {
+            try {
+              const evidenceId = `source-evidence:gmail:gmail.dsn:${gmailRecord.data.recordId}`;
+              await input.persistence.repositories.sourceEvidence.append({
+                id: evidenceId,
+                provider: "gmail",
+                providerRecordType: "gmail.dsn",
+                providerRecordId: gmailRecord.data.recordId,
+                receivedAt: gmailRecord.data.receivedAt,
+                occurredAt: gmailRecord.data.occurredAt,
+                payloadRef: gmailRecord.data.payloadRef,
+                idempotencyKey: `gmail:gmail.dsn:${gmailRecord.data.recordId}`,
+                checksum: gmailRecord.data.checksum
+              });
+            } catch {
+              // Replay-safe duplicate evidence writes can be ignored.
+            }
+
+            const dsnOriginalMessageId = gmailRecord.data.dsnOriginalMessageId;
+
+            if (
+              dsnOriginalMessageId !== null &&
+              dsnOriginalMessageId.length > 0
+            ) {
+              const pending =
+                await input.persistence.repositories.pendingOutbounds.findBySentRfc822MessageId(
+                  dsnOriginalMessageId
+                );
+
+              if (pending !== null && pending.status === "pending") {
+                await input.persistence.repositories.pendingOutbounds.markFailed(
+                  pending.id,
+                  {
+                    reason: "bounce",
+                    detail: gmailRecord.data.bodyTextPreview.slice(0, 500)
+                  }
+                );
+                logger.info({
+                  event: "composer.bounce.matched",
+                  pendingOutboundId: pending.id,
+                  dsnOriginalMessageId,
+                  dsnGmailMessageId: gmailRecord.data.recordId
+                });
+              } else if (pending === null) {
+                logger.info({
+                  event: "composer.bounce.unmatched",
+                  dsnOriginalMessageId,
+                  dsnGmailMessageId: gmailRecord.data.recordId
+                });
+              }
+            }
+          }
         }
 
         if (

--- a/apps/worker/test/stage1-orchestration.test.ts
+++ b/apps/worker/test/stage1-orchestration.test.ts
@@ -86,8 +86,12 @@ function buildGmailMessageRecord(
     readonly checksum: string;
     readonly snippet: string;
     readonly subject: string | null;
+    readonly fromHeader: string | null;
+    readonly toHeader: string | null;
+    readonly ccHeader: string | null;
     readonly snippetClean: string;
     readonly bodyTextPreview: string;
+    readonly dsnOriginalMessageId: string | null;
     readonly threadId: string | null;
     readonly rfc822MessageId: string | null;
     readonly normalizedParticipantEmails: readonly string[];
@@ -112,8 +116,12 @@ function buildGmailMessageRecord(
     checksum: "checksum-1",
     snippet: "Following up by email",
     subject: null,
+    fromHeader: "Project Team <orcas@adventurescientists.org>",
+    toHeader: "Volunteer <volunteer@example.org>",
+    ccHeader: null,
     snippetClean: "Following up by email",
     bodyTextPreview: "Following up by email",
+    dsnOriginalMessageId: null,
     threadId: "thread-1",
     rfc822MessageId: "<message-1@example.org>",
     normalizedParticipantEmails: ["volunteer@example.org"],
@@ -894,6 +902,192 @@ Alias drift outbound message.
         messageId: "gmail-live-duplicate-1",
         windowStart: "2026-01-01T23:52:00.000Z",
         windowEnd: "2026-01-02T00:02:00.000Z"
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("writes Gmail DSN evidence and marks the matched pending outbound failed", async () => {
+    const dsnRecord = buildGmailMessageRecord({
+      recordId: "gmail-dsn-match-1",
+      direction: "inbound",
+      occurredAt: "2026-01-02T00:02:00.000Z",
+      receivedAt: "2026-01-02T00:02:30.000Z",
+      payloadRef:
+        "gmail://volunteers@adventurescientists.org/messages/gmail-dsn-match-1",
+      checksum: "checksum:gmail-dsn-match-1",
+      snippet: "Delivery Status Notification (Failure)",
+      subject: "Delivery Status Notification (Failure)",
+      fromHeader: "Mail Delivery Subsystem <mailer-daemon@googlemail.com>",
+      toHeader: "Project <orcas@adventurescientists.org>",
+      snippetClean: "Delivery Status Notification (Failure)",
+      bodyTextPreview:
+        "550 5.1.1 The email account that you tried to reach does not exist.",
+      dsnOriginalMessageId: "<sent-match-1@example.org>",
+      threadId: "thread-dsn-match-1",
+      rfc822MessageId: "<gmail-dsn-match-1@example.org>",
+      supportingRecords: [],
+      crossProviderCollapseKey: null
+    });
+    const capture = createEmptyCapturePorts();
+    capture.gmail.captureLiveBatch = () =>
+      Promise.resolve(buildCapturedBatch([dsnRecord]));
+    const logger = { info: vi.fn() };
+    const context = await createTestWorkerContext({ capture, logger });
+
+    try {
+      await seedContact(context);
+      await context.settings.users.upsert({
+        id: "user:operator",
+        name: "Operator",
+        email: "operator@example.org",
+        emailVerified: new Date("2026-01-01T00:00:00.000Z"),
+        image: null,
+        role: "operator",
+        deactivatedAt: null,
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      });
+      await context.repositories.pendingOutbounds.insert({
+        id: "pending:dsn-match",
+        fingerprint: "fp:dsn-match",
+        actorId: "user:operator",
+        canonicalContactId: contactId,
+        projectId: null,
+        fromAlias: "orcas@adventurescientists.org",
+        toEmailNormalized: "volunteer@example.org",
+        subject: "Prior send",
+        bodyPlaintext: "Prior send body",
+        bodySha256: "sha256:dsn-match",
+        attachmentMetadata: [],
+        gmailThreadId: null,
+        inReplyToRfc822: null,
+        sentAt: "2026-01-02T00:01:00.000Z"
+      });
+      await context.repositories.pendingOutbounds.markSentRfc822(
+        "pending:dsn-match",
+        "<sent-match-1@example.org>"
+      );
+
+      const result = await context.orchestration.runGmailLiveCaptureBatch({
+        version: 1,
+        jobId: "job:gmail:dsn:match",
+        correlationId: "corr:gmail:dsn:match",
+        traceId: null,
+        batchId: "batch:gmail:dsn:match",
+        syncStateId: "sync:gmail:dsn:match",
+        attempt: 1,
+        maxAttempts: 3,
+        provider: "gmail",
+        mode: "live",
+        jobType: "live_ingest",
+        cursor: null,
+        checkpoint: null,
+        windowStart: "2026-01-02T00:00:00.000Z",
+        windowEnd: "2026-01-02T00:03:00.000Z",
+        recordIds: ["gmail-dsn-match-1"],
+        maxRecords: 10
+      });
+
+      expect(result.outcome).toBe("succeeded");
+      if (result.outcome !== "succeeded") {
+        throw new Error("Expected Gmail DSN batch to succeed.");
+      }
+      expect(result.summary.deferred).toBe(1);
+      await expect(
+        context.repositories.canonicalEvents.countAll()
+      ).resolves.toBe(0);
+      await expect(
+        context.repositories.sourceEvidence.findById(
+          "source-evidence:gmail:gmail.dsn:gmail-dsn-match-1"
+        )
+      ).resolves.toMatchObject({
+        providerRecordType: "gmail.dsn",
+        providerRecordId: "gmail-dsn-match-1"
+      });
+      await expect(
+        context.repositories.pendingOutbounds.findByFingerprint("fp:dsn-match")
+      ).resolves.toMatchObject({
+        id: "pending:dsn-match",
+        status: "failed",
+        failedReason: "bounce",
+        failedDetail:
+          "550 5.1.1 The email account that you tried to reach does not exist."
+      });
+      expect(logger.info).toHaveBeenCalledWith({
+        event: "composer.bounce.matched",
+        pendingOutboundId: "pending:dsn-match",
+        dsnOriginalMessageId: "<sent-match-1@example.org>",
+        dsnGmailMessageId: "gmail-dsn-match-1"
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("logs unmatched Gmail DSNs without throwing or writing canonical events", async () => {
+    const dsnRecord = buildGmailMessageRecord({
+      recordId: "gmail-dsn-unmatched-1",
+      direction: "inbound",
+      occurredAt: "2026-01-02T00:04:00.000Z",
+      receivedAt: "2026-01-02T00:04:30.000Z",
+      payloadRef:
+        "gmail://volunteers@adventurescientists.org/messages/gmail-dsn-unmatched-1",
+      checksum: "checksum:gmail-dsn-unmatched-1",
+      snippet: "Undelivered Mail Returned to Sender",
+      subject: "Undelivered Mail Returned to Sender",
+      fromHeader: "mailer-daemon@googlemail.com",
+      toHeader: "Project <orcas@adventurescientists.org>",
+      snippetClean: "Undelivered Mail Returned to Sender",
+      bodyTextPreview: "550 5.1.1 user unknown",
+      dsnOriginalMessageId: "<missing-match@example.org>",
+      threadId: "thread-dsn-unmatched-1",
+      rfc822MessageId: "<gmail-dsn-unmatched-1@example.org>",
+      supportingRecords: [],
+      crossProviderCollapseKey: null
+    });
+    const capture = createEmptyCapturePorts();
+    capture.gmail.captureLiveBatch = () =>
+      Promise.resolve(buildCapturedBatch([dsnRecord]));
+    const logger = { info: vi.fn() };
+    const context = await createTestWorkerContext({ capture, logger });
+
+    try {
+      await seedContact(context);
+
+      const result = await context.orchestration.runGmailLiveCaptureBatch({
+        version: 1,
+        jobId: "job:gmail:dsn:unmatched",
+        correlationId: "corr:gmail:dsn:unmatched",
+        traceId: null,
+        batchId: "batch:gmail:dsn:unmatched",
+        syncStateId: "sync:gmail:dsn:unmatched",
+        attempt: 1,
+        maxAttempts: 3,
+        provider: "gmail",
+        mode: "live",
+        jobType: "live_ingest",
+        cursor: null,
+        checkpoint: null,
+        windowStart: "2026-01-02T00:03:00.000Z",
+        windowEnd: "2026-01-02T00:05:00.000Z",
+        recordIds: ["gmail-dsn-unmatched-1"],
+        maxRecords: 10
+      });
+
+      expect(result.outcome).toBe("succeeded");
+      if (result.outcome !== "succeeded") {
+        throw new Error("Expected unmatched Gmail DSN batch to succeed.");
+      }
+      expect(result.summary.deferred).toBe(1);
+      await expect(
+        context.repositories.canonicalEvents.countAll()
+      ).resolves.toBe(0);
+      expect(logger.info).toHaveBeenCalledWith({
+        event: "composer.bounce.unmatched",
+        dsnOriginalMessageId: "<missing-match@example.org>",
+        dsnGmailMessageId: "gmail-dsn-unmatched-1"
       });
     } finally {
       await context.dispose();

--- a/packages/contracts/src/stage1-timeline.ts
+++ b/packages/contracts/src/stage1-timeline.ts
@@ -103,6 +103,8 @@ export const oneToOneEmailTimelineItemSchema = timelineItemBaseSchema.extend({
   rfc822MessageId: nullableStringSchema.optional(),
   inReplyToRfc822: nullableStringSchema.optional(),
   sendStatus: z.enum(["pending", "failed", "orphaned"]).nullable().optional(),
+  failedReason: z.string().nullable().optional(),
+  failedDetail: z.string().nullable().optional(),
   attachmentCount: z.number().int().nonnegative().optional(),
 });
 export type OneToOneEmailTimelineItem = z.infer<

--- a/packages/db/drizzle/0028_pending_outbound_sent_rfc822.sql
+++ b/packages/db/drizzle/0028_pending_outbound_sent_rfc822.sql
@@ -1,0 +1,7 @@
+ALTER TABLE pending_composer_outbounds
+  ADD COLUMN sent_rfc822_message_id TEXT,
+  ADD COLUMN failed_detail TEXT;
+
+CREATE INDEX pending_composer_outbounds_sent_rfc822_idx
+  ON pending_composer_outbounds (sent_rfc822_message_id)
+  WHERE sent_rfc822_message_id IS NOT NULL;

--- a/packages/db/src/mappers.ts
+++ b/packages/db/src/mappers.ts
@@ -1014,6 +1014,8 @@ export function mapPendingComposerOutboundRow(
     reconciledEventId: row.reconciledEventId,
     reconciledAt: fromDate(row.reconciledAt),
     failedReason: row.failedReason,
+    sentRfc822MessageId: row.sentRfc822MessageId,
+    failedDetail: row.failedDetail,
     orphanedAt: fromDate(row.orphanedAt),
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),
@@ -1044,6 +1046,8 @@ export function mapPendingComposerOutboundToInsert(
     reconciledAt:
       record.reconciledAt === null ? null : toDate(record.reconciledAt),
     failedReason: record.failedReason,
+    sentRfc822MessageId: record.sentRfc822MessageId,
+    failedDetail: record.failedDetail,
     orphanedAt: record.orphanedAt === null ? null : toDate(record.orphanedAt),
     createdAt: toDate(record.createdAt),
     updatedAt: toDate(record.updatedAt),

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -1882,6 +1882,8 @@ function createStage1RepositoriesInternal(
           reconciledEventId: null,
           reconciledAt: null,
           failedReason: null,
+          sentRfc822MessageId: null,
+          failedDetail: null,
           orphanedAt: null,
           createdAt: now.toISOString(),
           updatedAt: now.toISOString(),
@@ -1912,6 +1914,23 @@ function createStage1RepositoriesInternal(
         return row === undefined ? null : mapPendingComposerOutboundRow(row);
       },
 
+      async markSentRfc822(id, sentRfc822MessageId) {
+        await db
+          .update(pendingComposerOutbounds)
+          .set({ sentRfc822MessageId, updatedAt: new Date() })
+          .where(eq(pendingComposerOutbounds.id, id));
+      },
+
+      async findBySentRfc822MessageId(messageId) {
+        const [row] = (await db
+          .select()
+          .from(pendingComposerOutbounds)
+          .where(eq(pendingComposerOutbounds.sentRfc822MessageId, messageId))
+          .orderBy(desc(pendingComposerOutbounds.sentAt))
+          .limit(1)) as PendingComposerOutboundRow[];
+        return row === undefined ? null : mapPendingComposerOutboundRow(row);
+      },
+
       async markConfirmed(id, input) {
         await db
           .update(pendingComposerOutbounds)
@@ -1920,6 +1939,7 @@ function createStage1RepositoriesInternal(
             reconciledEventId: input.reconciledEventId,
             reconciledAt: new Date(),
             failedReason: null,
+            failedDetail: null,
             orphanedAt: null,
             updatedAt: new Date(),
           })
@@ -1943,6 +1963,7 @@ function createStage1RepositoriesInternal(
           .set({
             status: "failed",
             failedReason: input.reason,
+            failedDetail: input.detail ?? null,
             updatedAt: new Date(),
           })
           .where(

--- a/packages/db/src/schema/tables.ts
+++ b/packages/db/src/schema/tables.ts
@@ -759,6 +759,8 @@ export const pendingComposerOutbounds = pgTable(
       withTimezone: true,
     }),
     failedReason: text("failed_reason"),
+    sentRfc822MessageId: text("sent_rfc822_message_id"),
+    failedDetail: text("failed_detail"),
     orphanedAt: timestamp("orphaned_at", {
       mode: "date",
       withTimezone: true,
@@ -772,6 +774,9 @@ export const pendingComposerOutbounds = pgTable(
       table.canonicalContactId,
       table.status,
     ),
+    index("pending_composer_outbounds_sent_rfc822_idx")
+      .on(table.sentRfc822MessageId)
+      .where(sql`${table.sentRfc822MessageId} is not null`),
     index("pending_composer_outbounds_pending_sweep_idx")
       .on(table.status, table.sentAt)
       .where(sql`${table.status} = 'pending'`),

--- a/packages/db/test/stage3-pending-outbounds.test.ts
+++ b/packages/db/test/stage3-pending-outbounds.test.ts
@@ -81,11 +81,18 @@ describe("pending composer outbound repositories", () => {
           },
         ],
         sentAt,
+        sentRfc822MessageId: null,
+        failedDetail: null,
       });
 
       await context.repositories.pendingOutbounds.markFailed("pending:1", {
         reason: "provider_transient",
+        detail: "Temporary provider failure",
       });
+      await context.repositories.pendingOutbounds.markSentRfc822(
+        "pending:1",
+        "<pending-1@example.org>",
+      );
       await context.repositories.pendingOutbounds.insert({
         id: "pending:2",
         fingerprint: "fp:pending:2",
@@ -127,8 +134,21 @@ describe("pending composer outbound repositories", () => {
         ),
       ).resolves.toMatchObject([
         { id: "pending:3", status: "pending" },
-        { id: "pending:1", status: "failed", failedReason: "provider_transient" },
+        {
+          id: "pending:1",
+          status: "failed",
+          failedReason: "provider_transient",
+          failedDetail: "Temporary provider failure",
+          sentRfc822MessageId: "<pending-1@example.org>",
+        },
       ]);
+      await expect(
+        context.repositories.pendingOutbounds.findBySentRfc822MessageId(
+          "<pending-1@example.org>",
+        ),
+      ).resolves.toMatchObject({
+        id: "pending:1",
+      });
     } finally {
       await context.client.close();
     }

--- a/packages/domain/src/pending-outbounds.ts
+++ b/packages/domain/src/pending-outbounds.ts
@@ -34,6 +34,8 @@ export interface PendingComposerOutboundRecord {
   readonly reconciledEventId: string | null;
   readonly reconciledAt: string | null;
   readonly failedReason: string | null;
+  readonly sentRfc822MessageId: string | null;
+  readonly failedDetail: string | null;
   readonly orphanedAt: string | null;
   readonly createdAt: string;
   readonly updatedAt: string;

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -264,11 +264,18 @@ export interface PendingComposerOutboundRepository {
   findByFingerprint(
     fingerprint: string,
   ): Promise<PendingComposerOutboundRecord | null>;
+  markSentRfc822(id: string, sentRfc822MessageId: string): Promise<void>;
+  findBySentRfc822MessageId(
+    messageId: string,
+  ): Promise<PendingComposerOutboundRecord | null>;
   markConfirmed(
     id: string,
     input: { readonly reconciledEventId: string | null },
   ): Promise<void>;
-  markFailed(id: string, input: { readonly reason: string }): Promise<void>;
+  markFailed(
+    id: string,
+    input: { readonly reason: string; readonly detail?: string | null },
+  ): Promise<void>;
   markSuperseded(id: string): Promise<void>;
   sweepOrphans(input: { readonly olderThan: Date }): Promise<number>;
   findForContact(

--- a/packages/domain/src/timeline.ts
+++ b/packages/domain/src/timeline.ts
@@ -264,6 +264,8 @@ function buildPendingTimelineItems(
         row.status === "orphaned"
           ? row.status
           : null,
+      failedReason: row.failedReason,
+      failedDetail: row.failedDetail,
       attachmentCount: row.attachmentMetadata.length,
     })),
   );

--- a/packages/domain/test/normalization.test.ts
+++ b/packages/domain/test/normalization.test.ts
@@ -376,6 +376,9 @@ function buildContext(input: {
       insert: ({ id }) => Promise.resolve(id),
       findByFingerprint: () =>
         Promise.resolve<PendingComposerOutboundRecord | null>(null),
+      markSentRfc822: () => Promise.resolve(),
+      findBySentRfc822MessageId: () =>
+        Promise.resolve<PendingComposerOutboundRecord | null>(null),
       markConfirmed: () => Promise.resolve(),
       markFailed: () => Promise.resolve(),
       markSuperseded: () => Promise.resolve(),

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -122,6 +122,9 @@ describe("defineStage1RepositoryBundle", () => {
         insert: ({ id }) => Promise.resolve(id),
         findByFingerprint: () =>
           Promise.resolve<PendingComposerOutboundRecord | null>(null),
+        markSentRfc822: () => Promise.resolve(),
+        findBySentRfc822MessageId: () =>
+          Promise.resolve<PendingComposerOutboundRecord | null>(null),
         markConfirmed: () => Promise.resolve(),
         markFailed: () => Promise.resolve(),
         markSuperseded: () => Promise.resolve(),

--- a/packages/domain/test/stage3-last-inbound-alias.test.ts
+++ b/packages/domain/test/stage3-last-inbound-alias.test.ts
@@ -141,6 +141,9 @@ function buildRepositoryBundle(input: {
       insert: ({ id }) => Promise.resolve(id),
       findByFingerprint: () =>
         Promise.resolve<PendingComposerOutboundRecord | null>(null),
+      markSentRfc822: () => Promise.resolve(),
+      findBySentRfc822MessageId: () =>
+        Promise.resolve<PendingComposerOutboundRecord | null>(null),
       markConfirmed: () => Promise.resolve(),
       markFailed: () => Promise.resolve(),
       markSuperseded: () => Promise.resolve(),

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -223,6 +223,8 @@ function createRepositoryBundle(input: {
     pendingOutbounds: {
       insert: ({ id }) => Promise.resolve(id),
       findByFingerprint: () => Promise.resolve(null),
+      markSentRfc822: () => Promise.resolve(),
+      findBySentRfc822MessageId: () => Promise.resolve(null),
       markConfirmed: () => Promise.resolve(),
       markFailed: () => Promise.resolve(),
       markSuperseded: () => Promise.resolve(),
@@ -752,6 +754,8 @@ describe("Stage 1 timeline presenter", () => {
           reconciledEventId: null,
           reconciledAt: null,
           failedReason: null,
+          sentRfc822MessageId: null,
+          failedDetail: null,
           orphanedAt: null,
           createdAt: "2026-01-01T00:02:00.000Z",
           updatedAt: "2026-01-01T00:02:00.000Z",

--- a/packages/integrations/src/capture-services/gmail.ts
+++ b/packages/integrations/src/capture-services/gmail.ts
@@ -20,6 +20,7 @@ import {
   type GmailProviderCloseMessageInput
 } from "../providers/gmail-record-builder.js";
 import {
+  extractDsnOriginalMessageId,
   extractGmailBodyPreviewFromPayloadResult,
   type GmailApiMessagePart
 } from "../providers/gmail-body.js";
@@ -414,19 +415,44 @@ export async function mapLiveGmailMessageToRecord(input: {
   readonly receivedAt: string;
 }): Promise<GmailRecord> {
   const headers = buildHeaderRecord(input.message.payload.headers ?? []);
+  const topLevelMimeType = (headers["Content-Type"] ?? "").toLowerCase();
+  const fromHeader = headers.From ?? "";
+  const subjectHeader = (headers.Subject ?? "").toLowerCase().trimStart();
+  const isPossiblyDsn =
+    fromHeader.toLowerCase().includes("mailer-daemon") ||
+    fromHeader.toLowerCase().includes("mail delivery subsystem") ||
+    subjectHeader.startsWith("delivery status notification") ||
+    subjectHeader.startsWith("undelivered mail") ||
+    subjectHeader.startsWith("returned mail") ||
+    subjectHeader.startsWith("mail delivery failed") ||
+    topLevelMimeType.includes("multipart/report");
+  const bodyPreviewResult = await extractGmailBodyPreviewFromPayloadResult(
+    input.message.payload
+  );
+  const previewMessageIdPattern =
+    /Message-ID:\s*(<\d+\.[a-f0-9-]+@[a-z.]+>)/iu;
+  const dsnOriginalMessageIdFromParts = isPossiblyDsn
+    ? extractDsnOriginalMessageId(input.message.payload)
+    : null;
+  const dsnOriginalMessageIdFromPreview = isPossiblyDsn
+    ? (previewMessageIdPattern.exec(bodyPreviewResult.bodyTextPreview)?.[1] ??
+      null)
+    : null;
   const builderInput: GmailProviderCloseMessageInput = {
     recordId: input.message.id,
     threadId: input.message.threadId,
     labelIds: input.message.labelIds,
     snippet: input.message.snippet,
     snippetClean: input.message.snippet,
-    ...(await extractGmailBodyPreviewFromPayloadResult(input.message.payload)),
+    ...bodyPreviewResult,
     internalDate: input.message.internalDate,
     headers,
     payloadRef: `gmail://${encodeURIComponent(input.capturedMailbox)}/messages/${encodeURIComponent(input.message.id)}`,
     checksum: buildLiveGmailChecksum(input.message),
     capturedMailbox: input.capturedMailbox,
     receivedAt: input.receivedAt,
+    dsnOriginalMessageId:
+      dsnOriginalMessageIdFromParts ?? dsnOriginalMessageIdFromPreview,
     internalAddresses: uniqueValues([
       input.liveAccount,
       ...input.projectInboxAliases

--- a/packages/integrations/src/provider-types.ts
+++ b/packages/integrations/src/provider-types.ts
@@ -23,7 +23,8 @@ export type SupportingProviderRecord = z.infer<
 export const providerMappingDeferredReasonValues = [
   "unsupported_record_type",
   "deferred_record_family",
-  "skipped_by_policy"
+  "skipped_by_policy",
+  "gmail_dsn"
 ] as const;
 export const providerMappingDeferredReasonSchema = z.enum(
   providerMappingDeferredReasonValues

--- a/packages/integrations/src/providers/gmail-body.ts
+++ b/packages/integrations/src/providers/gmail-body.ts
@@ -212,6 +212,20 @@ function decodeBase64Url(value: string): Buffer {
   return Buffer.from(paddedValue, "base64");
 }
 
+function decodePartBodyToString(part: GmailApiMessagePart): string | null {
+  const bodyData = part.body?.data;
+
+  if (typeof bodyData !== "string" || bodyData.length === 0) {
+    return null;
+  }
+
+  try {
+    return decodeBase64Url(bodyData).toString("utf8");
+  } catch {
+    return null;
+  }
+}
+
 function getPartHeader(
   part: GmailApiMessagePart,
   headerName: string
@@ -225,6 +239,78 @@ function getPartHeader(
 
 function normalizeMimeType(value: string | null | undefined): string {
   return value?.split(";")[0]?.trim().toLowerCase() ?? "";
+}
+
+function extractHeaderValue(
+  value: string,
+  patterns: readonly RegExp[]
+): string | null {
+  for (const pattern of patterns) {
+    const match = value.match(pattern);
+
+    if (match?.[1] !== undefined) {
+      const extracted = match[1].trim();
+
+      if (extracted.length > 0) {
+        return extracted;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function extractDsnOriginalMessageId(
+  payload: GmailApiMessagePart
+): string | null {
+  const mimeType = normalizeMimeType(payload.mimeType);
+
+  if (mimeType === "message/delivery-status") {
+    const decoded = decodePartBodyToString(payload);
+
+    if (decoded !== null) {
+      const originalMessageId = extractHeaderValue(decoded, [
+        /^Original-Message-ID:\s*(.+)$/imu,
+        /^Message-ID:\s*(.+)$/imu
+      ]);
+
+      if (originalMessageId !== null) {
+        return originalMessageId;
+      }
+
+      const finalRecipient = extractHeaderValue(decoded, [
+        /^Final-Recipient:\s*(.+)$/imu
+      ]);
+
+      if (finalRecipient !== null) {
+        return finalRecipient;
+      }
+    }
+  }
+
+  if (mimeType === "message/rfc822") {
+    const decoded = decodePartBodyToString(payload);
+
+    if (decoded !== null) {
+      const embeddedMessageId = extractHeaderValue(decoded, [
+        /^Message-ID:\s*(.+)$/imu
+      ]);
+
+      if (embeddedMessageId !== null) {
+        return embeddedMessageId;
+      }
+    }
+  }
+
+  for (const childPart of payload.parts ?? []) {
+    const nestedMatch = extractDsnOriginalMessageId(childPart);
+
+    if (nestedMatch !== null) {
+      return nestedMatch;
+    }
+  }
+
+  return null;
 }
 
 function buildBodyPreviewResult(

--- a/packages/integrations/src/providers/gmail-record-builder.ts
+++ b/packages/integrations/src/providers/gmail-record-builder.ts
@@ -19,6 +19,7 @@ export interface GmailProviderCloseMessageInput {
     | "encrypted_placeholder"
     | "binary_fallback"
     | null;
+  readonly dsnOriginalMessageId?: string | null;
   readonly internalDate: string | null;
   readonly headers: Readonly<Record<string, string>>;
   readonly payloadRef: string;
@@ -257,6 +258,7 @@ export function buildGmailMessageRecord(
     snippetClean,
     bodyTextPreview,
     bodyKind: input.bodyKind ?? "plaintext",
+    dsnOriginalMessageId: input.dsnOriginalMessageId ?? null,
     threadId: input.threadId,
     rfc822MessageId,
     capturedMailbox: input.capturedMailbox,

--- a/packages/integrations/src/providers/gmail.ts
+++ b/packages/integrations/src/providers/gmail.ts
@@ -46,6 +46,7 @@ export const gmailMessageRecordSchema = z.object({
     .enum(["plaintext", "encrypted_placeholder", "binary_fallback"])
     .nullable()
     .optional(),
+  dsnOriginalMessageId: z.string().nullable().default(null),
   threadId: nullableStringSchema.default(null),
   rfc822MessageId: nullableStringSchema.default(null),
   capturedMailbox: nullableStringSchema.default(null),
@@ -190,13 +191,34 @@ export function mapGmailRecord(rawRecord: GmailRecord): ProviderMappingResult {
   const supportedRecord = gmailMessageRecordSchema.safeParse(rawRecord);
 
   if (supportedRecord.success) {
-    const labelIds = supportedRecord.data.labelIds ?? [];
+    const rec = supportedRecord.data;
+    const fromLower = (rec.fromHeader ?? "").toLowerCase();
+    const subjectLower = (rec.subject ?? "").toLowerCase().trimStart();
+    const isDsn =
+      fromLower.includes("mailer-daemon@") ||
+      fromLower.includes("mail delivery subsystem") ||
+      subjectLower.startsWith("delivery status notification") ||
+      subjectLower.startsWith("undelivered mail") ||
+      subjectLower.startsWith("returned mail") ||
+      subjectLower.startsWith("mail delivery failed");
+
+    if (isDsn) {
+      return createDeferredMappingResult({
+        provider: "gmail",
+        sourceRecordType: rec.recordType,
+        sourceRecordId: rec.recordId,
+        reason: "gmail_dsn",
+        detail: rec.dsnOriginalMessageId ?? ""
+      });
+    }
+
+    const labelIds = rec.labelIds ?? [];
 
     if (labelIds.includes("DRAFT") && !labelIds.includes("SENT")) {
       return createDeferredMappingResult({
         provider: "gmail",
-        sourceRecordType: supportedRecord.data.recordType,
-        sourceRecordId: supportedRecord.data.recordId,
+        sourceRecordType: rec.recordType,
+        sourceRecordId: rec.recordId,
         reason: "skipped_by_policy",
         detail: "Gmail draft-only messages are skipped before canonical ingest."
       });
@@ -204,11 +226,9 @@ export function mapGmailRecord(rawRecord: GmailRecord): ProviderMappingResult {
 
     return createCommandMappingResult({
       provider: "gmail",
-      sourceRecordType: supportedRecord.data.recordType,
-      sourceRecordId: supportedRecord.data.recordId,
-      command: createCanonicalEventCommand(
-        mapGmailMessageRecord(supportedRecord.data)
-      )
+      sourceRecordType: rec.recordType,
+      sourceRecordId: rec.recordId,
+      command: createCanonicalEventCommand(mapGmailMessageRecord(rec))
     });
   }
 

--- a/packages/integrations/src/providers/gmail.ts
+++ b/packages/integrations/src/providers/gmail.ts
@@ -203,12 +203,19 @@ export function mapGmailRecord(rawRecord: GmailRecord): ProviderMappingResult {
       subjectLower.startsWith("mail delivery failed");
 
     if (isDsn) {
+      // detail is required (z.string().min(1)). When the DSN payload didn't
+      // expose an Original-Message-ID (e.g. detected only by subject prefix),
+      // fall back to a descriptive marker so the audit trail still has a value.
+      const dsnDetail =
+        rec.dsnOriginalMessageId !== null && rec.dsnOriginalMessageId.length > 0
+          ? `original_message_id=${rec.dsnOriginalMessageId}`
+          : "no original_message_id in dsn body";
       return createDeferredMappingResult({
         provider: "gmail",
         sourceRecordType: rec.recordType,
         sourceRecordId: rec.recordId,
         reason: "gmail_dsn",
-        detail: rec.dsnOriginalMessageId ?? ""
+        detail: dsnDetail
       });
     }
 

--- a/packages/integrations/test/gmail-body-extraction.test.ts
+++ b/packages/integrations/test/gmail-body-extraction.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   cleanGmailBodyPreviewText,
+  extractDsnOriginalMessageId,
   extractGmailBodyPreviewFromMimeMessageResult,
   extractGmailBodyPreviewFromPayloadResult,
   extractGmailBodyPreviewFromMimeMessage,
@@ -215,5 +216,54 @@ describe("Gmail body extraction", () => {
     const longBody = `Hello Samantha,\n\n${"A".repeat(2_600)}`;
 
     expect(cleanGmailBodyPreviewText(longBody)).toBe(longBody);
+  });
+
+  it("extracts the original message id from a delivery-status MIME part", () => {
+    const payload: GmailApiMessagePart = {
+      mimeType: "multipart/report",
+      parts: [
+        {
+          mimeType: "message/delivery-status",
+          body: {
+            data: Buffer.from(
+              [
+                "Reporting-MTA: dns; googlemail.com",
+                "Final-Recipient: rfc822; volunteer@example.org",
+                "Original-Message-ID: <123.abcde-67890@example.org>",
+              ].join("\r\n"),
+              "utf8",
+            )
+              .toString("base64")
+              .replace(/\+/g, "-")
+              .replace(/\//g, "_")
+              .replace(/=+$/u, ""),
+          },
+        },
+      ],
+    };
+
+    expect(extractDsnOriginalMessageId(payload)).toBe(
+      "<123.abcde-67890@example.org>",
+    );
+  });
+
+  it("returns null when no DSN-bearing MIME parts exist", () => {
+    const payload: GmailApiMessagePart = {
+      mimeType: "multipart/alternative",
+      parts: [
+        {
+          mimeType: "text/plain",
+          body: {
+            data: Buffer.from("Normal body", "utf8")
+              .toString("base64")
+              .replace(/\+/g, "-")
+              .replace(/\//g, "_")
+              .replace(/=+$/u, ""),
+          },
+        },
+      ],
+    };
+
+    expect(extractDsnOriginalMessageId(payload)).toBeNull();
   });
 });

--- a/packages/integrations/test/stage1-mappers.test.ts
+++ b/packages/integrations/test/stage1-mappers.test.ts
@@ -233,6 +233,80 @@ describe("Stage 1 provider-close mappers", () => {
     expect(result.outcome).toBe("command");
   });
 
+  it("defers Gmail DSNs detected from a mailer-daemon from-header", () => {
+    const result = mapGmailRecord({
+      recordType: "message",
+      recordId: "gmail-dsn-1",
+      direction: "inbound",
+      occurredAt: "2026-01-01T00:00:00.000Z",
+      receivedAt: "2026-01-01T00:01:00.000Z",
+      payloadRef: "payloads/gmail/gmail-dsn-1.json",
+      checksum: "checksum-dsn-1",
+      snippet: "Delivery failed",
+      subject: "Re: prior message",
+      fromHeader: "Mail Delivery Subsystem <mailer-daemon@googlemail.com>",
+      toHeader: "Project <project@example.org>",
+      ccHeader: null,
+      snippetClean: "Delivery failed",
+      bodyTextPreview: "Original-Message-ID: <123.abc@example.org>",
+      dsnOriginalMessageId: "<123.abc@example.org>",
+      capturedMailbox: "volunteers@example.org",
+      projectInboxAlias: null,
+      normalizedParticipantEmails: ["volunteer@example.org"],
+      salesforceContactId: null,
+      volunteerIdPlainValues: [],
+      normalizedPhones: [],
+      supportingRecords: [],
+      crossProviderCollapseKey: null,
+      threadId: "thread-dsn-1",
+      rfc822MessageId: "<dsn-1@example.org>"
+    });
+
+    expect(result).toEqual({
+      outcome: "deferred",
+      provider: "gmail",
+      sourceRecordType: "message",
+      sourceRecordId: "gmail-dsn-1",
+      reason: "gmail_dsn",
+      detail: "<123.abc@example.org>"
+    });
+  });
+
+  it("defers Gmail DSNs detected from a delivery-status subject prefix", () => {
+    const result = mapGmailRecord({
+      recordType: "message",
+      recordId: "gmail-dsn-2",
+      direction: "inbound",
+      occurredAt: "2026-01-01T00:00:00.000Z",
+      receivedAt: "2026-01-01T00:01:00.000Z",
+      payloadRef: "payloads/gmail/gmail-dsn-2.json",
+      checksum: "checksum-dsn-2",
+      snippet: "Delivery status notification",
+      subject: "  Delivery Status Notification (Failure)",
+      fromHeader: "postmaster@example.org",
+      toHeader: "Project <project@example.org>",
+      ccHeader: null,
+      snippetClean: "Delivery status notification",
+      bodyTextPreview: "Bounce body",
+      dsnOriginalMessageId: null,
+      capturedMailbox: "volunteers@example.org",
+      projectInboxAlias: null,
+      normalizedParticipantEmails: ["volunteer@example.org"],
+      salesforceContactId: null,
+      volunteerIdPlainValues: [],
+      normalizedPhones: [],
+      supportingRecords: [],
+      crossProviderCollapseKey: null,
+      threadId: "thread-dsn-2",
+      rfc822MessageId: "<dsn-2@example.org>"
+    });
+
+    expect(result).toMatchObject({
+      outcome: "deferred",
+      reason: "gmail_dsn"
+    });
+  });
+
   it("maps Salesforce contact snapshots into contact graph upserts", () => {
     const result = mapSalesforceRecord({
       recordType: "contact_snapshot",

--- a/packages/integrations/test/stage1-mappers.test.ts
+++ b/packages/integrations/test/stage1-mappers.test.ts
@@ -268,7 +268,7 @@ describe("Stage 1 provider-close mappers", () => {
       sourceRecordType: "message",
       sourceRecordId: "gmail-dsn-1",
       reason: "gmail_dsn",
-      detail: "<123.abc@example.org>"
+      detail: "original_message_id=<123.abc@example.org>"
     });
   });
 


### PR DESCRIPTION
## Summary

Closes D3 from the composer email design grill. Today, Gmail Delivery Status Notification (DSN) bounces are being ingested as if the volunteer sent them: they appear in the inbox feed under the recipient's contact, the read-state flips to `new`, and the matching `pending_composer_outbounds` row sits as `pending` until the orphan sweep flips it to `orphaned` 30 minutes later — so the operator never sees a clear "your reply bounced" signal.

## Fix

- **Detect DSN at Gmail mapping time**: `From: mailer-daemon`, `Content-Type: multipart/report; report-type=delivery-status` (RFC 3464), or `Subject: Delivery Status Notification`.
- **Divert from inbox feed**: DSN evidence is logged with `provider_record_type='gmail.dsn'` instead of creating a canonical event under the volunteer's contact.
- **Match to pending row**: parse the original `Message-ID` out of the DSN's `message/rfc822` part, look up `pending_composer_outbounds` where `sent_rfc822_message_id` matches.
- **Transition status**: `pending → failed`, `failed_reason='bounce'`, capture bounce detail.
- **Persist outbound rfc822 on send**: composer send action now stores `sent_rfc822_message_id` so future DSNs can match.
- **UI banner**: inbox timeline shows a per-thread bounce banner for affected pending rows.

## Schema change

New migration `packages/db/drizzle/0028_pending_outbound_sent_rfc822.sql` adds two columns to `pending_composer_outbounds`:
- `sent_rfc822_message_id text` — the rfc822 Message-ID returned by Gmail send
- `failed_detail text` — bounce reason text from the DSN

Architect runs post-merge:
```bash
psql -f packages/db/drizzle/0028_pending_outbound_sent_rfc822.sql "$DATABASE_URL"
```

(0026/0027 already in tree, hence 0028.)

## Out of scope

- Retro-classification of historical DSN rows (separate ops; brief notes a query for one-off cleanup)
- Auto-retry on bounce (intentional per design D3 — bad addresses don't fix themselves)

## Verification

- `pnpm --filter @as-comms/{integrations,db,domain,worker,web} typecheck` ✅
- `pnpm lint` ✅
- `pnpm test:unit` blocked locally on macOS rollup; CI is authoritative

## Brief

`.codex-fix-dsn-bounce-ingestion-2026-04-25.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)