### PR TITLE
chore(db): default statement_timeout + index alignment for inbox recency + #185 project filter

### DIFF
--- a/packages/db/drizzle/0033_inbox_recency_and_project_membership_indexes.sql
+++ b/packages/db/drizzle/0033_inbox_recency_and_project_membership_indexes.sql
@@ -1,0 +1,8 @@
+CREATE INDEX IF NOT EXISTS contact_inbox_projection_recency_inbound_idx
+  ON contact_inbox_projection (last_inbound_at DESC NULLS LAST, last_activity_at DESC, contact_id ASC);
+
+CREATE INDEX IF NOT EXISTS contact_inbox_projection_recency_outbound_idx
+  ON contact_inbox_projection (last_outbound_at DESC NULLS LAST, last_activity_at DESC, contact_id ASC);
+
+CREATE INDEX IF NOT EXISTS contact_memberships_project_contact_idx
+  ON contact_memberships (project_id, contact_id);

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -28,8 +28,20 @@ export function createDatabaseConnection(rawConfig: DatabaseConfig): DatabaseCon
   // connection budget across the web + worker services. Override via
   // DB_POOL_MAX env var if Railway tier limits change.
   const poolSize = Number.parseInt(process.env.DB_POOL_MAX ?? "20", 10);
+  // Set a server-side default statement timeout for all queries. Override via
+  // DB_STATEMENT_TIMEOUT_MS if environment-specific tuning is needed.
+  const statementTimeoutMs = Number.parseInt(
+    process.env.DB_STATEMENT_TIMEOUT_MS ?? "30000",
+    10,
+  );
   const sql = postgres(config.connectionString, {
     max: Number.isFinite(poolSize) && poolSize > 0 ? poolSize : 20,
+    connection: {
+      statement_timeout:
+        Number.isFinite(statementTimeoutMs) && statementTimeoutMs > 0
+          ? statementTimeoutMs
+          : 30000,
+    },
     prepare: false
   });
 

--- a/packages/db/src/schema/tables.ts
+++ b/packages/db/src/schema/tables.ts
@@ -171,6 +171,10 @@ export const contactMemberships = pgTable(
       table.projectId,
       table.expeditionId,
     ),
+    index("contact_memberships_project_contact_idx").on(
+      table.projectId,
+      table.contactId,
+    ),
   ],
 );
 
@@ -528,6 +532,16 @@ export const contactInboxProjection = pgTable(
     index("contact_inbox_projection_bucket_idx").on(
       table.bucket,
       table.lastActivityAt,
+    ),
+    index("contact_inbox_projection_recency_inbound_idx").on(
+      table.lastInboundAt.desc().nullsLast(),
+      table.lastActivityAt.desc(),
+      table.contactId.asc(),
+    ),
+    index("contact_inbox_projection_recency_outbound_idx").on(
+      table.lastOutboundAt.desc().nullsLast(),
+      table.lastActivityAt.desc(),
+      table.contactId.asc(),
     ),
     index("contact_inbox_projection_unresolved_idx").on(
       table.hasUnresolved,


### PR DESCRIPTION
## Summary

Three additive DB-layer hardenings from the overnight `.codex-review-slice5-db.md` review:

1. **Default `statement_timeout` on app DB connections** (`packages/db/src/client.ts`). Defaults to 30s; override via `DB_STATEMENT_TIMEOUT_MS`. Mitigates DoS / pool-exhaustion when slow paths consume the whole pool.

2. **Two new btree indexes on `contact_inbox_projection`** matching the actual default and last-outbound query order shapes (the existing `recency_idx` indexes `coalesce(last_inbound_at, last_activity_at)` — different shape from the actual ORDER BY). Existing index kept for safety.

3. **Covering index `contact_memberships(project_id, contact_id)`** for the #185 EXISTS subquery semi-join. Existing membership indexes don't satisfy both halves.

All additive; no destructive changes.

## Migration

`packages/db/drizzle/0033_inbox_recency_and_project_membership_indexes.sql` — chosen two above the current highest (`0031`) per the architect's collision rule (recent #194 had to renumber 0030).

`pnpm exec drizzle-kit generate` confirms schema and migration are in sync.

## New env var

`DB_STATEMENT_TIMEOUT_MS` — optional override of the 30s default. No action required to ship; Railway env can be set later if tuning needed.

## Held back deliberately (future briefs)

- `source_evidence_log` UNIQUE redefinition — semantic contract change
- `salesforce_membership_id NOT NULL` — needs data audit
- `contact_memberships` FKs to dimensions — destructive on existing orphan rows

## Test plan

- [x] `pnpm typecheck && pnpm lint` clean locally
- [ ] `pnpm test:unit` blocked locally by macOS rollup darwin-arm64 code-signature env issue (per `project_macos_rollup_gotcha`); CI authoritative
- [ ] CI green
- [ ] Verify migration applies cleanly on next Railway deploy (drizzle journal drift may require manual reconciliation per `.STATE-2026-04-28-evening.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)