### PR TITLE
feat(inbox): rail Active/Past discriminates by project.is_active + R.1 fix

### DIFF
--- a/apps/web/app/inbox/_components/inbox-contact-rail.tsx
+++ b/apps/web/app/inbox/_components/inbox-contact-rail.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { SectionLabel } from "@/components/ui/section-label";
 import { StatusBadge } from "@/components/ui/status-badge";
 import { PROJECT_STATUS_BADGE } from "@/app/_lib/design-tokens";
+import { ExternalLink } from "lucide-react";
 import {
   LAYOUT,
   SPACING,
@@ -150,6 +151,8 @@ interface ProjectsSectionProps {
 }
 
 function ProjectsSection({ title, projects, emptyLabel }: ProjectsSectionProps) {
+  const isPastSection = title === "Past Projects";
+
   return (
     <section className={`border-b border-slate-200 ${SPACING.section}`}>
       <SectionLabel as="h3">
@@ -161,17 +164,12 @@ function ProjectsSection({ title, projects, emptyLabel }: ProjectsSectionProps) 
         <ul className="mt-2 space-y-1">
           {projects.map((project) => {
             const tone = STATUS_TONE[project.status];
-            return (
-              <li
-                key={project.membershipId}
-                className="group flex items-center gap-2 rounded-lg px-2 py-1.5 transition hover:bg-white hover:ring-1 hover:ring-slate-200"
-              >
-                <a
-                  href={project.expeditionMemberUrl ?? project.crmUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="flex min-w-0 flex-1 items-center gap-2"
-                >
+            const rowClassName =
+              "group flex items-center gap-2 rounded-lg px-2 py-1.5 transition";
+            const isClickable = project.expeditionMemberUrl !== null;
+            const content = (
+              <>
+                <div className="flex min-w-0 flex-1 items-center gap-2">
                   <span
                     aria-hidden="true"
                     className={`mt-1 h-1.5 w-1.5 shrink-0 rounded-full ${TONE_CLASSES[tone].dot}`}
@@ -181,23 +179,45 @@ function ProjectsSection({ title, projects, emptyLabel }: ProjectsSectionProps) 
                       {project.projectName}
                     </p>
                     <p className="mt-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
-                      <span className="tabular-nums">
-                        {project.year.toString()}
-                      </span>
-                      <span className="text-slate-300">·</span>
-                      <InboxProjectStatusBadge status={project.status} />
+                      {isPastSection ? (
+                        <>
+                          <span className="tabular-nums">
+                            {project.signupYear.toString()}
+                          </span>
+                          <span className="text-slate-300">·</span>
+                        </>
+                      ) : null}
+                      <InboxProjectStatusBadge
+                        status={project.status}
+                        label={project.statusLabel}
+                      />
                     </p>
                   </div>
-                </a>
-                <a
-                  href={project.crmUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                  aria-label={`Open ${project.projectName} project page in Salesforce`}
-                  className="shrink-0 rounded text-[11px] text-slate-400 transition hover:text-slate-600"
-                >
-                  ↗ Project
-                </a>
+                </div>
+                {isClickable ? (
+                  <ExternalLink
+                    aria-hidden="true"
+                    className="h-3.5 w-3.5 shrink-0 text-slate-400 opacity-0 transition group-hover:opacity-100"
+                  />
+                ) : null}
+              </>
+            );
+
+            return (
+              <li key={project.membershipId}>
+                {!isClickable ? (
+                  <div className={rowClassName}>{content}</div>
+                ) : (
+                  <a
+                    href={project.expeditionMemberUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className={`${rowClassName} hover:bg-white hover:ring-1 hover:ring-slate-200`}
+                    aria-label={`Open ${project.projectName} expedition member record in Salesforce`}
+                  >
+                    {content}
+                  </a>
+                )}
               </li>
             );
           })}
@@ -206,15 +226,6 @@ function ProjectsSection({ title, projects, emptyLabel }: ProjectsSectionProps) 
     </section>
   );
 }
-
-const PROJECT_STATUS_LABEL: Record<InboxProjectStatus, string> = {
-  lead: "Lead",
-  applied: "Applied",
-  "in-training": "In Training",
-  "trip-planning": "Trip Planning",
-  "in-field": "In the Field",
-  successful: "Successful"
-};
 
 const STATUS_TONE: Record<InboxProjectStatus, ToneNameV2> = {
   lead: "slate",
@@ -226,15 +237,17 @@ const STATUS_TONE: Record<InboxProjectStatus, ToneNameV2> = {
 };
 
 export function InboxProjectStatusBadge({
-  status
+  status,
+  label,
 }: {
   readonly status: InboxProjectStatus;
+  readonly label: string;
 }) {
   return (
     <StatusBadge
       variant="subtle"
       colorClasses={PROJECT_STATUS_BADGE[status]}
-      label={PROJECT_STATUS_LABEL[status]}
+      label={label}
     />
   );
 }

--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -415,9 +415,12 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
               {activeProject ? (
                 <div className="flex min-w-0 items-center gap-2 text-xs">
                   <span className="min-w-0 truncate font-medium text-slate-700">
-                    {activeProject.projectName} {activeProject.year.toString()}
+                    {activeProject.projectName}
                   </span>
-                  <InboxProjectStatusBadge status={activeProject.status} />
+                  <InboxProjectStatusBadge
+                    status={activeProject.status}
+                    label={activeProject.statusLabel}
+                  />
                 </div>
               ) : (
                 <span className="text-xs text-slate-400">

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -87,7 +87,15 @@ interface InboxDetailCacheData {
   readonly campaignActivitySummaryByCampaignId: Readonly<
     Record<string, CampaignActivitySummary>
   >;
-  readonly projectNameById: Readonly<Record<string, string>>;
+  readonly projectMetadataById: Readonly<
+    Record<
+      string,
+      {
+        readonly projectName: string;
+        readonly isActive: boolean;
+      }
+    >
+  >;
   readonly projectLabelByAlias: ReadonlyMap<string, string>;
   readonly timelinePage: {
     readonly hasMore: boolean;
@@ -535,6 +543,7 @@ function membershipSortRank(membership: ContactMembershipRecord): number {
     case "trip-planning":
       return 3;
     case "in-field":
+    case "in-the-field":
     case "active":
       return 4;
     case "successful":
@@ -589,6 +598,7 @@ function mapVolunteerStage(
     case "training":
     case "trip-planning":
     case "in-field":
+    case "in-the-field":
     case "active":
       return "active";
     case "successful":
@@ -635,6 +645,7 @@ function mapProjectStatus(status: string | null): InboxProjectStatus {
     case "trip-planning":
       return "trip-planning";
     case "in-field":
+    case "in-the-field":
     case "active":
       return "in-field";
     case "successful":
@@ -642,6 +653,49 @@ function mapProjectStatus(status: string | null): InboxProjectStatus {
       return "successful";
     default:
       return "applied";
+  }
+}
+
+function mapProjectStatusLabel(status: string | null): string {
+  switch (normalizeMembershipStatus(status)) {
+    case "lead":
+      return "Lead";
+    case "confirmed":
+      return "Confirmed";
+    case "applied":
+    case "applicant":
+      return "Applied";
+    case "pending-acceptance":
+      return "Pending Acceptance";
+    case "accepted":
+      return "Accepted";
+    case "in-training":
+    case "training":
+      return "In Training";
+    case "trip-planning":
+      return "Trip Planning";
+    case "in-field":
+    case "in-the-field":
+    case "active":
+      return "In the Field";
+    case "returning-gear":
+      return "Returning Gear";
+    case "successful":
+      return "Successful";
+    case "completed":
+      return "Completed";
+    case "denied":
+      return "Denied";
+    case "declined":
+      return "Declined";
+    case "aborted":
+      return "Aborted";
+    case "failed":
+      return "Failed";
+    case "waitlist":
+      return "Waitlist";
+    default:
+      return "Applied";
   }
 }
 
@@ -658,9 +712,21 @@ function resolveProjectName(
 
 function buildProjectMembershipViewModel(
   membership: ContactMembershipRecord,
-  projectNameById: Readonly<Record<string, string>>,
+  projectMetadataById: Readonly<
+    Record<
+      string,
+      {
+        readonly projectName: string;
+        readonly isActive: boolean;
+      }
+    >
+  >,
 ): InboxProjectMembershipViewModel | null {
-  const projectName = resolveProjectName(membership, projectNameById);
+  const projectName =
+    membership.projectId === null
+      ? null
+      : (projectMetadataById[membership.projectId]?.projectName ??
+        membership.projectId);
 
   if (projectName === null || membership.projectId === null) {
     return null;
@@ -670,10 +736,11 @@ function buildProjectMembershipViewModel(
     membershipId: membership.id,
     projectId: membership.projectId,
     projectName,
-    // Gap: the canonical membership season/year is not persisted yet, so the
-    // shell keeps its existing contract with a selector-derived current year.
-    year: new Date().getUTCFullYear(),
+    signupYear: new Date(membership.createdAt).getUTCFullYear(),
+    projectIsActive:
+      projectMetadataById[membership.projectId]?.isActive ?? false,
     status: mapProjectStatus(membership.status),
+    statusLabel: mapProjectStatusLabel(membership.status),
     crmUrl: `https://adventurescientists.lightning.force.com/lightning/r/Project__c/${encodeURIComponent(
       membership.projectId,
     )}/view`,
@@ -685,8 +752,23 @@ function buildProjectMembershipViewModel(
   };
 }
 
-function isPastProject(status: InboxProjectStatus): boolean {
-  return status === "successful";
+function isPastProject(
+  membership: ContactMembershipRecord,
+  projectMetadataById: Readonly<
+    Record<
+      string,
+      {
+        readonly projectName: string;
+        readonly isActive: boolean;
+      }
+    >
+  >,
+): boolean {
+  if (membership.projectId === null) {
+    return true;
+  }
+
+  return !(projectMetadataById[membership.projectId]?.isActive ?? false);
 }
 
 function formatJoinedAtLabel(createdAt: string): string {
@@ -2114,9 +2196,19 @@ function groupMembershipsByContactId(
   return grouped;
 }
 
-async function loadProjectNameById(
+async function loadProjectMetadataById(
   memberships: readonly ContactMembershipRecord[],
-): Promise<Readonly<Record<string, string>>> {
+): Promise<
+  Readonly<
+    Record<
+      string,
+      {
+        readonly projectName: string;
+        readonly isActive: boolean;
+      }
+    >
+  >
+> {
   const projectIds = uniqueStrings(
     memberships.map((membership) => membership.projectId),
   );
@@ -2130,7 +2222,29 @@ async function loadProjectNameById(
     await runtime.repositories.projectDimensions.listByIds(projectIds);
 
   return Object.fromEntries(
-    dimensions.map((dimension) => [dimension.projectId, dimension.projectName]),
+    dimensions.map((dimension) => [
+      dimension.projectId,
+      {
+        projectName:
+          dimension.projectAlias?.trim().length
+            ? dimension.projectAlias
+            : dimension.projectName,
+        isActive: dimension.isActive ?? false,
+      },
+    ]),
+  );
+}
+
+async function loadProjectNameById(
+  memberships: readonly ContactMembershipRecord[],
+): Promise<Readonly<Record<string, string>>> {
+  const projectMetadataById = await loadProjectMetadataById(memberships);
+
+  return Object.fromEntries(
+    Object.entries(projectMetadataById).map(([projectId, metadata]) => [
+      projectId,
+      metadata.projectName,
+    ]),
   );
 }
 
@@ -2672,7 +2786,7 @@ async function readInboxDetailCacheData(
         runtime,
         canonicalEvents,
       }),
-    projectNameById: await loadProjectLabelById(memberships),
+    projectMetadataById: await loadProjectMetadataById(memberships),
     projectLabelByAlias: await loadProjectLabelByAlias(projectAliasRecords),
     timelinePage: {
       hasMore: timelinePage.hasMore,
@@ -2843,13 +2957,30 @@ function buildContactSummary(input: {
     readonly createdAt: string;
   } | null;
   readonly activityTimelineItems: readonly TimelineItem[];
-  readonly projectNameById: Readonly<Record<string, string>>;
+  readonly projectMetadataById: Readonly<
+    Record<
+      string,
+      {
+        readonly projectName: string;
+        readonly isActive: boolean;
+      }
+    >
+  >;
   readonly referenceNowIso: string;
 }): InboxContactSummaryViewModel {
-  const memberships = sortMembershipsByCreatedAt(input.memberships);
-  const projectMemberships = memberships
+  const activeProjects = sortMemberships(input.memberships)
+    .filter((membership) => !isPastProject(membership, input.projectMetadataById))
     .map((membership) =>
-      buildProjectMembershipViewModel(membership, input.projectNameById),
+      buildProjectMembershipViewModel(membership, input.projectMetadataById),
+    )
+    .filter(
+      (membership): membership is InboxProjectMembershipViewModel =>
+        membership !== null,
+    );
+  const pastProjects = sortMembershipsByCreatedAt(input.memberships)
+    .filter((membership) => isPastProject(membership, input.projectMetadataById))
+    .map((membership) =>
+      buildProjectMembershipViewModel(membership, input.projectMetadataById),
     )
     .filter(
       (membership): membership is InboxProjectMembershipViewModel =>
@@ -2875,12 +3006,8 @@ function buildContactSummary(input: {
               input.referenceNowIso,
             ),
           },
-    activeProjects: projectMemberships.filter(
-      (membership) => !isPastProject(membership.status),
-    ),
-    pastProjects: projectMemberships.filter((membership) =>
-      isPastProject(membership.status),
-    ),
+    activeProjects,
+    pastProjects,
     recentActivity: buildRecentActivity(
       input.activityTimelineItems,
       input.referenceNowIso,
@@ -3090,7 +3217,7 @@ export async function getInboxDetail(
       memberships: cachedData.memberships,
       latestNote: cachedData.latestNote,
       activityTimelineItems: cachedData.activityTimelineItems,
-      projectNameById: cachedData.projectNameById,
+      projectMetadataById: cachedData.projectMetadataById,
       referenceNowIso,
     }),
     timeline: cachedData.timelineItems.map((item) =>

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -100,8 +100,10 @@ export interface InboxProjectMembershipViewModel {
   readonly membershipId: string;
   readonly projectId: string;
   readonly projectName: string;
-  readonly year: number;
+  readonly signupYear: number;
+  readonly projectIsActive: boolean;
   readonly status: InboxProjectStatus;
+  readonly statusLabel: string;
   readonly crmUrl: string;
   readonly expeditionMemberUrl: string | null;
 }

--- a/apps/web/tests/unit/composer-canonical-modal.test.tsx
+++ b/apps/web/tests/unit/composer-canonical-modal.test.tsx
@@ -163,6 +163,23 @@ vi.mock("../../app/inbox/actions", () => ({
   sendComposerAction: vi.fn(),
 }));
 
+vi.mock("../../app/inbox/_components/composer-shared", async () => {
+  const actual = await vi.importActual(
+    "../../app/inbox/_components/composer-shared",
+  );
+
+  return {
+    ...actual,
+    readFileAsAttachment: async (file: File) => ({
+      id: `${file.name}:${String(file.size)}`,
+      filename: file.name,
+      size: file.size,
+      contentType: file.type || "application/octet-stream",
+      contentBase64: "YXR0YWNobWVudC1ib2R5",
+    }),
+  };
+});
+
 vi.mock("../../app/inbox/_components/composer-detail-surfaces", () => ({
   ComposerEmailSurface: ({
     attachments,

--- a/apps/web/tests/unit/composer-canonical-modal.test.tsx
+++ b/apps/web/tests/unit/composer-canonical-modal.test.tsx
@@ -170,13 +170,14 @@ vi.mock("../../app/inbox/_components/composer-shared", async () => {
 
   return {
     ...actual,
-    readFileAsAttachment: async (file: File) => ({
-      id: `${file.name}:${String(file.size)}`,
-      filename: file.name,
-      size: file.size,
-      contentType: file.type || "application/octet-stream",
-      contentBase64: "YXR0YWNobWVudC1ib2R5",
-    }),
+    readFileAsAttachment: (file: File) =>
+      Promise.resolve({
+        id: `${file.name}:${String(file.size)}`,
+        filename: file.name,
+        size: file.size,
+        contentType: file.type || "application/octet-stream",
+        contentBase64: "YXR0YWNobWVudC1ib2R5",
+      }),
   };
 });
 

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -1098,6 +1098,7 @@ describe("real inbox selectors", () => {
     expect(detail?.contact.activeProjects[0]).toMatchObject({
       projectName: "Amazon Basin Research",
       status: "in-training",
+      statusLabel: "In Training",
       crmUrl:
         "https://adventurescientists.lightning.force.com/lightning/r/Project__c/project%3Aamazon-basin/view",
       expeditionMemberUrl:
@@ -1119,7 +1120,7 @@ describe("real inbox selectors", () => {
     });
   });
 
-  it("renders the contact rail project card with expeditionMemberUrl as primary and crmUrl as secondary", async () => {
+  it("renders the contact rail project row as a single expedition-member anchor with a hover affordance", async () => {
     const detail = await getInboxDetail("contact:sarah-martinez");
 
     if (detail === null) {
@@ -1134,12 +1135,19 @@ describe("real inbox selectors", () => {
     expect(markup).toContain(
       'href="https://adventurescientists.lightning.force.com/lightning/r/Expedition_Members__c/a0B-sarah-membership/view"',
     );
-    expect(markup).toContain(
-      'href="https://adventurescientists.lightning.force.com/lightning/r/Project__c/project%3Aamazon-basin/view"',
-    );
+    expect(markup).toContain("group-hover:opacity-100");
+    expect(markup).not.toContain("↗ Project");
   });
 
-  it("falls back to crmUrl as the primary project link when expeditionMemberUrl is null", async () => {
+  it("does not render a project-page fallback link when expeditionMemberUrl is null", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await runtime.context.settings.projects.setActive(
+      "project:killer-whales",
+      false,
+    );
     const detail = await getInboxDetail("contact:lisa-zhang");
 
     if (detail === null) {
@@ -1151,10 +1159,254 @@ describe("real inbox selectors", () => {
       }),
     );
 
-    expect(markup).toContain(
-      'href="https://adventurescientists.lightning.force.com/lightning/r/Project__c/project%3Akiller-whales/view"',
-    );
+    expect(markup).not.toContain("href=");
     expect(markup).not.toContain("Expedition_Members__c");
+  });
+
+  it("keeps a successful membership on an active project in Active Projects", async () => {
+    const detail = await getInboxDetail("contact:lisa-zhang");
+
+    expect(detail).not.toBeNull();
+    expect(detail?.contact.activeProjects).toHaveLength(1);
+    expect(detail?.contact.activeProjects[0]).toMatchObject({
+      projectName: "Searching for Killer Whales",
+      projectIsActive: true,
+      status: "successful",
+      statusLabel: "Successful",
+    });
+    expect(detail?.contact.pastProjects).toHaveLength(0);
+  });
+
+  it("places inactive memberships in Past Projects regardless of volunteer status", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:ryan-davis",
+      salesforceContactId: "003-ryan",
+      displayName: "Ryan Davis",
+      primaryEmail: "ryan@example.org",
+      primaryPhone: null,
+      projectId: "project:plastic-free-parks",
+      projectName: "Plastic Free Parks 2025",
+      membershipId: "membership:ryan:parks",
+      salesforceMembershipId: "a0B-ryan-parks",
+      membershipStatus: "applied",
+      membershipCreatedAt: "2024-02-01T12:00:00.000Z",
+    });
+    await runtime.context.settings.projects.setActive(
+      "project:plastic-free-parks",
+      false,
+    );
+    const latest = await seedInboxEmailEvent(runtime.context, {
+      id: "ryan-inbound-1",
+      contactId: "contact:ryan-davis",
+      occurredAt: "2026-04-20T13:00:00.000Z",
+      direction: "inbound",
+      subject: "Checking project placement",
+      snippet: "This project should now be in past projects.",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:ryan-davis",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-20T13:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-04-20T13:00:00.000Z",
+      snippet: "This project should now be in past projects.",
+      lastCanonicalEventId: latest.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+
+    const detail = await getInboxDetail("contact:ryan-davis");
+
+    expect(detail).not.toBeNull();
+    expect(detail?.contact.activeProjects).toHaveLength(0);
+    expect(detail?.contact.pastProjects[0]).toMatchObject({
+      projectName: "Plastic Free Parks 2025",
+      projectIsActive: false,
+      status: "applied",
+      statusLabel: "Applied",
+      signupYear: 2024,
+      expeditionMemberUrl:
+        "https://adventurescientists.lightning.force.com/lightning/r/Expedition_Members__c/a0B-ryan-parks/view",
+    });
+  });
+
+  it("sorts Past Projects by membership createdAt descending", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:past-order",
+      salesforceContactId: "003-past-order",
+      displayName: "Past Order",
+      primaryEmail: "past@example.org",
+      primaryPhone: null,
+      projectId: "project:older",
+      projectName: "Older Project",
+      membershipId: "membership:past:older",
+      salesforceMembershipId: "a0B-past-older",
+      membershipStatus: "lead",
+      membershipCreatedAt: "2022-01-01T12:00:00.000Z",
+    });
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:past-order",
+      salesforceContactId: "003-past-order",
+      displayName: "Past Order",
+      primaryEmail: "past@example.org",
+      primaryPhone: null,
+      projectId: "project:newer",
+      projectName: "Newer Project",
+      membershipId: "membership:past:newer",
+      salesforceMembershipId: "a0B-past-newer",
+      membershipStatus: "successful",
+      membershipCreatedAt: "2025-01-01T12:00:00.000Z",
+    });
+    await runtime.context.settings.projects.setActive("project:older", false);
+    await runtime.context.settings.projects.setActive("project:newer", false);
+    const latest = await seedInboxEmailEvent(runtime.context, {
+      id: "past-order-inbound-1",
+      contactId: "contact:past-order",
+      occurredAt: "2026-04-22T13:00:00.000Z",
+      direction: "inbound",
+      subject: "Past sort",
+      snippet: "Checking past project order.",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:past-order",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-22T13:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-04-22T13:00:00.000Z",
+      snippet: "Checking past project order.",
+      lastCanonicalEventId: latest.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+
+    const detail = await getInboxDetail("contact:past-order");
+
+    expect(detail?.contact.pastProjects.map((project) => project.projectName)).toEqual([
+      "Newer Project",
+      "Older Project",
+    ]);
+    expect(detail?.contact.pastProjects.map((project) => project.signupYear)).toEqual([
+      2025,
+      2022,
+    ]);
+  });
+
+  it("normalizes the full Salesforce membership-status label surface for rail badges", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    const statuses = [
+      ["lead", "Lead"],
+      ["confirmed", "Confirmed"],
+      ["applied", "Applied"],
+      ["pending_acceptance", "Pending Acceptance"],
+      ["accepted", "Accepted"],
+      ["in_training", "In Training"],
+      ["trip_planning", "Trip Planning"],
+      ["in_the_field", "In the Field"],
+      ["returning_gear", "Returning Gear"],
+      ["successful", "Successful"],
+      ["completed", "Completed"],
+      ["denied", "Denied"],
+      ["declined", "Declined"],
+      ["aborted", "Aborted"],
+      ["failed", "Failed"],
+      ["waitlist", "Waitlist"],
+    ] as const;
+
+    for (const [index, [status]] of statuses.entries()) {
+      const projectId = `project:status-${index.toString()}`;
+      await seedInboxContact(runtime.context, {
+        contactId: "contact:status-labels",
+        salesforceContactId: "003-status-labels",
+        displayName: "Status Labels",
+        primaryEmail: "status@example.org",
+        primaryPhone: null,
+        projectId,
+        projectName: `Status Project ${index.toString()}`,
+        membershipId: `membership:status:${index.toString()}`,
+        salesforceMembershipId: `a0B-status-${index.toString()}`,
+        membershipStatus: status,
+        membershipCreatedAt: `202${Math.min(index, 9).toString()}-01-01T00:00:00.000Z`,
+      });
+      await runtime.context.settings.projects.setActive(projectId, false);
+    }
+
+    const latest = await seedInboxEmailEvent(runtime.context, {
+      id: "status-labels-inbound-1",
+      contactId: "contact:status-labels",
+      occurredAt: "2026-04-24T13:00:00.000Z",
+      direction: "inbound",
+      subject: "Status labels",
+      snippet: "Checking status labels.",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:status-labels",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-24T13:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-04-24T13:00:00.000Z",
+      snippet: "Checking status labels.",
+      lastCanonicalEventId: latest.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+
+    const detail = await getInboxDetail("contact:status-labels");
+
+    expect(detail).not.toBeNull();
+    expect(
+      new Set(detail?.contact.pastProjects.map((project) => project.statusLabel)),
+    ).toEqual(new Set(statuses.map(([, label]) => label)));
+  });
+
+  it("shows signup year only for past-project rows", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await runtime.context.settings.projects.setActive(
+      "project:killer-whales",
+      false,
+    );
+    const [activeDetail, pastDetail] = await Promise.all([
+      getInboxDetail("contact:sarah-martinez"),
+      getInboxDetail("contact:lisa-zhang"),
+    ]);
+
+    if (activeDetail === null || pastDetail === null) {
+      throw new Error("Expected inbox detail for active and past contacts");
+    }
+
+    const activeMarkup = renderToStaticMarkup(
+      createElement(InboxContactRail, {
+        contact: activeDetail.contact,
+      }),
+    );
+    const pastMarkup = renderToStaticMarkup(
+      createElement(InboxContactRail, {
+        contact: pastDetail.contact,
+      }),
+    );
+
+    const activeSection = activeMarkup.split("Past Projects")[0] ?? activeMarkup;
+    const pastSection = pastMarkup.split("Past Projects")[1] ?? pastMarkup;
+
+    expect(activeSection).not.toContain("tabular-nums");
+    expect(pastSection).toContain("tabular-nums");
+    expect(pastSection).toContain("2026");
   });
 
   it("uses the most recent internal note as the pinned note proxy", async () => {
@@ -1194,7 +1446,7 @@ describe("real inbox selectors", () => {
     );
   });
 
-  it("orders contact rail active projects newest-first by membership createdAt and uses short aliases", async () => {
+  it("orders contact rail active projects by status rank and uses short aliases", async () => {
     if (runtime === null) {
       throw new Error("Expected inbox test runtime");
     }
@@ -1266,9 +1518,9 @@ describe("real inbox selectors", () => {
     }
 
     expect(detail.contact.activeProjects.map((project) => project.projectName)).toEqual([
-      "Passive Acoustic",
-      "Whitebark Pine",
       "Illegal Timber",
+      "Whitebark Pine",
+      "Passive Acoustic",
     ]);
     expect(
       renderToStaticMarkup(
@@ -1279,11 +1531,23 @@ describe("real inbox selectors", () => {
     ).not.toContain("WPEF Tracking Whitebark Pine OR WA 2025-2026 2026");
   });
 
-  it("sets expeditionMemberUrl to null when the membership has no Salesforce membership id", async () => {
+  it("keeps inactive memberships in past projects and non-clickable when Salesforce membership id is missing", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await runtime.context.settings.projects.setActive(
+      "project:killer-whales",
+      false,
+    );
     const detail = await getInboxDetail("contact:lisa-zhang");
 
     expect(detail).not.toBeNull();
     expect(detail?.contact.pastProjects[0]).toMatchObject({
+      projectIsActive: false,
+      signupYear: 2026,
+      status: "successful",
+      statusLabel: "Successful",
       crmUrl:
         "https://adventurescientists.lightning.force.com/lightning/r/Project__c/project%3Akiller-whales/view",
       expeditionMemberUrl: null,


### PR DESCRIPTION
## Summary

Two related changes from architect/Nico grill 2026-04-27 (Block 3 issue 3.2A + recurring complaint R.1):

1. **Rail "Active Projects" / "Past Projects" sections now discriminate by `project_dimensions.is_active`**, not membership status. Volunteer status (Lead, Applied, In Training, etc.) is purely a row label, never a section assignment.
2. **R.1 fix:** removed the secondary "↗ Project" link from each rail row. The entire row is now a single anchor to the volunteer's expedition member SF URL. A delicate hover-only link icon shows on the right.

Verified pre-dispatch: 0 of 7,706 prod memberships have NULL `salesforce_membership_id`, so the row anchor always has a valid URL.

## Acceptance (from brief)

- [x] Active section = memberships where `project_dimensions.is_active = true`
- [x] Past section = memberships where `project_dimensions.is_active = false` or no project dimension row
- [x] Status badge always shown on every row regardless of section
- [x] Year column appears only in Past Projects section, derived from `membership.createdAt`
- [x] Active section keeps existing membership-status sort rank
- [x] Past section sorts by `createdAt DESC`
- [x] Secondary "↗ Project" link removed
- [x] Entire row clickable to expedition member URL
- [x] Hover-only link icon on the right

## Validation

`pnpm typecheck`, `pnpm lint`, `pnpm test:unit` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)