### PR TITLE
fix(inbox): close projection-gap blind spot + narrow auto_email display dedup

### DIFF
--- a/packages/domain/src/timeline.ts
+++ b/packages/domain/src/timeline.ts
@@ -479,6 +479,18 @@ function timelineOccurredAtMs(value: string): number {
   return Number.isNaN(parsed) ? 0 : parsed;
 }
 
+function timelinePresentationDuplicateWindowMs(
+  left: CanonicalTimelineItemWithEvent,
+  right: CanonicalTimelineItemWithEvent,
+): number {
+  if (left.item.family === "auto_email" && right.item.family === "auto_email") {
+    // Auto-emails can legitimately repeat the same template minutes apart.
+    return 30 * 1000;
+  }
+
+  return timelineDuplicateWindowMs;
+}
+
 function isTimelinePresentationDuplicate(
   left: CanonicalTimelineItemWithEvent,
   right: CanonicalTimelineItemWithEvent,
@@ -512,7 +524,7 @@ function isTimelinePresentationDuplicate(
     Math.abs(
       timelineOccurredAtMs(left.canonicalEvent.occurredAt) -
         timelineOccurredAtMs(right.canonicalEvent.occurredAt),
-    ) <= timelineDuplicateWindowMs
+    ) <= timelinePresentationDuplicateWindowMs(left, right)
   );
 }
 
@@ -710,6 +722,65 @@ function mergeTimelineItems(input: {
       ...buildPendingTimelineItems(input.pendingRows),
     ].sort((left, right) => left.sortKey.localeCompare(right.sortKey)),
   );
+}
+
+function isDisplayableCommunicationEvent(input: {
+  readonly event: CanonicalEventRecord;
+  readonly context: TimelinePresentationContext;
+}): boolean {
+  if (!input.event.eventType.startsWith("communication.")) {
+    return false;
+  }
+
+  try {
+    resolveFamily(
+      input.event,
+      input.context.salesforceCommunicationBySourceEvidenceId.get(
+        input.event.sourceEvidenceId,
+      ),
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function warnTimelineProjectionGaps(input: {
+  readonly contactId: string;
+  readonly canonicalEvents: readonly CanonicalEventRecord[];
+  readonly timelineRows: readonly TimelineProjectionRow[];
+  readonly context: TimelinePresentationContext;
+}): void {
+  try {
+    const projectedCanonicalEventIds = new Set(
+      input.timelineRows.map((row) => row.canonicalEventId),
+    );
+
+    for (const event of input.canonicalEvents) {
+      if (
+        !isDisplayableCommunicationEvent({
+          event,
+          context: input.context,
+        }) ||
+        projectedCanonicalEventIds.has(event.id)
+      ) {
+        continue;
+      }
+
+      console.warn(
+        "Timeline projection gap detected for canonical communication event.",
+        {
+          contactId: input.contactId,
+          canonicalEventId: event.id,
+          eventType: event.eventType,
+          provider: event.provenance.primaryProvider,
+          timestamp: event.occurredAt,
+        },
+      );
+    }
+  } catch {
+    // Projection-gap diagnostics must never block timeline rendering.
+  }
 }
 
 export interface Stage1TimelinePresentationService {
@@ -1079,6 +1150,12 @@ export function createStage1TimelinePresentationService(
         repositories,
         canonicalEvents,
       );
+      warnTimelineProjectionGaps({
+        contactId,
+        canonicalEvents,
+        timelineRows: rows,
+        context,
+      });
       const canonicalItems = collapseDuplicateTimelineItems({
         canonicalItems: buildTimelineItemsFromRows({
           timelineRows: rows,

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type {
   AuditEvidenceRecord,
@@ -930,6 +930,113 @@ describe("Stage 1 timeline presenter", () => {
     });
   });
 
+  it("does not warn when every displayable communication event has a timeline projection row", async () => {
+    const autoEmail = buildSalesforceEmailEvent({
+      id: "evt_projection_complete",
+      sourceEvidenceId: "sev_projection_complete",
+      occurredAt: "2026-01-01T00:10:00.000Z",
+      direction: "outbound",
+      canonicalMessageKind: "auto",
+      subject: "Plan your Adventure Today",
+      snippet: "Body: Reminder sent.",
+      contentFingerprint: "fp:projection-complete",
+    });
+    const repositories = createRepositoryBundle({
+      canonicalEvents: [autoEmail.canonicalEvent],
+      sourceEvidence: [
+        buildSourceEvidence({
+          id: "sev_projection_complete",
+          providerRecordId: "projection-complete",
+        }),
+      ],
+      salesforceCommunicationDetails: [autoEmail.detail],
+      timelineRows: [autoEmail.timelineRow],
+    });
+    const presenter = createStage1TimelinePresentationService(repositories);
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+
+    try {
+      await presenter.listTimelineItemsPageByContactId("contact_1", {
+        limit: 40,
+        beforeSortKey: null,
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("warns when a displayable communication event is missing from the timeline projection", async () => {
+    const firstAutoEmail = buildSalesforceEmailEvent({
+      id: "evt_projection_present",
+      sourceEvidenceId: "sev_projection_present",
+      occurredAt: "2026-01-01T00:10:00.000Z",
+      direction: "outbound",
+      canonicalMessageKind: "auto",
+      subject: "Plan your Adventure Today",
+      snippet: "Body: First reminder sent.",
+      contentFingerprint: "fp:projection-gap",
+    });
+    const missingAutoEmail = buildSalesforceEmailEvent({
+      id: "evt_projection_missing",
+      sourceEvidenceId: "sev_projection_missing",
+      occurredAt: "2026-01-01T00:12:00.000Z",
+      direction: "outbound",
+      canonicalMessageKind: "auto",
+      subject: "Plan your Adventure Today",
+      snippet: "Body: Second reminder sent.",
+      contentFingerprint: "fp:projection-gap",
+    });
+    const repositories = createRepositoryBundle({
+      canonicalEvents: [
+        firstAutoEmail.canonicalEvent,
+        missingAutoEmail.canonicalEvent,
+      ],
+      sourceEvidence: [
+        buildSourceEvidence({
+          id: "sev_projection_present",
+          providerRecordId: "projection-present",
+        }),
+        buildSourceEvidence({
+          id: "sev_projection_missing",
+          providerRecordId: "projection-missing",
+        }),
+      ],
+      salesforceCommunicationDetails: [
+        firstAutoEmail.detail,
+        missingAutoEmail.detail,
+      ],
+      timelineRows: [firstAutoEmail.timelineRow],
+    });
+    const presenter = createStage1TimelinePresentationService(repositories);
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+
+    try {
+      await presenter.listTimelineItemsPageByContactId("contact_1", {
+        limit: 40,
+        beforeSortKey: null,
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        "Timeline projection gap detected for canonical communication event.",
+        {
+          contactId: "contact_1",
+          canonicalEventId: "evt_projection_missing",
+          eventType: "communication.email.outbound",
+          provider: "salesforce",
+          timestamp: "2026-01-01T00:12:00.000Z",
+        },
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it("collapses duplicate campaign rows before pagination counts them", async () => {
     const duplicateFingerprint = "fp:campaign-april-update";
     const firstCampaign = buildMailchimpCampaignEmailEvent({
@@ -1052,6 +1159,116 @@ describe("Stage 1 timeline presenter", () => {
       activityType: "sent",
       campaignName: "Trailhead Update",
       snippet: "Subject: Trailhead Update\n\nBody:\nBring your field notebook.",
+    });
+  });
+
+  it("keeps auto-email rows with the same signature when they are minutes apart", async () => {
+    const firstAutoEmail = buildSalesforceEmailEvent({
+      id: "evt_auto_email_1",
+      sourceEvidenceId: "sev_auto_email_1",
+      occurredAt: "2026-01-01T00:10:00.000Z",
+      direction: "outbound",
+      canonicalMessageKind: "auto",
+      subject: "Plan your Adventure Today",
+      snippet: "Body: Reminder sent.",
+      contentFingerprint: "fp:auto-email-repeat",
+    });
+    const secondAutoEmail = buildSalesforceEmailEvent({
+      id: "evt_auto_email_2",
+      sourceEvidenceId: "sev_auto_email_2",
+      occurredAt: "2026-01-01T00:12:00.000Z",
+      direction: "outbound",
+      canonicalMessageKind: "auto",
+      subject: "Plan your Adventure Today",
+      snippet: "Body: Reminder sent.",
+      contentFingerprint: "fp:auto-email-repeat",
+    });
+    const repositories = createRepositoryBundle({
+      canonicalEvents: [
+        firstAutoEmail.canonicalEvent,
+        secondAutoEmail.canonicalEvent,
+      ],
+      sourceEvidence: [
+        buildSourceEvidence({
+          id: "sev_auto_email_1",
+          providerRecordId: "auto-email-1",
+        }),
+        buildSourceEvidence({
+          id: "sev_auto_email_2",
+          providerRecordId: "auto-email-2",
+        }),
+      ],
+      salesforceCommunicationDetails: [
+        firstAutoEmail.detail,
+        secondAutoEmail.detail,
+      ],
+      timelineRows: [firstAutoEmail.timelineRow, secondAutoEmail.timelineRow],
+    });
+    const presenter = createStage1TimelinePresentationService(repositories);
+
+    const items = await presenter.listTimelineItemsByContactId("contact_1");
+
+    expect(items).toHaveLength(2);
+    expect(items.map((item) => item.canonicalEventId)).toEqual([
+      "evt_auto_email_1",
+      "evt_auto_email_2",
+    ]);
+    expect(items.every((item) => item.family === "auto_email")).toBe(true);
+  });
+
+  it("still collapses non-auto-email rows with the same signature in the duplicate window", async () => {
+    const firstOneToOneEmail = buildSalesforceEmailEvent({
+      id: "evt_one_to_one_1",
+      sourceEvidenceId: "sev_one_to_one_1",
+      occurredAt: "2026-01-01T00:10:00.000Z",
+      direction: "outbound",
+      canonicalMessageKind: "one_to_one",
+      subject: "Checking in",
+      snippet: "Body: Following up on your question.",
+      contentFingerprint: "fp:one-to-one-repeat",
+    });
+    const secondOneToOneEmail = buildSalesforceEmailEvent({
+      id: "evt_one_to_one_2",
+      sourceEvidenceId: "sev_one_to_one_2",
+      occurredAt: "2026-01-01T00:12:00.000Z",
+      direction: "outbound",
+      canonicalMessageKind: "one_to_one",
+      subject: "Checking in",
+      snippet: "Body: Following up on your question.",
+      contentFingerprint: "fp:one-to-one-repeat",
+    });
+    const repositories = createRepositoryBundle({
+      canonicalEvents: [
+        firstOneToOneEmail.canonicalEvent,
+        secondOneToOneEmail.canonicalEvent,
+      ],
+      sourceEvidence: [
+        buildSourceEvidence({
+          id: "sev_one_to_one_1",
+          providerRecordId: "one-to-one-1",
+        }),
+        buildSourceEvidence({
+          id: "sev_one_to_one_2",
+          providerRecordId: "one-to-one-2",
+        }),
+      ],
+      salesforceCommunicationDetails: [
+        firstOneToOneEmail.detail,
+        secondOneToOneEmail.detail,
+      ],
+      timelineRows: [
+        firstOneToOneEmail.timelineRow,
+        secondOneToOneEmail.timelineRow,
+      ],
+    });
+    const presenter = createStage1TimelinePresentationService(repositories);
+
+    const items = await presenter.listTimelineItemsByContactId("contact_1");
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      canonicalEventId: "evt_one_to_one_1",
+      family: "one_to_one_email",
     });
   });
 });


### PR DESCRIPTION
## Summary

Slice 4 web review § Debugging: Missing Message-History Items. Two display-side reasons a canonical communication event can be invisible in the inbox detail timeline:

1. Detail rendering trusts `contact_timeline_projection`, not `canonical_event_ledger`. If the projection writer drops a row, the event silently disappears with no signal.
2. `collapseDuplicateTimelineItems()` has a 5-min window that can hide repeated outbound auto-emails sharing a signature.

## Fixes (both in `packages/domain/src/timeline.ts`)

### Projection-gap diagnostic (log-only)

`warnTimelineProjectionGaps()` runs inside `listTimelineItemsPageByContactId()`. Compares displayable canonical communication events against `timelineProjection` row `canonicalEventId`s; emits a structured `console.warn` per missing event with `{contactId, canonicalEventId, eventType, provider, timestamp}`. Wrapped in try/catch — never throws.

### Narrowed `auto_email` dedup window

`timelinePresentationDuplicateWindowMs()` returns **30s** for `auto_email` ↔ `auto_email` pairs (down from 5min). Other families unchanged.

## Tests in `packages/domain/test/timeline.test.ts`

- no projection gap → no warning
- gap → structured warning emitted
- two `auto_email` rows ~2 min apart both survive collapse
- non-`auto_email` duplicates still collapse (carve-out is targeted)

## Test plan

- [x] `pnpm typecheck && pnpm lint` clean
- [ ] CI green
- [ ] Watch projection-gap warnings in production logs after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)