### PR TITLE
feat(notes): swap domain + UI to internal_notes table (B2 of notes architecture refactor)

### DIFF
--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -2755,7 +2755,19 @@ async function readInboxDetailCacheData(
     runtime.repositories.contacts.findById(contactId),
     runtime.repositories.inboxProjection.findByContactId(contactId),
     runtime.repositories.contactMemberships.listByContactId(contactId),
-    runtime.repositories.manualNoteDetails.findLatestForContact(contactId),
+    runtime.repositories.internalNotes
+      .findByContactId(contactId, 1)
+      .then((rows) => {
+        const latestNote = rows[0];
+        return latestNote === undefined
+          ? null
+          : {
+              body: latestNote.body,
+              authorDisplayName: latestNote.authorDisplayName,
+              authorId: latestNote.authorId,
+              createdAt: latestNote.createdAt.toISOString(),
+            };
+      }),
     runtime.timelinePresentation.listTimelineItemsByContactId(contactId),
     runtime.timelinePresentation.listTimelineItemsPageByContactId(contactId, {
       limit: input.timelineLimit,

--- a/apps/web/app/inbox/actions.ts
+++ b/apps/web/app/inbox/actions.ts
@@ -539,20 +539,15 @@ function resolveCurrentUserDisplayName(input: {
   return "Internal note";
 }
 
-function buildManualNoteCanonicalEventId(noteId: string): string {
-  return `canonical-event:manual:note:${noteId}`;
-}
-
-async function resolveManualNoteContactId(input: {
+async function resolveInternalNoteContactId(input: {
   readonly runtime: Awaited<ReturnType<typeof getStage1WebRuntime>>;
   readonly noteId: string;
 }): Promise<string | null> {
-  const canonicalEvent =
-    await input.runtime.repositories.canonicalEvents.findById(
-      buildManualNoteCanonicalEventId(input.noteId),
-    );
+  const note = await input.runtime.repositories.internalNotes.findById(
+    input.noteId,
+  );
 
-  return canonicalEvent?.contactId ?? null;
+  return note?.contactId ?? null;
 }
 
 function normalizeMembershipStatus(value: string | null): string {
@@ -1088,7 +1083,7 @@ export async function updateNoteAction(rawInput: {
   }
 
   const runtime = await getStage1WebRuntime();
-  const contactId = await resolveManualNoteContactId({
+  const contactId = await resolveInternalNoteContactId({
     runtime,
     noteId,
   });
@@ -1179,13 +1174,14 @@ export async function deleteNoteAction(rawInput: {
   }
 
   const runtime = await getStage1WebRuntime();
-  const contactId = await resolveManualNoteContactId({
+  const contactId = await resolveInternalNoteContactId({
     runtime,
     noteId,
   });
   const result = await runtime.internalNotes.deleteNote({
     noteId,
     authorId: currentUser.id,
+    actorIsAdmin: currentUser.role === "admin",
   });
 
   if (result.outcome === "not_authorized") {

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -1785,10 +1785,8 @@ describe("real inbox selectors", () => {
 
     const detail = await getInboxDetail("contact:sarah-martinez");
 
-    // manual_note_details.created_at defaults to now() at insert time (not the
-    // fixture's occurredAt), so the relative label is computed from real elapsed
-    // time during the test run. Assert structure + content; don't pin the exact
-    // relative label.
+    // The pinned-note timestamp is rendered as a relative label, so assert the
+    // content and structure without pinning the exact phrasing.
     expect(detail?.contact.pinnedNote).toMatchObject({
       body: "Latest note body",
       authorLabel: "Sam Bowes",

--- a/apps/web/tests/unit/inbox-stage1-helpers.ts
+++ b/apps/web/tests/unit/inbox-stage1-helpers.ts
@@ -769,82 +769,28 @@ export async function seedInboxInternalNoteEvent(
     readonly authorId?: string | null;
   },
 ): Promise<{ readonly canonicalEventId: string }> {
-  const sourceEvidenceId = `source:${input.id}`;
-  const canonicalEventId = `event:${input.id}`;
+  const canonicalEventId = `note:${input.id}`;
+  const authorId = input.authorId ?? `user:${input.id}:internal-note`;
 
-  await context.repositories.sourceEvidence.append({
-    id: sourceEvidenceId,
-    provider: "manual",
-    providerRecordType: "note",
-    providerRecordId: input.id,
-    receivedAt: input.occurredAt,
-    occurredAt: input.occurredAt,
-    payloadRef: `payloads/manual/${input.id}.json`,
-    idempotencyKey: `manual:${input.id}`,
-    checksum: `checksum:${input.id}`,
+  await context.settings.users.upsert({
+    id: authorId,
+    email: `${authorId.replace(/[^a-zA-Z0-9]/g, "-")}@test.local`,
+    name: input.authorDisplayName,
+    emailVerified: null,
+    image: null,
+    role: "operator",
+    deactivatedAt: null,
+    createdAt: new Date(input.occurredAt),
+    updatedAt: new Date(input.occurredAt),
   });
 
-  await context.repositories.canonicalEvents.upsert({
-    id: canonicalEventId,
+  await context.repositories.internalNotes.create({
+    id: input.id,
     contactId: input.contactId,
-    eventType: "note.internal.created",
-    channel: "note",
-    occurredAt: input.occurredAt,
-    sourceEvidenceId,
-    idempotencyKey: `canonical:${input.id}`,
-    contentFingerprint: null,
-    provenance: {
-      primaryProvider: "manual",
-      primarySourceEvidenceId: sourceEvidenceId,
-      supportingSourceEvidenceIds: [],
-      winnerReason: "single_source",
-      sourceRecordType: "note",
-      sourceRecordId: input.id,
-      messageKind: null,
-      campaignRef: null,
-      threadRef: null,
-      direction: null,
-      notes: null,
-    },
-    reviewState: "clear",
-  });
-
-  // FK from manual_note_details.author_id → users.id requires the user to exist
-  // before we can insert a note that references it. Upsert a minimal user row
-  // when authorId is provided.
-  if (input.authorId) {
-    await context.settings.users.upsert({
-      id: input.authorId,
-      email: `${input.authorId.replace(/[^a-zA-Z0-9]/g, "-")}@test.local`,
-      name: input.authorDisplayName,
-      emailVerified: null,
-      image: null,
-      role: "operator",
-      deactivatedAt: null,
-      createdAt: new Date(input.occurredAt),
-      updatedAt: new Date(input.occurredAt),
-    });
-  }
-
-  await context.repositories.manualNoteDetails.upsert({
-    sourceEvidenceId,
-    providerRecordId: input.id,
     body: input.body,
-    authorDisplayName: input.authorDisplayName,
-    authorId: input.authorId ?? null,
-  });
-
-  await context.repositories.timelineProjection.upsert({
-    id: `timeline:${input.id}`,
-    contactId: input.contactId,
-    canonicalEventId,
-    occurredAt: input.occurredAt,
-    sortKey: `${input.occurredAt}::${canonicalEventId}`,
-    eventType: "note.internal.created",
-    summary: "Internal note added",
-    channel: "note",
-    primaryProvider: "manual",
-    reviewState: "clear",
+    authorId,
+    createdAt: new Date(input.occurredAt),
+    updatedAt: new Date(input.occurredAt),
   });
 
   return {

--- a/apps/web/tests/unit/stage3-note-actions.test.ts
+++ b/apps/web/tests/unit/stage3-note-actions.test.ts
@@ -27,6 +27,7 @@ function buildCurrentUser(input?: {
   readonly id?: string;
   readonly name?: string | null;
   readonly email?: string;
+  readonly role?: "admin" | "operator";
 }) {
   const now = new Date("2026-04-21T12:00:00.000Z");
 
@@ -36,7 +37,7 @@ function buildCurrentUser(input?: {
     email: input?.email ?? "operator@example.org",
     emailVerified: now,
     image: null,
-    role: "operator" as const,
+    role: input?.role ?? ("operator" as const),
     deactivatedAt: null,
     createdAt: now,
     updatedAt: now,
@@ -97,25 +98,22 @@ describe("note server actions", () => {
       throw new Error("Expected runtime and successful result.");
     }
 
-    const sourceEvidenceId = `source-evidence:manual:note:${result.data.noteId}`;
-    const notes =
-      await runtime.context.repositories.manualNoteDetails.listBySourceEvidenceIds(
-        [sourceEvidenceId],
-      );
+    const note = await runtime.context.repositories.internalNotes.findById(
+      result.data.noteId,
+    );
     const audits =
       await runtime.context.repositories.auditEvidence.listByEntity({
         entityType: "internal_note",
         entityId: result.data.noteId,
       });
 
-    expect(notes).toEqual([
-      expect.objectContaining({
-        sourceEvidenceId,
-        body: "Call back on Thursday",
-        authorDisplayName: "Operator Name",
-        authorId: "user:operator",
-      }),
-    ]);
+    expect(note).toMatchObject({
+      id: result.data.noteId,
+      contactId: "contact:existing",
+      body: "Call back on Thursday",
+      authorDisplayName: "Operator Name",
+      authorId: "user:operator",
+    });
     expect(audits.map((audit) => audit.action)).toEqual(["inbox.note_created"]);
   });
 
@@ -224,6 +222,65 @@ describe("note server actions", () => {
       ok: false,
       code: "forbidden",
     });
+  });
+
+  it("allows admins to delete another operator's note", async () => {
+    if (runtime === null) {
+      throw new Error("Expected runtime.");
+    }
+
+    await runtime.context.settings.users.upsert(
+      buildCurrentUser({
+        id: "user:author",
+        name: "Author User",
+        email: "author@example.org",
+      }),
+    );
+    requireSession.mockResolvedValue(
+      buildCurrentUser({
+        id: "user:admin",
+        name: "Admin User",
+        email: "admin@example.org",
+        role: "admin",
+      }),
+    );
+    await seedOperator(
+      runtime,
+      buildCurrentUser({
+        id: "user:admin",
+        name: "Admin User",
+        email: "admin@example.org",
+        role: "admin",
+      }),
+    );
+
+    const internalNotes = createStage1InternalNoteService({
+      persistence: runtime.context.persistence,
+      normalization: runtime.context.normalization,
+    });
+
+    await internalNotes.createNote({
+      noteId: "note-delete-admin",
+      contactId: "contact:existing",
+      body: "Original body",
+      occurredAt: "2026-04-21T12:00:00.000Z",
+      authorDisplayName: "Author User",
+      authorId: "user:author",
+    });
+
+    await expect(
+      deleteNoteAction({
+        noteId: "note-delete-admin",
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      data: {
+        noteId: "note-delete-admin",
+      },
+    });
+    await expect(
+      runtime.context.repositories.internalNotes.findById("note-delete-admin"),
+    ).resolves.toBeUndefined();
   });
 
   it("rate limits note creation after 60 requests per minute", async () => {

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -198,6 +198,12 @@ type SimpleTextingMessageDetailRow = SimpleTextingMessageDetailRecord;
 type MailchimpCampaignActivityDetailRow = MailchimpCampaignActivityDetailRecord;
 type ManualNoteDetailRow = ManualNoteDetailRecord;
 type InternalNoteRow = typeof internalNotes.$inferSelect;
+interface InternalNoteWithAuthorRow {
+  readonly internal_notes: InternalNoteRow;
+  readonly users: {
+    readonly name: string | null;
+  } | null;
+}
 type PendingComposerOutboundRow = typeof pendingComposerOutbounds.$inferSelect;
 type SourceEvidenceLogRow = typeof sourceEvidenceLog.$inferSelect;
 interface SourceEvidenceCollisionGroupRow {
@@ -408,9 +414,19 @@ function mapInternalNoteRowLocal(row: InternalNoteRow): InternalNoteRecord {
     id: row.id,
     contactId: row.contactId,
     body: row.body,
+    authorDisplayName: null,
     authorId: row.authorId,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
+  };
+}
+
+function mapInternalNoteWithAuthorRow(
+  row: InternalNoteWithAuthorRow,
+): InternalNoteRecord {
+  return {
+    ...mapInternalNoteRowLocal(row.internal_notes),
+    authorDisplayName: row.users?.name ?? null,
   };
 }
 
@@ -2036,66 +2052,116 @@ function createStage1RepositoriesInternal(
 
     internalNotes: {
       async create(input) {
-        const now = new Date();
-        const [row] = await db
+        const createdAt = input.createdAt ?? new Date();
+        const updatedAt = input.updatedAt ?? createdAt;
+        await db
           .insert(internalNotes)
           .values({
             id: input.id,
             contactId: input.contactId,
             body: input.body,
             authorId: input.authorId,
-            createdAt: now,
-            updatedAt: now,
+            createdAt,
+            updatedAt,
           })
-          .returning();
+          .returning({
+            id: internalNotes.id,
+          });
 
-        return mapInternalNoteRowLocal(
-          requireRow(row, "Expected internal_notes row to be returned."),
+        const [row] = await db
+          .select({
+            internal_notes: internalNotes,
+            users: {
+              name: users.name,
+            },
+          })
+          .from(internalNotes)
+          .leftJoin(users, eq(internalNotes.authorId, users.id))
+          .where(eq(internalNotes.id, input.id))
+          .limit(1);
+
+        return mapInternalNoteWithAuthorRow(
+          requireRow(
+            row,
+            `Expected internal_notes row ${input.id} to be returned.`,
+          ),
         );
       },
 
       async findById(id) {
         const [row] = await db
-          .select()
+          .select({
+            internal_notes: internalNotes,
+            users: {
+              name: users.name,
+            },
+          })
           .from(internalNotes)
+          .leftJoin(users, eq(internalNotes.authorId, users.id))
           .where(eq(internalNotes.id, id))
           .limit(1);
 
-        return row === undefined ? undefined : mapInternalNoteRowLocal(row);
+        return row === undefined ? undefined : mapInternalNoteWithAuthorRow(row);
       },
 
       async findByContactId(contactId, limit) {
         if (limit === undefined) {
           const rows = await db
-            .select()
+            .select({
+              internal_notes: internalNotes,
+              users: {
+                name: users.name,
+              },
+            })
             .from(internalNotes)
+            .leftJoin(users, eq(internalNotes.authorId, users.id))
             .where(eq(internalNotes.contactId, contactId))
             .orderBy(desc(internalNotes.createdAt), desc(internalNotes.id));
 
-          return rows.map(mapInternalNoteRowLocal);
+          return rows.map(mapInternalNoteWithAuthorRow);
         }
 
         const rows = await db
-          .select()
+          .select({
+            internal_notes: internalNotes,
+            users: {
+              name: users.name,
+            },
+          })
           .from(internalNotes)
+          .leftJoin(users, eq(internalNotes.authorId, users.id))
           .where(eq(internalNotes.contactId, contactId))
           .orderBy(desc(internalNotes.createdAt), desc(internalNotes.id))
           .limit(limit);
 
-        return rows.map(mapInternalNoteRowLocal);
+        return rows.map(mapInternalNoteWithAuthorRow);
       },
 
       async update(input) {
-        const [row] = await db
+        await db
           .update(internalNotes)
           .set({
             body: input.body,
-            updatedAt: new Date(),
+            updatedAt: input.updatedAt ?? new Date(),
           })
           .where(eq(internalNotes.id, input.id))
-          .returning();
+          .returning({
+            id: internalNotes.id,
+          });
 
-        return mapInternalNoteRowLocal(
+        const [row] = await db
+          .select({
+            internal_notes: internalNotes,
+            users: {
+              name: users.name,
+            },
+          })
+          .from(internalNotes)
+          .leftJoin(users, eq(internalNotes.authorId, users.id))
+          .where(eq(internalNotes.id, input.id))
+          .limit(1);
+
+        return mapInternalNoteWithAuthorRow(
           requireRow(
             row,
             `Expected internal_notes row ${input.id} to update.`,

--- a/packages/db/test/stage1-timeline-and-notes.test.ts
+++ b/packages/db/test/stage1-timeline-and-notes.test.ts
@@ -76,6 +76,29 @@ async function seedVolunteerContact(input: {
   return context;
 }
 
+async function seedUser(
+  context: Awaited<ReturnType<typeof createTestStage1Context>>,
+  input: {
+    readonly id: string;
+    readonly name: string;
+    readonly email: string;
+  },
+) {
+  const now = new Date("2026-01-01T00:00:00.000Z");
+
+  await context.settings.users.upsert({
+    id: input.id,
+    name: input.name,
+    email: input.email,
+    emailVerified: now,
+    image: null,
+    role: "operator",
+    deactivatedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
 function buildCommunicationClassification(input: {
   readonly sourceRecordType: string;
   readonly sourceRecordId: string;
@@ -106,13 +129,18 @@ function buildCommunicationClassification(input: {
 }
 
 describe("Stage 1 notes and timeline presenter", () => {
-  it("creates an internal note through the canonical pipeline without mutating inbox state", async () => {
+  it("creates an internal note through internal_notes without mutating inbox state", async () => {
     const context = await seedVolunteerContact({
       contactId: "contact_1",
       salesforceContactId: "003-stage1",
       displayName: "Stage One Volunteer",
       email: "volunteer@example.org",
       phone: "+15555550123"
+    });
+    await seedUser(context, {
+      id: "user:author",
+      name: "Author User",
+      email: "author@example.org",
     });
     const noteService = createStage1InternalNoteService({
       persistence: context.persistence,
@@ -124,17 +152,19 @@ describe("Stage 1 notes and timeline presenter", () => {
       noteId: "note-1",
       contactId: "contact_1",
       body: "Volunteer asked to be contacted again next week.",
-      occurredAt: "2026-01-02T00:00:00.000Z"
+      occurredAt: "2026-01-02T00:00:00.000Z",
+      authorDisplayName: "Author User",
+      authorId: "user:author",
     });
 
     expect(result.outcome).toBe("applied");
-    expect(result.sourceEvidence.provider).toBe("manual");
-    expect(result.canonicalEvent.eventType).toBe("note.internal.created");
-    expect(result.timelineProjection.channel).toBe("note");
-    expect(result.noteDetail.body).toBe(
-      "Volunteer asked to be contacted again next week."
-    );
-    expect(result.inboxProjection).toBeNull();
+    expect(result.note).toMatchObject({
+      id: "note-1",
+      contactId: "contact_1",
+      body: "Volunteer asked to be contacted again next week.",
+      authorDisplayName: "Author User",
+      authorId: "user:author",
+    });
     await expect(
       context.repositories.inboxProjection.findByContactId("contact_1")
     ).resolves.toBeNull();
@@ -145,7 +175,7 @@ describe("Stage 1 notes and timeline presenter", () => {
       expect.objectContaining({
         family: "internal_note",
         body: "Volunteer asked to be contacted again next week.",
-        authorDisplayName: null
+        authorDisplayName: "Author User"
       })
     ]);
   });
@@ -163,6 +193,11 @@ describe("Stage 1 notes and timeline presenter", () => {
       normalization: context.normalization
     });
     const presenter = createStage1TimelinePresentationService(context.repositories);
+    await seedUser(context, {
+      id: "user:author",
+      name: "Author User",
+      email: "author@example.org",
+    });
 
     await context.repositories.projectDimensions.upsert({
       projectId: "project-stage1",
@@ -455,7 +490,8 @@ describe("Stage 1 notes and timeline presenter", () => {
       contactId: "contact_1",
       body: "Internal follow-up note.",
       occurredAt: "2026-01-01T00:06:00.000Z",
-      authorDisplayName: null
+      authorDisplayName: "Author User",
+      authorId: "user:author",
     });
 
     const items = await presenter.listTimelineItemsByContactId("contact_1");
@@ -526,7 +562,7 @@ describe("Stage 1 notes and timeline presenter", () => {
       expect.objectContaining({
         family: "internal_note",
         body: "Internal follow-up note.",
-        authorDisplayName: null
+        authorDisplayName: "Author User"
       })
     );
   });

--- a/packages/domain/src/notes.ts
+++ b/packages/domain/src/notes.ts
@@ -1,15 +1,4 @@
-import { createHash } from "node:crypto";
-
-import {
-  canonicalEventSchema,
-  manualNoteDetailSchema,
-  type CanonicalEventRecord,
-  type InboxProjectionRow,
-  type ManualNoteDetailRecord,
-  type SourceEvidenceRecord,
-  type TimelineProjectionRow,
-} from "@as-comms/contracts";
-
+import type { InternalNoteRecord } from "./repositories.js";
 import type { Stage1NormalizationService } from "./normalization.js";
 import type { Stage1PersistenceService } from "./persistence.js";
 
@@ -24,11 +13,7 @@ export interface Stage1InternalNoteCreateInput {
 
 export interface Stage1InternalNoteCreateResult {
   readonly outcome: "applied" | "duplicate";
-  readonly sourceEvidence: SourceEvidenceRecord;
-  readonly canonicalEvent: CanonicalEventRecord;
-  readonly timelineProjection: TimelineProjectionRow;
-  readonly inboxProjection: InboxProjectionRow | null;
-  readonly noteDetail: ManualNoteDetailRecord;
+  readonly note: InternalNoteRecord;
 }
 
 export interface Stage1InternalNoteService {
@@ -45,27 +30,18 @@ export interface Stage1InternalNoteService {
   deleteNote(input: {
     readonly noteId: string;
     readonly authorId: string;
+    readonly actorIsAdmin?: boolean;
   }): Promise<{
     readonly outcome: "applied" | "not_authorized" | "not_found";
   }>;
 }
 
-function buildManualNoteChecksum(input: {
-  readonly noteId: string;
-  readonly contactId: string;
-  readonly body: string;
-  readonly occurredAt: string;
-}): string {
-  return createHash("sha256")
-    .update(
-      JSON.stringify({
-        noteId: input.noteId,
-        contactId: input.contactId,
-        body: input.body,
-        occurredAt: input.occurredAt,
-      }),
-    )
-    .digest("hex");
+function isUniqueViolation(error: unknown): boolean {
+  if (typeof error !== "object" || error === null || !("code" in error)) {
+    return false;
+  }
+
+  return (error as { readonly code?: unknown }).code === "23505";
 }
 
 export function createStage1InternalNoteService(input: {
@@ -75,39 +51,7 @@ export function createStage1InternalNoteService(input: {
     "applyTimelineProjection" | "refreshInboxReviewOverlay"
   >;
 }): Stage1InternalNoteService {
-  async function loadExistingNote(inputValue: {
-    readonly noteId: string;
-  }): Promise<{
-    readonly sourceEvidence: SourceEvidenceRecord;
-    readonly noteDetail: ManualNoteDetailRecord;
-    readonly canonicalEvent: CanonicalEventRecord | null;
-  } | null> {
-    const sourceEvidenceId = `source-evidence:manual:note:${inputValue.noteId}`;
-    const canonicalEventId = `canonical-event:manual:note:${inputValue.noteId}`;
-    const [sourceEvidence, noteDetails, canonicalEvent] = await Promise.all([
-      input.persistence.repositories.sourceEvidence.findById(sourceEvidenceId),
-      input.persistence.repositories.manualNoteDetails.listBySourceEvidenceIds([
-        sourceEvidenceId,
-      ]),
-      input.persistence.repositories.canonicalEvents.findById(canonicalEventId),
-    ]);
-
-    if (sourceEvidence === null) {
-      return null;
-    }
-
-    const noteDetail = noteDetails[0] ?? null;
-
-    if (noteDetail === null) {
-      return null;
-    }
-
-    return {
-      sourceEvidence,
-      noteDetail,
-      canonicalEvent,
-    };
-  }
+  void input.normalization;
 
   return {
     async createNote(noteInput) {
@@ -119,119 +63,82 @@ export function createStage1InternalNoteService(input: {
         throw new Error(`Contact ${noteInput.contactId} was not found.`);
       }
 
-      const sourceEvidenceId = `source-evidence:manual:note:${noteInput.noteId}`;
-      const sourceEvidence = {
-        id: sourceEvidenceId,
-        provider: "manual" as const,
-        providerRecordType: "note",
-        providerRecordId: noteInput.noteId,
-        receivedAt: noteInput.occurredAt,
-        occurredAt: noteInput.occurredAt,
-        payloadRef: `manual://note/${noteInput.noteId}`,
-        idempotencyKey: `manual:note:${noteInput.noteId}`,
-        checksum: buildManualNoteChecksum(noteInput),
-      };
-
-      const sourceEvidenceResult =
-        await input.persistence.recordSourceEvidence(sourceEvidence);
-
-      if (sourceEvidenceResult.outcome === "conflict") {
-        throw new Error(
-          `Manual note ${noteInput.noteId} conflicted with existing source evidence.`,
-        );
+      if (
+        typeof noteInput.authorId !== "string" ||
+        noteInput.authorId.trim().length === 0
+      ) {
+        throw new Error("Internal notes require an authorId.");
       }
 
-      const canonicalEvent = canonicalEventSchema.parse({
-        id: `canonical-event:manual:note:${noteInput.noteId}`,
-        contactId: noteInput.contactId,
-        eventType: "note.internal.created",
-        channel: "note",
-        occurredAt: noteInput.occurredAt,
-        sourceEvidenceId: sourceEvidenceResult.record.id,
-        idempotencyKey: `canonical-event:manual:note:${noteInput.noteId}`,
-        provenance: {
-          primaryProvider: "manual",
-          primarySourceEvidenceId: sourceEvidenceResult.record.id,
-          supportingSourceEvidenceIds: [],
-          winnerReason: "single_source",
-          sourceRecordType: "note",
-          sourceRecordId: noteInput.noteId,
-          messageKind: null,
-          campaignRef: null,
-          threadRef: null,
-          direction: null,
-          notes: null,
-        },
-        reviewState: "clear",
-      });
-
-      const canonicalEventResult =
-        await input.persistence.persistCanonicalEvent(canonicalEvent);
-
-      if (canonicalEventResult.outcome === "conflict") {
-        throw new Error(
-          `Manual note ${noteInput.noteId} conflicted with existing canonical event state.`,
-        );
-      }
-
-      const noteDetail = await input.persistence.upsertManualNoteDetail(
-        manualNoteDetailSchema.parse({
-          sourceEvidenceId: sourceEvidenceResult.record.id,
-          providerRecordId: noteInput.noteId,
-          body: noteInput.body,
-          authorDisplayName: noteInput.authorDisplayName ?? null,
-          authorId: noteInput.authorId ?? null,
-        }),
+      const existing = await input.persistence.repositories.internalNotes.findById(
+        noteInput.noteId,
       );
 
-      const persistedEvent = canonicalEventResult.record;
-      const timelineProjection =
-        await input.normalization.applyTimelineProjection({
-          canonicalEvent: persistedEvent,
-          summary: "Internal note added",
-        });
-      const inboxProjection =
-        await input.normalization.refreshInboxReviewOverlay({
+      if (existing !== undefined) {
+        return {
+          outcome: "duplicate",
+          note: existing,
+        };
+      }
+
+      const createdAt = new Date(noteInput.occurredAt);
+
+      try {
+        const note = await input.persistence.repositories.internalNotes.create({
+          id: noteInput.noteId,
           contactId: noteInput.contactId,
+          body: noteInput.body,
+          authorId: noteInput.authorId,
+          createdAt,
+          updatedAt: createdAt,
         });
 
-      return {
-        outcome:
-          sourceEvidenceResult.outcome === "inserted" &&
-          canonicalEventResult.outcome === "inserted"
-            ? "applied"
-            : "duplicate",
-        sourceEvidence: sourceEvidenceResult.record,
-        canonicalEvent: persistedEvent,
-        timelineProjection,
-        inboxProjection,
-        noteDetail,
-      };
+        return {
+          outcome: "applied",
+          note,
+        };
+      } catch (error) {
+        if (!isUniqueViolation(error)) {
+          throw error;
+        }
+
+        const duplicate =
+          await input.persistence.repositories.internalNotes.findById(
+            noteInput.noteId,
+          );
+
+        if (duplicate === undefined) {
+          throw error;
+        }
+
+        return {
+          outcome: "duplicate",
+          note: duplicate,
+        };
+      }
     },
 
     async updateNote(updateInput) {
-      const existing = await loadExistingNote({
-        noteId: updateInput.noteId,
-      });
+      const existing = await input.persistence.repositories.internalNotes.findById(
+        updateInput.noteId,
+      );
 
-      if (existing === null) {
+      if (existing === undefined) {
         return {
           outcome: "not_found",
         };
       }
 
-      const updated =
-        await input.persistence.repositories.manualNoteDetails.updateBody({
-          sourceEvidenceId: existing.sourceEvidence.id,
-          authorId: updateInput.authorId,
-          body: updateInput.body,
-        });
-
-      if (updated === null) {
+      if (existing.authorId !== updateInput.authorId) {
         return {
           outcome: "not_authorized",
         };
       }
+
+      await input.persistence.repositories.internalNotes.update({
+        id: updateInput.noteId,
+        body: updateInput.body,
+      });
 
       return {
         outcome: "applied",
@@ -239,33 +146,28 @@ export function createStage1InternalNoteService(input: {
     },
 
     async deleteNote(deleteInput) {
-      const existing = await loadExistingNote({
-        noteId: deleteInput.noteId,
-      });
+      const existing = await input.persistence.repositories.internalNotes.findById(
+        deleteInput.noteId,
+      );
 
-      if (existing === null) {
+      if (existing === undefined) {
         return {
           outcome: "not_found",
         };
       }
 
-      const deletedCount =
-        await input.persistence.repositories.manualNoteDetails.deleteByAuthor({
-          sourceEvidenceId: existing.sourceEvidence.id,
-          authorId: deleteInput.authorId,
-        });
-
-      if (deletedCount === 0) {
+      if (
+        !deleteInput.actorIsAdmin &&
+        existing.authorId !== deleteInput.authorId
+      ) {
         return {
           outcome: "not_authorized",
         };
       }
 
-      if (existing.canonicalEvent !== null) {
-        await input.normalization.refreshInboxReviewOverlay({
-          contactId: existing.canonicalEvent.contactId,
-        });
-      }
+      await input.persistence.repositories.internalNotes.delete(
+        deleteInput.noteId,
+      );
 
       return {
         outcome: "applied",

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -267,6 +267,7 @@ export interface InternalNoteRecord {
   readonly id: string;
   readonly contactId: string;
   readonly body: string;
+  readonly authorDisplayName: string | null;
   readonly authorId: string;
   readonly createdAt: Date;
   readonly updatedAt: Date;
@@ -278,6 +279,8 @@ export interface InternalNoteRepository {
     readonly contactId: string;
     readonly body: string;
     readonly authorId: string;
+    readonly createdAt?: Date;
+    readonly updatedAt?: Date;
   }): Promise<InternalNoteRecord>;
   findById(id: string): Promise<InternalNoteRecord | undefined>;
   findByContactId(
@@ -287,6 +290,7 @@ export interface InternalNoteRepository {
   update(input: {
     readonly id: string;
     readonly body: string;
+    readonly updatedAt?: Date;
   }): Promise<InternalNoteRecord>;
   delete(id: string): Promise<void>;
 }

--- a/packages/domain/src/timeline.ts
+++ b/packages/domain/src/timeline.ts
@@ -10,7 +10,10 @@ import {
 } from "@as-comms/contracts";
 
 import { buildOutboundEmailDuplicateFingerprint } from "./outbound-email-dedup.js";
-import type { Stage1RepositoryBundle } from "./repositories.js";
+import type {
+  InternalNoteRecord,
+  Stage1RepositoryBundle,
+} from "./repositories.js";
 import type { PendingComposerOutboundRecord } from "./pending-outbounds.js";
 
 type TimelineProvenance = CanonicalEventRecord["provenance"] & {
@@ -58,14 +61,6 @@ interface MailchimpCampaignActivityDetail {
   readonly snippet: string;
 }
 
-interface ManualNoteDetail {
-  readonly sourceEvidenceId: string;
-  readonly providerRecordId: string;
-  readonly body: string;
-  readonly authorDisplayName: string | null;
-  readonly authorId: string | null;
-}
-
 interface TimelinePresentationContext {
   readonly sourceEvidenceById: ReadonlyMap<string, SourceEvidenceRecord>;
   readonly salesforceContextBySourceEvidenceId: ReadonlyMap<
@@ -87,10 +82,6 @@ interface TimelinePresentationContext {
   readonly mailchimpDetailBySourceEvidenceId: ReadonlyMap<
     string,
     MailchimpCampaignActivityDetail
-  >;
-  readonly manualNoteDetailBySourceEvidenceId: ReadonlyMap<
-    string,
-    ManualNoteDetail
   >;
   readonly projectNameById: ReadonlyMap<string, string>;
   readonly expeditionNameById: ReadonlyMap<string, string>;
@@ -155,10 +146,6 @@ function resolveFamily(
 
   if (eventType.startsWith("lifecycle.")) {
     return "salesforce_event";
-  }
-
-  if (eventType === "note.internal.created") {
-    return "internal_note";
   }
 
   if (eventType.startsWith("campaign.email.")) {
@@ -230,6 +217,40 @@ function commonFields(
 
 function buildPendingTimelineSortKey(id: string, sentAt: string): string {
   return `${sentAt}::pending-outbound:${id}`;
+}
+
+function isInternalNoteEvent(event: CanonicalEventRecord): boolean {
+  return event.eventType === "note.internal.created";
+}
+
+function buildNoteCanonicalEventId(noteId: string): string {
+  return `note:${noteId}`;
+}
+
+function buildNoteSortKey(note: InternalNoteRecord): string {
+  return `${note.createdAt.toISOString()}::${buildNoteCanonicalEventId(note.id)}`;
+}
+
+function buildInternalNoteTimelineItems(
+  notes: readonly InternalNoteRecord[],
+): readonly TimelineItem[] {
+  return timelineItemListSchema.parse(
+    notes.map((note) => ({
+      id: buildNoteCanonicalEventId(note.id),
+      contactId: note.contactId,
+      canonicalEventId: buildNoteCanonicalEventId(note.id),
+      family: "internal_note" as const,
+      occurredAt: note.createdAt.toISOString(),
+      sortKey: buildNoteSortKey(note),
+      reviewState: "clear" as const,
+      primaryProvider: "manual" as const,
+      summary: "Internal note added",
+      noteId: note.id,
+      body: note.body,
+      authorDisplayName: note.authorDisplayName,
+      authorId: note.authorId,
+    })),
+  );
 }
 
 function buildPendingTimelineItems(
@@ -837,7 +858,6 @@ async function loadTimelinePresentationContext(
     salesforceCommunicationDetails,
     simpleTextingMessageDetails,
     mailchimpCampaignActivityDetails,
-    manualNoteDetails,
   ] = (await Promise.all([
     repositories.gmailMessageDetails.listBySourceEvidenceIds(sourceEvidenceIds),
     repositories.salesforceEventContext.listBySourceEvidenceIds(
@@ -852,14 +872,12 @@ async function loadTimelinePresentationContext(
     repositories.mailchimpCampaignActivityDetails.listBySourceEvidenceIds(
       sourceEvidenceIds,
     ),
-    repositories.manualNoteDetails.listBySourceEvidenceIds(sourceEvidenceIds),
   ])) as [
     readonly GmailMessageDetailRecord[],
     readonly SalesforceEventContextDetail[],
     readonly SalesforceCommunicationDetail[],
     readonly SimpleTextingMessageDetail[],
     readonly MailchimpCampaignActivityDetail[],
-    readonly ManualNoteDetail[],
   ];
 
   const [projectDimensions, expeditionDimensions] = await Promise.all([
@@ -896,9 +914,6 @@ async function loadTimelinePresentationContext(
         detail,
       ]),
     ),
-    manualNoteDetailBySourceEvidenceId: new Map(
-      manualNoteDetails.map((detail) => [detail.sourceEvidenceId, detail]),
-    ),
     projectNameById: new Map(
       projectDimensions.map((dimension) => [
         dimension.projectId,
@@ -924,7 +939,7 @@ function buildTimelineItemsFromRows(input: {
   for (const row of input.timelineRows) {
     const event = input.canonicalEventById.get(row.canonicalEventId);
 
-    if (event === undefined) {
+    if (event === undefined || isInternalNoteEvent(event)) {
       continue;
     }
 
@@ -951,8 +966,6 @@ function buildTimelineItemsFromRows(input: {
     const mailchimpDetail = input.context.mailchimpDetailBySourceEvidenceId.get(
       evidence.id,
     );
-    const manualNoteDetail =
-      input.context.manualNoteDetailBySourceEvidenceId.get(evidence.id);
 
     switch (family) {
       case "salesforce_event":
@@ -1084,17 +1097,6 @@ function buildTimelineItemsFromRows(input: {
             null,
         });
         break;
-      case "internal_note":
-        items.push({
-          ...base,
-          family,
-          noteId:
-            manualNoteDetail?.providerRecordId ?? evidence.providerRecordId,
-          body: manualNoteDetail?.body ?? "",
-          authorDisplayName: manualNoteDetail?.authorDisplayName ?? null,
-          authorId: manualNoteDetail?.authorId ?? null,
-        });
-        break;
     }
   }
 
@@ -1106,21 +1108,26 @@ export function createStage1TimelinePresentationService(
 ): Stage1TimelinePresentationService {
   return {
     async listTimelineItemsByContactId(contactId) {
-      const [canonicalEvents, timelineRows, pendingRows] = await Promise.all([
+      const [canonicalEvents, timelineRows, pendingRows, internalNotes] =
+        await Promise.all([
         repositories.canonicalEvents.listByContactId(contactId),
         repositories.timelineProjection.listByContactId(contactId),
         repositories.pendingOutbounds.findForContact(contactId, {
           limit: Number.MAX_SAFE_INTEGER,
         }),
-      ]);
+          repositories.internalNotes.findByContactId(contactId),
+        ]);
+      const canonicalTimelineEvents = canonicalEvents.filter(
+        (event) => !isInternalNoteEvent(event),
+      );
       const canonicalEventById = new Map(
-        canonicalEvents.map((event) => [event.id, event]),
+        canonicalTimelineEvents.map((event) => [event.id, event]),
       );
       const context = await loadTimelinePresentationContext(
         repositories,
-        canonicalEvents,
+        canonicalTimelineEvents,
       );
-      const canonicalItems = collapseDuplicateTimelineItems({
+      const mergedCanonicalItems = collapseDuplicateTimelineItems({
         canonicalItems: buildTimelineItemsFromRows({
           timelineRows,
           canonicalEventById,
@@ -1128,6 +1135,9 @@ export function createStage1TimelinePresentationService(
         }),
         canonicalEventById,
       });
+      const canonicalItems = [...mergedCanonicalItems, ...buildInternalNoteTimelineItems(internalNotes)].sort(
+        (left, right) => left.sortKey.localeCompare(right.sortKey),
+      );
 
       return mergeTimelineItems({
         canonicalItems,
@@ -1136,27 +1146,32 @@ export function createStage1TimelinePresentationService(
     },
 
     async listTimelineItemsPageByContactId(contactId, input) {
-      const [canonicalEvents, rows, pendingRows] = await Promise.all([
+      const [canonicalEvents, rows, pendingRows, internalNotes] =
+        await Promise.all([
         repositories.canonicalEvents.listByContactId(contactId),
         repositories.timelineProjection.listByContactId(contactId),
         repositories.pendingOutbounds.findForContact(contactId, {
           limit: Number.MAX_SAFE_INTEGER,
         }),
-      ]);
+          repositories.internalNotes.findByContactId(contactId),
+        ]);
+      const canonicalTimelineEvents = canonicalEvents.filter(
+        (event) => !isInternalNoteEvent(event),
+      );
       const canonicalEventById = new Map(
-        canonicalEvents.map((event) => [event.id, event]),
+        canonicalTimelineEvents.map((event) => [event.id, event]),
       );
       const context = await loadTimelinePresentationContext(
         repositories,
-        canonicalEvents,
+        canonicalTimelineEvents,
       );
       warnTimelineProjectionGaps({
         contactId,
-        canonicalEvents,
+        canonicalEvents: canonicalTimelineEvents,
         timelineRows: rows,
         context,
       });
-      const canonicalItems = collapseDuplicateTimelineItems({
+      const mergedCanonicalItems = collapseDuplicateTimelineItems({
         canonicalItems: buildTimelineItemsFromRows({
           timelineRows: rows,
           canonicalEventById,
@@ -1164,6 +1179,9 @@ export function createStage1TimelinePresentationService(
         }),
         canonicalEventById,
       });
+      const canonicalItems = [...mergedCanonicalItems, ...buildInternalNoteTimelineItems(internalNotes)].sort(
+        (left, right) => left.sortKey.localeCompare(right.sortKey),
+      );
       const mergedItems = mergeTimelineItems({
         canonicalItems,
         pendingRows,

--- a/packages/domain/test/normalization.test.ts
+++ b/packages/domain/test/normalization.test.ts
@@ -402,6 +402,7 @@ function buildContext(input: {
       create: (input) =>
         Promise.resolve({
           ...input,
+          authorDisplayName: null,
           createdAt: new Date(0),
           updatedAt: new Date(0),
         }),
@@ -412,6 +413,7 @@ function buildContext(input: {
           id: input.id,
           contactId: "contact_1",
           body: input.body,
+          authorDisplayName: "Author",
           authorId: "user:author",
           createdAt: new Date(0),
           updatedAt: new Date(0),

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -121,6 +121,7 @@ describe("defineStage1RepositoryBundle", () => {
         create: (input) =>
           Promise.resolve({
             ...input,
+            authorDisplayName: null,
             createdAt: new Date(0),
             updatedAt: new Date(0),
           }),
@@ -131,6 +132,7 @@ describe("defineStage1RepositoryBundle", () => {
             id: input.id,
             contactId: "contact_1",
             body: input.body,
+            authorDisplayName: "User 1",
             authorId: "user_1",
             createdAt: new Date(0),
             updatedAt: new Date(0),

--- a/packages/domain/test/stage3-internal-note-service.test.ts
+++ b/packages/domain/test/stage3-internal-note-service.test.ts
@@ -1,14 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 
-import type {
-  CanonicalEventRecord,
-  InboxProjectionRow,
-  ManualNoteDetailRecord,
-  SourceEvidenceRecord,
-  TimelineProjectionRow,
-} from "@as-comms/contracts";
-
 import { createStage1InternalNoteService } from "../src/notes.js";
+import type {
+  InternalNoteRecord,
+  InternalNoteRepository,
+} from "../src/repositories.js";
 
 function buildContact() {
   return {
@@ -22,135 +18,160 @@ function buildContact() {
   };
 }
 
-describe("Stage1InternalNoteService", () => {
-  it("passes authorId through createNote", async () => {
-    const upsertManualNoteDetail = vi.fn((record: ManualNoteDetailRecord) =>
-      Promise.resolve(record),
-    );
+function createHarness() {
+  const notes = new Map<string, InternalNoteRecord>();
+  let timestamp = Date.parse("2026-04-21T12:00:00.000Z");
 
-    const service = createStage1InternalNoteService({
-      persistence: {
-        repositories: {
-          contacts: {
-            findById: vi.fn(() => Promise.resolve(buildContact())),
-          },
-          sourceEvidence: {
-            findById: vi.fn(() => Promise.resolve(null)),
-          },
-          canonicalEvents: {
-            findById: vi.fn(() => Promise.resolve(null)),
-          },
-          manualNoteDetails: {
-            listBySourceEvidenceIds: vi.fn(() => Promise.resolve([])),
-            findLatestForContact: vi.fn(() => Promise.resolve(null)),
-            updateBody: vi.fn(() => Promise.resolve(null)),
-            deleteByAuthor: vi.fn(() => Promise.resolve(0)),
-          },
+  const recordSourceEvidence = vi.fn();
+  const persistCanonicalEvent = vi.fn();
+  const upsertManualNoteDetail = vi.fn();
+  const applyTimelineProjection = vi.fn();
+  const refreshInboxReviewOverlay = vi.fn();
+
+  const service = createStage1InternalNoteService({
+    persistence: {
+      repositories: {
+        contacts: {
+          findById: vi.fn(() => Promise.resolve(buildContact())),
         },
-        recordSourceEvidence: vi.fn(
-          (record: SourceEvidenceRecord) =>
-            ({ outcome: "inserted", record }) as const,
-        ),
-        persistCanonicalEvent: vi.fn(
-          (record: CanonicalEventRecord) =>
-            ({ outcome: "inserted", record }) as const,
-        ),
-        upsertManualNoteDetail,
-      } as never,
-      normalization: {
-        applyTimelineProjection: vi.fn(
-          (...args: unknown[]): Promise<TimelineProjectionRow> => {
-            void args;
-            return Promise.resolve({
-              id: "timeline:note-1",
-              contactId: "contact:one",
-              canonicalEventId: "canonical-event:manual:note:note-1",
-              occurredAt: "2026-04-21T12:00:00.000Z",
-              sortKey:
-                "2026-04-21T12:00:00.000Z::canonical-event:manual:note:note-1",
-              eventType: "note.internal.created",
-              summary: "Internal note added",
-              channel: "note",
-              primaryProvider: "manual",
-              reviewState: "clear",
-            } satisfies TimelineProjectionRow);
-          },
-        ),
-        refreshInboxReviewOverlay: vi.fn(() =>
-          Promise.resolve(null as InboxProjectionRow | null),
-        ),
-      },
-    });
+        internalNotes: {
+          create: vi.fn((input: Parameters<InternalNoteRepository["create"]>[0]) => {
+            const createdAt = input.createdAt ?? new Date((timestamp += 1_000));
+            const updatedAt = input.updatedAt ?? createdAt;
+            const record: InternalNoteRecord = {
+              id: input.id,
+              contactId: input.contactId,
+              body: input.body,
+              authorDisplayName:
+                input.authorId === "user:author" ? "Author User" : null,
+              authorId: input.authorId,
+              createdAt,
+              updatedAt,
+            };
+            notes.set(record.id, record);
+            return Promise.resolve(record);
+          }),
+          findById: vi.fn((id: string) => Promise.resolve(notes.get(id))),
+          findByContactId: vi.fn((contactId: string) =>
+            Promise.resolve(
+              [...notes.values()].filter((note) => note.contactId === contactId),
+            ),
+          ),
+          update: vi.fn((input: Parameters<InternalNoteRepository["update"]>[0]) => {
+            const existing = notes.get(input.id);
+            if (existing === undefined) {
+              throw new Error(`Missing note ${input.id}`);
+            }
 
-    await service.createNote({
+            const updated: InternalNoteRecord = {
+              ...existing,
+              body: input.body,
+              updatedAt: input.updatedAt ?? new Date((timestamp += 1_000)),
+            };
+            notes.set(updated.id, updated);
+            return Promise.resolve(updated);
+          }),
+          delete: vi.fn((id: string) => {
+            notes.delete(id);
+            return Promise.resolve();
+          }),
+        },
+      },
+      recordSourceEvidence,
+      persistCanonicalEvent,
+      upsertManualNoteDetail,
+    } as never,
+    normalization: {
+      applyTimelineProjection,
+      refreshInboxReviewOverlay,
+    },
+  });
+
+  return {
+    notes,
+    recordSourceEvidence,
+    persistCanonicalEvent,
+    upsertManualNoteDetail,
+    applyTimelineProjection,
+    refreshInboxReviewOverlay,
+    service,
+  };
+}
+
+describe("Stage1InternalNoteService", () => {
+  it("creates a single internal_notes row and returns it without legacy writes", async () => {
+    const harness = createHarness();
+
+    const result = await harness.service.createNote({
       noteId: "note-1",
       contactId: "contact:one",
       body: "Author-owned note",
       occurredAt: "2026-04-21T12:00:00.000Z",
-      authorDisplayName: "Operator",
+      authorDisplayName: "Author User",
       authorId: "user:author",
     });
 
-    expect(upsertManualNoteDetail).toHaveBeenCalledWith(
-      expect.objectContaining({
+    expect(result).toMatchObject({
+      outcome: "applied",
+      note: {
+        id: "note-1",
+        contactId: "contact:one",
+        body: "Author-owned note",
         authorId: "user:author",
-      }),
-    );
+      },
+    });
+    expect(harness.notes.get("note-1")).toMatchObject({
+      id: "note-1",
+      body: "Author-owned note",
+    });
+    expect(harness.recordSourceEvidence).not.toHaveBeenCalled();
+    expect(harness.persistCanonicalEvent).not.toHaveBeenCalled();
+    expect(harness.upsertManualNoteDetail).not.toHaveBeenCalled();
+    expect(harness.applyTimelineProjection).not.toHaveBeenCalled();
+    expect(harness.refreshInboxReviewOverlay).not.toHaveBeenCalled();
   });
 
-  it("returns not_authorized when a non-author tries to update a note", async () => {
-    const service = createStage1InternalNoteService({
-      persistence: {
-        repositories: {
-          contacts: {
-            findById: vi.fn(() => Promise.resolve(buildContact())),
-          },
-          sourceEvidence: {
-            findById: vi.fn(
-              () =>
-                ({
-                  id: "source-evidence:manual:note:note-2",
-                  provider: "manual",
-                  providerRecordType: "note",
-                  providerRecordId: "note-2",
-                  receivedAt: "2026-04-21T12:00:00.000Z",
-                  occurredAt: "2026-04-21T12:00:00.000Z",
-                  payloadRef: "manual://note/note-2",
-                  idempotencyKey: "manual:note:note-2",
-                  checksum: "checksum-note-2",
-                }) satisfies SourceEvidenceRecord,
-            ),
-          },
-          canonicalEvents: {
-            findById: vi.fn(() => Promise.resolve(null)),
-          },
-          manualNoteDetails: {
-            listBySourceEvidenceIds: vi.fn(
-              () =>
-                [
-                  {
-                    sourceEvidenceId: "source-evidence:manual:note:note-2",
-                    providerRecordId: "note-2",
-                    body: "Original",
-                    authorDisplayName: "Author",
-                    authorId: "user:author",
-                  },
-                ] satisfies ManualNoteDetailRecord[],
-            ),
-            findLatestForContact: vi.fn(() => Promise.resolve(null)),
-            updateBody: vi.fn(() => Promise.resolve(null)),
-            deleteByAuthor: vi.fn(() => Promise.resolve(0)),
-          },
-        },
-      } as never,
-      normalization: {
-        applyTimelineProjection: vi.fn(),
-        refreshInboxReviewOverlay: vi.fn(() => Promise.resolve(null)),
-      },
+  it("is idempotent on noteId", async () => {
+    const harness = createHarness();
+
+    await harness.service.createNote({
+      noteId: "note-1",
+      contactId: "contact:one",
+      body: "First body",
+      occurredAt: "2026-04-21T12:00:00.000Z",
+      authorId: "user:author",
     });
 
     await expect(
-      service.updateNote({
+      harness.service.createNote({
+        noteId: "note-1",
+        contactId: "contact:one",
+        body: "Second body",
+        occurredAt: "2026-04-21T12:05:00.000Z",
+        authorId: "user:author",
+      }),
+    ).resolves.toMatchObject({
+      outcome: "duplicate",
+      note: {
+        id: "note-1",
+        body: "First body",
+      },
+    });
+  });
+
+  it("enforces author-only updates", async () => {
+    const harness = createHarness();
+
+    await harness.service.createNote({
+      noteId: "note-2",
+      contactId: "contact:one",
+      body: "Original",
+      occurredAt: "2026-04-21T12:00:00.000Z",
+      authorId: "user:author",
+    });
+
+    await expect(
+      harness.service.updateNote({
         noteId: "note-2",
         authorId: "user:other",
         body: "Updated",
@@ -160,91 +181,110 @@ describe("Stage1InternalNoteService", () => {
     });
   });
 
-  it("returns not_authorized when a non-author tries to delete a note", async () => {
-    const service = createStage1InternalNoteService({
-      persistence: {
-        repositories: {
-          contacts: {
-            findById: vi.fn(() => Promise.resolve(buildContact())),
-          },
-          sourceEvidence: {
-            findById: vi.fn(
-              () =>
-                ({
-                  id: "source-evidence:manual:note:note-3",
-                  provider: "manual",
-                  providerRecordType: "note",
-                  providerRecordId: "note-3",
-                  receivedAt: "2026-04-21T12:00:00.000Z",
-                  occurredAt: "2026-04-21T12:00:00.000Z",
-                  payloadRef: "manual://note/note-3",
-                  idempotencyKey: "manual:note:note-3",
-                  checksum: "checksum-note-3",
-                }) satisfies SourceEvidenceRecord,
-            ),
-          },
-          canonicalEvents: {
-            findById: vi.fn(
-              () =>
-                ({
-                  id: "canonical-event:manual:note:note-3",
-                  contactId: "contact:one",
-                  eventType: "note.internal.created",
-                  channel: "note",
-                  occurredAt: "2026-04-21T12:00:00.000Z",
-                  sourceEvidenceId: "source-evidence:manual:note:note-3",
-                  idempotencyKey: "canonical-event:manual:note:note-3",
-                  contentFingerprint: null,
-                  provenance: {
-                    primaryProvider: "manual",
-                    primarySourceEvidenceId:
-                      "source-evidence:manual:note:note-3",
-                    supportingSourceEvidenceIds: [],
-                    winnerReason: "single_source",
-                    sourceRecordType: "note",
-                    sourceRecordId: "note-3",
-                    messageKind: null,
-                    campaignRef: null,
-                    threadRef: null,
-                    direction: null,
-                    notes: null,
-                  },
-                  reviewState: "clear",
-                }) satisfies CanonicalEventRecord,
-            ),
-          },
-          manualNoteDetails: {
-            listBySourceEvidenceIds: vi.fn(
-              () =>
-                [
-                  {
-                    sourceEvidenceId: "source-evidence:manual:note:note-3",
-                    providerRecordId: "note-3",
-                    body: "Original",
-                    authorDisplayName: "Author",
-                    authorId: "user:author",
-                  },
-                ] satisfies ManualNoteDetailRecord[],
-            ),
-            findLatestForContact: vi.fn(() => Promise.resolve(null)),
-            updateBody: vi.fn(() => Promise.resolve(null)),
-            deleteByAuthor: vi.fn(() => Promise.resolve(0)),
-          },
-        },
-      } as never,
-      normalization: {
-        applyTimelineProjection: vi.fn(),
-        refreshInboxReviewOverlay: vi.fn(() => Promise.resolve(null)),
-      },
+  it("bumps updatedAt when an update applies", async () => {
+    const harness = createHarness();
+
+    const created = await harness.service.createNote({
+      noteId: "note-3",
+      contactId: "contact:one",
+      body: "Before",
+      occurredAt: "2026-04-21T12:00:00.000Z",
+      authorId: "user:author",
     });
 
     await expect(
-      service.deleteNote({
+      harness.service.updateNote({
         noteId: "note-3",
+        authorId: "user:author",
+        body: "After",
+      }),
+    ).resolves.toEqual({
+      outcome: "applied",
+    });
+
+    const updated = harness.notes.get("note-3");
+    expect(updated?.body).toBe("After");
+    expect(updated?.updatedAt.getTime()).toBeGreaterThan(
+      created.note.updatedAt.getTime(),
+    );
+  });
+
+  it("deletes a note for the author", async () => {
+    const harness = createHarness();
+
+    await harness.service.createNote({
+      noteId: "note-4",
+      contactId: "contact:one",
+      body: "Delete me",
+      occurredAt: "2026-04-21T12:00:00.000Z",
+      authorId: "user:author",
+    });
+
+    await expect(
+      harness.service.deleteNote({
+        noteId: "note-4",
+        authorId: "user:author",
+      }),
+    ).resolves.toEqual({
+      outcome: "applied",
+    });
+    expect(harness.notes.has("note-4")).toBe(false);
+  });
+
+  it("returns not_authorized when a non-author non-admin deletes a note", async () => {
+    const harness = createHarness();
+
+    await harness.service.createNote({
+      noteId: "note-5",
+      contactId: "contact:one",
+      body: "Protected",
+      occurredAt: "2026-04-21T12:00:00.000Z",
+      authorId: "user:author",
+    });
+
+    await expect(
+      harness.service.deleteNote({
+        noteId: "note-5",
         authorId: "user:other",
       }),
     ).resolves.toEqual({
       outcome: "not_authorized",
+    });
+  });
+
+  it("allows admins to delete another author's note", async () => {
+    const harness = createHarness();
+
+    await harness.service.createNote({
+      noteId: "note-6",
+      contactId: "contact:one",
+      body: "Admin removable",
+      occurredAt: "2026-04-21T12:00:00.000Z",
+      authorId: "user:author",
+    });
+
+    await expect(
+      harness.service.deleteNote({
+        noteId: "note-6",
+        authorId: "user:admin",
+        actorIsAdmin: true,
+      }),
+    ).resolves.toEqual({
+      outcome: "applied",
+    });
+    expect(harness.notes.has("note-6")).toBe(false);
+  });
+
+  it("returns not_found when deleting a missing note", async () => {
+    const harness = createHarness();
+
+    await expect(
+      harness.service.deleteNote({
+        noteId: "note-missing",
+        authorId: "user:author",
+      }),
+    ).resolves.toEqual({
+      outcome: "not_found",
     });
   });
 });

--- a/packages/domain/test/stage3-last-inbound-alias.test.ts
+++ b/packages/domain/test/stage3-last-inbound-alias.test.ts
@@ -140,6 +140,7 @@ function buildRepositoryBundle(input: {
       create: (input) =>
         Promise.resolve({
           ...input,
+          authorDisplayName: null,
           createdAt: new Date(0),
           updatedAt: new Date(0),
         }),
@@ -150,6 +151,7 @@ function buildRepositoryBundle(input: {
           id: input.id,
           contactId: "contact:volunteer",
           body: input.body,
+          authorDisplayName: "Author",
           authorId: "user:author",
           createdAt: new Date(0),
           updatedAt: new Date(0),

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -14,6 +14,7 @@ import type {
 } from "@as-comms/contracts";
 
 import {
+  type InternalNoteRecord,
   type Stage1RepositoryBundle,
   defineStage1RepositoryBundle,
 } from "../src/repositories.js";
@@ -37,6 +38,7 @@ function createRepositoryBundle(input: {
   readonly gmailMessageDetails?: readonly GmailMessageDetailRecord[];
   readonly messageAttachments?: readonly MessageAttachmentRecord[];
   readonly mailchimpCampaignActivityDetails?: readonly MailchimpCampaignActivityDetailRecord[];
+  readonly internalNotes?: readonly InternalNoteRecord[];
   readonly timelineRows: readonly TimelineProjectionRow[];
   readonly pendingOutbounds?: readonly PendingComposerOutboundRecord[];
 }): Stage1RepositoryBundle {
@@ -245,16 +247,23 @@ function createRepositoryBundle(input: {
       create: (input) =>
         Promise.resolve({
           ...input,
+          authorDisplayName: null,
           createdAt: new Date(0),
           updatedAt: new Date(0),
         }),
       findById: () => Promise.resolve(undefined),
-      findByContactId: () => Promise.resolve([]),
+      findByContactId: (contactId, limit) =>
+        Promise.resolve(
+          (input.internalNotes ?? [])
+            .filter((note) => note.contactId === contactId)
+            .slice(0, limit),
+        ),
       update: (input) =>
         Promise.resolve({
           id: input.id,
           contactId: "contact_1",
           body: input.body,
+          authorDisplayName: "Author",
           authorId: "user:author",
           createdAt: new Date(0),
           updatedAt: new Date(0),
@@ -597,6 +606,25 @@ function buildMailchimpCampaignEmailEvent(input: {
       primaryProvider: "mailchimp",
       reviewState: "clear",
     },
+  };
+}
+
+function buildInternalNote(input: {
+  readonly id: string;
+  readonly contactId?: string;
+  readonly body: string;
+  readonly authorDisplayName?: string | null;
+  readonly authorId?: string;
+  readonly createdAt: string;
+}): InternalNoteRecord {
+  return {
+    id: input.id,
+    contactId: input.contactId ?? "contact_1",
+    body: input.body,
+    authorDisplayName: input.authorDisplayName ?? null,
+    authorId: input.authorId ?? "user:author",
+    createdAt: new Date(input.createdAt),
+    updatedAt: new Date(input.createdAt),
   };
 }
 
@@ -1292,5 +1320,232 @@ describe("Stage 1 timeline presenter", () => {
       canonicalEventId: "evt_one_to_one_1",
       family: "one_to_one_email",
     });
+  });
+
+  it("interleaves internal notes with canonical events by occurredAt", async () => {
+    const firstEvent = buildSalesforceEmailEvent({
+      id: "evt_t0",
+      sourceEvidenceId: "sev_t0",
+      occurredAt: "2026-01-01T00:00:00.000Z",
+      direction: "outbound",
+      canonicalMessageKind: "one_to_one",
+      subject: "First event",
+      snippet: "First event body",
+    });
+    const secondEvent = buildSalesforceEmailEvent({
+      id: "evt_t2",
+      sourceEvidenceId: "sev_t2",
+      occurredAt: "2026-01-01T00:00:02.000Z",
+      direction: "outbound",
+      canonicalMessageKind: "one_to_one",
+      subject: "Second event",
+      snippet: "Second event body",
+    });
+    const repositories = createRepositoryBundle({
+      canonicalEvents: [firstEvent.canonicalEvent, secondEvent.canonicalEvent],
+      sourceEvidence: [
+        buildSourceEvidence({
+          id: "sev_t0",
+          providerRecordId: "timeline-t0",
+        }),
+        buildSourceEvidence({
+          id: "sev_t2",
+          providerRecordId: "timeline-t2",
+        }),
+      ],
+      salesforceCommunicationDetails: [firstEvent.detail, secondEvent.detail],
+      internalNotes: [
+        buildInternalNote({
+          id: "note_t1",
+          body: "Interleaved note",
+          authorDisplayName: "Author",
+          createdAt: "2026-01-01T00:00:01.000Z",
+        }),
+      ],
+      timelineRows: [firstEvent.timelineRow, secondEvent.timelineRow],
+    });
+    const presenter = createStage1TimelinePresentationService(repositories);
+
+    const items = await presenter.listTimelineItemsByContactId("contact_1");
+
+    expect(items.map((item) => item.canonicalEventId)).toEqual([
+      "evt_t0",
+      "note:note_t1",
+      "evt_t2",
+    ]);
+  });
+
+  it("uses a deterministic sort-key tiebreaker when a note and event share a timestamp", async () => {
+    const event = buildSalesforceEmailEvent({
+      id: "evt_same_time",
+      sourceEvidenceId: "sev_same_time",
+      occurredAt: "2026-01-01T00:00:00.000Z",
+      direction: "outbound",
+      canonicalMessageKind: "one_to_one",
+      subject: "Same timestamp",
+      snippet: "Canonical event",
+    });
+    const repositories = createRepositoryBundle({
+      canonicalEvents: [event.canonicalEvent],
+      sourceEvidence: [
+        buildSourceEvidence({
+          id: "sev_same_time",
+          providerRecordId: "same-time",
+        }),
+      ],
+      salesforceCommunicationDetails: [event.detail],
+      internalNotes: [
+        buildInternalNote({
+          id: "note_same_time",
+          body: "Same timestamp note",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        }),
+      ],
+      timelineRows: [event.timelineRow],
+    });
+    const presenter = createStage1TimelinePresentationService(repositories);
+
+    const items = await presenter.listTimelineItemsByContactId("contact_1");
+
+    expect(items.map((item) => item.canonicalEventId)).toEqual([
+      "evt_same_time",
+      "note:note_same_time",
+    ]);
+  });
+
+  it("paginates across interleaved canonical events and internal notes without drops or duplicates", async () => {
+    const event0 = buildSalesforceEmailEvent({
+      id: "evt_page_0",
+      sourceEvidenceId: "sev_page_0",
+      occurredAt: "2026-01-01T00:00:00.000Z",
+      direction: "outbound",
+      canonicalMessageKind: "one_to_one",
+      subject: "Page 0",
+      snippet: "Page 0 body",
+    });
+    const event2 = buildSalesforceEmailEvent({
+      id: "evt_page_2",
+      sourceEvidenceId: "sev_page_2",
+      occurredAt: "2026-01-01T00:00:02.000Z",
+      direction: "outbound",
+      canonicalMessageKind: "one_to_one",
+      subject: "Page 2",
+      snippet: "Page 2 body",
+    });
+    const event4 = buildSalesforceEmailEvent({
+      id: "evt_page_4",
+      sourceEvidenceId: "sev_page_4",
+      occurredAt: "2026-01-01T00:00:04.000Z",
+      direction: "outbound",
+      canonicalMessageKind: "one_to_one",
+      subject: "Page 4",
+      snippet: "Page 4 body",
+    });
+    const repositories = createRepositoryBundle({
+      canonicalEvents: [
+        event0.canonicalEvent,
+        event2.canonicalEvent,
+        event4.canonicalEvent,
+      ],
+      sourceEvidence: [
+        buildSourceEvidence({
+          id: "sev_page_0",
+          providerRecordId: "page-0",
+        }),
+        buildSourceEvidence({
+          id: "sev_page_2",
+          providerRecordId: "page-2",
+        }),
+        buildSourceEvidence({
+          id: "sev_page_4",
+          providerRecordId: "page-4",
+        }),
+      ],
+      salesforceCommunicationDetails: [
+        event0.detail,
+        event2.detail,
+        event4.detail,
+      ],
+      internalNotes: [
+        buildInternalNote({
+          id: "note_page_1",
+          body: "Page 1",
+          createdAt: "2026-01-01T00:00:01.000Z",
+        }),
+        buildInternalNote({
+          id: "note_page_3",
+          body: "Page 3",
+          createdAt: "2026-01-01T00:00:03.000Z",
+        }),
+      ],
+      timelineRows: [event0.timelineRow, event2.timelineRow, event4.timelineRow],
+    });
+    const presenter = createStage1TimelinePresentationService(repositories);
+
+    const page1 = await presenter.listTimelineItemsPageByContactId("contact_1", {
+      limit: 2,
+      beforeSortKey: null,
+    });
+    const page2 = await presenter.listTimelineItemsPageByContactId("contact_1", {
+      limit: 2,
+      beforeSortKey: page1.nextBeforeSortKey,
+    });
+    const page3 = await presenter.listTimelineItemsPageByContactId("contact_1", {
+      limit: 2,
+      beforeSortKey: page2.nextBeforeSortKey,
+    });
+
+    expect(page1.total).toBe(5);
+    expect(page1.items.map((item) => item.canonicalEventId)).toEqual([
+      "note:note_page_3",
+      "evt_page_4",
+    ]);
+    expect(page2.items.map((item) => item.canonicalEventId)).toEqual([
+      "note:note_page_1",
+      "evt_page_2",
+    ]);
+    expect(page3.items.map((item) => item.canonicalEventId)).toEqual([
+      "evt_page_0",
+    ]);
+    expect([
+      ...page1.items,
+      ...page2.items,
+      ...page3.items,
+    ].map((item) => item.canonicalEventId)).toEqual([
+      "note:note_page_3",
+      "evt_page_4",
+      "note:note_page_1",
+      "evt_page_2",
+      "evt_page_0",
+    ]);
+  });
+
+  it("does not collapse duplicate internal notes", async () => {
+    const repositories = createRepositoryBundle({
+      canonicalEvents: [],
+      sourceEvidence: [],
+      salesforceCommunicationDetails: [],
+      internalNotes: [
+        buildInternalNote({
+          id: "note_dup_1",
+          body: "Same body",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        }),
+        buildInternalNote({
+          id: "note_dup_2",
+          body: "Same body",
+          createdAt: "2026-01-01T00:04:00.000Z",
+        }),
+      ],
+      timelineRows: [],
+    });
+    const presenter = createStage1TimelinePresentationService(repositories);
+
+    const items = await presenter.listTimelineItemsByContactId("contact_1");
+
+    expect(items.map((item) => item.canonicalEventId)).toEqual([
+      "note:note_dup_1",
+      "note:note_dup_2",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

**B2 of two sequential PRs** in the Notes architecture refactor per [`PRD-notes-architecture-separate-table-2026-04-29`](.PRD-notes-architecture-separate-table-2026-04-29.md).

[B1 (#209)](https://github.com/nico-kneler-as/as-comms-platform/pull/209) introduced the `internal_notes` table + `InternalNoteRepository`. This PR flips writers and the timeline read so the legacy four-row pattern is gone. After this merges, notes are isolated from `canonical_event_ledger` / `contact_timeline_projection` per locked decision D-029.

## Domain `notes.ts` rewrite

Single-row writes via `InternalNoteRepository`:
- `createNote` — single row insert, no canonical event, no projection call, no manual_note_details write
- `updateNote` — author-only edit (Q6)
- `deleteNote` — hard delete (Q5), author OR admin (Q6)
- Idempotent on `noteId` via PK conflict

## Domain `timeline.ts` UNION rewrite

Both `listTimelineItemsByContactId` and `listTimelineItemsPageByContactId` fetch `internal_notes` alongside canonical events and merge chronologically by `occurred_at`. Notes get `canonicalEventId = "note:<id>"` synthesized per Q3.

Notes excluded from the canonical-event duplicate-collapse window — they have their own collision shape.

## UI swap

- `apps/web/app/inbox/actions.ts` — create/update/delete via new flow; admin flag threaded for delete
- `apps/web/app/inbox/_lib/selectors.ts` — pinned/latest-note lookups switched to `internalNotes`

## Tests

Domain note service tests fully rewritten for new storage. Timeline UNION ordering tests added (chronological interleaving + auto_email dedup preserved). UI tests cover admin-delete authorization. Internal_notes fixture shape across all relevant test files.

## Test plan

- [x] `pnpm typecheck && pnpm lint` clean (VALIDATION_PASSED locally; `test:unit` skipped per new dispatch policy — CI authoritative)
- [ ] CI green
- [ ] After merge: verify a fresh note create/edit/delete cycle works in the inbox UI (no canonical_event_ledger writes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)