### PR TITLE
fix(deploy): add railway.json for gmail-capture to build @as-comms/db

### DIFF
--- a/apps/gmail-capture/railway.json
+++ b/apps/gmail-capture/railway.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "RAILPACK",
+    "buildCommand": "pnpm install --frozen-lockfile && pnpm --filter @as-comms/gmail-capture... build"
+  },
+  "deploy": {
+    "startCommand": "pnpm --filter @as-comms/gmail-capture start"
+  }
+}


### PR DESCRIPTION
## Why

`gmail-capture` service has been **CRASHED** since 14:30 UTC. It's blocking inbound Gmail capture and triggering the "gmail integration is degraded" banner in the inbox UI.

#191 added `@as-comms/db` as a workspace dependency to `apps/gmail-capture/package.json` (for attachment metadata persistence). The Railway dashboard's build command for that service was hardcoded to build only `contracts + integrations + gmail-capture`, so `@as-comms/db`'s `dist/` is missing in the deploy bundle. Service crashes on startup:

\`\`\`
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/app/apps/gmail-capture/node_modules/@as-comms/db/dist/index.js'
\`\`\`

## Fix

Mirror what `apps/web/railway.json` and `apps/worker/railway.json` already do: use `pnpm --filter @as-comms/gmail-capture... build` (note the `...` suffix that pulls all transitive workspace deps).

This file overrides the dashboard config once merged.

## Verification after deploy

Within ~5 min of deploy:
- Service goes from CRASHED → SUCCESS in `railway deployment list --service gmail-capture`
- `integration_health` row for gmail goes from `needs_attention` → `healthy`
- Inbox UI banner "gmail integration is degraded" disappears

## Out of scope

Not touching `apps/salesforce-capture` — verified it doesn't depend on `@as-comms/db`, so the existing dashboard config still works for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)