### PR TITLE
perf(db): warm connection pool at server boot (v2)

### DIFF
--- a/apps/web/instrumentation-node.ts
+++ b/apps/web/instrumentation-node.ts
@@ -1,0 +1,24 @@
+/**
+ * Node-runtime-only instrumentation. Imported dynamically from
+ * `instrumentation.ts` so the postgres-js + drizzle module graph never
+ * enters the Edge bundle.
+ */
+import { warmConnectionPool } from "@as-comms/db";
+
+import { getStage1WebRuntime } from "@/src/server/stage1-runtime";
+
+const probeCountRaw = Number.parseInt(process.env.DB_WARM_PROBES ?? "5", 10);
+const probeCount =
+  Number.isFinite(probeCountRaw) && probeCountRaw > 0 ? probeCountRaw : 5;
+
+try {
+  const runtime = await getStage1WebRuntime();
+  if (runtime.connection !== null) {
+    await warmConnectionPool(runtime.connection, probeCount);
+    console.log(
+      `[db] connection pool warmed with ${String(probeCount)} probes at boot`
+    );
+  }
+} catch (error) {
+  console.warn("[db] connection pool warm-up failed:", error);
+}

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,0 +1,11 @@
+/**
+ * Next.js server-startup hook (Next 15+ auto-loads `instrumentation.ts` at
+ * the project root). Stays trivial — just dispatches into the Node-only
+ * inner module so webpack never traces postgres-js into the Edge bundle.
+ */
+export async function register(): Promise<void> {
+  if (process.env.NEXT_RUNTIME !== "nodejs") {
+    return;
+  }
+  await import("./instrumentation-node");
+}

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -42,3 +42,31 @@ export function createDatabaseConnection(rawConfig: DatabaseConfig): DatabaseCon
 export async function closeDatabaseConnection(connection: DatabaseConnection): Promise<void> {
   await connection.sql.end({ timeout: 5 });
 }
+
+/**
+ * Eagerly opens N connections in the pool by issuing N parallel trivial
+ * queries. Use at server boot (e.g. via Next.js instrumentation.ts) so the
+ * first user request doesn't pay the connection-handshake cost.
+ *
+ * Errors are swallowed and logged — DB warm-up failure should never crash
+ * the server. The next real query will retry the connection naturally.
+ */
+export async function warmConnectionPool(
+  connection: Pick<DatabaseConnection, "sql">,
+  count: number,
+): Promise<void> {
+  if (count <= 0) {
+    return;
+  }
+  const probes = Array.from({ length: count }, async (_, index) => {
+    try {
+      await connection.sql`select 1`;
+    } catch (error) {
+      console.warn(
+        `[db] warm-up probe ${String(index + 1)}/${String(count)} failed:`,
+        error,
+      );
+    }
+  });
+  await Promise.all(probes);
+}


### PR DESCRIPTION
Supersedes [#180](https://github.com/nico-kneler-as/as-comms-platform/pull/180) (closed — broke the Edge build).

## Why
After [#179](https://github.com/nico-kneler-as/as-comms-platform/pull/179) raised the pool to \`max: 20\`, the pool itself was still opened lazily on first query. The first user to hit a fresh container after a deploy paid ~500ms-1s of connection-handshake cost.

## Fix
Wire up Next 15's \`instrumentation.ts\` server-boot hook to fire 5 trivial \`select 1\` probes at startup, populating the pool before any user request lands.

## Why two files this time
\`#180\` failed CI because Next compiles \`instrumentation.ts\` for both Node AND Edge runtimes; even with dynamic-import + \`NEXT_RUNTIME\` guard inside \`register()\`, webpack still traced the postgres-js graph for Edge and choked on Node-only \`stream\`. The fix is the standard Next pattern:
- \`instrumentation.ts\` stays trivial (just runtime guard + \`await import("./instrumentation-node")\`)
- \`instrumentation-node.ts\` holds the actual postgres-js warmup, only loaded via that conditional dynamic import

This keeps postgres-js out of the Edge bundle entirely.

## Risk
Same as #180 — very low. Worst case warmup fails silently, server starts normally, first query reconnects on demand.

## Validation
- \`pnpm typecheck\` clean (db + web)
- \`pnpm lint\` clean (db + web)