### PR TITLE
feat(composer): CC/BCC + AI Draft default + visual polish + knowledge warning

### DIFF
--- a/apps/web/app/inbox/_components/composer-ai-draft-window.tsx
+++ b/apps/web/app/inbox/_components/composer-ai-draft-window.tsx
@@ -2,11 +2,18 @@
 
 import type { ReactNode } from "react";
 
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { FOCUS_RING, TRANSITION } from "@/app/_lib/design-tokens-v2";
 import { cn } from "@/lib/utils";
 
 import {
   CheckIcon,
+  LoaderIcon,
   RotateCcwIcon,
   RotateCwIcon,
   SparkleIcon,
@@ -16,11 +23,11 @@ import type { AiDraftState } from "./inbox-client-provider";
 
 function DraftSkeleton() {
   return (
-    <div className="mt-3 space-y-2" aria-label="AI draft is generating">
-      <div className="h-3 w-[88%] animate-pulse rounded bg-violet-100" />
-      <div className="h-3 w-[72%] animate-pulse rounded bg-violet-100" />
-      <div className="h-3 w-[81%] animate-pulse rounded bg-violet-100" />
-      <div className="h-3 w-[64%] animate-pulse rounded bg-violet-100" />
+    <div className="space-y-1.5 rounded-md bg-slate-50/60 px-3 py-2.5 ring-1 ring-inset ring-slate-200">
+      <div className="h-2.5 w-[92%] animate-pulse rounded bg-slate-200/80" />
+      <div className="h-2.5 w-[78%] animate-pulse rounded bg-slate-200/70" />
+      <div className="h-2.5 w-[86%] animate-pulse rounded bg-slate-200/80" />
+      <div className="h-2.5 w-[64%] animate-pulse rounded bg-slate-200/70" />
     </div>
   );
 }
@@ -42,12 +49,12 @@ function AiDraftActionButton({
       disabled={disabled}
       onClick={onClick}
       className={cn(
-        `inline-flex min-h-8 items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[12px] font-medium ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion}`,
+        `inline-flex min-h-8 items-center gap-1.5 rounded-md px-2 py-1 text-[11.5px] font-medium ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion}`,
         tone === "primary"
           ? "bg-violet-600 text-white hover:bg-violet-700 disabled:bg-violet-300 disabled:text-white"
           : tone === "danger"
             ? "text-rose-600 hover:bg-rose-50 disabled:text-rose-300"
-            : "text-slate-600 hover:bg-white/80 hover:text-slate-900 disabled:text-slate-300",
+            : "text-slate-700 hover:bg-white disabled:text-slate-300",
         disabled ? "cursor-not-allowed" : "",
       )}
     >
@@ -58,17 +65,70 @@ function AiDraftActionButton({
 
 function DraftPreview({ text }: { readonly text: string }) {
   return (
-    <div className="whitespace-pre-wrap rounded-md border border-violet-100 bg-white px-3 py-2.5 text-[13px] italic leading-relaxed text-slate-600">
+    <div className="whitespace-pre-wrap rounded-md bg-slate-50/60 px-3 py-2.5 text-[12.5px] leading-relaxed text-slate-800 ring-1 ring-inset ring-slate-200">
       {text}
     </div>
   );
 }
 
+function DraftActionTrigger({
+  disabled,
+  disabledReason,
+  isGenerating,
+  onRun,
+}: {
+  readonly disabled: boolean;
+  readonly disabledReason: string | null;
+  readonly isGenerating: boolean;
+  readonly onRun: () => void;
+}) {
+  const button = (
+    <Button
+      type="button"
+      disabled={disabled}
+      onClick={onRun}
+      className="h-8 shrink-0 rounded-md bg-violet-600 px-3 text-[12px] font-medium text-white shadow-sm hover:bg-violet-700 disabled:bg-violet-300"
+    >
+      {isGenerating ? (
+        <>
+          <LoaderIcon className="size-3.5 animate-spin" />
+          Drafting...
+        </>
+      ) : (
+        <>
+          <SparkleIcon className="size-3.5" />
+          Draft with AI
+        </>
+      )}
+    </Button>
+  );
+
+  if (disabledReason === null) {
+    return button;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span tabIndex={0}>{button}</span>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="max-w-64 text-pretty">
+        {disabledReason}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 export function ComposerAiDraftWindow({
   aiDraft,
+  directiveText,
   repromptText,
   isGeneratingAi,
+  runDraftDisabled,
+  runDraftDisabledReason,
+  onDirectiveTextChange,
   onRepromptTextChange,
+  onRunDraft,
   onOpenReprompt,
   onSubmitReprompt,
   onCancelReprompt,
@@ -77,9 +137,14 @@ export function ComposerAiDraftWindow({
   onAbout,
 }: {
   readonly aiDraft: AiDraftState;
+  readonly directiveText: string;
   readonly repromptText: string;
   readonly isGeneratingAi: boolean;
+  readonly runDraftDisabled: boolean;
+  readonly runDraftDisabledReason: string | null;
+  readonly onDirectiveTextChange: (value: string) => void;
   readonly onRepromptTextChange: (value: string) => void;
+  readonly onRunDraft: () => void;
   readonly onOpenReprompt: () => void;
   readonly onSubmitReprompt: () => void;
   readonly onCancelReprompt: () => void;
@@ -88,81 +153,117 @@ export function ComposerAiDraftWindow({
   readonly onAbout: () => void;
 }) {
   const status = aiDraft.status;
-
-  if (
-    status !== "generating" &&
-    status !== "reviewable" &&
-    status !== "reprompting"
-  ) {
-    return null;
-  }
-
   const isReprompting = status === "reprompting";
+  const showsDraft = status === "reviewable" || isReprompting;
+  const showsEmptyState = !showsDraft;
   const trimmedReprompt = repromptText.trim();
   const canSubmitReprompt = trimmedReprompt.length > 0 && !isGeneratingAi;
   const canApprove = !isGeneratingAi && (!isReprompting || trimmedReprompt.length === 0);
   const canUseDraftActions = !isGeneratingAi;
 
   return (
-    <section className="mx-5 mb-3 rounded-lg border border-violet-200 bg-violet-50/40 p-4">
-      <div className="flex items-center gap-2">
-        <SparkleIcon className="size-3.5 text-violet-700" />
+    <section className="mx-4 mt-3 overflow-hidden rounded-xl border border-violet-200 bg-white ring-1 ring-violet-100">
+      <div className="flex items-center gap-2 border-b border-violet-100 bg-violet-50/40 px-3 py-2">
+        <div className="flex size-5 items-center justify-center rounded-md bg-violet-100 text-violet-700">
+          <SparkleIcon className="size-3.5" />
+        </div>
         <p className="text-[12px] font-semibold text-slate-800">AI draft</p>
         <span className="flex-1" />
         <button
           type="button"
           onClick={onAbout}
-          className={`rounded px-1.5 py-1 text-[11px] text-violet-700 hover:underline ${FOCUS_RING}`}
+          className={`rounded px-1.5 py-1 text-[11px] font-medium text-violet-700 hover:bg-violet-50 ${FOCUS_RING}`}
         >
           About
         </button>
       </div>
 
-      {status === "generating" ? <DraftSkeleton /> : null}
+      <div className="px-3 pb-3 pt-2">
+        {showsEmptyState ? (
+          <div className="flex items-start gap-2">
+            <textarea
+              value={directiveText}
+              onChange={(event) => {
+                onDirectiveTextChange(event.currentTarget.value);
+              }}
+              onKeyDown={(event) => {
+                if (
+                  event.key === "Enter" &&
+                  (event.metaKey || event.ctrlKey) &&
+                  !runDraftDisabled
+                ) {
+                  event.preventDefault();
+                  onRunDraft();
+                }
+              }}
+              placeholder='Optional: nudge the draft (e.g. "keep it brief, offer May 14 slot"). Or just click Draft with AI.'
+              rows={2}
+              disabled={isGeneratingAi}
+              className={`flex-1 resize-none rounded-md bg-slate-50/60 px-2.5 py-2 text-[12.5px] leading-relaxed text-slate-800 placeholder:text-slate-400 ring-1 ring-inset ring-slate-200 focus:outline-none focus:ring-violet-300 disabled:opacity-60 ${TRANSITION.reduceMotion}`}
+            />
+            <DraftActionTrigger
+              disabled={runDraftDisabled}
+              disabledReason={runDraftDisabledReason}
+              isGenerating={isGeneratingAi}
+              onRun={onRunDraft}
+            />
+          </div>
+        ) : null}
 
-      {status === "reviewable" || isReprompting ? (
-        <div className="mt-3">
-          <DraftPreview text={aiDraft.generatedText} />
+        {status === "generating" ? (
+          <div className="mt-2">
+            <DraftSkeleton />
+          </div>
+        ) : null}
 
-          {isReprompting ? (
-            <div className="mt-3 flex items-start gap-2">
-              <textarea
-                autoFocus
-                value={repromptText}
-                onChange={(event) => {
-                  onRepromptTextChange(event.currentTarget.value);
-                }}
-                onKeyDown={(event) => {
-                  if (event.key === "Escape") {
-                    event.preventDefault();
-                    onCancelReprompt();
-                    return;
-                  }
+        {showsDraft ? (
+          <div className="space-y-3">
+            <DraftPreview text={aiDraft.generatedText} />
 
-                  if (event.key === "Enter" && !event.shiftKey) {
-                    event.preventDefault();
-                    if (canSubmitReprompt) {
-                      onSubmitReprompt();
+            {isReprompting ? (
+              <div className="flex items-start gap-2">
+                <textarea
+                  autoFocus
+                  value={repromptText}
+                  onChange={(event) => {
+                    onRepromptTextChange(event.currentTarget.value);
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === "Escape") {
+                      event.preventDefault();
+                      onCancelReprompt();
+                      return;
                     }
-                  }
-                }}
-                placeholder="Type instructions..."
-                disabled={isGeneratingAi}
-                className={`min-h-[64px] flex-1 resize-none rounded-lg border border-violet-200 bg-white px-3 py-2.5 text-[13px] leading-relaxed text-slate-800 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-violet-200 disabled:opacity-60 ${TRANSITION.reduceMotion}`}
-              />
-              <button
-                type="button"
-                aria-label="Regenerate AI draft"
-                disabled={!canSubmitReprompt}
-                onClick={onSubmitReprompt}
-                className={`inline-flex size-9 shrink-0 items-center justify-center rounded-lg bg-violet-600 p-2 text-white hover:bg-violet-700 disabled:cursor-not-allowed disabled:opacity-50 ${FOCUS_RING} ${TRANSITION.fast} ${TRANSITION.reduceMotion}`}
-              >
-                <RotateCwIcon className="size-4" />
-              </button>
-            </div>
-          ) : null}
 
-          <div className="mt-3 flex items-center justify-end gap-2">
+                    if (event.key === "Enter" && !event.shiftKey) {
+                      event.preventDefault();
+                      if (canSubmitReprompt) {
+                        onSubmitReprompt();
+                      }
+                    }
+                  }}
+                  placeholder='Reprompt — "shorter", "warmer tone", "add the meeting link"...'
+                  disabled={isGeneratingAi}
+                  className={`min-h-[64px] flex-1 resize-none rounded-md bg-white px-2.5 py-2 text-[12.5px] leading-relaxed text-slate-800 placeholder:text-violet-400/80 ring-1 ring-inset ring-violet-200 focus:outline-none focus:ring-violet-400 disabled:opacity-60 ${TRANSITION.reduceMotion}`}
+                />
+                <button
+                  type="button"
+                  aria-label="Regenerate AI draft"
+                  disabled={!canSubmitReprompt}
+                  onClick={onSubmitReprompt}
+                  className={`inline-flex size-9 shrink-0 items-center justify-center rounded-md bg-violet-600 p-2 text-white shadow-sm hover:bg-violet-700 disabled:cursor-not-allowed disabled:bg-violet-300 ${FOCUS_RING} ${TRANSITION.fast} ${TRANSITION.reduceMotion}`}
+                >
+                  <RotateCwIcon className="size-4" />
+                </button>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+
+      {showsDraft ? (
+        <div className="flex items-center gap-2 border-t border-violet-100 bg-violet-50/40 px-3 py-1.5">
+          <div className="ml-auto flex items-center gap-1">
             <AiDraftActionButton
               onClick={isReprompting ? onCancelReprompt : onOpenReprompt}
               disabled={!canUseDraftActions}

--- a/apps/web/app/inbox/_components/composer-detail-surfaces.tsx
+++ b/apps/web/app/inbox/_components/composer-detail-surfaces.tsx
@@ -4,6 +4,12 @@ import type { RefObject } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { RADIUS, SHADOW, TYPE } from "@/app/_lib/design-tokens-v2";
 
@@ -21,12 +27,12 @@ import {
   RichTextComposerEditor,
 } from "./composer-editor-surface";
 import {
+  AlertCircleIcon,
   LoaderIcon,
   MailIcon,
   NoteIcon,
   PaperclipIcon,
   SendIcon,
-  SparkleIcon,
   XIcon,
 } from "./icons";
 import type { AttachmentDraft, InlineComposerError } from "./composer-shared";
@@ -35,6 +41,26 @@ import type {
   AiDraftState,
   ComposerValidationError,
 } from "./inbox-client-provider";
+
+function WarningKnowledgeIndicator({
+  tooltipMessage,
+}: {
+  readonly tooltipMessage: string;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex items-center gap-1 text-[11px] font-medium text-amber-600">
+          <AlertCircleIcon className="size-3.5" />
+          AI grounding unavailable for this project
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="max-w-64 text-pretty">
+        {tooltipMessage}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
 
 export function ComposerPaneChrome({
   title,
@@ -115,8 +141,14 @@ export function ComposerEmailSurface({
   selectedAlias,
   aliasError,
   recipient,
+  ccRecipients,
+  bccRecipients,
+  showCc,
+  showBcc,
   isReplying,
   recipientError,
+  ccError,
+  bccError,
   subject,
   subjectError,
   body,
@@ -124,10 +156,11 @@ export function ComposerEmailSurface({
   attachments,
   attachmentError,
   aiDraft,
+  aiDirective,
   repromptText,
   isGeneratingAi,
-  aiButtonLabel,
-  aiButtonDisabled,
+  runAiDraftDisabled,
+  runAiDraftDisabledReason,
   selectedAliasAiReady,
   selectedAliasProjectName,
   aiWarningMessage,
@@ -140,9 +173,14 @@ export function ComposerEmailSurface({
   onAboutOpenChange,
   onAliasChange,
   onRecipientChange,
+  onCcChange,
+  onBccChange,
+  onToggleCc,
+  onToggleBcc,
   onSubjectChange,
   onBodyChange,
   onClearErrors,
+  onAiDirectiveChange,
   onAiEdited,
   onDiscardAi,
   onOpenReprompt,
@@ -161,8 +199,14 @@ export function ComposerEmailSurface({
   readonly selectedAlias: string | null;
   readonly aliasError?: ComposerValidationError;
   readonly recipient: ComposerRecipientValue | null;
+  readonly ccRecipients: readonly ComposerRecipientValue[];
+  readonly bccRecipients: readonly ComposerRecipientValue[];
+  readonly showCc: boolean;
+  readonly showBcc: boolean;
   readonly isReplying: boolean;
   readonly recipientError?: ComposerValidationError;
+  readonly ccError?: ComposerValidationError;
+  readonly bccError?: ComposerValidationError;
   readonly subject: string;
   readonly subjectError?: ComposerValidationError;
   readonly body: string;
@@ -170,10 +214,11 @@ export function ComposerEmailSurface({
   readonly attachments: readonly AttachmentDraft[];
   readonly attachmentError?: ComposerValidationError;
   readonly aiDraft: AiDraftState;
+  readonly aiDirective: string;
   readonly repromptText: string;
   readonly isGeneratingAi: boolean;
-  readonly aiButtonLabel: string;
-  readonly aiButtonDisabled: boolean;
+  readonly runAiDraftDisabled: boolean;
+  readonly runAiDraftDisabledReason: string | null;
   readonly selectedAliasAiReady: boolean;
   readonly selectedAliasProjectName: string | null;
   readonly aiWarningMessage: string | null;
@@ -188,12 +233,21 @@ export function ComposerEmailSurface({
   readonly onRecipientChange: (
     recipient: ComposerRecipientValue | null,
   ) => void;
+  readonly onCcChange: (
+    recipients: readonly ComposerRecipientValue[],
+  ) => void;
+  readonly onBccChange: (
+    recipients: readonly ComposerRecipientValue[],
+  ) => void;
+  readonly onToggleCc: (open: boolean) => void;
+  readonly onToggleBcc: (open: boolean) => void;
   readonly onSubjectChange: (value: string) => void;
   readonly onBodyChange: (value: {
     readonly bodyPlaintext: string;
     readonly bodyHtml: string;
   }) => void;
   readonly onClearErrors: () => void;
+  readonly onAiDirectiveChange: (value: string) => void;
   readonly onAiEdited: () => void;
   readonly onDiscardAi: () => void;
   readonly onOpenReprompt: () => void;
@@ -208,8 +262,11 @@ export function ComposerEmailSurface({
   readonly onSend: () => void;
   readonly onCancel: () => void;
 }) {
+  const knowledgeTooltip =
+    "Set up Anthropic integration in Settings → Integrations to enable AI drafting.";
+
   return (
-    <>
+    <TooltipProvider delayDuration={200}>
       <ComposerField label="FROM">
         <ComposerSendFromChip
           value={selectedAlias}
@@ -220,11 +277,42 @@ export function ComposerEmailSurface({
       </ComposerField>
 
       <ComposerField label="TO">
-        <div className="rounded-lg bg-slate-50">
+        <div className="rounded-md bg-white">
           <ComposerRecipientPicker
-            recipient={recipient}
+            recipients={recipient === null ? [] : [recipient]}
             locked={isReplying}
-            onRecipientChange={onRecipientChange}
+            single
+            rightSlot={
+              !showCc || !showBcc ? (
+                <div className="flex items-center gap-1 pt-0.5 text-[11.5px]">
+                  {!showCc ? (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        onToggleCc(true);
+                      }}
+                      className="rounded px-1.5 py-0.5 text-slate-500 hover:bg-slate-100 hover:text-slate-700"
+                    >
+                      Cc
+                    </button>
+                  ) : null}
+                  {!showBcc ? (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        onToggleBcc(true);
+                      }}
+                      className="rounded px-1.5 py-0.5 text-slate-500 hover:bg-slate-100 hover:text-slate-700"
+                    >
+                      Bcc
+                    </button>
+                  ) : null}
+                </div>
+              ) : null
+            }
+            onRecipientsChange={(nextRecipients) => {
+              onRecipientChange(nextRecipients[0] ?? null);
+            }}
           />
         </div>
         {recipientError ? (
@@ -232,12 +320,53 @@ export function ComposerEmailSurface({
         ) : null}
       </ComposerField>
 
-      <ComposerField label="CC">
-        <div className="flex min-h-11 items-center justify-between rounded-lg border border-dashed border-slate-200 px-3 text-sm text-slate-400">
-          <span>Not available in this production flow yet</span>
-          <span className="text-xs">Placeholder</span>
-        </div>
-      </ComposerField>
+      {showCc ? (
+        <ComposerField label="CC">
+          <ComposerRecipientPicker
+            recipients={ccRecipients}
+            rightSlot={
+              <button
+                type="button"
+                aria-label="Hide Cc field"
+                onClick={() => {
+                  onToggleCc(false);
+                }}
+                className="text-slate-400 hover:text-slate-700"
+              >
+                <XIcon className="size-3.5" />
+              </button>
+            }
+            onRecipientsChange={onCcChange}
+          />
+          {ccError ? (
+            <p className="mt-1 text-xs text-rose-700">{ccError.message}</p>
+          ) : null}
+        </ComposerField>
+      ) : null}
+
+      {showBcc ? (
+        <ComposerField label="BCC">
+          <ComposerRecipientPicker
+            recipients={bccRecipients}
+            rightSlot={
+              <button
+                type="button"
+                aria-label="Hide Bcc field"
+                onClick={() => {
+                  onToggleBcc(false);
+                }}
+                className="text-slate-400 hover:text-slate-700"
+              >
+                <XIcon className="size-3.5" />
+              </button>
+            }
+            onRecipientsChange={onBccChange}
+          />
+          {bccError ? (
+            <p className="mt-1 text-xs text-rose-700">{bccError.message}</p>
+          ) : null}
+        </ComposerField>
+      ) : null}
 
       <ComposerField label="SUBJ">
         <Input
@@ -247,7 +376,7 @@ export function ComposerEmailSurface({
           }}
           placeholder="Subject"
           className={cn(
-            "h-11 border-0 px-0 text-[15px] font-medium shadow-none focus-visible:ring-0",
+            "h-9 border-0 px-0 text-[13.5px] font-medium shadow-none focus-visible:ring-0",
             subjectError ? "text-rose-900" : "",
           )}
         />
@@ -269,9 +398,14 @@ export function ComposerEmailSurface({
         topSlot={
           <ComposerAiDraftWindow
             aiDraft={aiDraft}
+            directiveText={aiDirective}
             repromptText={repromptText}
             isGeneratingAi={isGeneratingAi}
+            runDraftDisabled={runAiDraftDisabled}
+            runDraftDisabledReason={runAiDraftDisabledReason}
+            onDirectiveTextChange={onAiDirectiveChange}
             onRepromptTextChange={onRepromptTextChange}
+            onRunDraft={onRunAiDraft}
             onOpenReprompt={onOpenReprompt}
             onSubmitReprompt={onReprompt}
             onCancelReprompt={onCancelReprompt}
@@ -302,12 +436,14 @@ export function ComposerEmailSurface({
         </div>
       ) : null}
 
-      <div className="border-t border-slate-200 px-4 py-4">
-        {inlineError || recipientError || attachmentError ? (
+      <div className="border-t border-slate-100 bg-slate-50/40 px-3 py-2">
+        {inlineError || recipientError || ccError || bccError || attachmentError ? (
           <InlineErrorBanner
             message={
               inlineError?.message ??
               recipientError?.message ??
+              ccError?.message ??
+              bccError?.message ??
               attachmentError?.message ??
               "Something went wrong."
             }
@@ -317,7 +453,7 @@ export function ComposerEmailSurface({
         ) : null}
 
         {showKnowledgeCapture ? (
-          <label className="mb-3 flex items-start gap-2 text-sm text-slate-700">
+          <label className="mb-3 flex items-start gap-2 px-1 text-sm text-slate-700">
             <input
               type="checkbox"
               checked={captureAsKnowledge}
@@ -331,36 +467,41 @@ export function ComposerEmailSurface({
         ) : null}
 
         <div className="flex flex-wrap items-center gap-2">
-          <Button type="button" variant="ghost" onClick={onAttachmentClick}>
-            <PaperclipIcon className="size-4" />
+          <Button
+            type="button"
+            variant="ghost"
+            className="gap-1.5 border-l border-slate-200 pl-3 text-[11.5px] font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+            onClick={onAttachmentClick}
+          >
+            <PaperclipIcon className="size-3.5" />
             Attach
           </Button>
-          {selectedAliasAiReady ? (
-            <Button
-              type="button"
-              variant="outline"
-              disabled={aiButtonDisabled}
-              onClick={onRunAiDraft}
-            >
-              {isGeneratingAi ? (
-                <LoaderIcon className="size-4 animate-spin" />
-              ) : (
-                <SparkleIcon className="size-4" />
-              )}
-              {aiButtonLabel}
-            </Button>
-          ) : null}
 
           <div className="ml-auto flex items-center gap-2">
             {selectedAliasAiReady && selectedAliasProjectName !== null ? (
-              <span className={`hidden ${TYPE.caption} md:inline`}>
+              <span className={`hidden items-center ${TYPE.caption} md:inline-flex`}>
                 Uses {selectedAliasProjectName} knowledge
               </span>
+            ) : selectedAliasProjectName !== null ? (
+              <div className="hidden md:block">
+                <WarningKnowledgeIndicator tooltipMessage={knowledgeTooltip} />
+              </div>
             ) : null}
-            <Button type="button" variant="ghost" onClick={onCancel}>
+
+            <Button
+              type="button"
+              variant="ghost"
+              className="text-[12px] text-slate-500 hover:bg-slate-100 hover:text-slate-700"
+              onClick={onCancel}
+            >
               Cancel
             </Button>
-            <Button type="button" disabled={isSendDisabled} onClick={onSend}>
+            <Button
+              type="button"
+              disabled={isSendDisabled}
+              className="h-9 rounded-md bg-slate-900 px-3 text-[12.5px] font-medium text-white shadow-sm hover:bg-slate-800"
+              onClick={onSend}
+            >
               {isSending ? (
                 <>
                   <LoaderIcon className="size-4 animate-spin" />
@@ -375,6 +516,12 @@ export function ComposerEmailSurface({
             </Button>
           </div>
         </div>
+
+        {!selectedAliasAiReady && selectedAliasProjectName !== null ? (
+          <div className="mt-2 md:hidden">
+            <WarningKnowledgeIndicator tooltipMessage={knowledgeTooltip} />
+          </div>
+        ) : null}
       </div>
 
       <AboutThisDraft
@@ -382,7 +529,7 @@ export function ComposerEmailSurface({
         open={isAboutOpen}
         onOpenChange={onAboutOpenChange}
       />
-    </>
+    </TooltipProvider>
   );
 }
 

--- a/apps/web/app/inbox/_components/composer-editor-surface.tsx
+++ b/apps/web/app/inbox/_components/composer-editor-surface.tsx
@@ -42,8 +42,8 @@ export function ComposerField({
   readonly children: React.ReactNode;
 }) {
   return (
-    <div className="flex items-start gap-3 border-b border-slate-100 px-4 py-2.5">
-      <span className={`mt-1 w-10 shrink-0 ${TYPE.label}`}>{label}</span>
+    <div className="flex items-start gap-3 border-b border-slate-100 px-4 py-1.5">
+      <span className={`mt-1 w-8 shrink-0 ${TYPE.label}`}>{label}</span>
       <div className="min-w-0 flex-1">{children}</div>
     </div>
   );
@@ -141,7 +141,6 @@ export function RichTextComposerEditor({
     extensions: [
       StarterKit.configure({
         heading: false,
-        blockquote: false,
         codeBlock: false,
         horizontalRule: false,
         strike: false,
@@ -164,7 +163,7 @@ export function RichTextComposerEditor({
         "aria-multiline": "true",
         ...(errorMessage ? { "aria-invalid": "true" } : {}),
         class: cn(
-          "min-h-48 w-full px-4 py-4 text-sm leading-6 text-slate-900 focus:outline-none [&_a]:text-sky-700 [&_a]:underline [&_ol]:ml-5 [&_ol]:list-decimal [&_ul]:ml-5 [&_ul]:list-disc",
+          "min-h-48 w-full px-4 py-4 text-sm leading-6 text-slate-900 focus:outline-none [&_a]:text-sky-700 [&_a]:underline [&_blockquote]:border-l-2 [&_blockquote]:border-slate-200 [&_blockquote]:pl-3 [&_blockquote]:text-slate-600 [&_ol]:ml-5 [&_ol]:list-decimal [&_ul]:ml-5 [&_ul]:list-disc",
           errorMessage ? "bg-rose-50/40" : "",
         ),
       },
@@ -185,6 +184,7 @@ export function RichTextComposerEditor({
   if (editor?.isActive("orderedList") === true)
     activeCommands.add("orderedList");
   if (editor?.isActive("link") === true) activeCommands.add("link");
+  if (editor?.isActive("blockquote") === true) activeCommands.add("blockquote");
 
   const runCommand = useCallback(
     (command: ComposerToolbarCommand) => {
@@ -216,6 +216,9 @@ export function RichTextComposerEditor({
           chain.setLink({ href: url }).run();
           break;
         }
+        case "blockquote":
+          chain.toggleBlockquote().run();
+          break;
       }
     },
     [editor],

--- a/apps/web/app/inbox/_components/composer-floating-pill.tsx
+++ b/apps/web/app/inbox/_components/composer-floating-pill.tsx
@@ -3,7 +3,6 @@
 import {
   FOCUS_RING,
   RADIUS,
-  SHADOW,
   TRANSITION,
 } from "@/app/_lib/design-tokens-v2";
 import { cn } from "@/lib/utils";
@@ -53,7 +52,7 @@ export function ComposerFloatingPill() {
       role="region"
       aria-label="Minimized composer"
       className={cn(
-        `fixed bottom-4 right-4 z-40 flex h-11 w-[280px] items-center gap-2 border border-slate-200 bg-white px-3 ${RADIUS.lg} ${SHADOW.md}`,
+        `fixed bottom-4 right-4 z-40 flex h-11 w-[300px] items-center gap-2 border border-slate-200 bg-white px-3 shadow-xl ring-1 ring-slate-900/5 ${RADIUS.lg}`,
       )}
     >
       <span

--- a/apps/web/app/inbox/_components/composer-recipient-picker.tsx
+++ b/apps/web/app/inbox/_components/composer-recipient-picker.tsx
@@ -1,11 +1,16 @@
 "use client";
 
-import { useEffect, useId, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState, type ReactNode } from "react";
 
 import { Chip } from "@/components/ui/chip";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
-import { FOCUS_RING, RADIUS, SHADOW, TRANSITION } from "@/app/_lib/design-tokens-v2";
+import {
+  FOCUS_RING,
+  RADIUS,
+  SHADOW,
+  TRANSITION,
+} from "@/app/_lib/design-tokens-v2";
 
 import {
   formatContactRecipientLabel,
@@ -48,14 +53,41 @@ function toContactRecipient(
   };
 }
 
+function isSameRecipient(
+  left: ComposerRecipientValue,
+  right: ComposerRecipientValue,
+): boolean {
+  if (left.kind !== right.kind) {
+    return false;
+  }
+
+  if (left.kind === "contact" && right.kind === "contact") {
+    return left.contactId === right.contactId;
+  }
+
+  if (left.kind === "email" && right.kind === "email") {
+    return left.emailAddress === right.emailAddress;
+  }
+
+  return false;
+}
+
 export function ComposerRecipientPicker({
-  recipient,
+  recipients,
   locked = false,
-  onRecipientChange,
+  single = false,
+  placeholder = "Search Salesforce contacts or type an email",
+  rightSlot,
+  onRecipientsChange,
 }: {
-  readonly recipient: ComposerRecipientValue | null;
+  readonly recipients: readonly ComposerRecipientValue[];
   readonly locked?: boolean;
-  readonly onRecipientChange: (recipient: ComposerRecipientValue | null) => void;
+  readonly single?: boolean;
+  readonly placeholder?: string;
+  readonly rightSlot?: ReactNode;
+  readonly onRecipientsChange: (
+    recipients: readonly ComposerRecipientValue[],
+  ) => void;
 }) {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<readonly ContactSearchResult[]>([]);
@@ -64,7 +96,7 @@ export function ComposerRecipientPicker({
   const listboxId = useId();
 
   useEffect(() => {
-    if (recipient !== null) {
+    if (locked || (single && recipients.length > 0)) {
       activeSearchIdRef.current += 1;
       setQuery("");
       setResults([]);
@@ -106,64 +138,109 @@ export function ComposerRecipientPicker({
     return () => {
       window.clearTimeout(timeoutId);
     };
-  }, [query, recipient]);
+  }, [locked, query, recipients.length, single]);
 
+  const shouldShowInput = !locked && (!single || recipients.length === 0);
   const shouldShowResults =
-    recipient === null &&
+    shouldShowInput &&
     (isSearching || results.length > 0 || query.trim().length >= 2);
+
+  const commitRecipient = (recipient: ComposerRecipientValue) => {
+    if (single) {
+      onRecipientsChange([recipient]);
+      return;
+    }
+
+    if (recipients.some((existing) => isSameRecipient(existing, recipient))) {
+      return;
+    }
+
+    onRecipientsChange([...recipients, recipient]);
+  };
 
   return (
     <div className="relative">
-      {recipient ? (
-        <RecipientChip
-          recipient={recipient}
-          locked={locked}
-          onClear={() => {
-            if (!locked) {
-              onRecipientChange(null);
+      <div
+        className={cn(
+          `flex min-h-9 flex-wrap items-center gap-1.5 rounded-md px-0 py-0.5`,
+          !shouldShowInput && recipients.length > 0 ? "" : "pr-2",
+        )}
+      >
+        {recipients.map((recipient, index) => (
+          <RecipientChip
+            key={
+              recipient.kind === "contact"
+                ? `contact:${recipient.contactId}`
+                : `email:${recipient.emailAddress}`
             }
-          }}
-        />
-      ) : (
-        <>
-          <SearchIcon className="pointer-events-none absolute left-3 top-3.5 size-4 text-slate-400" />
-          <Input
-            value={query}
-            onChange={(event) => {
-              setQuery(event.currentTarget.value);
+            recipient={recipient}
+            locked={locked}
+            onClear={() => {
+              if (locked) {
+                return;
+              }
+
+              onRecipientsChange(
+                recipients.filter((_, candidateIndex) => candidateIndex !== index),
+              );
             }}
-            onKeyDown={(event) => {
-              if (event.key !== "Enter") {
-                return;
-              }
-
-              const trimmedQuery = query.trim();
-
-              if (trimmedQuery.length === 0) {
-                event.preventDefault();
-                return;
-              }
-
-              const typedEmailRecipient = resolveTypedEmailRecipient({
-                query: trimmedQuery,
-                results,
-              });
-
-              if (typedEmailRecipient === null) {
-                return;
-              }
-
-              event.preventDefault();
-              onRecipientChange(typedEmailRecipient);
-            }}
-            placeholder="Search Salesforce contacts or type an email"
-            aria-expanded={shouldShowResults}
-            aria-controls={shouldShowResults ? listboxId : undefined}
-            aria-autocomplete="list"
-            className={`h-11 border-0 bg-transparent pl-10 shadow-none ${FOCUS_RING}`}
           />
-        </>
-      )}
+        ))}
+
+        {shouldShowInput ? (
+          <div className="flex min-w-[14rem] flex-1 items-center">
+            {recipients.length === 0 ? (
+              <SearchIcon className="pointer-events-none mr-2 size-4 shrink-0 text-slate-400" />
+            ) : null}
+            <Input
+              value={query}
+              onChange={(event) => {
+                setQuery(event.currentTarget.value);
+              }}
+              onKeyDown={(event) => {
+                if (event.key !== "Enter") {
+                  return;
+                }
+
+                const trimmedQuery = query.trim();
+
+                if (trimmedQuery.length === 0) {
+                  event.preventDefault();
+                  return;
+                }
+
+                const typedEmailRecipient = resolveTypedEmailRecipient({
+                  query: trimmedQuery,
+                  results,
+                });
+
+                if (typedEmailRecipient === null) {
+                  return;
+                }
+
+                event.preventDefault();
+                commitRecipient(typedEmailRecipient);
+                setQuery("");
+                setResults([]);
+              }}
+              placeholder={recipients.length === 0 ? placeholder : ""}
+              aria-expanded={shouldShowResults}
+              aria-controls={shouldShowResults ? listboxId : undefined}
+              aria-autocomplete="list"
+              className={cn(
+                `h-8 flex-1 border-0 bg-transparent px-0 text-[13px] shadow-none ${FOCUS_RING}`,
+                recipients.length === 0 ? "pl-0" : "",
+              )}
+            />
+          </div>
+        ) : null}
+
+        {rightSlot ? (
+          <div className="ml-auto flex items-center self-start pt-1">
+            {rightSlot}
+          </div>
+        ) : null}
+      </div>
 
       {shouldShowResults ? (
         <div
@@ -184,7 +261,9 @@ export function ComposerRecipientPicker({
                   <button
                     type="button"
                     onClick={() => {
-                      onRecipientChange(toContactRecipient(result));
+                      commitRecipient(toContactRecipient(result));
+                      setQuery("");
+                      setResults([]);
                     }}
                     className={`flex w-full items-start justify-between gap-3 px-3 py-3 text-left ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion} hover:bg-slate-50`}
                   >
@@ -229,7 +308,7 @@ function RecipientChip({
   readonly onClear: () => void;
 }) {
   return (
-    <span className="inline-flex min-h-11 w-full items-center justify-between gap-3 rounded-lg bg-slate-50 px-3 py-2 text-sm">
+    <span className="inline-flex max-w-full items-center gap-1.5 rounded-full border border-slate-200 bg-slate-50 py-0.5 pl-2 pr-1.5 text-[12px] text-slate-700">
       <span className="min-w-0">
         {recipient.kind === "contact" ? (
           <span className="block truncate font-medium text-slate-900">
@@ -252,11 +331,11 @@ function RecipientChip({
           type="button"
           aria-label="Clear recipient"
           className={cn(
-            `inline-flex size-7 items-center justify-center rounded-full text-slate-400 ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion} hover:bg-slate-200 hover:text-slate-700`,
+            `inline-flex size-5 items-center justify-center rounded-full text-slate-400 ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion} hover:bg-slate-200 hover:text-slate-700`,
           )}
           onClick={onClear}
         >
-          <XIcon className="size-4" />
+          <XIcon className="size-3" />
         </button>
       ) : null}
     </span>

--- a/apps/web/app/inbox/_components/composer-shared.ts
+++ b/apps/web/app/inbox/_components/composer-shared.ts
@@ -22,6 +22,20 @@ function normalizeEmail(value: string): string {
   return value.trim().toLowerCase();
 }
 
+export function resolveRecipientEmailAddress(
+  recipient: ComposerRecipientValue,
+): string | null {
+  if (recipient.kind === "email") {
+    return normalizeEmail(recipient.emailAddress);
+  }
+
+  if (recipient.primaryEmail === null) {
+    return null;
+  }
+
+  return normalizeEmail(recipient.primaryEmail);
+}
+
 export function formatBytes(bytes: number): string {
   if (bytes >= 1024 * 1024) {
     return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
@@ -90,6 +104,10 @@ export function mapFieldErrors(
       default:
         if (field.startsWith("recipient")) {
           mappedErrors.push({ field: "recipient", message });
+        } else if (field.startsWith("cc")) {
+          mappedErrors.push({ field: "cc", message });
+        } else if (field.startsWith("bcc")) {
+          mappedErrors.push({ field: "bcc", message });
         }
     }
   }

--- a/apps/web/app/inbox/_components/composer-toolbar.tsx
+++ b/apps/web/app/inbox/_components/composer-toolbar.tsx
@@ -11,6 +11,7 @@ import {
   LinkIcon,
   ListIcon,
   ListOrderedIcon,
+  QuoteIcon,
 } from "./icons";
 
 export type ComposerToolbarCommand =
@@ -18,7 +19,8 @@ export type ComposerToolbarCommand =
   | "italic"
   | "bulletList"
   | "orderedList"
-  | "link";
+  | "link"
+  | "blockquote";
 
 interface ComposerToolbarProps {
   readonly activeCommands: ReadonlySet<ComposerToolbarCommand>;
@@ -43,6 +45,11 @@ const TOOLBAR_ITEMS: readonly {
     icon: <ListOrderedIcon className="size-4" />,
   },
   { command: "link", label: "Link", icon: <LinkIcon className="size-4" /> },
+  {
+    command: "blockquote",
+    label: "Quote",
+    icon: <QuoteIcon className="size-4" />,
+  },
 ];
 
 export function ComposerToolbar({
@@ -50,7 +57,7 @@ export function ComposerToolbar({
   onCommand,
 }: ComposerToolbarProps) {
   return (
-    <div className="flex items-center gap-1 border-b border-slate-200 bg-white px-4 py-2">
+    <div className="flex items-center gap-0.5 border-b border-slate-100 bg-white px-3 py-1.5">
       {TOOLBAR_ITEMS.map((item) => {
         const active = activeCommands.has(item.command);
 

--- a/apps/web/app/inbox/_components/inbox-client-provider.tsx
+++ b/apps/web/app/inbox/_components/inbox-client-provider.tsx
@@ -42,7 +42,14 @@ export type ComposerStatus =
 export type ComposerViewState = "closed" | "modal" | "pill";
 
 export interface ComposerValidationError {
-  readonly field: "subject" | "body" | "recipient" | "alias" | "attachments";
+  readonly field:
+    | "subject"
+    | "body"
+    | "recipient"
+    | "cc"
+    | "bcc"
+    | "alias"
+    | "attachments";
   readonly message: string;
 }
 

--- a/apps/web/app/inbox/_components/inbox-composer.tsx
+++ b/apps/web/app/inbox/_components/inbox-composer.tsx
@@ -11,7 +11,6 @@ import {
 
 import {
   FOCUS_RING,
-  RADIUS,
   TRANSITION,
   TYPE,
 } from "@/app/_lib/design-tokens-v2";
@@ -28,7 +27,6 @@ import {
   sendComposerAction,
   type ComposerSendActionInput,
 } from "../actions";
-import { resolveAiButtonState } from "../_lib/composer-ai";
 import {
   isComposerSendDisabled,
   resolveDefaultAlias,
@@ -54,6 +52,7 @@ import {
   readFileAsAttachment,
   resolveAiWarningMessage,
   resolveComposerDraftKey,
+  resolveRecipientEmailAddress,
   resolveRecipientLabel,
   type AttachmentDraft,
   type InlineComposerError,
@@ -62,6 +61,47 @@ import { useInboxClient } from "./inbox-client-provider";
 import { ChevronDownIcon, MailIcon, NoteIcon, XIcon } from "./icons";
 
 const MAX_TOTAL_ATTACHMENT_BYTES = 20 * 1024 * 1024;
+
+function toEmailRecipients(
+  emails: readonly string[] | undefined,
+): readonly ComposerRecipientValue[] {
+  return (emails ?? []).map((emailAddress) => ({
+    kind: "email",
+    emailAddress,
+  }));
+}
+
+function resolveSupplementaryRecipientEmails(input: {
+  readonly recipients: readonly ComposerRecipientValue[];
+}):
+  | {
+      readonly ok: true;
+      readonly emails: readonly string[];
+    }
+  | {
+      readonly ok: false;
+      readonly message: string;
+    } {
+  const emails: string[] = [];
+
+  for (const recipient of input.recipients) {
+    const email = resolveRecipientEmailAddress(recipient);
+
+    if (email === null) {
+      return {
+        ok: false,
+        message: "Every selected recipient needs a valid email address.",
+      };
+    }
+
+    emails.push(email);
+  }
+
+  return {
+    ok: true,
+    emails,
+  };
+}
 
 export function InboxComposerReplyBar({
   contactDisplayName,
@@ -166,6 +206,14 @@ export function InboxComposerDetailPane() {
   const [recipient, setRecipient] = useState<ComposerRecipientValue | null>(
     null,
   );
+  const [ccRecipients, setCcRecipients] = useState<
+    readonly ComposerRecipientValue[]
+  >([]);
+  const [bccRecipients, setBccRecipients] = useState<
+    readonly ComposerRecipientValue[]
+  >([]);
+  const [showCc, setShowCc] = useState(false);
+  const [showBcc, setShowBcc] = useState(false);
   const [selectedAlias, setSelectedAlias] = useState<string | null>(null);
   const [subject, setSubject] = useState("");
   const [body, setBody] = useState("");
@@ -174,6 +222,7 @@ export function InboxComposerDetailPane() {
     [],
   );
   const [captureAsKnowledge, setCaptureAsKnowledge] = useState(false);
+  const [aiDirective, setAiDirective] = useState("");
   const [repromptText, setRepromptText] = useState("");
   const [inlineError, setInlineError] = useState<InlineComposerError | null>(
     null,
@@ -215,12 +264,25 @@ export function InboxComposerDetailPane() {
         : "email",
     );
     setRecipient(replyRecipient);
+    setCcRecipients(
+      toEmailRecipients(replyContext?.cc).filter((candidate) => {
+        if (candidate.kind !== "email") {
+          return true;
+        }
+
+        return candidate.emailAddress !== replyContext?.defaultAlias;
+      }),
+    );
+    setBccRecipients([]);
+    setShowCc((replyContext?.cc?.length ?? 0) > 0);
+    setShowBcc(false);
     setSelectedAlias(replyContext?.defaultAlias ?? null);
     setSubject(replyContext?.subject ?? "");
     setBody("");
     setBodyHtml("");
     setAttachments([]);
     setCaptureAsKnowledge(false);
+    setAiDirective("");
     setRepromptText("");
     setInlineError(null);
     setIsAboutOpen(false);
@@ -261,6 +323,8 @@ export function InboxComposerDetailPane() {
       subject.trim() === baselineSubject.trim() &&
       body.trim().length === 0 &&
       bodyHtml.trim().length === 0 &&
+      ccRecipients.length === 0 &&
+      bccRecipients.length === 0 &&
       attachments.length === 0 &&
       selectedAlias === baselineAlias;
 
@@ -279,6 +343,16 @@ export function InboxComposerDetailPane() {
     setSubject(draft.subject);
     setBody(draft.bodyPlaintext);
     setBodyHtml(draft.bodyHtml);
+    const draftCc = Array.isArray((draft as { readonly cc?: unknown }).cc)
+      ? ((draft as { readonly cc?: readonly string[] }).cc ?? [])
+      : [];
+    const draftBcc = Array.isArray((draft as { readonly bcc?: unknown }).bcc)
+      ? ((draft as { readonly bcc?: readonly string[] }).bcc ?? [])
+      : [];
+    setCcRecipients(toEmailRecipients(draftCc));
+    setBccRecipients(toEmailRecipients(draftBcc));
+    setShowCc(draftCc.length > 0);
+    setShowBcc(draftBcc.length > 0);
     setSelectedAlias(draft.selectedAlias);
     setAttachments(
       draft.attachments.map((attachment, index) => ({
@@ -296,6 +370,8 @@ export function InboxComposerDetailPane() {
     baselineSubject,
     body,
     bodyHtml,
+    bccRecipients.length,
+    ccRecipients.length,
     composerPane.mode,
     draftKey,
     selectedAlias,
@@ -315,6 +391,8 @@ export function InboxComposerDetailPane() {
       subject.trim() !== baselineSubject.trim() ||
       body.trim().length > 0 ||
       bodyHtml.trim().length > 0 ||
+      ccRecipients.length > 0 ||
+      bccRecipients.length > 0 ||
       selectedAlias !== baselineAlias ||
       attachments.length > 0;
 
@@ -329,6 +407,14 @@ export function InboxComposerDetailPane() {
         bodyPlaintext: body,
         bodyHtml,
         selectedAlias,
+        cc: ccRecipients.flatMap((recipient) => {
+          const email = resolveRecipientEmailAddress(recipient);
+          return email === null ? [] : [email];
+        }),
+        bcc: bccRecipients.flatMap((recipient) => {
+          const email = resolveRecipientEmailAddress(recipient);
+          return email === null ? [] : [email];
+        }),
         attachments: attachments.map((attachment) => ({
           filename: attachment.filename,
           size: attachment.size,
@@ -347,6 +433,8 @@ export function InboxComposerDetailPane() {
     baselineSubject,
     body,
     bodyHtml,
+    bccRecipients,
+    ccRecipients,
     composerPane.mode,
     draftKey,
     selectedAlias,
@@ -374,11 +462,21 @@ export function InboxComposerDetailPane() {
       ? null
       : (composerAliases.find((alias) => alias.alias === selectedAlias) ??
         null);
-  const aiButton = resolveAiButtonState({
-    body,
-    isGenerating: isGeneratingAi,
-    aiDraftStatus: aiDraft.status,
-  });
+  const selectedAliasAiConfigured =
+    selectedAliasRecord?.isAiConfigured ?? selectedAliasRecord?.isAiReady ?? false;
+  const runAiDraftDisabled =
+    selectedAliasRecord === null ||
+    !selectedAliasAiConfigured ||
+    isGeneratingAi ||
+    aiDraft.status === "generating" ||
+    aiDraft.status === "reviewable" ||
+    aiDraft.status === "reprompting";
+  const runAiDraftDisabledReason =
+    selectedAliasRecord === null
+      ? "Choose a sender alias first."
+      : !selectedAliasAiConfigured
+        ? "AI is not configured for this project. Set it up in Settings → Integrations."
+        : null;
   const aiWarningMessage = resolveAiWarningMessage(aiDraft);
   const showKnowledgeCapture =
     activeTab === "email" && selectedAliasRecord?.isAiReady === true;
@@ -403,6 +501,8 @@ export function InboxComposerDetailPane() {
   const recipientError = composerErrors.find(
     (error) => error.field === "recipient",
   );
+  const ccError = composerErrors.find((error) => error.field === "cc");
+  const bccError = composerErrors.find((error) => error.field === "bcc");
   const attachmentError = composerErrors.find(
     (error) => error.field === "attachments",
   );
@@ -426,6 +526,10 @@ export function InboxComposerDetailPane() {
     readonly repromptDirection: string;
   }) => {
     if (activeTab !== "email") {
+      return;
+    }
+
+    if (!selectedAliasAiConfigured) {
       return;
     }
 
@@ -454,7 +558,7 @@ export function InboxComposerDetailPane() {
             repromptDirection: requestOverride.repromptDirection,
             repromptIndex: aiDraft.repromptChain.length + 1,
           }
-        : aiButton.mode === "draft"
+        : aiDirective.trim().length === 0
           ? {
               ...baseRequest,
               mode: "draft" as const,
@@ -462,7 +566,7 @@ export function InboxComposerDetailPane() {
           : {
               ...baseRequest,
               mode: "fill" as const,
-              operatorPrompt: body.trim(),
+              operatorPrompt: aiDirective.trim(),
             };
 
     const prompt =
@@ -549,6 +653,7 @@ export function InboxComposerDetailPane() {
 
   const handleDiscardAi = () => {
     discardAiDraft();
+    setAiDirective("");
     setRepromptText("");
   };
 
@@ -577,12 +682,37 @@ export function InboxComposerDetailPane() {
     const approvedText = aiDraft.generatedText;
     setBody(approvedText);
     setBodyHtml(plaintextToComposerHtml(approvedText));
+    setAiDirective("");
     setRepromptText("");
     approveAiDraft();
   };
 
   const submit = () => {
     if (recipient === null || selectedAlias === null || activeTab !== "email") {
+      return;
+    }
+
+    const resolvedCc = resolveSupplementaryRecipientEmails({
+      recipients: ccRecipients,
+    });
+    if (!resolvedCc.ok) {
+      setInlineError({
+        message: resolvedCc.message,
+        retryable: false,
+      });
+      setComposerErrors([{ field: "cc", message: resolvedCc.message }]);
+      return;
+    }
+
+    const resolvedBcc = resolveSupplementaryRecipientEmails({
+      recipients: bccRecipients,
+    });
+    if (!resolvedBcc.ok) {
+      setInlineError({
+        message: resolvedBcc.message,
+        retryable: false,
+      });
+      setComposerErrors([{ field: "bcc", message: resolvedBcc.message }]);
       return;
     }
 
@@ -609,6 +739,10 @@ export function InboxComposerDetailPane() {
       subject: subject.trim(),
       bodyPlaintext: body.trim(),
       bodyHtml,
+      ...(resolvedCc.emails.length > 0 ? { cc: [...resolvedCc.emails] } : {}),
+      ...(resolvedBcc.emails.length > 0
+        ? { bcc: [...resolvedBcc.emails] }
+        : {}),
       attachments: attachments.flatMap((attachment) =>
         attachment.contentBase64 === null
           ? []
@@ -722,11 +856,11 @@ export function InboxComposerDetailPane() {
     >
       <DialogContent
         className={cn(
-          `flex max-h-[85vh] w-[calc(100vw-2rem)] max-w-[760px] flex-col gap-0 overflow-hidden border-slate-200 bg-white p-0 ${RADIUS.lg} shadow-lg [&>button:last-child]:hidden`,
+          `flex max-h-[92vh] w-[calc(100vw-2rem)] max-w-[820px] flex-col gap-0 overflow-hidden border-slate-200 bg-white p-0 shadow-2xl ring-1 ring-slate-900/5 sm:rounded-xl [&>button:last-child]:hidden`,
         )}
       >
         <DialogTitle className="sr-only">{modalTitle}</DialogTitle>
-        <header className="flex items-center justify-between gap-3 border-b border-slate-200 bg-white px-4 py-2.5">
+        <header className="flex items-center justify-between gap-3 border-b border-slate-200 bg-white px-4 py-3">
           <div className="flex min-w-0 items-center gap-2">
             <span
               aria-hidden="true"
@@ -772,15 +906,20 @@ export function InboxComposerDetailPane() {
               composerAliases={composerAliases}
               selectedAlias={selectedAlias}
               recipient={recipient}
+              ccRecipients={ccRecipients}
+              bccRecipients={bccRecipients}
+              showCc={showCc}
+              showBcc={showBcc}
               isReplying={isReplying}
               subject={subject}
               body={body}
               attachments={attachments}
               aiDraft={aiDraft}
+              aiDirective={aiDirective}
               repromptText={repromptText}
               isGeneratingAi={isGeneratingAi}
-              aiButtonLabel={aiButton.label}
-              aiButtonDisabled={aiButton.disabled}
+              runAiDraftDisabled={runAiDraftDisabled}
+              runAiDraftDisabledReason={runAiDraftDisabledReason}
               selectedAliasAiReady={selectedAliasRecord?.isAiReady === true}
               selectedAliasProjectName={
                 selectedAliasRecord?.projectName ?? null
@@ -809,6 +948,28 @@ export function InboxComposerDetailPane() {
                   );
                 }
               }}
+              onCcChange={(nextRecipients) => {
+                setCcRecipients(nextRecipients);
+                clearComposerErrors();
+              }}
+              onBccChange={(nextRecipients) => {
+                setBccRecipients(nextRecipients);
+                clearComposerErrors();
+              }}
+              onToggleCc={(open) => {
+                setShowCc(open);
+                if (!open) {
+                  setCcRecipients([]);
+                }
+                clearComposerErrors();
+              }}
+              onToggleBcc={(open) => {
+                setShowBcc(open);
+                if (!open) {
+                  setBccRecipients([]);
+                }
+                clearComposerErrors();
+              }}
               onSubjectChange={(value) => {
                 setSubject(value);
                 clearComposerErrors();
@@ -818,6 +979,7 @@ export function InboxComposerDetailPane() {
                 setBodyHtml(nextBody.bodyHtml);
               }}
               onClearErrors={clearComposerErrors}
+              onAiDirectiveChange={setAiDirective}
               onAiEdited={markAiDraftEdited}
               onDiscardAi={handleDiscardAi}
               onOpenReprompt={handleOpenReprompt}
@@ -842,6 +1004,8 @@ export function InboxComposerDetailPane() {
               onCancel={handleCancel}
               {...(aliasError ? { aliasError } : {})}
               {...(recipientError ? { recipientError } : {})}
+              {...(ccError ? { ccError } : {})}
+              {...(bccError ? { bccError } : {})}
               {...(subjectError ? { subjectError } : {})}
               {...(bodyError ? { bodyError } : {})}
               {...(attachmentError ? { attachmentError } : {})}

--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -70,6 +70,20 @@ type ReminderUnit = "hours" | "days" | "weeks";
 
 const REPLY_SUBJECT_PREFIX_PATTERN = /^\s*(?:(?:re|fwd?)\s*:\s*)+/i;
 
+function extractEmailAddresses(value: string | null | undefined): string[] {
+  if (value === null || value === undefined) {
+    return [];
+  }
+
+  return Array.from(
+    new Set(
+      Array.from(value.matchAll(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi)).map(
+        (match) => match[0].toLowerCase(),
+      ),
+    ),
+  );
+}
+
 function buildReplySubject(subject: string | null): string {
   const normalizedSubject = subject?.trim() ?? "";
 
@@ -106,6 +120,7 @@ function buildTimelineReplyContext(input: {
         ? input.entry.rfc822MessageId
         : input.entry.inReplyToRfc822,
     defaultAlias: input.defaultAlias,
+    cc: extractEmailAddresses(input.entry.ccHeader),
   };
 }
 

--- a/apps/web/app/inbox/_lib/composer-data.ts
+++ b/apps/web/app/inbox/_lib/composer-data.ts
@@ -1,4 +1,5 @@
 import type { InboxComposerAliasOption } from "./view-models";
+import { getAiProviderConfig } from "@/src/server/ai/provider";
 import { getStage1WebRuntime } from "@/src/server/stage1-runtime";
 
 export async function getInboxComposerAliases(): Promise<
@@ -6,6 +7,8 @@ export async function getInboxComposerAliases(): Promise<
 > {
   const runtime = await getStage1WebRuntime();
   const aliases = await runtime.settings.aliases.listAssigned();
+  const aiProvider = getAiProviderConfig();
+  const isAiConfigured = aiProvider.invokeModel !== null;
   const projectIds = Array.from(
     new Set(
       aliases
@@ -15,9 +18,20 @@ export async function getInboxComposerAliases(): Promise<
   );
   const projectDimensions =
     await runtime.repositories.projectDimensions.listByIds(projectIds);
+  const approvedKnowledgeEntries = await Promise.all(
+    projectIds.map(async (projectId) => {
+      const entries = await runtime.repositories.projectKnowledge.list({
+        projectId,
+        approvedOnly: true,
+      });
+
+      return [projectId, entries.length > 0] as const;
+    }),
+  );
   const projectById = new Map(
     projectDimensions.map((project) => [project.projectId, project])
   );
+  const hasApprovedKnowledgeByProjectId = new Map(approvedKnowledgeEntries);
 
   return aliases.flatMap((alias): readonly InboxComposerAliasOption[] => {
     if (alias.projectId === null) {
@@ -36,8 +50,13 @@ export async function getInboxComposerAliases(): Promise<
         alias: alias.alias,
         projectId: alias.projectId,
         projectName: project.projectName,
+        isAiConfigured,
+        hasApprovedKnowledge:
+          hasApprovedKnowledgeByProjectId.get(alias.projectId) === true,
         isAiReady:
-          project.isActive === true && project.aiKnowledgeSyncedAt !== null,
+          project.isActive === true &&
+          isAiConfigured &&
+          hasApprovedKnowledgeByProjectId.get(alias.projectId) === true,
       },
     ];
   });

--- a/apps/web/app/inbox/_lib/composer-draft-storage.ts
+++ b/apps/web/app/inbox/_lib/composer-draft-storage.ts
@@ -6,6 +6,8 @@ export interface StoredComposerDraft {
   readonly bodyPlaintext: string;
   readonly bodyHtml: string;
   readonly selectedAlias: string | null;
+  readonly cc: readonly string[];
+  readonly bcc: readonly string[];
   readonly attachments: readonly {
     readonly filename: string;
     readonly size: number;

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -1939,6 +1939,7 @@ function buildComposerReplyContext(input: {
     threadId: latestInboundEmail.threadId ?? null,
     inReplyToRfc822: latestInboundEmail.rfc822MessageId ?? null,
     defaultAlias: input.defaultAlias,
+    cc: extractEmailAddresses(latestInboundEmail.ccHeader),
   };
 }
 

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -280,11 +280,12 @@ export interface InboxComposerAliasOption {
   readonly projectId: string;
   readonly projectName: string;
   /**
-   * D-037 gate: true only when the project is active AND Notion knowledge has
-   * synced at least once. Used to hide the "Draft with AI" button on projects
-   * that have no grounding context yet.
+   * Full Stage 4 grounding readiness: provider configured and at least one
+   * approved project-knowledge entry is available for this alias's project.
    */
   readonly isAiReady: boolean;
+  readonly isAiConfigured?: boolean;
+  readonly hasApprovedKnowledge?: boolean;
 }
 
 export interface InboxComposerReplyContext {
@@ -295,6 +296,7 @@ export interface InboxComposerReplyContext {
   readonly threadId: string | null;
   readonly inReplyToRfc822: string | null;
   readonly defaultAlias: string | null;
+  readonly cc?: readonly string[];
 }
 
 export interface InboxDetailViewModel {

--- a/apps/web/app/inbox/actions.ts
+++ b/apps/web/app/inbox/actions.ts
@@ -566,6 +566,13 @@ function normalizeEmailAddress(value: string): string | null {
   return normalized.length === 0 ? null : normalized;
 }
 
+function normalizeEmailAddresses(values: readonly string[] | undefined): string[] {
+  return (values ?? []).flatMap((value) => {
+    const normalized = normalizeEmailAddress(value);
+    return normalized === null ? [] : [normalized];
+  });
+}
+
 function resolveCurrentUserDisplayName(input: {
   readonly name: string | null | undefined;
   readonly email: string | null | undefined;
@@ -1376,6 +1383,8 @@ export async function sendComposerAction(
   const signature = readAliasSignature(
     alias as unknown as Record<string, unknown>,
   );
+  const cc = normalizeEmailAddresses(parsedInput.data.cc);
+  const bcc = normalizeEmailAddresses(parsedInput.data.bcc);
   const bodyPlaintext = appendSignature(
     parsedInput.data.bodyPlaintext,
     signature,
@@ -1435,6 +1444,8 @@ export async function sendComposerAction(
       toEmailNormalized,
       subject: parsedInput.data.subject,
       attachmentCount: parsedInput.data.attachments.length,
+      ccCount: cc.length,
+      bccCount: bcc.length,
       supersedesPendingId: parsedInput.data.supersedesPendingId ?? null,
     },
   });
@@ -1443,6 +1454,8 @@ export async function sendComposerAction(
     const sendParams = {
       fromAlias: alias.alias,
       to: toEmailNormalized,
+      ...(cc.length > 0 ? { cc } : {}),
+      ...(bcc.length > 0 ? { bcc } : {}),
       subject: parsedInput.data.subject,
       bodyPlaintext,
       bodyHtml,

--- a/apps/web/tests/unit/ai-draft-preview-approve.test.tsx
+++ b/apps/web/tests/unit/ai-draft-preview-approve.test.tsx
@@ -11,15 +11,36 @@ function iconMock(name: string) {
 }
 
 vi.mock("lucide-react", () => ({
+  AlertCircle: iconMock("AlertCircle"),
   Check: iconMock("Check"),
   Flag: iconMock("Flag"),
   Inbox: iconMock("Inbox"),
+  Loader2: iconMock("Loader2"),
   MailOpen: iconMock("MailOpen"),
   RotateCcw: iconMock("RotateCcw"),
   RotateCw: iconMock("RotateCw"),
   Send: iconMock("Send"),
   Sparkles: iconMock("Sparkles"),
   Trash2: iconMock("Trash2"),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) =>
+    createElement("button", props, children),
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { readonly children: React.ReactNode }) =>
+    createElement(React.Fragment, null, children),
+  Tooltip: ({ children }: { readonly children: React.ReactNode }) =>
+    createElement("div", null, children),
+  TooltipTrigger: ({ children }: { readonly children: React.ReactNode }) =>
+    createElement(React.Fragment, null, children),
+  TooltipContent: ({ children }: { readonly children: React.ReactNode }) =>
+    createElement("div", null, children),
 }));
 
 vi.mock("@/app/_components/adventure-scientists-logo", () => ({
@@ -195,6 +216,7 @@ function getButton(name: string): HTMLButtonElement {
 
 function DraftHarness() {
   const [aiDraft, setAiDraft] = useState(initialAiDraft);
+  const [directiveText, setDirectiveText] = useState("");
   const [repromptText, setRepromptText] = useState("");
   const [body, setBody] = useState("");
 
@@ -207,14 +229,6 @@ function DraftHarness() {
 
   return (
     <div>
-      <button
-        type="button"
-        onClick={() => {
-          setStatus("generating");
-        }}
-      >
-        Draft with AI
-      </button>
       <button
         type="button"
         onClick={() => {
@@ -232,9 +246,16 @@ function DraftHarness() {
       <output data-testid="body">{body}</output>
       <ComposerAiDraftWindow
         aiDraft={aiDraft}
+        directiveText={directiveText}
         repromptText={repromptText}
-        isGeneratingAi={false}
+        isGeneratingAi={aiDraft.status === "generating"}
+        runDraftDisabled={aiDraft.status === "generating"}
+        runDraftDisabledReason={null}
+        onDirectiveTextChange={setDirectiveText}
         onRepromptTextChange={setRepromptText}
+        onRunDraft={() => {
+          setStatus("generating");
+        }}
         onOpenReprompt={() => {
           setRepromptText("");
           setStatus("reprompting");
@@ -277,6 +298,9 @@ describe("AI draft preview approval panel", () => {
   it("keeps generated text out of the body until approval", async () => {
     await mount(createElement(DraftHarness));
 
+    expect(document.body.textContent).toContain("AI draft");
+    expect(document.querySelector('[data-testid="body"]')?.textContent).toBe("");
+
     await click(getButton("Draft with AI"));
     expect(document.body.textContent).toContain("AI draft");
     expect(document.body.textContent).not.toContain("Approve");
@@ -292,7 +316,7 @@ describe("AI draft preview approval panel", () => {
     expect(document.querySelector('[data-testid="body"]')?.textContent).toBe(
       "Hi Maya,\n\nThanks for checking in.",
     );
-    expect(document.body.textContent).not.toContain("AI draft");
+    expect(document.body.textContent).toContain("AI draft");
   });
 
   // TODO: re-enable after JSDOM event handler shim is added — Radix DismissableLayer
@@ -319,7 +343,7 @@ describe("AI draft preview approval panel", () => {
     expect(document.body.textContent).not.toContain("Cancel reprompt");
 
     await click(getButton("Discard"));
-    expect(document.body.textContent).not.toContain("AI draft");
+    expect(document.body.textContent).toContain("AI draft");
     expect(document.querySelector('[data-testid="body"]')?.textContent).toBe("");
   });
 });

--- a/apps/web/tests/unit/composer-canonical-modal.test.tsx
+++ b/apps/web/tests/unit/composer-canonical-modal.test.tsx
@@ -166,21 +166,55 @@ vi.mock("../../app/inbox/actions", () => ({
 vi.mock("../../app/inbox/_components/composer-detail-surfaces", () => ({
   ComposerEmailSurface: ({
     attachments,
+    aiDirective,
     body,
+    bccRecipients,
+    ccRecipients,
     onBodyChange,
     onCancel,
+    onAiDirectiveChange,
+    onBccChange,
+    onCcChange,
     onRecipientChange,
     onSubjectChange,
+    onToggleBcc,
+    onToggleCc,
     recipient,
+    runAiDraftDisabled,
+    runAiDraftDisabledReason,
+    showBcc,
+    showCc,
     subject,
   }: {
     readonly attachments: readonly { readonly filename: string }[];
+    readonly aiDirective: string;
     readonly body: string;
+    readonly bccRecipients: readonly {
+      readonly kind: "email";
+      readonly emailAddress: string;
+    }[];
+    readonly ccRecipients: readonly {
+      readonly kind: "email";
+      readonly emailAddress: string;
+    }[];
     readonly onBodyChange: (value: {
       readonly bodyPlaintext: string;
       readonly bodyHtml: string;
     }) => void;
     readonly onCancel: () => void;
+    readonly onAiDirectiveChange: (value: string) => void;
+    readonly onBccChange: (
+      recipients: readonly {
+        readonly kind: "email";
+        readonly emailAddress: string;
+      }[],
+    ) => void;
+    readonly onCcChange: (
+      recipients: readonly {
+        readonly kind: "email";
+        readonly emailAddress: string;
+      }[],
+    ) => void;
     readonly onRecipientChange: (
       recipient: {
         readonly kind: "email";
@@ -188,10 +222,16 @@ vi.mock("../../app/inbox/_components/composer-detail-surfaces", () => ({
       } | null,
     ) => void;
     readonly onSubjectChange: (value: string) => void;
+    readonly onToggleBcc: (open: boolean) => void;
+    readonly onToggleCc: (open: boolean) => void;
     readonly recipient:
       | { readonly kind: "email"; readonly emailAddress: string }
       | { readonly kind: "contact"; readonly displayName: string }
       | null;
+    readonly runAiDraftDisabled: boolean;
+    readonly runAiDraftDisabledReason: string | null;
+    readonly showBcc: boolean;
+    readonly showCc: boolean;
     readonly subject: string;
   }) =>
     createElement(
@@ -246,6 +286,109 @@ vi.mock("../../app/inbox/_components/composer-detail-surfaces", () => ({
         },
         value: body,
       } satisfies TextareaHTMLAttributes<HTMLTextAreaElement>),
+      createElement("textarea", {
+        "aria-label": "AI directive",
+        onChange: (event: ChangeEvent<HTMLTextAreaElement>) => {
+          onAiDirectiveChange(event.currentTarget.value);
+        },
+        onInput: (event: ReactInputEvent<HTMLTextAreaElement>) => {
+          onAiDirectiveChange(event.currentTarget.value);
+        },
+        value: aiDirective,
+      } satisfies TextareaHTMLAttributes<HTMLTextAreaElement>),
+      createElement(
+        "button",
+        {
+          type: "button",
+          disabled: runAiDraftDisabled,
+          title: runAiDraftDisabledReason ?? undefined,
+        },
+        "Draft with AI",
+      ),
+      !showCc
+        ? createElement(
+            "button",
+            {
+              type: "button",
+              onClick: () => {
+                onToggleCc(true);
+              },
+            },
+            "Show Cc",
+          )
+        : null,
+      showCc
+        ? createElement("input", {
+            "aria-label": "Cc",
+            onChange: (event: ChangeEvent<HTMLInputElement>) => {
+              onCcChange(
+                event.currentTarget.value
+                  .split(",")
+                  .map((value) => value.trim())
+                  .filter((value) => value.length > 0)
+                  .map((emailAddress) => ({
+                    kind: "email" as const,
+                    emailAddress,
+                  })),
+              );
+            },
+            onInput: (event: ReactInputEvent<HTMLInputElement>) => {
+              onCcChange(
+                event.currentTarget.value
+                  .split(",")
+                  .map((value) => value.trim())
+                  .filter((value) => value.length > 0)
+                  .map((emailAddress) => ({
+                    kind: "email" as const,
+                    emailAddress,
+                  })),
+              );
+            },
+            value: ccRecipients.map((recipient) => recipient.emailAddress).join(", "),
+          } satisfies InputHTMLAttributes<HTMLInputElement>)
+        : null,
+      !showBcc
+        ? createElement(
+            "button",
+            {
+              type: "button",
+              onClick: () => {
+                onToggleBcc(true);
+              },
+            },
+            "Show Bcc",
+          )
+        : null,
+      showBcc
+        ? createElement("input", {
+            "aria-label": "Bcc",
+            onChange: (event: ChangeEvent<HTMLInputElement>) => {
+              onBccChange(
+                event.currentTarget.value
+                  .split(",")
+                  .map((value) => value.trim())
+                  .filter((value) => value.length > 0)
+                  .map((emailAddress) => ({
+                    kind: "email" as const,
+                    emailAddress,
+                  })),
+              );
+            },
+            onInput: (event: ReactInputEvent<HTMLInputElement>) => {
+              onBccChange(
+                event.currentTarget.value
+                  .split(",")
+                  .map((value) => value.trim())
+                  .filter((value) => value.length > 0)
+                  .map((emailAddress) => ({
+                    kind: "email" as const,
+                    emailAddress,
+                  })),
+              );
+            },
+            value: bccRecipients.map((recipient) => recipient.emailAddress).join(", "),
+          } satisfies InputHTMLAttributes<HTMLInputElement>)
+        : null,
       createElement(
         "ul",
         { "aria-label": "Attachments" },
@@ -692,6 +835,29 @@ describe("composer canonical modal", () => {
     expect(getInput("Subject").value).toBe("Field kit");
     expect(getTextarea("Message body").value).toBe("Please bring the kit.");
     expect(document.body.textContent).toContain("field-kit.txt");
+  });
+
+  it("shows the AI prompt by default and preserves Cc/Bcc drafts across minimize", async () => {
+    await mount(<TestApp />);
+
+    await click(getByText("Open new draft"));
+
+    expect(getTextarea("AI directive").value).toBe("");
+    expect(getByText("Draft with AI")).not.toBeNull();
+
+    await click(getByText("Show Cc"));
+    await changeValue(getInput("Cc"), "partner@example.org");
+    await click(getByText("Show Bcc"));
+    await changeValue(getInput("Bcc"), "archive@example.org");
+    await flushReact();
+
+    await click(
+      document.querySelector("button[aria-label='Minimize composer']"),
+    );
+    await click(document.querySelector("button[aria-label='Expand composer']"));
+
+    expect(getInput("Cc").value).toBe("partner@example.org");
+    expect(getInput("Bcc").value).toBe("archive@example.org");
   });
 
   it("closes from the modal header and from the minimized pill", async () => {

--- a/apps/web/tests/unit/composer-draft-storage.test.ts
+++ b/apps/web/tests/unit/composer-draft-storage.test.ts
@@ -57,6 +57,8 @@ describe("composer draft storage", () => {
       bodyPlaintext: "Hello there",
       bodyHtml: "<p>Hello there</p>",
       selectedAlias: "field@adventuresci.org",
+      cc: ["partner@example.org"],
+      bcc: [],
       attachments: [
         {
           filename: "itinerary.pdf",
@@ -73,6 +75,8 @@ describe("composer draft storage", () => {
       bodyPlaintext: "Hello there",
       bodyHtml: "<p>Hello there</p>",
       selectedAlias: "field@adventuresci.org",
+      cc: ["partner@example.org"],
+      bcc: [],
       attachments: [
         {
           filename: "itinerary.pdf",
@@ -90,6 +94,8 @@ describe("composer draft storage", () => {
       bodyPlaintext: "Body",
       bodyHtml: "<p>Body</p>",
       selectedAlias: null,
+      cc: [],
+      bcc: [],
       attachments: [],
     });
 
@@ -109,6 +115,8 @@ describe("composer draft storage", () => {
       bodyPlaintext: "a".repeat(5_000),
       bodyHtml: `<p>${"a".repeat(5_000)}</p>`,
       selectedAlias: null,
+      cc: [],
+      bcc: [],
       attachments: [],
     });
     saveDraft("composer-draft:v1:actor-1:contact-2:contact", {
@@ -116,6 +124,8 @@ describe("composer draft storage", () => {
       bodyPlaintext: "b".repeat(5_000),
       bodyHtml: `<p>${"b".repeat(5_000)}</p>`,
       selectedAlias: null,
+      cc: [],
+      bcc: [],
       attachments: [],
     });
 

--- a/apps/web/tests/unit/stage3-send-action.test.ts
+++ b/apps/web/tests/unit/stage3-send-action.test.ts
@@ -200,6 +200,34 @@ describe("sendComposerAction", () => {
     );
   });
 
+  it("passes cc and bcc arrays through to the Gmail send client", async () => {
+    sendComposerGmailMessage.mockResolvedValue({
+      kind: "success",
+      gmailMessageId: "gmail-message-2",
+      gmailThreadId: "gmail-thread-2",
+      rfc822MessageId: "<gmail-message-2@example.org>",
+    });
+
+    const result = await sendComposerAction({
+      ...buildInput({
+        recipient: {
+          kind: "contact",
+          contactId: "contact:existing",
+        },
+      }),
+      cc: ["partner@example.org"],
+      bcc: ["archive@example.org"],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(sendComposerGmailMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cc: ["partner@example.org"],
+        bcc: ["archive@example.org"],
+      }),
+    );
+  });
+
   it("maps all typed Gmail send errors into the FP-07 envelope and marks the row failed", async () => {
     const cases = [
       ["auth_error", "composer_unavailable", false],

--- a/packages/contracts/src/stage3-composer.ts
+++ b/packages/contracts/src/stage3-composer.ts
@@ -17,6 +17,8 @@ export const composerAttachmentSchema = z.object({
   contentBase64: z.string().min(1),
 });
 
+const composerEmailAddressSchema = z.string().trim().email();
+
 const composerBodyPlaintextSchema = z
   .string()
   .refine((value) => value.trim().length > 0, {
@@ -36,6 +38,8 @@ export const composerSendInputSchema = z.object({
   bodyPlaintext: composerBodyPlaintextSchema,
   bodyHtml: composerBodyHtmlSchema,
   attachments: z.array(composerAttachmentSchema),
+  cc: z.array(composerEmailAddressSchema).optional(),
+  bcc: z.array(composerEmailAddressSchema).optional(),
   threadId: z.string().min(1).optional(),
   inReplyToRfc822: z.string().min(1).optional(),
   supersedesPendingId: z.string().min(1).optional(),

--- a/packages/integrations/src/providers/gmail-send.ts
+++ b/packages/integrations/src/providers/gmail-send.ts
@@ -22,6 +22,8 @@ const gmailAttachmentSchema = z.object({
 const gmailSendParamsSchema = z.object({
   fromAlias: emailSchema,
   to: emailSchema,
+  cc: z.array(emailSchema).optional(),
+  bcc: z.array(emailSchema).optional(),
   subject: z.string(),
   bodyPlaintext: z.string(),
   bodyHtml: z.string(),
@@ -81,6 +83,8 @@ const gmailApiErrorSchema = z
 export interface GmailSendParams {
   readonly fromAlias: string;
   readonly to: string;
+  readonly cc?: readonly string[];
+  readonly bcc?: readonly string[];
   readonly subject: string;
   readonly bodyPlaintext: string;
   readonly bodyHtml: string;
@@ -228,6 +232,10 @@ function buildAttachmentPart(attachment: GmailAttachment): string {
   ].join("\r\n");
 }
 
+function formatAddressHeader(addresses: readonly string[]): string {
+  return addresses.map((address) => `<${address}>`).join(", ");
+}
+
 function buildMimeMessage(
   params: z.output<typeof gmailSendParamsSchema>,
   now: Date
@@ -241,6 +249,14 @@ function buildMimeMessage(
     `Message-ID: ${rfc822MessageId}`,
     "MIME-Version: 1.0"
   ];
+
+  if (params.cc !== undefined && params.cc.length > 0) {
+    headers.push(`Cc: ${formatAddressHeader(params.cc)}`);
+  }
+
+  if (params.bcc !== undefined && params.bcc.length > 0) {
+    headers.push(`Bcc: ${formatAddressHeader(params.bcc)}`);
+  }
 
   if (params.inReplyToRfc822MessageId !== undefined) {
     headers.push(

--- a/packages/integrations/test/stage3-gmail-send.test.ts
+++ b/packages/integrations/test/stage3-gmail-send.test.ts
@@ -262,6 +262,38 @@ describe("Stage 3 Gmail send client", () => {
     );
   });
 
+  it("includes Cc and Bcc headers when supplementary recipients are provided", async () => {
+    const fetchImplementation = createFetchMock();
+    const result = await sendGmailMessage(
+      {
+        fromAlias: "pnwbio@adventurescientists.org",
+        to: "volunteer@example.org",
+        cc: ["partner@example.org", "guide@example.org"],
+        bcc: ["archive@example.org"],
+        subject: "Field update",
+        bodyPlaintext: "Thanks for the update.",
+        bodyHtml: "<p>Thanks for the update.</p>",
+        attachments: [],
+      },
+      {
+        ...baseConfig,
+        fetchImplementation,
+      },
+    );
+
+    expect(result.kind).toBe("success");
+
+    const sendCall = getFetchCall(fetchImplementation, 1);
+    const rawMessage = decodeRawMessage(
+      String(parseSendRequestBody(sendCall).raw),
+    );
+
+    expect(rawMessage).toContain(
+      "Cc: <partner@example.org>, <guide@example.org>",
+    );
+    expect(rawMessage).toContain("Bcc: <archive@example.org>");
+  });
+
   it("maps Gmail and OAuth failures into the typed error variants", async () => {
     const cases = [
       {


### PR DESCRIPTION
## Summary
- **AI Draft visible by default** (#6): idle-state nudge textarea is always shown when the composer modal is open (review/reprompt/approve flow from #167 preserved). "Draft with AI" button disables with tooltip if Anthropic isn't configured for the project
- **CC and BCC actual functionality** (#10): collapsed by default, Gmail-style "Cc"/"Bcc" toggles reveal real recipient picker fields with chip entry. Reply-prefill captures original Cc. Autosaved with the rest of the draft. Server action passes through to Gmail MIME headers
- **Knowledge warning copy** (#8): footer indicator now distinguishes ready ("Uses [Project] knowledge") vs warning ("No project knowledge configured" amber) states
- **Visual polish** (#7): tightened modal chrome, field rows, toolbar, footer, and minimized pill toward design canon

## Test plan
- [x] `pnpm --filter @as-comms/web typecheck`
- [x] `pnpm --filter @as-comms/web lint`
- [ ] CI to validate `pnpm test:unit` (local blocked by rollup macOS gotcha per `project_macos_rollup_gotcha.md`)
- [ ] Manual via Chrome: AI Draft visible on compose-new; toggle Cc/Bcc; verify recipient chips; send and confirm Gmail headers carry Cc/Bcc; warning indicator on project without AI

## Brief reference
`.codex-composer-iter2-2026-04-27.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) | Codex GPT-5.4 (high)