### PR TITLE
fix(integrations): bump provider-text caps to unblock SF live capture (P0)

### DIFF
--- a/packages/integrations/src/capture-services/salesforce.ts
+++ b/packages/integrations/src/capture-services/salesforce.ts
@@ -47,7 +47,7 @@ import {
   uniqueValues,
 } from "./shared.js";
 
-const SALESFORCE_CAPTURE_TASK_SNIPPET_MAX = 2_000;
+const SALESFORCE_CAPTURE_TASK_SNIPPET_MAX = 10_000;
 
 const salesforceCaptureServiceResponseSchema =
   createCapturedBatchResponseSchema(salesforceRecordSchema);

--- a/packages/integrations/src/providers/gmail.ts
+++ b/packages/integrations/src/providers/gmail.ts
@@ -25,8 +25,8 @@ const nullableStringSchema = z.string().min(1).nullable();
 const stringArraySchema = z.array(z.string().min(1));
 const timestampSchema = z.string().datetime();
 const nullableStringArraySchema = z.array(z.string().min(1)).nullable();
-const GMAIL_SNIPPET_MAX = 2_000;
-const GMAIL_BODY_PREVIEW_MAX = 20_000;
+const GMAIL_SNIPPET_MAX = 10_000;
+const GMAIL_BODY_PREVIEW_MAX = 100_000;
 
 export const gmailMessageRecordSchema = z.object({
   recordType: z.literal("message"),

--- a/packages/integrations/src/providers/salesforce.ts
+++ b/packages/integrations/src/providers/salesforce.ts
@@ -29,7 +29,7 @@ import {
 const nullableStringSchema = z.string().min(1).nullable();
 const stringArraySchema = z.array(z.string().min(1));
 const timestampSchema = z.string().datetime();
-const SALESFORCE_TASK_SNIPPET_MAX = 20_000;
+const SALESFORCE_TASK_SNIPPET_MAX = 100_000;
 
 const salesforceLifecycleMilestoneSchema = z.enum([
   "signed_up",

--- a/packages/integrations/test/gmail-body-extraction.test.ts
+++ b/packages/integrations/test/gmail-body-extraction.test.ts
@@ -129,9 +129,9 @@ describe("Gmail body extraction", () => {
       receivedAt: "2026-01-01T00:01:00.000Z",
       payloadRef: "payloads/gmail/gmail-oversized-1.json",
       checksum: "checksum-oversized-1",
-      snippet: "x".repeat(2_001),
-      snippetClean: "x".repeat(2_001),
-      bodyTextPreview: "x".repeat(20_001),
+      snippet: "x".repeat(10_001),
+      snippetClean: "x".repeat(10_001),
+      bodyTextPreview: "x".repeat(100_001),
       normalizedParticipantEmails: ["volunteer@example.org"],
     });
 

--- a/packages/integrations/test/stage1-mappers.test.ts
+++ b/packages/integrations/test/stage1-mappers.test.ts
@@ -70,7 +70,7 @@ describe("Stage 1 provider-close mappers", () => {
       receivedAt: "2026-01-01T00:01:00.000Z",
       payloadRef: "salesforce://Task/task-oversized-1",
       checksum: "checksum-task-oversized-1",
-      snippet: "x".repeat(20_001)
+      snippet: "x".repeat(100_001)
     });
 
     expect(result.success).toBe(false);

--- a/packages/integrations/test/stage1-salesforce-capture-service.test.ts
+++ b/packages/integrations/test/stage1-salesforce-capture-service.test.ts
@@ -341,7 +341,7 @@ describe("Salesforce capture service", () => {
                   },
                   TaskSubtype: "Email",
                   Subject: "Outbound follow-up",
-                  Description: "x".repeat(2_001),
+                  Description: "x".repeat(10_001),
                   CreatedDate: "2026-01-05T00:02:00.000Z",
                   LastModifiedDate: "2026-01-05T00:03:00.000Z"
                 }


### PR DESCRIPTION
## Summary — P0 hotfix

Production observation 2026-04-29: Salesforce live capture started 400-ing every cycle after #205 deployed. Real Salesforce Task records have `Description` fields exceeding the 2K cap on the capture-service intake schema. Per the rejection contract, the schema correctly rejected oversized inputs — but the cap was set against pathological-attack-size, not realistic-data-size.

## Caps bumped

| Field | Old | New |
|---|---|---|
| Gmail `snippet` / `snippetClean` | 2K | **10K** |
| Gmail `bodyTextPreview` | 20K | **100K** |
| Salesforce task `snippet` (provider) | 20K | **100K** |
| Salesforce capture-service task snippet intake | 2K | **10K** |

## Why these numbers

- Salesforce `Description` column max is **32K** typed chars. 100K gives 3× realistic headroom.
- Snippet caps at 10K cover any reasonable preview shape (operators don't write 10K-char preview strings).
- Rejection contract preserved — caps only fire on truly pathological payloads now.
- The Logs page (#208) will surface any future overflow events for operator visibility.

## Tests

Test fixtures updated to use just-over-new-cap values for the rejection-path tests.

## Test plan

- [x] `pnpm typecheck && pnpm lint` clean
- [ ] CI green
- [ ] After merge: Salesforce live capture resumes within ~1 cron cycle (5 min)
- [ ] If F3 dead-letter has already fired, the row needs manual unflip (worker `--ops` or direct SQL UPDATE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)