### PR TITLE
fix(domain): tighten identity-resolution provider trust + ambiguity discipline

### DIFF
--- a/apps/web/app/inbox/actions.ts
+++ b/apps/web/app/inbox/actions.ts
@@ -5,7 +5,10 @@ import { createHash, randomUUID } from "node:crypto";
 import { z } from "zod";
 
 import { composerSendInputSchema } from "@as-comms/contracts";
-import { computePendingComposerOutboundFingerprint } from "@as-comms/domain";
+import {
+  CanonicalContactAmbiguityError,
+  computePendingComposerOutboundFingerprint,
+} from "@as-comms/domain";
 import { requireSession } from "@/src/server/auth/session";
 import { sendComposerGmailMessage } from "@/src/server/composer/gmail-send";
 import {
@@ -1313,11 +1316,21 @@ export async function sendComposerAction(
       return mapComposerProviderError(requestId, "invalid_recipient");
     }
 
-    const contact = await runtime.normalization.ensureCanonicalContactForEmail({
-      emailAddress: toEmailNormalized,
-      createdAt: sentAtIso,
-      source: "manual",
-    });
+    let contact;
+    try {
+      contact = await runtime.normalization.ensureCanonicalContactForEmail({
+        emailAddress: toEmailNormalized,
+        createdAt: sentAtIso,
+        source: "manual",
+      });
+    } catch (error) {
+      if (error instanceof CanonicalContactAmbiguityError) {
+        // TODO: Surface ambiguous-recipient routing review UX instead of refusing.
+        return mapComposerProviderError(requestId, "invalid_recipient");
+      }
+
+      throw error;
+    }
     canonicalContactId = contact.id;
   }
 

--- a/apps/web/tests/unit/stage3-send-action.test.ts
+++ b/apps/web/tests/unit/stage3-send-action.test.ts
@@ -320,6 +320,48 @@ describe("sendComposerAction", () => {
     ).resolves.toEqual([]);
   });
 
+  it("maps ambiguous net-new recipient emails to invalid_recipient", async () => {
+    if (!runtime) {
+      throw new Error("Expected runtime.");
+    }
+
+    const now = new Date("2026-04-21T12:05:00.000Z").toISOString();
+    await runtime.context.repositories.contacts.upsert({
+      id: "contact:duplicate",
+      salesforceContactId: null,
+      displayName: "Duplicate Contact",
+      primaryEmail: "existing@example.org",
+      primaryPhone: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await runtime.context.repositories.contactIdentities.upsert({
+      id: "identity:duplicate:email",
+      contactId: "contact:duplicate",
+      kind: "email",
+      normalizedValue: "existing@example.org",
+      isPrimary: true,
+      source: "manual",
+      verifiedAt: now,
+    });
+
+    const result = await sendComposerAction(
+      buildInput({
+        recipient: {
+          kind: "email",
+          emailAddress: "existing@example.org",
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "invalid_recipient",
+      retryable: false,
+    });
+    expect(sendComposerGmailMessage).not.toHaveBeenCalled();
+  });
+
   it("maps all typed Gmail send errors into the FP-07 envelope and marks the row failed", async () => {
     const cases = [
       ["auth_error", "composer_unavailable", false],

--- a/packages/db/test/stage1-normalization.test.ts
+++ b/packages/db/test/stage1-normalization.test.ts
@@ -855,7 +855,7 @@ describe("Stage 1 normalization service", () => {
       identity: {
         salesforceContactId: "003-stage1",
         volunteerIdPlainValues: [],
-        normalizedEmails: [],
+        normalizedEmails: ["volunteer@example.org"],
         normalizedPhones: []
       },
       supportingSources: [
@@ -905,7 +905,7 @@ describe("Stage 1 normalization service", () => {
       identity: {
         salesforceContactId: "003-stage1",
         volunteerIdPlainValues: [],
-        normalizedEmails: [],
+        normalizedEmails: ["volunteer@example.org"],
         normalizedPhones: []
       },
       supportingSources: [
@@ -946,7 +946,7 @@ describe("Stage 1 normalization service", () => {
       identity: {
         salesforceContactId: "003-stage1",
         volunteerIdPlainValues: [],
-        normalizedEmails: [],
+        normalizedEmails: ["volunteer@example.org"],
         normalizedPhones: []
       },
       supportingSources: []
@@ -1885,7 +1885,7 @@ describe("Stage 1 normalization service", () => {
 
     expect(firstResult.outcome).toBe("applied");
     expect(lookupCounts).toEqual({
-      anchor: 1,
+      anchor: 0,
       byId: 1,
       byValue: 2
     });
@@ -1932,7 +1932,7 @@ describe("Stage 1 normalization service", () => {
 
     expect(secondResult.outcome).toBe("applied");
     expect(lookupCounts).toEqual({
-      anchor: 1,
+      anchor: 0,
       byId: 1,
       byValue: 2
     });

--- a/packages/domain/src/normalization.ts
+++ b/packages/domain/src/normalization.ts
@@ -42,6 +42,7 @@ import {
   type NormalizedIdentityEvidence,
   type ProjectDimensionRecord,
   type NormalizedSourceEvidenceIntake,
+  type Provider,
   type ProvenanceWinnerReason,
   type QuarantineReasonCode,
   type RoutingAmbiguityInput,
@@ -88,6 +89,23 @@ interface IdentityResolutionContext {
 interface WinnerDecision {
   readonly winnerReason: ProvenanceWinnerReason;
   readonly notes: string | null;
+}
+
+export class CanonicalContactAmbiguityError extends Error {
+  readonly normalizedEmail: string;
+  readonly candidateContactIds: readonly string[];
+
+  constructor(input: {
+    readonly normalizedEmail: string;
+    readonly candidateContactIds: readonly string[];
+  }) {
+    super(
+      `Normalized email ${input.normalizedEmail} maps to multiple contacts.`
+    );
+    this.name = "CanonicalContactAmbiguityError";
+    this.normalizedEmail = input.normalizedEmail;
+    this.candidateContactIds = input.candidateContactIds;
+  }
 }
 
 interface ProviderDetailMaps {
@@ -1272,7 +1290,8 @@ async function resolveIdentityDecision(
   context: IdentityResolutionContext,
   sourceEvidenceId: string,
   openedAt: string,
-  identity: NormalizedIdentityEvidence
+  identity: NormalizedIdentityEvidence,
+  provider: Provider
 ): Promise<IdentityResolutionDecision> {
   const emailMatches = await context.loadContactsForIdentityKind(
     "email",
@@ -1288,7 +1307,10 @@ async function resolveIdentityDecision(
   );
   const normalizedIdentityValues = buildNormalizedIdentityValues(identity);
 
-  if (identity.salesforceContactId !== null) {
+  if (
+    identity.salesforceContactId !== null &&
+    provider === "salesforce"
+  ) {
     const anchored = await context.findAnchoredContact(
       identity.salesforceContactId
     );
@@ -1983,14 +2005,21 @@ export function createStage1NormalizationService(
       if (existingContacts.length > 0) {
         const [existingContact] = existingContacts;
 
-        if (existingContact === undefined) {
-          throw new Error(
-            "Expected an existing contact when normalized email matches."
-          );
-        }
-
-        return existingContact;
+      if (existingContact === undefined) {
+        throw new Error(
+          "Expected an existing contact when normalized email matches."
+        );
       }
+
+      if (existingContacts.length > 1) {
+        throw new CanonicalContactAmbiguityError({
+          normalizedEmail,
+          candidateContactIds: existingContacts.map((contact) => contact.id)
+        });
+      }
+
+      return existingContact;
+    }
 
       return (
         await service.upsertNormalizedContactGraph(
@@ -2307,7 +2336,8 @@ export function createStage1NormalizationService(
         identityResolutionContext,
         sourceEvidenceResult.record.id,
         parsed.sourceEvidence.receivedAt,
-        parsed.identity
+        parsed.identity,
+        parsed.sourceEvidence.provider
       );
 
       if (identityDecision.outcome === "needs_identity_review") {

--- a/packages/domain/test/normalization.test.ts
+++ b/packages/domain/test/normalization.test.ts
@@ -29,6 +29,7 @@ import {
   type PendingComposerOutboundRecord,
   type Stage1RepositoryBundle,
 } from "../src/index.js";
+import type { CanonicalContactAmbiguityError } from "../src/index.js";
 
 const contact: ContactRecord = {
   id: "contact:volunteer",
@@ -197,14 +198,30 @@ function buildReplayInput(event: CanonicalEventRecord): NormalizedCanonicalEvent
 function buildContext(input: {
   readonly events: readonly CanonicalEventRecord[];
   readonly existingProjection?: InboxProjectionRow | null;
+  readonly contacts?: readonly ContactRecord[];
+  readonly contactIdentities?: readonly ContactIdentityRecord[];
+  readonly sourceProvider?: SourceEvidenceRecord["provider"];
 }): TestContext {
+  const contacts = input.contacts ?? [contact];
+  const contactIdentities = input.contactIdentities ?? [emailIdentity];
+  const contactsById = new Map(contacts.map((entry) => [entry.id, entry]));
+  const contactsBySalesforceContactId = new Map(
+    contacts
+      .filter((entry): entry is ContactRecord & { salesforceContactId: string } =>
+        entry.salesforceContactId !== null
+      )
+      .map((entry) => [entry.salesforceContactId, entry]),
+  );
   const sourceEvidenceById = new Map(
     input.events.map((event) => [
       event.sourceEvidenceId,
-      buildSourceEvidence({
-        key: event.id.replace("event:", ""),
-        occurredAt: event.occurredAt,
-      }),
+      {
+        ...buildSourceEvidence({
+          key: event.id.replace("event:", ""),
+          occurredAt: event.occurredAt,
+        }),
+        provider: input.sourceProvider ?? "gmail",
+      },
     ]),
   );
   const sourceEvidenceByIdempotencyKey = new Map(
@@ -292,19 +309,29 @@ function buildContext(input: {
       getForRetrieval: () => Promise.resolve([]),
     },
     contacts: {
-      findById: (id) => Promise.resolve(id === contact.id ? contact : null),
-      findBySalesforceContactId: () => Promise.resolve(null),
-      listAll: () => Promise.resolve([contact]),
-      listByIds: () => Promise.resolve([contact]),
-      searchByQuery: () => Promise.resolve([contact]),
+      findById: (id) => Promise.resolve(contactsById.get(id) ?? null),
+      findBySalesforceContactId: (salesforceContactId) =>
+        Promise.resolve(contactsBySalesforceContactId.get(salesforceContactId) ?? null),
+      listAll: () => Promise.resolve([...contacts]),
+      listByIds: (ids) =>
+        Promise.resolve(
+          ids
+            .map((id) => contactsById.get(id))
+            .filter((entry): entry is ContactRecord => entry !== undefined),
+        ),
+      searchByQuery: () => Promise.resolve([...contacts]),
       upsert: (record) => Promise.resolve(record),
     },
     contactIdentities: {
       listByContactId: (contactId) =>
-        Promise.resolve(contactId === contact.id ? [emailIdentity] : []),
+        Promise.resolve(
+          contactIdentities.filter((identity) => identity.contactId === contactId),
+        ),
       listByNormalizedValue: ({ normalizedValue }) =>
         Promise.resolve(
-          normalizedValue === emailIdentity.normalizedValue ? [emailIdentity] : [],
+          contactIdentities.filter(
+            (identity) => identity.normalizedValue === normalizedValue,
+          ),
         ),
       upsert: (record) => Promise.resolve(record),
     },
@@ -463,7 +490,7 @@ function buildContext(input: {
       countByContactId: () => Promise.resolve(timelineRowsByCanonicalEventId.size),
       getFreshnessByContactId: () =>
         Promise.resolve({
-          contactId: contact.id,
+          contactId: contacts[0]?.id ?? contact.id,
           total: timelineRowsByCanonicalEventId.size,
           latestUpdatedAt: null,
           latestSortKey: null,
@@ -696,5 +723,151 @@ describe("rebuildInboxProjectionForContact bucket semantics", () => {
       bucket: "New",
       lastInboundAt: latestInbound.occurredAt,
     });
+  });
+});
+
+describe("identity resolution hardening", () => {
+  it("still anchors Salesforce intakes by salesforceContactId", async () => {
+    const anchoredContact: ContactRecord = {
+      ...contact,
+      id: "contact:anchored",
+      salesforceContactId: "sf-contact-1",
+    };
+    const event = buildEvent({
+      key: "salesforce-anchor",
+      occurredAt: "2026-04-25T10:00:00.000Z",
+      direction: "inbound",
+    });
+    const context = buildContext({
+      events: [],
+      contacts: [anchoredContact],
+      contactIdentities: [],
+    });
+
+    const result = await context.normalization.applyNormalizedCanonicalEvent({
+      ...buildReplayInput(event),
+      sourceEvidence: {
+        ...buildSourceEvidence({
+          key: "salesforce-anchor",
+          occurredAt: event.occurredAt,
+        }),
+        provider: "salesforce",
+      },
+      identity: {
+        salesforceContactId: "sf-contact-1",
+        volunteerIdPlainValues: [],
+        normalizedEmails: [],
+        normalizedPhones: [],
+      },
+    });
+
+    expect(result.outcome).toBe("applied");
+    if (result.outcome !== "applied") {
+      throw new Error("Expected applied result.");
+    }
+    expect(result.canonicalEvent.contactId).toBe(anchoredContact.id);
+  });
+
+  it("ignores salesforceContactId from non-Salesforce intakes", async () => {
+    const anchoredContact: ContactRecord = {
+      ...contact,
+      id: "contact:anchored",
+      salesforceContactId: "sf-contact-1",
+      primaryEmail: "anchored@example.org",
+    };
+    const emailMatchedContact: ContactRecord = {
+      ...contact,
+      id: "contact:email-match",
+      salesforceContactId: null,
+      primaryEmail: "volunteer@example.org",
+    };
+    const event = buildEvent({
+      key: "gmail-untrusted-anchor",
+      occurredAt: "2026-04-25T11:00:00.000Z",
+      direction: "inbound",
+    });
+    const context = buildContext({
+      events: [],
+      contacts: [anchoredContact, emailMatchedContact],
+      contactIdentities: [
+        {
+          ...emailIdentity,
+          contactId: emailMatchedContact.id,
+        },
+      ],
+    });
+
+    const result = await context.normalization.applyNormalizedCanonicalEvent({
+      ...buildReplayInput(event),
+      sourceEvidence: {
+        ...buildSourceEvidence({
+          key: "gmail-untrusted-anchor",
+          occurredAt: event.occurredAt,
+        }),
+        provider: "gmail",
+      },
+      identity: {
+        salesforceContactId: "sf-contact-1",
+        volunteerIdPlainValues: [],
+        normalizedEmails: ["volunteer@example.org"],
+        normalizedPhones: [],
+      },
+    });
+
+    expect(result.outcome).toBe("applied");
+    if (result.outcome !== "applied") {
+      throw new Error("Expected applied result.");
+    }
+    expect(result.canonicalEvent.contactId).toBe(emailMatchedContact.id);
+  });
+
+  it("returns the single contact for an unambiguous email", async () => {
+    const context = buildContext({
+      events: [],
+    });
+
+    await expect(
+      context.normalization.ensureCanonicalContactForEmail({
+        emailAddress: "volunteer@example.org",
+      }),
+    ).resolves.toMatchObject({
+      id: contact.id,
+    });
+  });
+
+  it("throws CanonicalContactAmbiguityError when the email maps to multiple contacts", async () => {
+    const duplicateContact: ContactRecord = {
+      ...contact,
+      id: "contact:duplicate",
+      primaryEmail: "volunteer@example.org",
+    };
+    const duplicateIdentity: ContactIdentityRecord = {
+      ...emailIdentity,
+      id: "identity:duplicate:email",
+      contactId: duplicateContact.id,
+    };
+    const context = buildContext({
+      events: [],
+      contacts: [contact, duplicateContact],
+      contactIdentities: [emailIdentity, duplicateIdentity],
+    });
+
+    try {
+      await context.normalization.ensureCanonicalContactForEmail({
+        emailAddress: "volunteer@example.org",
+      });
+      throw new Error("Expected CanonicalContactAmbiguityError.");
+    } catch (error) {
+      if (!(error instanceof Error)) {
+        throw error;
+      }
+
+      const ambiguityError = error as CanonicalContactAmbiguityError;
+      expect(ambiguityError.name).toBe("CanonicalContactAmbiguityError");
+      expect(ambiguityError.normalizedEmail).toBe("volunteer@example.org");
+      expect([...ambiguityError.candidateContactIds].sort()).toEqual(
+        [contact.id, duplicateContact.id].sort(),
+      );
+    }
   });
 });


### PR DESCRIPTION
## Summary

Two related Slice 1 P1 findings landing in one PR. Both sit in `packages/domain/src/normalization.ts` and relax identity-resolution discipline in ways that can attach events/sends to the wrong contact.

## Fix 1 — Provider trust gate on `salesforceContactId` (Slice 1 #5, security)

`resolveIdentityDecision` previously consumed `identity.salesforceContactId` as a trusted anchor regardless of which provider supplied the value. A non-Salesforce intake (gmail, simpletexting, mailchimp, manual) populating that field — accidentally or maliciously — would attach correspondence to the anchored Salesforce contact, with the conflict path only flagging via overlay rather than gating.

**Now** `resolveIdentityDecision` takes a `provider: Provider` parameter; the SF-anchored branch is gated on `provider === "salesforce"`. Untrusted SF Contact IDs from non-SF providers fall through to standard email/phone matching paths. The single call site at `:2306` passes `parsed.sourceEvidence.provider`.

All existing happy-path Salesforce ingestion behavior preserved (anchor found → resolved; anchor missing → `identity_missing_anchor`; conflict → `identity_anchor_mismatch` overlay).

## Fix 2 — Ambiguity discipline in `ensureCanonicalContactForEmail` (Slice 1 #10, bug)

Previously returned the first contact when an email mapped to multiple, silently picking one. Operator-initiated sends to ambiguous addresses bound to the wrong contact's timeline with no signal.

**Now** throws exported `CanonicalContactAmbiguityError` (with `normalizedEmail` + `candidateContactIds` fields) on `existingContacts.length > 1`. Single-contact and zero-contact paths preserved.

`apps/web/app/inbox/actions.ts:1316` catches the typed error and maps to `invalid_recipient` via the existing `mapComposerProviderError` catalog. `// TODO` comment notes the long-term picker UX is out of scope.

## Tests

- `packages/domain/test/normalization.test.ts` — happy + tightened paths for both fixes
- `apps/web/tests/unit/stage3-send-action.test.ts` — composer catch path
- `packages/db/test/stage1-normalization.test.ts` updated for new non-Salesforce anchor behavior

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test:unit` clean (VALIDATION_PASSED)
- [ ] CI green
- [ ] Watch production logs after deploy for any spike in `invalid_recipient` composer errors (would indicate operators hitting ambiguity in practice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)