### PR TITLE
fix(timeline): rich text, quote consistency, recipient labels

### DIFF
--- a/apps/web/app/inbox/_components/email-participant-header.tsx
+++ b/apps/web/app/inbox/_components/email-participant-header.tsx
@@ -2,16 +2,16 @@
 
 import { useId, useState } from "react";
 
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 import { FOCUS_RING, TRANSITION, TYPE } from "@/app/_lib/design-tokens-v2";
 
 import type { InboxTimelineEntryViewModel } from "../_lib/view-models";
-import {
-  ArrowRightIcon,
-  ChevronDownIcon,
-  MailIcon,
-} from "./icons";
+import { ArrowRightIcon, ChevronDownIcon, MailIcon } from "./icons";
 
 const WRAP_ANYWHERE = "break-words [overflow-wrap:anywhere]";
 const EXACT_TIMESTAMP_FORMATTER = new Intl.DateTimeFormat("en-US", {
@@ -28,13 +28,24 @@ function formatExactTimestamp(timestamp: string): string {
   return EXACT_TIMESTAMP_FORMATTER.format(new Date(timestamp));
 }
 
-function extractDisplayName(value: string | null): string | null {
+function normalizeHeaderValue(value: string | null): string | null {
   if (value === null) {
     return null;
   }
 
-  const stripped = value.replace(/\s*<[^>]+>\s*/g, "").trim();
-  return stripped.length === 0 ? value.trim() : stripped;
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+function extractDisplayName(value: string | null): string | null {
+  const normalized = normalizeHeaderValue(value);
+
+  if (normalized === null) {
+    return null;
+  }
+
+  const stripped = normalized.replace(/\s*<[^>]+>\s*/g, "").trim();
+  return stripped.length === 0 ? normalized : stripped;
 }
 
 function RelativeTimestamp({
@@ -77,9 +88,16 @@ export function EmailParticipantHeader({
     return null;
   }
 
+  const recipient =
+    entry.recipientLabel ??
+    extractDisplayName(entry.toHeader) ??
+    normalizeHeaderValue(entry.toHeader);
   const rows = [
-    { label: "From", value: entry.fromHeader ?? entry.actorLabel },
-    { label: "To", value: entry.toHeader ?? "Unknown recipient" },
+    {
+      label: "From",
+      value: normalizeHeaderValue(entry.fromHeader) ?? entry.actorLabel,
+    },
+    { label: "To", value: normalizeHeaderValue(entry.toHeader) ?? recipient },
     { label: "Cc", value: entry.ccHeader },
   ].filter(
     (
@@ -91,7 +109,6 @@ export function EmailParticipantHeader({
   );
 
   const sender = extractDisplayName(entry.fromHeader) ?? entry.actorLabel;
-  const recipient = extractDisplayName(entry.toHeader) ?? "Unknown recipient";
   const hasCc = entry.ccHeader !== null && entry.ccHeader.trim().length > 0;
   const headerBorderClass =
     tone === "sky" ? "border-sky-100/60" : "border-slate-100";
@@ -100,7 +117,9 @@ export function EmailParticipantHeader({
       ? "border-sky-100/60 bg-sky-50/40"
       : "border-slate-100 bg-slate-50/40";
   const ccClass =
-    tone === "sky" ? "bg-sky-100/70 text-sky-700" : "bg-slate-100 text-slate-500";
+    tone === "sky"
+      ? "bg-sky-100/70 text-sky-700"
+      : "bg-slate-100 text-slate-500";
 
   return (
     <Collapsible open={expanded} onOpenChange={setExpanded}>
@@ -114,7 +133,9 @@ export function EmailParticipantHeader({
           <button
             type="button"
             aria-controls={contentId}
-            aria-label={expanded ? "Hide full email headers" : "Show full email headers"}
+            aria-label={
+              expanded ? "Hide full email headers" : "Show full email headers"
+            }
             className={cn(
               "flex min-w-0 flex-1 items-center gap-1.5 text-left text-[12px]",
               FOCUS_RING,

--- a/apps/web/app/inbox/_components/inbox-timeline-bubble.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-bubble.tsx
@@ -1,8 +1,14 @@
 "use client";
 
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { SHADOW, TRANSITION, TYPE } from "@/app/_lib/design-tokens-v2";
+import { sanitizeComposerHtml } from "@/src/lib/html-sanitizer";
 
 import type { InboxTimelineEntryViewModel } from "../_lib/view-models";
 import { autolinkText } from "./_autolink";
@@ -18,6 +24,9 @@ import {
 } from "./icons";
 
 const WRAP_ANYWHERE = "break-words [overflow-wrap:anywhere]";
+const HTML_TAG_PATTERN = /<\/?[a-zA-Z][^>]*>/u;
+const EMAIL_HTML_BODY_CLASS =
+  "text-pretty text-[14px] leading-relaxed text-slate-700 [&_a]:text-sky-700 [&_a]:underline [&_blockquote]:border-l-2 [&_blockquote]:border-slate-200 [&_blockquote]:pl-3 [&_blockquote]:text-slate-600 [&_code]:rounded-sm [&_code]:bg-slate-100 [&_code]:px-1 [&_code]:py-0.5 [&_h1]:text-lg [&_h1]:font-semibold [&_h2]:text-base [&_h2]:font-semibold [&_h3]:text-sm [&_h3]:font-semibold [&_ol]:ml-5 [&_ol]:list-decimal [&_pre]:overflow-x-auto [&_pre]:rounded-md [&_pre]:bg-slate-100 [&_pre]:p-3 [&_table]:my-2 [&_table]:border-collapse [&_td]:border [&_td]:border-slate-200 [&_td]:px-2 [&_td]:py-1 [&_th]:border [&_th]:border-slate-200 [&_th]:px-2 [&_th]:py-1 [&_ul]:ml-5 [&_ul]:list-disc";
 
 function initialsForLabel(label: string): string {
   const parts = label.trim().split(/\s+/).filter(Boolean);
@@ -35,6 +44,14 @@ function initialsForLabel(label: string): string {
 
 function bodyTextForEntry(entry: InboxTimelineEntryViewModel): string {
   return entry.body.trim();
+}
+
+function bodyContainsHtml(body: string): boolean {
+  return HTML_TAG_PATTERN.test(body);
+}
+
+function sanitizeTimelineHtmlBody(body: string): string {
+  return sanitizeComposerHtml(body);
 }
 
 function ReplyFooter({
@@ -228,6 +245,8 @@ export function MessageBubble({
   const isEmail = entry.channel === "email";
   const isOutbound = direction === "outbound";
   const body = bodyTextForEntry(entry);
+  const sanitizedHtmlBody =
+    isEmail && bodyContainsHtml(body) ? sanitizeTimelineHtmlBody(body) : null;
   const inboundAvatar = (
     <InboxAvatar
       initials={initialsForLabel(entry.actorLabel)}
@@ -298,7 +317,12 @@ export function MessageBubble({
               </p>
             ) : null}
 
-            {body.length > 0 ? (
+            {sanitizedHtmlBody !== null && sanitizedHtmlBody.length > 0 ? (
+              <div
+                className={cn(EMAIL_HTML_BODY_CLASS, WRAP_ANYWHERE)}
+                dangerouslySetInnerHTML={{ __html: sanitizedHtmlBody }}
+              />
+            ) : body.length > 0 ? (
               <p
                 className={cn(
                   "whitespace-pre-wrap text-pretty text-[14px] leading-relaxed",

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -85,6 +85,7 @@ interface InboxDetailCacheData {
     Record<string, CampaignActivitySummary>
   >;
   readonly projectNameById: Readonly<Record<string, string>>;
+  readonly projectLabelByAlias: ReadonlyMap<string, string>;
   readonly timelinePage: {
     readonly hasMore: boolean;
     readonly nextCursor: string | null;
@@ -817,6 +818,13 @@ function extractEmailAddresses(value: string | null | undefined): string[] {
   );
 }
 
+function normalizeEmailAddress(
+  value: string | null | undefined,
+): string | null {
+  const email = extractEmailAddresses(value)[0];
+  return email ?? null;
+}
+
 function firstNonEmptyNormalized(
   values: readonly (string | null | undefined)[],
 ): string | null {
@@ -887,7 +895,12 @@ function trimQuotedReplyContent(value: string): string {
   }
 
   const boundaries = [
+    // Keep quoted-reply cropping consistent for common email-client markers.
+    // This intentionally keys off the marker line itself, not provider classes
+    // that are frequently missing from plaintext fallbacks.
     /(?:\n|^)\s*On .+ wrote:\s*$/im,
+    /(?:\n|^)\s*On .+? wrote:\s*(?=\n|>)/is,
+    /(?:\n|^)\s*El .+ escribi[oó]:\s*(?=\n|>)/is,
     /(?:\n|^)\s*From:\s.+?(?:Date:|Sent:)\s.+/is,
     /(?:\n|^)\s*-{2,}\s*Original Message\s*-{2,}/im,
     /(?:\n|^)\s*Begin forwarded message:/im,
@@ -1603,6 +1616,60 @@ function timelineBody(item: TimelineItem): string {
   }
 }
 
+function projectLabelForAlias(input: {
+  readonly alias: string | null | undefined;
+  readonly projectLabelByAlias: ReadonlyMap<string, string>;
+}): string | null {
+  const normalizedAlias = normalizeEmailAddress(input.alias);
+
+  if (normalizedAlias === null) {
+    return null;
+  }
+
+  return input.projectLabelByAlias.get(normalizedAlias) ?? null;
+}
+
+function hasDisplayNameHeader(value: string | null | undefined): boolean {
+  if (value === null || value === undefined) {
+    return false;
+  }
+
+  return PARTICIPANT_HEADER_NAME_PATTERN.test(value.trim());
+}
+
+function resolveRecipientLabel(input: {
+  readonly item: TimelineItem;
+  readonly contactPrimaryEmail: string | null;
+  readonly projectLabelByAlias: ReadonlyMap<string, string>;
+}): string | null {
+  if (input.item.family !== "one_to_one_email") {
+    return null;
+  }
+
+  const toHeader = normalizeInlineText(input.item.toHeader);
+
+  if (hasDisplayNameHeader(toHeader)) {
+    return participantHeaderLabel(toHeader);
+  }
+
+  const toEmail = normalizeEmailAddress(toHeader);
+
+  if (toEmail !== null) {
+    return input.item.direction === "inbound"
+      ? (input.projectLabelByAlias.get(toEmail) ?? toEmail)
+      : toEmail;
+  }
+
+  if (input.item.direction === "inbound") {
+    return projectLabelForAlias({
+      alias: input.item.mailbox,
+      projectLabelByAlias: input.projectLabelByAlias,
+    });
+  }
+
+  return normalizeEmailAddress(input.contactPrimaryEmail);
+}
+
 function formatCampaignActivityLabel(
   activityType: Exclude<CampaignActivityType, "sent">,
   occurredAtLabel: string,
@@ -1693,6 +1760,7 @@ function buildTimelineEntry(input: {
   readonly campaignActivitySummaryByCampaignId: Readonly<
     Record<string, CampaignActivitySummary>
   >;
+  readonly projectLabelByAlias: ReadonlyMap<string, string>;
   readonly referenceNowIso: string;
 }): InboxTimelineEntryViewModel {
   const latestProjectionSnippet =
@@ -1795,6 +1863,11 @@ function buildTimelineEntry(input: {
       input.item.family === "one_to_one_email"
         ? (input.item.toHeader ?? null)
         : null,
+    recipientLabel: resolveRecipientLabel({
+      item: input.item,
+      contactPrimaryEmail: input.contactPrimaryEmail,
+      projectLabelByAlias: input.projectLabelByAlias,
+    }),
     ccHeader:
       input.item.family === "one_to_one_email"
         ? (input.item.ccHeader ?? null)
@@ -1931,6 +2004,52 @@ async function loadProjectLabelById(
         : dimension.projectName,
     ]),
   );
+}
+
+async function loadProjectLabelByAlias(
+  aliases: readonly {
+    readonly alias: string;
+    readonly projectId: string | null;
+  }[],
+): Promise<ReadonlyMap<string, string>> {
+  const projectIds = uniqueStrings(aliases.map((alias) => alias.projectId));
+
+  if (projectIds.length === 0) {
+    return new Map();
+  }
+
+  const runtime = await getStage1WebRuntime();
+  const dimensions =
+    await runtime.repositories.projectDimensions.listByIds(projectIds);
+  const projectLabelById = new Map(
+    dimensions.map((dimension) => [
+      dimension.projectId,
+      dimension.projectAlias?.trim().length
+        ? dimension.projectAlias
+        : dimension.projectName,
+    ]),
+  );
+  const projectLabelByAlias = new Map<string, string>();
+
+  for (const alias of aliases) {
+    if (alias.projectId === null) {
+      continue;
+    }
+
+    const projectLabel = projectLabelById.get(alias.projectId);
+
+    if (projectLabel === undefined) {
+      continue;
+    }
+
+    const normalizedAlias = normalizeEmailAddress(alias.alias);
+
+    if (normalizedAlias !== null) {
+      projectLabelByAlias.set(normalizedAlias, projectLabel);
+    }
+  }
+
+  return projectLabelByAlias;
 }
 
 async function loadLatestSubjectByCanonicalEventId(
@@ -2233,6 +2352,7 @@ async function readInboxDetailCacheData(
     inboxFreshness,
     timelineFreshness,
     canonicalEvents,
+    projectAliasRecords,
   ] = await Promise.all([
     runtime.repositories.contacts.findById(contactId),
     runtime.repositories.inboxProjection.findByContactId(contactId),
@@ -2246,6 +2366,7 @@ async function readInboxDetailCacheData(
     runtime.repositories.inboxProjection.getFreshnessByContactId(contactId),
     runtime.repositories.timelineProjection.getFreshnessByContactId(contactId),
     runtime.repositories.canonicalEvents.listByContactId(contactId),
+    runtime.settings.aliases.listAssigned(),
   ]);
 
   if (contact === null || inboxProjection === null) {
@@ -2265,6 +2386,7 @@ async function readInboxDetailCacheData(
         canonicalEvents,
       }),
     projectNameById: await loadProjectLabelById(memberships),
+    projectLabelByAlias: await loadProjectLabelByAlias(projectAliasRecords),
     timelinePage: {
       hasMore: timelinePage.hasMore,
       nextCursor: timelinePage.hasMore ? timelinePage.nextBeforeSortKey : null,
@@ -2592,6 +2714,7 @@ export async function getInboxTimelinePage(
         item,
         campaignActivitySummaryByCampaignId:
           cachedData.campaignActivitySummaryByCampaignId,
+        projectLabelByAlias: cachedData.projectLabelByAlias,
         referenceNowIso,
       }),
     ),
@@ -2689,6 +2812,7 @@ export async function getInboxDetail(
         item,
         campaignActivitySummaryByCampaignId:
           cachedData.campaignActivitySummaryByCampaignId,
+        projectLabelByAlias: cachedData.projectLabelByAlias,
         referenceNowIso,
       }),
     ),

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -172,6 +172,7 @@ export interface InboxTimelineEntryViewModel {
   readonly isPreview: boolean;
   readonly fromHeader: string | null;
   readonly toHeader: string | null;
+  readonly recipientLabel?: string | null;
   readonly ccHeader: string | null;
   readonly mailbox: string | null;
   readonly threadId: string | null;

--- a/apps/web/src/lib/html-sanitizer.ts
+++ b/apps/web/src/lib/html-sanitizer.ts
@@ -1,15 +1,54 @@
 const ALLOWED_CONTAINER_TAGS = new Set([
+  "blockquote",
+  "code",
+  "div",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "li",
+  "ol",
   "p",
+  "pre",
+  "span",
   "strong",
+  "table",
+  "tbody",
+  "td",
+  "th",
+  "thead",
+  "tr",
   "em",
   "b",
   "i",
   "ul",
-  "ol",
-  "li",
 ]);
-const VOID_TAGS = new Set(["br"]);
-const STRIP_WITH_CONTENT_TAGS = new Set(["script", "style"]);
+const VOID_TAGS = new Set(["br", "hr"]);
+const DROP_TAGS = new Set([
+  "embed",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "source",
+  "track",
+]);
+const STRIP_WITH_CONTENT_TAGS = new Set([
+  "applet",
+  "audio",
+  "button",
+  "form",
+  "iframe",
+  "math",
+  "object",
+  "picture",
+  "script",
+  "style",
+  "svg",
+  "video",
+]);
 const TAG_PATTERN = /<\/?[^>]+>/gu;
 const TAG_NAME_PATTERN = /^<\/?\s*([a-zA-Z0-9:-]+)/u;
 const HREF_PATTERN = /\shref\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/iu;
@@ -76,6 +115,10 @@ export function sanitizeComposerHtml(input: string): string {
       continue;
     }
 
+    if (DROP_TAGS.has(tagName)) {
+      continue;
+    }
+
     if (STRIP_WITH_CONTENT_TAGS.has(tagName) && !rawTag.startsWith("</")) {
       strippedContentTag = tagName;
       continue;
@@ -94,7 +137,7 @@ export function sanitizeComposerHtml(input: string): string {
     }
 
     if (VOID_TAGS.has(tagName)) {
-      output += "<br>";
+      output += `<${tagName}>`;
       continue;
     }
 
@@ -157,7 +200,5 @@ export function appendComposerHtmlSignature(input: {
     plaintextToComposerHtml(input.signaturePlaintext),
   );
 
-  return signatureHtml.length > 0
-    ? `${bodyHtml}${signatureHtml}`
-    : bodyHtml;
+  return signatureHtml.length > 0 ? `${bodyHtml}${signatureHtml}` : bodyHtml;
 }

--- a/apps/web/tests/unit/composer-html-sanitizer.test.ts
+++ b/apps/web/tests/unit/composer-html-sanitizer.test.ts
@@ -13,7 +13,28 @@ describe("composer html sanitizer", () => {
         '<p class="x">Hello <strong data-x="1">bold</strong> <em>italic</em> <a id="bad" href="https://example.org/path">link</a></p><script>alert(1)</script><style>p{color:red}</style><img src="x"><table><tr><td>cell</td></tr></table>',
       ),
     ).toBe(
-      '<p>Hello <strong>bold</strong> <em>italic</em> <a href="https://example.org/path" class="text-sky-700 hover:underline" target="_blank" rel="noopener noreferrer">link</a></p>cell',
+      '<p>Hello <strong>bold</strong> <em>italic</em> <a href="https://example.org/path" class="text-sky-700 hover:underline" target="_blank" rel="noopener noreferrer">link</a></p><table><tr><td>cell</td></tr></table>',
+    );
+  });
+
+  it("keeps safe email presentation tags without preserving attributes", () => {
+    expect(sanitizeComposerHtml("<blockquote>quoted</blockquote>")).toBe(
+      "<blockquote>quoted</blockquote>",
+    );
+    expect(sanitizeComposerHtml('<h2 data-x="1">Heading</h2>')).toBe(
+      "<h2>Heading</h2>",
+    );
+    expect(
+      sanitizeComposerHtml(
+        '<div class="x"><span style="color:red">nested</span></div>',
+      ),
+    ).toBe("<div><span>nested</span></div>");
+    expect(
+      sanitizeComposerHtml(
+        '<table class="x"><thead><tr><th>head</th></tr></thead><tbody><tr><td>cell</td></tr></tbody></table><hr data-x="1">',
+      ),
+    ).toBe(
+      "<table><thead><tr><th>head</th></tr></thead><tbody><tr><td>cell</td></tr></tbody></table><hr>",
     );
   });
 
@@ -25,7 +46,18 @@ describe("composer html sanitizer", () => {
     ).toBe("<p>Click me</p>");
   });
 
-  it("converts plaintext and appends signature html without widening tags", () => {
+  it("strips unsafe tags and image tags without leaking image fallback text", () => {
+    expect(sanitizeComposerHtml("<script>alert(1)</script><p>safe</p>")).toBe(
+      "<p>safe</p>",
+    );
+    expect(
+      sanitizeComposerHtml(
+        '<p>before</p><img src="x" alt="leaked" onerror="alert(1)"><p>after</p>',
+      ),
+    ).toBe("<p>before</p><p>after</p>");
+  });
+
+  it("converts plaintext and appends signature html while keeping safe structure", () => {
     expect(
       appendComposerHtmlSignature({
         bodyHtml: '<p>Body <span style="color:red">copy</span></p>',
@@ -33,7 +65,7 @@ describe("composer html sanitizer", () => {
         signaturePlaintext: "Adventure Scientists\nhttps://example.org",
       }),
     ).toBe(
-      '<p>Body copy</p><p>Adventure Scientists<br><a href="https://example.org" class="text-sky-700 hover:underline" target="_blank" rel="noopener noreferrer">https://example.org</a></p>',
+      '<p>Body <span>copy</span></p><p>Adventure Scientists<br><a href="https://example.org" class="text-sky-700 hover:underline" target="_blank" rel="noopener noreferrer">https://example.org</a></p>',
     );
 
     expect(plaintextToComposerHtml("One\nTwo\n\nThree")).toBe(

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -1126,9 +1126,112 @@ describe("real inbox selectors", () => {
       kind: "outbound-email",
       fromHeader: "PNW Project <pnwbio@adventurescientists.org>",
       toHeader: "Shaina Dotson <shaina.dotson@gmail.com>",
+      recipientLabel: "Shaina Dotson",
       ccHeader:
         "Ricky Jones <ricky@adventurescientists.org>, Samantha Doe <samantha@adventurescientists.org>",
     });
+  });
+
+  it("infers timeline recipient labels from display names, bare emails, and project aliases", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:recipient-labels",
+      salesforceContactId: "003-recipient-labels",
+      displayName: "Recipient Label",
+      primaryEmail: "recipient@example.org",
+      primaryPhone: null,
+      projectId: "project:pnw-forest",
+      projectName: "Pacific Northwest Forest Biodiversity",
+      projectAlias: "PNW Forest Biodiversity",
+      membershipId: "membership:recipient-labels",
+      membershipStatus: "active",
+    });
+    await runtime.context.settings.aliases.create({
+      id: "alias:pnw-forest",
+      alias: "pnwbio@adventurescientists.org",
+      signature: "",
+      projectId: "project:pnw-forest",
+      createdAt: new Date("2026-04-20T12:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T12:00:00.000Z"),
+      createdBy: null,
+      updatedBy: null,
+    });
+    const displayNameEvent = await seedInboxEmailEvent(runtime.context, {
+      id: "recipient-label-display",
+      contactId: "contact:recipient-labels",
+      occurredAt: "2026-04-22T01:00:00.000Z",
+      direction: "outbound",
+      subject: "Display recipient",
+      snippet: "Display recipient body.",
+      bodyTextPreview: "Display recipient body.",
+      toHeader: "Display Name <email@example.com>",
+    });
+    const bareEmailEvent = await seedInboxEmailEvent(runtime.context, {
+      id: "recipient-label-bare",
+      contactId: "contact:recipient-labels",
+      occurredAt: "2026-04-22T01:01:00.000Z",
+      direction: "outbound",
+      subject: "Bare recipient",
+      snippet: "Bare recipient body.",
+      bodyTextPreview: "Bare recipient body.",
+      toHeader: "email@example.com",
+    });
+    const projectAliasEvent = await seedInboxEmailEvent(runtime.context, {
+      id: "recipient-label-project",
+      contactId: "contact:recipient-labels",
+      occurredAt: "2026-04-22T01:02:00.000Z",
+      direction: "inbound",
+      subject: "Project recipient",
+      snippet: "Project recipient body.",
+      bodyTextPreview: "Project recipient body.",
+      fromHeader: "Volunteer <recipient@example.org>",
+      toHeader: "pnwbio@adventurescientists.org",
+      projectInboxAlias: "pnwbio@adventurescientists.org",
+    });
+    const missingHeaderEvent = await seedInboxEmailEvent(runtime.context, {
+      id: "recipient-label-missing",
+      contactId: "contact:recipient-labels",
+      occurredAt: "2026-04-22T01:03:00.000Z",
+      direction: "inbound",
+      subject: "Missing recipient",
+      snippet: "Missing recipient body.",
+      bodyTextPreview: "Missing recipient body.",
+      fromHeader: "Volunteer <recipient@example.org>",
+      toHeader: null,
+      projectInboxAlias: "pnwbio@adventurescientists.org",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:recipient-labels",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-22T01:03:00.000Z",
+      lastOutboundAt: "2026-04-22T01:01:00.000Z",
+      lastActivityAt: "2026-04-22T01:03:00.000Z",
+      snippet: "Missing recipient body.",
+      lastCanonicalEventId: missingHeaderEvent.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+
+    const detail = await getInboxDetail("contact:recipient-labels");
+    const labelBySubject = new Map(
+      detail?.timeline.map((entry) => [entry.subject, entry.recipientLabel]),
+    );
+
+    expect(displayNameEvent.canonicalEventId).toBeTruthy();
+    expect(bareEmailEvent.canonicalEventId).toBeTruthy();
+    expect(projectAliasEvent.canonicalEventId).toBeTruthy();
+    expect(labelBySubject.get("Display recipient")).toBe("Display Name");
+    expect(labelBySubject.get("Bare recipient")).toBe("email@example.com");
+    expect(labelBySubject.get("Project recipient")).toBe(
+      "PNW Forest Biodiversity",
+    );
+    expect(labelBySubject.get("Missing recipient")).toBe(
+      "PNW Forest Biodiversity",
+    );
   });
 
   it("uses the Gmail From header as the inbound actor label when present", async () => {
@@ -1845,6 +1948,54 @@ describe("real inbox selectors", () => {
     });
   });
 
+  it("consistently crops inline quoted-reply markers in timeline email bodies", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:inline-quote",
+      salesforceContactId: "003-inline-quote",
+      displayName: "Inline Quote",
+      primaryEmail: "inline.quote@example.org",
+      primaryPhone: null,
+    });
+    const latestEvent = await seedInboxEmailEvent(runtime.context, {
+      id: "inline-quote-latest",
+      contactId: "contact:inline-quote",
+      occurredAt: "2026-04-25T16:30:00.000Z",
+      direction: "inbound",
+      subject: "Re: Field packet",
+      snippet: "Thanks for sending this.",
+      bodyTextPreview: [
+        "Thanks for sending this.",
+        "",
+        "On 2026-04-25 at 10:00 AM, Alison Example wrote:",
+        "> Original field packet details",
+      ].join("\n"),
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:inline-quote",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-25T16:30:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-04-25T16:30:00.000Z",
+      snippet: "Thanks for sending this.",
+      lastCanonicalEventId: latestEvent.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+
+    const detail = await getInboxDetail("contact:inline-quote");
+    const latestEntry = detail?.timeline.at(-1);
+
+    expect(latestEntry).toMatchObject({
+      kind: "inbound-email",
+      body: "Thanks for sending this.",
+    });
+  });
+
   it("skips encrypted placeholder bodies when deriving composer reply context", async () => {
     if (runtime === null) {
       throw new Error("Expected inbox test runtime");
@@ -2171,10 +2322,11 @@ describe("real inbox selectors", () => {
       subject: "April Volunteer Update",
       body: "Hi Sarah,\nPlease bring your field notebook.",
     });
-    expect(campaignEntries[0]?.campaignActivity.map((activity) => activity.activityType)).toEqual([
-      "opened",
-      "clicked",
-    ]);
+    expect(
+      campaignEntries[0]?.campaignActivity.map(
+        (activity) => activity.activityType,
+      ),
+    ).toEqual(["opened", "clicked"]);
   });
 
   it("falls back to stripped campaign subjects when no campaign name exists", async () => {
@@ -2223,7 +2375,8 @@ describe("real inbox selectors", () => {
       id: "sarah-auto-email-bare-prefix",
       contactId: "contact:sarah-martinez",
       occurredAt: "2026-04-12T15:55:00.000Z",
-      subject: "Email: Aplicacion en Revision: Monitoreo y Restauracion de Arrecifes de Coral",
+      subject:
+        "Email: Aplicacion en Revision: Monitoreo y Restauracion de Arrecifes de Coral",
       snippet: "Coral project review workflow.",
     });
 

--- a/apps/web/tests/unit/inbox-timeline.test.ts
+++ b/apps/web/tests/unit/inbox-timeline.test.ts
@@ -336,6 +336,89 @@ describe("InboxTimeline", () => {
     expect(markup).toContain("Reply");
   });
 
+  it("renders sanitized rich html bodies for email timeline entries", () => {
+    const markup = renderToStaticMarkup(
+      createElement(InboxTimeline, {
+        entries: [
+          {
+            ...baseEntry,
+            id: "timeline:rich-email",
+            kind: "inbound-email" as const,
+            actorLabel: "Shaina Dotson",
+            subject: "Rich update",
+            body: '<h2>Heading</h2><p>Hello <strong>bold</strong> 🎉 <a href="https://example.org">link</a></p><blockquote>quoted</blockquote><img src="x" onerror="alert(1)"><script>alert(1)</script>',
+            fromHeader: "Shaina Dotson <shaina.dotson@gmail.com>",
+            toHeader: "pnwbio@adventurescientists.org",
+          },
+        ],
+        volunteerFirstName: "Shaina",
+        currentOperatorUserId: "user:operator",
+      }),
+    );
+
+    expect(markup).toContain("<h2>Heading</h2>");
+    expect(markup).toContain("<strong>bold</strong>");
+    expect(markup).toContain("🎉");
+    expect(markup).toContain("<blockquote>quoted</blockquote>");
+    expect(markup).toContain('href="https://example.org"');
+    expect(markup).not.toContain("<script>");
+    expect(markup).not.toContain("<img");
+    expect(markup).not.toContain("alert(1)");
+  });
+
+  it("uses recipient labels without falling back to unknown recipient", () => {
+    const markup = renderToStaticMarkup(
+      createElement(InboxTimeline, {
+        entries: [
+          {
+            ...baseEntry,
+            id: "timeline:display-recipient",
+            kind: "outbound-email" as const,
+            actorLabel: "You",
+            subject: "Display recipient",
+            fromHeader: "PNW Project <pnwbio@adventurescientists.org>",
+            toHeader: "Display Name <email@example.com>",
+          },
+          {
+            ...baseEntry,
+            id: "timeline:bare-recipient",
+            kind: "outbound-email" as const,
+            actorLabel: "You",
+            subject: "Bare recipient",
+            fromHeader: "PNW Project <pnwbio@adventurescientists.org>",
+            toHeader: "email@example.com",
+          },
+          {
+            ...baseEntry,
+            id: "timeline:project-recipient",
+            kind: "inbound-email" as const,
+            actorLabel: "Volunteer",
+            subject: "Project recipient",
+            fromHeader: "Volunteer <volunteer@example.com>",
+            toHeader: "",
+            recipientLabel: "PNW Forest Biodiversity",
+          },
+          {
+            ...baseEntry,
+            id: "timeline:no-recipient",
+            kind: "inbound-email" as const,
+            actorLabel: "Volunteer",
+            subject: "No recipient",
+            fromHeader: "Volunteer <volunteer@example.com>",
+            toHeader: null,
+          },
+        ],
+        volunteerFirstName: "Volunteer",
+        currentOperatorUserId: "user:operator",
+      }),
+    );
+
+    expect(markup).toContain("Display Name");
+    expect(markup).toContain("email@example.com");
+    expect(markup).toContain("PNW Forest Biodiversity");
+    expect(markup).not.toContain("Unknown recipient");
+  });
+
   it("renders a header toggle for every one-to-one email bubble", () => {
     const markup = renderToStaticMarkup(
       createElement(InboxTimeline, {


### PR DESCRIPTION
## Summary
- **Rich text** (#1): broadened `html-sanitizer` allowlist to include safe presentation tags (`blockquote`, `code`, `pre`, `h1`-`h6`, `span`, `div`, `table`/`thead`/`tbody`/`tr`/`th`/`td`, `hr`). Still strips `script`/`style`/`iframe`/`img`/etc. and unsafe `<a href>`. Timeline email bodies now render sanitized HTML, not plain text.
- **Quote consistency** (#2): cropping now uses a documented gate matching common `On ... wrote:` and Spanish `escribió:` patterns. Consistent across messages.
- **Recipient labels** (#3): replaces `Unknown recipient` with a fallback chain (display name → bare email → project alias label), so the `To:` line is always meaningful.

## Test plan
- [x] `pnpm --filter @as-comms/web typecheck`
- [x] `pnpm --filter @as-comms/web lint`
- [x] `pnpm --filter @as-comms/web test:unit`
- [ ] Manual via Chrome: open Steve Herman thread; bold/italic/links render; recipient labels readable; quote chains consistent

## Brief reference
`.codex-msg-history-fixes-2026-04-27.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)