### PR TITLE
fix(security): gate /settings/access read + require auth on inbox-rebuild

### DIFF
--- a/apps/web/app/api/internal/inbox-rebuild/route.ts
+++ b/apps/web/app/api/internal/inbox-rebuild/route.ts
@@ -19,6 +19,16 @@ const rebuildRequestSchema = z.object({
   selection: z.enum(["all", "invalid"]).default("all")
 });
 
+function isAuthorized(request: Request): boolean {
+  const expectedToken = process.env.INTERNAL_INBOX_REBUILD_TOKEN;
+
+  if (!expectedToken || expectedToken.trim().length === 0) {
+    return false;
+  }
+
+  return request.headers.get("authorization") === `Bearer ${expectedToken}`;
+}
+
 function compareCanonicalEventOrder(
   left: CanonicalEventRecord,
   right: CanonicalEventRecord
@@ -109,6 +119,18 @@ async function loadInboxSnippetForEvent(
 }
 
 export async function POST(request: Request) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json(
+      {
+        ok: false,
+        code: "unauthorized"
+      },
+      {
+        status: 401
+      }
+    );
+  }
+
   if (process.env.NODE_ENV === "production") {
     return NextResponse.json(
       {

--- a/apps/web/app/settings/access/page.tsx
+++ b/apps/web/app/settings/access/page.tsx
@@ -23,7 +23,16 @@ export default async function SettingsAccessPage() {
     throw error;
   }
 
-  const viewModel = await loadAccessSettings();
+  let viewModel;
+
+  try {
+    viewModel = await loadAccessSettings();
+  } catch (error) {
+    if (error instanceof Error && error.message === "FORBIDDEN") {
+      redirect("/settings");
+    }
+    throw error;
+  }
 
   return (
     <SettingsContent>

--- a/apps/web/src/server/settings/selectors.ts
+++ b/apps/web/src/server/settings/selectors.ts
@@ -496,11 +496,16 @@ export async function loadProjectSettingsDetail(
 }
 
 export async function loadAccessSettings(): Promise<AccessSettingsViewModel> {
-  const [currentUser, cachedData] = await Promise.all([
-    getCurrentUser(),
-    loadAccessSettingsCacheData()
-  ]);
-  const currentUserId = currentUser?.id ?? null;
+  const currentUser = await getCurrentUser();
+  if (currentUser === null) {
+    throw new Error("UNAUTHORIZED");
+  }
+  if (currentUser.role !== "admin") {
+    throw new Error("FORBIDDEN");
+  }
+
+  const cachedData = await loadAccessSettingsCacheData();
+  const currentUserId = currentUser.id;
   const admins = sortUsers(
     cachedData.rows.filter((user) => user.role === "admin"),
     currentUserId
@@ -520,7 +525,7 @@ export async function loadAccessSettings(): Promise<AccessSettingsViewModel> {
   });
 
   return {
-    isAdmin: currentUser?.role === "admin",
+    isAdmin: true,
     currentUserId,
     admins,
     internalUsers

--- a/apps/web/tests/unit/inbox-rebuild-route.test.ts
+++ b/apps/web/tests/unit/inbox-rebuild-route.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const revalidateInboxViews = vi.hoisted(() => vi.fn());
+const getStage1WebRuntime = vi.hoisted(() => vi.fn());
+const createStage1PersistenceService = vi.hoisted(() => vi.fn());
+const createStage1NormalizationService = vi.hoisted(() => vi.fn());
+
+vi.mock("@as-comms/domain", () => ({
+  createStage1NormalizationService,
+  createStage1PersistenceService,
+  isInboxDrivingCanonicalEvent: vi.fn(() => true),
+}));
+
+vi.mock("../../src/server/inbox/revalidate", () => ({
+  revalidateInboxViews,
+}));
+
+vi.mock("../../src/server/stage1-runtime", () => ({
+  getStage1WebRuntime,
+}));
+
+import { POST } from "../../app/api/internal/inbox-rebuild/route";
+
+describe("internal inbox rebuild route", () => {
+  beforeEach(() => {
+    vi.stubEnv("INTERNAL_INBOX_REBUILD_TOKEN", "test-token");
+    vi.stubEnv("NODE_ENV", "development");
+    revalidateInboxViews.mockReset();
+    createStage1PersistenceService.mockReset();
+    createStage1NormalizationService.mockReset();
+    getStage1WebRuntime.mockReset();
+    createStage1PersistenceService.mockReturnValue({});
+    createStage1NormalizationService.mockReturnValue({});
+    getStage1WebRuntime.mockResolvedValue({
+      connection: {
+        sql: vi.fn().mockResolvedValue(undefined),
+      },
+      repositories: {
+        inboxProjection: {
+          countInvalidRecencyRows: vi
+            .fn()
+            .mockResolvedValueOnce(0)
+            .mockResolvedValueOnce(0),
+          listInvalidRecencyContactIds: vi.fn().mockResolvedValue([]),
+        },
+        contacts: {
+          listAll: vi.fn().mockResolvedValue([]),
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("rejects requests without a bearer token", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/internal/inbox-rebuild", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ contactIds: [] }),
+      })
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      code: "unauthorized",
+    });
+  });
+
+  it("rejects requests with the wrong bearer token", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/internal/inbox-rebuild", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer wrong-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ contactIds: [] }),
+      })
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      code: "unauthorized",
+    });
+  });
+
+  it("accepts requests with the correct bearer token", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/internal/inbox-rebuild", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer test-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ contactIds: [] }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      selection: "all",
+      rebuiltContactIds: [],
+      rebuiltInboxRows: 0,
+      invalidBefore: 0,
+      invalidAfter: 0,
+    });
+  });
+});

--- a/apps/web/tests/unit/settings-selectors.test.ts
+++ b/apps/web/tests/unit/settings-selectors.test.ts
@@ -369,6 +369,15 @@ describe("settings selectors", () => {
     ]);
   });
 
+  it("rejects non-admin callers from loading access settings", async () => {
+    getCurrentUser.mockResolvedValueOnce({
+      id: "user:operator",
+      role: "operator"
+    });
+
+    await expect(loadAccessSettings()).rejects.toThrow("FORBIDDEN");
+  });
+
   it("returns the six seeded integrations in stable order on first read", async () => {
     const viewModel = await loadIntegrationHealth();
 

--- a/apps/web/tests/unit/settings-users-read-audit.test.ts
+++ b/apps/web/tests/unit/settings-users-read-audit.test.ts
@@ -128,4 +128,20 @@ describe("settings users read audit", () => {
     expect(typeof metadata.visibleUserCount).toBe("number");
     expect(metadata.visibleUserCount).toBeGreaterThan(0);
   });
+
+  it("redirects non-admin operators back to settings", async () => {
+    const operator = buildUser({
+      id: "user:operator",
+      email: "operator@adventurescientists.org",
+      role: "operator",
+    });
+    requireSession.mockResolvedValueOnce(operator);
+    getCurrentUser.mockResolvedValueOnce(operator);
+    redirect.mockImplementationOnce(() => {
+      throw new Error("NEXT_REDIRECT_SETTINGS");
+    });
+
+    await expect(SettingsAccessPage()).rejects.toThrow("NEXT_REDIRECT_SETTINGS");
+    expect(redirect).toHaveBeenCalledWith("/settings");
+  });
 });


### PR DESCRIPTION
## Summary

Two P1 security fixes from the overnight `.codex-review-slice4-web.md` review:

1. **`/settings/access` PII leak** — page formerly only required a session, then `loadAccessSettings()` returned all teammate emails/roles/status to any signed-in operator (mutations were correctly admin-gated; reads weren't). Now both the page and the selector enforce admin role; non-admin operators get redirected to `/settings`.

2. **`/api/internal/inbox-rebuild` was unauthenticated** in any non-prod environment, where a POST could delete + rebuild `contact_inbox_projection`. Now requires `Authorization: Bearer <token>` using a new `INTERNAL_INBOX_REBUILD_TOKEN` env var, mirroring the `/api/internal/revalidate` pattern. Production block kept as defense-in-depth.

## Files

- `apps/web/app/settings/access/page.tsx` — admin guard
- `apps/web/src/server/settings/selectors.ts` — `loadAccessSettings()` admin-gate
- `apps/web/app/api/internal/inbox-rebuild/route.ts` — bearer-token auth
- Test additions in `apps/web/tests/unit/settings-users-read-audit.test.ts`

## New env var

`INTERNAL_INBOX_REBUILD_TOKEN` — required for any non-prod inbox rebuild. Set in Railway dashboard for preview/staging environments. Production already blocks the route via `NODE_ENV` check.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test:unit` clean locally
- [ ] CI green
- [ ] Set `INTERNAL_INBOX_REBUILD_TOKEN` in Railway preview env before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)