### PR TITLE
feat(settings): add Logs page (source-evidence quarantine stream)

### DIFF
--- a/apps/web/app/settings/_components/logs-page.tsx
+++ b/apps/web/app/settings/_components/logs-page.tsx
@@ -1,0 +1,357 @@
+"use client";
+
+import { Fragment, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ChevronDown, ChevronRight } from "lucide-react";
+
+import { FOCUS_RING, RADIUS, SHADOW, TRANSITION, TYPE } from "@/app/_lib/design-tokens-v2";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+import type {
+  LogsSettingsViewModel,
+  LogStreamDescriptorViewModel,
+  SourceEvidenceCollisionDetailViewModel
+} from "@/src/server/settings/selectors";
+
+import { SettingsSection } from "./settings-section";
+
+const EXACT_TIMESTAMP_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+  timeZone: "UTC",
+  timeZoneName: "short"
+});
+
+function formatTimestamp(timestamp: string): string {
+  return EXACT_TIMESTAMP_FORMATTER.format(new Date(timestamp));
+}
+
+function toStreamHref(streamId: string, beforeTimestamp?: string | null): string {
+  const params = new URLSearchParams();
+  params.set("stream", streamId);
+
+  if (beforeTimestamp !== null && beforeTimestamp !== undefined) {
+    params.set("before", beforeTimestamp);
+  }
+
+  return `/settings/logs?${params.toString()}`;
+}
+
+function isSourceEvidenceCollisionDetail(
+  value: Readonly<Record<string, unknown>>
+): value is SourceEvidenceCollisionDetailViewModel {
+  return (
+    typeof value.provider === "string" &&
+    typeof value.idempotencyKey === "string" &&
+    typeof value.winning === "object" &&
+    value.winning !== null &&
+    Array.isArray(value.losing)
+  );
+}
+
+function formatCollisionLine(input: {
+  readonly sourceEvidenceId: string;
+  readonly checksum: string;
+  readonly receivedAt: string;
+}): string {
+  return `${input.sourceEvidenceId} • ${input.checksum} • ${formatTimestamp(input.receivedAt)}`;
+}
+
+function StreamSelector({
+  activeStream,
+  streams,
+  onChange
+}: {
+  readonly activeStream: LogStreamDescriptorViewModel;
+  readonly streams: readonly LogStreamDescriptorViewModel[];
+  readonly onChange: (streamId: string) => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "flex min-h-11 w-full items-center justify-between gap-3 border border-slate-200 bg-white px-3 py-2 text-left",
+            RADIUS.md,
+            SHADOW.sm,
+            TRANSITION.fast,
+            TRANSITION.reduceMotion,
+            FOCUS_RING,
+            "hover:border-slate-300"
+          )}
+          aria-label="Select log stream"
+        >
+          <span className="min-w-0">
+            <span className="block truncate text-[13px] font-medium text-slate-900">
+              {activeStream.label}
+            </span>
+            <span className={cn("mt-0.5 block truncate", TYPE.caption)}>
+              {activeStream.description}
+            </span>
+          </span>
+          <ChevronDown className="size-4 shrink-0 text-slate-400" aria-hidden="true" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="start"
+        className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-[20rem] rounded-xl p-2"
+      >
+        <DropdownMenuLabel className="px-2 pb-2 pt-1 text-[11px] font-semibold text-slate-500">
+          Log stream
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuRadioGroup
+          value={activeStream.id}
+          onValueChange={(nextValue) => {
+            onChange(nextValue);
+          }}
+        >
+          {streams.map((stream) => (
+            <DropdownMenuRadioItem
+              key={stream.id}
+              value={stream.id}
+              className="rounded-lg"
+            >
+              <div className="flex min-w-0 flex-col">
+                <span className="truncate text-sm font-medium text-slate-900">
+                  {stream.label}
+                </span>
+                <span className={cn("truncate", TYPE.caption)}>
+                  {stream.description}
+                </span>
+              </div>
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function DetailPanel({
+  detail
+}: {
+  readonly detail: Readonly<Record<string, unknown>>;
+}) {
+  if (!isSourceEvidenceCollisionDetail(detail)) {
+    return (
+      <div className={cn(TYPE.caption, "text-slate-500")}>
+        Detail unavailable.
+      </div>
+    );
+  }
+
+  return (
+    <dl className="grid gap-x-6 gap-y-3 sm:grid-cols-[12rem_minmax(0,1fr)]">
+      <dt className={TYPE.label}>Provider</dt>
+      <dd className={cn(TYPE.bodySm, "text-slate-700")}>{detail.provider}</dd>
+
+      <dt className={TYPE.label}>Idempotency key</dt>
+      <dd className={cn(TYPE.bodySm, "break-all text-slate-700")}>
+        {detail.idempotencyKey}
+      </dd>
+
+      <dt className={TYPE.label}>Winning source-evidence</dt>
+      <dd className={cn(TYPE.bodySm, "break-all text-slate-700")}>
+        {formatCollisionLine(detail.winning)}
+      </dd>
+
+      <dt className={TYPE.label}>Losing source-evidence</dt>
+      <dd className={cn("space-y-1", TYPE.bodySm, "text-slate-700")}>
+        {detail.losing.map((entry) => (
+          <div key={entry.sourceEvidenceId}>{formatCollisionLine(entry)}</div>
+        ))}
+      </dd>
+    </dl>
+  );
+}
+
+export function LogsPage({
+  viewModel
+}: {
+  readonly viewModel: LogsSettingsViewModel;
+}) {
+  const router = useRouter();
+  const [expandedEntryId, setExpandedEntryId] = useState<string | null>(null);
+  const streamsById = new Map(viewModel.streams.map((stream) => [stream.id, stream]));
+  const activeStream =
+    streamsById.get(viewModel.activeStreamId) ??
+    viewModel.streams[0];
+
+  if (activeStream === undefined) {
+    return null;
+  }
+
+  return (
+    <SettingsSection
+      id="logs"
+      title="Logs"
+      description="Operational signals from ingestion and sync."
+    >
+      <div className="flex flex-col gap-4">
+        <StreamSelector
+          activeStream={activeStream}
+          streams={viewModel.streams}
+          onChange={(streamId) => {
+            router.replace(toStreamHref(streamId), { scroll: false });
+          }}
+        />
+
+        <div
+          className={cn(
+            "overflow-hidden border border-slate-200 bg-white",
+            RADIUS.lg,
+            SHADOW.sm
+          )}
+        >
+          {viewModel.entries.length === 0 ? (
+            <div className="px-5 py-10 text-center">
+              <p className={TYPE.caption}>No log entries.</p>
+            </div>
+          ) : (
+            <table className="min-w-full divide-y divide-slate-200 text-sm">
+              <thead className="bg-slate-50/80">
+                <tr>
+                  <th
+                    scope="col"
+                    className={cn("px-5 py-3 text-left", TYPE.label)}
+                  >
+                    Timestamp
+                  </th>
+                  <th
+                    scope="col"
+                    className={cn("px-5 py-3 text-left", TYPE.label)}
+                  >
+                    Stream
+                  </th>
+                  <th
+                    scope="col"
+                    className={cn("px-5 py-3 text-left", TYPE.label)}
+                  >
+                    Summary
+                  </th>
+                  <th
+                    scope="col"
+                    className={cn("w-28 px-5 py-3 text-left", TYPE.label)}
+                  >
+                    Detail
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100">
+                {viewModel.entries.map((entry) => {
+                  const expanded = expandedEntryId === entry.id;
+                  const streamLabel =
+                    streamsById.get(entry.streamId)?.label ?? entry.streamId;
+
+                  return (
+                    <Fragment key={entry.id}>
+                      <tr
+                        className={cn(
+                          "cursor-pointer align-top",
+                          TRANSITION.fast,
+                          "hover:bg-slate-50/80"
+                        )}
+                        onClick={() => {
+                          setExpandedEntryId((current) =>
+                            current === entry.id ? null : entry.id
+                          );
+                        }}
+                      >
+                        <td className="px-5 py-3 align-top">
+                          <div className={cn(TYPE.caption, "tabular-nums text-slate-600")}>
+                            {formatTimestamp(entry.timestamp)}
+                          </div>
+                        </td>
+                        <td className="px-5 py-3 align-top">
+                          <span className={cn(TYPE.bodySm, "text-slate-700")}>
+                            {streamLabel}
+                          </span>
+                        </td>
+                        <td className="px-5 py-3 align-top">
+                          <p className={cn(TYPE.bodySm, "text-slate-900")}>
+                            {entry.summary}
+                          </p>
+                        </td>
+                        <td className="px-5 py-3 align-top">
+                          <button
+                            type="button"
+                            aria-expanded={expanded}
+                            aria-controls={`${entry.id}-detail`}
+                            className={cn(
+                              "inline-flex items-center gap-1.5 text-sm font-medium text-slate-600",
+                              TRANSITION.fast,
+                              "hover:text-slate-900",
+                              FOCUS_RING,
+                              RADIUS.sm
+                            )}
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              setExpandedEntryId((current) =>
+                                current === entry.id ? null : entry.id
+                              );
+                            }}
+                          >
+                            {expanded ? (
+                              <ChevronDown className="size-4" aria-hidden="true" />
+                            ) : (
+                              <ChevronRight className="size-4" aria-hidden="true" />
+                            )}
+                            {expanded ? "Hide" : "Show"}
+                          </button>
+                        </td>
+                      </tr>
+                      {expanded ? (
+                        <tr id={`${entry.id}-detail`}>
+                          <td
+                            colSpan={4}
+                            className="bg-slate-50/70 px-5 py-4"
+                          >
+                            <DetailPanel detail={entry.detail} />
+                          </td>
+                        </tr>
+                      ) : null}
+                    </Fragment>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        {viewModel.nextBeforeTimestamp !== null ? (
+          <div className="flex justify-end">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                router.replace(
+                  toStreamHref(
+                    viewModel.activeStreamId,
+                    viewModel.nextBeforeTimestamp
+                  ),
+                  { scroll: false }
+                );
+              }}
+            >
+              Load more
+            </Button>
+          </div>
+        ) : null}
+      </div>
+    </SettingsSection>
+  );
+}

--- a/apps/web/app/settings/_components/settings-section-nav.tsx
+++ b/apps/web/app/settings/_components/settings-section-nav.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type { LucideIcon } from "lucide-react";
-import { FolderOpen, Plug, Users } from "lucide-react";
+import { FolderOpen, Plug, ScrollText, Users } from "lucide-react";
 
 import {
   FOCUS_RING,
@@ -44,6 +44,13 @@ const ITEMS: readonly SectionItem[] = [
     description: "Providers this workspace depends on.",
     href: "/settings/integrations",
     Icon: Plug
+  },
+  {
+    id: "logs",
+    label: "Logs",
+    description: "Operational signals from ingestion and sync.",
+    href: "/settings/logs",
+    Icon: ScrollText
   }
 ];
 

--- a/apps/web/app/settings/logs/page.tsx
+++ b/apps/web/app/settings/logs/page.tsx
@@ -1,0 +1,35 @@
+import { redirect } from "next/navigation";
+
+import { resolveAdminSession } from "@/src/server/auth/api";
+import { loadLogsSettings } from "@/src/server/settings/selectors";
+
+import { LogsPage } from "../_components/logs-page";
+import { SettingsContent } from "../_components/settings-content";
+
+export const dynamic = "force-dynamic";
+
+export default async function SettingsLogsPage({
+  searchParams
+}: {
+  readonly searchParams: Promise<{
+    readonly stream?: string;
+    readonly before?: string;
+  }>;
+}) {
+  const session = await resolveAdminSession();
+  if (!session.ok) {
+    redirect(session.code === "unauthorized" ? "/auth/sign-in" : "/settings");
+  }
+
+  const params = await searchParams;
+  const viewModel = await loadLogsSettings({
+    streamId: params.stream ?? "source-evidence-quarantine",
+    beforeTimestamp: params.before ?? null
+  });
+
+  return (
+    <SettingsContent>
+      <LogsPage viewModel={viewModel} />
+    </SettingsContent>
+  );
+}

--- a/apps/web/src/server/settings/selectors.ts
+++ b/apps/web/src/server/settings/selectors.ts
@@ -2,7 +2,8 @@ import { unstable_cache } from "next/cache";
 
 import type {
   IntegrationHealthCategory,
-  IntegrationHealthStatus
+  IntegrationHealthStatus,
+  Provider
 } from "@as-comms/contracts";
 
 import { getCurrentUser } from "../auth/session";
@@ -79,6 +80,45 @@ export interface IntegrationsSettingsViewModel {
   readonly integrations: readonly IntegrationHealthViewModel[];
 }
 
+export type LogStreamId = "source-evidence-quarantine";
+
+export interface LogStreamDescriptorViewModel {
+  readonly id: LogStreamId;
+  readonly label: string;
+  readonly description: string;
+}
+
+export interface SourceEvidenceCollisionDetailViewModel
+  extends Readonly<Record<string, unknown>> {
+  readonly provider: Provider;
+  readonly idempotencyKey: string;
+  readonly winning: {
+    readonly sourceEvidenceId: string;
+    readonly checksum: string;
+    readonly receivedAt: string;
+  };
+  readonly losing: readonly {
+    readonly sourceEvidenceId: string;
+    readonly checksum: string;
+    readonly receivedAt: string;
+  }[];
+}
+
+export interface LogEntryViewModel {
+  readonly id: string;
+  readonly streamId: LogStreamId;
+  readonly timestamp: string;
+  readonly summary: string;
+  readonly detail: Readonly<Record<string, unknown>>;
+}
+
+export interface LogsSettingsViewModel {
+  readonly streams: readonly LogStreamDescriptorViewModel[];
+  readonly activeStreamId: LogStreamId;
+  readonly entries: readonly LogEntryViewModel[];
+  readonly nextBeforeTimestamp: string | null;
+}
+
 const INTEGRATION_ORDER = [
   "salesforce",
   "gmail",
@@ -128,9 +168,48 @@ const INTEGRATION_META = {
   }
 >;
 
+const DEFAULT_LOG_STREAM_ID = "source-evidence-quarantine" as const;
+const LOGS_PAGE_SIZE = 25;
+const LOG_STREAMS: readonly LogStreamDescriptorViewModel[] = [
+  {
+    id: DEFAULT_LOG_STREAM_ID,
+    label: "Source-evidence quarantines",
+    description: "Checksum collisions for provider idempotency keys."
+  }
+];
+const PROVIDER_LABEL: Record<Provider, string> = {
+  manual: "Manual",
+  gmail: "Gmail",
+  salesforce: "Salesforce",
+  simpletexting: "SimpleTexting",
+  mailchimp: "Mailchimp"
+};
+
 function normalizeSearch(value: string | null | undefined): string | null {
   const trimmed = value?.trim() ?? "";
   return trimmed.length === 0 ? null : trimmed.toLowerCase();
+}
+
+function normalizeLogStreamId(value: string | null | undefined): LogStreamId {
+  return value === DEFAULT_LOG_STREAM_ID
+    ? DEFAULT_LOG_STREAM_ID
+    : DEFAULT_LOG_STREAM_ID;
+}
+
+function parseBeforeTimestamp(value: string | null | undefined): Date | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const timestamp = new Date(value);
+  return Number.isNaN(timestamp.getTime()) ? null : timestamp;
+}
+
+function buildSourceEvidenceCollisionSummary(
+  detail: SourceEvidenceCollisionDetailViewModel
+): string {
+  const checksumCount = detail.losing.length + 1;
+  return `${PROVIDER_LABEL[detail.provider]} • ${String(checksumCount)} different checksums for idempotency key ${detail.idempotencyKey}`;
 }
 
 function hasActivationRequirements(input: {
@@ -384,6 +463,54 @@ async function readIntegrationHealth() {
   };
 }
 
+async function readLogsSettings(input: {
+  readonly streamId: LogStreamId;
+  readonly beforeTimestamp: Date | null;
+}): Promise<Pick<LogsSettingsViewModel, "entries" | "nextBeforeTimestamp">> {
+  const runtime = await getStage1WebRuntime();
+  const result =
+    await runtime.repositories.sourceEvidence.listIdempotencyChecksumCollisions(
+      input.beforeTimestamp === null
+        ? {
+            limit: LOGS_PAGE_SIZE
+          }
+        : {
+            limit: LOGS_PAGE_SIZE,
+            beforeTimestamp: input.beforeTimestamp
+          }
+    );
+
+  return {
+    entries: result.entries.map((entry) => {
+      const detail: SourceEvidenceCollisionDetailViewModel = {
+        provider: entry.provider,
+        idempotencyKey: entry.idempotencyKey,
+        winning: {
+          sourceEvidenceId: entry.winning.sourceEvidenceId,
+          checksum: entry.winning.checksum,
+          receivedAt: entry.winning.receivedAt.toISOString()
+        },
+        losing: entry.losing.map((losingEntry) => ({
+          sourceEvidenceId: losingEntry.sourceEvidenceId,
+          checksum: losingEntry.checksum,
+          receivedAt: losingEntry.receivedAt.toISOString()
+        }))
+      };
+
+      return {
+        id: `${entry.provider}:${entry.idempotencyKey}`,
+        streamId: input.streamId,
+        timestamp: entry.latestReceivedAt.toISOString(),
+        summary: buildSourceEvidenceCollisionSummary(detail),
+        detail
+      };
+    }),
+    nextBeforeTimestamp: result.hasMore
+      ? (result.entries.at(-1)?.latestReceivedAt.toISOString() ?? null)
+      : null
+  };
+}
+
 function loadProjectsSettingsCacheData(input: {
   readonly filter: "active" | "inactive" | "all";
   readonly search?: string | null;
@@ -437,6 +564,35 @@ function loadIntegrationHealthCacheData() {
     ["settings:integrations"],
     {
       tags: ["settings:integrations"]
+    }
+  )();
+}
+
+function loadLogsSettingsCacheData(input: {
+  readonly streamId: LogStreamId;
+  readonly beforeTimestampIso: string | null;
+}) {
+  const beforeTimestamp =
+    input.beforeTimestampIso === null
+      ? null
+      : new Date(input.beforeTimestampIso);
+
+  if (process.env.NODE_ENV !== "production") {
+    return readLogsSettings({
+      streamId: input.streamId,
+      beforeTimestamp
+    });
+  }
+
+  return unstable_cache(
+    () =>
+      readLogsSettings({
+        streamId: input.streamId,
+        beforeTimestamp
+      }),
+    [`settings:logs:${input.streamId}:${input.beforeTimestampIso ?? "none"}`],
+    {
+      tags: ["settings:logs"]
     }
   )();
 }
@@ -550,5 +706,42 @@ export async function loadIntegrationHealth(): Promise<IntegrationsSettingsViewM
   return {
     isAdmin: currentUser?.role === "admin",
     integrations: cachedData.integrations
+  };
+}
+
+export async function loadLogsSettings(input: {
+  readonly streamId: string;
+  readonly beforeTimestamp: string | null;
+}): Promise<LogsSettingsViewModel> {
+  const currentUser = await getCurrentUser();
+  if (currentUser === null) {
+    throw new Error("UNAUTHORIZED");
+  }
+  if (currentUser.role !== "admin") {
+    throw new Error("FORBIDDEN");
+  }
+
+  const activeStreamId = normalizeLogStreamId(input.streamId);
+  const beforeTimestamp = parseBeforeTimestamp(input.beforeTimestamp);
+  const cachedData = await loadLogsSettingsCacheData({
+    streamId: activeStreamId,
+    beforeTimestampIso: beforeTimestamp?.toISOString() ?? null
+  });
+
+  recordSensitiveReadForCurrentUserDetached({
+    action: "settings.logs.read",
+    entityType: "settings_page",
+    entityId: "logs",
+    metadataJson: {
+      streamId: activeStreamId,
+      visibleEntryCount: cachedData.entries.length
+    }
+  });
+
+  return {
+    streams: LOG_STREAMS,
+    activeStreamId,
+    entries: cachedData.entries,
+    nextBeforeTimestamp: cachedData.nextBeforeTimestamp
   };
 }

--- a/apps/web/tests/unit/settings-logs-page.test.ts
+++ b/apps/web/tests/unit/settings-logs-page.test.ts
@@ -1,0 +1,102 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveAdminSession = vi.hoisted(() => vi.fn());
+const loadLogsSettings = vi.hoisted(() => vi.fn());
+const redirect = vi.hoisted(() => vi.fn());
+
+Object.assign(globalThis, { React });
+
+vi.mock("next/navigation", () => ({
+  redirect
+}));
+
+vi.mock("@/src/server/auth/api", () => ({
+  resolveAdminSession
+}));
+
+vi.mock("@/src/server/settings/selectors", () => ({
+  loadLogsSettings
+}));
+
+vi.mock("../../app/settings/_components/logs-page", () => ({
+  LogsPage: () => null
+}));
+
+import SettingsLogsPage from "../../app/settings/logs/page";
+
+describe("settings logs page", () => {
+  beforeEach(() => {
+    resolveAdminSession.mockReset();
+    loadLogsSettings.mockReset();
+    redirect.mockReset();
+  });
+
+  it("redirects unauthenticated callers to sign-in", async () => {
+    resolveAdminSession.mockResolvedValue({
+      ok: false,
+      code: "unauthorized"
+    });
+    redirect.mockImplementationOnce(() => {
+      throw new Error("NEXT_REDIRECT_SIGN_IN");
+    });
+
+    await expect(
+      SettingsLogsPage({
+        searchParams: Promise.resolve({})
+      })
+    ).rejects.toThrow("NEXT_REDIRECT_SIGN_IN");
+    expect(redirect).toHaveBeenCalledWith("/auth/sign-in");
+    expect(loadLogsSettings).not.toHaveBeenCalled();
+  });
+
+  it("redirects authenticated non-admin callers back to settings", async () => {
+    resolveAdminSession.mockResolvedValue({
+      ok: false,
+      code: "forbidden"
+    });
+    redirect.mockImplementationOnce(() => {
+      throw new Error("NEXT_REDIRECT_SETTINGS");
+    });
+
+    await expect(
+      SettingsLogsPage({
+        searchParams: Promise.resolve({})
+      })
+    ).rejects.toThrow("NEXT_REDIRECT_SETTINGS");
+    expect(redirect).toHaveBeenCalledWith("/settings");
+    expect(loadLogsSettings).not.toHaveBeenCalled();
+  });
+
+  it("loads the logs settings view model for admins", async () => {
+    resolveAdminSession.mockResolvedValue({
+      ok: true,
+      user: {
+        id: "user:admin",
+        role: "admin"
+      }
+    });
+    loadLogsSettings.mockResolvedValue({
+      streams: [
+        {
+          id: "source-evidence-quarantine",
+          label: "Source-evidence quarantines",
+          description: "Checksum collisions for provider idempotency keys."
+        }
+      ],
+      activeStreamId: "source-evidence-quarantine",
+      entries: [],
+      nextBeforeTimestamp: null
+    });
+
+    const page = await SettingsLogsPage({
+      searchParams: Promise.resolve({})
+    });
+
+    expect(page).toBeTruthy();
+    expect(loadLogsSettings).toHaveBeenCalledWith({
+      streamId: "source-evidence-quarantine",
+      beforeTimestamp: null
+    });
+  });
+});

--- a/apps/web/tests/unit/settings-selectors.test.ts
+++ b/apps/web/tests/unit/settings-selectors.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/src/server/auth/session", () => ({
 import {
   loadAccessSettings,
   loadIntegrationHealth,
+  loadLogsSettings,
   loadProjectSettingsDetail,
   loadProjectsSettings
 } from "../../src/server/settings/selectors";
@@ -135,6 +136,41 @@ async function seedProject(
       createdAt: `2026-04-20T15:${String(index).padStart(2, "0")}:00.000Z`,
     });
   }
+}
+
+async function seedSourceEvidenceCollision(
+  runtime: Stage1WebTestRuntime,
+  input: {
+    readonly provider: "gmail" | "salesforce";
+    readonly idempotencyKey: string;
+    readonly winningId: string;
+    readonly losingId: string;
+    readonly winningReceivedAt: string;
+    readonly losingReceivedAt: string;
+  }
+): Promise<void> {
+  await runtime.context.repositories.sourceEvidence.append({
+    id: input.winningId,
+    provider: input.provider,
+    providerRecordType: "message",
+    providerRecordId: `${input.winningId}:record`,
+    receivedAt: input.winningReceivedAt,
+    occurredAt: input.winningReceivedAt,
+    payloadRef: `payloads/${input.provider}/${input.winningId}.json`,
+    idempotencyKey: input.idempotencyKey,
+    checksum: `${input.winningId}:checksum`
+  });
+  await runtime.context.repositories.sourceEvidence.append({
+    id: input.losingId,
+    provider: input.provider,
+    providerRecordType: "message",
+    providerRecordId: `${input.losingId}:record`,
+    receivedAt: input.losingReceivedAt,
+    occurredAt: input.losingReceivedAt,
+    payloadRef: `payloads/${input.provider}/${input.losingId}.json`,
+    idempotencyKey: input.idempotencyKey,
+    checksum: `${input.losingId}:checksum`
+  });
 }
 
 describe("settings selectors", () => {
@@ -401,5 +437,78 @@ describe("settings selectors", () => {
         "not_configured"
       ]
     );
+  });
+
+  it("maps source-evidence collisions into the logs settings view model", async () => {
+    if (!runtime) {
+      throw new Error("runtime not initialized");
+    }
+
+    await seedSourceEvidenceCollision(runtime, {
+      provider: "gmail",
+      idempotencyKey: "gmail:collision:newer",
+      winningId: "sev-newer-winning",
+      losingId: "sev-newer-losing",
+      winningReceivedAt: "2026-04-20T14:00:00.000Z",
+      losingReceivedAt: "2026-04-20T14:05:00.000Z"
+    });
+    await seedSourceEvidenceCollision(runtime, {
+      provider: "salesforce",
+      idempotencyKey: "salesforce:collision:older",
+      winningId: "sev-older-winning",
+      losingId: "sev-older-losing",
+      winningReceivedAt: "2026-04-20T13:00:00.000Z",
+      losingReceivedAt: "2026-04-20T13:05:00.000Z"
+    });
+    for (let index = 0; index < 24; index += 1) {
+      const minute = String(index).padStart(2, "0");
+      await seedSourceEvidenceCollision(runtime, {
+        provider: "gmail",
+        idempotencyKey: `gmail:collision:extra:${minute}`,
+        winningId: `sev-extra-winning-${minute}`,
+        losingId: `sev-extra-losing-${minute}`,
+        winningReceivedAt: `2026-04-20T12:${minute}:00.000Z`,
+        losingReceivedAt: `2026-04-20T12:${minute}:30.000Z`
+      });
+    }
+
+    const viewModel = await loadLogsSettings({
+      streamId: "source-evidence-quarantine",
+      beforeTimestamp: null
+    });
+
+    expect(viewModel.streams).toEqual([
+      {
+        id: "source-evidence-quarantine",
+        label: "Source-evidence quarantines",
+        description: "Checksum collisions for provider idempotency keys."
+      }
+    ]);
+    expect(viewModel.activeStreamId).toBe("source-evidence-quarantine");
+    expect(viewModel.entries[0]).toMatchObject({
+      id: "gmail:gmail:collision:newer",
+      streamId: "source-evidence-quarantine",
+      timestamp: "2026-04-20T14:05:00.000Z",
+      summary:
+        "Gmail • 2 different checksums for idempotency key gmail:collision:newer",
+      detail: {
+        provider: "gmail",
+        idempotencyKey: "gmail:collision:newer",
+        winning: {
+          sourceEvidenceId: "sev-newer-winning",
+          checksum: "sev-newer-winning:checksum",
+          receivedAt: "2026-04-20T14:00:00.000Z"
+        },
+        losing: [
+          {
+            sourceEvidenceId: "sev-newer-losing",
+            checksum: "sev-newer-losing:checksum",
+            receivedAt: "2026-04-20T14:05:00.000Z"
+          }
+        ]
+      }
+    });
+    expect(typeof viewModel.nextBeforeTimestamp).toBe("string");
+    expect(viewModel.nextBeforeTimestamp).not.toBeNull();
   });
 });

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -18,6 +18,7 @@ import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
 import type {
   PendingComposerOutboundRecord,
   ProjectAliasRecord,
+  SourceEvidenceCollisionEntry,
   Stage1RepositoryBundle,
   Stage2RepositoryBundle,
   UserRecord,
@@ -195,6 +196,12 @@ type SimpleTextingMessageDetailRow = SimpleTextingMessageDetailRecord;
 type MailchimpCampaignActivityDetailRow = MailchimpCampaignActivityDetailRecord;
 type ManualNoteDetailRow = ManualNoteDetailRecord;
 type PendingComposerOutboundRow = typeof pendingComposerOutbounds.$inferSelect;
+type SourceEvidenceLogRow = typeof sourceEvidenceLog.$inferSelect;
+interface SourceEvidenceCollisionGroupRow {
+  readonly provider: SourceEvidenceCollisionEntry["provider"];
+  readonly idempotencyKey: string;
+  readonly latestReceivedAt: Date;
+}
 
 function mapSalesforceCommunicationDetailRowLocal(
   row: SalesforceCommunicationDetailRow,
@@ -222,6 +229,89 @@ function mapSalesforceCommunicationDetailToInsertLocal(
     snippet: record.snippet,
     sourceLabel: record.sourceLabel,
   };
+}
+
+function normalizeSqlResultRows<TRow>(
+  result:
+    | readonly TRow[]
+    | {
+        readonly rows?: readonly TRow[];
+      },
+): readonly TRow[] {
+  if (Array.isArray(result)) {
+    return result as readonly TRow[];
+  }
+
+  return (result as { readonly rows?: readonly TRow[] }).rows ?? [];
+}
+
+function clampSourceEvidenceCollisionLimit(limit: number): number {
+  return Math.max(1, Math.min(limit, 100));
+}
+
+function buildSourceEvidenceCollisionKey(
+  provider: SourceEvidenceCollisionEntry["provider"],
+  idempotencyKey: string,
+): string {
+  return `${provider}\u0000${idempotencyKey}`;
+}
+
+function mapSourceEvidenceCollisionEntries(input: {
+  readonly groups: readonly SourceEvidenceCollisionGroupRow[];
+  readonly rows: readonly SourceEvidenceLogRow[];
+}): readonly SourceEvidenceCollisionEntry[] {
+  const rowsByCollisionKey = new Map<string, SourceEvidenceLogRow[]>();
+
+  for (const row of input.rows) {
+    const collisionKey = buildSourceEvidenceCollisionKey(
+      row.provider,
+      row.idempotencyKey,
+    );
+    const existingRows = rowsByCollisionKey.get(collisionKey) ?? [];
+    existingRows.push(row);
+    rowsByCollisionKey.set(collisionKey, existingRows);
+  }
+
+  return input.groups.flatMap((group) => {
+    const collisionKey = buildSourceEvidenceCollisionKey(
+      group.provider,
+      group.idempotencyKey,
+    );
+    const rows = rowsByCollisionKey.get(collisionKey) ?? [];
+    const [winning, ...losing] = rows;
+
+    if (winning === undefined) {
+      return [];
+    }
+
+    return [
+      {
+        provider: group.provider,
+        idempotencyKey: group.idempotencyKey,
+        latestReceivedAt: group.latestReceivedAt,
+        winning: {
+          sourceEvidenceId: winning.id,
+          checksum: winning.checksum,
+          receivedAt: winning.receivedAt,
+        },
+        losing: losing.map((row) => ({
+          sourceEvidenceId: row.id,
+          checksum: row.checksum,
+          receivedAt: row.receivedAt,
+        })),
+      },
+    ];
+  });
+}
+
+function coerceSourceEvidenceCollisionGroups(
+  rows: readonly SourceEvidenceCollisionGroupRow[],
+): readonly SourceEvidenceCollisionGroupRow[] {
+  return rows.map((row) => ({
+    provider: row.provider,
+    idempotencyKey: row.idempotencyKey,
+    latestReceivedAt: new Date(row.latestReceivedAt),
+  }));
 }
 
 function mapSimpleTextingMessageDetailRowLocal(
@@ -657,6 +747,78 @@ function createStage1RepositoriesInternal(
           .limit(1);
 
         return row === undefined ? null : mapSourceEvidenceRow(row);
+      },
+
+      async listIdempotencyChecksumCollisions(input) {
+        const limit = clampSourceEvidenceCollisionLimit(input.limit);
+        const groupResult = await db.execute(
+          sql`
+            select
+              ${sourceEvidenceLog.provider} as "provider",
+              ${sourceEvidenceLog.idempotencyKey} as "idempotencyKey",
+              max(${sourceEvidenceLog.receivedAt}) as "latestReceivedAt"
+            from ${sourceEvidenceLog}
+            group by ${sourceEvidenceLog.provider}, ${sourceEvidenceLog.idempotencyKey}
+            having count(distinct ${sourceEvidenceLog.checksum}) > 1
+            ${
+              input.beforeTimestamp === undefined
+                ? sql``
+                : sql`and max(${sourceEvidenceLog.receivedAt}) < ${input.beforeTimestamp}`
+            }
+            order by
+              max(${sourceEvidenceLog.receivedAt}) desc,
+              ${sourceEvidenceLog.provider} asc,
+              ${sourceEvidenceLog.idempotencyKey} asc
+            limit ${limit + 1}
+          `,
+        );
+        const groups = coerceSourceEvidenceCollisionGroups(
+          normalizeSqlResultRows<SourceEvidenceCollisionGroupRow>(
+            groupResult as
+              | readonly SourceEvidenceCollisionGroupRow[]
+              | {
+                  readonly rows?: readonly SourceEvidenceCollisionGroupRow[];
+                },
+          ),
+        );
+        const visibleGroups = groups.slice(0, limit);
+
+        if (visibleGroups.length === 0) {
+          return {
+            entries: [],
+            hasMore: false,
+          };
+        }
+
+        const groupPredicates = visibleGroups.map((group) =>
+          and(
+            eq(sourceEvidenceLog.provider, group.provider),
+            eq(sourceEvidenceLog.idempotencyKey, group.idempotencyKey),
+          ),
+        );
+        const rows = await db
+          .select()
+          .from(sourceEvidenceLog)
+          .where(
+            groupPredicates.length === 1
+              ? groupPredicates[0]
+              : or(...groupPredicates),
+          )
+          .orderBy(
+            asc(sourceEvidenceLog.provider),
+            asc(sourceEvidenceLog.idempotencyKey),
+            asc(sourceEvidenceLog.receivedAt),
+            asc(sourceEvidenceLog.createdAt),
+            asc(sourceEvidenceLog.id),
+          );
+
+        return {
+          entries: mapSourceEvidenceCollisionEntries({
+            groups: visibleGroups,
+            rows,
+          }),
+          hasMore: groups.length > limit,
+        };
       },
 
       async countByProvider(provider) {

--- a/packages/db/test/stage1-repositories.test.ts
+++ b/packages/db/test/stage1-repositories.test.ts
@@ -172,6 +172,39 @@ async function seedSharedInboxRecencyFixture(): Promise<{
   return context;
 }
 
+async function appendSourceEvidenceRows(
+  repositories: Awaited<
+    ReturnType<typeof createTestStage1Context>
+  >["repositories"],
+  rows: readonly {
+    readonly id: string;
+    readonly provider:
+      | "gmail"
+      | "salesforce"
+      | "simpletexting"
+      | "mailchimp"
+      | "manual";
+    readonly providerRecordId: string;
+    readonly receivedAt: string;
+    readonly idempotencyKey: string;
+    readonly checksum: string;
+  }[],
+): Promise<void> {
+  for (const row of rows) {
+    await repositories.sourceEvidence.append({
+      id: row.id,
+      provider: row.provider,
+      providerRecordType: "message",
+      providerRecordId: row.providerRecordId,
+      receivedAt: row.receivedAt,
+      occurredAt: row.receivedAt,
+      payloadRef: `payloads/${row.provider}/${row.providerRecordId}.json`,
+      idempotencyKey: row.idempotencyKey,
+      checksum: row.checksum,
+    });
+  }
+}
+
 describe("Stage 1 DB repositories", () => {
   it("persists and maps source evidence, contacts, identities, and memberships", async () => {
     const { repositories, settings } = await createTestStage1Context();
@@ -414,6 +447,197 @@ describe("Stage 1 DB repositories", () => {
         sourceEvidence.id,
       ]),
     ).resolves.toEqual([manualNoteDetail]);
+  });
+
+  it("returns no source-evidence collisions when the table is empty", async () => {
+    const { repositories } = await createTestStage1Context();
+
+    await expect(
+      repositories.sourceEvidence.listIdempotencyChecksumCollisions({
+        limit: 10,
+      }),
+    ).resolves.toEqual({
+      entries: [],
+      hasMore: false,
+    });
+  });
+
+  it("ignores source-evidence keys that only have one checksum", async () => {
+    const { repositories } = await createTestStage1Context();
+
+    await appendSourceEvidenceRows(repositories, [
+      {
+        id: "sev-single",
+        provider: "gmail",
+        providerRecordId: "gmail-single",
+        receivedAt: "2026-01-01T00:00:00.000Z",
+        idempotencyKey: "gmail:single",
+        checksum: "checksum-single",
+      },
+    ]);
+
+    await expect(
+      repositories.sourceEvidence.listIdempotencyChecksumCollisions({
+        limit: 10,
+      }),
+    ).resolves.toEqual({
+      entries: [],
+      hasMore: false,
+    });
+  });
+
+  it("returns the earliest row as the winning source-evidence collision entry", async () => {
+    const { repositories } = await createTestStage1Context();
+
+    await appendSourceEvidenceRows(repositories, [
+      {
+        id: "sev-winning",
+        provider: "gmail",
+        providerRecordId: "gmail-winning",
+        receivedAt: "2026-01-01T00:00:00.000Z",
+        idempotencyKey: "gmail:collision",
+        checksum: "checksum-a",
+      },
+      {
+        id: "sev-losing",
+        provider: "gmail",
+        providerRecordId: "gmail-losing",
+        receivedAt: "2026-01-01T00:01:00.000Z",
+        idempotencyKey: "gmail:collision",
+        checksum: "checksum-b",
+      },
+    ]);
+
+    const result =
+      await repositories.sourceEvidence.listIdempotencyChecksumCollisions({
+        limit: 10,
+      });
+
+    expect(result.hasMore).toBe(false);
+    expect(result.entries).toEqual([
+      {
+        provider: "gmail",
+        idempotencyKey: "gmail:collision",
+        latestReceivedAt: new Date("2026-01-01T00:01:00.000Z"),
+        winning: {
+          sourceEvidenceId: "sev-winning",
+          checksum: "checksum-a",
+          receivedAt: new Date("2026-01-01T00:00:00.000Z"),
+        },
+        losing: [
+          {
+            sourceEvidenceId: "sev-losing",
+            checksum: "checksum-b",
+            receivedAt: new Date("2026-01-01T00:01:00.000Z"),
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("pages source-evidence collisions by latest received timestamp", async () => {
+    const { repositories } = await createTestStage1Context();
+
+    await appendSourceEvidenceRows(repositories, [
+      {
+        id: "sev-older-1",
+        provider: "gmail",
+        providerRecordId: "gmail-older-1",
+        receivedAt: "2026-01-01T00:00:00.000Z",
+        idempotencyKey: "gmail:older",
+        checksum: "older-a",
+      },
+      {
+        id: "sev-older-2",
+        provider: "gmail",
+        providerRecordId: "gmail-older-2",
+        receivedAt: "2026-01-01T00:05:00.000Z",
+        idempotencyKey: "gmail:older",
+        checksum: "older-b",
+      },
+      {
+        id: "sev-newer-1",
+        provider: "salesforce",
+        providerRecordId: "sf-newer-1",
+        receivedAt: "2026-01-01T01:00:00.000Z",
+        idempotencyKey: "salesforce:newer",
+        checksum: "newer-a",
+      },
+      {
+        id: "sev-newer-2",
+        provider: "salesforce",
+        providerRecordId: "sf-newer-2",
+        receivedAt: "2026-01-01T01:15:00.000Z",
+        idempotencyKey: "salesforce:newer",
+        checksum: "newer-b",
+      },
+    ]);
+
+    const result =
+      await repositories.sourceEvidence.listIdempotencyChecksumCollisions({
+        limit: 1,
+      });
+
+    expect(result.hasMore).toBe(true);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0]).toMatchObject({
+      provider: "salesforce",
+      idempotencyKey: "salesforce:newer",
+      latestReceivedAt: new Date("2026-01-01T01:15:00.000Z"),
+    });
+  });
+
+  it("applies the beforeTimestamp cursor to source-evidence collisions", async () => {
+    const { repositories } = await createTestStage1Context();
+
+    await appendSourceEvidenceRows(repositories, [
+      {
+        id: "sev-cursor-old-1",
+        provider: "gmail",
+        providerRecordId: "gmail-cursor-old-1",
+        receivedAt: "2026-01-01T00:00:00.000Z",
+        idempotencyKey: "gmail:cursor-old",
+        checksum: "cursor-old-a",
+      },
+      {
+        id: "sev-cursor-old-2",
+        provider: "gmail",
+        providerRecordId: "gmail-cursor-old-2",
+        receivedAt: "2026-01-01T00:10:00.000Z",
+        idempotencyKey: "gmail:cursor-old",
+        checksum: "cursor-old-b",
+      },
+      {
+        id: "sev-cursor-new-1",
+        provider: "mailchimp",
+        providerRecordId: "mailchimp-cursor-new-1",
+        receivedAt: "2026-01-01T01:00:00.000Z",
+        idempotencyKey: "mailchimp:cursor-new",
+        checksum: "cursor-new-a",
+      },
+      {
+        id: "sev-cursor-new-2",
+        provider: "mailchimp",
+        providerRecordId: "mailchimp-cursor-new-2",
+        receivedAt: "2026-01-01T01:20:00.000Z",
+        idempotencyKey: "mailchimp:cursor-new",
+        checksum: "cursor-new-b",
+      },
+    ]);
+
+    const result =
+      await repositories.sourceEvidence.listIdempotencyChecksumCollisions({
+        limit: 10,
+        beforeTimestamp: new Date("2026-01-01T01:20:00.000Z"),
+      });
+
+    expect(result.hasMore).toBe(false);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0]).toMatchObject({
+      provider: "gmail",
+      idempotencyKey: "gmail:cursor-old",
+      latestReceivedAt: new Date("2026-01-01T00:10:00.000Z"),
+    });
   });
 
   it("persists canonical events, review queues, and projections", async () => {

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -39,12 +39,35 @@ export interface SourceEvidenceRepository {
   findByIdempotencyKey(
     idempotencyKey: string,
   ): Promise<SourceEvidenceRecord | null>;
+  listIdempotencyChecksumCollisions(input: {
+    readonly limit: number;
+    readonly beforeTimestamp?: Date;
+  }): Promise<{
+    readonly entries: readonly SourceEvidenceCollisionEntry[];
+    readonly hasMore: boolean;
+  }>;
   countByProvider(provider: Provider): Promise<number>;
   listByProviderRecord(input: {
     readonly provider: Provider;
     readonly providerRecordType: string;
     readonly providerRecordId: string;
   }): Promise<readonly SourceEvidenceRecord[]>;
+}
+
+export interface SourceEvidenceCollisionEntry {
+  readonly provider: Provider;
+  readonly idempotencyKey: string;
+  readonly latestReceivedAt: Date;
+  readonly winning: {
+    readonly sourceEvidenceId: string;
+    readonly checksum: string;
+    readonly receivedAt: Date;
+  };
+  readonly losing: readonly {
+    readonly sourceEvidenceId: string;
+    readonly checksum: string;
+    readonly receivedAt: Date;
+  }[];
 }
 
 export interface CanonicalEventRepository {

--- a/packages/domain/test/normalization.test.ts
+++ b/packages/domain/test/normalization.test.ts
@@ -257,6 +257,8 @@ function buildContext(input: {
         ),
       findByIdempotencyKey: (idempotencyKey) =>
         Promise.resolve(sourceEvidenceByIdempotencyKey.get(idempotencyKey) ?? null),
+      listIdempotencyChecksumCollisions: () =>
+        Promise.resolve({ entries: [], hasMore: false }),
       countByProvider: () => Promise.resolve(sourceEvidenceById.size),
       listByProviderRecord: ({ provider, providerRecordType, providerRecordId }) =>
         Promise.resolve(

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -26,6 +26,8 @@ describe("defineStage1RepositoryBundle", () => {
         findById: () => Promise.resolve(null),
         listByIds: () => Promise.resolve([]),
         findByIdempotencyKey: () => Promise.resolve(null),
+        listIdempotencyChecksumCollisions: () =>
+          Promise.resolve({ entries: [], hasMore: false }),
         countByProvider: () => Promise.resolve(0),
         listByProviderRecord: () => Promise.resolve([]),
       },

--- a/packages/domain/test/stage3-last-inbound-alias.test.ts
+++ b/packages/domain/test/stage3-last-inbound-alias.test.ts
@@ -35,6 +35,8 @@ function buildRepositoryBundle(input: {
       findById: () => Promise.resolve(null),
       listByIds: () => Promise.resolve([]),
       findByIdempotencyKey: () => Promise.resolve(null),
+      listIdempotencyChecksumCollisions: () =>
+        Promise.resolve({ entries: [], hasMore: false }),
       countByProvider: () => Promise.resolve(0),
       listByProviderRecord: () => Promise.resolve([]),
     },

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -100,6 +100,8 @@ function createRepositoryBundle(input: {
           }),
         ),
       findByIdempotencyKey: () => Promise.resolve(null),
+      listIdempotencyChecksumCollisions: () =>
+        Promise.resolve({ entries: [], hasMore: false }),
       countByProvider: () => Promise.resolve(0),
       listByProviderRecord: () => Promise.resolve([]),
     },


### PR DESCRIPTION
## Summary

New admin-gated Settings → **Logs** page surfacing `source_evidence_log` quarantine events (different-checksum collisions on the same `(provider, idempotency_key)`). First step toward operational visibility on the source_evidence_log idempotency race (Slice 1+5 #9) — gives the architect a window into how often it happens before deciding on schema-tightening semantics.

The page is built as a **pluggable log-stream surface** — first stream is source-evidence quarantine; future streams (sync failures, routing-review backlog, identity-queue stalls) plug in without restructuring.

## Read path

- New `SourceEvidenceRepository.listIdempotencyChecksumCollisions({ limit, beforeTimestamp })` returns paged collision groups + winning/losing rows
- Drizzle impl uses `GROUP BY (provider, idempotency_key)`. EXPLAIN confirms left-prefix on `source_evidence_log_replay_unique` is used — **no new index needed**, no migration
- `loadLogsSettings` selector wraps with admin auth + audit logging

## UI

- `/settings/logs` admin-gated; non-admin → `/settings`, unauthorized → `/auth/sign-in`
- Single stream selector (extensible), expandable detail rows, empty state, `?before=` pagination
- Settings nav updated to include Logs

## Tests

- Repo paging + collision shape
- Admin gate + selector shape
- Page render + auth flows

## Out of scope (deliberately)

- Tightening `source_evidence_log_replay_unique` UNIQUE constraint + quarantine semantics — separate brief, lands once we see a few collisions on the new page
- Bulk actions (acknowledge/dismiss) — page is read-only first
- Other log streams beyond source-evidence — abstraction supports them but only one stream ships in this PR

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test:unit` clean (VALIDATION_PASSED)
- [ ] CI green
- [ ] Architect navigates to /settings/logs after deploy and confirms the page loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)