### PR TITLE
chore(ops): backfill garbled gmail_message_details bodies

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -11,6 +11,7 @@
     "start": "node dist/index.js",
     "ops": "tsx src/ops/cli.ts",
     "ops:backfill-content-fingerprint": "tsx src/ops/backfill-content-fingerprint.ts",
+    "ops:backfill-garbled-message-bodies": "tsx src/ops/cli.ts backfill-garbled-message-bodies",
     "ops:check-config": "tsx src/ops/cli.ts check-config",
     "ops:backfill-gmail-message-bodies": "tsx src/ops/backfill-gmail-message-bodies.ts",
     "ops:backfill-gmail-mbox-bodies": "tsx src/ops/cli.ts backfill-gmail-mbox-bodies",

--- a/apps/worker/src/ops/backfill-garbled-message-bodies.ts
+++ b/apps/worker/src/ops/backfill-garbled-message-bodies.ts
@@ -1,0 +1,252 @@
+#!/usr/bin/env tsx
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+import { and, asc, eq, gt, isNull, sql } from "drizzle-orm";
+
+import {
+  closeDatabaseConnection,
+  createDatabaseConnection,
+  gmailMessageDetails,
+  type Stage1Database,
+} from "@as-comms/db";
+import { isLikelyBinaryNoise } from "@as-comms/integrations";
+
+import { parseCliFlags, readOptionalIntegerFlag } from "./helpers.js";
+
+const BINARY_FALLBACK_PLACEHOLDER =
+  "[Message body could not be extracted — open in Gmail]";
+const DEFAULT_BATCH_SIZE = 200;
+const BINARY_NOISE_MIN_LENGTH = 32;
+const REPLACEMENT_CHARACTER = "�";
+
+interface BackfillLogger {
+  info(message: string): void;
+}
+
+interface GarbledMessageBodyCandidateRow {
+  readonly sourceEvidenceId: string;
+  readonly bodyTextPreview: string;
+}
+
+export interface GarbledMessageBodiesBackfillResult {
+  readonly dryRun: boolean;
+  readonly limit: number | null;
+  readonly scanned: number;
+  readonly garbled: number;
+  readonly dryRunWouldUpdate: number;
+  readonly updated: number;
+}
+
+function readConnectionString(env: NodeJS.ProcessEnv): string {
+  const connectionString = env.WORKER_DATABASE_URL ?? env.DATABASE_URL;
+
+  if (connectionString === undefined || connectionString.trim().length === 0) {
+    throw new Error(
+      "DATABASE_URL or WORKER_DATABASE_URL is required for Stage 1 ops commands.",
+    );
+  }
+
+  return connectionString;
+}
+
+function calculateReplacementRatio(text: string): number {
+  if (text.length < BINARY_NOISE_MIN_LENGTH) {
+    return 0;
+  }
+
+  let suspicious = 0;
+  let total = 0;
+
+  for (const ch of text) {
+    total += 1;
+
+    if (ch === REPLACEMENT_CHARACTER) {
+      suspicious += 1;
+      continue;
+    }
+
+    const code = ch.codePointAt(0) ?? 0;
+
+    if (
+      code < 0x20 &&
+      code !== 0x09 &&
+      code !== 0x0a &&
+      code !== 0x0d
+    ) {
+      suspicious += 1;
+    }
+  }
+
+  return total === 0 ? 0 : suspicious / total;
+}
+
+async function loadCandidateBatch(input: {
+  readonly db: Stage1Database;
+  readonly afterSourceEvidenceId: string | null;
+  readonly batchSize: number;
+}): Promise<readonly GarbledMessageBodyCandidateRow[]> {
+  return input.db
+    .select({
+      sourceEvidenceId: gmailMessageDetails.sourceEvidenceId,
+      bodyTextPreview: gmailMessageDetails.bodyTextPreview,
+    })
+    .from(gmailMessageDetails)
+    .where(
+      and(
+        isNull(gmailMessageDetails.bodyKind),
+        sql<boolean>`length(${gmailMessageDetails.bodyTextPreview}) >= ${BINARY_NOISE_MIN_LENGTH}`,
+        input.afterSourceEvidenceId === null
+          ? undefined
+          : gt(gmailMessageDetails.sourceEvidenceId, input.afterSourceEvidenceId),
+      ),
+    )
+    .orderBy(asc(gmailMessageDetails.sourceEvidenceId))
+    .limit(input.batchSize);
+}
+
+async function updateGarbledBodyRow(input: {
+  readonly db: Stage1Database;
+  readonly sourceEvidenceId: string;
+}): Promise<void> {
+  await input.db
+    .update(gmailMessageDetails)
+    .set({
+      bodyTextPreview: BINARY_FALLBACK_PLACEHOLDER,
+      snippetClean: BINARY_FALLBACK_PLACEHOLDER,
+      bodyKind: "binary_fallback",
+      updatedAt: new Date(),
+    })
+    .where(eq(gmailMessageDetails.sourceEvidenceId, input.sourceEvidenceId));
+}
+
+export async function backfillGarbledMessageBodies(input: {
+  readonly db: Stage1Database;
+  readonly dryRun?: boolean;
+  readonly limit?: number | null;
+  readonly logger?: BackfillLogger;
+}): Promise<GarbledMessageBodiesBackfillResult> {
+  const dryRun = input.dryRun ?? true;
+  const limit = input.limit ?? null;
+  const logger = input.logger ?? {
+    info(message: string) {
+      console.info(message);
+    },
+  };
+
+  let remaining = limit;
+  let afterSourceEvidenceId: string | null = null;
+  let scanned = 0;
+  let garbled = 0;
+  let dryRunWouldUpdate = 0;
+  let updated = 0;
+
+  for (;;) {
+    const batchSize =
+      remaining === null
+        ? DEFAULT_BATCH_SIZE
+        : Math.min(DEFAULT_BATCH_SIZE, remaining);
+
+    if (batchSize <= 0) {
+      break;
+    }
+
+    const candidates = await loadCandidateBatch({
+      db: input.db,
+      afterSourceEvidenceId,
+      batchSize,
+    });
+
+    if (candidates.length === 0) {
+      break;
+    }
+
+    afterSourceEvidenceId =
+      candidates.at(-1)?.sourceEvidenceId ?? afterSourceEvidenceId;
+    scanned += candidates.length;
+    remaining = remaining === null ? null : remaining - candidates.length;
+
+    for (const candidate of candidates) {
+      if (!isLikelyBinaryNoise(candidate.bodyTextPreview)) {
+        continue;
+      }
+
+      garbled += 1;
+      const replacementRatio = calculateReplacementRatio(
+        candidate.bodyTextPreview,
+      );
+
+      if (dryRun) {
+        dryRunWouldUpdate += 1;
+        logger.info(
+          JSON.stringify({
+            source_evidence_id: candidate.sourceEvidenceId,
+            body_len: candidate.bodyTextPreview.length,
+            replacement_ratio: Number(replacementRatio.toFixed(4)),
+            sample: candidate.bodyTextPreview.slice(0, 80),
+          }),
+        );
+        continue;
+      }
+
+      await updateGarbledBodyRow({
+        db: input.db,
+        sourceEvidenceId: candidate.sourceEvidenceId,
+      });
+      updated += 1;
+    }
+  }
+
+  return {
+    dryRun,
+    limit,
+    scanned,
+    garbled,
+    dryRunWouldUpdate,
+    updated,
+  };
+}
+
+export async function runBackfillGarbledMessageBodiesCommand(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+): Promise<void> {
+  const flags = parseCliFlags(args);
+  const execute = Boolean(flags.execute);
+  const explicitDryRun = Boolean(flags["dry-run"]);
+
+  if (execute && explicitDryRun) {
+    throw new Error("Flags --execute and --dry-run are mutually exclusive.");
+  }
+
+  const connection = createDatabaseConnection({
+    connectionString: readConnectionString(env),
+  });
+
+  try {
+    const result = await backfillGarbledMessageBodies({
+      db: connection.db,
+      dryRun: !execute,
+      limit: readOptionalIntegerFlag(flags, "limit", 0) || null,
+    });
+
+    console.info(JSON.stringify(result, null, 2));
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}
+
+const entrypoint = process.argv[1];
+
+if (entrypoint !== undefined && import.meta.url === pathToFileURL(entrypoint).href) {
+  void runBackfillGarbledMessageBodiesCommand(process.argv.slice(2), process.env).catch(
+    (error: unknown) => {
+      console.error(
+        error instanceof Error
+          ? error.message
+          : "backfill-garbled-message-bodies failed.",
+      );
+      process.exitCode = 1;
+    },
+  );
+}

--- a/apps/worker/src/ops/cli.ts
+++ b/apps/worker/src/ops/cli.ts
@@ -32,6 +32,7 @@ import { runBackfillSalesforceCommunicationDetailsCommand } from "./backfill-sal
 import { runBackfillMembershipSfIdsCommand } from "./backfill-membership-sf-ids.js";
 import { runBackfillGmailMboxBodiesCommand } from "./backfill-gmail-mbox-bodies.js";
 import { runBackfillContentFingerprintCommand } from "./backfill-content-fingerprint.js";
+import { runBackfillGarbledMessageBodiesCommand } from "./backfill-garbled-message-bodies.js";
 import { runBackfillMailchimpCampaignBodyCommand } from "./backfill-mailchimp-campaign-body.js";
 import { runCleanupGmailDraftEventsCommand } from "./cleanup-gmail-draft-events.js";
 import { runCleanupSalesforceOwnerScopeCommand } from "./cleanup-salesforce-owner-scope.js";
@@ -356,6 +357,9 @@ async function main(): Promise<void> {
     case "backfill-content-fingerprint":
       await runBackfillContentFingerprintCommand(rest, process.env);
       return;
+    case "backfill-garbled-message-bodies":
+      await runBackfillGarbledMessageBodiesCommand(rest, process.env);
+      return;
     case "backfill-mailchimp-campaign-body":
       await runBackfillMailchimpCampaignBodyCommand(rest, process.env);
       return;
@@ -376,7 +380,7 @@ async function main(): Promise<void> {
       return;
     default:
       throw new Error(
-        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-membership-sf-ids, backfill-gmail-mbox-bodies, backfill-content-fingerprint, backfill-mailchimp-campaign-body, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, dedup-historical-ledger, reconcile-identity-queue, reclassify-sf-direction.",
+        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-membership-sf-ids, backfill-gmail-mbox-bodies, backfill-content-fingerprint, backfill-garbled-message-bodies, backfill-mailchimp-campaign-body, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, dedup-historical-ledger, reconcile-identity-queue, reclassify-sf-direction.",
       );
   }
 }

--- a/apps/worker/test/stage1-backfill-garbled-message-bodies.test.ts
+++ b/apps/worker/test/stage1-backfill-garbled-message-bodies.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+
+import { backfillGarbledMessageBodies } from "../src/ops/backfill-garbled-message-bodies.js";
+import { createTestWorkerContext } from "./helpers.js";
+
+const BINARY_FALLBACK_PLACEHOLDER =
+  "[Message body could not be extracted — open in Gmail]";
+
+function buildGarbledBody(): string {
+  return "A�".repeat(20);
+}
+
+function buildCleanBody(): string {
+  return "Hello there.\n\nThis message is readable and should stay untouched.";
+}
+
+async function seedGmailMessageDetail(input: {
+  readonly context: Awaited<ReturnType<typeof createTestWorkerContext>>;
+  readonly sourceEvidenceId: string;
+  readonly providerRecordId: string;
+  readonly bodyTextPreview: string;
+  readonly bodyKind?: "binary_fallback" | null;
+}): Promise<void> {
+  await input.context.repositories.sourceEvidence.append({
+    id: input.sourceEvidenceId,
+    provider: "gmail",
+    providerRecordType: "message",
+    providerRecordId: input.providerRecordId,
+    receivedAt: "2026-04-28T00:00:00.000Z",
+    occurredAt: "2026-04-28T00:00:00.000Z",
+    payloadRef: `gmail://volunteers%40example.org/messages/${input.providerRecordId}`,
+    idempotencyKey: input.sourceEvidenceId,
+    checksum: `checksum:${input.providerRecordId}`,
+  });
+
+  await input.context.repositories.gmailMessageDetails.upsert({
+    sourceEvidenceId: input.sourceEvidenceId,
+    providerRecordId: input.providerRecordId,
+    gmailThreadId: "thread-garbled-1",
+    rfc822MessageId: `<${input.providerRecordId}@example.org>`,
+    direction: "inbound",
+    subject: "Security alert",
+    fromHeader: "Google <no-reply@accounts.google.com>",
+    toHeader: "Volunteer <volunteer@example.org>",
+    ccHeader: null,
+    labelIds: null,
+    snippetClean: input.bodyTextPreview,
+    bodyTextPreview: input.bodyTextPreview,
+    bodyKind: input.bodyKind ?? null,
+    capturedMailbox: "volunteers@example.org",
+    projectInboxAlias: "volunteers@example.org",
+  });
+}
+
+describe("Stage 1 garbled Gmail message body backfill", () => {
+  it("reports dry-run updates without mutating the stored row", async () => {
+    const context = await createTestWorkerContext();
+    const sourceEvidenceId = "source-evidence:gmail:message:garbled-dry-run";
+    const garbledBody = buildGarbledBody();
+
+    try {
+      await seedGmailMessageDetail({
+        context,
+        sourceEvidenceId,
+        providerRecordId: "garbled-dry-run",
+        bodyTextPreview: garbledBody,
+      });
+
+      const result = await backfillGarbledMessageBodies({
+        db: context.db,
+        dryRun: true,
+      });
+      const [persisted] =
+        await context.repositories.gmailMessageDetails.listBySourceEvidenceIds([
+          sourceEvidenceId,
+        ]);
+
+      expect(result).toMatchObject({
+        dryRun: true,
+        scanned: 1,
+        garbled: 1,
+        dryRunWouldUpdate: 1,
+        updated: 0,
+      });
+      expect(persisted).toMatchObject({
+        bodyTextPreview: garbledBody,
+        snippetClean: garbledBody,
+        bodyKind: null,
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("writes the placeholder and body kind in execute mode", async () => {
+    const context = await createTestWorkerContext();
+    const sourceEvidenceId = "source-evidence:gmail:message:garbled-execute";
+
+    try {
+      await seedGmailMessageDetail({
+        context,
+        sourceEvidenceId,
+        providerRecordId: "garbled-execute",
+        bodyTextPreview: buildGarbledBody(),
+      });
+
+      const result = await backfillGarbledMessageBodies({
+        db: context.db,
+        dryRun: false,
+      });
+      const [persisted] =
+        await context.repositories.gmailMessageDetails.listBySourceEvidenceIds([
+          sourceEvidenceId,
+        ]);
+
+      expect(result).toMatchObject({
+        dryRun: false,
+        scanned: 1,
+        garbled: 1,
+        dryRunWouldUpdate: 0,
+        updated: 1,
+      });
+      expect(persisted).toMatchObject({
+        bodyTextPreview: BINARY_FALLBACK_PLACEHOLDER,
+        snippetClean: BINARY_FALLBACK_PLACEHOLDER,
+        bodyKind: "binary_fallback",
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("leaves readable bodies untouched", async () => {
+    const context = await createTestWorkerContext();
+    const sourceEvidenceId = "source-evidence:gmail:message:garbled-clean";
+    const cleanBody = buildCleanBody();
+
+    try {
+      await seedGmailMessageDetail({
+        context,
+        sourceEvidenceId,
+        providerRecordId: "garbled-clean",
+        bodyTextPreview: cleanBody,
+      });
+
+      const result = await backfillGarbledMessageBodies({
+        db: context.db,
+        dryRun: false,
+      });
+      const [persisted] =
+        await context.repositories.gmailMessageDetails.listBySourceEvidenceIds([
+          sourceEvidenceId,
+        ]);
+
+      expect(result).toMatchObject({
+        scanned: 1,
+        garbled: 0,
+        dryRunWouldUpdate: 0,
+        updated: 0,
+      });
+      expect(persisted).toMatchObject({
+        bodyTextPreview: cleanBody,
+        snippetClean: cleanBody,
+        bodyKind: null,
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("skips rows that already have a classified body kind", async () => {
+    const context = await createTestWorkerContext();
+    const sourceEvidenceId = "source-evidence:gmail:message:garbled-skipped";
+    const garbledBody = buildGarbledBody();
+
+    try {
+      await seedGmailMessageDetail({
+        context,
+        sourceEvidenceId,
+        providerRecordId: "garbled-skipped",
+        bodyTextPreview: garbledBody,
+        bodyKind: "binary_fallback",
+      });
+
+      const result = await backfillGarbledMessageBodies({
+        db: context.db,
+        dryRun: false,
+      });
+      const [persisted] =
+        await context.repositories.gmailMessageDetails.listBySourceEvidenceIds([
+          sourceEvidenceId,
+        ]);
+
+      expect(result).toMatchObject({
+        scanned: 0,
+        garbled: 0,
+        dryRunWouldUpdate: 0,
+        updated: 0,
+      });
+      expect(persisted).toMatchObject({
+        bodyTextPreview: garbledBody,
+        snippetClean: garbledBody,
+        bodyKind: "binary_fallback",
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+});

--- a/packages/integrations/src/providers/gmail-body.ts
+++ b/packages/integrations/src/providers/gmail-body.ts
@@ -65,7 +65,7 @@ const REPLACEMENT_CHARACTER = "�";
 const BINARY_NOISE_THRESHOLD = 0.3;
 const BINARY_NOISE_MIN_LENGTH = 32;
 
-function isLikelyBinaryNoise(text: string): boolean {
+export function isLikelyBinaryNoise(text: string): boolean {
   if (text.length < BINARY_NOISE_MIN_LENGTH) {
     return false;
   }


### PR DESCRIPTION
- adds a `backfill-garbled-message-bodies` worker op that scans unclassified `gmail_message_details` rows, reuses `isLikelyBinaryNoise`, logs dry-run JSON samples, and writes the `binary_fallback` placeholder in execute mode
- exports `isLikelyBinaryNoise` from `@as-comms/integrations` for worker reuse without changing the existing Block 2.1 body-extraction behavior
- wires the op into the worker CLI/package scripts and adds Stage 1 coverage for dry-run, execute, readable-body, and already-classified cases

Acceptance:
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm --filter @as-comms/integrations test:unit`
- [x] `pnpm --filter @as-comms/worker test:unit`
- [x] new script defaults to dry-run and supports `--execute` plus `--limit`
- [x] added 4 worker backfill tests for the garbled-body cases in the brief

Depends on: #188

Architect note: run dry-run against prod first, review the reported rows, then run `--execute` after sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
