### PR TITLE
perf(db): warm connection pool at server boot

### DIFF
--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,0 +1,35 @@
+/**
+ * Next.js server-startup hook (Next 15+ auto-loads `instrumentation.ts` at
+ * the project root). Eagerly opens database connections so the first user
+ * request after a cold deploy doesn't pay the connection-handshake cost.
+ *
+ * Edge runtime is intentionally skipped — the postgres-js client is Node-only.
+ * Failures are swallowed so DB warm-up issues never crash the server.
+ */
+export async function register(): Promise<void> {
+  if (process.env.NEXT_RUNTIME !== "nodejs") {
+    return;
+  }
+  try {
+    const [{ getStage1WebRuntime }, { warmConnectionPool }] = await Promise.all([
+      import("@/src/server/stage1-runtime"),
+      import("@as-comms/db")
+    ]);
+    const runtime = await getStage1WebRuntime();
+    if (runtime.connection === null) {
+      return;
+    }
+    const probeCountRaw = Number.parseInt(
+      process.env.DB_WARM_PROBES ?? "5",
+      10
+    );
+    const probeCount =
+      Number.isFinite(probeCountRaw) && probeCountRaw > 0 ? probeCountRaw : 5;
+    await warmConnectionPool(runtime.connection, probeCount);
+    console.log(
+      `[db] connection pool warmed with ${String(probeCount)} probes at boot`
+    );
+  } catch (error) {
+    console.warn("[db] connection pool warm-up failed:", error);
+  }
+}

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -42,3 +42,31 @@ export function createDatabaseConnection(rawConfig: DatabaseConfig): DatabaseCon
 export async function closeDatabaseConnection(connection: DatabaseConnection): Promise<void> {
   await connection.sql.end({ timeout: 5 });
 }
+
+/**
+ * Eagerly opens N connections in the pool by issuing N parallel trivial
+ * queries. Use at server boot (e.g. via Next.js instrumentation.ts) so the
+ * first user request doesn't pay the connection-handshake cost.
+ *
+ * Errors are swallowed and logged — DB warm-up failure should never crash
+ * the server. The next real query will retry the connection naturally.
+ */
+export async function warmConnectionPool(
+  connection: Pick<DatabaseConnection, "sql">,
+  count: number,
+): Promise<void> {
+  if (count <= 0) {
+    return;
+  }
+  const probes = Array.from({ length: count }, async (_, index) => {
+    try {
+      await connection.sql`select 1`;
+    } catch (error) {
+      console.warn(
+        `[db] warm-up probe ${String(index + 1)}/${String(count)} failed:`,
+        error,
+      );
+    }
+  });
+  await Promise.all(probes);
+}


### PR DESCRIPTION
## Summary
After [#179](https://github.com/nico-kneler-as/as-comms-platform/pull/179) raised the DB pool to \`max: 20\`, the pool itself was still opened lazily on first query. So the very first user to hit a freshly-deployed container paid the connection-handshake cost (~500ms-1s extra). This wires up Next 15's \`instrumentation.ts\` server-boot hook to fire 5 trivial \`select 1\` probes at startup, populating the pool before any user request lands.

## Changes
- \`packages/db/src/client.ts\`: new \`warmConnectionPool(connection, count)\` exported helper. Fires N parallel probes; swallows + logs errors so warmup failure can never crash boot
- \`apps/web/instrumentation.ts\` (new file): Next.js \`register()\` hook that runs once at server boot on the Node runtime (skipped on Edge). Awaits the runtime singleton + warmup, configurable probe count via \`DB_WARM_PROBES\` (default 5)

## Risk
Very low. Worst case: warmup fails silently, server starts normally, first query reconnects on demand exactly like today. Failure mode is identical to the pre-warmup behavior.

## Validation
- \`pnpm typecheck\` clean (db + web)
- \`pnpm lint\` clean

## Verification
First /inbox load after deploy should show TTFB closer to the warm-load number (~1.7s) instead of the cold-load number (~2.1s).