### PR TITLE
fix(worker): F1 Mailchimp lease/heartbeat + stale-running sweeper

### DIFF
--- a/apps/worker/src/jobs/reconcile-stale-running.ts
+++ b/apps/worker/src/jobs/reconcile-stale-running.ts
@@ -1,0 +1,58 @@
+import type { Task } from "graphile-worker";
+
+import type { Stage1Database } from "@as-comms/db";
+import type { Stage1RepositoryBundle } from "@as-comms/domain";
+
+import { reconcileStaleRunning } from "../ops/reconcile-stale-running.js";
+import type { Stage1SyncStateService } from "../orchestration/index.js";
+
+export const reconcileStaleRunningJobName = "reconcile-stale-running" as const;
+
+export interface ReconcileStaleRunningTaskDependencies {
+  readonly db: Stage1Database;
+  readonly repositories: Stage1RepositoryBundle;
+  readonly syncState: Stage1SyncStateService;
+  readonly leaseThresholdMs: number;
+  readonly now?: () => Date;
+  readonly logger?: Pick<Console, "log">;
+}
+
+export function createReconcileStaleRunningTask(
+  dependencies: ReconcileStaleRunningTaskDependencies
+): Task {
+  const logger = dependencies.logger ?? console;
+
+  return () =>
+    reconcileStaleRunning({
+      db: dependencies.db,
+      repositories: dependencies.repositories,
+      syncState: dependencies.syncState,
+      leaseThresholdMs: dependencies.leaseThresholdMs,
+      ...(dependencies.now === undefined ? {} : { now: dependencies.now }),
+      logger
+    }).then((report) => {
+      if (report.errors.length > 0) {
+        logger.log(
+          JSON.stringify({
+            event: "sync_state.stale_running.reconcile.errors",
+            sample: report.errors.slice(0, 5)
+          })
+        );
+      }
+
+      logger.log(
+        JSON.stringify({
+          event: "sync_state.stale_running.reconcile.completed",
+          scanned: report.scanned,
+          swept: report.swept,
+          errors: report.errors.length
+        })
+      );
+
+      if (report.errors.length > 0 && report.swept === 0) {
+        throw new Error(
+          `Stale running reconcile made no progress and produced ${report.errors.length.toString()} errors.`
+        );
+      }
+    });
+}

--- a/apps/worker/src/ops/mailchimp-artifacts.ts
+++ b/apps/worker/src/ops/mailchimp-artifacts.ts
@@ -95,6 +95,7 @@ interface Stage1MailchimpArtifactImportDependencies {
 }
 
 const MAILCHIMP_RECORD_PROGRESS_INTERVAL = 25;
+const DEFAULT_SYNC_STATE_HEARTBEAT_INTERVAL_MS = 30_000;
 const emptyMailchimpKnownIdentityIndex: MailchimpKnownIdentityIndex = {
   knownEmails: new Set<string>(),
   knownVolunteerIds: new Set<string>(),
@@ -1043,6 +1044,16 @@ function buildImportFailure(error: unknown): Stage1JobFailure {
   };
 }
 
+function readSyncStateHeartbeatIntervalMs(): number {
+  const parsed = Number(process.env.SYNC_STATE_HEARTBEAT_INTERVAL_MS ?? "30000");
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_SYNC_STATE_HEARTBEAT_INTERVAL_MS;
+  }
+
+  return parsed;
+}
+
 function buildMailchimpRecordCursor(
   campaignId: string,
   nextRecordIndex: number,
@@ -1378,6 +1389,15 @@ export function createStage1MailchimpArtifactImportService(
         createMailchimpIdentityPresenceResolver(dependencies);
       let pendingDeadLetterCountIncrement = 0;
       let latestCursor = startedSyncState.cursor;
+      const heartbeatIntervalMs = readSyncStateHeartbeatIntervalMs();
+      const heartbeatTimer = setInterval(() => {
+        void dependencies.syncState
+          .heartbeat({ syncStateId: parsedInput.syncStateId })
+          .catch(() => {
+            // Best-effort only; the stale-running sweeper handles missed heartbeats.
+          });
+      }, heartbeatIntervalMs);
+      heartbeatTimer.unref();
 
       try {
         for (const campaignPath of campaignPaths) {
@@ -1644,6 +1664,8 @@ export function createStage1MailchimpArtifactImportService(
                 unmatchedReportCsvPath: unmatchedReportPaths.csvPath,
               }),
         };
+      } finally {
+        clearInterval(heartbeatTimer);
       }
     },
   };

--- a/apps/worker/src/ops/reconcile-stale-running.ts
+++ b/apps/worker/src/ops/reconcile-stale-running.ts
@@ -1,0 +1,88 @@
+import { and, eq, isNull, lt, or } from "drizzle-orm";
+
+import { syncState, type Stage1Database } from "@as-comms/db";
+import type { Stage1RepositoryBundle } from "@as-comms/domain";
+
+import type { Stage1SyncStateService } from "../orchestration/index.js";
+
+export interface ReconcileStaleRunningError {
+  readonly syncStateId: string;
+  readonly message: string;
+}
+
+export interface ReconcileStaleRunningReport {
+  readonly scanned: number;
+  readonly swept: number;
+  readonly errors: readonly ReconcileStaleRunningError[];
+}
+
+interface ReconcileStaleRunningDependencies {
+  readonly db: Stage1Database;
+  readonly repositories: Stage1RepositoryBundle;
+  readonly syncState: Stage1SyncStateService;
+  readonly leaseThresholdMs: number;
+  readonly now?: () => Date;
+  readonly logger?: Pick<Console, "log">;
+}
+
+function subtractLeaseThreshold(now: Date, leaseThresholdMs: number): Date {
+  return new Date(now.getTime() - leaseThresholdMs);
+}
+
+export async function reconcileStaleRunning(
+  dependencies: ReconcileStaleRunningDependencies
+): Promise<ReconcileStaleRunningReport> {
+  const now = dependencies.now ?? (() => new Date());
+  const logger = dependencies.logger ?? console;
+  const cutoff = subtractLeaseThreshold(now(), dependencies.leaseThresholdMs);
+  const staleRows = await dependencies.db
+    .select()
+    .from(syncState)
+    .where(
+      and(
+        eq(syncState.status, "running"),
+        or(
+          lt(syncState.heartbeatAt, cutoff),
+          and(isNull(syncState.heartbeatAt), lt(syncState.updatedAt, cutoff))
+        )
+      )
+    );
+  const errors: ReconcileStaleRunningError[] = [];
+  let swept = 0;
+
+  for (const row of staleRows) {
+    try {
+      await dependencies.syncState.failWindow({
+        syncStateId: row.id,
+        scope: row.scope,
+        provider: row.provider,
+        jobType: row.jobType,
+        cursor: row.cursor,
+        checkpoint: row.cursor,
+        windowStart: row.windowStart === null ? null : row.windowStart.toISOString(),
+        windowEnd: row.windowEnd === null ? null : row.windowEnd.toISOString(),
+        deadLetterCountIncrement: 1,
+        deadLettered: false
+      });
+      logger.log(
+        JSON.stringify({
+          event: "sync_state.stale_running_sweep.recovered",
+          syncStateId: row.id,
+          reason: "stale_running_sweep"
+        })
+      );
+      swept += 1;
+    } catch (error) {
+      errors.push({
+        syncStateId: row.id,
+        message: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+
+  return {
+    scanned: staleRows.length,
+    swept,
+    errors
+  };
+}

--- a/apps/worker/src/orchestration/sync-state.ts
+++ b/apps/worker/src/orchestration/sync-state.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import {
   syncStateSchema,
   type Provider,
@@ -6,6 +8,9 @@ import {
   type SyncStateRecord
 } from "@as-comms/contracts";
 import type { Stage1PersistenceService } from "@as-comms/domain";
+
+const WORKER_INSTANCE_ID = randomUUID();
+export const workerInstanceId = WORKER_INSTANCE_ID;
 
 function chooseCursor(
   existing: SyncStateRecord | null,
@@ -39,6 +44,8 @@ function toSyncState(input: {
   readonly freshnessP99Seconds: number | null;
   readonly lastSuccessfulAt: string | null;
   readonly consecutiveFailureCount: number;
+  readonly leaseOwner: string | null;
+  readonly heartbeatAt: string | null;
   readonly deadLetterCount: number;
 }): SyncStateRecord {
   return syncStateSchema.parse({
@@ -55,6 +62,8 @@ function toSyncState(input: {
     freshnessP99Seconds: input.freshnessP99Seconds,
     lastSuccessfulAt: input.lastSuccessfulAt,
     consecutiveFailureCount: input.consecutiveFailureCount,
+    leaseOwner: input.leaseOwner,
+    heartbeatAt: input.heartbeatAt,
     deadLetterCount: input.deadLetterCount
   });
 }
@@ -81,6 +90,9 @@ export interface Stage1SyncStateService {
     readonly windowEnd: string | null;
     readonly deadLetterCountIncrement: number;
   }): Promise<SyncStateRecord>;
+  heartbeat(input: {
+    readonly syncStateId: string;
+  }): Promise<SyncStateRecord | null>;
   completeWindow(input: {
     readonly syncStateId: string;
     readonly scope: SyncScope;
@@ -112,6 +124,8 @@ export interface Stage1SyncStateService {
 export function createStage1SyncStateService(
   persistence: Stage1PersistenceService
 ): Stage1SyncStateService {
+  const heartbeatTimestamp = (): string => new Date().toISOString();
+
   return {
     async startWindow(input) {
       const existing = await persistence.repositories.syncState.findById(
@@ -139,6 +153,8 @@ export function createStage1SyncStateService(
           freshnessP99Seconds: existing?.freshnessP99Seconds ?? null,
           lastSuccessfulAt: existing?.lastSuccessfulAt ?? null,
           consecutiveFailureCount: existing?.consecutiveFailureCount ?? 0,
+          leaseOwner: WORKER_INSTANCE_ID,
+          heartbeatAt: heartbeatTimestamp(),
           deadLetterCount: existing?.deadLetterCount ?? 0
         })
       );
@@ -170,8 +186,50 @@ export function createStage1SyncStateService(
           freshnessP99Seconds: existing?.freshnessP99Seconds ?? null,
           lastSuccessfulAt: existing?.lastSuccessfulAt ?? null,
           consecutiveFailureCount: existing?.consecutiveFailureCount ?? 0,
+          leaseOwner: existing?.leaseOwner ?? WORKER_INSTANCE_ID,
+          heartbeatAt: heartbeatTimestamp(),
           deadLetterCount:
             (existing?.deadLetterCount ?? 0) + input.deadLetterCountIncrement
+        })
+      );
+    },
+
+    async heartbeat(input) {
+      const existing = await persistence.repositories.syncState.findById(
+        input.syncStateId
+      );
+
+      if (existing === null) {
+        return null;
+      }
+
+      if (
+        existing.status !== "running" ||
+        existing.leaseOwner !== WORKER_INSTANCE_ID
+      ) {
+        return existing;
+      }
+
+      return persistence.saveSyncState(
+        toSyncState({
+          existing,
+          id: existing.id,
+          scope: existing.scope,
+          provider: existing.provider,
+          jobType: existing.jobType,
+          cursor: existing.cursor,
+          checkpoint: null,
+          windowStart: existing.windowStart,
+          windowEnd: existing.windowEnd,
+          status: existing.status,
+          parityPercent: existing.parityPercent,
+          freshnessP95Seconds: existing.freshnessP95Seconds,
+          freshnessP99Seconds: existing.freshnessP99Seconds,
+          lastSuccessfulAt: existing.lastSuccessfulAt,
+          consecutiveFailureCount: existing.consecutiveFailureCount,
+          leaseOwner: existing.leaseOwner,
+          heartbeatAt: heartbeatTimestamp(),
+          deadLetterCount: existing.deadLetterCount
         })
       );
     },
@@ -204,6 +262,8 @@ export function createStage1SyncStateService(
             input.freshnessP99Seconds ?? existing?.freshnessP99Seconds ?? null,
           lastSuccessfulAt: input.completedAt,
           consecutiveFailureCount: 0,
+          leaseOwner: null,
+          heartbeatAt: null,
           deadLetterCount: existing?.deadLetterCount ?? 0
         })
       );
@@ -231,6 +291,8 @@ export function createStage1SyncStateService(
           freshnessP99Seconds: existing?.freshnessP99Seconds ?? null,
           lastSuccessfulAt: existing?.lastSuccessfulAt ?? null,
           consecutiveFailureCount: (existing?.consecutiveFailureCount ?? 0) + 1,
+          leaseOwner: null,
+          heartbeatAt: null,
           deadLetterCount:
             (existing?.deadLetterCount ?? 0) + input.deadLetterCountIncrement
         })

--- a/apps/worker/src/runtime.ts
+++ b/apps/worker/src/runtime.ts
@@ -33,6 +33,7 @@ import {
 import { readNotionKnowledgeSyncConfig } from "./jobs/notion-knowledge-sync/index.js";
 import { reconcileRoutingReviewQueueJobName } from "./jobs/reconcile-routing-review-queue.js";
 import {
+  createStage1SyncStateService,
   createStage1WorkerOrchestrationService,
   type MailchimpCapturePort,
   pollGmailLiveJobName,
@@ -43,7 +44,10 @@ import {
 } from "./orchestration/index.js";
 import { createTaskList } from "./tasks.js";
 import { reconcileIdentityQueueJobName } from "./jobs/reconcile-identity-queue.js";
+import { reconcileStaleRunningJobName } from "./jobs/reconcile-stale-running.js";
 import { sweepPendingOutboundsJobName } from "./jobs/sweep-pending-outbounds.js";
+
+const defaultSyncStateLeaseThresholdMs = 5 * 60 * 1000;
 
 const workerCaptureConfigSchema = z.object({
   gmail: capturePortHttpConfigSchema,
@@ -99,9 +103,23 @@ export function buildWorkerCrontab(config: WorkerConfig): string {
     `*/${String(salesforceMinutes)} * * * * ${pollSalesforceLiveJobName} ?id=salesforce-live-poll&max=1`,
     `*/5 * * * * ${pollIntegrationHealthJobName} ?id=integration-health-poll&max=1`,
     `*/5 * * * * ${sweepPendingOutboundsJobName} ?id=composer-orphan-sweep&max=1`,
+    `* * * * * ${reconcileStaleRunningJobName} ?id=stale-running-sweep&max=1`,
     `*/15 * * * * ${reconcileIdentityQueueJobName} ?id=identity-queue-reconcile&max=1`,
     `*/15 * * * * ${reconcileRoutingReviewQueueJobName} ?id=routing-review-queue-reconcile&max=1`,
   ].join("\n");
+}
+
+function readSyncStateLeaseThresholdMs(env: NodeJS.ProcessEnv): number {
+  const parsed = Number(
+    env.SYNC_STATE_LEASE_THRESHOLD_MS ??
+      String(defaultSyncStateLeaseThresholdMs)
+  );
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return defaultSyncStateLeaseThresholdMs;
+  }
+
+  return parsed;
 }
 
 function readOptionalCaptureConfig(
@@ -262,6 +280,7 @@ export async function createStage1WorkerRuntimeServices(
   const persistence = createStage1PersistenceService(repositories);
   const normalization = createStage1NormalizationService(persistence);
   const ingest = createStage1IngestService(normalization);
+  const syncState = createStage1SyncStateService(persistence);
   const fetchOptions =
     input?.fetchImplementation === undefined
       ? undefined
@@ -269,6 +288,7 @@ export async function createStage1WorkerRuntimeServices(
           fetchImplementation: input.fetchImplementation,
         };
   const fetchImplementation = input?.fetchImplementation ?? fetch;
+  const leaseThresholdMs = readSyncStateLeaseThresholdMs(input?.env ?? process.env);
   const capture = {
     gmail: createGmailCapturePort(config.capture.gmail, fetchOptions),
     salesforce: createSalesforceCapturePort(
@@ -341,6 +361,12 @@ export async function createStage1WorkerRuntimeServices(
       reconcileRoutingReviewQueue: {
         db: connection.db,
         repositories,
+      },
+      reconcileStaleRunning: {
+        db: connection.db,
+        repositories,
+        syncState,
+        leaseThresholdMs,
       },
     }),
     dispose() {

--- a/apps/worker/src/tasks.ts
+++ b/apps/worker/src/tasks.ts
@@ -18,6 +18,11 @@ import {
   type ReconcileRoutingReviewQueueTaskDependencies,
 } from "./jobs/reconcile-routing-review-queue.js";
 import {
+  createReconcileStaleRunningTask,
+  reconcileStaleRunningJobName,
+  type ReconcileStaleRunningTaskDependencies,
+} from "./jobs/reconcile-stale-running.js";
+import {
   createNotionKnowledgeSyncTask,
   notionKnowledgeSyncJobName,
   type NotionKnowledgeSyncDependencies,
@@ -37,6 +42,7 @@ export function createTaskList(
     readonly pendingOutboundSweep?: PendingOutboundSweepTaskDependencies;
     readonly reconcileIdentityQueue?: ReconcileIdentityQueueTaskDependencies;
     readonly reconcileRoutingReviewQueue?: ReconcileRoutingReviewQueueTaskDependencies;
+    readonly reconcileStaleRunning?: ReconcileStaleRunningTaskDependencies;
   },
 ): TaskList {
   return {
@@ -62,6 +68,13 @@ export function createTaskList(
             createReconcileRoutingReviewQueueTask(
               input.reconcileRoutingReviewQueue,
             ),
+        }),
+    ...(input?.reconcileStaleRunning === undefined
+      ? {}
+      : {
+          [reconcileStaleRunningJobName]: createReconcileStaleRunningTask(
+            input.reconcileStaleRunning
+          )
         }),
     ...(input?.notionKnowledgeSync === undefined
       ? {}

--- a/apps/worker/test/jobs/reconcile-stale-running.test.ts
+++ b/apps/worker/test/jobs/reconcile-stale-running.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import { createTaskList } from "../../src/tasks.js";
+import {
+  createReconcileStaleRunningTask,
+  reconcileStaleRunningJobName
+} from "../../src/jobs/reconcile-stale-running.js";
+import { createTestWorkerContext } from "../helpers.js";
+
+describe("reconcile stale running task", () => {
+  it("fails stale running rows and leaves fresh or terminal rows untouched", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await context.repositories.syncState.upsert({
+        id: "sync:stale-running:stale",
+        scope: "provider",
+        provider: "mailchimp",
+        jobType: "historical_backfill",
+        cursor: "cursor:stale",
+        windowStart: "2026-01-01T00:00:00.000Z",
+        windowEnd: "2026-01-01T00:05:00.000Z",
+        status: "running",
+        parityPercent: null,
+        freshnessP95Seconds: null,
+        freshnessP99Seconds: null,
+        lastSuccessfulAt: null,
+        consecutiveFailureCount: 0,
+        leaseOwner: "worker:stale",
+        heartbeatAt: "2026-01-01T00:00:00.000Z",
+        deadLetterCount: 0
+      });
+      await context.repositories.syncState.upsert({
+        id: "sync:stale-running:fresh",
+        scope: "provider",
+        provider: "mailchimp",
+        jobType: "historical_backfill",
+        cursor: "cursor:fresh",
+        windowStart: "2026-01-01T00:00:00.000Z",
+        windowEnd: "2026-01-01T00:05:00.000Z",
+        status: "running",
+        parityPercent: null,
+        freshnessP95Seconds: null,
+        freshnessP99Seconds: null,
+        lastSuccessfulAt: null,
+        consecutiveFailureCount: 0,
+        leaseOwner: "worker:fresh",
+        heartbeatAt: "2026-01-01T00:09:30.000Z",
+        deadLetterCount: 0
+      });
+      await context.repositories.syncState.upsert({
+        id: "sync:stale-running:succeeded",
+        scope: "provider",
+        provider: "mailchimp",
+        jobType: "historical_backfill",
+        cursor: "cursor:succeeded",
+        windowStart: "2026-01-01T00:00:00.000Z",
+        windowEnd: "2026-01-01T00:05:00.000Z",
+        status: "succeeded",
+        parityPercent: null,
+        freshnessP95Seconds: null,
+        freshnessP99Seconds: null,
+        lastSuccessfulAt: "2026-01-01T00:10:00.000Z",
+        consecutiveFailureCount: 0,
+        leaseOwner: null,
+        heartbeatAt: null,
+        deadLetterCount: 0
+      });
+
+      const task = createReconcileStaleRunningTask({
+        db: context.db,
+        repositories: context.repositories,
+        syncState: context.syncState,
+        leaseThresholdMs: 5 * 60 * 1000,
+        now: () => new Date("2026-01-01T00:10:00.000Z"),
+        logger: {
+          log: () => undefined
+        }
+      });
+
+      await task({} as never, {} as never);
+
+      await expect(
+        context.repositories.syncState.findById("sync:stale-running:stale")
+      ).resolves.toMatchObject({
+        status: "failed",
+        leaseOwner: null,
+        heartbeatAt: null,
+        deadLetterCount: 1
+      });
+      await expect(
+        context.repositories.syncState.findById("sync:stale-running:fresh")
+      ).resolves.toMatchObject({
+        status: "running",
+        leaseOwner: "worker:fresh",
+        heartbeatAt: "2026-01-01T00:09:30.000Z",
+        deadLetterCount: 0
+      });
+      await expect(
+        context.repositories.syncState.findById("sync:stale-running:succeeded")
+      ).resolves.toMatchObject({
+        status: "succeeded",
+        deadLetterCount: 0
+      });
+
+      const taskList = createTaskList(undefined, {
+        reconcileStaleRunning: {
+          db: context.db,
+          repositories: context.repositories,
+          syncState: context.syncState,
+          leaseThresholdMs: 5 * 60 * 1000
+        }
+      });
+
+      expect(taskList[reconcileStaleRunningJobName]).toBeDefined();
+    } finally {
+      await context.dispose();
+    }
+  });
+});

--- a/apps/worker/test/stage1-live-polling.test.ts
+++ b/apps/worker/test/stage1-live-polling.test.ts
@@ -40,6 +40,9 @@ async function saveLiveSyncState(
     parityPercent: null,
     lastSuccessfulAt: input.lastSuccessfulAt,
     consecutiveFailureCount: 0,
+    leaseOwner: input.status === "running" ? "worker:test" : null,
+    heartbeatAt:
+      input.status === "running" ? "2026-01-01T00:00:30.000Z" : null,
     deadLetterCount: 0,
     freshnessP95Seconds: null,
     freshnessP99Seconds: null

--- a/apps/worker/test/stage1-mailchimp-artifact-import.test.ts
+++ b/apps/worker/test/stage1-mailchimp-artifact-import.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { createStage1MailchimpArtifactImportService } from "../src/ops/mailchimp-artifacts.js";
 import { Stage1RetryableJobError } from "../src/orchestration/index.js";
@@ -615,6 +615,69 @@ describe("Stage 1 Mailchimp artifact importer", () => {
         cursor: "campaign-resume"
       });
     } finally {
+      await rm(artifactRoot, {
+        recursive: true,
+        force: true
+      });
+      await context.dispose();
+    }
+  });
+
+  it("heartbeats while a long Mailchimp artifact import is still running", async () => {
+    vi.useFakeTimers();
+    const context = await createTestWorkerContext();
+    const artifactRoot = await writeArtifactCampaign();
+
+    try {
+      await seedContact(context);
+
+      let notifyIngestStarted: (() => void) | undefined;
+      const ingestStarted = new Promise<void>((resolve) => {
+        notifyIngestStarted = resolve;
+      });
+      let releaseIngest: (() => void) | undefined;
+      const holdIngest = new Promise<void>((resolve) => {
+        releaseIngest = resolve;
+      });
+      const heartbeat = vi.fn(({ syncStateId }: { readonly syncStateId: string }) =>
+        context.syncState.heartbeat({ syncStateId })
+      );
+      const importer = createStage1MailchimpArtifactImportService({
+        ingest: {
+          ingestMailchimpHistoricalRecord(record) {
+            notifyIngestStarted?.();
+
+            return holdIngest.then(() =>
+              context.ingest.ingestMailchimpHistoricalRecord(record)
+            );
+          }
+        },
+        persistence: context.persistence,
+        syncState: {
+          ...context.syncState,
+          heartbeat
+        },
+        now: () => new Date("2026-02-03T00:00:00.000Z")
+      });
+
+      const importPromise = importer.importArtifacts({
+        artifactPath: artifactRoot,
+        syncStateId: "sync:mailchimp:artifacts:heartbeat",
+        correlationId: "corr:mailchimp:artifacts:heartbeat",
+        traceId: null,
+        receivedAt: "2026-02-03T00:00:00.000Z"
+      });
+
+      await ingestStarted;
+      await vi.advanceTimersByTimeAsync(30_000);
+      if (releaseIngest !== undefined) {
+        releaseIngest();
+      }
+      await importPromise;
+
+      expect(heartbeat).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
       await rm(artifactRoot, {
         recursive: true,
         force: true

--- a/apps/worker/test/stage1-ops.test.ts
+++ b/apps/worker/test/stage1-ops.test.ts
@@ -150,6 +150,8 @@ async function seedInspectableContact(context: TestWorkerContext): Promise<void>
     parityPercent: null,
     lastSuccessfulAt: "2026-01-01T00:05:00.000Z",
     consecutiveFailureCount: 0,
+    leaseOwner: null,
+    heartbeatAt: null,
     deadLetterCount: 0,
     freshnessP95Seconds: 60,
     freshnessP99Seconds: 120
@@ -300,6 +302,8 @@ describe("Stage 1 ops helpers", () => {
         parityPercent: null,
         lastSuccessfulAt: null,
         consecutiveFailureCount: 0,
+        leaseOwner: null,
+        heartbeatAt: null,
         deadLetterCount: 0,
         freshnessP95Seconds: null,
         freshnessP99Seconds: null

--- a/apps/worker/test/stage1-orchestration.test.ts
+++ b/apps/worker/test/stage1-orchestration.test.ts
@@ -1771,6 +1771,8 @@ Alias drift outbound message.
         freshnessP99Seconds: 120,
         lastSuccessfulAt: "2026-01-02T01:00:00.000Z",
         consecutiveFailureCount: 0,
+        leaseOwner: null,
+        heartbeatAt: null,
         deadLetterCount: 0
       });
 

--- a/apps/worker/test/stage1-runtime.test.ts
+++ b/apps/worker/test/stage1-runtime.test.ts
@@ -11,6 +11,7 @@ import {
   pollIntegrationHealthJobName,
   pollSalesforceLiveJobName,
 } from "../src/orchestration/tasks.js";
+import { reconcileStaleRunningJobName } from "../src/jobs/reconcile-stale-running.js";
 import { sweepPendingOutboundsJobName } from "../src/jobs/sweep-pending-outbounds.js";
 import { createTaskList } from "../src/tasks.js";
 import {
@@ -146,6 +147,7 @@ describe("Stage 1 worker runtime task registration", () => {
         `*/5 * * * * ${pollSalesforceLiveJobName} ?id=salesforce-live-poll&max=1`,
         `*/5 * * * * ${pollIntegrationHealthJobName} ?id=integration-health-poll&max=1`,
         `*/5 * * * * ${sweepPendingOutboundsJobName} ?id=composer-orphan-sweep&max=1`,
+        `* * * * * ${reconcileStaleRunningJobName} ?id=stale-running-sweep&max=1`,
         "*/15 * * * * reconcile-identity-queue ?id=identity-queue-reconcile&max=1",
         "*/15 * * * * reconcile-routing-review-queue ?id=routing-review-queue-reconcile&max=1",
       ].join("\n"),

--- a/apps/worker/test/stage1-sync-failure-audit.test.ts
+++ b/apps/worker/test/stage1-sync-failure-audit.test.ts
@@ -20,6 +20,8 @@ describe("Stage 1 sync failure audit", () => {
         parityPercent: null,
         lastSuccessfulAt: null,
         consecutiveFailureCount: 0,
+        leaseOwner: null,
+        heartbeatAt: null,
         deadLetterCount: 0,
         freshnessP95Seconds: null,
         freshnessP99Seconds: null

--- a/apps/worker/test/stage1-sync-state.test.ts
+++ b/apps/worker/test/stage1-sync-state.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { workerInstanceId } from "../src/orchestration/sync-state.js";
 import { createTestWorkerContext } from "./helpers.js";
 
 describe("Stage 1 worker sync-state service", () => {
@@ -61,13 +62,19 @@ describe("Stage 1 worker sync-state service", () => {
       });
 
       expect(started.status).toBe("running");
+      expect(started.leaseOwner).toBe(workerInstanceId);
+      expect(started.heartbeatAt).not.toBeNull();
       expect(progressed.cursor).toBe("checkpoint:1");
       expect(progressed.deadLetterCount).toBe(1);
       expect(progressed.consecutiveFailureCount).toBe(0);
+      expect(progressed.leaseOwner).toBe(workerInstanceId);
+      expect(progressed.heartbeatAt).not.toBeNull();
       expect(completed.status).toBe("succeeded");
       expect(completed.cursor).toBe("cursor:complete");
       expect(completed.parityPercent).toBe(100);
       expect(completed.consecutiveFailureCount).toBe(0);
+      expect(completed.leaseOwner).toBeNull();
+      expect(completed.heartbeatAt).toBeNull();
       expect(completedAgain).toEqual(completed);
     } finally {
       await context.dispose();
@@ -95,6 +102,101 @@ describe("Stage 1 worker sync-state service", () => {
       expect(failed.cursor).toBe("replay:checkpoint:1");
       expect(failed.consecutiveFailureCount).toBe(1);
       expect(failed.deadLetterCount).toBe(1);
+      expect(failed.leaseOwner).toBeNull();
+      expect(failed.heartbeatAt).toBeNull();
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("refreshes heartbeats only for running rows owned by this worker", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      const started = await context.syncState.startWindow({
+        syncStateId: "sync:gmail:heartbeat:1",
+        scope: "provider",
+        provider: "gmail",
+        jobType: "historical_backfill",
+        cursor: null,
+        checkpoint: null,
+        windowStart: null,
+        windowEnd: null
+      });
+      const firstHeartbeatAt = started.heartbeatAt;
+      const heartbeated = await context.syncState.heartbeat({
+        syncStateId: started.id
+      });
+
+      expect(heartbeated?.leaseOwner).toBe(workerInstanceId);
+      expect(heartbeated?.heartbeatAt).not.toBeNull();
+      expect(Date.parse(heartbeated?.heartbeatAt ?? "")).toBeGreaterThanOrEqual(
+        Date.parse(firstHeartbeatAt ?? "")
+      );
+      if (heartbeated === null) {
+        throw new Error("Expected heartbeat to return the running sync state.");
+      }
+
+      await context.repositories.syncState.upsert({
+        ...heartbeated,
+        id: "sync:gmail:heartbeat:other-owner",
+        leaseOwner: "worker:other",
+        heartbeatAt: "2026-01-01T00:00:00.000Z"
+      });
+      await context.repositories.syncState.upsert({
+        ...heartbeated,
+        id: "sync:gmail:heartbeat:failed",
+        status: "failed",
+        leaseOwner: workerInstanceId,
+        heartbeatAt: "2026-01-01T00:00:00.000Z"
+      });
+      await context.repositories.syncState.upsert({
+        ...heartbeated,
+        id: "sync:gmail:heartbeat:quarantined",
+        status: "quarantined",
+        leaseOwner: workerInstanceId,
+        heartbeatAt: "2026-01-01T00:00:00.000Z"
+      });
+      await context.repositories.syncState.upsert({
+        ...heartbeated,
+        id: "sync:gmail:heartbeat:succeeded",
+        status: "succeeded",
+        leaseOwner: workerInstanceId,
+        heartbeatAt: "2026-01-01T00:00:00.000Z"
+      });
+
+      await expect(
+        context.syncState.heartbeat({
+          syncStateId: "sync:gmail:heartbeat:other-owner"
+        })
+      ).resolves.toMatchObject({
+        leaseOwner: "worker:other",
+        heartbeatAt: "2026-01-01T00:00:00.000Z"
+      });
+      await expect(
+        context.syncState.heartbeat({
+          syncStateId: "sync:gmail:heartbeat:failed"
+        })
+      ).resolves.toMatchObject({
+        status: "failed",
+        heartbeatAt: "2026-01-01T00:00:00.000Z"
+      });
+      await expect(
+        context.syncState.heartbeat({
+          syncStateId: "sync:gmail:heartbeat:quarantined"
+        })
+      ).resolves.toMatchObject({
+        status: "quarantined",
+        heartbeatAt: "2026-01-01T00:00:00.000Z"
+      });
+      await expect(
+        context.syncState.heartbeat({
+          syncStateId: "sync:gmail:heartbeat:succeeded"
+        })
+      ).resolves.toMatchObject({
+        status: "succeeded",
+        heartbeatAt: "2026-01-01T00:00:00.000Z"
+      });
     } finally {
       await context.dispose();
     }
@@ -221,8 +323,12 @@ describe("Stage 1 worker sync-state service", () => {
       expect(firstFailure.consecutiveFailureCount).toBe(1);
       expect(secondFailure.consecutiveFailureCount).toBe(2);
       expect(progressed.consecutiveFailureCount).toBe(2);
+      expect(progressed.leaseOwner).toBe(workerInstanceId);
+      expect(progressed.heartbeatAt).not.toBeNull();
       expect(completed.consecutiveFailureCount).toBe(0);
       expect(nextFailure.consecutiveFailureCount).toBe(1);
+      expect(nextFailure.leaseOwner).toBeNull();
+      expect(nextFailure.heartbeatAt).toBeNull();
     } finally {
       await context.dispose();
     }

--- a/packages/contracts/src/stage1-records.ts
+++ b/packages/contracts/src/stage1-records.ts
@@ -527,6 +527,8 @@ export const syncStateSchema = z
     freshnessP99Seconds: z.number().int().nonnegative().nullable(),
     lastSuccessfulAt: optionalTimestampSchema,
     consecutiveFailureCount: z.number().int().nonnegative(),
+    leaseOwner: z.string().min(1).nullable(),
+    heartbeatAt: optionalTimestampSchema,
     deadLetterCount: z.number().int().nonnegative(),
   })
   .superRefine((value, context) => {

--- a/packages/contracts/test/stage1-contracts.test.ts
+++ b/packages/contracts/test/stage1-contracts.test.ts
@@ -104,6 +104,8 @@ describe("Stage 1 contracts", () => {
       freshnessP99Seconds: 120,
       lastSuccessfulAt: null,
       consecutiveFailureCount: 0,
+      leaseOwner: "worker:test",
+      heartbeatAt: "2026-01-01T00:00:30.000Z",
       deadLetterCount: 0
     });
     const orchestrationScoped = syncStateSchema.safeParse({
@@ -120,6 +122,8 @@ describe("Stage 1 contracts", () => {
       freshnessP99Seconds: null,
       lastSuccessfulAt: "2026-01-01T01:00:00.000Z",
       consecutiveFailureCount: 0,
+      leaseOwner: null,
+      heartbeatAt: null,
       deadLetterCount: 0
     });
     const invalid = syncStateSchema.safeParse({
@@ -136,6 +140,8 @@ describe("Stage 1 contracts", () => {
       freshnessP99Seconds: null,
       lastSuccessfulAt: null,
       consecutiveFailureCount: 0,
+      leaseOwner: "worker:test",
+      heartbeatAt: "2026-01-01T00:00:30.000Z",
       deadLetterCount: 0
     });
 

--- a/packages/db/drizzle/0037_sync_state_lease_heartbeat.sql
+++ b/packages/db/drizzle/0037_sync_state_lease_heartbeat.sql
@@ -1,0 +1,3 @@
+ALTER TABLE sync_state
+  ADD COLUMN lease_owner text,
+  ADD COLUMN heartbeat_at timestamptz;

--- a/packages/db/src/mappers.ts
+++ b/packages/db/src/mappers.ts
@@ -864,6 +864,8 @@ export function mapSyncStateRow(row: SyncStateRow): SyncStateRecord {
     freshnessP99Seconds: row.freshnessP99Seconds,
     lastSuccessfulAt: fromDate(row.lastSuccessfulAt),
     consecutiveFailureCount: row.consecutiveFailureCount,
+    leaseOwner: row.leaseOwner,
+    heartbeatAt: fromDate(row.heartbeatAt),
     deadLetterCount: row.deadLetterCount,
   });
 }
@@ -890,6 +892,8 @@ export function mapSyncStateToInsert(
     lastSuccessfulAt:
       parsed.lastSuccessfulAt === null ? null : toDate(parsed.lastSuccessfulAt),
     consecutiveFailureCount: parsed.consecutiveFailureCount,
+    leaseOwner: parsed.leaseOwner,
+    heartbeatAt: parsed.heartbeatAt === null ? null : toDate(parsed.heartbeatAt),
     deadLetterCount: parsed.deadLetterCount,
   };
 }

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -2606,6 +2606,8 @@ function createStage1RepositoriesInternal(
               freshnessP99Seconds: values.freshnessP99Seconds,
               lastSuccessfulAt: values.lastSuccessfulAt,
               consecutiveFailureCount: values.consecutiveFailureCount,
+              leaseOwner: values.leaseOwner,
+              heartbeatAt: values.heartbeatAt,
               deadLetterCount: values.deadLetterCount,
               updatedAt: new Date(),
             },

--- a/packages/db/src/schema/tables.ts
+++ b/packages/db/src/schema/tables.ts
@@ -616,6 +616,11 @@ export const syncState = pgTable(
     consecutiveFailureCount: integer("consecutive_failure_count")
       .notNull()
       .default(0),
+    leaseOwner: text("lease_owner"),
+    heartbeatAt: timestamp("heartbeat_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
     deadLetterCount: integer("dead_letter_count").notNull().default(0),
     createdAt: createdAtColumn,
     updatedAt: updatedAtColumn,

--- a/packages/db/test/stage1-persistence.test.ts
+++ b/packages/db/test/stage1-persistence.test.ts
@@ -365,6 +365,8 @@ describe("Stage 1 persistence service", () => {
       freshnessP99Seconds: 120,
       lastSuccessfulAt: "2026-01-01T01:00:00.000Z",
       consecutiveFailureCount: 3,
+      leaseOwner: null,
+      heartbeatAt: null,
       deadLetterCount: 0
     });
 

--- a/packages/db/test/stage1-repositories.test.ts
+++ b/packages/db/test/stage1-repositories.test.ts
@@ -685,6 +685,8 @@ describe("Stage 1 DB repositories", () => {
       freshnessP99Seconds: null,
       lastSuccessfulAt: "2026-01-01T01:00:00.000Z",
       consecutiveFailureCount: 4,
+      leaseOwner: "worker:test",
+      heartbeatAt: "2026-01-01T00:30:00.000Z",
       deadLetterCount: 2,
     });
 
@@ -693,6 +695,8 @@ describe("Stage 1 DB repositories", () => {
       status: "succeeded",
       parityPercent: 100,
       consecutiveFailureCount: 0,
+      leaseOwner: null,
+      heartbeatAt: null,
       deadLetterCount: 0,
     });
 

--- a/packages/db/test/stage1-schema.test.ts
+++ b/packages/db/test/stage1-schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { getTableName } from "drizzle-orm";
+import { getTableName, sql } from "drizzle-orm";
 import {
   canonicalEventTypeValues,
   channelValues,
@@ -20,6 +20,7 @@ import {
   sourceEvidenceLog,
   syncState
 } from "../src/index.js";
+import { createTestStage1Context } from "./helpers.js";
 import { mapSyncStateRow, mapSyncStateToInsert } from "../src/mappers.js";
 
 describe("Stage 1 DB schema", () => {
@@ -110,6 +111,8 @@ describe("Stage 1 DB schema", () => {
       freshnessP99Seconds: null,
       lastSuccessfulAt: null,
       consecutiveFailureCount: 4,
+      leaseOwner: "worker:test",
+      heartbeatAt: "2026-01-05T00:04:00.000Z",
       deadLetterCount: 1
     });
     const row = mapSyncStateRow({
@@ -126,6 +129,8 @@ describe("Stage 1 DB schema", () => {
       freshnessP99Seconds: insert.freshnessP99Seconds ?? null,
       lastSuccessfulAt: insert.lastSuccessfulAt ?? null,
       consecutiveFailureCount: insert.consecutiveFailureCount ?? 0,
+      leaseOwner: insert.leaseOwner ?? null,
+      heartbeatAt: insert.heartbeatAt ?? null,
       deadLetterCount: insert.deadLetterCount ?? 0,
       createdAt: new Date("2026-01-05T00:05:00.000Z"),
       updatedAt: new Date("2026-01-05T00:05:00.000Z")
@@ -133,6 +138,81 @@ describe("Stage 1 DB schema", () => {
 
     expect(syncState.consecutiveFailureCount.name).toBe("consecutive_failure_count");
     expect(row.consecutiveFailureCount).toBe(4);
+    expect(row.leaseOwner).toBe("worker:test");
+    expect(row.heartbeatAt).toBe("2026-01-05T00:04:00.000Z");
     expect(row.deadLetterCount).toBe(1);
+  });
+
+  it("adds nullable lease and heartbeat columns to sync_state and preserves null round-trips", async () => {
+    const context = await createTestStage1Context();
+
+    try {
+      const columnResult: unknown = await context.db.execute(sql<{
+        readonly columnName: string;
+        readonly dataType: string;
+        readonly isNullable: "YES" | "NO";
+      }>`
+        select
+          column_name as "columnName",
+          data_type as "dataType",
+          is_nullable as "isNullable"
+        from information_schema.columns
+        where table_schema = 'public'
+          and table_name = 'sync_state'
+          and column_name in ('lease_owner', 'heartbeat_at')
+        order by column_name
+      `);
+      const columns = Array.isArray(columnResult)
+        ? (columnResult as readonly {
+            readonly columnName: string;
+            readonly dataType: string;
+            readonly isNullable: "YES" | "NO";
+          }[])
+        : (
+            columnResult as {
+              readonly rows: readonly {
+                readonly columnName: string;
+                readonly dataType: string;
+                readonly isNullable: "YES" | "NO";
+              }[];
+            }
+          ).rows;
+      const inserted = await context.repositories.syncState.upsert({
+        id: "sync:schema:lease-heartbeat",
+        scope: "provider",
+        provider: "gmail",
+        jobType: "historical_backfill",
+        cursor: null,
+        windowStart: null,
+        windowEnd: null,
+        status: "running",
+        parityPercent: null,
+        freshnessP95Seconds: null,
+        freshnessP99Seconds: null,
+        lastSuccessfulAt: null,
+        consecutiveFailureCount: 0,
+        leaseOwner: null,
+        heartbeatAt: null,
+        deadLetterCount: 0
+      });
+
+      await expect(
+        context.repositories.syncState.findById(inserted.id)
+      ).resolves.toEqual(inserted);
+      expect(columns).toEqual([
+        {
+          columnName: "heartbeat_at",
+          dataType: "timestamp with time zone",
+          isNullable: "YES"
+        },
+        {
+          columnName: "lease_owner",
+          dataType: "text",
+          isNullable: "YES"
+        }
+      ]);
+    } finally {
+      await context.dispose();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Mailchimp historical imports could stay `running` forever after process death (SIGTERM during deploy, OOM kill, host timeout). Normal thrown errors are caught by `failWindow`, but the catch path doesn't run on process kill — leaving `sync_state` rows wedged in `running` with no automatic recovery.

**Approach:** lease + heartbeat tracking on `sync_state` + a periodic sweeper that flips orphan rows to `failed`.

## Schema (migration 0037 — additive only)

- `sync_state.lease_owner text NULL` — process UUID of the worker holding the lease
- `sync_state.heartbeat_at timestamptz NULL` — last heartbeat timestamp; only populated while `status = 'running'`

## Worker changes

- `Stage1SyncStateService.startWindow` acquires lease
- New `heartbeat({ syncStateId })` method (no-ops if not running, or if another owner)
- `recordBatchProgress` refreshes the heartbeat as a side-effect
- `completeWindow` and `failWindow` release the lease (set both fields to null)
- Mailchimp `importArtifacts` wraps the long loop with a `setInterval` heartbeat (30s default; env `SYNC_STATE_HEARTBEAT_INTERVAL_MS`)
- New `reconcile-stale-running` cron (every minute; env `SYNC_STATE_LEASE_THRESHOLD_MS`, default 5min) flips orphan `running` rows to `failed`

## Tests

Schema, sync-state methods (lease acquire/release/heartbeat), Mailchimp heartbeat invocation, sweeper happy-path, runtime crontab assertion extended.

## Conflict resolution

Merged with #202 (routing-review-queue task registration). Both periodic tasks coexist.

## Migration sequencing

`0037` chosen with `0036` skipped as a buffer (per the project's collision-prevention pattern from #194). Latest applied to prod is currently `0029`; `0033` and `0035` from #198/#200 are already in code but not yet applied to prod (manual application required per repo convention). When applying 0037, also apply 0033 + 0035 in order.

## Test plan

- [x] `pnpm typecheck && pnpm lint` clean
- [ ] `pnpm test:unit` blocked locally by macOS rollup env; CI authoritative
- [ ] CI green
- [ ] Architect applies 0033 + 0035 + 0037 to prod in order before deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)