### PR TITLE
fix(ops): backfill-membership-sf-ids — int4-safe limit + verbose error logging

### DIFF
--- a/apps/worker/src/ops/backfill-membership-sf-ids.ts
+++ b/apps/worker/src/ops/backfill-membership-sf-ids.ts
@@ -589,7 +589,11 @@ export async function runBackfillMembershipSfIdsCommand(
     connectionString,
     env,
     dryRun: !executeRequested,
-    limit: readOptionalIntegerFlag(flags, "limit", Number.MAX_SAFE_INTEGER),
+    // Postgres int4 max is 2_147_483_647. Number.MAX_SAFE_INTEGER (2^53-1)
+    // overflows the limit parameter on the wire, so use a large-but-int4-safe
+    // default. The fleet has ~10k memberships at most, so 1B is effectively
+    // "no limit".
+    limit: readOptionalIntegerFlag(flags, "limit", 1_000_000_000),
   });
 }
 
@@ -600,11 +604,13 @@ const isDirectExecution =
 if (isDirectExecution) {
   void runBackfillMembershipSfIdsCommand(process.argv.slice(2), process.env).catch(
     (error: unknown) => {
-      console.error(
-        error instanceof Error
-          ? error.message
-          : "backfill-membership-sf-ids failed.",
-      );
+      if (error instanceof Error) {
+        console.error("backfill-membership-sf-ids failed:", error.message);
+        if (error.stack) console.error(error.stack);
+        if ("cause" in error && error.cause) console.error("cause:", error.cause);
+      } else {
+        console.error("backfill-membership-sf-ids failed:", error);
+      }
       process.exitCode = 1;
     },
   );


### PR DESCRIPTION
## Summary

Two small hardenings discovered while running the backfill against prod on 2026-04-26.

## Bugs

### 1. `--limit` default overflowed Postgres int4

`readOptionalIntegerFlag(flags, "limit", Number.MAX_SAFE_INTEGER)` — `Number.MAX_SAFE_INTEGER` is 2^53-1 = 9_007_199_254_740_991. Postgres `int4` (which Drizzle uses for the bound parameter) maxes at 2_147_483_647. Result: every dry-run / execute failed with an opaque "Failed query: ... limit \$1" error and no clear cause.

**Fix**: default to `1_000_000_000` (well inside int4). Fleet has ~10k memberships max, so this is effectively no limit.

### 2. Error handler swallowed actual cause

`console.error(error.message)` was empty for some drizzle/postgres-js wrapped errors (e.g. the DNS-error case where `cause` had the real message). Operators saw "undefined" with no actionable info.

**Fix**: log `message + stack + cause`. The dry-run had been failing for a different reason (DNS to `postgres.railway.internal` not resolvable from outside Railway) and only this fix surfaced it.

## Verified by running the backfill end-to-end

Same script with these fixes:
- Dry-run: `7,644 candidates / 7,639 would-update / 0 missing / 5 ambiguous`
- Execute: succeeded; 7,639 memberships now have correct `salesforce_membership_id`; the 5 ambiguous rows stay NULL by design

## Test plan

- [x] Dry-run + execute confirmed working in prod
- [ ] CI verify green

🤖 Generated with [Claude Code](https://claude.com/claude-code)