### PR TITLE
fix(integrations): validate Salesforce nextRecordsUrl origin to prevent bearer-token exfil

### DIFF
--- a/packages/integrations/src/capture-services/salesforce.ts
+++ b/packages/integrations/src/capture-services/salesforce.ts
@@ -117,6 +117,22 @@ class SalesforceHealthCheckError extends Error {
   }
 }
 
+export class SalesforcePaginationOriginError extends Error {
+  constructor(input: {
+    readonly expectedOrigin: string;
+    readonly resolvedUrl: string;
+    readonly reason: "origin" | "path";
+  }) {
+    const resolvedUrl = new URL(input.resolvedUrl);
+    const message =
+      input.reason === "origin"
+        ? `Salesforce nextRecordsUrl origin mismatch: expected ${input.expectedOrigin}, received ${resolvedUrl.origin} (${resolvedUrl.host}).`
+        : `Salesforce nextRecordsUrl path is outside /services/data/: ${resolvedUrl.pathname} on ${resolvedUrl.origin}. Expected origin ${input.expectedOrigin}.`;
+    super(message);
+    this.name = "SalesforcePaginationOriginError";
+  }
+}
+
 const salesforceTokenResponseSchema = z.object({
   access_token: z.string().min(1),
   instance_url: z.string().url(),
@@ -646,6 +662,7 @@ export function createSalesforceApiClient(
   return {
     async queryAll(soql) {
       const token = await getAccessToken();
+      const expectedInstanceOrigin = new URL(token.instanceUrl).origin;
       const records: SalesforceRow[] = [];
       let nextUrl = new URL(
         `/services/data/v${parsedConfig.apiVersion}/query?q=${encodeURIComponent(soql)}`,
@@ -672,13 +689,32 @@ export function createSalesforceApiClient(
         const queryPayload: unknown = JSON.parse(await response.text());
         const queryResponse = salesforceQueryResponseSchema.parse(queryPayload);
         records.push(...queryResponse.records);
-        nextUrl =
-          queryResponse.nextRecordsUrl === undefined
-            ? ""
-            : new URL(
-                queryResponse.nextRecordsUrl,
-                token.instanceUrl,
-              ).toString();
+        if (queryResponse.nextRecordsUrl === undefined) {
+          nextUrl = "";
+          continue;
+        }
+
+        const resolvedNextUrl = new URL(
+          queryResponse.nextRecordsUrl,
+          token.instanceUrl,
+        );
+        if (resolvedNextUrl.origin !== expectedInstanceOrigin) {
+          throw new SalesforcePaginationOriginError({
+            expectedOrigin: expectedInstanceOrigin,
+            resolvedUrl: resolvedNextUrl.toString(),
+            reason: "origin",
+          });
+        }
+
+        if (!resolvedNextUrl.pathname.startsWith("/services/data/")) {
+          throw new SalesforcePaginationOriginError({
+            expectedOrigin: expectedInstanceOrigin,
+            resolvedUrl: resolvedNextUrl.toString(),
+            reason: "path",
+          });
+        }
+
+        nextUrl = resolvedNextUrl.toString();
       }
 
       return records;

--- a/packages/integrations/test/stage1-salesforce-capture-service.test.ts
+++ b/packages/integrations/test/stage1-salesforce-capture-service.test.ts
@@ -4,6 +4,7 @@ import {
   createSalesforceApiClient,
   createSalesforceCapturePort,
   createSalesforceCaptureService,
+  SalesforcePaginationOriginError,
   type CaptureServiceHttpRequest,
   type SalesforceApiClient,
   type SalesforceCaptureService,
@@ -1234,6 +1235,144 @@ describe("Salesforce capture service", () => {
       aud: "https://login.example.test",
       exp: expectedExp,
     });
+  });
+
+  it("throws when nextRecordsUrl points to a different origin", async () => {
+    const fetchImplementation = vi.fn<typeof fetch>((input) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof Request
+            ? input.url
+            : input.toString();
+
+      if (url === "https://test.salesforce.com/services/oauth2/token") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              access_token: "token-123",
+              instance_url: "https://instance.example.test",
+            }),
+            {
+              status: 200,
+              headers: {
+                "content-type": "application/json",
+              },
+            },
+          ),
+        );
+      }
+
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            records: [{ Id: "003-first" }],
+            done: false,
+            nextRecordsUrl:
+              "https://evil.example.com/services/data/v60.0/query/01g-next",
+          }),
+          {
+            status: 200,
+            headers: {
+              "content-type": "application/json",
+            },
+          },
+        ),
+      );
+    });
+
+    const client = createSalesforceApiClient(createSalesforceServiceConfig(), {
+      fetchImplementation,
+    });
+
+    const queryPromise = client.queryAll("SELECT Id FROM Contact");
+
+    await expect(queryPromise).rejects.toThrow(SalesforcePaginationOriginError);
+    await expect(queryPromise).rejects.toThrow(
+      /expected https:\/\/instance\.example\.test, received https:\/\/evil\.example\.com/u,
+    );
+    expect(fetchImplementation).toHaveBeenCalledTimes(2);
+  });
+
+  it("continues normally when nextRecordsUrl is a relative path under /services/data/", async () => {
+    const fetchImplementation = vi.fn<typeof fetch>((input) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof Request
+            ? input.url
+            : input.toString();
+
+      if (url === "https://test.salesforce.com/services/oauth2/token") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              access_token: "token-123",
+              instance_url: "https://instance.example.test/base/path",
+            }),
+            {
+              status: 200,
+              headers: {
+                "content-type": "application/json",
+              },
+            },
+          ),
+        );
+      }
+
+      if (
+        url ===
+        "https://instance.example.test/services/data/v61.0/query?q=SELECT%20Id%20FROM%20Contact"
+      ) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              records: [{ Id: "003-first" }],
+              done: false,
+              nextRecordsUrl: "/services/data/v61.0/query/01g-next",
+            }),
+            {
+              status: 200,
+              headers: {
+                "content-type": "application/json",
+              },
+            },
+          ),
+        );
+      }
+
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            records: [{ Id: "003-second" }],
+            done: true,
+          }),
+          {
+            status: 200,
+            headers: {
+              "content-type": "application/json",
+            },
+          },
+        ),
+      );
+    });
+
+    const client = createSalesforceApiClient(createSalesforceServiceConfig(), {
+      fetchImplementation,
+    });
+
+    await expect(client.queryAll("SELECT Id FROM Contact")).resolves.toEqual([
+      { Id: "003-first" },
+      { Id: "003-second" },
+    ]);
+    const thirdCall = fetchImplementation.mock.calls[2];
+
+    expect(thirdCall?.[0]).toBe(
+      "https://instance.example.test/services/data/v61.0/query/01g-next",
+    );
+    expect(new Headers(thirdCall?.[1]?.headers).get("authorization")).toBe(
+      "Bearer token-123",
+    );
   });
 
   it("includes the Salesforce response body in token exchange errors when available", async () => {


### PR DESCRIPTION
## Summary

Slice 3 P1 #1: `createSalesforceApiClient.queryAll` previously resolved `nextRecordsUrl` against `token.instanceUrl` and sent the bearer token to whatever URL came back. An absolute attacker-origin `nextRecordsUrl` would keep the attacker origin through `new URL(..., instanceUrl)` — so a compromised SF response (or MITM) could exfiltrate the bearer token to a third-party host.

## Fix

- Compute `expectedInstanceOrigin = new URL(token.instanceUrl).origin` once per `queryAll`.
- For every `nextRecordsUrl`, resolve and check `origin === expectedInstanceOrigin`. Mismatch throws a new typed `SalesforcePaginationOriginError` **before** the bearer is sent.
- Defense-in-depth: also reject paths outside `/services/data/`. Same typed error.
- Error message includes only origin/host/path — no auth material leaks.

## Tests

- `queryAll throws when nextRecordsUrl points to a different origin`
- `queryAll continues normally when nextRecordsUrl is a relative path under /services/data/`

## Test plan

- [x] `pnpm typecheck && pnpm lint` clean
- [x] `pnpm test:unit` clean for `packages/integrations/`
- [ ] CI green
- Six worker-test timeouts seen locally on macOS (`apps/worker/test/stage1-*`) — environmental, no worker code touched. CI authoritative.

Cites `.codex-review-slice3-integrations.md` § Security P1 #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)