### PR TITLE
fix(worker): schedule identity-resolution-queue reconcile every 15 min

### DIFF
--- a/apps/worker/src/jobs/reconcile-identity-queue.ts
+++ b/apps/worker/src/jobs/reconcile-identity-queue.ts
@@ -1,0 +1,55 @@
+import type { Task } from "graphile-worker";
+
+import type { Stage1Database } from "@as-comms/db";
+import type { Stage1RepositoryBundle } from "@as-comms/domain";
+
+import { reconcileIdentityQueue } from "../ops/reconcile-identity-queue.js";
+import type { Stage1ProviderCapturePorts } from "../orchestration/index.js";
+
+export const reconcileIdentityQueueJobName = "reconcile-identity-queue" as const;
+
+interface GmailHistoricalReplayConfig {
+  readonly liveAccount: string;
+  readonly projectInboxAliases: readonly string[];
+}
+
+export interface ReconcileIdentityQueueTaskDependencies {
+  readonly db: Stage1Database;
+  readonly repositories: Stage1RepositoryBundle;
+  readonly capture: Stage1ProviderCapturePorts;
+  readonly gmailHistoricalReplay: GmailHistoricalReplayConfig;
+  readonly logger?: Pick<Console, "log">;
+}
+
+export function createReconcileIdentityQueueTask(
+  dependencies: ReconcileIdentityQueueTaskDependencies
+): Task {
+  const logger = dependencies.logger ?? console;
+
+  return () =>
+    Promise.resolve(
+      reconcileIdentityQueue({
+        db: dependencies.db,
+        repositories: dependencies.repositories,
+        capture: dependencies.capture,
+        gmailHistoricalReplay: dependencies.gmailHistoricalReplay,
+        dryRun: false,
+        limit: 1,
+        logger: {
+          log: () => undefined
+        }
+      })
+    ).then((report) => {
+      logger.log(
+        JSON.stringify({
+          event: "identity_queue.reconcile.completed",
+          scanned: report.scanned,
+          resolved: report.resolved,
+          created: report.created,
+          skipped: report.skipped,
+          errors: report.errors.length,
+          dryRun: report.dryRun
+        })
+      );
+    });
+}

--- a/apps/worker/src/jobs/reconcile-identity-queue.ts
+++ b/apps/worker/src/jobs/reconcile-identity-queue.ts
@@ -34,7 +34,7 @@ export function createReconcileIdentityQueueTask(
         capture: dependencies.capture,
         gmailHistoricalReplay: dependencies.gmailHistoricalReplay,
         dryRun: false,
-        limit: 1,
+        limit: 200,
         logger: {
           log: () => undefined
         }

--- a/apps/worker/src/runtime.ts
+++ b/apps/worker/src/runtime.ts
@@ -43,6 +43,7 @@ import {
   type Stage1WorkerOrchestrationService
 } from "./orchestration/index.js";
 import { createTaskList } from "./tasks.js";
+import { reconcileIdentityQueueJobName } from "./jobs/reconcile-identity-queue.js";
 import { sweepPendingOutboundsJobName } from "./jobs/sweep-pending-outbounds.js";
 
 const workerCaptureConfigSchema = z.object({
@@ -98,7 +99,8 @@ export function buildWorkerCrontab(config: WorkerConfig): string {
     `*/${String(gmailMinutes)} * * * * ${pollGmailLiveJobName} ?id=gmail-live-poll&max=1`,
     `*/${String(salesforceMinutes)} * * * * ${pollSalesforceLiveJobName} ?id=salesforce-live-poll&max=1`,
     `*/5 * * * * ${pollIntegrationHealthJobName} ?id=integration-health-poll&max=1`,
-    `*/5 * * * * ${sweepPendingOutboundsJobName} ?id=composer-orphan-sweep&max=1`
+    `*/5 * * * * ${sweepPendingOutboundsJobName} ?id=composer-orphan-sweep&max=1`,
+    `*/15 * * * * ${reconcileIdentityQueueJobName} ?id=identity-queue-reconcile&max=1`
   ].join("\n");
 }
 
@@ -321,6 +323,15 @@ export async function createStage1WorkerRuntimeServices(
       },
       pendingOutboundSweep: {
         pendingOutbounds: repositories.pendingOutbounds
+      },
+      reconcileIdentityQueue: {
+        db: connection.db,
+        repositories,
+        capture,
+        gmailHistoricalReplay: {
+          liveAccount: config.launchScope.gmail.liveAccount,
+          projectInboxAliases
+        }
       }
     }),
     dispose() {

--- a/apps/worker/src/tasks.ts
+++ b/apps/worker/src/tasks.ts
@@ -8,6 +8,11 @@ import {
   type PendingOutboundSweepTaskDependencies
 } from "./jobs/sweep-pending-outbounds.js";
 import {
+  createReconcileIdentityQueueTask,
+  reconcileIdentityQueueJobName,
+  type ReconcileIdentityQueueTaskDependencies
+} from "./jobs/reconcile-identity-queue.js";
+import {
   createNotionKnowledgeSyncTask,
   notionKnowledgeSyncJobName,
   type NotionKnowledgeSyncDependencies
@@ -25,6 +30,7 @@ export function createTaskList(
     readonly integrationHealth?: IntegrationHealthTaskDependencies;
     readonly notionKnowledgeSync?: NotionKnowledgeSyncDependencies;
     readonly pendingOutboundSweep?: PendingOutboundSweepTaskDependencies;
+    readonly reconcileIdentityQueue?: ReconcileIdentityQueueTaskDependencies;
   }
 ): TaskList {
   return {
@@ -34,6 +40,13 @@ export function createTaskList(
       : {
           [sweepPendingOutboundsJobName]: createSweepPendingOutboundsTask(
             input.pendingOutboundSweep
+          )
+        }),
+    ...(input?.reconcileIdentityQueue === undefined
+      ? {}
+      : {
+          [reconcileIdentityQueueJobName]: createReconcileIdentityQueueTask(
+            input.reconcileIdentityQueue
           )
         }),
     ...(input?.notionKnowledgeSync === undefined

--- a/apps/worker/test/jobs/reconcile-identity-queue.test.ts
+++ b/apps/worker/test/jobs/reconcile-identity-queue.test.ts
@@ -62,7 +62,7 @@ async function seedStoredGmailCase(
 }
 
 describe("reconcile identity queue task", () => {
-  it("reconciles one open case per scheduled run and logs the report", async () => {
+  it("reconciles open cases up to the configured limit and logs the report", async () => {
     const context = await createTestWorkerContext();
     const logger = { log: vi.fn() };
 
@@ -108,16 +108,16 @@ describe("reconcile identity queue task", () => {
         context.repositories.identityResolutionQueue.findById(secondCaseId)
       ]);
 
-      expect(await context.repositories.canonicalEvents.countAll()).toBe(1);
+      expect(await context.repositories.canonicalEvents.countAll()).toBe(2);
       expect(
         [firstCase?.status, secondCase?.status].sort()
-      ).toEqual(["open", "resolved"]);
+      ).toEqual(["resolved", "resolved"]);
       expect(logger.log).toHaveBeenCalledWith(
         JSON.stringify({
           event: "identity_queue.reconcile.completed",
-          scanned: 1,
+          scanned: 2,
           resolved: 0,
-          created: 1,
+          created: 2,
           skipped: 0,
           errors: 0,
           dryRun: false

--- a/apps/worker/test/jobs/reconcile-identity-queue.test.ts
+++ b/apps/worker/test/jobs/reconcile-identity-queue.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { reconcileIdentityQueueJobName } from "../../src/jobs/reconcile-identity-queue.js";
+import { createTaskList } from "../../src/tasks.js";
+import {
+  createTestWorkerContext,
+  type TestWorkerContext
+} from "../helpers.js";
+
+async function seedStoredGmailCase(
+  context: TestWorkerContext,
+  input: {
+    readonly recordId: string;
+    readonly email: string;
+    readonly occurredAt: string;
+    readonly receivedAt: string;
+  }
+): Promise<string> {
+  const sourceEvidenceId = `source-evidence:gmail:message:${input.recordId}`;
+  const caseId = `identity-review:${sourceEvidenceId}:identity_missing_anchor`;
+
+  await context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "gmail",
+    providerRecordType: "message",
+    providerRecordId: input.recordId,
+    receivedAt: input.receivedAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `capture://gmail/${input.recordId}`,
+    idempotencyKey: `source-evidence:gmail:message:${input.recordId}`,
+    checksum: `checksum:${input.recordId}`
+  });
+  await context.repositories.gmailMessageDetails.upsert({
+    sourceEvidenceId,
+    providerRecordId: input.recordId,
+    gmailThreadId: `thread:${input.recordId}`,
+    rfc822MessageId: `<${input.recordId}@example.org>`,
+    direction: "inbound",
+    subject: `Subject ${input.recordId}`,
+    fromHeader: `Volunteer <${input.email}>`,
+    toHeader: "volunteers@adventurescientists.org",
+    ccHeader: null,
+    snippetClean: `snippet:${input.recordId}`,
+    bodyTextPreview: `body:${input.recordId}`,
+    capturedMailbox: "volunteers@adventurescientists.org",
+    projectInboxAlias: null
+  });
+  await context.repositories.identityResolutionQueue.upsert({
+    id: caseId,
+    sourceEvidenceId,
+    candidateContactIds: [],
+    reasonCode: "identity_missing_anchor",
+    status: "open",
+    openedAt: input.receivedAt,
+    resolvedAt: null,
+    normalizedIdentityValues: [input.email],
+    anchoredContactId: null,
+    explanation: "Seeded scheduled reconcile case."
+  });
+
+  return caseId;
+}
+
+describe("reconcile identity queue task", () => {
+  it("reconciles one open case per scheduled run and logs the report", async () => {
+    const context = await createTestWorkerContext();
+    const logger = { log: vi.fn() };
+
+    try {
+      const [firstCaseId, secondCaseId] = await Promise.all([
+        seedStoredGmailCase(context, {
+          recordId: "gmail-scheduled-1",
+          email: "first@example.org",
+          occurredAt: "2026-04-28T12:00:00.000Z",
+          receivedAt: "2026-04-28T12:00:00.000Z"
+        }),
+        seedStoredGmailCase(context, {
+          recordId: "gmail-scheduled-2",
+          email: "second@example.org",
+          occurredAt: "2026-04-28T12:01:00.000Z",
+          receivedAt: "2026-04-28T12:01:00.000Z"
+        })
+      ]);
+
+      const taskList = createTaskList(undefined, {
+        reconcileIdentityQueue: {
+          db: context.db,
+          repositories: context.repositories,
+          capture: context.capture,
+          gmailHistoricalReplay: {
+            liveAccount: "volunteers@adventurescientists.org",
+            projectInboxAliases: ["orcas@adventurescientists.org"]
+          },
+          logger
+        }
+      });
+
+      const task = taskList[reconcileIdentityQueueJobName];
+
+      if (task === undefined) {
+        throw new Error("Expected reconcile identity queue task to be registered.");
+      }
+
+      await task({}, {} as never);
+
+      const [firstCase, secondCase] = await Promise.all([
+        context.repositories.identityResolutionQueue.findById(firstCaseId),
+        context.repositories.identityResolutionQueue.findById(secondCaseId)
+      ]);
+
+      expect(await context.repositories.canonicalEvents.countAll()).toBe(1);
+      expect(
+        [firstCase?.status, secondCase?.status].sort()
+      ).toEqual(["open", "resolved"]);
+      expect(logger.log).toHaveBeenCalledWith(
+        JSON.stringify({
+          event: "identity_queue.reconcile.completed",
+          scanned: 1,
+          resolved: 0,
+          created: 1,
+          skipped: 0,
+          errors: 0,
+          dryRun: false
+        })
+      );
+    } finally {
+      await context.dispose();
+    }
+  });
+});

--- a/apps/worker/test/stage1-runtime.test.ts
+++ b/apps/worker/test/stage1-runtime.test.ts
@@ -144,7 +144,8 @@ describe("Stage 1 worker runtime task registration", () => {
         `*/1 * * * * ${pollGmailLiveJobName} ?id=gmail-live-poll&max=1`,
         `*/5 * * * * ${pollSalesforceLiveJobName} ?id=salesforce-live-poll&max=1`,
         `*/5 * * * * ${pollIntegrationHealthJobName} ?id=integration-health-poll&max=1`,
-        `*/5 * * * * ${sweepPendingOutboundsJobName} ?id=composer-orphan-sweep&max=1`
+        `*/5 * * * * ${sweepPendingOutboundsJobName} ?id=composer-orphan-sweep&max=1`,
+        "*/15 * * * * reconcile-identity-queue ?id=identity-queue-reconcile&max=1"
       ].join("\n")
     );
   });


### PR DESCRIPTION
## Summary

Adds a periodic worker job that runs `reconcileIdentityQueue` every 15 minutes, automatically clearing race-condition victims from the identity-resolution-queue.

## Why

Direct architect investigation 2026-04-28 found **9,233 stuck `identity_resolution_queue` cases in production**, of which 8,645 are now resolvable. Root cause: race condition where Salesforce batches contain a `contact_snapshot` AND child records (`task_communication`, `lifecycle_milestone`) for the same SF contact id; if a child is processed before the contact_snapshot commits, `findAnchoredContact` returns null → record shunted to identity_resolution_queue with `reason_code = identity_missing_anchor` and **never auto-retried**.

Breakdown of the 9,233 stuck cases:
- 7,645 lifecycle_milestone (the 3.3 "missing milestones" symptom — Matt Bromley etc.)
- 1,558 task_communication (some of the 3.1 "missing emails" symptom)
- 30 gmail message

Concrete example: Matt Bromley's WPEF Whitebark Pine membership has 3 source_evidence rows (signed_up, received_training, completed_training); only completed_training was promoted to canonical_event_ledger; the other 2 sit in identity_resolution_queue with anchored_contact_id=null even though Matt's contact has existed since 2025-12-14.

This PR is the **automatic safety net**. The actual race condition fix in the orchestration batch loop is a separate brief (saved for after Codex token reset).

## Changes

1. **NEW** [`apps/worker/src/jobs/reconcile-identity-queue.ts`](apps/worker/src/jobs/reconcile-identity-queue.ts) — Task factory, mirrors `sweep-pending-outbounds` pattern
2. **NEW** [`apps/worker/test/jobs/reconcile-identity-queue.test.ts`](apps/worker/test/jobs/reconcile-identity-queue.test.ts) — unit test covering scan/resolve/create flow
3. **EDIT** `apps/worker/src/runtime.ts` — task registration + crontab entry `*/15 * * * *`
4. **EDIT** `apps/worker/src/tasks.ts` — central task table wiring
5. **EDIT** `apps/worker/test/stage1-runtime.test.ts` — extend the existing crontab assertion by one line

Per-tick limit: 200 cases. Brief default — clears the 8,645 backlog in ~11 ticks (~3 hours) once the architect runs the one-time `--execute` backfill on deploy.

## Validation

- `pnpm typecheck`: PASS
- `pnpm lint`: PASS
- `pnpm test:unit`: not runnable locally on macOS (rollup-darwin-arm64 ERR_DLOPEN_FAILED — known env issue per CLAUDE memory). CI is authoritative.
- Direct verification via `node --import tsx/esm`: the new task path successfully reconciled one stuck case → created one canonical event → resolved the case → emitted completion log.

## Operational sequence after merge

1. Merge → scheduled job ships
2. Architect runs (with explicit Nico authorization) `railway run --service salesforce-capture pnpm --filter @as-comms/worker ops:cli reconcile-identity-queue --execute` once → clears 8,645 stuck cases (creates ~7,645 lifecycle canonical events + ~1,558 task-communication canonical events; ~588 still-unresolvable cases stay open for review)
3. Scheduled job continues catching new race victims every 15 min

## Out of scope

- Underlying race-condition fix in orchestration batch loop (separate brief, after token reset)
- Auto-running the one-time backfill against prod (architect operation)
- Changes to the existing `reconcile-identity-queue.ts` core function
- Env knobs for cron interval / batch size / limit (can be added later if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)