### PR TITLE
feat(inbox): canonical composer modal + minimize-to-pill

### DIFF
--- a/apps/web/app/_lib/design-tokens-v2.ts
+++ b/apps/web/app/_lib/design-tokens-v2.ts
@@ -138,6 +138,8 @@ export type ToneNameV2 = keyof typeof TONE_CLASSES;
 export const TYPE = {
   /** Page / detail titles — `text-lg font-semibold text-slate-900` */
   headingLg: "text-lg font-semibold text-slate-900",
+  /** Modal / panel titles — `text-base font-semibold text-slate-900` */
+  headingMd: "text-base font-semibold text-slate-900",
   /** Section / rail headers — `text-sm font-semibold text-slate-900` */
   headingSm: "text-sm font-semibold text-slate-900",
   /** Default body text — `text-sm text-slate-700` */

--- a/apps/web/app/inbox/_components/composer-detail-surfaces.tsx
+++ b/apps/web/app/inbox/_components/composer-detail-surfaces.tsx
@@ -8,12 +8,28 @@ import { cn } from "@/lib/utils";
 import { RADIUS, SHADOW, TYPE } from "@/app/_lib/design-tokens-v2";
 
 import { ComposerAiDraftWindow } from "./composer-ai-draft-window";
-import { ComposerRecipientPicker, type ComposerRecipientValue } from "./composer-recipient-picker";
+import {
+  ComposerRecipientPicker,
+  type ComposerRecipientValue,
+} from "./composer-recipient-picker";
 import { ComposerSendFromChip } from "./composer-send-from-chip";
 import { AboutThisDraft } from "./about-this-draft";
 import { AiDraftReprompt } from "./ai-draft-reprompt";
-import { AttachmentRow, ComposerField, InlineErrorBanner, RichTextComposerEditor } from "./composer-editor-surface";
-import { LoaderIcon, MailIcon, NoteIcon, PaperclipIcon, SendIcon, SparkleIcon, XIcon } from "./icons";
+import {
+  AttachmentRow,
+  ComposerField,
+  InlineErrorBanner,
+  RichTextComposerEditor,
+} from "./composer-editor-surface";
+import {
+  LoaderIcon,
+  MailIcon,
+  NoteIcon,
+  PaperclipIcon,
+  SendIcon,
+  SparkleIcon,
+  XIcon,
+} from "./icons";
 import type { AttachmentDraft, InlineComposerError } from "./composer-shared";
 import type { InboxComposerAliasOption } from "../_lib/view-models";
 import type {
@@ -114,6 +130,7 @@ export function ComposerEmailSurface({
   isGeneratingAi,
   aiButtonLabel,
   selectedAliasAiReady,
+  selectedAliasProjectName,
   aiWarningMessage,
   inlineError,
   showKnowledgeCapture,
@@ -160,6 +177,7 @@ export function ComposerEmailSurface({
   readonly isGeneratingAi: boolean;
   readonly aiButtonLabel: string;
   readonly selectedAliasAiReady: boolean;
+  readonly selectedAliasProjectName: string | null;
   readonly aiWarningMessage: string | null;
   readonly inlineError: InlineComposerError | null;
   readonly showKnowledgeCapture: boolean;
@@ -169,9 +187,14 @@ export function ComposerEmailSurface({
   readonly isAboutOpen: boolean;
   readonly onAboutOpenChange: (open: boolean) => void;
   readonly onAliasChange: (value: string | null) => void;
-  readonly onRecipientChange: (recipient: ComposerRecipientValue | null) => void;
+  readonly onRecipientChange: (
+    recipient: ComposerRecipientValue | null,
+  ) => void;
   readonly onSubjectChange: (value: string) => void;
-  readonly onBodyChange: (value: { readonly bodyPlaintext: string; readonly bodyHtml: string }) => void;
+  readonly onBodyChange: (value: {
+    readonly bodyPlaintext: string;
+    readonly bodyHtml: string;
+  }) => void;
   readonly onClearErrors: () => void;
   readonly onAiEdited: () => void;
   readonly onDiscardAi: () => void;
@@ -188,7 +211,7 @@ export function ComposerEmailSurface({
 }) {
   return (
     <>
-      <ComposerField label="Send from">
+      <ComposerField label="FROM">
         <ComposerSendFromChip
           value={selectedAlias}
           aliases={composerAliases}
@@ -197,7 +220,7 @@ export function ComposerEmailSurface({
         />
       </ComposerField>
 
-      <ComposerField label="To">
+      <ComposerField label="TO">
         <div className="rounded-lg bg-slate-50">
           <ComposerRecipientPicker
             recipient={recipient}
@@ -210,14 +233,14 @@ export function ComposerEmailSurface({
         ) : null}
       </ComposerField>
 
-      <ComposerField label="Cc">
+      <ComposerField label="CC">
         <div className="flex min-h-11 items-center justify-between rounded-lg border border-dashed border-slate-200 px-3 text-sm text-slate-400">
           <span>Not available in this production flow yet</span>
           <span className="text-xs">Placeholder</span>
         </div>
       </ComposerField>
 
-      <ComposerField label="Subject">
+      <ComposerField label="SUBJ">
         <Input
           value={subject}
           onChange={(event) => {
@@ -272,7 +295,9 @@ export function ComposerEmailSurface({
         </div>
       ) : null}
       {bodyError ? (
-        <div className="px-4 py-2 text-xs text-rose-700">{bodyError.message}</div>
+        <div className="px-4 py-2 text-xs text-rose-700">
+          {bodyError.message}
+        </div>
       ) : null}
 
       <AttachmentRow attachments={attachments} onRemove={onAttachmentRemove} />
@@ -316,7 +341,12 @@ export function ComposerEmailSurface({
             Attach
           </Button>
           {selectedAliasAiReady ? (
-            <Button type="button" variant="outline" disabled={isGeneratingAi} onClick={onRunAiDraft}>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={isGeneratingAi}
+              onClick={onRunAiDraft}
+            >
               {isGeneratingAi ? (
                 <LoaderIcon className="size-4 animate-spin" />
               ) : (
@@ -327,6 +357,11 @@ export function ComposerEmailSurface({
           ) : null}
 
           <div className="ml-auto flex items-center gap-2">
+            {selectedAliasAiReady && selectedAliasProjectName !== null ? (
+              <span className={`hidden ${TYPE.caption} md:inline`}>
+                Uses {selectedAliasProjectName} knowledge
+              </span>
+            ) : null}
             <Button type="button" variant="ghost" onClick={onCancel}>
               Cancel
             </Button>
@@ -381,10 +416,14 @@ export function ComposerNoteSurface({
 }) {
   return (
     <>
-      <div className={`border-l-4 border-amber-300 bg-amber-50/50 px-4 py-4 ${SHADOW.sm}`}>
+      <div
+        className={`border-l-4 border-amber-300 bg-amber-50/50 px-4 py-4 ${SHADOW.sm}`}
+      >
         <div className="mb-3 flex items-center justify-between gap-3">
           <div>
-            <p className="text-sm font-semibold text-amber-900">Internal note</p>
+            <p className="text-sm font-semibold text-amber-900">
+              Internal note
+            </p>
             <p className={`mt-1 ${TYPE.caption} text-amber-800`}>
               Team-visible note only. This will not be sent to the contact.
             </p>
@@ -441,7 +480,11 @@ export function ComposerNoteSurface({
           <Button type="button" variant="ghost" onClick={onCancel}>
             Cancel
           </Button>
-          <Button type="button" disabled={isSaveNoteDisabled} onClick={onSaveNote}>
+          <Button
+            type="button"
+            disabled={isSaveNoteDisabled}
+            onClick={onSaveNote}
+          >
             {isSavingNote ? (
               <>
                 <LoaderIcon className="size-4 animate-spin" />

--- a/apps/web/app/inbox/_components/composer-editor-surface.tsx
+++ b/apps/web/app/inbox/_components/composer-editor-surface.tsx
@@ -5,13 +5,21 @@ import { EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import { useCallback, useEffect, type KeyboardEvent } from "react";
 
-import { FOCUS_RING, SHADOW, TRANSITION } from "@/app/_lib/design-tokens-v2";
+import {
+  FOCUS_RING,
+  SHADOW,
+  TRANSITION,
+  TYPE,
+} from "@/app/_lib/design-tokens-v2";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { sanitizeComposerHtml } from "@/src/lib/html-sanitizer";
 
 import { plaintextToComposerHtml } from "./composer-html";
-import { ComposerToolbar, type ComposerToolbarCommand } from "./composer-toolbar";
+import {
+  ComposerToolbar,
+  type ComposerToolbarCommand,
+} from "./composer-toolbar";
 import { AlertCircleIcon, XIcon } from "./icons";
 import { formatBytes, type AttachmentDraft } from "./composer-shared";
 
@@ -35,9 +43,7 @@ export function ComposerField({
 }) {
   return (
     <div className="flex items-start gap-3 border-b border-slate-100 px-4 py-2.5">
-      <span className="mt-1 w-16 shrink-0 text-[11px] font-semibold uppercase text-slate-400">
-        {label}
-      </span>
+      <span className={`mt-1 w-10 shrink-0 ${TYPE.label}`}>{label}</span>
       <div className="min-w-0 flex-1">{children}</div>
     </div>
   );
@@ -63,7 +69,9 @@ export function AttachmentRow({
             className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs text-slate-700"
           >
             <span className="font-medium">{attachment.filename}</span>
-            <span className="text-slate-500">{formatBytes(attachment.size)}</span>
+            <span className="text-slate-500">
+              {formatBytes(attachment.size)}
+            </span>
             <button
               type="button"
               aria-label={`Remove ${attachment.filename}`}
@@ -174,7 +182,8 @@ export function RichTextComposerEditor({
   if (editor?.isActive("bold") === true) activeCommands.add("bold");
   if (editor?.isActive("italic") === true) activeCommands.add("italic");
   if (editor?.isActive("bulletList") === true) activeCommands.add("bulletList");
-  if (editor?.isActive("orderedList") === true) activeCommands.add("orderedList");
+  if (editor?.isActive("orderedList") === true)
+    activeCommands.add("orderedList");
   if (editor?.isActive("link") === true) activeCommands.add("link");
 
   const runCommand = useCallback(

--- a/apps/web/app/inbox/_components/composer-floating-pill.tsx
+++ b/apps/web/app/inbox/_components/composer-floating-pill.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import {
+  FOCUS_RING,
+  RADIUS,
+  SHADOW,
+  TRANSITION,
+} from "@/app/_lib/design-tokens-v2";
+import { cn } from "@/lib/utils";
+
+import type { ComposerPaneState } from "../_lib/composer-ui";
+import { ChevronUpIcon, MailIcon, NoteIcon, XIcon } from "./icons";
+import { useInboxClient } from "./inbox-client-provider";
+
+export function resolveFloatingComposerLabel(
+  composerPane: ComposerPaneState,
+): string {
+  if (composerPane.mode === "new-draft") {
+    return "New message";
+  }
+
+  if (composerPane.mode === "replying") {
+    if (composerPane.initialTab === "note") {
+      return `Note about ${composerPane.replyContext.contactDisplayName}`;
+    }
+
+    const subject = composerPane.replyContext.subject.trim();
+    const base =
+      subject.length > 0
+        ? subject
+        : composerPane.replyContext.contactDisplayName;
+
+    return /^re:/iu.test(base) ? base : `Re: ${base}`;
+  }
+
+  return "Composer";
+}
+
+export function ComposerFloatingPill() {
+  const { composerPane, composerView, closeComposer, expandComposer } =
+    useInboxClient();
+
+  if (composerView !== "pill" || composerPane.mode === "closed") {
+    return null;
+  }
+
+  const isNote =
+    composerPane.mode === "replying" && composerPane.initialTab === "note";
+  const label = resolveFloatingComposerLabel(composerPane);
+
+  return (
+    <aside
+      role="region"
+      aria-label="Minimized composer"
+      className={cn(
+        `fixed bottom-4 right-4 z-40 flex h-11 w-[280px] items-center gap-2 border border-slate-200 bg-white px-3 ${RADIUS.lg} ${SHADOW.md}`,
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className="inline-flex size-7 shrink-0 items-center justify-center rounded-md bg-slate-100 text-slate-500"
+      >
+        {isNote ? (
+          <NoteIcon className="size-3.5" />
+        ) : (
+          <MailIcon className="size-3.5" />
+        )}
+      </span>
+      <span className="min-w-0 flex-1 truncate text-[12.5px] font-medium text-slate-800">
+        {label}
+      </span>
+      <button
+        type="button"
+        aria-label="Expand composer"
+        className={cn(
+          `inline-flex size-7 shrink-0 items-center justify-center rounded-md text-slate-400 ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion} hover:bg-slate-100 hover:text-slate-700`,
+        )}
+        onClick={expandComposer}
+      >
+        <ChevronUpIcon className="size-3.5" />
+      </button>
+      <button
+        type="button"
+        aria-label="Close composer"
+        className={cn(
+          `inline-flex size-7 shrink-0 items-center justify-center rounded-md text-slate-400 ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion} hover:bg-slate-100 hover:text-slate-700`,
+        )}
+        onClick={closeComposer}
+      >
+        <XIcon className="size-3.5" />
+      </button>
+    </aside>
+  );
+}

--- a/apps/web/app/inbox/_components/inbox-client-provider.tsx
+++ b/apps/web/app/inbox/_components/inbox-client-provider.tsx
@@ -6,20 +6,17 @@ import {
   useContext,
   useMemo,
   useState,
-  type ReactNode
+  type ReactNode,
 } from "react";
 
-import type {
-  AiDraftRequestPayload,
-  AiDraftResponseVm,
-} from "../actions";
+import type { AiDraftRequestPayload, AiDraftResponseVm } from "../actions";
 import type {
   InboxComposerAliasOption,
-  InboxComposerReplyContext
+  InboxComposerReplyContext,
 } from "../_lib/view-models";
 import {
   reduceComposerPane,
-  type ComposerPaneState
+  type ComposerPaneState,
 } from "../_lib/composer-ui";
 
 /**
@@ -41,6 +38,8 @@ export type ComposerStatus =
   | "sending"
   | "sent-success"
   | "send-failure";
+
+export type ComposerViewState = "closed" | "modal" | "pill";
 
 export interface ComposerValidationError {
   readonly field: "subject" | "body" | "recipient" | "alias" | "attachments";
@@ -105,7 +104,7 @@ export interface SearchState {
 const INITIAL_SEARCH: SearchState = {
   query: "",
   isActive: false,
-  resultContactIds: []
+  resultContactIds: [],
 };
 
 export interface InboxToastState {
@@ -132,23 +131,25 @@ interface InboxClientState {
 
   readonly composerAliases: readonly InboxComposerAliasOption[];
   readonly composerPane: ComposerPaneState;
+  readonly composerView: ComposerViewState;
   readonly openNewDraft: () => void;
   readonly openReplyDraft: (
     replyContext: InboxComposerReplyContext,
     initialTab?: "email" | "note",
   ) => void;
   readonly closeComposer: () => void;
+  readonly minimizeComposer: () => void;
+  readonly expandComposer: () => void;
 
   readonly composerStatus: ComposerStatus;
   readonly composerErrors: readonly ComposerValidationError[];
   readonly setComposerStatus: (status: ComposerStatus) => void;
-  readonly setComposerErrors: (errors: readonly ComposerValidationError[]) => void;
+  readonly setComposerErrors: (
+    errors: readonly ComposerValidationError[],
+  ) => void;
 
   readonly toast: InboxToastState | null;
-  readonly showToast: (
-    message: string,
-    tone?: InboxToastState["tone"]
-  ) => void;
+  readonly showToast: (message: string, tone?: InboxToastState["tone"]) => void;
   readonly clearToast: () => void;
 
   readonly aiDraft: AiDraftState;
@@ -186,14 +187,15 @@ export function InboxClientProvider({
   readonly currentActorId: string;
 }) {
   const [reminders, setReminders] = useState<ReadonlyMap<string, Reminder>>(
-    () => new Map<string, Reminder>()
+    () => new Map<string, Reminder>(),
   );
   const [search, setSearch] = useState(INITIAL_SEARCH);
   const [isQueueLoading, setQueueLoading] = useState(false);
   const [isTimelineLoading, setTimelineLoading] = useState(false);
   const [composerPane, setComposerPane] = useState<ComposerPaneState>({
-    mode: "closed"
+    mode: "closed",
   });
+  const [composerView, setComposerView] = useState<ComposerViewState>("closed");
   const [composerStatus, setComposerStatus] = useState<ComposerStatus>("idle");
   const [composerErrors, setComposerErrors] = useState<
     readonly ComposerValidationError[]
@@ -225,14 +227,14 @@ export function InboxClientProvider({
     setSearch((previous) => ({
       ...previous,
       query,
-      isActive: query.length > 0
+      isActive: query.length > 0,
     }));
   }, []);
 
   const setSearchResults = useCallback((contactIds: readonly string[]) => {
     setSearch((previous) => ({
       ...previous,
-      resultContactIds: contactIds
+      resultContactIds: contactIds,
     }));
   }, []);
 
@@ -243,9 +245,10 @@ export function InboxClientProvider({
   const openNewDraft = useCallback(() => {
     setComposerPane((previous) =>
       reduceComposerPane(previous, {
-        type: "open-new-draft"
-      })
+        type: "open-new-draft",
+      }),
     );
+    setComposerView("modal");
     setComposerStatus("idle");
     setComposerErrors([]);
   }, []);
@@ -260,22 +263,32 @@ export function InboxClientProvider({
           type: "open-reply",
           replyContext,
           initialTab,
-        })
+        }),
       );
+      setComposerView("modal");
       setComposerStatus("idle");
       setComposerErrors([]);
     },
-    []
+    [],
   );
 
   const closeComposer = useCallback(() => {
+    setComposerView("closed");
     setComposerPane((previous) =>
       reduceComposerPane(previous, {
-        type: "close"
-      })
+        type: "close",
+      }),
     );
     setComposerStatus("idle");
     setComposerErrors([]);
+  }, []);
+
+  const minimizeComposer = useCallback(() => {
+    setComposerView("pill");
+  }, []);
+
+  const expandComposer = useCallback(() => {
+    setComposerView("modal");
   }, []);
 
   const showToast = useCallback(
@@ -283,78 +296,84 @@ export function InboxClientProvider({
       setToast({
         id: Date.now(),
         message,
-        tone
+        tone,
       });
     },
-    []
+    [],
   );
 
   const clearToast = useCallback(() => {
     setToast(null);
   }, []);
 
-  const startAiGeneration = useCallback((input: {
-    readonly request: AiDraftRequestPayload;
-    readonly prompt: string;
-  }) => {
-    setAiDraft({
-      status: "generating",
-      mode: input.request.mode,
-      responseMode: null,
-      prompt: input.prompt,
-      generatedText: "",
-      errorMessage: null,
-      grounding: [],
-      warnings: [],
-      costEstimateUsd: null,
-      draftId: null,
-      repromptIndex: input.request.repromptIndex ?? 0,
-      repromptChain: [],
-      promptPreview: "",
-      model: null,
-      lastRequest: input.request,
-    });
-  }, []);
+  const startAiGeneration = useCallback(
+    (input: {
+      readonly request: AiDraftRequestPayload;
+      readonly prompt: string;
+    }) => {
+      setAiDraft({
+        status: "generating",
+        mode: input.request.mode,
+        responseMode: null,
+        prompt: input.prompt,
+        generatedText: "",
+        errorMessage: null,
+        grounding: [],
+        warnings: [],
+        costEstimateUsd: null,
+        draftId: null,
+        repromptIndex: input.request.repromptIndex ?? 0,
+        repromptChain: [],
+        promptPreview: "",
+        model: null,
+        lastRequest: input.request,
+      });
+    },
+    [],
+  );
 
-  const insertAiDraft = useCallback((input: {
-    readonly request: AiDraftRequestPayload;
-    readonly response: AiDraftResponseVm;
-    readonly prompt: string;
-    readonly repromptDirection?: string;
-  }) => {
-    setAiDraft((previous) => ({
-      ...previous,
-      status: "inserted",
-      mode: input.request.mode,
-      responseMode: input.response.mode,
-      prompt: input.prompt,
-      generatedText: input.response.draft,
-      errorMessage: null,
-      grounding: input.response.grounding,
-      warnings: input.response.warnings,
-      costEstimateUsd: input.response.costEstimateUsd,
-      draftId: input.response.draftId,
-      repromptIndex: input.response.repromptIndex,
-      repromptChain:
-        input.request.mode === "reprompt" && input.repromptDirection
-          ? [
-              ...previous.repromptChain,
-              {
-                direction: input.repromptDirection,
-                draft: input.response.draft,
-              },
-            ]
-          : previous.repromptChain,
-      promptPreview: input.response.promptPreview,
-      model: input.response.model,
-      lastRequest: input.request,
-    }));
-  }, []);
+  const insertAiDraft = useCallback(
+    (input: {
+      readonly request: AiDraftRequestPayload;
+      readonly response: AiDraftResponseVm;
+      readonly prompt: string;
+      readonly repromptDirection?: string;
+    }) => {
+      setAiDraft((previous) => ({
+        ...previous,
+        status: "inserted",
+        mode: input.request.mode,
+        responseMode: input.response.mode,
+        prompt: input.prompt,
+        generatedText: input.response.draft,
+        errorMessage: null,
+        grounding: input.response.grounding,
+        warnings: input.response.warnings,
+        costEstimateUsd: input.response.costEstimateUsd,
+        draftId: input.response.draftId,
+        repromptIndex: input.response.repromptIndex,
+        repromptChain:
+          input.request.mode === "reprompt" && input.repromptDirection
+            ? [
+                ...previous.repromptChain,
+                {
+                  direction: input.repromptDirection,
+                  draft: input.response.draft,
+                },
+              ]
+            : previous.repromptChain,
+        promptPreview: input.response.promptPreview,
+        model: input.response.model,
+        lastRequest: input.request,
+      }));
+    },
+    [],
+  );
 
   const markAiDraftEdited = useCallback(() => {
     setAiDraft((previous) => ({
       ...previous,
-      status: "edited-after-generation"
+      status: "edited-after-generation",
     }));
   }, []);
 
@@ -369,30 +388,33 @@ export function InboxClientProvider({
     setAiDraft((previous) => ({
       ...previous,
       status: "discarded",
-      generatedText: ""
+      generatedText: "",
     }));
   }, []);
 
-  const repromptAi = useCallback((input: {
-    readonly request: AiDraftRequestPayload;
-    readonly prompt: string;
-  }) => {
-    setAiDraft((previous) => ({
-      ...previous,
-      status: "reprompting",
-      mode: "reprompt",
-      prompt: input.prompt,
-      errorMessage: null,
-      lastRequest: input.request,
-      repromptIndex: input.request.repromptIndex ?? previous.repromptIndex,
-    }));
-  }, []);
+  const repromptAi = useCallback(
+    (input: {
+      readonly request: AiDraftRequestPayload;
+      readonly prompt: string;
+    }) => {
+      setAiDraft((previous) => ({
+        ...previous,
+        status: "reprompting",
+        mode: "reprompt",
+        prompt: input.prompt,
+        errorMessage: null,
+        lastRequest: input.request,
+        repromptIndex: input.request.repromptIndex ?? previous.repromptIndex,
+      }));
+    },
+    [],
+  );
 
   const setAiUnavailable = useCallback(() => {
     setAiDraft((previous) => ({
       ...previous,
       status: "unavailable",
-      errorMessage: "AI drafting is currently unavailable."
+      errorMessage: "AI drafting is currently unavailable.",
     }));
   }, []);
 
@@ -400,7 +422,7 @@ export function InboxClientProvider({
     setAiDraft((previous) => ({
       ...previous,
       status: "error",
-      errorMessage: message
+      errorMessage: message,
     }));
   }, []);
 
@@ -424,9 +446,12 @@ export function InboxClientProvider({
       setTimelineLoading,
       composerAliases,
       composerPane,
+      composerView,
       openNewDraft,
       openReplyDraft,
       closeComposer,
+      minimizeComposer,
+      expandComposer,
       composerStatus,
       composerErrors,
       setComposerStatus,
@@ -443,7 +468,7 @@ export function InboxClientProvider({
       repromptAi,
       setAiUnavailable,
       setAiError,
-      resetAiDraft
+      resetAiDraft,
     }),
     [
       currentActorId,
@@ -458,9 +483,12 @@ export function InboxClientProvider({
       isTimelineLoading,
       composerAliases,
       composerPane,
+      composerView,
       openNewDraft,
       openReplyDraft,
       closeComposer,
+      minimizeComposer,
+      expandComposer,
       composerStatus,
       composerErrors,
       toast,
@@ -475,8 +503,8 @@ export function InboxClientProvider({
       repromptAi,
       setAiUnavailable,
       setAiError,
-      resetAiDraft
-    ]
+      resetAiDraft,
+    ],
   );
 
   return (

--- a/apps/web/app/inbox/_components/inbox-composer.tsx
+++ b/apps/web/app/inbox/_components/inbox-composer.tsx
@@ -9,7 +9,14 @@ import {
   type ChangeEvent,
 } from "react";
 
-import { RADIUS, SHADOW } from "@/app/_lib/design-tokens-v2";
+import {
+  FOCUS_RING,
+  RADIUS,
+  TRANSITION,
+  TYPE,
+} from "@/app/_lib/design-tokens-v2";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
 import {
   getInternalNoteValidationError,
   normalizeInternalNoteBody,
@@ -36,7 +43,6 @@ import { ComposerCollapsedPill } from "./composer-collapsed-pill";
 import {
   ComposerEmailSurface,
   ComposerNoteSurface,
-  ComposerPaneChrome,
 } from "./composer-detail-surfaces";
 import {
   type ComposerContactRecipient,
@@ -52,11 +58,8 @@ import {
   type AttachmentDraft,
   type InlineComposerError,
 } from "./composer-shared";
-import {
-  useInboxClient,
-} from "./inbox-client-provider";
-import {
-} from "./icons";
+import { useInboxClient } from "./inbox-client-provider";
+import { ChevronDownIcon, MailIcon, NoteIcon, XIcon } from "./icons";
 
 const MAX_TOTAL_ATTACHMENT_BYTES = 20 * 1024 * 1024;
 
@@ -78,14 +81,72 @@ export function InboxComposerReplyBar({
   );
 }
 
+function resolveReplyTitle(input: {
+  readonly subject: string | null | undefined;
+  readonly fallbackName: string;
+}): string {
+  const subject = input.subject?.trim() ?? "";
+  const base = subject.length > 0 ? subject : input.fallbackName;
+
+  return /^re:/iu.test(base) ? base : `Re: ${base}`;
+}
+
+function ComposerModeTabs({
+  activeTab,
+}: {
+  readonly activeTab: "email" | "note";
+}) {
+  const isNote = activeTab === "note";
+
+  return (
+    <div className="border-b border-slate-200 px-4 py-2.5">
+      <div
+        role="tablist"
+        aria-label="Composer type"
+        className="inline-flex rounded-md bg-slate-100 p-0.5 text-[12px]"
+      >
+        <button
+          type="button"
+          role="tab"
+          aria-selected={!isNote}
+          tabIndex={-1}
+          className={cn(
+            `inline-flex items-center gap-1.5 rounded px-2.5 py-1 font-medium ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion}`,
+            !isNote
+              ? "bg-white text-slate-900 shadow-sm ring-1 ring-slate-200"
+              : "text-slate-500",
+          )}
+        >
+          <MailIcon className="size-3.5" />
+          Email
+        </button>
+        {isNote ? (
+          <button
+            type="button"
+            role="tab"
+            aria-selected="true"
+            tabIndex={-1}
+            className={`inline-flex items-center gap-1.5 rounded px-2.5 py-1 font-medium bg-white text-amber-700 shadow-sm ring-1 ring-amber-200 ${FOCUS_RING}`}
+          >
+            <NoteIcon className="size-3.5" />
+            Note
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
 export function InboxComposerDetailPane() {
   const router = useRouter();
   const {
     currentActorId,
     composerAliases,
     composerPane,
+    composerView,
     aiDraft,
     closeComposer,
+    minimizeComposer,
     showToast,
     composerErrors,
     setComposerErrors,
@@ -100,15 +161,21 @@ export function InboxComposerDetailPane() {
     setAiError,
   } = useInboxClient();
   const [activeTab, setActiveTab] = useState<"email" | "note">("email");
-  const [recipient, setRecipient] = useState<ComposerRecipientValue | null>(null);
+  const [recipient, setRecipient] = useState<ComposerRecipientValue | null>(
+    null,
+  );
   const [selectedAlias, setSelectedAlias] = useState<string | null>(null);
   const [subject, setSubject] = useState("");
   const [body, setBody] = useState("");
   const [bodyHtml, setBodyHtml] = useState("");
-  const [attachments, setAttachments] = useState<readonly AttachmentDraft[]>([]);
+  const [attachments, setAttachments] = useState<readonly AttachmentDraft[]>(
+    [],
+  );
   const [captureAsKnowledge, setCaptureAsKnowledge] = useState(false);
   const [repromptText, setRepromptText] = useState("");
-  const [inlineError, setInlineError] = useState<InlineComposerError | null>(null);
+  const [inlineError, setInlineError] = useState<InlineComposerError | null>(
+    null,
+  );
   const [isAboutOpen, setIsAboutOpen] = useState(false);
   const [isSending, startSendTransition] = useTransition();
   const [isSavingNote, startSaveNoteTransition] = useTransition();
@@ -168,7 +235,7 @@ export function InboxComposerDetailPane() {
 
   const baselineSubject = replyContext?.subject ?? "";
   const baselineAlias = isReplying
-    ? replyContext?.defaultAlias ?? null
+    ? (replyContext?.defaultAlias ?? null)
     : resolveDefaultAlias({
         recipient,
         aliases: composerAliases,
@@ -303,7 +370,8 @@ export function InboxComposerDetailPane() {
   const selectedAliasRecord =
     selectedAlias === null
       ? null
-      : composerAliases.find((alias) => alias.alias === selectedAlias) ?? null;
+      : (composerAliases.find((alias) => alias.alias === selectedAlias) ??
+        null);
   const aiButton = resolveAiButtonState({
     body,
     isGenerating: isGeneratingAi,
@@ -325,7 +393,9 @@ export function InboxComposerDetailPane() {
     body.trim().length === 0 ||
     isSavingNote;
   const aliasError = composerErrors.find((error) => error.field === "alias");
-  const subjectError = composerErrors.find((error) => error.field === "subject");
+  const subjectError = composerErrors.find(
+    (error) => error.field === "subject",
+  );
   const bodyError = composerErrors.find((error) => error.field === "body");
   const recipientError = composerErrors.find(
     (error) => error.field === "recipient",
@@ -333,6 +403,15 @@ export function InboxComposerDetailPane() {
   const attachmentError = composerErrors.find(
     (error) => error.field === "attachments",
   );
+  const modalTitle =
+    activeTab === "note"
+      ? "Note"
+      : isReplying && replyContext !== null
+        ? resolveReplyTitle({
+            subject: replyContext.subject,
+            fallbackName: replyContext.contactDisplayName,
+          })
+        : "New message";
 
   const clearComposerErrors = () => {
     setInlineError(null);
@@ -617,142 +696,171 @@ export function InboxComposerDetailPane() {
   };
 
   return (
-    <>
-      <section className="flex min-h-0 flex-1 flex-col bg-white">
-        <div className="min-h-0 flex-1 overflow-y-auto bg-slate-50/40 px-5 py-5">
-          <div className={`mx-auto w-full max-w-4xl overflow-hidden border border-slate-200 bg-white ${RADIUS.lg} ${SHADOW.sm}`}>
-            <ComposerPaneChrome
-              title={
-                isReplying && recipient?.kind === "contact"
-                  ? `Reply to ${recipient.displayName}`
-                  : "New message"
-              }
-              description={
-                activeTab === "note"
-                  ? "Internal note for the team timeline."
-                  : "Production send, autosave, attachments, and AI draft flow preserved."
-              }
-              activeTab={activeTab}
-              canUseNoteTab={canUseNoteTab}
-              onEmail={() => {
-                setActiveTab("email");
-                clearComposerErrors();
-              }}
-              onNote={() => {
-                setActiveTab("note");
-                clearComposerErrors();
-              }}
-              onClose={closeComposer}
-            />
-
-            {activeTab === "email" ? (
-              <ComposerEmailSurface
-                composerAliases={composerAliases}
-                selectedAlias={selectedAlias}
-                recipient={recipient}
-                isReplying={isReplying}
-                subject={subject}
-                body={body}
-                attachments={attachments}
-                aiDraft={aiDraft}
-                repromptText={repromptText}
-                isGeneratingAi={isGeneratingAi}
-                aiButtonLabel={aiButton.label}
-                selectedAliasAiReady={selectedAliasRecord?.isAiReady === true}
-                aiWarningMessage={aiWarningMessage}
-                inlineError={inlineError}
-                showKnowledgeCapture={showKnowledgeCapture}
-                captureAsKnowledge={captureAsKnowledge}
-                isSendDisabled={isSendDisabled}
-                isSending={isSending}
-                isAboutOpen={isAboutOpen}
-                onAboutOpenChange={setIsAboutOpen}
-                onAliasChange={(nextAlias) => {
-                  setSelectedAlias(nextAlias);
-                  clearComposerErrors();
-                }}
-                onRecipientChange={(nextRecipient) => {
-                  setRecipient(nextRecipient);
-                  clearComposerErrors();
-                  if (!isReplying) {
-                    setSelectedAlias(
-                      resolveDefaultAlias({
-                        recipient: nextRecipient,
-                        aliases: composerAliases,
-                      }),
-                    );
-                  }
-                }}
-                onSubjectChange={(value) => {
-                  setSubject(value);
-                  clearComposerErrors();
-                }}
-                onBodyChange={(nextBody) => {
-                  setBody(nextBody.bodyPlaintext);
-                  setBodyHtml(nextBody.bodyHtml);
-                }}
-                onClearErrors={clearComposerErrors}
-                onAiEdited={markAiDraftEdited}
-                onDiscardAi={handleDiscardAi}
-                onRegenerateAi={handleRegenerateAi}
-                onRunAiDraft={() => {
-                  runAiDraft();
-                }}
-                onRepromptTextChange={setRepromptText}
-                onReprompt={handleRegenerateAi}
-                onSuggestion={(value) => {
-                  setRepromptText(value);
-                  runAiDraft({
-                    mode: "reprompt",
-                    repromptDirection: value,
-                  });
-                }}
-                onAttachmentClick={() => {
-                  attachmentInputRef.current?.click();
-                }}
-                onAttachmentRemove={(id) => {
-                  clearComposerErrors();
-                  setAttachments((previous) =>
-                    previous.filter((attachment) => attachment.id !== id),
-                  );
-                }}
-                onKnowledgeCaptureChange={setCaptureAsKnowledge}
-                onSend={submit}
-                onCancel={handleCancel}
-                {...(aliasError ? { aliasError } : {})}
-                {...(recipientError ? { recipientError } : {})}
-                {...(subjectError ? { subjectError } : {})}
-                {...(bodyError ? { bodyError } : {})}
-                {...(attachmentError ? { attachmentError } : {})}
-              />
-            ) : (
-              <ComposerNoteSurface
-                body={body}
-                isSavingNote={isSavingNote}
-                isSaveNoteDisabled={isSaveNoteDisabled}
-                inlineError={inlineError}
-                textareaRef={bodyRef}
-                onBodyChange={(value) => {
-                  setBody(value);
-                  clearComposerErrors();
-                }}
-                onTextareaInput={autoResizeTextarea}
-                onSaveNote={saveNote}
-                onCancel={handleCancel}
-                {...(bodyError ? { bodyError } : {})}
-              />
-            )}
-
-            <input
-              ref={attachmentInputRef}
-              type="file"
-              multiple
-              className="hidden"
-              onChange={handleFilesSelected}
-            />
+    <Dialog
+      open={composerView === "modal"}
+      onOpenChange={(open) => {
+        if (!open) {
+          minimizeComposer();
+        }
+      }}
+    >
+      <DialogContent
+        className={cn(
+          `flex max-h-[85vh] w-[calc(100vw-2rem)] max-w-[760px] flex-col gap-0 overflow-hidden border-slate-200 bg-white p-0 ${RADIUS.lg} shadow-lg [&>button:last-child]:hidden`,
+        )}
+      >
+        <DialogTitle className="sr-only">{modalTitle}</DialogTitle>
+        <header className="flex items-center justify-between gap-3 border-b border-slate-200 bg-white px-4 py-2.5">
+          <div className="flex min-w-0 items-center gap-2">
+            <span
+              aria-hidden="true"
+              className="inline-flex size-7 shrink-0 items-center justify-center rounded-md bg-slate-900 text-white"
+            >
+              {activeTab === "note" ? (
+                <NoteIcon className="size-3.5" />
+              ) : (
+                <MailIcon className="size-3.5" />
+              )}
+            </span>
+            <h2 className={`truncate ${TYPE.headingMd}`}>{modalTitle}</h2>
           </div>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              aria-label="Minimize composer"
+              className={cn(
+                `inline-flex size-8 items-center justify-center rounded-md text-slate-400 ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion} hover:bg-slate-100 hover:text-slate-700`,
+              )}
+              onClick={minimizeComposer}
+            >
+              <ChevronDownIcon className="size-4" />
+            </button>
+            <button
+              type="button"
+              aria-label="Close composer"
+              className={cn(
+                `inline-flex size-8 items-center justify-center rounded-md text-slate-400 ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion} hover:bg-slate-100 hover:text-slate-700`,
+              )}
+              onClick={closeComposer}
+            >
+              <XIcon className="size-4" />
+            </button>
+          </div>
+        </header>
+
+        <div className="min-h-0 flex-1 overflow-y-auto bg-white">
+          <ComposerModeTabs activeTab={activeTab} />
+
+          {activeTab === "email" ? (
+            <ComposerEmailSurface
+              composerAliases={composerAliases}
+              selectedAlias={selectedAlias}
+              recipient={recipient}
+              isReplying={isReplying}
+              subject={subject}
+              body={body}
+              attachments={attachments}
+              aiDraft={aiDraft}
+              repromptText={repromptText}
+              isGeneratingAi={isGeneratingAi}
+              aiButtonLabel={aiButton.label}
+              selectedAliasAiReady={selectedAliasRecord?.isAiReady === true}
+              selectedAliasProjectName={
+                selectedAliasRecord?.projectName ?? null
+              }
+              aiWarningMessage={aiWarningMessage}
+              inlineError={inlineError}
+              showKnowledgeCapture={showKnowledgeCapture}
+              captureAsKnowledge={captureAsKnowledge}
+              isSendDisabled={isSendDisabled}
+              isSending={isSending}
+              isAboutOpen={isAboutOpen}
+              onAboutOpenChange={setIsAboutOpen}
+              onAliasChange={(nextAlias) => {
+                setSelectedAlias(nextAlias);
+                clearComposerErrors();
+              }}
+              onRecipientChange={(nextRecipient) => {
+                setRecipient(nextRecipient);
+                clearComposerErrors();
+                if (!isReplying) {
+                  setSelectedAlias(
+                    resolveDefaultAlias({
+                      recipient: nextRecipient,
+                      aliases: composerAliases,
+                    }),
+                  );
+                }
+              }}
+              onSubjectChange={(value) => {
+                setSubject(value);
+                clearComposerErrors();
+              }}
+              onBodyChange={(nextBody) => {
+                setBody(nextBody.bodyPlaintext);
+                setBodyHtml(nextBody.bodyHtml);
+              }}
+              onClearErrors={clearComposerErrors}
+              onAiEdited={markAiDraftEdited}
+              onDiscardAi={handleDiscardAi}
+              onRegenerateAi={handleRegenerateAi}
+              onRunAiDraft={() => {
+                runAiDraft();
+              }}
+              onRepromptTextChange={setRepromptText}
+              onReprompt={handleRegenerateAi}
+              onSuggestion={(value) => {
+                setRepromptText(value);
+                runAiDraft({
+                  mode: "reprompt",
+                  repromptDirection: value,
+                });
+              }}
+              onAttachmentClick={() => {
+                attachmentInputRef.current?.click();
+              }}
+              onAttachmentRemove={(id) => {
+                clearComposerErrors();
+                setAttachments((previous) =>
+                  previous.filter((attachment) => attachment.id !== id),
+                );
+              }}
+              onKnowledgeCaptureChange={setCaptureAsKnowledge}
+              onSend={submit}
+              onCancel={handleCancel}
+              {...(aliasError ? { aliasError } : {})}
+              {...(recipientError ? { recipientError } : {})}
+              {...(subjectError ? { subjectError } : {})}
+              {...(bodyError ? { bodyError } : {})}
+              {...(attachmentError ? { attachmentError } : {})}
+            />
+          ) : (
+            <ComposerNoteSurface
+              body={body}
+              isSavingNote={isSavingNote}
+              isSaveNoteDisabled={isSaveNoteDisabled}
+              inlineError={inlineError}
+              textareaRef={bodyRef}
+              onBodyChange={(value) => {
+                setBody(value);
+                clearComposerErrors();
+              }}
+              onTextareaInput={autoResizeTextarea}
+              onSaveNote={saveNote}
+              onCancel={handleCancel}
+              {...(bodyError ? { bodyError } : {})}
+            />
+          )}
+
+          <input
+            ref={attachmentInputRef}
+            type="file"
+            multiple
+            className="hidden"
+            onChange={handleFilesSelected}
+          />
         </div>
-      </section>
-    </>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/web/app/inbox/_components/inbox-keyboard-provider.tsx
+++ b/apps/web/app/inbox/_components/inbox-keyboard-provider.tsx
@@ -6,14 +6,14 @@ import {
   useEffect,
   useRef,
   useState,
-  type ReactNode
+  type ReactNode,
 } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
   Popover,
   PopoverAnchor,
-  PopoverContent
+  PopoverContent,
 } from "@/components/ui/popover";
 
 import {
@@ -25,7 +25,7 @@ import {
   INBOX_ROW_SELECTOR,
   INBOX_SEARCH_INPUT_SELECTOR,
   isEditableShortcutTarget,
-  isInboxKeyboardPath
+  isInboxKeyboardPath,
 } from "./inbox-keyboard-helpers";
 import { useInboxClient } from "./inbox-client-provider";
 import { XIcon } from "./icons";
@@ -47,18 +47,18 @@ const SHORTCUTS = [
   { key: "Esc", description: "Return to the inbox list" },
   { key: "F", description: "Toggle Needs Follow-Up" },
   { key: "/", description: "Focus search" },
-  { key: "?", description: "Show this shortcuts list" }
+  { key: "?", description: "Show this shortcuts list" },
 ] as const;
 
 export function InboxKeyboardProvider({
-  children
+  children,
 }: InboxKeyboardProviderProps) {
   const pathname = usePathname();
   const router = useRouter();
   const rootRef = useRef<HTMLDivElement>(null);
   const lastFocusedContactIdRef = useRef<string | null>(null);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
-  const { composerPane, closeComposer, openNewDraft } = useInboxClient();
+  const { composerView, minimizeComposer, openNewDraft } = useInboxClient();
 
   const getRowTargets = useCallback((): readonly RowTarget[] => {
     const root = rootRef.current;
@@ -70,7 +70,7 @@ export function InboxKeyboardProvider({
     return Array.from(root.querySelectorAll<HTMLElement>(INBOX_ROW_SELECTOR))
       .map((element) => ({
         element,
-        contactId: element.dataset.contactId ?? ""
+        contactId: element.dataset.contactId ?? "",
       }))
       .filter((target) => target.contactId.length > 0);
   }, []);
@@ -100,7 +100,7 @@ export function InboxKeyboardProvider({
         rowContactIds: rows.map((row) => row.contactId),
         currentFocusedContactId: getCurrentFocusedContactId(),
         activeContactId: extractInboxContactId(pathname),
-        direction
+        direction,
       });
 
       if (nextContactId === null) {
@@ -117,10 +117,10 @@ export function InboxKeyboardProvider({
       nextRow.element.focus();
       nextRow.element.scrollIntoView({
         block: "nearest",
-        inline: "nearest"
+        inline: "nearest",
       });
     },
-    [getCurrentFocusedContactId, getRowTargets, pathname]
+    [getCurrentFocusedContactId, getRowTargets, pathname],
   );
 
   const openFocusedRow = useCallback(() => {
@@ -128,7 +128,7 @@ export function InboxKeyboardProvider({
     const contactId = getPreferredFocusedRowContactId({
       rowContactIds: rows.map((row) => row.contactId),
       currentFocusedContactId: getCurrentFocusedContactId(),
-      activeContactId: extractInboxContactId(pathname)
+      activeContactId: extractInboxContactId(pathname),
     });
 
     if (contactId === null) {
@@ -136,14 +136,14 @@ export function InboxKeyboardProvider({
     }
 
     router.push(`/inbox/${encodeURIComponent(contactId)}`, {
-      scroll: false
+      scroll: false,
     });
   }, [getCurrentFocusedContactId, getRowTargets, pathname, router]);
 
   const focusSearch = useCallback(() => {
     const root = rootRef.current;
     const input = root?.querySelector<HTMLInputElement>(
-      INBOX_SEARCH_INPUT_SELECTOR
+      INBOX_SEARCH_INPUT_SELECTOR,
     );
 
     if (!input) {
@@ -157,7 +157,7 @@ export function InboxKeyboardProvider({
   const triggerFollowUpToggle = useCallback(() => {
     const root = rootRef.current;
     const button = root?.querySelector<HTMLButtonElement>(
-      INBOX_FOLLOW_UP_TOGGLE_SELECTOR
+      INBOX_FOLLOW_UP_TOGGLE_SELECTOR,
     );
 
     if (!button || button.disabled) {
@@ -220,15 +220,15 @@ export function InboxKeyboardProvider({
         return;
       }
 
-      const target =
-        event.target instanceof HTMLElement ? event.target : null;
+      const target = event.target instanceof HTMLElement ? event.target : null;
       const targetMeta = {
-        tagName: target?.closest("input, textarea, select")?.tagName ??
+        tagName:
+          target?.closest("input, textarea, select")?.tagName ??
           target?.tagName ??
           null,
         isContentEditable:
           target?.isContentEditable === true ||
-          target?.closest("[contenteditable='true']") !== null
+          target?.closest("[contenteditable='true']") !== null,
       };
       const isEditable = isEditableShortcutTarget(targetMeta);
 
@@ -248,9 +248,9 @@ export function InboxKeyboardProvider({
           setShortcutsOpen(false);
         }
 
-        if (composerPane.mode !== "closed") {
+        if (composerView === "modal") {
           event.preventDefault();
-          closeComposer();
+          minimizeComposer();
           return;
         }
 
@@ -327,10 +327,10 @@ export function InboxKeyboardProvider({
     router,
     shortcutsOpen,
     triggerFollowUpToggle,
-    composerPane.mode,
-    closeComposer,
+    composerView,
     isListFocused,
-    openNewDraft
+    minimizeComposer,
+    openNewDraft,
   ]);
 
   return (

--- a/apps/web/app/inbox/_components/inbox-workspace.tsx
+++ b/apps/web/app/inbox/_components/inbox-workspace.tsx
@@ -4,15 +4,12 @@ import { useEffect, type ReactNode } from "react";
 
 import { Button } from "@/components/ui/button";
 
+import { ComposerFloatingPill } from "./composer-floating-pill";
 import { useInboxClient } from "./inbox-client-provider";
 import { InboxComposerDetailPane } from "./inbox-composer";
 import { XIcon } from "./icons";
 
-export function InboxWorkspace({
-  children
-}: {
-  readonly children: ReactNode;
-}) {
+export function InboxWorkspace({ children }: { readonly children: ReactNode }) {
   const { composerPane, toast, clearToast } = useInboxClient();
 
   useEffect(() => {
@@ -31,7 +28,9 @@ export function InboxWorkspace({
 
   return (
     <main className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
-      {composerPane.mode === "closed" ? children : <InboxComposerDetailPane />}
+      {children}
+      {composerPane.mode === "closed" ? null : <InboxComposerDetailPane />}
+      <ComposerFloatingPill />
 
       {toast ? (
         <div className="pointer-events-none absolute right-5 top-5 z-50 flex justify-end">

--- a/apps/web/tests/unit/composer-canonical-modal.test.tsx
+++ b/apps/web/tests/unit/composer-canonical-modal.test.tsx
@@ -1,0 +1,739 @@
+import { createRequire } from "node:module";
+import React, {
+  act,
+  createElement,
+  type ButtonHTMLAttributes,
+  type ChangeEvent,
+  type InputEvent as ReactInputEvent,
+  type InputHTMLAttributes,
+  type ReactElement,
+  type ReactNode,
+  type TextareaHTMLAttributes,
+} from "react";
+
+Object.assign(globalThis, { React });
+
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const routerPush = vi.hoisted(() => vi.fn());
+const routerRefresh = vi.hoisted(() => vi.fn());
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/inbox",
+  useRouter: () => ({
+    push: routerPush,
+    refresh: routerRefresh,
+  }),
+}));
+
+function iconMock(name: string) {
+  return (props: Record<string, unknown>) =>
+    createElement("svg", { "data-icon": name, ...props });
+}
+
+vi.mock("lucide-react", () => ({
+  AlertCircle: iconMock("AlertCircle"),
+  AlertTriangle: iconMock("AlertTriangle"),
+  ArrowRight: iconMock("ArrowRight"),
+  ArrowUpRight: iconMock("ArrowUpRight"),
+  Bold: iconMock("Bold"),
+  Bot: iconMock("Bot"),
+  Calendar: iconMock("Calendar"),
+  CheckCircle2: iconMock("CheckCircle2"),
+  ChevronDown: iconMock("ChevronDown"),
+  ChevronRight: iconMock("ChevronRight"),
+  ChevronUp: iconMock("ChevronUp"),
+  Clock: iconMock("Clock"),
+  CornerUpLeft: iconMock("CornerUpLeft"),
+  Database: iconMock("Database"),
+  Eye: iconMock("Eye"),
+  FileIcon: iconMock("FileIcon"),
+  FileText: iconMock("FileText"),
+  Flag: iconMock("Flag"),
+  Image: iconMock("Image"),
+  Inbox: iconMock("Inbox"),
+  Italic: iconMock("Italic"),
+  Link: iconMock("Link"),
+  List: iconMock("List"),
+  ListOrdered: iconMock("ListOrdered"),
+  Loader2: iconMock("Loader2"),
+  LogOut: iconMock("LogOut"),
+  Mail: iconMock("Mail"),
+  MailOpen: iconMock("MailOpen"),
+  MapPin: iconMock("MapPin"),
+  Megaphone: iconMock("Megaphone"),
+  MousePointerClick: iconMock("MousePointerClick"),
+  PanelRightClose: iconMock("PanelRightClose"),
+  PanelRightOpen: iconMock("PanelRightOpen"),
+  Paperclip: iconMock("Paperclip"),
+  Pencil: iconMock("Pencil"),
+  Phone: iconMock("Phone"),
+  Quote: iconMock("Quote"),
+  RefreshCw: iconMock("RefreshCw"),
+  RotateCcw: iconMock("RotateCcw"),
+  Save: iconMock("Save"),
+  Search: iconMock("Search"),
+  SearchX: iconMock("SearchX"),
+  Send: iconMock("Send"),
+  Settings: iconMock("Settings"),
+  SlidersHorizontal: iconMock("SlidersHorizontal"),
+  Sparkles: iconMock("Sparkles"),
+  Trash2: iconMock("Trash2"),
+  Upload: iconMock("Upload"),
+  Wand2: iconMock("Wand2"),
+  WifiOff: iconMock("WifiOff"),
+  X: iconMock("X"),
+  XCircle: iconMock("XCircle"),
+  Zap: iconMock("Zap"),
+}));
+
+vi.mock("@/app/_components/adventure-scientists-logo", () => ({
+  AdventureScientistsLogo: (props: Record<string, unknown>) =>
+    createElement("svg", { "data-icon": "AdventureScientistsLogo", ...props }),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) =>
+    createElement("button", props, children),
+}));
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({
+    children,
+    open,
+  }: {
+    readonly children: ReactNode;
+    readonly open?: boolean;
+  }) => createElement("div", { "data-popover-open": String(open) }, children),
+  PopoverAnchor: ({ children }: { readonly children: ReactNode }) =>
+    createElement(React.Fragment, null, children),
+  PopoverContent: ({ children }: { readonly children: ReactNode }) =>
+    createElement("div", null, children),
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({
+    children,
+    onOpenChange,
+    open,
+  }: {
+    readonly children: ReactNode;
+    readonly onOpenChange?: (open: boolean) => void;
+    readonly open?: boolean;
+  }) =>
+    open
+      ? createElement(
+          "div",
+          { "data-dialog-root": "true" },
+          createElement(
+            "button",
+            {
+              "aria-label": "Composer overlay",
+              onClick: () => onOpenChange?.(false),
+              type: "button",
+            },
+            "overlay",
+          ),
+          children,
+        )
+      : null,
+  DialogContent: ({
+    children,
+    className,
+  }: {
+    readonly children: ReactNode;
+    readonly className?: string;
+  }) => createElement("div", { className, role: "dialog" }, children),
+  DialogTitle: ({
+    children,
+    className,
+  }: {
+    readonly children: ReactNode;
+    readonly className?: string;
+  }) => createElement("h2", { className }, children),
+}));
+
+vi.mock("../../app/inbox/actions", () => ({
+  createNoteAction: vi.fn(),
+  draftWithAiAction: vi.fn(),
+  searchContactsAction: vi.fn(),
+  sendComposerAction: vi.fn(),
+}));
+
+vi.mock("../../app/inbox/_components/composer-detail-surfaces", () => ({
+  ComposerEmailSurface: ({
+    attachments,
+    body,
+    onBodyChange,
+    onCancel,
+    onRecipientChange,
+    onSubjectChange,
+    recipient,
+    subject,
+  }: {
+    readonly attachments: readonly { readonly filename: string }[];
+    readonly body: string;
+    readonly onBodyChange: (value: {
+      readonly bodyPlaintext: string;
+      readonly bodyHtml: string;
+    }) => void;
+    readonly onCancel: () => void;
+    readonly onRecipientChange: (
+      recipient: {
+        readonly kind: "email";
+        readonly emailAddress: string;
+      } | null,
+    ) => void;
+    readonly onSubjectChange: (value: string) => void;
+    readonly recipient:
+      | { readonly kind: "email"; readonly emailAddress: string }
+      | { readonly kind: "contact"; readonly displayName: string }
+      | null;
+    readonly subject: string;
+  }) =>
+    createElement(
+      "div",
+      { "data-testid": "email-surface" },
+      createElement("input", {
+        "aria-label": "Recipient",
+        onChange: (event: ChangeEvent<HTMLInputElement>) => {
+          const value = event.currentTarget.value.trim();
+          onRecipientChange(
+            value.length > 0 ? { kind: "email", emailAddress: value } : null,
+          );
+        },
+        onInput: (event: ReactInputEvent<HTMLInputElement>) => {
+          const value = event.currentTarget.value.trim();
+          onRecipientChange(
+            value.length > 0 ? { kind: "email", emailAddress: value } : null,
+          );
+        },
+        value:
+          recipient?.kind === "email"
+            ? recipient.emailAddress
+            : recipient?.kind === "contact"
+              ? recipient.displayName
+              : "",
+      } satisfies InputHTMLAttributes<HTMLInputElement>),
+      createElement("input", {
+        "aria-label": "Subject",
+        onChange: (event: ChangeEvent<HTMLInputElement>) => {
+          onSubjectChange(event.currentTarget.value);
+        },
+        onInput: (event: ReactInputEvent<HTMLInputElement>) => {
+          onSubjectChange(event.currentTarget.value);
+        },
+        value: subject,
+      } satisfies InputHTMLAttributes<HTMLInputElement>),
+      createElement("textarea", {
+        "aria-label": "Message body",
+        onChange: (event: ChangeEvent<HTMLTextAreaElement>) => {
+          const value = event.currentTarget.value;
+          onBodyChange({
+            bodyPlaintext: value,
+            bodyHtml: `<p>${value}</p>`,
+          });
+        },
+        onInput: (event: ReactInputEvent<HTMLTextAreaElement>) => {
+          const value = event.currentTarget.value;
+          onBodyChange({
+            bodyPlaintext: value,
+            bodyHtml: `<p>${value}</p>`,
+          });
+        },
+        value: body,
+      } satisfies TextareaHTMLAttributes<HTMLTextAreaElement>),
+      createElement(
+        "ul",
+        { "aria-label": "Attachments" },
+        attachments.map((attachment) =>
+          createElement(
+            "li",
+            { key: attachment.filename },
+            attachment.filename,
+          ),
+        ),
+      ),
+      createElement("button", { onClick: onCancel, type: "button" }, "Cancel"),
+    ),
+  ComposerNoteSurface: ({
+    body,
+    onBodyChange,
+  }: {
+    readonly body: string;
+    readonly onBodyChange: (value: string) => void;
+  }) =>
+    createElement("textarea", {
+      "aria-label": "Internal note body",
+      onChange: (event: ChangeEvent<HTMLTextAreaElement>) => {
+        onBodyChange(event.currentTarget.value);
+      },
+      onInput: (event: ReactInputEvent<HTMLTextAreaElement>) => {
+        onBodyChange(event.currentTarget.value);
+      },
+      value: body,
+    } satisfies TextareaHTMLAttributes<HTMLTextAreaElement>),
+}));
+
+import type { InboxComposerAliasOption } from "../../app/inbox/_lib/view-models";
+import {
+  InboxClientProvider,
+  useInboxClient,
+} from "../../app/inbox/_components/inbox-client-provider";
+import { InboxKeyboardProvider } from "../../app/inbox/_components/inbox-keyboard-provider";
+import { InboxWorkspace } from "../../app/inbox/_components/inbox-workspace";
+
+const workerRequire = createRequire(
+  new URL("../../../worker/package.json", import.meta.url),
+);
+const { JSDOM } = workerRequire("jsdom") as {
+  readonly JSDOM: new (
+    html: string,
+    options: { readonly url: string },
+  ) => {
+    readonly window: Window &
+      typeof globalThis & {
+        close: () => void;
+      };
+  };
+};
+
+const composerAliases: readonly InboxComposerAliasOption[] = [
+  {
+    id: "alias:whitebark",
+    alias: "whitebark@adventurescientists.org",
+    projectId: "project:whitebark",
+    projectName: "Whitebark Pine",
+    isAiReady: true,
+  },
+];
+
+const replyContext = {
+  contactId: "contact:maya",
+  contactDisplayName: "Maya Lee",
+  subject: "Trip logistics",
+  threadCursor: "event:inbound-1",
+  threadId: "thread:gmail-1",
+  inReplyToRfc822: "message:gmail-1",
+  defaultAlias: "whitebark@adventurescientists.org",
+};
+
+interface RenderSession {
+  readonly cleanup: () => Promise<void>;
+  readonly container: HTMLDivElement;
+  readonly root: Root;
+}
+
+let activeSession: RenderSession | null = null;
+
+afterEach(async () => {
+  await activeSession?.cleanup();
+  activeSession = null;
+  routerPush.mockReset();
+  routerRefresh.mockReset();
+});
+
+function invokeTimerHandler(
+  handler: TimerHandler,
+  args: readonly unknown[],
+): void {
+  if (typeof handler === "function") {
+    (handler as (...handlerArgs: readonly unknown[]) => void)(...args);
+    return;
+  }
+
+  throw new TypeError("String timers are not supported in tests.");
+}
+
+function setDomGlobals(window: Window & typeof globalThis) {
+  const entries = {
+    document: window.document,
+    Element: window.Element,
+    Event: window.Event,
+    File: window.File,
+    FileReader: window.FileReader,
+    HTMLElement: window.HTMLElement,
+    HTMLInputElement: window.HTMLInputElement,
+    HTMLTextAreaElement: window.HTMLTextAreaElement,
+    KeyboardEvent: window.KeyboardEvent,
+    MouseEvent: window.MouseEvent,
+    MutationObserver: window.MutationObserver,
+    navigator: window.navigator,
+    Node: window.Node,
+    self: window,
+    window,
+  } as const;
+
+  for (const [key, value] of Object.entries(entries)) {
+    Object.defineProperty(globalThis, key, {
+      configurable: true,
+      value,
+      writable: true,
+    });
+  }
+
+  Object.defineProperty(globalThis, "getComputedStyle", {
+    configurable: true,
+    value: window.getComputedStyle.bind(window),
+    writable: true,
+  });
+
+  window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+    return globalThis.setTimeout(() => {
+      callback(Date.now());
+    }, 16);
+  }) as unknown as typeof window.requestAnimationFrame;
+  window.cancelAnimationFrame = ((handle: number) => {
+    globalThis.clearTimeout(handle);
+  }) as unknown as typeof window.cancelAnimationFrame;
+  window.setTimeout = ((
+    handler: TimerHandler,
+    timeout?: number,
+    ...args: unknown[]
+  ) => {
+    return globalThis.setTimeout(() => {
+      invokeTimerHandler(handler, args);
+    }, timeout);
+  }) as unknown as typeof window.setTimeout;
+  window.clearTimeout = ((handle?: number) => {
+    globalThis.clearTimeout(handle);
+  }) as unknown as typeof window.clearTimeout;
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+}
+
+function ComposerControls() {
+  const {
+    closeComposer,
+    composerPane,
+    composerView,
+    expandComposer,
+    minimizeComposer,
+    openNewDraft,
+    openReplyDraft,
+  } = useInboxClient();
+
+  return (
+    <div>
+      <button type="button" onClick={openNewDraft}>
+        Open new draft
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          openReplyDraft(replyContext);
+        }}
+      >
+        Open reply draft
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          openReplyDraft(replyContext, "note");
+        }}
+      >
+        Open note draft
+      </button>
+      <button type="button" onClick={minimizeComposer}>
+        Minimize from context
+      </button>
+      <button type="button" onClick={expandComposer}>
+        Expand from context
+      </button>
+      <button type="button" onClick={closeComposer}>
+        Close from context
+      </button>
+      <output data-testid="composer-state">
+        {composerPane.mode}:{composerView}
+      </output>
+    </div>
+  );
+}
+
+function TestApp() {
+  return (
+    <InboxClientProvider
+      composerAliases={composerAliases}
+      currentActorId="user:operator"
+    >
+      <InboxKeyboardProvider>
+        <InboxWorkspace>
+          <section data-testid="underlying-conversation">
+            Conversation remains visible
+          </section>
+          <ComposerControls />
+        </InboxWorkspace>
+      </InboxKeyboardProvider>
+    </InboxClientProvider>
+  );
+}
+
+async function mount(element: ReactElement): Promise<RenderSession> {
+  const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+    url: "http://localhost/inbox",
+  });
+  setDomGlobals(dom.window);
+
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(element);
+    await Promise.resolve();
+  });
+
+  const session = {
+    container,
+    root,
+    cleanup: async () => {
+      await act(async () => {
+        root.unmount();
+        await Promise.resolve();
+      });
+      dom.window.close();
+    },
+  };
+  activeSession = session;
+  return session;
+}
+
+async function flushReact() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function click(element: Element | null) {
+  if (!(element instanceof HTMLElement)) {
+    throw new Error("Expected a clickable element.");
+  }
+
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await Promise.resolve();
+  });
+}
+
+async function changeValue(element: Element | null, value: string) {
+  if (
+    !(element instanceof HTMLInputElement) &&
+    !(element instanceof HTMLTextAreaElement)
+  ) {
+    throw new Error("Expected an input or textarea.");
+  }
+
+  await act(async () => {
+    const valueDescriptor = Object.getOwnPropertyDescriptor(element, "value");
+    const prototypeValueDescriptor = Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(element) as HTMLInputElement | HTMLTextAreaElement,
+      "value",
+    );
+
+    if (
+      prototypeValueDescriptor?.set &&
+      prototypeValueDescriptor.set !== valueDescriptor?.set
+    ) {
+      prototypeValueDescriptor.set.call(element, value);
+    } else if (valueDescriptor?.set) {
+      valueDescriptor.set.call(element, value);
+    } else {
+      element.value = value;
+    }
+
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+    element.dispatchEvent(new Event("change", { bubbles: true }));
+    await Promise.resolve();
+  });
+}
+
+function getByText(text: string): HTMLElement {
+  const element = Array.from(document.querySelectorAll<HTMLElement>("*")).find(
+    (candidate) => candidate.textContent.trim() === text,
+  );
+
+  if (!element) {
+    throw new Error(`Unable to find text: ${text}`);
+  }
+
+  return element;
+}
+
+function getStateText(): string {
+  return (
+    document.querySelector<HTMLOutputElement>("[data-testid='composer-state']")
+      ?.textContent ?? ""
+  );
+}
+
+function getInput(label: string): HTMLInputElement {
+  const input = document.querySelector<HTMLInputElement>(
+    `input[aria-label='${label}']`,
+  );
+
+  if (!input) {
+    throw new Error(`Unable to find input: ${label}`);
+  }
+
+  return input;
+}
+
+function getTextarea(label: string): HTMLTextAreaElement {
+  const textarea = document.querySelector<HTMLTextAreaElement>(
+    `textarea[aria-label='${label}']`,
+  );
+
+  if (!textarea) {
+    throw new Error(`Unable to find textarea: ${label}`);
+  }
+
+  return textarea;
+}
+
+async function attachFile(filename: string) {
+  const fileInput =
+    document.querySelector<HTMLInputElement>("input[type='file']");
+
+  if (!fileInput) {
+    throw new Error("Unable to find attachment input.");
+  }
+
+  const file = new File(["attachment-body"], filename, {
+    type: "text/plain",
+  });
+
+  Object.defineProperty(fileInput, "files", {
+    configurable: true,
+    value: [file],
+  });
+
+  await act(async () => {
+    fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+    await new Promise((resolve) => {
+      window.setTimeout(resolve, 0);
+    });
+  });
+}
+
+describe("composer canonical modal", () => {
+  it("opens new drafts in a Dialog over the existing workspace", async () => {
+    await mount(<TestApp />);
+
+    expect(document.querySelector("[role='dialog']")).toBeNull();
+    expect(document.querySelector("[role='region']")).toBeNull();
+
+    await click(getByText("Open new draft"));
+
+    expect(document.querySelector("[role='dialog']")).not.toBeNull();
+    expect(
+      document.querySelector("[data-testid='underlying-conversation']"),
+    ).not.toBeNull();
+    expect(getStateText()).toBe("new-draft:modal");
+    expect(document.body.textContent).toContain("New message");
+  });
+
+  it("opens reply and note entry points in the same modal state machine", async () => {
+    await mount(<TestApp />);
+
+    await click(getByText("Open reply draft"));
+    expect(getStateText()).toBe("replying:modal");
+    expect(document.body.textContent).toContain("Re: Trip logistics");
+    expect(getInput("Recipient").value).toBe("Maya Lee");
+
+    await click(document.querySelector("button[aria-label='Close composer']"));
+    await click(getByText("Open note draft"));
+
+    expect(getStateText()).toBe("replying:modal");
+    expect(document.body.textContent).toContain("Note");
+    expect(getTextarea("Internal note body").value).toBe("");
+  });
+
+  it("minimizes to a pill and expands back to the modal", async () => {
+    await mount(<TestApp />);
+
+    await click(getByText("Open new draft"));
+    await click(
+      document.querySelector("button[aria-label='Minimize composer']"),
+    );
+
+    expect(document.querySelector("[role='dialog']")).toBeNull();
+    expect(document.querySelector("[role='region']")).not.toBeNull();
+    expect(getStateText()).toBe("new-draft:pill");
+
+    await click(document.querySelector("button[aria-label='Expand composer']"));
+
+    expect(document.querySelector("[role='dialog']")).not.toBeNull();
+    expect(document.querySelector("[role='region']")).toBeNull();
+    expect(getStateText()).toBe("new-draft:modal");
+  });
+
+  it("preserves draft fields and attachments across minimize and expand", async () => {
+    await mount(<TestApp />);
+
+    await click(getByText("Open new draft"));
+    await changeValue(getInput("Recipient"), "partner@example.org");
+    await changeValue(getInput("Subject"), "Field kit");
+    await changeValue(getTextarea("Message body"), "Please bring the kit.");
+    await attachFile("field-kit.txt");
+    await flushReact();
+
+    expect(document.body.textContent).toContain("field-kit.txt");
+
+    await click(
+      document.querySelector("button[aria-label='Minimize composer']"),
+    );
+    await click(document.querySelector("button[aria-label='Expand composer']"));
+
+    expect(getInput("Recipient").value).toBe("partner@example.org");
+    expect(getInput("Subject").value).toBe("Field kit");
+    expect(getTextarea("Message body").value).toBe("Please bring the kit.");
+    expect(document.body.textContent).toContain("field-kit.txt");
+  });
+
+  it("closes from the modal header and from the minimized pill", async () => {
+    await mount(<TestApp />);
+
+    await click(getByText("Open new draft"));
+    await click(document.querySelector("button[aria-label='Close composer']"));
+
+    expect(document.querySelector("[role='dialog']")).toBeNull();
+    expect(document.querySelector("[role='region']")).toBeNull();
+    expect(getStateText()).toBe("closed:closed");
+
+    await click(getByText("Open new draft"));
+    await click(
+      document.querySelector("button[aria-label='Minimize composer']"),
+    );
+    await click(document.querySelector("button[aria-label='Close composer']"));
+
+    expect(document.querySelector("[role='dialog']")).toBeNull();
+    expect(document.querySelector("[role='region']")).toBeNull();
+    expect(getStateText()).toBe("closed:closed");
+  });
+
+  it("minimizes on Escape and overlay click instead of closing", async () => {
+    await mount(<TestApp />);
+
+    await click(getByText("Open new draft"));
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(getStateText()).toBe("new-draft:pill");
+    expect(document.querySelector("[role='region']")).not.toBeNull();
+
+    await click(document.querySelector("button[aria-label='Expand composer']"));
+    await click(
+      document.querySelector("button[aria-label='Composer overlay']"),
+    );
+
+    expect(getStateText()).toBe("new-draft:pill");
+    expect(document.querySelector("[role='region']")).not.toBeNull();
+  });
+});

--- a/apps/web/tests/unit/stage3-composer-ui.test.tsx
+++ b/apps/web/tests/unit/stage3-composer-ui.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { InboxComposerReplyContext } from "../../app/inbox/_lib/view-models";
+import { resolveFloatingComposerLabel } from "../../app/inbox/_components/composer-floating-pill";
 import { plaintextToComposerHtml } from "../../app/inbox/_components/composer-html";
 import {
   formatContactRecipientLabel,
@@ -8,7 +9,7 @@ import {
   resolveTypedEmailRecipient,
   isComposerSendDisabled,
   resolveDefaultAlias,
-  type ComposerPaneState
+  type ComposerPaneState,
 } from "../../app/inbox/_lib/composer-ui";
 
 const replyContext: InboxComposerReplyContext = {
@@ -18,7 +19,7 @@ const replyContext: InboxComposerReplyContext = {
   threadCursor: "event-1",
   threadId: "thread-1",
   inReplyToRfc822: "message-1",
-  defaultAlias: "field@adventuresci.org"
+  defaultAlias: "field@adventuresci.org",
 };
 
 describe("stage3 composer ui helpers", () => {
@@ -26,19 +27,19 @@ describe("stage3 composer ui helpers", () => {
     const opened = reduceComposerPane(
       { mode: "closed" },
       {
-        type: "open-new-draft"
-      }
+        type: "open-new-draft",
+      },
     );
     const closed = reduceComposerPane(opened, {
-      type: "close"
+      type: "close",
     });
 
     expect(opened).toEqual({
       mode: "new-draft",
-      initialTab: "email"
+      initialTab: "email",
     } satisfies ComposerPaneState);
     expect(closed).toEqual({
-      mode: "closed"
+      mode: "closed",
     } satisfies ComposerPaneState);
   });
 
@@ -47,26 +48,51 @@ describe("stage3 composer ui helpers", () => {
       { mode: "closed" },
       {
         type: "open-reply",
-        replyContext
-      }
+        replyContext,
+      },
     );
 
     expect(replying).toEqual({
       mode: "replying",
       replyContext,
-      initialTab: "email"
+      initialTab: "email",
     } satisfies ComposerPaneState);
+  });
+
+  it("derives minimized composer labels from the active composer pane", () => {
+    expect(
+      resolveFloatingComposerLabel({
+        mode: "new-draft",
+        initialTab: "email",
+      }),
+    ).toBe("New message");
+
+    expect(
+      resolveFloatingComposerLabel({
+        mode: "replying",
+        replyContext,
+        initialTab: "email",
+      }),
+    ).toBe("Re: Trip logistics");
+
+    expect(
+      resolveFloatingComposerLabel({
+        mode: "replying",
+        replyContext,
+        initialTab: "note",
+      }),
+    ).toBe("Note about Alice Smith");
   });
 
   it("accepts an unmatched valid email as an external recipient", () => {
     expect(
       resolveTypedEmailRecipient({
         query: "outside@example.com",
-        results: []
-      })
+        results: [],
+      }),
     ).toEqual({
       kind: "email",
-      emailAddress: "outside@example.com"
+      emailAddress: "outside@example.com",
     });
 
     expect(
@@ -74,10 +100,10 @@ describe("stage3 composer ui helpers", () => {
         query: "alice@example.com",
         results: [
           {
-            primaryEmail: "alice@example.com"
-          }
-        ]
-      })
+            primaryEmail: "alice@example.com",
+          },
+        ],
+      }),
     ).toBeNull();
   });
 
@@ -85,15 +111,15 @@ describe("stage3 composer ui helpers", () => {
     expect(
       formatContactRecipientLabel({
         displayName: "Alice Smith",
-        primaryEmail: "alice@example.com"
-      })
+        primaryEmail: "alice@example.com",
+      }),
     ).toBe("Alice Smith (alice@example.com)");
 
     expect(
       formatContactRecipientLabel({
         displayName: "Alice Smith",
-        primaryEmail: null
-      })
+        primaryEmail: null,
+      }),
     ).toBe("Alice Smith");
   });
 
@@ -102,7 +128,7 @@ describe("stage3 composer ui helpers", () => {
       resolveDefaultAlias({
         recipient: {
           kind: "contact",
-          primaryProjectName: "Coastal Survey"
+          primaryProjectName: "Coastal Survey",
         },
         aliases: [
           {
@@ -110,10 +136,10 @@ describe("stage3 composer ui helpers", () => {
             alias: "coastal@adventuresci.org",
             projectId: "project-1",
             projectName: "Coastal Survey",
-            isAiReady: true
-          }
-        ]
-      })
+            isAiReady: true,
+          },
+        ],
+      }),
     ).toBe("coastal@adventuresci.org");
 
     expect(
@@ -123,21 +149,21 @@ describe("stage3 composer ui helpers", () => {
         selectedAlias: "coastal@adventuresci.org",
         subject: "Hello",
         body: "Body",
-        isSending: false
-      })
+        isSending: false,
+      }),
     ).toBe(true);
 
     expect(
       isComposerSendDisabled({
         activeTab: "email",
         recipient: {
-          kind: "email"
+          kind: "email",
         },
         selectedAlias: "coastal@adventuresci.org",
         subject: "Hello",
         body: "",
-        isSending: false
-      })
+        isSending: false,
+      }),
     ).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- Composer is now a single canonical Dialog (`@/components/ui/dialog`) used by both Compose-new and Reply/Note entry points
- Conversation panel is no longer replaced when composer is open — modal floats over it
- New `composerView` state (`"closed" | "modal" | "pill"`) in `inbox-client-provider`
- Minimize-to-floating-pill (bottom-right) preserves draft state
- ESC + overlay click minimize; explicit X closes
- New `composer-floating-pill.tsx` component
- New `composer-canonical-modal.test.tsx` covers state transitions + state preservation

## Test plan
- [x] `pnpm --filter @as-comms/web typecheck`
- [x] `pnpm --filter @as-comms/web lint`
- [x] `pnpm --filter @as-comms/web exec vitest run --config ../../vitest.config.ts tests/unit` (32 files, 206 passed, 8 skipped)
- [ ] `pnpm --filter @as-comms/web test:unit` exact wrapper: blocked locally by the known macOS Rollup native binary signature error before test discovery; explicit full unit path above passes
- [ ] Manual browser smoke: blocked locally because the sandbox denies dev-server listen on both `0.0.0.0:3000` and `127.0.0.1:3001` (`listen EPERM`)
- [x] DOM/unit coverage: Compose-new opens modal with underlying workspace still rendered
- [x] DOM/unit coverage: Reply opens modal with reply context
- [x] DOM/unit coverage: minimize → pill → expand preserves body / recipient / subject / attachments
- [x] DOM/unit coverage: ESC minimizes; overlay click minimizes; header X closes; pill X closes; pill ^ expands

## Brief reference
`.codex-composer-canonical-modal-2026-04-26.md`
