### PR TITLE
diag(inbox): temporary timing logs to identify TTFB bottleneck

### DIFF
--- a/apps/web/app/inbox/layout.tsx
+++ b/apps/web/app/inbox/layout.tsx
@@ -44,11 +44,22 @@ export default async function InboxLayout({
     throw error;
   });
 
+  const __t0 = Date.now();
+  async function __timed<T>(label: string, p: Promise<T>): Promise<T> {
+    const s = Date.now();
+    try {
+      return await p;
+    } finally {
+      console.log(`[ibx-perf] ${label}=${String(Date.now() - s)}ms`);
+    }
+  }
+  console.log(`[ibx-perf] start session=${currentUser.id}`);
   const [list, composerAliases, healthBanner] = await Promise.all([
-    getInboxList("all"),
-    getInboxComposerAliases(),
-    getInboxIntegrationHealthBanner(),
+    __timed("getInboxList", getInboxList("all")),
+    __timed("getInboxComposerAliases", getInboxComposerAliases()),
+    __timed("getInboxIntegrationHealthBanner", getInboxIntegrationHealthBanner()),
   ]);
+  console.log(`[ibx-perf] total=${String(Date.now() - __t0)}ms`);
 
   return (
     <InboxShell


### PR DESCRIPTION
Diagnostic-only — adds `[ibx-perf]` console.log around the three parallel fetches in inbox layout. Two prior hotfixes didn't move the 14s TTFB; this gets us actual per-fetch numbers from prod. Will be reverted right after the diagnosis.