### PR TITLE
feat(timeline): from/to expand consistency, bubble visuals, AS logo on outbound, inline link rendering

### DIFF
--- a/apps/web/app/inbox/_components/_autolink.tsx
+++ b/apps/web/app/inbox/_components/_autolink.tsx
@@ -2,8 +2,13 @@ import { Fragment, type ReactNode } from "react";
 
 import { cn } from "@/lib/utils";
 
-const URL_PATTERN = /(https?:\/\/[^\s<>"]+)/g;
+const URL_PATTERN = /https?:\/\/[^\s<>"]+/gu;
+const MARKDOWN_LINK_PATTERN = /\[([^\]\n]+)\]\((https?:\/\/[^\s<>)"]+)\)/gu;
+const PARENTHETICAL_LINK_PATTERN =
+  /(^|[\n.!?]\s+)([^\n()[\]]{1,80}?)\s+\((https?:\/\/[^\s<>)"]+)\)/gu;
 const TRAILING_PUNCTUATION_PATTERN = /[.,!?;:)]/;
+const LINK_CLASS_NAME =
+  "text-sky-700 hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 [overflow-wrap:anywhere]";
 
 function splitTrailingPunctuation(segment: string): {
   readonly href: string;
@@ -43,34 +48,102 @@ function splitTrailingPunctuation(segment: string): {
 
 export function autolinkText(
   body: string,
-  linkClassName: string,
+  linkClassName?: string,
 ): ReactNode {
-  return body.split(URL_PATTERN).map((segment, index) => {
-    if (index % 2 === 0) {
-      return segment;
+  return renderLinks(body, linkClassName);
+}
+
+function renderLinks(body: string, linkClassName?: string): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  let cursor = 0;
+  let index = 0;
+  const richLinkPattern = new RegExp(
+    `${MARKDOWN_LINK_PATTERN.source}|${PARENTHETICAL_LINK_PATTERN.source}`,
+    "gu",
+  );
+
+  for (const match of body.matchAll(richLinkPattern)) {
+    const rawMatch = match[0];
+    const matchIndex = match.index;
+    const markdownLabel = match[1];
+    const markdownHref = match[2];
+    const boundary = match[3] ?? "";
+    const parentheticalLabel = match[4];
+    const parentheticalHref = match[5];
+    const label = markdownLabel ?? parentheticalLabel;
+    const href = markdownHref ?? parentheticalHref;
+
+    if (label === undefined || href === undefined) {
+      continue;
     }
 
-    const { href, trailingText } = splitTrailingPunctuation(segment);
+    const linkStart = matchIndex + boundary.length;
+    nodes.push(
+      ...renderBareUrls(
+        body.slice(cursor, linkStart),
+        `plain-${String(index)}`,
+        linkClassName,
+      ),
+    );
+    nodes.push(renderLink(href, label.trim(), `rich-${String(index)}`, linkClassName));
+    cursor = matchIndex + rawMatch.length;
+    index += 1;
+  }
+
+  nodes.push(
+    ...renderBareUrls(body.slice(cursor), `plain-${String(index)}`, linkClassName),
+  );
+
+  return nodes;
+}
+
+function renderBareUrls(
+  segment: string,
+  keyPrefix: string,
+  linkClassName?: string,
+): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  let cursor = 0;
+  let index = 0;
+
+  for (const match of segment.matchAll(URL_PATTERN)) {
+    const rawUrl = match[0];
+    const matchIndex = match.index;
+    const { href, trailingText } = splitTrailingPunctuation(rawUrl);
+
+    nodes.push(segment.slice(cursor, matchIndex));
 
     if (href.length === 0) {
-      return segment;
+      nodes.push(rawUrl);
+    } else {
+      nodes.push(renderLink(href, href, `${keyPrefix}-${String(index)}`, linkClassName));
+      nodes.push(trailingText);
     }
 
-    return (
-      <Fragment key={`${segment}-${String(index)}`}>
-        <a
-          href={href}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={cn(
-            "font-medium underline decoration-current/70 underline-offset-2 transition-[text-decoration-color] hover:decoration-current focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 [overflow-wrap:anywhere]",
-            linkClassName,
-          )}
-        >
-          {href}
-        </a>
-        {trailingText}
-      </Fragment>
-    );
-  });
+    cursor = matchIndex + rawUrl.length;
+    index += 1;
+  }
+
+  nodes.push(segment.slice(cursor));
+  return nodes;
+}
+
+function renderLink(
+  href: string,
+  label: string,
+  key: string,
+  linkClassName?: string,
+): ReactNode {
+  return (
+    <Fragment key={key}>
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={cn(linkClassName, LINK_CLASS_NAME)}
+      >
+        {label}
+      </a>
+    </Fragment>
+  );
 }

--- a/apps/web/app/inbox/_components/email-participant-header.tsx
+++ b/apps/web/app/inbox/_components/email-participant-header.tsx
@@ -4,7 +4,7 @@ import { useId, useState } from "react";
 
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
-import { FOCUS_RING, TONE_CLASSES, TRANSITION, TYPE } from "@/app/_lib/design-tokens-v2";
+import { FOCUS_RING, TRANSITION, TYPE } from "@/app/_lib/design-tokens-v2";
 
 import type { InboxTimelineEntryViewModel } from "../_lib/view-models";
 import {
@@ -73,18 +73,13 @@ export function EmailParticipantHeader({
   const [expanded, setExpanded] = useState(false);
   const contentId = useId();
 
-  if (
-    entry.channel !== "email" ||
-    (entry.fromHeader === null &&
-      entry.toHeader === null &&
-      entry.ccHeader === null)
-  ) {
+  if (entry.channel !== "email") {
     return null;
   }
 
   const rows = [
-    { label: "From", value: entry.fromHeader },
-    { label: "To", value: entry.toHeader },
+    { label: "From", value: entry.fromHeader ?? entry.actorLabel },
+    { label: "To", value: entry.toHeader ?? "Unknown recipient" },
     { label: "Cc", value: entry.ccHeader },
   ].filter(
     (
@@ -95,90 +90,89 @@ export function EmailParticipantHeader({
     } => row.value !== null,
   );
 
-  if (rows.length === 0) {
-    return null;
-  }
-
   const sender = extractDisplayName(entry.fromHeader) ?? entry.actorLabel;
   const recipient = extractDisplayName(entry.toHeader) ?? "Unknown recipient";
   const hasCc = entry.ccHeader !== null && entry.ccHeader.trim().length > 0;
-  const dividerClass =
-    tone === "sky" ? "border-sky-100 bg-sky-50/40" : "border-slate-100 bg-slate-50/40";
-  const ccTone = tone === "sky" ? TONE_CLASSES.sky : TONE_CLASSES.slate;
+  const headerBorderClass =
+    tone === "sky" ? "border-sky-100/60" : "border-slate-100";
+  const detailBorderClass =
+    tone === "sky"
+      ? "border-sky-100/60 bg-sky-50/40"
+      : "border-slate-100 bg-slate-50/40";
+  const ccClass =
+    tone === "sky" ? "bg-sky-100/70 text-sky-700" : "bg-slate-100 text-slate-500";
 
   return (
     <Collapsible open={expanded} onOpenChange={setExpanded}>
-      <div className="mb-2.5">
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0 flex-1">
-            <div className="flex min-w-0 items-center gap-1.5">
-              <MailIcon className="h-3.5 w-3.5 shrink-0 text-slate-400" />
-              <span className="min-w-0 truncate text-[12.5px] font-medium text-slate-700">
-                {sender}
-              </span>
-              <ArrowRightIcon className="h-3 w-3 shrink-0 text-slate-300" />
-              <span className="min-w-0 truncate text-[12.5px] text-slate-600">
-                {recipient}
-              </span>
-              {hasCc ? (
-                <span
-                  className={cn(
-                    "shrink-0 rounded-md px-1.5 py-0.5 text-[10px] font-medium",
-                    ccTone.subtle,
-                    "text-slate-500",
-                  )}
-                >
-                  +cc
-                </span>
-              ) : null}
-              <CollapsibleTrigger
-                type="button"
-                aria-controls={contentId}
-                aria-label={expanded ? "Hide full email headers" : "Show full email headers"}
+      <div
+        className={cn(
+          "flex items-center justify-between gap-3 border-b px-4 py-2",
+          headerBorderClass,
+        )}
+      >
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
+            aria-controls={contentId}
+            aria-label={expanded ? "Hide full email headers" : "Show full email headers"}
+            className={cn(
+              "flex min-w-0 flex-1 items-center gap-1.5 text-left text-[12px]",
+              FOCUS_RING,
+              TRANSITION.fast,
+              TRANSITION.reduceMotion,
+            )}
+          >
+            <MailIcon className="h-3 w-3 shrink-0 text-slate-400" />
+            <span className="min-w-0 truncate font-medium text-slate-800">
+              {sender}
+            </span>
+            <ArrowRightIcon className="h-3 w-3 shrink-0 text-slate-400" />
+            <span className="min-w-0 truncate text-slate-700">{recipient}</span>
+            {hasCc ? (
+              <span
                 className={cn(
-                  "inline-flex shrink-0 items-center justify-center rounded-sm text-slate-400 hover:text-slate-700",
-                  FOCUS_RING,
-                  TRANSITION.fast,
-                  TRANSITION.reduceMotion,
+                  "shrink-0 rounded-sm px-1 py-px text-[10px] font-medium",
+                  ccClass,
                 )}
               >
-                <ChevronDownIcon
-                  className={cn(
-                    "h-3 w-3 transition-transform duration-150",
-                    expanded && "rotate-180",
-                    TRANSITION.reduceMotion,
-                  )}
-                />
-              </CollapsibleTrigger>
-            </div>
-          </div>
+                +cc
+              </span>
+            ) : null}
+            <ChevronDownIcon
+              className={cn(
+                "h-3 w-3 shrink-0 text-slate-400 transition-transform duration-150",
+                expanded && "rotate-180",
+                TRANSITION.reduceMotion,
+              )}
+            />
+          </button>
+        </CollapsibleTrigger>
 
-          <RelativeTimestamp
-            timestamp={entry.occurredAt}
-            label={entry.occurredAtLabel}
-            className={cn(TYPE.micro, "shrink-0 text-slate-400")}
-          />
-        </div>
-
-        <CollapsibleContent
-          id={contentId}
-          className={cn("mt-2.5 rounded-xl border px-3 py-2", dividerClass)}
-        >
-          <dl className="space-y-1 text-[11.5px] leading-relaxed text-slate-600">
-            {rows.map((row) => (
-              <div
-                key={row.label}
-                className="grid grid-cols-[2rem_minmax(0,1fr)] gap-2"
-              >
-                <dt className="font-medium text-slate-400">{row.label}</dt>
-                <dd className={cn("min-w-0 text-slate-700", WRAP_ANYWHERE)}>
-                  {row.value}
-                </dd>
-              </div>
-            ))}
-          </dl>
-        </CollapsibleContent>
+        <RelativeTimestamp
+          timestamp={entry.occurredAt}
+          label={entry.occurredAtLabel}
+          className={cn(TYPE.micro, "shrink-0 text-slate-400")}
+        />
       </div>
+
+      <CollapsibleContent
+        id={contentId}
+        className={cn("border-b px-4 py-2", detailBorderClass)}
+      >
+        <dl className="space-y-1 text-[11.5px] leading-relaxed text-slate-600">
+          {rows.map((row) => (
+            <div
+              key={row.label}
+              className="grid grid-cols-[2rem_minmax(0,1fr)] gap-2"
+            >
+              <dt className="font-medium text-slate-400">{row.label}</dt>
+              <dd className={cn("min-w-0 text-slate-700", WRAP_ANYWHERE)}>
+                {row.value}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </CollapsibleContent>
     </Collapsible>
   );
 }

--- a/apps/web/app/inbox/_components/inbox-timeline-bubble.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-bubble.tsx
@@ -9,6 +9,7 @@ import { autolinkText } from "./_autolink";
 import { EmailParticipantHeader } from "./email-participant-header";
 import { InboxAvatar } from "./inbox-avatar";
 import {
+  AdventureScientistsLogo,
   CornerUpLeftIcon,
   LoaderIcon,
   MailIcon,
@@ -36,7 +37,7 @@ function bodyTextForEntry(entry: InboxTimelineEntryViewModel): string {
   return entry.body.trim();
 }
 
-function ReplyButton({
+function ReplyFooter({
   entryId,
   tone,
   onReply,
@@ -50,25 +51,34 @@ function ReplyButton({
   }
 
   return (
-    <button
-      type="button"
-      onClick={() => {
-        onReply(entryId);
-      }}
+    <div
       className={cn(
-        "mt-3 ml-auto inline-flex items-center gap-1 text-[11.5px]",
-        TRANSITION.fast,
-        TRANSITION.reduceMotion,
+        "flex items-center justify-end border-t px-4 py-2",
         tone === "sky-inverse"
-          ? "text-sky-100 hover:text-white"
+          ? "border-sky-500/40"
           : tone === "sky"
-            ? "text-sky-700 hover:text-sky-900"
-            : "text-slate-500 hover:text-slate-900",
+            ? "border-sky-100/60"
+            : "border-slate-100",
       )}
     >
-      <CornerUpLeftIcon className="h-3.5 w-3.5" />
-      <span>Reply</span>
-    </button>
+      <button
+        type="button"
+        onClick={() => {
+          onReply(entryId);
+        }}
+        className={cn(
+          "inline-flex items-center gap-1 text-[12px]",
+          TRANSITION.fast,
+          TRANSITION.reduceMotion,
+          tone === "sky-inverse"
+            ? "text-sky-100 hover:text-white hover:underline"
+            : "text-sky-700 hover:underline",
+        )}
+      >
+        <CornerUpLeftIcon className="h-3 w-3" />
+        <span>Reply</span>
+      </button>
+    </div>
   );
 }
 
@@ -144,14 +154,14 @@ function OutboundStatusBanner({
       : null;
 
   return (
-      <div className="mb-3 flex items-center justify-between gap-3 rounded-md border border-rose-300 bg-rose-50 px-3 py-2 text-xs text-rose-900">
-        <span>
-          {entry.failedReason === "bounce"
-            ? "Your last reply to this contact bounced — recipient address may be invalid."
-            : entry.sendStatus === "failed"
-              ? "Send failed."
-              : "Send stalled before confirmation."}
-        </span>
+    <div className="mb-3 flex items-center justify-between gap-3 rounded-md border border-rose-300 bg-rose-50 px-3 py-2 text-xs text-rose-900">
+      <span>
+        {entry.failedReason === "bounce"
+          ? "Your last reply to this contact bounced — recipient address may be invalid."
+          : entry.sendStatus === "failed"
+            ? "Send failed."
+            : "Send stalled before confirmation."}
+      </span>
       {retryDisabledReason ? (
         <TooltipProvider>
           <Tooltip>
@@ -191,6 +201,17 @@ function OutboundStatusBanner({
   );
 }
 
+function OutboundBrandAvatar() {
+  return (
+    <span
+      aria-label="Adventure Scientists"
+      className="flex size-8 shrink-0 items-center justify-center rounded-full bg-slate-900 text-white ring-1 ring-slate-900/10"
+    >
+      <AdventureScientistsLogo className="size-6" />
+    </span>
+  );
+}
+
 export function MessageBubble({
   entry,
   direction,
@@ -207,21 +228,22 @@ export function MessageBubble({
   const isEmail = entry.channel === "email";
   const isOutbound = direction === "outbound";
   const body = bodyTextForEntry(entry);
-  const avatar = (
+  const inboundAvatar = (
     <InboxAvatar
       initials={initialsForLabel(entry.actorLabel)}
       tone="slate"
-      size="md"
+      size="sm"
     />
   );
 
   const bubbleClassName = isEmail
     ? isOutbound
-      ? "border border-sky-200 bg-sky-50/40 px-4 py-3"
-      : "border border-slate-200 bg-white px-4 py-3"
+      ? "border border-sky-100 bg-sky-50"
+      : "border border-slate-200 bg-white"
     : isOutbound
-      ? "bg-sky-600 px-4 py-2.5 text-white"
-      : "bg-slate-100 px-4 py-2.5 text-slate-900";
+      ? "border border-sky-600 bg-sky-600 text-white"
+      : "border border-slate-200 bg-white";
+  const replyTone = isOutbound ? (isEmail ? "sky" : "sky-inverse") : "slate";
 
   return (
     <li
@@ -238,25 +260,17 @@ export function MessageBubble({
           isOutbound ? "justify-end" : "justify-start",
         )}
       >
-        {!isOutbound ? <div className="shrink-0 pt-1">{avatar}</div> : null}
+        {!isOutbound ? (
+          <div className="mt-2 shrink-0">{inboundAvatar}</div>
+        ) : null}
 
         <div
           className={cn(
-            "min-w-0 w-full max-w-[640px] rounded-2xl",
+            "min-w-0 w-full max-w-[640px] overflow-hidden rounded-xl",
             SHADOW.sm,
             bubbleClassName,
           )}
         >
-          {isOutbound ? (
-            <OutboundStatusBanner
-              entry={entry}
-              isRetrying={isRetrying}
-              {...(onRetryPending === undefined
-                ? {}
-                : { onRetryPending })}
-            />
-          ) : null}
-
           {isEmail ? (
             <EmailParticipantHeader
               entry={entry}
@@ -264,46 +278,51 @@ export function MessageBubble({
             />
           ) : null}
 
-          {isEmail && entry.subject ? (
-            <p
-              className={cn(
-                "mb-1.5 mt-2 text-balance text-[13px] font-semibold text-slate-900",
-                WRAP_ANYWHERE,
-              )}
-            >
-              {entry.subject}
-            </p>
-          ) : null}
+          <div className={cn("px-4", isEmail ? "py-3" : "py-2.5")}>
+            {isOutbound ? (
+              <OutboundStatusBanner
+                entry={entry}
+                isRetrying={isRetrying}
+                {...(onRetryPending === undefined ? {} : { onRetryPending })}
+              />
+            ) : null}
 
-          {body.length > 0 ? (
-            <p
-              className={cn(
-                isEmail
-                  ? `font-message-body whitespace-pre-wrap text-pretty ${TYPE.bodySerifSm}`
-                  : "whitespace-pre-wrap text-[13px] leading-relaxed",
-                isOutbound && !isEmail ? "text-white" : undefined,
-                WRAP_ANYWHERE,
-              )}
-            >
-              {autolinkText(
-                body,
-                isOutbound && !isEmail
-                  ? "text-white underline decoration-white/40"
-                  : isOutbound
-                    ? "text-sky-700"
-                    : "text-sky-600",
-              )}
-            </p>
-          ) : null}
+            {isEmail && entry.subject ? (
+              <p
+                className={cn(
+                  "mb-1.5 text-balance text-[14px] font-semibold text-slate-900",
+                  WRAP_ANYWHERE,
+                )}
+              >
+                {entry.subject}
+              </p>
+            ) : null}
 
-          <ReplyButton
+            {body.length > 0 ? (
+              <p
+                className={cn(
+                  "whitespace-pre-wrap text-pretty text-[14px] leading-relaxed",
+                  isOutbound && !isEmail ? "text-white" : "text-slate-700",
+                  WRAP_ANYWHERE,
+                )}
+              >
+                {autolinkText(body)}
+              </p>
+            ) : null}
+          </div>
+
+          <ReplyFooter
             entryId={entry.id}
-            tone={isOutbound ? (isEmail ? "sky" : "sky-inverse") : "slate"}
+            tone={replyTone}
             {...(onReply === undefined ? {} : { onReply })}
           />
         </div>
 
-        {isOutbound ? <div className="shrink-0 pt-1">{avatar}</div> : null}
+        {isOutbound ? (
+          <div className="mt-2 shrink-0">
+            <OutboundBrandAvatar />
+          </div>
+        ) : null}
       </div>
 
       {!isOutbound ? <InboundMetadataRow entry={entry} /> : null}

--- a/apps/web/src/lib/html-sanitizer.ts
+++ b/apps/web/src/lib/html-sanitizer.ts
@@ -13,6 +13,8 @@ const STRIP_WITH_CONTENT_TAGS = new Set(["script", "style"]);
 const TAG_PATTERN = /<\/?[^>]+>/gu;
 const TAG_NAME_PATTERN = /^<\/?\s*([a-zA-Z0-9:-]+)/u;
 const HREF_PATTERN = /\shref\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/iu;
+const SAFE_LINK_ATTRIBUTES =
+  'class="text-sky-700 hover:underline" target="_blank" rel="noopener noreferrer"';
 
 function escapeHtml(value: string): string {
   return value
@@ -106,7 +108,7 @@ export function sanitizeComposerHtml(input: string): string {
       if (href === null) {
         skippedAnchorDepth += 1;
       } else {
-        output += `<a href="${href}">`;
+        output += `<a href="${href}" ${SAFE_LINK_ATTRIBUTES}>`;
       }
     }
   }
@@ -121,7 +123,7 @@ export function sanitizeComposerHtml(input: string): string {
 function linkifyEscapedLine(line: string): string {
   return line.replace(/https?:\/\/[^\s<]+/gu, (url) => {
     const escapedUrl = escapeHtml(url);
-    return `<a href="${escapedUrl}">${escapedUrl}</a>`;
+    return `<a href="${escapedUrl}" ${SAFE_LINK_ATTRIBUTES}>${escapedUrl}</a>`;
   });
 }
 

--- a/apps/web/tests/unit/composer-html-sanitizer.test.ts
+++ b/apps/web/tests/unit/composer-html-sanitizer.test.ts
@@ -13,7 +13,7 @@ describe("composer html sanitizer", () => {
         '<p class="x">Hello <strong data-x="1">bold</strong> <em>italic</em> <a id="bad" href="https://example.org/path">link</a></p><script>alert(1)</script><style>p{color:red}</style><img src="x"><table><tr><td>cell</td></tr></table>',
       ),
     ).toBe(
-      '<p>Hello <strong>bold</strong> <em>italic</em> <a href="https://example.org/path">link</a></p>cell',
+      '<p>Hello <strong>bold</strong> <em>italic</em> <a href="https://example.org/path" class="text-sky-700 hover:underline" target="_blank" rel="noopener noreferrer">link</a></p>cell',
     );
   });
 
@@ -33,11 +33,21 @@ describe("composer html sanitizer", () => {
         signaturePlaintext: "Adventure Scientists\nhttps://example.org",
       }),
     ).toBe(
-      '<p>Body copy</p><p>Adventure Scientists<br><a href="https://example.org">https://example.org</a></p>',
+      '<p>Body copy</p><p>Adventure Scientists<br><a href="https://example.org" class="text-sky-700 hover:underline" target="_blank" rel="noopener noreferrer">https://example.org</a></p>',
     );
 
     expect(plaintextToComposerHtml("One\nTwo\n\nThree")).toBe(
       "<p>One<br>Two</p><p>Three</p>",
+    );
+  });
+
+  it("keeps safe link attributes while rejecting scripts", () => {
+    expect(
+      sanitizeComposerHtml(
+        '<p><a href="https://example.org" target="_self" rel="bad" onclick="alert(1)">Example</a><script>alert(1)</script></p>',
+      ),
+    ).toBe(
+      '<p><a href="https://example.org" class="text-sky-700 hover:underline" target="_blank" rel="noopener noreferrer">Example</a></p>',
     );
   });
 });

--- a/apps/web/tests/unit/inbox-autolink.test.ts
+++ b/apps/web/tests/unit/inbox-autolink.test.ts
@@ -25,6 +25,35 @@ describe("autolinkText", () => {
     expect(markup).toContain(">https://example.org/forms<");
   });
 
+  it("renders markdown-style links with only the label visible", () => {
+    const markup = renderToStaticMarkup(
+      createElement(
+        "p",
+        null,
+        autolinkText("Open [Field packet](https://example.org/forms)."),
+      ),
+    );
+
+    expect(markup).toContain('href="https://example.org/forms"');
+    expect(markup).toContain(">Field packet<");
+    expect(markup).not.toContain("[Field packet]");
+    expect(markup).not.toContain("(https://example.org/forms)");
+  });
+
+  it("renders parenthesized URLs as inline links when link text is present", () => {
+    const markup = renderToStaticMarkup(
+      createElement(
+        "p",
+        null,
+        autolinkText("Field packet (https://example.org/forms)"),
+      ),
+    );
+
+    expect(markup).toContain('href="https://example.org/forms"');
+    expect(markup).toContain(">Field packet<");
+    expect(markup).not.toContain("(https://example.org/forms)");
+  });
+
   it("links multiple URLs in one body", () => {
     const markup = renderToStaticMarkup(
       createElement(

--- a/apps/web/tests/unit/inbox-timeline.test.ts
+++ b/apps/web/tests/unit/inbox-timeline.test.ts
@@ -336,6 +336,62 @@ describe("InboxTimeline", () => {
     expect(markup).toContain("Reply");
   });
 
+  it("renders a header toggle for every one-to-one email bubble", () => {
+    const markup = renderToStaticMarkup(
+      createElement(InboxTimeline, {
+        entries: [
+          {
+            ...baseEntry,
+            id: "timeline:older-email",
+            kind: "inbound-email" as const,
+            actorLabel: "Shaina Dotson",
+            subject: "Older message",
+            body: "Older body.",
+            fromHeader: "Shaina Dotson <shaina.dotson@gmail.com>",
+            toHeader: "PNW Project <pnwbio@adventurescientists.org>",
+          },
+          {
+            ...baseEntry,
+            id: "timeline:newer-email",
+            kind: "outbound-email" as const,
+            actorLabel: "You",
+            subject: "Newer message",
+            body: "Newer body.",
+            fromHeader: "PNW Project <pnwbio@adventurescientists.org>",
+            toHeader: "Shaina Dotson <shaina.dotson@gmail.com>",
+          },
+        ],
+        volunteerFirstName: "Shaina",
+        currentOperatorUserId: "user:operator",
+      }),
+    );
+
+    expect(markup.match(/Show full email headers/g)).toHaveLength(2);
+    expect(markup).toContain("Older message");
+    expect(markup).toContain("Newer message");
+  });
+
+  it("uses the Adventure Scientists mark for outbound message avatars", () => {
+    const markup = renderToStaticMarkup(
+      createElement(InboxTimeline, {
+        entries: [
+          {
+            ...baseEntry,
+            kind: "outbound-email" as const,
+            actorLabel: "Your Operator",
+            fromHeader: "PNW Project <pnwbio@adventurescientists.org>",
+            toHeader: "Shaina Dotson <shaina.dotson@gmail.com>",
+          },
+        ],
+        volunteerFirstName: "Shaina",
+        currentOperatorUserId: "user:operator",
+      }),
+    );
+
+    expect(markup).toContain('aria-label="Adventure Scientists"');
+    expect(markup).not.toContain(">YO<");
+  });
+
   it("classifies first-data system dividers into the emerald data category", () => {
     expect(
       classifySystemDivider("Submitted first batch from the field."),


### PR DESCRIPTION
## Summary
- Email header (from/to/cc) chevron now toggleable on every email bubble, not just the most recent few
- Bubble visuals tightened to match design canon: rounded-xl shells, header/body/footer dividers, typography density
- Outbound message avatars now use the Adventure Scientists mark (consistent with the top-left brand mark) instead of operator initials (was "YO" for Nico)
- Inline link rendering: `[Text](url)` and bare `Text (url)` patterns now render as inline `<a>` tags opening in new tab; sanitizer preserves safe `<a>` attributes (`href`, `target`, `rel`) and rejects unsafe `javascript:` / `<script>` content

## Test plan
- [x] `pnpm --filter @as-comms/web typecheck` — passed locally
- [x] `pnpm --filter @as-comms/web lint` — passed locally
- [x] Focused unit tests passed: `inbox-autolink`, `inbox-timeline`, `composer-html-sanitizer`
- [ ] CI to validate full unit suite (codex saw unrelated 30s timeout hooks in AI/settings/inbox-selector tests during local run; touched tests passed)
- [ ] Manual via Chrome: confirm older bubbles in a long thread show the chevron, outbound avatar shows AS logo, in-body links open in new tab

## Brief reference
`.codex-message-history-polish-2026-04-26.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)