### PR TITLE
refactor(settings): migrate to design-tokens-v2 + typography polish

### DIFF
--- a/apps/web/app/settings/_components/access-section.tsx
+++ b/apps/web/app/settings/_components/access-section.tsx
@@ -5,9 +5,9 @@ import { useState, useTransition } from "react";
 import {
   RADIUS,
   SHADOW,
-  TEXT,
+  TYPE,
   TRANSITION
-} from "@/app/_lib/design-tokens";
+} from "@/app/_lib/design-tokens-v2";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { StatusBadge } from "@/components/ui/status-badge";
@@ -245,7 +245,7 @@ export function AccessSection({ viewModel }: { readonly viewModel: AccessSetting
               <h3 id="invite-teammates-heading" className="text-sm font-semibold text-slate-900">
                 Invite teammates
               </h3>
-              <p className={TEXT.caption}>
+              <p className={TYPE.caption}>
                 Invites create a pending teammate row that links automatically
                 when they sign in with Google.
               </p>
@@ -269,7 +269,7 @@ export function AccessSection({ viewModel }: { readonly viewModel: AccessSetting
               </div>
 
               <div className="flex flex-col gap-2">
-                <span className={cn(TEXT.label, "text-slate-600")}>Role</span>
+                <span className={cn(TYPE.label, "text-slate-600")}>Role</span>
                 <ToggleGroup
                   type="single"
                   value={inviteRole}
@@ -331,26 +331,26 @@ export function AccessSection({ viewModel }: { readonly viewModel: AccessSetting
               <tr>
                 <th
                   scope="col"
-                  className={cn("px-5 py-3 text-left", TEXT.label, "tracking-wider")}
+                  className={cn("px-5 py-3 text-left", TYPE.label, "tracking-wider")}
                 >
                   Teammate
                 </th>
                 <th
                   scope="col"
-                  className={cn("px-5 py-3 text-left", TEXT.label, "tracking-wider")}
+                  className={cn("px-5 py-3 text-left", TYPE.label, "tracking-wider")}
                 >
                   Role
                 </th>
                 <th
                   scope="col"
-                  className={cn("px-5 py-3 text-left", TEXT.label, "tracking-wider")}
+                  className={cn("px-5 py-3 text-left", TYPE.label, "tracking-wider")}
                 >
                   Last active
                 </th>
                 {viewModel.isAdmin ? (
                   <th
                     scope="col"
-                    className={cn("px-5 py-3 text-left", TEXT.label, "tracking-wider")}
+                    className={cn("px-5 py-3 text-left", TYPE.label, "tracking-wider")}
                   >
                     Actions
                   </th>
@@ -398,7 +398,7 @@ export function AccessSection({ viewModel }: { readonly viewModel: AccessSetting
                               {user.displayName}
                             </p>
                             {isSelf ? (
-                              <span className={cn(TEXT.micro, "text-slate-400")}>
+                              <span className={cn(TYPE.micro, "text-slate-400")}>
                                 (you)
                               </span>
                             ) : null}
@@ -406,7 +406,7 @@ export function AccessSection({ viewModel }: { readonly viewModel: AccessSetting
                           <p
                             className={cn(
                               "truncate",
-                              TEXT.caption,
+                              TYPE.caption,
                               user.status === "deactivated" && "text-slate-400"
                             )}
                           >
@@ -423,7 +423,7 @@ export function AccessSection({ viewModel }: { readonly viewModel: AccessSetting
                     </td>
                     <td className="px-5 py-3 align-middle">
                       <span
-                        className={cn("tabular-nums", TEXT.bodySm, "text-slate-600")}
+                        className={cn("tabular-nums", TYPE.bodySm, "text-slate-600")}
                       >
                         {formatRelative(user.lastActiveAt)}
                       </span>
@@ -432,7 +432,7 @@ export function AccessSection({ viewModel }: { readonly viewModel: AccessSetting
                       <td className="px-5 py-3 align-middle">
                         <div className="flex flex-wrap items-center gap-2">
                           {isSelf ? (
-                            <span className={TEXT.caption}>Current session</span>
+                            <span className={TYPE.caption}>Current session</span>
                           ) : user.status === "deactivated" ? (
                             <Button
                               type="button"
@@ -475,7 +475,7 @@ export function AccessSection({ viewModel }: { readonly viewModel: AccessSetting
                             </>
                           )}
                           {isOnlyActiveAdmin ? (
-                            <span className={TEXT.caption}>Keep one active admin</span>
+                            <span className={TYPE.caption}>Keep one active admin</span>
                           ) : null}
                         </div>
                       </td>

--- a/apps/web/app/settings/_components/integrations-section.tsx
+++ b/apps/web/app/settings/_components/integrations-section.tsx
@@ -6,10 +6,10 @@ import { RefreshCw } from "lucide-react";
 import {
   RADIUS,
   SHADOW,
-  TEXT,
-  TONE,
-  TRANSITION
-} from "@/app/_lib/design-tokens";
+  TONE_CLASSES,
+  TRANSITION,
+  TYPE
+} from "@/app/_lib/design-tokens-v2";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { StatusBadge } from "@/components/ui/status-badge";
@@ -146,7 +146,7 @@ export function IntegrationsSection({ viewModel }: IntegrationsSectionProps) {
         <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
           {items.map((integration) => {
             const statusMeta = STATUS_META[integration.status];
-            const categoryTone = TONE[CATEGORY_TONE[integration.category]];
+            const categoryTone = TONE_CLASSES[CATEGORY_TONE[integration.category]];
             const isRowPending =
               pending && pendingId === integration.serviceName;
             const isSyncDisabled =
@@ -183,7 +183,7 @@ export function IntegrationsSection({ viewModel }: IntegrationsSectionProps) {
                           {CATEGORY_LABEL[integration.category]}
                         </span>
                       </div>
-                      <p className={cn("mt-1", TEXT.caption, "text-slate-600")}>
+                      <p className={cn("mt-1", TYPE.caption, "text-slate-600")}>
                         {integration.description}
                       </p>
                     </div>
@@ -206,7 +206,7 @@ export function IntegrationsSection({ viewModel }: IntegrationsSectionProps) {
                   <p
                     className={cn(
                       "line-clamp-2",
-                      TEXT.bodySm,
+                      TYPE.bodySm,
                       integration.detail ? "text-slate-700" : "text-slate-500"
                     )}
                   >
@@ -216,10 +216,10 @@ export function IntegrationsSection({ viewModel }: IntegrationsSectionProps) {
 
                 <div className="flex items-center justify-between gap-3 border-t border-slate-100 pt-3">
                   <div className="flex min-w-0 flex-col gap-1">
-                    <span className={cn(TEXT.label, "text-slate-400")}>
+                    <span className={cn(TYPE.label, "text-slate-400")}>
                       Last checked
                     </span>
-                    <span className={cn(TEXT.micro, "tabular-nums text-slate-500")}>
+                    <span className={cn(TYPE.micro, "tabular-nums text-slate-500")}>
                       {formatRelative(integration.lastCheckedAt)}
                     </span>
                   </div>

--- a/apps/web/app/settings/_components/project-detail.tsx
+++ b/apps/web/app/settings/_components/project-detail.tsx
@@ -9,9 +9,9 @@ import {
   FOCUS_RING,
   RADIUS,
   SHADOW,
-  TEXT,
+  TYPE,
   TRANSITION
-} from "@/app/_lib/design-tokens";
+} from "@/app/_lib/design-tokens-v2";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -597,7 +597,7 @@ export function ProjectDetail({
                 <p
                   className={cn(
                     "max-w-[240px]",
-                    TEXT.caption,
+                    TYPE.caption,
                     "text-slate-600"
                   )}
                 >
@@ -634,7 +634,7 @@ export function ProjectDetail({
         )}
       >
         <div>
-          <h2 id="project-details-heading" className={TEXT.headingSm}>
+          <h2 id="project-details-heading" className={TYPE.headingSm}>
             Project details
           </h2>
         </div>
@@ -643,7 +643,7 @@ export function ProjectDetail({
           <div className="flex flex-col gap-2">
             <label
               htmlFor="project-salesforce-id"
-              className={cn(TEXT.label, "text-slate-600")}
+              className={cn(TYPE.label, "text-slate-600")}
             >
               Salesforce project ID
             </label>
@@ -659,7 +659,7 @@ export function ProjectDetail({
           <div className="flex flex-col gap-2">
             <label
               htmlFor="project-short-alias"
-              className={cn(TEXT.label, "text-slate-600")}
+              className={cn(TYPE.label, "text-slate-600")}
             >
               Project alias
             </label>
@@ -689,7 +689,7 @@ export function ProjectDetail({
                   </Button>
                 ) : null}
               </div>
-              <span className={TEXT.caption}>
+              <span className={TYPE.caption}>
                 Short name used in inbox tags and internal UI labels.
               </span>
             </div>
@@ -698,7 +698,7 @@ export function ProjectDetail({
           <div className="flex flex-col gap-2 md:col-span-2">
             <label
               htmlFor="project-ai-knowledge-url"
-              className={cn(TEXT.label, "text-slate-600")}
+              className={cn(TYPE.label, "text-slate-600")}
             >
               AI knowledge source
             </label>
@@ -742,7 +742,7 @@ export function ProjectDetail({
                   </>
                 ) : null}
               </div>
-              <span className={TEXT.caption}>
+              <span className={TYPE.caption}>
                 {formatLastSynced(optimisticProject.aiKnowledgeSyncedAt)}
               </span>
             </div>
@@ -842,10 +842,10 @@ export function ProjectDetail({
         )}
       >
         <div>
-          <h2 id="project-emails-heading" className={TEXT.headingSm}>
+          <h2 id="project-emails-heading" className={TYPE.headingSm}>
             Project inbox aliases
           </h2>
-          <p className={cn("mt-0.5", TEXT.caption)}>
+          <p className={cn("mt-0.5", TYPE.caption)}>
             Inbound mail to any alias listed here is routed to this project&apos;s
             inbox.
           </p>
@@ -922,7 +922,7 @@ export function ProjectDetail({
                 <div className="flex flex-col gap-2">
                   <label
                     htmlFor={`project-email-signature-${email.id}`}
-                    className={cn(TEXT.label, "text-slate-600")}
+                    className={cn(TYPE.label, "text-slate-600")}
                   >
                     Signature
                   </label>
@@ -945,7 +945,7 @@ export function ProjectDetail({
                     placeholder="Plain-text signature..."
                   />
                   <div className="flex items-center justify-between gap-3">
-                    <span className={cn(TEXT.caption, "tabular-nums")}>
+                    <span className={cn(TYPE.caption, "tabular-nums")}>
                       {String(normalizeProjectAliasSignature(signatureDraft).length)}/2000
                     </span>
                     {project.isAdmin ? (
@@ -963,7 +963,7 @@ export function ProjectDetail({
                     ) : null}
                   </div>
                   {signatureError ? (
-                    <p className={cn(TEXT.caption, "text-rose-700")}>
+                    <p className={cn(TYPE.caption, "text-rose-700")}>
                       {signatureError}
                     </p>
                   ) : null}
@@ -973,7 +973,7 @@ export function ProjectDetail({
           })}
           {optimisticProject.emails.length === 0 ? (
             <li className="px-3 py-4 text-center">
-              <p className={TEXT.caption}>
+              <p className={TYPE.caption}>
                 No connected addresses yet.
               </p>
             </li>

--- a/apps/web/app/settings/_components/projects-section.tsx
+++ b/apps/web/app/settings/_components/projects-section.tsx
@@ -10,9 +10,9 @@ import {
   RADIUS,
   SHADOW,
   SPACING,
-  TEXT,
+  TYPE,
   TRANSITION
-} from "@/app/_lib/design-tokens";
+} from "@/app/_lib/design-tokens-v2";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { StatusBadge } from "@/components/ui/status-badge";
@@ -54,7 +54,7 @@ export function ProjectsSection({
             <h3 className="text-sm font-semibold text-slate-900">
               Currently active
             </h3>
-            <span className={cn(TEXT.caption, "tabular-nums")}>
+            <span className={cn(TYPE.caption, "tabular-nums")}>
               {String(viewModel.counts.active)} active
             </span>
           </div>
@@ -86,13 +86,13 @@ export function ProjectsSection({
                 <h3 className="text-sm font-semibold text-slate-900">
                   Inactive projects
                 </h3>
-                <p className={cn("mt-0.5", TEXT.caption)}>
+                <p className={cn("mt-0.5", TYPE.caption)}>
                   {isSearching
                     ? "Search results across inactive project names, project aliases, and inbox aliases."
                     : "Showing the 3 most recently created inactive projects. Search to find older ones."}
                 </p>
               </div>
-              <span className={cn(TEXT.caption, "tabular-nums")}>
+              <span className={cn(TYPE.caption, "tabular-nums")}>
                 {String(viewModel.counts.inactive)} inactive
               </span>
             </div>
@@ -166,7 +166,7 @@ function ProjectList({
     <ul
       className={cn(
         "divide-y divide-slate-100",
-        RADIUS.md,
+        RADIUS.lg,
         "border border-slate-200 bg-white",
         SHADOW.sm
       )}
@@ -197,11 +197,11 @@ function ProjectList({
               {renderMeta ? renderMeta(project) : null}
             </div>
             {project.projectAlias ? (
-              <p className={cn(TEXT.caption, "truncate text-slate-500")}>
+              <p className={cn(TYPE.caption, "truncate text-slate-500")}>
                 Alias: {project.projectAlias}
               </p>
             ) : null}
-            <p className={cn(TEXT.caption, "truncate")}>
+            <p className={cn(TYPE.caption, "truncate")}>
               {project.primaryEmail
                 ? project.additionalEmailCount > 0
                   ? `${project.primaryEmail} + ${String(project.additionalEmailCount)} more alias${project.additionalEmailCount === 1 ? "" : "es"}`
@@ -216,7 +216,7 @@ function ProjectList({
 
       {projects.length === 0 ? (
         <li className="px-5 py-10 text-center">
-          <p className={TEXT.caption}>{emptyMessage}</p>
+          <p className={TYPE.caption}>{emptyMessage}</p>
         </li>
       ) : null}
     </ul>

--- a/apps/web/app/settings/_components/settings-section-nav.tsx
+++ b/apps/web/app/settings/_components/settings-section-nav.tsx
@@ -10,9 +10,9 @@ import {
   LAYOUT,
   RADIUS,
   SPACING,
-  TEXT,
+  TYPE,
   TRANSITION
-} from "@/app/_lib/design-tokens";
+} from "@/app/_lib/design-tokens-v2";
 import { cn } from "@/lib/utils";
 
 interface SectionItem {
@@ -75,7 +75,7 @@ export function SettingsSectionNav() {
           SPACING.section
         )}
       >
-        <h2 className={TEXT.headingSm}>Settings</h2>
+        <h2 className={TYPE.headingSm}>Settings</h2>
       </div>
 
       <nav className="flex flex-col gap-0.5 p-2">
@@ -101,7 +101,7 @@ export function SettingsSectionNav() {
             >
               <span
                 className={cn(
-                  "mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center",
+                  "mt-0.5 flex size-7 shrink-0 items-center justify-center",
                   RADIUS.md,
                   active
                     ? "bg-white text-sky-700 ring-1 ring-sky-200"
@@ -115,12 +115,12 @@ export function SettingsSectionNav() {
                 <span
                   className={cn(
                     "block truncate",
-                    active ? TEXT.headingSm : "text-sm font-medium text-slate-800"
+                    active ? TYPE.headingSm : "text-sm font-medium text-slate-800"
                   )}
                 >
                   {item.label}
                 </span>
-                <span className={cn("mt-0.5 block truncate", TEXT.caption)}>
+                <span className={cn("mt-0.5 block truncate", TYPE.caption)}>
                   {item.description}
                 </span>
               </span>


### PR DESCRIPTION
## Summary
- All 5 Settings client components migrated to `design-tokens-v2` (TEXT → TYPE, TONE → TONE_CLASSES, paths updated)
- Project list `<ul>` bumped to `RADIUS.lg` to match canon (rounded-xl card)
- Section nav icon disc tightened to `size-7` to match canon density
- No structural / API / behavioral changes

PR-1 of 4 in the Settings B-fresh design-fidelity polish sequence (vs Claude Design v2 canon at `/tmp/design-handoff-v3/as-comms-platform/project/settings.jsx`). Foundation for PR-2/3/4 visual polish.

Brief: `.codex-settings-tokens-v2-2026-04-26.md`. Implementer: `codex exec` GPT-5.4 high.

## Test plan
- [x] `pnpm --filter @as-comms/web typecheck` (pass)
- [x] `pnpm --filter @as-comms/web lint` (pass)
- [ ] `pnpm --filter @as-comms/web test:unit` — failed locally on the known macOS `@rollup/rollup-darwin-arm64` env issue (see `memory/project_macos_rollup_gotcha.md`); CI is authoritative
- [ ] /settings → /settings/projects renders without console errors
- [ ] /settings/access renders without console errors
- [ ] /settings/integrations renders without console errors
- [ ] /settings/projects/[projectId] renders without console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)