### PR TITLE
fix(auth): enforce AS Workspace + pre-seeded user on Google sign-in [P0]

### DIFF
--- a/apps/web/src/server/auth/config.ts
+++ b/apps/web/src/server/auth/config.ts
@@ -15,6 +15,8 @@
 import type { NextAuthConfig } from "next-auth";
 import Google from "next-auth/providers/google";
 
+import { GOOGLE_WORKSPACE_DOMAIN } from "./google-sign-in-policy";
+
 export const SESSION_MAX_AGE_SECONDS = 30 * 24 * 60 * 60; // 30-day rolling session
 export const SESSION_UPDATE_AGE_SECONDS = 24 * 60 * 60;
 
@@ -25,11 +27,18 @@ export const authEdgeConfig: NextAuthConfig = {
     // `OAuthAccountNotLinked`. The admin pre-seeding workflow (users
     // rows are created by `ops:promote-admin` or the initial setup
     // script before the operator has ever OAuth'd) relies on this. Safe
-    // here because Google is our only provider and the operator pool is
-    // restricted to the verified `@adventurescientists.org` Workspace
-    // domain; there is no third-party OAuth surface that could spoof a
-    // Workspace email.
-    Google({ allowDangerousEmailAccountLinking: true })
+    // here because Google is our only provider and sign-in is fail-closed
+    // to pre-seeded, active AS Workspace users. `hd` adds a provider-side
+    // hosted-domain restriction, while the full sign-in callback in
+    // `./index.ts` re-checks the email domain and existing user record.
+    Google({
+      allowDangerousEmailAccountLinking: true,
+      authorization: {
+        params: {
+          hd: GOOGLE_WORKSPACE_DOMAIN
+        }
+      }
+    })
   ],
   pages: {
     signIn: "/auth/sign-in"

--- a/apps/web/src/server/auth/google-sign-in-policy.ts
+++ b/apps/web/src/server/auth/google-sign-in-policy.ts
@@ -1,0 +1,27 @@
+export const GOOGLE_WORKSPACE_DOMAIN = "adventurescientists.org";
+
+const GOOGLE_WORKSPACE_EMAIL_SUFFIX = `@${GOOGLE_WORKSPACE_DOMAIN}`;
+
+interface GoogleSignInUserRecord {
+  readonly deactivatedAt: Date | null;
+}
+
+export function hasAuthorizedGoogleWorkspaceEmail(
+  email: string | null | undefined
+): boolean {
+  return (
+    typeof email === "string" &&
+    email.toLowerCase().endsWith(GOOGLE_WORKSPACE_EMAIL_SUFFIX)
+  );
+}
+
+export function canSignInWithGoogle(input: {
+  readonly email: string | null | undefined;
+  readonly userRecord: GoogleSignInUserRecord | null;
+}): boolean {
+  if (!hasAuthorizedGoogleWorkspaceEmail(input.email)) {
+    return false;
+  }
+
+  return input.userRecord !== null && input.userRecord.deactivatedAt === null;
+}

--- a/apps/web/src/server/auth/index.ts
+++ b/apps/web/src/server/auth/index.ts
@@ -38,6 +38,7 @@ import {
   SESSION_MAX_AGE_SECONDS,
   SESSION_UPDATE_AGE_SECONDS
 } from "./config";
+import { canSignInWithGoogle } from "./google-sign-in-policy";
 
 async function buildAuthConfig(): Promise<NextAuthConfig> {
   const runtime = await getStage1WebRuntime();
@@ -68,17 +69,17 @@ async function buildAuthConfig(): Promise<NextAuthConfig> {
     adapter: DrizzleAdapter(runtime.connection.db, authAdapterTables),
     callbacks: {
       async signIn({ user }) {
-        // Deactivated operators must not be able to sign in, even if an
-        // OAuth flow succeeds against Google. The schema default is
-        // `deactivatedAt = null` so freshly created operators pass.
         const email = user.email;
-        if (!email) return false;
         const repos = await getSettingsRepositories();
-        const record = await repos.users.findByEmail(email);
-        if (record?.deactivatedAt) {
-          return false;
-        }
-        return true;
+        const record = email ? await repos.users.findByEmail(email) : null;
+
+        // Fail closed: only pre-seeded, active AS Workspace users may
+        // complete Google OAuth. This blocks adapter-driven first-time
+        // operator creation for arbitrary Google accounts.
+        return canSignInWithGoogle({
+          email,
+          userRecord: record
+        });
       },
       async jwt({ token, user }) {
         // `user` is only present on the initial sign-in. On every

--- a/apps/web/tests/unit/auth-sign-in.test.ts
+++ b/apps/web/tests/unit/auth-sign-in.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { canSignInWithGoogle } from "../../src/server/auth/google-sign-in-policy";
+
+function buildUserRecord(input?: { readonly deactivatedAt?: Date | null }) {
+  return {
+    deactivatedAt: input?.deactivatedAt ?? null
+  };
+}
+
+describe("Google sign-in policy", () => {
+  it("returns false when no user record exists for the Google email", () => {
+    expect(
+      canSignInWithGoogle({
+        email: "operator@adventurescientists.org",
+        userRecord: null
+      })
+    ).toBe(false);
+  });
+
+  it("returns false when the user record exists but is deactivated", () => {
+    expect(
+      canSignInWithGoogle({
+        email: "operator@adventurescientists.org",
+        userRecord: buildUserRecord({
+          deactivatedAt: new Date("2026-04-28T12:00:00.000Z")
+        })
+      })
+    ).toBe(false);
+  });
+
+  it("returns true when an active user record exists with an AS Workspace email", () => {
+    expect(
+      canSignInWithGoogle({
+        email: "operator@adventurescientists.org",
+        userRecord: buildUserRecord()
+      })
+    ).toBe(true);
+  });
+
+  it("returns false when an AS Workspace email is not pre-seeded", () => {
+    expect(
+      canSignInWithGoogle({
+        email: "new-hire@adventurescientists.org",
+        userRecord: null
+      })
+    ).toBe(false);
+  });
+
+  it("returns false when a non-Workspace email exists in the users table", () => {
+    expect(
+      canSignInWithGoogle({
+        email: "operator@example.com",
+        userRecord: buildUserRecord()
+      })
+    ).toBe(false);
+  });
+});

--- a/docs/02-bundles/settings-bundle.md
+++ b/docs/02-bundles/settings-bundle.md
@@ -26,7 +26,7 @@ Make routing, access, integration health, timezone, and AI knowledge configurati
 - 30-day rolling cookie sessions
 - Google SSO + server-owned sessions in production
 - **Two flat roles: `admin` and `operator`** — no permissions matrix (per `D-025`)
-- First-time Google sign-in creates an `operator` by default; admins are promoted via a one-time ops script
+- First-time Google sign-in is allowed only for active, pre-seeded `@adventurescientists.org` users; Settings admins (or initial ops setup) create the user row first, and admin promotion remains an explicit ops/admin action
 - header auth is dev/internal only: trusted header `x-dev-operator: <email>` is accepted only when `NODE_ENV !== 'production'`, seeded by a dev-only `/api/dev-auth?email=X` route that must 404 in prod
 - Notion-backed AI knowledge uses background sync/cache with no approval gate
 - admin mutations must be auditable via `audit_policy_evidence`


### PR DESCRIPTION
## P0 SECURITY FIX

Per Codex 5.5/high Slice 4 Web review 2026-04-28: any Google account that completed OAuth could become an `operator`. Auth.js v5 `signIn` callback didn't reject null user records, the Google provider lacked a hosted-domain restriction, and `users.role` defaults to `operator`. Any external Google user → access to `/inbox`, `/settings`, contact timelines, composer send paths.

## Fix

1. **`signIn` callback fails closed** unless an active pre-seeded user exists with `@adventurescientists.org` email
2. **Google provider `hd: 'adventurescientists.org'`** parameter forces Google to enforce hosted-domain restriction server-side
3. New centralized policy helper at `apps/web/src/server/auth/google-sign-in-policy.ts` (testable in isolation)
4. 5 regression tests in `tests/unit/auth-sign-in.test.ts` covering: null record, non-Workspace email, deactivated user, positive paths, and defense-in-depth
5. `docs/02-bundles/settings-bundle.md` updated to reflect the new policy (previous "creates operator by default" line was the bug codified)

## Validation

- `pnpm typecheck` ✓
- `pnpm lint` ✓
- `pnpm test:unit` ✓

## ⚠️ OPERATIONAL NOTE FOR DEPLOY

This fix is **fail-closed**. Any active Workspace user lacking a row in `users` table will be locked out at sign-in.

Before merging, verify all current Workspace users have rows:

\`\`\`sh
railway run --service Postgres pnpm tsx -e "
  import { closeDatabaseConnection, createDatabaseConnection } from '@as-comms/db';
  const conn = createDatabaseConnection({ connectionString: process.env.DATABASE_PUBLIC_URL ?? process.env.DATABASE_URL ?? '' });
  const sql = conn.sql;
  const rows = await sql.unsafe(\`SELECT email, role, deactivated FROM users ORDER BY email\`);
  rows.forEach(r => console.log(JSON.stringify(r)));
  await closeDatabaseConnection(conn);
"
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)