### PR TITLE
perf(db): raise pool size from 1 to 20; revert inbox diag logs

### DIFF
--- a/apps/web/app/inbox/layout.tsx
+++ b/apps/web/app/inbox/layout.tsx
@@ -44,22 +44,11 @@ export default async function InboxLayout({
     throw error;
   });
 
-  const __t0 = Date.now();
-  async function __timed<T>(label: string, p: Promise<T>): Promise<T> {
-    const s = Date.now();
-    try {
-      return await p;
-    } finally {
-      console.log(`[ibx-perf] ${label}=${String(Date.now() - s)}ms`);
-    }
-  }
-  console.log(`[ibx-perf] start session=${currentUser.id}`);
   const [list, composerAliases, healthBanner] = await Promise.all([
-    __timed("getInboxList", getInboxList("all")),
-    __timed("getInboxComposerAliases", getInboxComposerAliases()),
-    __timed("getInboxIntegrationHealthBanner", getInboxIntegrationHealthBanner()),
+    getInboxList("all"),
+    getInboxComposerAliases(),
+    getInboxIntegrationHealthBanner(),
   ]);
-  console.log(`[ibx-perf] total=${String(Date.now() - __t0)}ms`);
 
   return (
     <InboxShell

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -19,8 +19,17 @@ export interface DatabaseConnection {
 
 export function createDatabaseConnection(rawConfig: DatabaseConfig): DatabaseConnection {
   const config = databaseConfigSchema.parse(rawConfig);
+  // Pool sized to allow Promise.all-style parallel queries within a single
+  // request. The inbox layout fires 3 in parallel (getInboxList,
+  // getInboxComposerAliases, getInboxIntegrationHealthBanner) and each of
+  // those internally does ~5-10 queries also via Promise.all. With max:1
+  // every "parallel" query serialized on the one connection, blowing inbox
+  // TTFB to ~5-6s. 20 fits comfortably under Railway's managed-Postgres
+  // connection budget across the web + worker services. Override via
+  // DB_POOL_MAX env var if Railway tier limits change.
+  const poolSize = Number.parseInt(process.env.DB_POOL_MAX ?? "20", 10);
   const sql = postgres(config.connectionString, {
-    max: 1,
+    max: Number.isFinite(poolSize) && poolSize > 0 ? poolSize : 20,
     prepare: false
   });
 


### PR DESCRIPTION
## Root cause (finally)
\`packages/db/src/client.ts\` created the postgres client with **\`max: 1\`** — every \`Promise.all\`-style parallel query within a request serialized on the single connection.

Diagnostic logs added in [#178](https://github.com/nico-kneler-as/as-comms-platform/pull/178) confirmed:
\`\`\`
[ibx-perf] start session=...
[ibx-perf] getInboxComposerAliases=5548ms
[ibx-perf] getInboxIntegrationHealthBanner=5549ms
[ibx-perf] getInboxList=5832ms
[ibx-perf] total=5245ms
\`\`\`
All three "parallel" fetches finishing at the same time = three queries queuing on one connection. Classic.

## Why earlier hotfixes helped but didn't solve it
- [#176](https://github.com/nico-kneler-as/as-comms-platform/pull/176) (composer-data batch) and [#177](https://github.com/nico-kneler-as/as-comms-platform/pull/177) (alias query date bound) reduced the **work** done per query, which lowered each fetch's actual SQL time. That's why TTFB dropped from ~14s → ~6s.
- But the underlying serialization stayed in place. Three fetches × ~1.8s of actual SQL each ≈ 5.5s wall time on a single connection.

## Fix
\`max: 1\` → \`max: 20\` (overridable via \`DB_POOL_MAX\`). Comfortably under Railway managed-Postgres connection budget across web (3 containers × ~15 connections each peak = 45) + worker (~5) + capture services. Plenty of headroom against the 100+ default cap.

This change is the right fix on its own; #176 and #177 are still useful (less DB work per request is always good).

## Also reverts
The diagnostic console.log instrumentation added by #178 — its job is done.

## Validation
- \`pnpm typecheck\` clean (db + web)
- \`pnpm -r lint\` clean

## Verification
Re-time prod TTFB on /inbox after merge. Expecting <1s warm.