### PR TITLE
fix(worker): F3 follow-up — carry consecutive_failure_count across cron polls

### DIFF
--- a/apps/worker/src/orchestration/sync-state.ts
+++ b/apps/worker/src/orchestration/sync-state.ts
@@ -131,10 +131,24 @@ export function createStage1SyncStateService(
       const existing = await persistence.repositories.syncState.findById(
         input.syncStateId
       );
+      const latestForComposite =
+        existing === null
+          ? await persistence.repositories.syncState.findLatest({
+              scope: input.scope,
+              provider: input.provider,
+              jobType: input.jobType
+            })
+          : null;
 
       if (existing?.status === "succeeded") {
         return existing;
       }
+
+      const carriedFailureCount =
+        existing?.consecutiveFailureCount ??
+        (latestForComposite?.status === "failed"
+          ? latestForComposite.consecutiveFailureCount
+          : 0);
 
       return persistence.saveSyncState(
         toSyncState({
@@ -152,7 +166,7 @@ export function createStage1SyncStateService(
           freshnessP95Seconds: existing?.freshnessP95Seconds ?? null,
           freshnessP99Seconds: existing?.freshnessP99Seconds ?? null,
           lastSuccessfulAt: existing?.lastSuccessfulAt ?? null,
-          consecutiveFailureCount: existing?.consecutiveFailureCount ?? 0,
+          consecutiveFailureCount: carriedFailureCount,
           leaseOwner: WORKER_INSTANCE_ID,
           heartbeatAt: heartbeatTimestamp(),
           deadLetterCount: existing?.deadLetterCount ?? 0

--- a/apps/worker/test/stage1-orchestration.test.ts
+++ b/apps/worker/test/stage1-orchestration.test.ts
@@ -915,6 +915,87 @@ Alias drift outbound message.
     }
   });
 
+  it("dead-letters Salesforce live ingest across 5 distinct sync_state rows (per-poll fresh UUIDs)", async () => {
+    const capture = createEmptyCapturePorts();
+    capture.salesforce.captureLiveBatch = () => {
+      throw new Stage1RetryableJobError("Temporary Salesforce live capture failure.");
+    };
+
+    const context = await createTestWorkerContext({ capture });
+
+    try {
+      for (let attempt = 1; attempt <= 4; attempt += 1) {
+        const pollId = String(attempt);
+        const result = await context.orchestration.runSalesforceLiveCaptureBatch(
+          buildSalesforceLivePayload({
+            syncStateId: `sync:salesforce:live:poll-${pollId}`
+          })
+        );
+
+        expect(result.outcome).toBe("failed");
+        if (result.outcome !== "failed") {
+          throw new Error("Expected Salesforce live cross-poll failure.");
+        }
+
+        expect(result.failure.disposition).toBe("retryable");
+        expect(result.syncState.status).toBe("failed");
+        expect(result.syncState.consecutiveFailureCount).toBe(attempt);
+        expect(result.syncState.deadLetterCount).toBe(0);
+      }
+
+      const deadLettered = await context.orchestration.runSalesforceLiveCaptureBatch(
+        buildSalesforceLivePayload({
+          syncStateId: "sync:salesforce:live:poll-5"
+        })
+      );
+
+      expect(deadLettered.outcome).toBe("failed");
+      if (deadLettered.outcome !== "failed") {
+        throw new Error("Expected fifth cross-poll Salesforce live failure.");
+      }
+
+      expect(deadLettered.failure.disposition).toBe("dead_letter");
+      expect(deadLettered.syncState.status).toBe("quarantined");
+      expect(deadLettered.syncState.consecutiveFailureCount).toBe(5);
+      expect(deadLettered.syncState.deadLetterCount).toBe(1);
+
+      capture.salesforce.captureLiveBatch = () => Promise.resolve(buildCapturedBatch([]));
+      const recovered = await context.orchestration.runSalesforceLiveCaptureBatch(
+        buildSalesforceLivePayload({
+          syncStateId: "sync:salesforce:live:poll-reset-success"
+        })
+      );
+
+      expect(recovered.outcome).toBe("succeeded");
+      if (recovered.outcome !== "succeeded") {
+        throw new Error("Expected cross-poll Salesforce live recovery batch.");
+      }
+
+      expect(recovered.syncState.consecutiveFailureCount).toBe(0);
+
+      capture.salesforce.captureLiveBatch = () => {
+        throw new Stage1RetryableJobError("Temporary Salesforce live capture failure.");
+      };
+      const afterReset = await context.orchestration.runSalesforceLiveCaptureBatch(
+        buildSalesforceLivePayload({
+          syncStateId: "sync:salesforce:live:poll-reset-failure"
+        })
+      );
+
+      expect(afterReset.outcome).toBe("failed");
+      if (afterReset.outcome !== "failed") {
+        throw new Error("Expected Salesforce live failure after cross-poll reset.");
+      }
+
+      expect(afterReset.failure.disposition).toBe("retryable");
+      expect(afterReset.syncState.status).toBe("failed");
+      expect(afterReset.syncState.consecutiveFailureCount).toBe(1);
+      expect(afterReset.syncState.deadLetterCount).toBe(0);
+    } finally {
+      await context.dispose();
+    }
+  });
+
   it("skips already-ingested Gmail live messages without duplicating events or projections", async () => {
     const gmailRecord = buildGmailMessageRecord({
       recordId: "gmail-live-duplicate-1",


### PR DESCRIPTION
## Summary

Follow-up to [#200](https://github.com/nico-kneler-as/as-comms-platform/pull/200) (F3 v1). The v1 fix added `consecutive_failure_count` on `sync_state` and dead-lettered at 5 — but it never actually fired in production because each cron tick creates a brand-new `sync_state` row with a fresh UUID, so the counter resets every poll.

**Production evidence (architect-gathered 2026-04-29):** recent Salesforce `live_ingest` `sync_state` rows show many distinct UUIDs, all `status = 'failed'` with `consecutive_failure_count = 1`. Counter never advances.

The v1 test passed because it reused one hardcoded `syncStateId` — not the cron's per-poll pattern.

## Fix (Option A — narrow shape, no schema change)

In `Stage1SyncStateService.startWindow`, when `findById(syncStateId)` returns null (brand-new row), call `findLatest({ scope, provider, jobType })` to retrieve the most recent prior row for the same composite key. If the prior row is `status = 'failed'`, seed the new row's `consecutive_failure_count` from the prior row's count. `failWindow` increments it normally; the catch-path threshold check (`>= 5`) now actually trips.

| Prior status | Carry forward? |
|---|---|
| null | No — start at 0 |
| `succeeded` | No — clean slate |
| `failed` | **Yes — carry forward** |
| `quarantined` | No — restart (planner skips) |
| `running` | No (defensive — planner skips) |

`findLatest` is already in the repo, already used by the planner. No new query, no schema change.

## Tests

`apps/worker/test/stage1-orchestration.test.ts` adds a cross-poll case:
- 5 distinct `syncStateId` UUIDs, sequential failures
- 5th failure flips disposition to `dead_letter` and status to `quarantined`
- After a successful poll on a fresh UUID, streak resets

Existing same-row regression test preserved.

## Test plan

- [x] `pnpm typecheck && pnpm lint` clean (VALIDATION_PASSED locally)
- [ ] CI green
- [ ] Post-deploy: confirm `consecutive_failure_count` in prod actually accumulates across polls (a single quick query proves the fix lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)