### PR TITLE
perf(inbox): bound listLastInboundAliasByContactIds to 180 days

### DIFF
--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -1393,6 +1393,10 @@ function createStage1RepositoriesInternal(
           return new Map();
         }
 
+        // Date-bound the scan to avoid an open-ended walk back through history
+        // when a contact's most recent activity is non-Gmail (e.g. SF Tasks).
+        // 180 days is well past any realistic window in which an inbound
+        // project-alias could be assumed stable for membership resolution.
         const result = await db.execute(
           sql`
             select distinct on (${canonicalEventLedger.contactId})
@@ -1404,6 +1408,7 @@ function createStage1RepositoriesInternal(
             where ${inArray(canonicalEventLedger.contactId, [...contactIds])}
               and ${gmailMessageDetails.direction} = 'inbound'
               and ${gmailMessageDetails.projectInboxAlias} is not null
+              and ${canonicalEventLedger.occurredAt} > now() - interval '180 days'
             order by
               ${canonicalEventLedger.contactId},
               ${canonicalEventLedger.occurredAt} desc


### PR DESCRIPTION
## Summary
Hotfix #2 for the inbox TTFB regression. PR [#176](https://github.com/nico-kneler-as/as-comms-platform/pull/176) batched the composer-data N+1 but inbox was still ~14s. This PR bounds the alias-aware-sort query added in [#174](https://github.com/nico-kneler-as/as-comms-platform/pull/174) — it was an unbounded scan that walked canonical_event_ledger backwards per contact looking for a Gmail inbound row, which at prod scale became the bottleneck.

## Diagnosis
\`listLastInboundAliasByContactIds\` (in packages/db/src/repositories.ts) is called for every inbox page load. For each contact in the page, the planner walks the canonical_event_ledger contact-occurred-desc index backward until it finds a row that joins to gmail_message_details with direction='inbound' and a non-null project_inbox_alias. When the most recent activity is non-Gmail (Salesforce Task, internal note, outbound reply), the walk continues into history. Across many contacts × many months of history, this dominates inbox TTFB.

## Fix
Add \`canonicalEventLedger.occurredAt > now() - interval '180 days'\` to the WHERE clause. The same \`canonical_event_ledger_contact_occurred_idx\` covers it. 180 days is far past any realistic window for "which project alias did this volunteer last write to" — a stale answer beyond that has no membership-resolution value.

## Behavior change
For volunteers with no inbound Gmail in the last 180 days, the membership resolver falls back to its non-alias path (sortMembershipsByCreatedAt). This is the same fallback that already runs for volunteers with no inbound Gmail at all.

## Validation
- \`pnpm -r typecheck\` clean
- \`pnpm -r lint\` clean

## Verification
Re-time prod TTFB on /inbox after merge.