### PR TITLE
perf(inbox): batch hasProjectNotionContent into one query (hotfix)

### DIFF
--- a/apps/web/app/inbox/_lib/composer-data.ts
+++ b/apps/web/app/inbox/_lib/composer-data.ts
@@ -16,20 +16,14 @@ export async function getInboxComposerAliases(): Promise<
         .filter((projectId): projectId is string => projectId !== null)
     )
   );
-  const projectDimensions =
-    await runtime.repositories.projectDimensions.listByIds(projectIds);
-  const cachedContentEntries = await Promise.all(
-    projectIds.map(async (projectId) => {
-      return [
-        projectId,
-        await runtime.repositories.aiKnowledge.hasProjectNotionContent(projectId),
-      ] as const;
-    }),
-  );
+  const [projectDimensions, projectIdsWithCachedContent] = await Promise.all([
+    runtime.repositories.projectDimensions.listByIds(projectIds),
+    runtime.repositories.aiKnowledge.findProjectIdsWithNotionContent(projectIds),
+  ]);
   const projectById = new Map(
     projectDimensions.map((project) => [project.projectId, project])
   );
-  const hasCachedContentByProjectId = new Map(cachedContentEntries);
+  const hasCachedContentByProjectId = new Set(projectIdsWithCachedContent);
 
   return aliases.flatMap((alias): readonly InboxComposerAliasOption[] => {
     if (alias.projectId === null) {
@@ -49,11 +43,11 @@ export async function getInboxComposerAliases(): Promise<
         projectId: alias.projectId,
         projectName: project.projectName,
         isAiConfigured,
-        hasCachedContent: hasCachedContentByProjectId.get(alias.projectId) === true,
+        hasCachedContent: hasCachedContentByProjectId.has(alias.projectId),
         isAiReady:
           project.isActive === true &&
           isAiConfigured &&
-          hasCachedContentByProjectId.get(alias.projectId) === true,
+          hasCachedContentByProjectId.has(alias.projectId),
       },
     ];
   });

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -892,6 +892,27 @@ function createStage1RepositoriesInternal(
         return row !== undefined;
       },
 
+      async findProjectIdsWithNotionContent(projectIds) {
+        if (projectIds.length === 0) {
+          return [];
+        }
+        const rows = await db
+          .selectDistinct({ scopeKey: aiKnowledgeEntries.scopeKey })
+          .from(aiKnowledgeEntries)
+          .where(
+            and(
+              eq(aiKnowledgeEntries.scope, "project"),
+              eq(aiKnowledgeEntries.sourceProvider, "notion"),
+              inArray(aiKnowledgeEntries.scopeKey, projectIds as string[]),
+              sql`length(btrim(${aiKnowledgeEntries.content})) > 0`,
+            ),
+          );
+
+        return rows
+          .map((row) => row.scopeKey)
+          .filter((key): key is string => key !== null);
+      },
+
       async upsert(record) {
         const values = mapAiKnowledgeEntryToInsert(record);
         const [row] = await db

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -73,6 +73,9 @@ export interface AiKnowledgeRepository {
   }): Promise<AiKnowledgeEntryRecord | null>;
   findProjectNotionContent(projectId: string): Promise<AiKnowledgeEntryRecord | null>;
   hasProjectNotionContent(projectId: string): Promise<boolean>;
+  findProjectIdsWithNotionContent(
+    projectIds: readonly string[],
+  ): Promise<readonly string[]>;
   upsert(record: AiKnowledgeEntryRecord): Promise<AiKnowledgeEntryRecord>;
 }
 

--- a/packages/domain/test/normalization.test.ts
+++ b/packages/domain/test/normalization.test.ts
@@ -281,6 +281,7 @@ function buildContext(input: {
       findByScope: () => Promise.resolve(null),
       findProjectNotionContent: () => Promise.resolve(null),
       hasProjectNotionContent: () => Promise.resolve(false),
+      findProjectIdsWithNotionContent: () => Promise.resolve([]),
       upsert: (record) => Promise.resolve(record),
     },
     projectKnowledge: {

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -44,6 +44,7 @@ describe("defineStage1RepositoryBundle", () => {
         findByScope: () => Promise.resolve(null),
         findProjectNotionContent: () => Promise.resolve(null),
         hasProjectNotionContent: () => Promise.resolve(false),
+        findProjectIdsWithNotionContent: () => Promise.resolve([]),
         upsert: (record) => Promise.resolve(record),
       },
       projectKnowledge: {

--- a/packages/domain/test/stage3-last-inbound-alias.test.ts
+++ b/packages/domain/test/stage3-last-inbound-alias.test.ts
@@ -58,6 +58,7 @@ function buildRepositoryBundle(input: {
       findByScope: () => Promise.resolve(null),
       findProjectNotionContent: () => Promise.resolve(null),
       hasProjectNotionContent: () => Promise.resolve(false),
+      findProjectIdsWithNotionContent: () => Promise.resolve([]),
       upsert: (record) => Promise.resolve(record),
     },
     projectKnowledge: {

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -117,6 +117,7 @@ function createRepositoryBundle(input: {
       findByScope: () => Promise.resolve(null),
       findProjectNotionContent: () => Promise.resolve(null),
       hasProjectNotionContent: () => Promise.resolve(false),
+      findProjectIdsWithNotionContent: () => Promise.resolve([]),
       upsert: (record) => Promise.resolve(record),
     },
     projectKnowledge: {


### PR DESCRIPTION
## Summary
Hotfix for the ~10–13s inbox TTFB regression introduced by [#175](https://github.com/nico-kneler-as/as-comms-platform/pull/175). Inbox layout was issuing **N hasProjectNotionContent queries** (one per project) on every page load via Promise.all in \`composer-data.ts\`. With 3 active projects in prod this added ~10s of latency to every inbox view.

## Fix
Add a batched repo method \`aiKnowledge.findProjectIdsWithNotionContent(projectIds)\` that returns a \`Set<projectId>\` in **one** DISTINCT query against \`ai_knowledge_entries\` using the existing \`scope/scope_key\` index plus \`inArray\`. Composer-data now calls it once and uses Set.has lookups.

This brings composer-data to parity with the settings selectors path, which already used a single \`inArray\` batched query for the same purpose.

## Files changed (7)
- \`packages/domain/src/repositories.ts\` — interface addition
- \`packages/db/src/repositories.ts\` — implementation
- \`apps/web/app/inbox/_lib/composer-data.ts\` — Promise.all → single batched call
- \`packages/domain/test/{repositories,normalization,stage3-last-inbound-alias,timeline}.test.ts\` — mock additions

## Validation
- \`pnpm -r typecheck\` clean
- \`pnpm -r lint\` clean
- Behavior is identical (same boolean per project) — pure perf refactor

## Verification target
Prod TTFB on \`/inbox\` after merge — target back to <2s, ideally <1s.