### PR TITLE
feat(ui): align settings + timeline width to welcome page column

### DIFF
--- a/apps/web/app/inbox/_components/inbox-timeline.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline.tsx
@@ -109,7 +109,7 @@ export function InboxTimeline({
           </div>
         ) : null}
 
-        <ol className="mx-auto flex w-full max-w-[840px] flex-col gap-3">
+        <ol className="mx-auto flex w-full max-w-[920px] flex-col gap-3">
           {presentationItems.map((item) => (
             <TimelinePresentationItem
               key={item.id}

--- a/apps/web/app/settings/_components/settings-content.tsx
+++ b/apps/web/app/settings/_components/settings-content.tsx
@@ -12,7 +12,7 @@ export function SettingsContent({ children }: SettingsContentProps) {
   return (
     <div className="flex min-w-0 flex-1 flex-col">
       <div className="flex-1 overflow-y-auto px-6 py-6">
-        <div className="w-full max-w-[800px]">{children}</div>
+        <div className="mx-auto w-full max-w-[920px]">{children}</div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Aligns the horizontal content width across three surfaces so they share the same left/right edges as the welcome page's main column (`max-w-[920px] mx-auto`):

- **`SettingsContent`** inner wrapper: `max-w-[800px]` (no centering) → `mx-auto w-full max-w-[920px]`
- **`InboxTimeline` `<ol>`**: `max-w-[840px]` → `max-w-[920px]`

### Before

| Surface | Max-width | Centered? |
|---|---|---|
| Welcome page | 920px | ✓ |
| Settings content | 800px | ✗ |
| Timeline list | 840px | ✓ |

### After

| Surface | Max-width | Centered? |
|---|---|---|
| Welcome page | 920px | ✓ |
| Settings content | 920px | ✓ |
| Timeline list | 920px | ✓ |

The math works out: with `px-6` outer padding + `mx-auto max-w-[920px]` inner wrapper, the 920px content box lands at the same left offset as the welcome page's `mx-auto max-w-[920px] px-10` column on typical desktop widths (≥ ~970px).

## Test plan

- [ ] Open `/settings/access` — content should be centered and not stretch beyond 920px
- [ ] Open `/settings/projects` — same
- [ ] Open an inbox thread — timeline bubbles should be slightly wider than before but still centered
- [ ] Compare left edge of settings content with the welcome page (select no contact, then select a contact) — edges should visually match

🤖 Generated with [Claude Code](https://claude.com/claude-code)