### PR TITLE
fix(worker): reconcile lifecycle_milestone + close gmail-orphan cases

### DIFF
--- a/apps/worker/src/ops/_reconcile-from-stored-evidence.ts
+++ b/apps/worker/src/ops/_reconcile-from-stored-evidence.ts
@@ -242,6 +242,59 @@ function buildMailchimpSummary(
   }
 }
 
+const lifecycleSources = [
+  {
+    milestone: "signed_up" as const,
+    sourceField: "Expedition_Members__c.CreatedDate" as const
+  },
+  {
+    milestone: "received_training" as const,
+    sourceField: "Expedition_Members__c.Date_Training_Sent__c" as const
+  },
+  {
+    milestone: "completed_training" as const,
+    sourceField: "Expedition_Members__c.Date_Training_Completed__c" as const
+  },
+  {
+    milestone: "submitted_first_data" as const,
+    sourceField: "Expedition_Members__c.Date_First_Sample_Collected__c" as const
+  }
+] as const;
+
+type LifecycleMilestone = (typeof lifecycleSources)[number]["milestone"];
+
+function resolveLifecycleEventType(
+  milestone: LifecycleMilestone
+): NormalizedCanonicalEventIntake["canonicalEvent"]["eventType"] {
+  switch (milestone) {
+    case "signed_up":
+      return "lifecycle.signed_up";
+    case "received_training":
+      return "lifecycle.received_training";
+    case "completed_training":
+      return "lifecycle.completed_training";
+    case "submitted_first_data":
+      return "lifecycle.submitted_first_data";
+  }
+}
+
+function buildLifecycleSummary(
+  eventType: NormalizedCanonicalEventIntake["canonicalEvent"]["eventType"]
+): string {
+  switch (eventType) {
+    case "lifecycle.signed_up":
+      return "Volunteer signed up";
+    case "lifecycle.received_training":
+      return "Volunteer received training";
+    case "lifecycle.completed_training":
+      return "Volunteer completed training";
+    case "lifecycle.submitted_first_data":
+      return "Volunteer submitted first data";
+    default:
+      throw new Error(`Unsupported lifecycle event type ${eventType}.`);
+  }
+}
+
 function buildSalesforceTaskSummary(input: {
   readonly eventType: NormalizedCanonicalEventIntake["canonicalEvent"]["eventType"];
   readonly messageKind: SalesforceCommunicationDetailRecord["messageKind"];
@@ -334,11 +387,150 @@ function parseSubjectDirection(rawSubject: string | null): {
   };
 }
 
-export async function buildEventFromStoredData(input: {
+function parseLifecycleProviderRecordId(input: {
+  readonly sourceEvidenceId: string;
+  readonly providerRecordId: string;
+}): {
+  readonly membershipId: string;
+  readonly sourceField: (typeof lifecycleSources)[number]["sourceField"];
+  readonly milestone: LifecycleMilestone;
+} {
+  const separatorIndex = input.providerRecordId.indexOf(":");
+
+  if (
+    separatorIndex <= 0 ||
+    separatorIndex === input.providerRecordId.length - 1
+  ) {
+    throw new Error(
+      `Expected lifecycle provider record id ${input.providerRecordId} for source evidence ${input.sourceEvidenceId} to use the format {membershipId}:{sourceField}.`
+    );
+  }
+
+  const membershipId = input.providerRecordId.slice(0, separatorIndex);
+  const sourceField = input.providerRecordId.slice(separatorIndex + 1);
+  const lifecycleSource = lifecycleSources.find(
+    (candidate) => candidate.sourceField === sourceField
+  );
+
+  if (lifecycleSource === undefined) {
+    throw new Error(
+      `Unsupported lifecycle source field ${sourceField} for source evidence ${input.sourceEvidenceId}.`
+    );
+  }
+
+  return {
+    membershipId,
+    sourceField: lifecycleSource.sourceField,
+    milestone: lifecycleSource.milestone
+  };
+}
+
+async function buildLifecycleIntakeFromStoredEvidence(input: {
   readonly repositories: Stage1RepositoryBundle;
   readonly sourceEvidence: SourceEvidenceRecord;
   readonly caseRecord: IdentityResolutionCase;
 }): Promise<NormalizedCanonicalEventIntake> {
+  const sourceEvidenceId = input.sourceEvidence.id;
+  const lifecycleRecord = parseLifecycleProviderRecordId({
+    sourceEvidenceId,
+    providerRecordId: input.sourceEvidence.providerRecordId
+  });
+  const eventContext = requireSingleDetail(
+    (
+      await input.repositories.salesforceEventContext.listBySourceEvidenceIds([
+        sourceEvidenceId
+      ])
+    )[0],
+    `Expected salesforce_event_context to exist for source evidence ${sourceEvidenceId}.`
+  );
+  const [project, expedition] = await Promise.all([
+    eventContext.projectId === null
+      ? Promise.resolve(undefined)
+      : input.repositories.projectDimensions
+          .listByIds([eventContext.projectId])
+          .then((records) => records[0]),
+    eventContext.expeditionId === null
+      ? Promise.resolve(undefined)
+      : input.repositories.expeditionDimensions
+          .listByIds([eventContext.expeditionId])
+          .then((records) => records[0])
+  ]);
+  const eventType = resolveLifecycleEventType(lifecycleRecord.milestone);
+  const routing = buildRoutingContext({
+    eventContext,
+    project,
+    expedition
+  });
+
+  return {
+    sourceEvidence: input.sourceEvidence,
+    canonicalEvent: {
+      id: buildCanonicalEventId({
+        provider: "salesforce",
+        providerRecordType: input.sourceEvidence.providerRecordType,
+        providerRecordId: input.sourceEvidence.providerRecordId,
+        eventType,
+        crossProviderCollapseKey: null
+      }),
+      eventType,
+      occurredAt: input.sourceEvidence.occurredAt,
+      idempotencyKey: buildCanonicalEventIdempotencyKey({
+        provider: "salesforce",
+        providerRecordType: input.sourceEvidence.providerRecordType,
+        providerRecordId: input.sourceEvidence.providerRecordId,
+        eventType,
+        crossProviderCollapseKey: null
+      }),
+      summary: buildLifecycleSummary(eventType),
+      snippet: ""
+    },
+    identity: buildIdentityFromCase({
+      caseRecord: input.caseRecord,
+      provider: input.sourceEvidence.provider,
+      preferredSalesforceContactId: eventContext.salesforceContactId
+    }),
+    ...(routing === undefined ? {} : { routing }),
+    supportingSources: [],
+    salesforceEventContext: {
+      ...eventContext,
+      sourceField: lifecycleRecord.sourceField
+    },
+    projectDimensions:
+      project === undefined
+        ? []
+        : [
+            {
+              projectId: project.projectId,
+              projectName: project.projectName,
+              source: project.source
+            }
+          ],
+    expeditionDimensions:
+      expedition === undefined
+        ? []
+        : [
+            {
+              expeditionId: expedition.expeditionId,
+              projectId: expedition.projectId,
+              expeditionName: expedition.expeditionName,
+              source: expedition.source
+            }
+          ]
+  };
+}
+
+export async function buildEventFromStoredData(input: {
+  readonly repositories: Stage1RepositoryBundle;
+  readonly sourceEvidence: SourceEvidenceRecord;
+  readonly caseRecord: IdentityResolutionCase;
+}): Promise<
+  | NormalizedCanonicalEventIntake
+  | {
+      readonly outcome: "skipped";
+      readonly reasonCode: "skipped_missing_presentation_detail";
+      readonly explanation: string;
+    }
+> {
   const sourceEvidenceId = input.sourceEvidence.id;
 
   switch (input.sourceEvidence.provider) {
@@ -349,14 +541,21 @@ export async function buildEventFromStoredData(input: {
           caseRecord: input.caseRecord,
           provider: input.sourceEvidence.provider
         });
-      const detail = requireSingleDetail(
-        (
-          await input.repositories.gmailMessageDetails.listBySourceEvidenceIds([
-            sourceEvidenceId
-          ])
-        )[0],
-        `Expected gmail_message_details to exist for source evidence ${sourceEvidenceId}.`
-      );
+      const detail = (
+        await input.repositories.gmailMessageDetails.listBySourceEvidenceIds([
+          sourceEvidenceId
+        ])
+      )[0];
+
+      if (detail === undefined) {
+        return {
+          outcome: "skipped",
+          reasonCode: "skipped_missing_presentation_detail",
+          explanation:
+            "Reconciled-as-skipped: source evidence has no gmail_message_details row (likely partial mbox import; cannot recover)"
+        };
+      }
+
       const crossProviderCollapseKey =
         detail.rfc822MessageId === null
           ? null
@@ -413,6 +612,10 @@ export async function buildEventFromStoredData(input: {
       };
     }
     case "salesforce": {
+      if (input.sourceEvidence.providerRecordType === "lifecycle_milestone") {
+        return buildLifecycleIntakeFromStoredEvidence(input);
+      }
+
       const [detail, eventContext] = await Promise.all([
         input.repositories.salesforceCommunicationDetails.listBySourceEvidenceIds([
           sourceEvidenceId

--- a/apps/worker/src/ops/reconcile-identity-queue.ts
+++ b/apps/worker/src/ops/reconcile-identity-queue.ts
@@ -68,6 +68,7 @@ type ReconcileExecutionResult =
     }
   | {
       readonly kind: "skipped";
+      readonly reasonCode?: "skipped_missing_presentation_detail";
     };
 
 class DryRunRollback extends Error {
@@ -204,7 +205,13 @@ async function loadOpenIdentityReconcileTargets(input: {
 
 function resolveOriginalCaseClosure(input: {
   readonly currentReasonCode: IdentityResolutionCase["reasonCode"];
-  readonly result: NormalizedCanonicalEventResult;
+  readonly result:
+    | NormalizedCanonicalEventResult
+    | {
+        readonly outcome: "skipped";
+        readonly reasonCode: "skipped_missing_presentation_detail";
+        readonly explanation: string;
+      };
 }): { readonly explanation: string } | null {
   const { currentReasonCode, result } = input;
 
@@ -215,6 +222,12 @@ function resolveOriginalCaseClosure(input: {
   }
 
   if (result.outcome === "skipped") {
+    if (result.reasonCode === "skipped_missing_presentation_detail") {
+      return {
+        explanation: result.explanation
+      };
+    }
+
     return {
       explanation:
         "Reconciled from stored evidence; task is outside volunteer scope (no memberships for anchored contact)."
@@ -331,11 +344,40 @@ async function executeTarget(input: {
       return;
     }
 
-    const normalizedIntake = await buildEventFromStoredData({
+    const storedEvidenceResult = await buildEventFromStoredData({
       repositories,
       sourceEvidence: input.target.sourceEvidence,
       caseRecord: currentCase
     });
+
+    if ("outcome" in storedEvidenceResult) {
+      const closure = resolveOriginalCaseClosure({
+        currentReasonCode: currentCase.reasonCode,
+        result: storedEvidenceResult
+      });
+
+      if (closure !== null) {
+        await markIdentityCaseResolved({
+          repositories,
+          caseRecord: currentCase,
+          resolvedAt: processedAt,
+          explanation: closure.explanation
+        });
+      }
+
+      execution = {
+        kind: "skipped",
+        reasonCode: storedEvidenceResult.reasonCode
+      };
+
+      if (input.dryRun) {
+        throw new DryRunRollback();
+      }
+
+      return;
+    }
+
+    const normalizedIntake = storedEvidenceResult;
     const beforeContactCount = (await repositories.contacts.listAll()).length;
     const normalizationResult =
       await normalization.applyNormalizedCanonicalEvent(normalizedIntake);

--- a/apps/worker/test/jobs/reconcile-identity-queue.test.ts
+++ b/apps/worker/test/jobs/reconcile-identity-queue.test.ts
@@ -61,7 +61,7 @@ async function seedStoredGmailCase(
   return caseId;
 }
 
-async function seedBrokenStoredGmailCase(
+async function seedBrokenStoredSalesforceCase(
   context: TestWorkerContext,
   input: {
     readonly recordId: string;
@@ -70,18 +70,27 @@ async function seedBrokenStoredGmailCase(
     readonly receivedAt: string;
   }
 ): Promise<void> {
-  const sourceEvidenceId = `source-evidence:gmail:message:${input.recordId}`;
+  const sourceEvidenceId =
+    `source-evidence:salesforce:task_communication:${input.recordId}`;
 
   await context.repositories.sourceEvidence.append({
     id: sourceEvidenceId,
-    provider: "gmail",
-    providerRecordType: "message",
+    provider: "salesforce",
+    providerRecordType: "task_communication",
     providerRecordId: input.recordId,
     receivedAt: input.receivedAt,
     occurredAt: input.occurredAt,
-    payloadRef: `capture://gmail/${input.recordId}`,
-    idempotencyKey: `source-evidence:gmail:message:${input.recordId}`,
+    payloadRef: `capture://salesforce/${input.recordId}`,
+    idempotencyKey:
+      `source-evidence:salesforce:task_communication:${input.recordId}`,
     checksum: `checksum:${input.recordId}`
+  });
+  await context.repositories.salesforceEventContext.upsert({
+    sourceEvidenceId,
+    salesforceContactId: null,
+    projectId: null,
+    expeditionId: null,
+    sourceField: null
   });
   await context.repositories.identityResolutionQueue.upsert({
     id: `identity-review:${sourceEvidenceId}:identity_missing_anchor`,
@@ -170,20 +179,20 @@ describe("reconcile identity queue task", () => {
 
     try {
       await Promise.all([
-        seedBrokenStoredGmailCase(context, {
-          recordId: "gmail-broken-1",
+        seedBrokenStoredSalesforceCase(context, {
+          recordId: "sf-broken-1",
           email: "broken-1@example.org",
           occurredAt: "2026-04-28T12:10:00.000Z",
           receivedAt: "2026-04-28T12:10:00.000Z"
         }),
-        seedBrokenStoredGmailCase(context, {
-          recordId: "gmail-broken-2",
+        seedBrokenStoredSalesforceCase(context, {
+          recordId: "sf-broken-2",
           email: "broken-2@example.org",
           occurredAt: "2026-04-28T12:11:00.000Z",
           receivedAt: "2026-04-28T12:11:00.000Z"
         }),
-        seedBrokenStoredGmailCase(context, {
-          recordId: "gmail-broken-3",
+        seedBrokenStoredSalesforceCase(context, {
+          recordId: "sf-broken-3",
           email: "broken-3@example.org",
           occurredAt: "2026-04-28T12:12:00.000Z",
           receivedAt: "2026-04-28T12:12:00.000Z"

--- a/apps/worker/test/stage1-reconcile-identity-queue.test.ts
+++ b/apps/worker/test/stage1-reconcile-identity-queue.test.ts
@@ -119,6 +119,7 @@ async function seedStoredGmailCase(
     readonly subject: string;
     readonly occurredAt: string;
     readonly receivedAt: string;
+    readonly includeDetails?: boolean;
     readonly lastAttemptedAt?: string | null;
     readonly reasonCode?:
       | "identity_missing_anchor"
@@ -139,21 +140,25 @@ async function seedStoredGmailCase(
     idempotencyKey: `source-evidence:gmail:message:${input.recordId}`,
     checksum: `checksum:${input.recordId}`
   });
-  await context.repositories.gmailMessageDetails.upsert({
-    sourceEvidenceId,
-    providerRecordId: input.recordId,
-    gmailThreadId: `thread:${input.recordId}`,
-    rfc822MessageId: `<${input.recordId}@example.org>`,
-    direction: "inbound",
-    subject: input.subject,
-    fromHeader: "Volunteer <volunteer@example.org>",
-    toHeader: "volunteers@adventurescientists.org",
-    ccHeader: null,
-    snippetClean: `snippet:${input.recordId}`,
-    bodyTextPreview: `body:${input.recordId}`,
-    capturedMailbox: "volunteers@adventurescientists.org",
-    projectInboxAlias: null
-  });
+
+  if (input.includeDetails !== false) {
+    await context.repositories.gmailMessageDetails.upsert({
+      sourceEvidenceId,
+      providerRecordId: input.recordId,
+      gmailThreadId: `thread:${input.recordId}`,
+      rfc822MessageId: `<${input.recordId}@example.org>`,
+      direction: "inbound",
+      subject: input.subject,
+      fromHeader: "Volunteer <volunteer@example.org>",
+      toHeader: "volunteers@adventurescientists.org",
+      ccHeader: null,
+      snippetClean: `snippet:${input.recordId}`,
+      bodyTextPreview: `body:${input.recordId}`,
+      capturedMailbox: "volunteers@adventurescientists.org",
+      projectInboxAlias: null
+    });
+  }
+
   await seedOpenIdentityCase(context, {
     sourceEvidenceId,
     normalizedIdentityValues: input.normalizedIdentityValues,
@@ -176,6 +181,7 @@ async function seedStoredSalesforceCase(
     readonly subject: string;
     readonly occurredAt: string;
     readonly receivedAt: string;
+    readonly includeCommunicationDetail?: boolean;
     readonly eventContextSalesforceContactId?: string | null;
   }
 ): Promise<void> {
@@ -193,21 +199,67 @@ async function seedStoredSalesforceCase(
     idempotencyKey: `source-evidence:salesforce:task_communication:${input.recordId}`,
     checksum: `checksum:${input.recordId}`
   });
-  await context.repositories.salesforceCommunicationDetails.upsert({
-    sourceEvidenceId,
-    providerRecordId: input.recordId,
-    channel: "email",
-    messageKind: "one_to_one",
-    subject: input.subject,
-    snippet: `snippet:${input.recordId}`,
-    sourceLabel: "Salesforce Task"
-  });
+
+  if (input.includeCommunicationDetail !== false) {
+    await context.repositories.salesforceCommunicationDetails.upsert({
+      sourceEvidenceId,
+      providerRecordId: input.recordId,
+      channel: "email",
+      messageKind: "one_to_one",
+      subject: input.subject,
+      snippet: `snippet:${input.recordId}`,
+      sourceLabel: "Salesforce Task"
+    });
+  }
+
   await context.repositories.salesforceEventContext.upsert({
     sourceEvidenceId,
     salesforceContactId: input.eventContextSalesforceContactId ?? null,
     projectId: null,
     expeditionId: null,
     sourceField: null
+  });
+  await seedOpenIdentityCase(context, {
+    sourceEvidenceId,
+    normalizedIdentityValues: input.normalizedIdentityValues,
+    openedAt: input.receivedAt
+  });
+}
+
+async function seedStoredSalesforceLifecycleCase(
+  context: TestWorkerContext,
+  input: {
+    readonly recordId: string;
+    readonly normalizedIdentityValues: readonly string[];
+    readonly occurredAt: string;
+    readonly receivedAt: string;
+    readonly salesforceContactId: string | null;
+  }
+): Promise<void> {
+  const sourceEvidenceId =
+    `source-evidence:salesforce:lifecycle_milestone:${encodeURIComponent(input.recordId)}`;
+  const separatorIndex = input.recordId.indexOf(":");
+  const sourceField =
+    separatorIndex === -1 ? null : input.recordId.slice(separatorIndex + 1);
+
+  await context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "salesforce",
+    providerRecordType: "lifecycle_milestone",
+    providerRecordId: input.recordId,
+    receivedAt: input.receivedAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `capture://salesforce/${encodeURIComponent(input.recordId)}`,
+    idempotencyKey:
+      `source-evidence:salesforce:lifecycle_milestone:${input.recordId}`,
+    checksum: `checksum:${input.recordId}`
+  });
+  await context.repositories.salesforceEventContext.upsert({
+    sourceEvidenceId,
+    salesforceContactId: input.salesforceContactId,
+    projectId: null,
+    expeditionId: null,
+    sourceField
   });
   await seedOpenIdentityCase(context, {
     sourceEvidenceId,
@@ -547,6 +599,172 @@ describe("reconcileIdentityQueue", () => {
         status: "resolved"
       });
       expect(resolvedCase?.explanation).toContain("outside volunteer scope");
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("reconciles a stuck salesforce lifecycle_milestone case", async () => {
+    const context = await createTestWorkerContext();
+    const recordId = "membership-stage1:Expedition_Members__c.Date_Training_Sent__c";
+    const caseId =
+      `identity-review:source-evidence:salesforce:lifecycle_milestone:${encodeURIComponent(recordId)}:identity_missing_anchor`;
+
+    try {
+      await seedDurableEmailContact(context, {
+        contactId: "contact_lifecycle_anchor",
+        email: "lifecycle@example.org",
+        displayName: "Lifecycle Contact",
+        salesforceContactId: "003-lifecycle-anchor"
+      });
+      await seedStoredSalesforceLifecycleCase(context, {
+        recordId,
+        normalizedIdentityValues: [],
+        occurredAt: "2026-01-01T00:08:00.000Z",
+        receivedAt: "2026-01-01T00:08:00.000Z",
+        salesforceContactId: "003-lifecycle-anchor"
+      });
+
+      const report = await reconcileIdentityQueue({
+        db: context.db,
+        repositories: context.repositories,
+        capture: context.capture,
+        gmailHistoricalReplay: {
+          liveAccount: "volunteers@adventurescientists.org",
+          projectInboxAliases: ["orcas@adventurescientists.org"]
+        },
+        dryRun: false,
+        logger: {
+          log: () => undefined
+        }
+      });
+
+      expect(report).toMatchObject({
+        dryRun: false,
+        scanned: 1,
+        resolved: 1,
+        created: 0,
+        skipped: 0
+      });
+      expect(report.errors).toEqual([]);
+      await expect(
+        context.repositories.canonicalEvents.listByContactId(
+          "contact_lifecycle_anchor"
+        )
+      ).resolves.toEqual([
+        expect.objectContaining({
+          eventType: "lifecycle.received_training"
+        })
+      ]);
+      await expect(
+        context.repositories.identityResolutionQueue.findById(caseId)
+      ).resolves.toMatchObject({
+        status: "resolved"
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("closes orphan gmail case as skipped when gmail_message_details missing", async () => {
+    const context = await createTestWorkerContext();
+    const recordId = "mbox:orphan-gmail-1";
+    const caseId =
+      "identity-review:source-evidence:gmail:message:mbox:orphan-gmail-1:identity_missing_anchor";
+
+    try {
+      await seedStoredGmailCase(context, {
+        recordId,
+        payloadRef: `mbox://archive.mbox#message=${encodeURIComponent(recordId)}`,
+        normalizedIdentityValues: ["orphan@example.org"],
+        subject: "Missing Gmail detail row",
+        occurredAt: "2026-01-01T00:09:00.000Z",
+        receivedAt: "2026-01-01T00:09:00.000Z",
+        includeDetails: false
+      });
+
+      const report = await reconcileIdentityQueue({
+        db: context.db,
+        repositories: context.repositories,
+        capture: context.capture,
+        gmailHistoricalReplay: {
+          liveAccount: "volunteers@adventurescientists.org",
+          projectInboxAliases: ["orcas@adventurescientists.org"]
+        },
+        dryRun: false,
+        logger: {
+          log: () => undefined
+        }
+      });
+
+      expect(report).toMatchObject({
+        dryRun: false,
+        scanned: 1,
+        resolved: 0,
+        created: 0,
+        skipped: 1
+      });
+      expect(report.errors).toEqual([]);
+      const resolvedCase =
+        await context.repositories.identityResolutionQueue.findById(caseId);
+
+      expect(resolvedCase?.status).toBe("resolved");
+      expect(resolvedCase?.explanation).toContain("gmail_message_details row");
+      await expect(
+        context.repositories.canonicalEvents.countAll()
+      ).resolves.toBe(0);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("still throws on orphan salesforce task_communication", async () => {
+    const context = await createTestWorkerContext();
+    const caseId =
+      "identity-review:source-evidence:salesforce:task_communication:sf-orphan-task-1:identity_missing_anchor";
+
+    try {
+      await seedStoredSalesforceCase(context, {
+        recordId: "sf-orphan-task-1",
+        normalizedIdentityValues: ["orphan-salesforce@example.org"],
+        subject: "Missing Salesforce detail row",
+        occurredAt: "2026-01-01T00:10:00.000Z",
+        receivedAt: "2026-01-01T00:10:00.000Z",
+        includeCommunicationDetail: false
+      });
+
+      const report = await reconcileIdentityQueue({
+        db: context.db,
+        repositories: context.repositories,
+        capture: context.capture,
+        gmailHistoricalReplay: {
+          liveAccount: "volunteers@adventurescientists.org",
+          projectInboxAliases: ["orcas@adventurescientists.org"]
+        },
+        dryRun: false,
+        logger: {
+          log: () => undefined
+        }
+      });
+
+      expect(report).toMatchObject({
+        dryRun: false,
+        scanned: 1,
+        resolved: 0,
+        created: 0,
+        skipped: 0
+      });
+      expect(report.errors).toHaveLength(1);
+      expect(report.errors[0]?.caseId).toBe(caseId);
+      expect(report.errors[0]?.reason).toBe("target_execution_failed");
+      expect(report.errors[0]?.message).toContain(
+        "Expected salesforce_communication_details to exist"
+      );
+      await expect(
+        context.repositories.identityResolutionQueue.findById(caseId)
+      ).resolves.toMatchObject({
+        status: "open"
+      });
     } finally {
       await context.dispose();
     }


### PR DESCRIPTION
## Summary

Follow-up to #193. After #193 deployed, the reconcile cron rotated 200 cases per */15 min via `last_attempted_at` but resolved 0 cases — every case errored with `"Expected gmail_message_details to exist"` or `"Expected salesforce_communication_details to exist"`.

Two compounding gaps in the original implementation:

1. **`lifecycle_milestone` source-evidence rows** have no `salesforce_communication_details` by design. Their data lives in the encoded `provider_record_id` (`membershipId:sourceField` format) plus `salesforce_event_context`.
2. **Older mbox-imported `gmail/message` rows** lack `gmail_message_details` (partial detail-table coverage from earlier capture passes); these can never resolve under the original precondition.

## Changes

- `apps/worker/src/ops/_reconcile-from-stored-evidence.ts`: add `buildLifecycleIntakeFromStoredEvidence` path. Parses `provider_record_id`, requires `salesforce_event_context` (this row IS expected to exist for lifecycle), resolves project/expedition routing, builds a canonical lifecycle event.
- `apps/worker/src/ops/reconcile-identity-queue.ts`: treat orphan gmail cases (missing `gmail_message_details`) as terminally skipped — `markIdentityCaseResolved` with explanation referencing the missing presentation detail.
- Orphan salesforce `task_communication` cases stay as hard errors — that path indicates data corruption and warrants investigation.

## Tests

Three new cases extend coverage:
- `reconciles a stuck salesforce lifecycle_milestone case` — verifies lifecycle resolution end-to-end
- `closes orphan gmail case as skipped when gmail_message_details missing` — verifies terminal-skip behavior
- `still throws on orphan salesforce task_communication` — preserves the existing investigation trigger

`pnpm typecheck && pnpm lint && pnpm test:unit` all pass locally.

## Test plan

- [x] CI green
- [ ] Deploy and confirm reconcile cron starts resolving cases (expect ~200 resolved per */15 min, ~12h to drain backlog of 9,233)
- [ ] On confirmation, architect to authorize `--execute` reconcile against prod for fast clearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)