### PR TITLE
fix(integrations): bound Gmail MIME parsing depth/parts/decoded-size/parser-time

### DIFF
--- a/packages/integrations/src/capture-services/gmail.ts
+++ b/packages/integrations/src/capture-services/gmail.ts
@@ -428,13 +428,18 @@ export async function mapLiveGmailMessageToRecord(input: {
     subjectHeader.startsWith("mail delivery failed") ||
     topLevelMimeType.includes("multipart/report");
   const bodyPreviewResult = await extractGmailBodyPreviewFromPayloadResult(
-    input.message.payload
+    input.message.payload,
+    {
+      messageIdentifier: input.message.id
+    }
   );
   const attachmentMetadata = collectGmailAttachmentMetadata(input.message.payload);
   const previewMessageIdPattern =
     /Message-ID:\s*(<\d+\.[a-f0-9-]+@[a-z.]+>)/iu;
   const dsnOriginalMessageIdFromParts = isPossiblyDsn
-    ? extractDsnOriginalMessageId(input.message.payload)
+    ? extractDsnOriginalMessageId(input.message.payload, {
+        messageIdentifier: input.message.id
+      })
     : null;
   const dsnOriginalMessageIdFromPreview = isPossiblyDsn
     ? (previewMessageIdPattern.exec(bodyPreviewResult.bodyTextPreview)?.[1] ??

--- a/packages/integrations/src/providers/gmail-body.ts
+++ b/packages/integrations/src/providers/gmail-body.ts
@@ -33,6 +33,40 @@ interface CandidateBodyPart {
   readonly part: GmailApiMessagePart;
 }
 
+interface GmailMimeBoundsConfig {
+  readonly maxDepth: number;
+  readonly maxParts: number;
+  readonly maxDecodedBytes: number;
+  readonly parseTimeoutMs: number;
+}
+
+type GmailMimeBudgetName =
+  | "depth"
+  | "parts"
+  | "decoded_bytes"
+  | "parse_timeout_ms";
+
+interface GmailMimeBudgetContext {
+  readonly bounds: GmailMimeBoundsConfig;
+  readonly messageIdentifier: string;
+  readonly warnedBudgets: Set<GmailMimeBudgetName>;
+}
+
+interface GmailMimeTraversalState {
+  visitedParts: number;
+  budgetExceeded: boolean;
+}
+
+interface GmailMimeDecodeState {
+  decodedBytes: number;
+  budgetExceeded: boolean;
+}
+
+interface SerializedMimePart {
+  readonly decodedBody: Buffer;
+  readonly serializedPart: Buffer;
+}
+
 export type GmailBodyKind =
   | "plaintext"
   | "encrypted_placeholder"
@@ -77,6 +111,121 @@ const REPLACEMENT_CHARACTER = "�";
 // in production sit at ~50%.
 const BINARY_NOISE_THRESHOLD = 0.3;
 const BINARY_NOISE_MIN_LENGTH = 32;
+const DEFAULT_GMAIL_MIME_MAX_DEPTH = 64;
+const DEFAULT_GMAIL_MIME_MAX_PARTS = 512;
+const DEFAULT_GMAIL_MIME_MAX_DECODED_BYTES = 20 * 1024 * 1024;
+const DEFAULT_GMAIL_MIME_PARSE_TIMEOUT_MS = 10_000;
+
+class GmailMimeParseTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Gmail MIME parsing exceeded timeout of ${String(timeoutMs)}ms.`);
+    this.name = "GmailMimeParseTimeoutError";
+  }
+}
+
+function parsePositiveIntEnv(
+  envName: string,
+  defaultValue: number
+): number {
+  const parsedValue = Number.parseInt(process.env[envName] ?? "", 10);
+
+  if (!Number.isFinite(parsedValue)) {
+    return defaultValue;
+  }
+
+  return Math.max(1, parsedValue);
+}
+
+function readGmailMimeBoundsConfig(): GmailMimeBoundsConfig {
+  return {
+    maxDepth: parsePositiveIntEnv(
+      "GMAIL_MIME_MAX_DEPTH",
+      DEFAULT_GMAIL_MIME_MAX_DEPTH
+    ),
+    maxParts: parsePositiveIntEnv(
+      "GMAIL_MIME_MAX_PARTS",
+      DEFAULT_GMAIL_MIME_MAX_PARTS
+    ),
+    maxDecodedBytes: parsePositiveIntEnv(
+      "GMAIL_MIME_MAX_DECODED_BYTES",
+      DEFAULT_GMAIL_MIME_MAX_DECODED_BYTES
+    ),
+    parseTimeoutMs: parsePositiveIntEnv(
+      "GMAIL_MIME_PARSE_TIMEOUT_MS",
+      DEFAULT_GMAIL_MIME_PARSE_TIMEOUT_MS
+    )
+  };
+}
+
+function createGmailMimeBudgetContext(
+  messageIdentifier?: string | null
+): GmailMimeBudgetContext {
+  return {
+    bounds: readGmailMimeBoundsConfig(),
+    messageIdentifier: messageIdentifier?.trim().length
+      ? messageIdentifier
+      : "unknown",
+    warnedBudgets: new Set<GmailMimeBudgetName>()
+  };
+}
+
+function warnGmailMimeBudgetExceeded(
+  context: GmailMimeBudgetContext,
+  budgetName: GmailMimeBudgetName,
+  limit: number
+): void {
+  if (context.warnedBudgets.has(budgetName)) {
+    return;
+  }
+
+  context.warnedBudgets.add(budgetName);
+  console.warn("Gmail MIME parsing budget exceeded.", {
+    budgetName,
+    limit,
+    messageIdentifier: context.messageIdentifier
+  });
+}
+
+function markTraversalBudgetExceeded(
+  context: GmailMimeBudgetContext,
+  traversalState: GmailMimeTraversalState,
+  budgetName: "depth" | "parts",
+  limit: number
+): void {
+  traversalState.budgetExceeded = true;
+  warnGmailMimeBudgetExceeded(context, budgetName, limit);
+}
+
+function markDecodedBytesBudgetExceeded(
+  context: GmailMimeBudgetContext,
+  decodeState: GmailMimeDecodeState
+): void {
+  decodeState.budgetExceeded = true;
+  warnGmailMimeBudgetExceeded(
+    context,
+    "decoded_bytes",
+    context.bounds.maxDecodedBytes
+  );
+}
+
+function visitChildPart(
+  context: GmailMimeBudgetContext,
+  traversalState: GmailMimeTraversalState
+): boolean {
+  traversalState.visitedParts += 1;
+
+  if (traversalState.visitedParts > context.bounds.maxParts) {
+    markTraversalBudgetExceeded(
+      context,
+      traversalState,
+      "parts",
+      context.bounds.maxParts
+    );
+    return true;
+  }
+
+  return false;
+}
 
 export function isLikelyBinaryNoise(text: string): boolean {
   if (text.length < BINARY_NOISE_MIN_LENGTH) {
@@ -270,18 +419,52 @@ function decodeBase64Url(value: string): Buffer {
   return Buffer.from(paddedValue, "base64");
 }
 
-function decodePartBodyToString(part: GmailApiMessagePart): string | null {
+function decodePartBody(
+  part: GmailApiMessagePart,
+  context: GmailMimeBudgetContext,
+  decodeState: GmailMimeDecodeState
+): Buffer | null {
   const bodyData = part.body?.data;
 
   if (typeof bodyData !== "string" || bodyData.length === 0) {
     return null;
   }
 
+  const declaredSize = Math.max(0, part.body?.size ?? 0);
+
+  if (
+    declaredSize > 0 &&
+    decodeState.decodedBytes + declaredSize > context.bounds.maxDecodedBytes
+  ) {
+    markDecodedBytesBudgetExceeded(context, decodeState);
+    return null;
+  }
+
   try {
-    return decodeBase64Url(bodyData).toString("utf8");
+    const decodedBody = decodeBase64Url(bodyData);
+
+    if (
+      decodeState.decodedBytes + decodedBody.length >
+      context.bounds.maxDecodedBytes
+    ) {
+      markDecodedBytesBudgetExceeded(context, decodeState);
+      return null;
+    }
+
+    decodeState.decodedBytes += decodedBody.length;
+    return decodedBody;
   } catch {
     return null;
   }
+}
+
+function decodePartBodyToString(
+  part: GmailApiMessagePart,
+  context: GmailMimeBudgetContext,
+  decodeState: GmailMimeDecodeState
+): string | null {
+  const decodedBody = decodePartBody(part, context, decodeState);
+  return decodedBody?.toString("utf8") ?? null;
 }
 
 function getPartHeader(
@@ -319,12 +502,54 @@ function extractHeaderValue(
 }
 
 export function extractDsnOriginalMessageId(
-  payload: GmailApiMessagePart
-): string | null {
+  payload: GmailApiMessagePart,
+  options?: {
+    readonly messageIdentifier?: string | null;
+  }
+): string | null | undefined {
+  const context = createGmailMimeBudgetContext(options?.messageIdentifier);
+  const traversalState: GmailMimeTraversalState = {
+    visitedParts: 0,
+    budgetExceeded: false
+  };
+  const decodeState: GmailMimeDecodeState = {
+    decodedBytes: 0,
+    budgetExceeded: false
+  };
+
+  return extractDsnOriginalMessageIdInternal(
+    payload,
+    context,
+    traversalState,
+    decodeState
+  );
+}
+
+function extractDsnOriginalMessageIdInternal(
+  payload: GmailApiMessagePart,
+  context: GmailMimeBudgetContext,
+  traversalState: GmailMimeTraversalState,
+  decodeState: GmailMimeDecodeState,
+  depth = 0
+): string | null | undefined {
+  if (depth > context.bounds.maxDepth) {
+    markTraversalBudgetExceeded(
+      context,
+      traversalState,
+      "depth",
+      context.bounds.maxDepth
+    );
+    return undefined;
+  }
+
   const mimeType = normalizeMimeType(payload.mimeType);
 
   if (mimeType === "message/delivery-status") {
-    const decoded = decodePartBodyToString(payload);
+    const decoded = decodePartBodyToString(payload, context, decodeState);
+
+    if (decodeState.budgetExceeded) {
+      return undefined;
+    }
 
     if (decoded !== null) {
       const originalMessageId = extractHeaderValue(decoded, [
@@ -347,7 +572,11 @@ export function extractDsnOriginalMessageId(
   }
 
   if (mimeType === "message/rfc822") {
-    const decoded = decodePartBodyToString(payload);
+    const decoded = decodePartBodyToString(payload, context, decodeState);
+
+    if (decodeState.budgetExceeded) {
+      return undefined;
+    }
 
     if (decoded !== null) {
       const embeddedMessageId = extractHeaderValue(decoded, [
@@ -361,7 +590,21 @@ export function extractDsnOriginalMessageId(
   }
 
   for (const childPart of payload.parts ?? []) {
-    const nestedMatch = extractDsnOriginalMessageId(childPart);
+    if (visitChildPart(context, traversalState)) {
+      return undefined;
+    }
+
+    const nestedMatch = extractDsnOriginalMessageIdInternal(
+      childPart,
+      context,
+      traversalState,
+      decodeState,
+      depth + 1
+    );
+
+    if (nestedMatch === undefined) {
+      return undefined;
+    }
 
     if (nestedMatch !== null) {
       return nestedMatch;
@@ -391,14 +634,38 @@ export function extractBodyKind(part: GmailApiMessagePart): GmailBodyKind {
     : "plaintext";
 }
 
-function containsEncryptedBodyPart(part: GmailApiMessagePart): boolean {
+function containsEncryptedBodyPartInternal(
+  part: GmailApiMessagePart,
+  context: GmailMimeBudgetContext,
+  traversalState: GmailMimeTraversalState,
+  depth = 0
+): boolean {
+  if (depth > context.bounds.maxDepth) {
+    markTraversalBudgetExceeded(
+      context,
+      traversalState,
+      "depth",
+      context.bounds.maxDepth
+    );
+    return true;
+  }
+
   if (extractBodyKind(part) === "encrypted_placeholder") {
     return true;
   }
 
-  return (part.parts ?? []).some((childPart) =>
-    containsEncryptedBodyPart(childPart)
-  );
+  return (part.parts ?? []).some((childPart) => {
+    if (visitChildPart(context, traversalState)) {
+      return true;
+    }
+
+    return containsEncryptedBodyPartInternal(
+      childPart,
+      context,
+      traversalState,
+      depth + 1
+    );
+  });
 }
 
 function isAttachmentPart(part: GmailApiMessagePart): boolean {
@@ -463,12 +730,39 @@ export function collectGmailAttachmentMetadata(
   return attachments;
 }
 
-function collectCandidateBodyParts(
+function collectCandidateBodyPartsInternal(
   part: GmailApiMessagePart,
-  candidates: CandidateBodyPart[] = []
+  context: GmailMimeBudgetContext,
+  traversalState: GmailMimeTraversalState,
+  candidates: CandidateBodyPart[] = [],
+  depth = 0
 ): CandidateBodyPart[] {
+  if (depth > context.bounds.maxDepth) {
+    markTraversalBudgetExceeded(
+      context,
+      traversalState,
+      "depth",
+      context.bounds.maxDepth
+    );
+    return candidates;
+  }
+
   for (const childPart of part.parts ?? []) {
-    collectCandidateBodyParts(childPart, candidates);
+    if (visitChildPart(context, traversalState)) {
+      return candidates;
+    }
+
+    collectCandidateBodyPartsInternal(
+      childPart,
+      context,
+      traversalState,
+      candidates,
+      depth + 1
+    );
+
+    if (traversalState.budgetExceeded) {
+      return candidates;
+    }
   }
 
   const mimeType = part.mimeType?.toLowerCase() ?? "";
@@ -490,7 +784,11 @@ function collectCandidateBodyParts(
   return candidates;
 }
 
-function serializeMimePart(part: GmailApiMessagePart): Buffer | null {
+function serializeMimePart(
+  part: GmailApiMessagePart,
+  context: GmailMimeBudgetContext,
+  decodeState: GmailMimeDecodeState
+): SerializedMimePart | null {
   const bodyData = part.body?.data;
 
   if (typeof bodyData !== "string" || bodyData.length === 0) {
@@ -509,15 +807,40 @@ function serializeMimePart(part: GmailApiMessagePart): Buffer | null {
   const serializedHeaders = headerLines
     .map((header) => `${header.name}: ${header.value}`)
     .join("\r\n");
+  const decodedBody = decodePartBody(part, context, decodeState);
 
-  return Buffer.concat([
-    Buffer.from(`${serializedHeaders}\r\n\r\n`, "utf8"),
-    decodeBase64Url(bodyData)
-  ]);
+  if (decodedBody === null) {
+    return null;
+  }
+
+  return {
+    decodedBody,
+    serializedPart: Buffer.concat([
+      Buffer.from(`${serializedHeaders}\r\n\r\n`, "utf8"),
+      decodedBody
+    ])
+  };
 }
 
-async function extractTextFromMimeDocument(document: string | Buffer): Promise<string> {
-  const parsed = await simpleParser(document, SIMPLE_PARSER_OPTIONS);
+async function extractTextFromMimeDocument(
+  document: string | Buffer,
+  context: GmailMimeBudgetContext
+): Promise<string> {
+  const parsePromise = simpleParser(document, SIMPLE_PARSER_OPTIONS);
+
+  // This timeout only stops awaiting `simpleParser`; mailparser does not
+  // expose cancellation, so the abandoned parse may still finish in the
+  // background.
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    const timeoutHandle = setTimeout(() => {
+      reject(new GmailMimeParseTimeoutError(context.bounds.parseTimeoutMs));
+    }, context.bounds.parseTimeoutMs);
+
+    void parsePromise.finally(() => {
+      clearTimeout(timeoutHandle);
+    });
+  });
+  const parsed = await Promise.race([parsePromise, timeoutPromise]);
 
   if (typeof parsed.text === "string" && parsed.text.trim().length > 0) {
     return parsed.text;
@@ -530,37 +853,98 @@ async function extractTextFromMimeDocument(document: string | Buffer): Promise<s
   return "";
 }
 
-async function extractTextFromMimePart(part: GmailApiMessagePart): Promise<string> {
-  const serializedPart = serializeMimePart(part);
+async function extractTextFromMimePart(
+  part: GmailApiMessagePart,
+  context: GmailMimeBudgetContext,
+  decodeState: GmailMimeDecodeState
+): Promise<string> {
+  const serializedPart = serializeMimePart(part, context, decodeState);
 
   if (serializedPart === null) {
     return "";
   }
 
   try {
-    const extractedText = await extractTextFromMimeDocument(serializedPart);
+    const extractedText = await extractTextFromMimeDocument(
+      serializedPart.serializedPart,
+      context
+    );
     return cleanGmailBodyPreviewText(extractedText);
-  } catch {
-    return cleanGmailBodyPreviewText(decodeBase64Url(part.body?.data ?? "").toString("utf8"));
+  } catch (error) {
+    if (error instanceof GmailMimeParseTimeoutError) {
+      warnGmailMimeBudgetExceeded(
+        context,
+        "parse_timeout_ms",
+        context.bounds.parseTimeoutMs
+      );
+      return "";
+    }
+
+    return cleanGmailBodyPreviewText(serializedPart.decodedBody.toString("utf8"));
   }
 }
 
 export async function extractGmailBodyPreviewFromPayloadResult(
-  payload: GmailApiMessagePart
+  payload: GmailApiMessagePart,
+  options?: {
+    readonly messageIdentifier?: string | null;
+  }
 ): Promise<GmailBodyPreviewResult> {
-  if (containsEncryptedBodyPart(payload)) {
+  const context = createGmailMimeBudgetContext(options?.messageIdentifier);
+  const encryptedTraversalState: GmailMimeTraversalState = {
+    visitedParts: 0,
+    budgetExceeded: false
+  };
+
+  if (
+    containsEncryptedBodyPartInternal(
+      payload,
+      context,
+      encryptedTraversalState
+    )
+  ) {
     return buildBodyPreviewResult(
       ENCRYPTED_MESSAGE_PLACEHOLDER,
       "encrypted_placeholder"
     );
   }
 
-  const candidates = collectCandidateBodyParts(payload);
+  const candidateTraversalState: GmailMimeTraversalState = {
+    visitedParts: 0,
+    budgetExceeded: false
+  };
+  const decodeState: GmailMimeDecodeState = {
+    decodedBytes: 0,
+    budgetExceeded: false
+  };
+  const candidates = collectCandidateBodyPartsInternal(
+    payload,
+    context,
+    candidateTraversalState
+  );
   let sawGarbledCandidate = false;
+
+  if (candidateTraversalState.budgetExceeded) {
+    return buildBodyPreviewResult(
+      BINARY_FALLBACK_PLACEHOLDER,
+      "binary_fallback"
+    );
+  }
 
   for (const kind of ["plain", "html"] as const) {
     for (const candidate of candidates.filter((entry) => entry.kind === kind)) {
-      const bodyPreview = await extractTextFromMimePart(candidate.part);
+      const bodyPreview = await extractTextFromMimePart(
+        candidate.part,
+        context,
+        decodeState
+      );
+
+      if (decodeState.budgetExceeded) {
+        return buildBodyPreviewResult(
+          BINARY_FALLBACK_PLACEHOLDER,
+          "binary_fallback"
+        );
+      }
 
       if (bodyPreview.length === 0) {
         continue;
@@ -586,7 +970,18 @@ export async function extractGmailBodyPreviewFromPayloadResult(
     );
   }
 
-  const fallbackBodyPreview = await extractTextFromMimePart(payload);
+  const fallbackBodyPreview = await extractTextFromMimePart(
+    payload,
+    context,
+    decodeState
+  );
+
+  if (decodeState.budgetExceeded) {
+    return buildBodyPreviewResult(
+      BINARY_FALLBACK_PLACEHOLDER,
+      "binary_fallback"
+    );
+  }
 
   if (fallbackBodyPreview.length === 0) {
     return buildBodyPreviewResult(cleanGmailBodyPreviewText(""), "plaintext");
@@ -598,9 +993,15 @@ export async function extractGmailBodyPreviewFromPayloadResult(
 }
 
 export async function extractGmailBodyPreviewFromPayload(
-  payload: GmailApiMessagePart
+  payload: GmailApiMessagePart,
+  options?: {
+    readonly messageIdentifier?: string | null;
+  }
 ): Promise<string> {
-  const result = await extractGmailBodyPreviewFromPayloadResult(payload);
+  const result = await extractGmailBodyPreviewFromPayloadResult(
+    payload,
+    options
+  );
   return result.bodyTextPreview;
 }
 
@@ -615,7 +1016,10 @@ function extractTopLevelContentType(rawMessage: string): string {
 export async function extractGmailBodyPreviewFromMimeMessageResult(input: {
   readonly rawMessage: string;
   readonly fallbackBodyText?: string | null;
+  readonly messageIdentifier?: string | null;
 }): Promise<GmailBodyPreviewResult> {
+  const context = createGmailMimeBudgetContext(input.messageIdentifier);
+
   if (ENCRYPTED_MIME_TYPES.has(extractTopLevelContentType(input.rawMessage))) {
     return buildBodyPreviewResult(
       ENCRYPTED_MESSAGE_PLACEHOLDER,
@@ -624,7 +1028,10 @@ export async function extractGmailBodyPreviewFromMimeMessageResult(input: {
   }
 
   try {
-    const extractedText = await extractTextFromMimeDocument(input.rawMessage);
+    const extractedText = await extractTextFromMimeDocument(
+      input.rawMessage,
+      context
+    );
     const cleaned = cleanGmailBodyPreviewText(extractedText);
 
     if (cleaned.length > 0) {
@@ -636,7 +1043,15 @@ export async function extractGmailBodyPreviewFromMimeMessageResult(input: {
       }
       return buildBodyPreviewResult(cleaned, "plaintext");
     }
-  } catch {
+  } catch (error) {
+    if (error instanceof GmailMimeParseTimeoutError) {
+      warnGmailMimeBudgetExceeded(
+        context,
+        "parse_timeout_ms",
+        context.bounds.parseTimeoutMs
+      );
+    }
+
     // Fall back to a conservative text clean-up below.
   }
 
@@ -654,6 +1069,7 @@ export async function extractGmailBodyPreviewFromMimeMessageResult(input: {
 export async function extractGmailBodyPreviewFromMimeMessage(input: {
   readonly rawMessage: string;
   readonly fallbackBodyText?: string | null;
+  readonly messageIdentifier?: string | null;
 }): Promise<string> {
   const result = await extractGmailBodyPreviewFromMimeMessageResult(input);
   return result.bodyTextPreview;

--- a/packages/integrations/src/providers/gmail-mbox.ts
+++ b/packages/integrations/src/providers/gmail-mbox.ts
@@ -271,7 +271,8 @@ export async function importGmailMboxRecords(
       toSafeIsoTimestamp(message.headers.Date) ?? parsedInput.receivedAt;
     const extractedBody = await extractGmailBodyPreviewFromMimeMessageResult({
       rawMessage: message.rawMessage,
-      fallbackBodyText: message.bodyText
+      fallbackBodyText: message.bodyText,
+      messageIdentifier: payloadRef
     });
     const bodyTextPreview = extractedBody.bodyTextPreview;
     const snippetClean = buildSnippet(bodyTextPreview, message.headers.Subject);

--- a/packages/integrations/test/gmail-body-extraction.test.ts
+++ b/packages/integrations/test/gmail-body-extraction.test.ts
@@ -1,6 +1,41 @@
 import { readFile } from "node:fs/promises";
+import type * as MailparserModule from "mailparser";
+import type { SimpleParserOptions } from "mailparser";
 
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getActualSimpleParser, setActualSimpleParser, simpleParserMock } =
+  vi.hoisted(() => {
+    let actualSimpleParser: ((
+      source: string | Buffer,
+      options?: SimpleParserOptions
+    ) => Promise<{ text?: string | null; html?: string | false | null }>) | null =
+      null;
+
+    return {
+      getActualSimpleParser: () => actualSimpleParser,
+      setActualSimpleParser: (
+        implementation: (
+          source: string | Buffer,
+          options?: SimpleParserOptions
+        ) => Promise<{ text?: string | null; html?: string | false | null }>
+      ) => {
+        actualSimpleParser = implementation;
+      },
+      simpleParserMock: vi.fn()
+    };
+  });
+
+vi.mock("mailparser", async () => {
+  const actual = await vi.importActual<typeof MailparserModule>("mailparser");
+  setActualSimpleParser(actual.simpleParser);
+  simpleParserMock.mockImplementation(actual.simpleParser);
+
+  return {
+    ...actual,
+    simpleParser: simpleParserMock
+  };
+});
 
 import {
   cleanGmailBodyPreviewText,
@@ -17,6 +52,8 @@ import {
 } from "../src/index.js";
 
 const fixturesDirectory = new URL("./fixtures/gmail/", import.meta.url);
+const ONE_MEBIBYTE = 1024 * 1024;
+const OVER_LIMIT_DECLARED_BYTES = 26 * 1024 * 1024;
 
 async function readFixtureText(name: string): Promise<string> {
   return readFile(new URL(name, fixturesDirectory), "utf8");
@@ -25,6 +62,62 @@ async function readFixtureText(name: string): Promise<string> {
 async function readFixtureJson<T>(name: string): Promise<T> {
   return JSON.parse(await readFixtureText(name)) as T;
 }
+
+function encodeBase64Url(value: string | Buffer): string {
+  const buffer = typeof value === "string" ? Buffer.from(value, "utf8") : value;
+
+  return buffer
+    .toString("base64")
+    .replace(/\+/gu, "-")
+    .replace(/\//gu, "_")
+    .replace(/=+$/u, "");
+}
+
+function buildTextBodyPart(
+  text: string,
+  size = Buffer.byteLength(text, "utf8")
+): GmailApiMessagePart {
+  return {
+    mimeType: "text/plain",
+    headers: [
+      { name: "Content-Type", value: "text/plain; charset=utf-8" }
+    ],
+    body: {
+      data: encodeBase64Url(text),
+      size
+    }
+  };
+}
+
+function buildNestedPayload(
+  depth: number,
+  leafPart: GmailApiMessagePart
+): GmailApiMessagePart {
+  let payload = leafPart;
+
+  for (let index = 0; index < depth; index += 1) {
+    payload = {
+      mimeType: "multipart/mixed",
+      parts: [payload]
+    };
+  }
+
+  return payload;
+}
+
+beforeEach(() => {
+  const actualSimpleParser = getActualSimpleParser();
+
+  if (actualSimpleParser !== null) {
+    simpleParserMock.mockReset();
+    simpleParserMock.mockImplementation(actualSimpleParser);
+  }
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
 
 describe("Gmail body extraction", () => {
   it("cleans flattened MIME previews without leaving scaffolding behind", async () => {
@@ -394,5 +487,205 @@ describe("Gmail body extraction", () => {
     };
 
     expect(extractDsnOriginalMessageId(payload)).toBeNull();
+  });
+
+  it("extracts a DSN original message id within the default depth budget", () => {
+    const payload = buildNestedPayload(32, {
+      mimeType: "message/delivery-status",
+      body: {
+        data: encodeBase64Url(
+          "Original-Message-ID: <depth-under-limit@example.org>"
+        ),
+        size: 51
+      }
+    });
+
+    expect(
+      extractDsnOriginalMessageId(payload, {
+        messageIdentifier: "gmail-depth-under-limit"
+      })
+    ).toBe("<depth-under-limit@example.org>");
+  });
+
+  it("returns undefined and warns once when DSN extraction exceeds the depth budget", () => {
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const payload = buildNestedPayload(128, {
+      mimeType: "message/delivery-status",
+      body: {
+        data: encodeBase64Url(
+          "Original-Message-ID: <depth-over-limit@example.org>"
+        ),
+        size: 50
+      }
+    });
+
+    expect(
+      extractDsnOriginalMessageId(payload, {
+        messageIdentifier: "gmail-depth-over-limit"
+      })
+    ).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Gmail MIME parsing budget exceeded.",
+      expect.objectContaining({
+        budgetName: "depth",
+        limit: 64,
+        messageIdentifier: "gmail-depth-over-limit"
+      })
+    );
+  });
+
+  it("extracts a plaintext part within the default part-count budget", async () => {
+    const payload: GmailApiMessagePart = {
+      mimeType: "multipart/mixed",
+      parts: Array.from({ length: 256 }, (_, index) =>
+        buildTextBodyPart(`Sibling part ${String(index)}`)
+      )
+    };
+
+    await expect(
+      extractGmailBodyPreviewFromPayloadResult(payload, {
+        messageIdentifier: "gmail-parts-under-limit"
+      })
+    ).resolves.toEqual({
+      bodyTextPreview: "Sibling part 0",
+      bodyKind: "plaintext"
+    });
+  });
+
+  it("returns the encrypted placeholder and warns once when part traversal exceeds the budget", async () => {
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const payload: GmailApiMessagePart = {
+      mimeType: "multipart/mixed",
+      parts: Array.from({ length: 1024 }, (_, index) =>
+        buildTextBodyPart(`Sibling part ${String(index)}`)
+      )
+    };
+
+    await expect(
+      extractGmailBodyPreviewFromPayloadResult(payload, {
+        messageIdentifier: "gmail-parts-over-limit"
+      })
+    ).resolves.toEqual({
+      bodyTextPreview: "[Encrypted message — open in Gmail to read]",
+      bodyKind: "encrypted_placeholder"
+    });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Gmail MIME parsing budget exceeded.",
+      expect.objectContaining({
+        budgetName: "parts",
+        limit: 512,
+        messageIdentifier: "gmail-parts-over-limit"
+      })
+    );
+  });
+
+  it("extracts plaintext within the default decoded-size budget", async () => {
+    const largeText = "A".repeat(ONE_MEBIBYTE);
+    const payload: GmailApiMessagePart = {
+      mimeType: "multipart/alternative",
+      parts: [buildTextBodyPart(largeText)]
+    };
+
+    const result = await extractGmailBodyPreviewFromPayloadResult(payload, {
+      messageIdentifier: "gmail-decoded-under-limit"
+    });
+
+    expect(result.bodyKind).toBe("plaintext");
+    expect(result.bodyTextPreview.length).toBe(ONE_MEBIBYTE);
+    expect(result.bodyTextPreview.startsWith("AAAA")).toBe(true);
+  });
+
+  it("returns the binary fallback and warns once when decoded bytes exceed the budget", async () => {
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const payload: GmailApiMessagePart = {
+      mimeType: "multipart/alternative",
+      parts: [
+        {
+          mimeType: "text/plain",
+          headers: [
+            { name: "Content-Type", value: "text/plain; charset=utf-8" }
+          ],
+          body: {
+            data: encodeBase64Url("small body"),
+            size: OVER_LIMIT_DECLARED_BYTES
+          }
+        }
+      ]
+    };
+
+    await expect(
+      extractGmailBodyPreviewFromPayloadResult(payload, {
+        messageIdentifier: "gmail-decoded-over-limit"
+      })
+    ).resolves.toEqual({
+      bodyTextPreview: "[Message body could not be extracted — open in Gmail]",
+      bodyKind: "binary_fallback"
+    });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Gmail MIME parsing budget exceeded.",
+      expect.objectContaining({
+        budgetName: "decoded_bytes",
+        limit: 20 * 1024 * 1024,
+        messageIdentifier: "gmail-decoded-over-limit"
+      })
+    );
+  });
+
+  it("parses a small MIME message within the default parser timeout", async () => {
+    const result = await extractGmailBodyPreviewFromMimeMessageResult({
+      rawMessage: "Subject: Quick parse\r\n\r\nHello within the timeout.",
+      messageIdentifier: "mbox://timeout-under-limit"
+    });
+
+    expect(result).toEqual({
+      bodyTextPreview: "Hello within the timeout.",
+      bodyKind: "plaintext"
+    });
+  });
+
+  it("falls back and warns once when MIME parsing exceeds the timeout budget", async () => {
+    vi.useFakeTimers();
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    simpleParserMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({ text: "Delayed parse output" });
+          }, 11_000);
+        })
+    );
+
+    const extractionPromise = extractGmailBodyPreviewFromMimeMessageResult({
+      rawMessage: "Subject: Slow parse\r\n\r\nIgnored body",
+      fallbackBodyText: "Fallback body",
+      messageIdentifier: "mbox://timeout-over-limit"
+    });
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    await expect(extractionPromise).resolves.toEqual({
+      bodyTextPreview: "Fallback body",
+      bodyKind: "plaintext"
+    });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Gmail MIME parsing budget exceeded.",
+      expect.objectContaining({
+        budgetName: "parse_timeout_ms",
+        limit: 10_000,
+        messageIdentifier: "mbox://timeout-over-limit"
+      })
+    );
+    await vi.advanceTimersByTimeAsync(1_000);
   });
 });


### PR DESCRIPTION
## Summary

Slice 3 P1 #2: Gmail MIME parsing in `gmail-body.ts` was recursive and unbounded across `extractDsnOriginalMessageId`, `containsEncryptedBodyPart`, and `collectCandidateBodyParts` — and `simpleParser` calls had no time budget. A malformed/deep payload could cause stack overflow, memory pressure, or long worker stalls before the existing fallback paths could return.

## Four env-configurable budgets at the integration boundary

| Env var | Default | Purpose |
|---|---|---|
| `GMAIL_MIME_MAX_DEPTH` | 64 | recursion depth |
| `GMAIL_MIME_MAX_PARTS` | 512 | total parts visited per traversal |
| `GMAIL_MIME_MAX_DECODED_BYTES` | 20 MB | accumulated decoded bytes per top-level extraction |
| `GMAIL_MIME_PARSE_TIMEOUT_MS` | 10 s | `simpleParser` wall time |

## Failure-mode contract

On any overrun:
- log once at `warn` with budget name + limit + message identifier (no body bytes leaked)
- return existing fallback (binary-noise / encrypted-fallback / `null` parse result)
- never throw, never crash the worker

Specific behaviors:
- `extractDsnOriginalMessageId` → `undefined` (no DSN linkage extracted)
- `containsEncryptedBodyPart` → `true` (safer default — routes through encrypted-fallback)
- `collectCandidateBodyParts` → return whatever was collected so far, capped
- `simpleParser` timeout → existing parse-failure branch via `Promise.race`

## Files

- `packages/integrations/src/providers/gmail-body.ts` (+486)
- `packages/integrations/src/capture-services/gmail.ts` (+9, threading message identifier)
- `packages/integrations/src/providers/gmail-mbox.ts` (+3, threading message identifier)
- `packages/integrations/test/gmail-body-extraction.test.ts` (+295) — under/over tests for each budget

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test:unit` all clean (VALIDATION_PASSED)
- [ ] CI green
- [ ] Watch worker logs after deploy for `Gmail MIME parsing budget exceeded` warnings — none expected on healthy traffic; would indicate a real malformed-message DoS attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)