### PR TITLE
fix(integrations): tighten source_evidence_log uniqueness + quarantine losers

### DIFF
--- a/apps/web/app/settings/_components/logs-page.tsx
+++ b/apps/web/app/settings/_components/logs-page.tsx
@@ -62,11 +62,11 @@ function isSourceEvidenceCollisionDetail(
 }
 
 function formatCollisionLine(input: {
-  readonly sourceEvidenceId: string;
+  readonly recordId: string;
   readonly checksum: string;
-  readonly receivedAt: string;
+  readonly timestamp: string;
 }): string {
-  return `${input.sourceEvidenceId} • ${input.checksum} • ${formatTimestamp(input.receivedAt)}`;
+  return `${input.recordId} • ${input.checksum} • ${formatTimestamp(input.timestamp)}`;
 }
 
 function StreamSelector({
@@ -166,13 +166,23 @@ function DetailPanel({
 
       <dt className={TYPE.label}>Winning source-evidence</dt>
       <dd className={cn(TYPE.bodySm, "break-all text-slate-700")}>
-        {formatCollisionLine(detail.winning)}
+        {formatCollisionLine({
+          recordId: detail.winning.sourceEvidenceId,
+          checksum: detail.winning.checksum,
+          timestamp: detail.winning.receivedAt,
+        })}
       </dd>
 
-      <dt className={TYPE.label}>Losing source-evidence</dt>
+      <dt className={TYPE.label}>Losing quarantine rows</dt>
       <dd className={cn("space-y-1", TYPE.bodySm, "text-slate-700")}>
         {detail.losing.map((entry) => (
-          <div key={entry.sourceEvidenceId}>{formatCollisionLine(entry)}</div>
+          <div key={entry.quarantineId}>
+            {formatCollisionLine({
+              recordId: entry.quarantineId,
+              checksum: entry.checksum,
+              timestamp: entry.attemptedAt,
+            })}
+          </div>
         ))}
       </dd>
     </dl>

--- a/apps/web/src/server/settings/selectors.ts
+++ b/apps/web/src/server/settings/selectors.ts
@@ -98,9 +98,9 @@ export interface SourceEvidenceCollisionDetailViewModel
     readonly receivedAt: string;
   };
   readonly losing: readonly {
-    readonly sourceEvidenceId: string;
+    readonly quarantineId: string;
     readonly checksum: string;
-    readonly receivedAt: string;
+    readonly attemptedAt: string;
   }[];
 }
 
@@ -491,9 +491,9 @@ async function readLogsSettings(input: {
           receivedAt: entry.winning.receivedAt.toISOString()
         },
         losing: entry.losing.map((losingEntry) => ({
-          sourceEvidenceId: losingEntry.sourceEvidenceId,
+          quarantineId: losingEntry.quarantineId,
           checksum: losingEntry.checksum,
-          receivedAt: losingEntry.receivedAt.toISOString()
+          attemptedAt: losingEntry.attemptedAt.toISOString()
         }))
       };
 

--- a/apps/web/tests/unit/settings-selectors.test.ts
+++ b/apps/web/tests/unit/settings-selectors.test.ts
@@ -147,7 +147,7 @@ async function seedSourceEvidenceCollision(
     readonly winningId: string;
     readonly losingId: string;
     readonly winningReceivedAt: string;
-    readonly losingReceivedAt: string;
+    readonly losingAttemptedAt: string;
   }
 ): Promise<void> {
   await runtime.context.repositories.sourceEvidence.append({
@@ -161,16 +161,24 @@ async function seedSourceEvidenceCollision(
     idempotencyKey: input.idempotencyKey,
     checksum: `${input.winningId}:checksum`
   });
-  await runtime.context.repositories.sourceEvidence.append({
-    id: input.losingId,
+  await runtime.context.repositories.sourceEvidenceQuarantine.record({
     provider: input.provider,
-    providerRecordType: "message",
-    providerRecordId: `${input.losingId}:record`,
-    receivedAt: input.losingReceivedAt,
-    occurredAt: input.losingReceivedAt,
-    payloadRef: `payloads/${input.provider}/${input.losingId}.json`,
     idempotencyKey: input.idempotencyKey,
-    checksum: `${input.losingId}:checksum`
+    checksum: `${input.losingId}:checksum`,
+    attemptedAt: new Date(input.losingAttemptedAt),
+    reason: "checksum_mismatch",
+    payloadRef: `payloads/${input.provider}/${input.losingId}.json`,
+    details: {
+      id: input.losingId,
+      provider: input.provider,
+      providerRecordType: "message",
+      providerRecordId: `${input.losingId}:record`,
+      receivedAt: input.losingAttemptedAt,
+      occurredAt: input.losingAttemptedAt,
+      payloadRef: `payloads/${input.provider}/${input.losingId}.json`,
+      idempotencyKey: input.idempotencyKey,
+      checksum: `${input.losingId}:checksum`
+    }
   });
 }
 
@@ -451,7 +459,7 @@ describe("settings selectors", () => {
       winningId: "sev-newer-winning",
       losingId: "sev-newer-losing",
       winningReceivedAt: "2026-04-20T14:00:00.000Z",
-      losingReceivedAt: "2026-04-20T14:05:00.000Z"
+      losingAttemptedAt: "2026-04-20T14:05:00.000Z"
     });
     await seedSourceEvidenceCollision(runtime, {
       provider: "salesforce",
@@ -459,7 +467,7 @@ describe("settings selectors", () => {
       winningId: "sev-older-winning",
       losingId: "sev-older-losing",
       winningReceivedAt: "2026-04-20T13:00:00.000Z",
-      losingReceivedAt: "2026-04-20T13:05:00.000Z"
+      losingAttemptedAt: "2026-04-20T13:05:00.000Z"
     });
     for (let index = 0; index < 24; index += 1) {
       const minute = String(index).padStart(2, "0");
@@ -469,7 +477,7 @@ describe("settings selectors", () => {
         winningId: `sev-extra-winning-${minute}`,
         losingId: `sev-extra-losing-${minute}`,
         winningReceivedAt: `2026-04-20T12:${minute}:00.000Z`,
-        losingReceivedAt: `2026-04-20T12:${minute}:30.000Z`
+        losingAttemptedAt: `2026-04-20T12:${minute}:30.000Z`
       });
     }
 
@@ -502,13 +510,20 @@ describe("settings selectors", () => {
         },
         losing: [
           {
-            sourceEvidenceId: "sev-newer-losing",
             checksum: "sev-newer-losing:checksum",
-            receivedAt: "2026-04-20T14:05:00.000Z"
+            attemptedAt: "2026-04-20T14:05:00.000Z"
           }
         ]
       }
     });
+    const firstLosingDetail = (
+      viewModel.entries[0]?.detail as {
+        readonly losing: readonly {
+          readonly quarantineId: string;
+        }[];
+      }
+    ).losing[0];
+    expect(typeof firstLosingDetail?.quarantineId).toBe("string");
     expect(typeof viewModel.nextBeforeTimestamp).toBe("string");
     expect(viewModel.nextBeforeTimestamp).not.toBeNull();
   });

--- a/packages/db/drizzle/0043_source_evidence_log_tightening.sql
+++ b/packages/db/drizzle/0043_source_evidence_log_tightening.sql
@@ -1,0 +1,19 @@
+DROP INDEX IF EXISTS "source_evidence_log_replay_unique";
+
+CREATE UNIQUE INDEX "source_evidence_log_provider_idempotency_unique"
+  ON "source_evidence_log" ("provider", "idempotency_key");
+
+CREATE TABLE "source_evidence_quarantine" (
+  "id" text PRIMARY KEY NOT NULL,
+  "provider" "provider" NOT NULL,
+  "idempotency_key" text NOT NULL,
+  "checksum" text NOT NULL,
+  "attempted_at" timestamp with time zone NOT NULL,
+  "reason" text NOT NULL,
+  "payload_ref" text NOT NULL,
+  "details_jsonb" jsonb NOT NULL,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+
+CREATE INDEX "source_evidence_quarantine_provider_idempotency_idx"
+  ON "source_evidence_quarantine" ("provider", "idempotency_key");

--- a/packages/db/src/mappers.ts
+++ b/packages/db/src/mappers.ts
@@ -50,6 +50,8 @@ import {
 import type {
   PendingComposerOutboundRecord,
   ProjectAliasRecord,
+  SourceEvidenceQuarantineInput,
+  SourceEvidenceQuarantineRecord,
   UserRecord,
 } from "@as-comms/domain";
 
@@ -78,11 +80,13 @@ import type {
   salesforceEventContext,
   simpleTextingMessageDetails,
   sourceEvidenceLog,
+  sourceEvidenceQuarantine,
   syncState,
   users,
 } from "./schema/index.js";
 
 type SourceEvidenceRow = typeof sourceEvidenceLog.$inferSelect;
+type SourceEvidenceQuarantineRow = typeof sourceEvidenceQuarantine.$inferSelect;
 type AiKnowledgeEntryRow = typeof aiKnowledgeEntries.$inferSelect;
 type ProjectKnowledgeEntryRow = typeof projectKnowledgeEntries.$inferSelect;
 type CanonicalEventRow = typeof canonicalEventLedger.$inferSelect;
@@ -243,6 +247,38 @@ export function mapSourceEvidenceToInsert(
     payloadRef: parsed.payloadRef,
     idempotencyKey: parsed.idempotencyKey,
     checksum: parsed.checksum,
+  };
+}
+
+export function mapSourceEvidenceQuarantineRow(
+  row: SourceEvidenceQuarantineRow,
+): SourceEvidenceQuarantineRecord {
+  return {
+    id: row.id,
+    provider: row.provider,
+    idempotencyKey: row.idempotencyKey,
+    checksum: row.checksum,
+    attemptedAt: row.attemptedAt,
+    reason: row.reason as SourceEvidenceQuarantineRecord["reason"],
+    payloadRef: row.payloadRef,
+    details: row.detailsJsonb as Readonly<Record<string, unknown>>,
+    createdAt: row.createdAt,
+  };
+}
+
+export function mapSourceEvidenceQuarantineToInsert(input: {
+  readonly id: string;
+  readonly record: SourceEvidenceQuarantineInput;
+}): typeof sourceEvidenceQuarantine.$inferInsert {
+  return {
+    id: input.id,
+    provider: input.record.provider,
+    idempotencyKey: input.record.idempotencyKey,
+    checksum: input.record.checksum,
+    attemptedAt: input.record.attemptedAt,
+    reason: input.record.reason,
+    payloadRef: input.record.payloadRef,
+    detailsJsonb: input.record.details,
   };
 }
 

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -70,6 +70,8 @@ import {
   mapSalesforceEventContextToInsert,
   mapSourceEvidenceRow,
   mapSourceEvidenceToInsert,
+  mapSourceEvidenceQuarantineRow,
+  mapSourceEvidenceQuarantineToInsert,
   mapSyncStateRow,
   mapSyncStateToInsert,
   mapTimelineProjectionRow,
@@ -104,6 +106,7 @@ import {
   salesforceEventContext,
   simpleTextingMessageDetails,
   sourceEvidenceLog,
+  sourceEvidenceQuarantine,
   syncState,
   users,
 } from "./schema/index.js";
@@ -205,11 +208,21 @@ interface InternalNoteWithAuthorRow {
   } | null;
 }
 type PendingComposerOutboundRow = typeof pendingComposerOutbounds.$inferSelect;
-type SourceEvidenceLogRow = typeof sourceEvidenceLog.$inferSelect;
 interface SourceEvidenceCollisionGroupRow {
   readonly provider: SourceEvidenceCollisionEntry["provider"];
   readonly idempotencyKey: string;
   readonly latestReceivedAt: Date;
+}
+interface SourceEvidenceCollisionJoinedRow {
+  readonly provider: SourceEvidenceCollisionEntry["provider"];
+  readonly idempotencyKey: string;
+  readonly latestReceivedAt: Date;
+  readonly winningSourceEvidenceId: string;
+  readonly winningChecksum: string;
+  readonly winningReceivedAt: Date;
+  readonly losingQuarantineId: string;
+  readonly losingChecksum: string;
+  readonly losingAttemptedAt: Date;
 }
 
 function mapSalesforceCommunicationDetailRowLocal(
@@ -267,9 +280,9 @@ function buildSourceEvidenceCollisionKey(
 
 function mapSourceEvidenceCollisionEntries(input: {
   readonly groups: readonly SourceEvidenceCollisionGroupRow[];
-  readonly rows: readonly SourceEvidenceLogRow[];
+  readonly rows: readonly SourceEvidenceCollisionJoinedRow[];
 }): readonly SourceEvidenceCollisionEntry[] {
-  const rowsByCollisionKey = new Map<string, SourceEvidenceLogRow[]>();
+  const rowsByCollisionKey = new Map<string, SourceEvidenceCollisionJoinedRow[]>();
 
   for (const row of input.rows) {
     const collisionKey = buildSourceEvidenceCollisionKey(
@@ -287,7 +300,7 @@ function mapSourceEvidenceCollisionEntries(input: {
       group.idempotencyKey,
     );
     const rows = rowsByCollisionKey.get(collisionKey) ?? [];
-    const [winning, ...losing] = rows;
+    const [winning] = rows;
 
     if (winning === undefined) {
       return [];
@@ -299,14 +312,14 @@ function mapSourceEvidenceCollisionEntries(input: {
         idempotencyKey: group.idempotencyKey,
         latestReceivedAt: group.latestReceivedAt,
         winning: {
-          sourceEvidenceId: winning.id,
-          checksum: winning.checksum,
-          receivedAt: winning.receivedAt,
+          sourceEvidenceId: winning.winningSourceEvidenceId,
+          checksum: winning.winningChecksum,
+          receivedAt: winning.winningReceivedAt,
         },
-        losing: losing.map((row) => ({
-          sourceEvidenceId: row.id,
-          checksum: row.checksum,
-          receivedAt: row.receivedAt,
+        losing: rows.map((row) => ({
+          quarantineId: row.losingQuarantineId,
+          checksum: row.losingChecksum,
+          attemptedAt: row.losingAttemptedAt,
         })),
       },
     ];
@@ -320,6 +333,22 @@ function coerceSourceEvidenceCollisionGroups(
     provider: row.provider,
     idempotencyKey: row.idempotencyKey,
     latestReceivedAt: new Date(row.latestReceivedAt),
+  }));
+}
+
+function coerceSourceEvidenceCollisionJoinedRows(
+  rows: readonly SourceEvidenceCollisionJoinedRow[],
+): readonly SourceEvidenceCollisionJoinedRow[] {
+  return rows.map((row) => ({
+    provider: row.provider,
+    idempotencyKey: row.idempotencyKey,
+    latestReceivedAt: new Date(row.latestReceivedAt),
+    winningSourceEvidenceId: row.winningSourceEvidenceId,
+    winningChecksum: row.winningChecksum,
+    winningReceivedAt: new Date(row.winningReceivedAt),
+    losingQuarantineId: row.losingQuarantineId,
+    losingChecksum: row.losingChecksum,
+    losingAttemptedAt: new Date(row.losingAttemptedAt),
   }));
 }
 
@@ -715,7 +744,6 @@ function createStage1RepositoriesInternal(
             target: [
               sourceEvidenceLog.provider,
               sourceEvidenceLog.idempotencyKey,
-              sourceEvidenceLog.checksum,
             ],
           })
           .returning();
@@ -731,7 +759,6 @@ function createStage1RepositoriesInternal(
             and(
               eq(sourceEvidenceLog.provider, values.provider),
               eq(sourceEvidenceLog.idempotencyKey, values.idempotencyKey),
-              eq(sourceEvidenceLog.checksum, values.checksum),
             ),
           )
           .limit(1);
@@ -784,21 +811,40 @@ function createStage1RepositoriesInternal(
         const groupResult = await db.execute(
           sql`
             select
-              ${sourceEvidenceLog.provider} as "provider",
-              ${sourceEvidenceLog.idempotencyKey} as "idempotencyKey",
-              max(${sourceEvidenceLog.receivedAt}) as "latestReceivedAt"
-            from ${sourceEvidenceLog}
-            group by ${sourceEvidenceLog.provider}, ${sourceEvidenceLog.idempotencyKey}
-            having count(distinct ${sourceEvidenceLog.checksum}) > 1
+              ${sourceEvidenceQuarantine.provider} as "provider",
+              ${sourceEvidenceQuarantine.idempotencyKey} as "idempotencyKey",
+              max(
+                greatest(
+                  ${sourceEvidenceLog.receivedAt},
+                  ${sourceEvidenceQuarantine.attemptedAt}
+                )
+              ) as "latestReceivedAt"
+            from ${sourceEvidenceQuarantine}
+            inner join ${sourceEvidenceLog}
+              on ${sourceEvidenceLog.provider} = ${sourceEvidenceQuarantine.provider}
+              and ${sourceEvidenceLog.idempotencyKey} = ${sourceEvidenceQuarantine.idempotencyKey}
+            group by ${sourceEvidenceQuarantine.provider}, ${sourceEvidenceQuarantine.idempotencyKey}
             ${
               input.beforeTimestamp === undefined
                 ? sql``
-                : sql`and max(${sourceEvidenceLog.receivedAt}) < ${input.beforeTimestamp}`
+                : sql`
+                    having max(
+                      greatest(
+                        ${sourceEvidenceLog.receivedAt},
+                        ${sourceEvidenceQuarantine.attemptedAt}
+                      )
+                    ) < ${input.beforeTimestamp}
+                  `
             }
             order by
-              max(${sourceEvidenceLog.receivedAt}) desc,
-              ${sourceEvidenceLog.provider} asc,
-              ${sourceEvidenceLog.idempotencyKey} asc
+              max(
+                greatest(
+                  ${sourceEvidenceLog.receivedAt},
+                  ${sourceEvidenceQuarantine.attemptedAt}
+                )
+              ) desc,
+              ${sourceEvidenceQuarantine.provider} asc,
+              ${sourceEvidenceQuarantine.idempotencyKey} asc
             limit ${limit + 1}
           `,
         );
@@ -822,25 +868,52 @@ function createStage1RepositoriesInternal(
 
         const groupPredicates = visibleGroups.map((group) =>
           and(
-            eq(sourceEvidenceLog.provider, group.provider),
-            eq(sourceEvidenceLog.idempotencyKey, group.idempotencyKey),
+            eq(sourceEvidenceQuarantine.provider, group.provider),
+            eq(sourceEvidenceQuarantine.idempotencyKey, group.idempotencyKey),
           ),
         );
-        const rows = await db
-          .select()
-          .from(sourceEvidenceLog)
-          .where(
-            groupPredicates.length === 1
-              ? groupPredicates[0]
-              : or(...groupPredicates),
-          )
-          .orderBy(
-            asc(sourceEvidenceLog.provider),
-            asc(sourceEvidenceLog.idempotencyKey),
-            asc(sourceEvidenceLog.receivedAt),
-            asc(sourceEvidenceLog.createdAt),
-            asc(sourceEvidenceLog.id),
-          );
+        const rows = coerceSourceEvidenceCollisionJoinedRows(
+          await db
+            .select({
+              provider: sourceEvidenceQuarantine.provider,
+              idempotencyKey: sourceEvidenceQuarantine.idempotencyKey,
+              latestReceivedAt: sql<Date>`
+                greatest(
+                  ${sourceEvidenceLog.receivedAt},
+                  ${sourceEvidenceQuarantine.attemptedAt}
+                )
+              `,
+              winningSourceEvidenceId: sourceEvidenceLog.id,
+              winningChecksum: sourceEvidenceLog.checksum,
+              winningReceivedAt: sourceEvidenceLog.receivedAt,
+              losingQuarantineId: sourceEvidenceQuarantine.id,
+              losingChecksum: sourceEvidenceQuarantine.checksum,
+              losingAttemptedAt: sourceEvidenceQuarantine.attemptedAt,
+            })
+            .from(sourceEvidenceQuarantine)
+            .innerJoin(
+              sourceEvidenceLog,
+              and(
+                eq(sourceEvidenceLog.provider, sourceEvidenceQuarantine.provider),
+                eq(
+                  sourceEvidenceLog.idempotencyKey,
+                  sourceEvidenceQuarantine.idempotencyKey,
+                ),
+              ),
+            )
+            .where(
+              groupPredicates.length === 1
+                ? groupPredicates[0]
+                : or(...groupPredicates),
+            )
+            .orderBy(
+              asc(sourceEvidenceQuarantine.provider),
+              asc(sourceEvidenceQuarantine.idempotencyKey),
+              asc(sourceEvidenceQuarantine.attemptedAt),
+              asc(sourceEvidenceQuarantine.createdAt),
+              asc(sourceEvidenceQuarantine.id),
+            ),
+        );
 
         return {
           entries: mapSourceEvidenceCollisionEntries({
@@ -882,6 +955,49 @@ function createStage1RepositoriesInternal(
           );
 
         return rows.map(mapSourceEvidenceRow);
+      },
+    },
+
+    sourceEvidenceQuarantine: {
+      async record(input) {
+        const [row] = await db
+          .insert(sourceEvidenceQuarantine)
+          .values(
+            mapSourceEvidenceQuarantineToInsert({
+              id: `source_evidence_quarantine:${crypto.randomUUID()}`,
+              record: input,
+            }),
+          )
+          .returning();
+
+        return mapSourceEvidenceQuarantineRow(
+          requireRow(row, "Expected source evidence quarantine row after insert."),
+        );
+      },
+
+      async listRecent(input) {
+        const limit = clampSourceEvidenceCollisionLimit(input.limit);
+        const rows = await db
+          .select()
+          .from(sourceEvidenceQuarantine)
+          .where(
+            input.beforeTimestamp === undefined
+              ? undefined
+              : lt(sourceEvidenceQuarantine.attemptedAt, input.beforeTimestamp),
+          )
+          .orderBy(
+            desc(sourceEvidenceQuarantine.attemptedAt),
+            desc(sourceEvidenceQuarantine.createdAt),
+            desc(sourceEvidenceQuarantine.id),
+          )
+          .limit(limit + 1);
+
+        const visibleRows = rows.slice(0, limit).map(mapSourceEvidenceQuarantineRow);
+
+        return {
+          entries: visibleRows,
+          hasMore: rows.length > limit,
+        };
       },
     },
 

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -28,6 +28,7 @@ import {
   sessions,
   simpleTextingMessageDetails,
   sourceEvidenceLog,
+  sourceEvidenceQuarantine,
   syncState,
   users,
   verificationTokens
@@ -35,6 +36,7 @@ import {
 
 export const databaseSchema = {
   sourceEvidenceLog,
+  sourceEvidenceQuarantine,
   aiKnowledgeEntries,
   contacts,
   contactIdentities,

--- a/packages/db/src/schema/tables.ts
+++ b/packages/db/src/schema/tables.ts
@@ -85,10 +85,34 @@ export const sourceEvidenceLog = pgTable(
       table.providerRecordType,
       table.providerRecordId,
     ),
-    uniqueIndex("source_evidence_log_replay_unique").on(
+    uniqueIndex("source_evidence_log_provider_idempotency_unique").on(
       table.provider,
       table.idempotencyKey,
-      table.checksum,
+    ),
+  ],
+);
+
+export const sourceEvidenceQuarantine = pgTable(
+  "source_evidence_quarantine",
+  {
+    id: text("id").primaryKey(),
+    provider: providerEnum("provider").notNull(),
+    idempotencyKey: text("idempotency_key").notNull(),
+    checksum: text("checksum").notNull(),
+    attemptedAt: timestamp("attempted_at", {
+      mode: "date",
+      withTimezone: true,
+    }).notNull(),
+    // Canonical values are free-text strings like "checksum_mismatch".
+    reason: text("reason").notNull(),
+    payloadRef: text("payload_ref").notNull(),
+    detailsJsonb: jsonb("details_jsonb").notNull(),
+    createdAt: createdAtColumn,
+  },
+  (table) => [
+    index("source_evidence_quarantine_provider_idempotency_idx").on(
+      table.provider,
+      table.idempotencyKey,
     ),
   ],
 );

--- a/packages/db/test/stage1-persistence.test.ts
+++ b/packages/db/test/stage1-persistence.test.ts
@@ -211,6 +211,7 @@ describe("Stage 1 persistence service", () => {
       sourceEvidence: {
         ...context.repositories.sourceEvidence,
         findByIdempotencyKey: () => Promise.resolve(null),
+        listByProviderRecord: () => Promise.resolve([]),
         append: () => Promise.resolve(winningRow)
       }
     });

--- a/packages/db/test/stage1-persistence.test.ts
+++ b/packages/db/test/stage1-persistence.test.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 
 import { describe, expect, it } from "vitest";
+import { createStage1PersistenceService } from "@as-comms/domain";
 
 import { createTestStage1Context } from "./helpers.js";
 
@@ -86,6 +87,164 @@ describe("Stage 1 persistence service", () => {
         providerRecordId: "gmail-message-1"
       })
     ).resolves.toEqual([firstResult.record]);
+  });
+
+  it("recordSourceEvidence preserves same-checksum replay as duplicate", async () => {
+    const { persistence } = await createTestStage1Context();
+
+    const firstResult = await persistence.recordSourceEvidence({
+      id: "sev_duplicate_1",
+      provider: "gmail",
+      providerRecordType: "message",
+      providerRecordId: "gmail-duplicate-1",
+      receivedAt: "2026-01-02T00:01:00.000Z",
+      occurredAt: "2026-01-02T00:00:00.000Z",
+      payloadRef: "payloads/gmail/gmail-duplicate-1.json",
+      idempotencyKey: "gmail:message:gmail-duplicate-1",
+      checksum: "checksum-duplicate-1"
+    });
+
+    if (firstResult.outcome !== "inserted") {
+      throw new Error("Expected the first source evidence write to insert.");
+    }
+
+    await expect(
+      persistence.recordSourceEvidence({
+        id: "sev_duplicate_2",
+        provider: "gmail",
+        providerRecordType: "message",
+        providerRecordId: "gmail-duplicate-1",
+        receivedAt: "2026-01-02T00:02:00.000Z",
+        occurredAt: "2026-01-02T00:00:00.000Z",
+        payloadRef: "payloads/gmail/gmail-duplicate-1.json",
+        idempotencyKey: "gmail:message:gmail-duplicate-1",
+        checksum: "checksum-duplicate-1"
+      })
+    ).resolves.toEqual({
+      outcome: "duplicate",
+      record: firstResult.record
+    });
+  });
+
+  it("recordSourceEvidence quarantines a different-checksum collision and returns conflict", async () => {
+    const { persistence, repositories } = await createTestStage1Context();
+
+    const firstResult = await persistence.recordSourceEvidence({
+      id: "sev_quarantine_winner",
+      provider: "gmail",
+      providerRecordType: "message",
+      providerRecordId: "gmail-quarantine-winner",
+      receivedAt: "2026-01-03T00:01:00.000Z",
+      occurredAt: "2026-01-03T00:00:00.000Z",
+      payloadRef: "payloads/gmail/gmail-quarantine-winner.json",
+      idempotencyKey: "gmail:message:gmail-quarantine",
+      checksum: "checksum-a"
+    });
+
+    if (firstResult.outcome !== "inserted") {
+      throw new Error("Expected the winning source evidence row to insert.");
+    }
+
+    const result = await persistence.recordSourceEvidence({
+      id: "sev_quarantine_loser",
+      provider: "gmail",
+      providerRecordType: "message",
+      providerRecordId: "gmail-quarantine-winner",
+      receivedAt: "2026-01-03T00:02:00.000Z",
+      occurredAt: "2026-01-03T00:00:00.000Z",
+      payloadRef: "payloads/gmail/gmail-quarantine-loser.json",
+      idempotencyKey: "gmail:message:gmail-quarantine",
+      checksum: "checksum-b"
+    });
+
+    expect(result.outcome).toBe("conflict");
+    if (result.outcome === "conflict") {
+      expect(result.reason).toBe("idempotency_key_mismatch");
+      expect(result.conflictingRecords).toEqual([firstResult.record]);
+    }
+
+    await expect(
+      repositories.sourceEvidence.listByProviderRecord({
+        provider: "gmail",
+        providerRecordType: "message",
+        providerRecordId: "gmail-quarantine-winner"
+      })
+    ).resolves.toEqual([firstResult.record]);
+
+    const quarantineRows = await repositories.sourceEvidenceQuarantine.listRecent({
+      limit: 10
+    });
+    expect(quarantineRows.entries).toHaveLength(1);
+    expect(quarantineRows.entries[0]).toMatchObject({
+      provider: "gmail",
+      idempotencyKey: "gmail:message:gmail-quarantine",
+      checksum: "checksum-b",
+      attemptedAt: new Date("2026-01-03T00:02:00.000Z"),
+      reason: "checksum_mismatch",
+      payloadRef: "payloads/gmail/gmail-quarantine-loser.json",
+      details: {
+        provider: "gmail",
+        providerRecordType: "message",
+        providerRecordId: "gmail-quarantine-winner",
+        payloadRef: "payloads/gmail/gmail-quarantine-loser.json",
+        idempotencyKey: "gmail:message:gmail-quarantine",
+        checksum: "checksum-b"
+      }
+    });
+  });
+
+  it("recordSourceEvidence handles DB-layer race losers via post-append re-read", async () => {
+    const context = await createTestStage1Context();
+    const winningRow = await context.repositories.sourceEvidence.append({
+      id: "sev_race_winner",
+      provider: "gmail",
+      providerRecordType: "message",
+      providerRecordId: "gmail-race-winner",
+      receivedAt: "2026-01-04T00:01:00.000Z",
+      occurredAt: "2026-01-04T00:00:00.000Z",
+      payloadRef: "payloads/gmail/gmail-race-winner.json",
+      idempotencyKey: "gmail:message:gmail-race",
+      checksum: "checksum-winner"
+    });
+    const persistence = createStage1PersistenceService({
+      ...context.repositories,
+      sourceEvidence: {
+        ...context.repositories.sourceEvidence,
+        findByIdempotencyKey: () => Promise.resolve(null),
+        append: () => Promise.resolve(winningRow)
+      }
+    });
+
+    const result = await persistence.recordSourceEvidence({
+      id: "sev_race_loser",
+      provider: "gmail",
+      providerRecordType: "message",
+      providerRecordId: "gmail-race-winner",
+      receivedAt: "2026-01-04T00:02:00.000Z",
+      occurredAt: "2026-01-04T00:00:00.000Z",
+      payloadRef: "payloads/gmail/gmail-race-loser.json",
+      idempotencyKey: "gmail:message:gmail-race",
+      checksum: "checksum-loser"
+    });
+
+    expect(result.outcome).toBe("conflict");
+    if (result.outcome === "conflict") {
+      expect(result.reason).toBe("idempotency_key_mismatch");
+      expect(result.conflictingRecords).toEqual([winningRow]);
+    }
+
+    const quarantineRows = await context.repositories.sourceEvidenceQuarantine.listRecent({
+      limit: 10
+    });
+    expect(quarantineRows.entries).toHaveLength(1);
+    expect(quarantineRows.entries[0]).toMatchObject({
+      provider: "gmail",
+      idempotencyKey: "gmail:message:gmail-race",
+      checksum: "checksum-loser",
+      attemptedAt: new Date("2026-01-04T00:02:00.000Z"),
+      reason: "checksum_mismatch",
+      payloadRef: "payloads/gmail/gmail-race-loser.json"
+    });
   });
 
   it("keeps live Gmail re-polls duplicate-safe when Subject is newly fetched", async () => {

--- a/packages/db/test/stage1-repositories.test.ts
+++ b/packages/db/test/stage1-repositories.test.ts
@@ -205,6 +205,52 @@ async function appendSourceEvidenceRows(
   }
 }
 
+async function recordSourceEvidenceQuarantineRows(
+  repositories: Awaited<
+    ReturnType<typeof createTestStage1Context>
+  >["repositories"],
+  rows: readonly {
+    readonly provider:
+      | "gmail"
+      | "salesforce"
+      | "simpletexting"
+      | "mailchimp"
+      | "manual";
+    readonly idempotencyKey: string;
+    readonly checksum: string;
+    readonly attemptedAt: string;
+    readonly payloadRef: string;
+    readonly providerRecordId: string;
+  }[],
+) {
+  const records = [];
+
+  for (const row of rows) {
+    records.push(
+      await repositories.sourceEvidenceQuarantine.record({
+        provider: row.provider,
+        idempotencyKey: row.idempotencyKey,
+        checksum: row.checksum,
+        attemptedAt: new Date(row.attemptedAt),
+        reason: "checksum_mismatch",
+        payloadRef: row.payloadRef,
+        details: {
+          provider: row.provider,
+          providerRecordType: "message",
+          providerRecordId: row.providerRecordId,
+          receivedAt: row.attemptedAt,
+          occurredAt: row.attemptedAt,
+          payloadRef: row.payloadRef,
+          idempotencyKey: row.idempotencyKey,
+          checksum: row.checksum,
+        },
+      }),
+    );
+  }
+
+  return records;
+}
+
 describe("Stage 1 DB repositories", () => {
   it("persists and maps source evidence, contacts, identities, and memberships", async () => {
     const { repositories, settings } = await createTestStage1Context();
@@ -499,7 +545,67 @@ describe("Stage 1 DB repositories", () => {
     });
   });
 
-  it("returns the earliest row as the winning source-evidence collision entry", async () => {
+  it("records and pages source-evidence quarantine rows", async () => {
+    const { repositories } = await createTestStage1Context();
+
+    const older = await repositories.sourceEvidenceQuarantine.record({
+      provider: "gmail",
+      idempotencyKey: "gmail:quarantine:older",
+      checksum: "checksum-older",
+      attemptedAt: new Date("2026-01-01T00:00:00.000Z"),
+      reason: "checksum_mismatch",
+      payloadRef: "payloads/gmail/quarantine-older.json",
+      details: {
+        provider: "gmail",
+        providerRecordType: "message",
+        providerRecordId: "gmail-quarantine-older",
+        receivedAt: "2026-01-01T00:00:00.000Z",
+        occurredAt: "2026-01-01T00:00:00.000Z",
+        payloadRef: "payloads/gmail/quarantine-older.json",
+        idempotencyKey: "gmail:quarantine:older",
+        checksum: "checksum-older",
+      },
+    });
+    const newer = await repositories.sourceEvidenceQuarantine.record({
+      provider: "gmail",
+      idempotencyKey: "gmail:quarantine:newer",
+      checksum: "checksum-newer",
+      attemptedAt: new Date("2026-01-01T00:05:00.000Z"),
+      reason: "checksum_mismatch",
+      payloadRef: "payloads/gmail/quarantine-newer.json",
+      details: {
+        provider: "gmail",
+        providerRecordType: "message",
+        providerRecordId: "gmail-quarantine-newer",
+        receivedAt: "2026-01-01T00:05:00.000Z",
+        occurredAt: "2026-01-01T00:05:00.000Z",
+        payloadRef: "payloads/gmail/quarantine-newer.json",
+        idempotencyKey: "gmail:quarantine:newer",
+        checksum: "checksum-newer",
+      },
+    });
+
+    await expect(
+      repositories.sourceEvidenceQuarantine.listRecent({
+        limit: 1,
+      }),
+    ).resolves.toEqual({
+      entries: [newer],
+      hasMore: true,
+    });
+
+    await expect(
+      repositories.sourceEvidenceQuarantine.listRecent({
+        limit: 10,
+        beforeTimestamp: new Date("2026-01-01T00:05:00.000Z"),
+      }),
+    ).resolves.toEqual({
+      entries: [older],
+      hasMore: false,
+    });
+  });
+
+  it("returns the winning log row with quarantine-backed losing entries", async () => {
     const { repositories } = await createTestStage1Context();
 
     await appendSourceEvidenceRows(repositories, [
@@ -511,15 +617,26 @@ describe("Stage 1 DB repositories", () => {
         idempotencyKey: "gmail:collision",
         checksum: "checksum-a",
       },
-      {
-        id: "sev-losing",
-        provider: "gmail",
-        providerRecordId: "gmail-losing",
-        receivedAt: "2026-01-01T00:01:00.000Z",
-        idempotencyKey: "gmail:collision",
-        checksum: "checksum-b",
-      },
     ]);
+    const [losingFirst, losingSecond] =
+      await recordSourceEvidenceQuarantineRows(repositories, [
+        {
+          provider: "gmail",
+          idempotencyKey: "gmail:collision",
+          checksum: "checksum-b",
+          attemptedAt: "2026-01-01T00:01:00.000Z",
+          payloadRef: "payloads/gmail/gmail-losing-1.json",
+          providerRecordId: "gmail-losing-1",
+        },
+        {
+          provider: "gmail",
+          idempotencyKey: "gmail:collision",
+          checksum: "checksum-c",
+          attemptedAt: "2026-01-01T00:02:00.000Z",
+          payloadRef: "payloads/gmail/gmail-losing-2.json",
+          providerRecordId: "gmail-losing-2",
+        },
+      ]);
 
     const result =
       await repositories.sourceEvidence.listIdempotencyChecksumCollisions({
@@ -531,7 +648,7 @@ describe("Stage 1 DB repositories", () => {
       {
         provider: "gmail",
         idempotencyKey: "gmail:collision",
-        latestReceivedAt: new Date("2026-01-01T00:01:00.000Z"),
+        latestReceivedAt: new Date("2026-01-01T00:02:00.000Z"),
         winning: {
           sourceEvidenceId: "sev-winning",
           checksum: "checksum-a",
@@ -539,9 +656,14 @@ describe("Stage 1 DB repositories", () => {
         },
         losing: [
           {
-            sourceEvidenceId: "sev-losing",
+            quarantineId: losingFirst?.id ?? "",
             checksum: "checksum-b",
-            receivedAt: new Date("2026-01-01T00:01:00.000Z"),
+            attemptedAt: new Date("2026-01-01T00:01:00.000Z"),
+          },
+          {
+            quarantineId: losingSecond?.id ?? "",
+            checksum: "checksum-c",
+            attemptedAt: new Date("2026-01-01T00:02:00.000Z"),
           },
         ],
       },
@@ -561,14 +683,6 @@ describe("Stage 1 DB repositories", () => {
         checksum: "older-a",
       },
       {
-        id: "sev-older-2",
-        provider: "gmail",
-        providerRecordId: "gmail-older-2",
-        receivedAt: "2026-01-01T00:05:00.000Z",
-        idempotencyKey: "gmail:older",
-        checksum: "older-b",
-      },
-      {
         id: "sev-newer-1",
         provider: "salesforce",
         providerRecordId: "sf-newer-1",
@@ -576,13 +690,23 @@ describe("Stage 1 DB repositories", () => {
         idempotencyKey: "salesforce:newer",
         checksum: "newer-a",
       },
+    ]);
+    await recordSourceEvidenceQuarantineRows(repositories, [
       {
-        id: "sev-newer-2",
+        provider: "gmail",
+        idempotencyKey: "gmail:older",
+        checksum: "older-b",
+        attemptedAt: "2026-01-01T00:05:00.000Z",
+        payloadRef: "payloads/gmail/gmail-older-2.json",
+        providerRecordId: "gmail-older-2",
+      },
+      {
         provider: "salesforce",
-        providerRecordId: "sf-newer-2",
-        receivedAt: "2026-01-01T01:15:00.000Z",
         idempotencyKey: "salesforce:newer",
         checksum: "newer-b",
+        attemptedAt: "2026-01-01T01:15:00.000Z",
+        payloadRef: "payloads/salesforce/sf-newer-2.json",
+        providerRecordId: "sf-newer-2",
       },
     ]);
 
@@ -613,14 +737,6 @@ describe("Stage 1 DB repositories", () => {
         checksum: "cursor-old-a",
       },
       {
-        id: "sev-cursor-old-2",
-        provider: "gmail",
-        providerRecordId: "gmail-cursor-old-2",
-        receivedAt: "2026-01-01T00:10:00.000Z",
-        idempotencyKey: "gmail:cursor-old",
-        checksum: "cursor-old-b",
-      },
-      {
         id: "sev-cursor-new-1",
         provider: "mailchimp",
         providerRecordId: "mailchimp-cursor-new-1",
@@ -628,13 +744,23 @@ describe("Stage 1 DB repositories", () => {
         idempotencyKey: "mailchimp:cursor-new",
         checksum: "cursor-new-a",
       },
+    ]);
+    await recordSourceEvidenceQuarantineRows(repositories, [
       {
-        id: "sev-cursor-new-2",
+        provider: "gmail",
+        idempotencyKey: "gmail:cursor-old",
+        checksum: "cursor-old-b",
+        attemptedAt: "2026-01-01T00:10:00.000Z",
+        payloadRef: "payloads/gmail/gmail-cursor-old-2.json",
+        providerRecordId: "gmail-cursor-old-2",
+      },
+      {
         provider: "mailchimp",
-        providerRecordId: "mailchimp-cursor-new-2",
-        receivedAt: "2026-01-01T01:20:00.000Z",
         idempotencyKey: "mailchimp:cursor-new",
         checksum: "cursor-new-b",
+        attemptedAt: "2026-01-01T01:20:00.000Z",
+        payloadRef: "payloads/mailchimp/mailchimp-cursor-new-2.json",
+        providerRecordId: "mailchimp-cursor-new-2",
       },
     ]);
 

--- a/packages/db/test/stage1-schema.test.ts
+++ b/packages/db/test/stage1-schema.test.ts
@@ -19,6 +19,7 @@ import {
   messageAttachments,
   projectKnowledgeEntries,
   sourceEvidenceLog,
+  sourceEvidenceQuarantine,
   syncState
 } from "../src/index.js";
 import { createTestStage1Context } from "./helpers.js";
@@ -55,6 +56,7 @@ describe("Stage 1 DB schema", () => {
       "sessions",
       "simpleTextingMessageDetails",
       "sourceEvidenceLog",
+      "sourceEvidenceQuarantine",
       "syncState",
       "users",
       "verificationTokens"
@@ -68,6 +70,9 @@ describe("Stage 1 DB schema", () => {
     );
     expect(getTableName(messageAttachments)).toBe("message_attachments");
     expect(getTableName(sourceEvidenceLog)).toBe("source_evidence_log");
+    expect(getTableName(sourceEvidenceQuarantine)).toBe(
+      "source_evidence_quarantine"
+    );
     expect(getTableName(canonicalEventLedger)).toBe("canonical_event_ledger");
     expect(getTableName(internalNotes)).toBe("internal_notes");
     expect(getTableName(contactInboxProjection)).toBe(

--- a/packages/domain/src/persistence.ts
+++ b/packages/domain/src/persistence.ts
@@ -218,6 +218,12 @@ function mergeAnchoredContact(
   });
 }
 
+function buildSourceEvidenceQuarantineDetails(
+  record: SourceEvidenceRecord
+): Readonly<Record<string, unknown>> {
+  return { ...record };
+}
+
 export function createStage1PersistenceService(
   repositories: Stage1RepositoryBundle
 ): Stage1PersistenceService {
@@ -243,6 +249,16 @@ export function createStage1PersistenceService(
             record: existingByIdempotency
           };
         }
+
+        await repositories.sourceEvidenceQuarantine.record({
+          provider: parsed.provider,
+          idempotencyKey: parsed.idempotencyKey,
+          checksum: parsed.checksum,
+          attemptedAt: new Date(parsed.receivedAt),
+          reason: "checksum_mismatch",
+          payloadRef: parsed.payloadRef,
+          details: buildSourceEvidenceQuarantineDetails(parsed)
+        });
 
         return {
           outcome: "conflict",
@@ -280,6 +296,32 @@ export function createStage1PersistenceService(
       }
 
       const inserted = await repositories.sourceEvidence.append(parsed);
+
+      if (inserted.checksum !== parsed.checksum) {
+        await repositories.sourceEvidenceQuarantine.record({
+          provider: parsed.provider,
+          idempotencyKey: parsed.idempotencyKey,
+          checksum: parsed.checksum,
+          attemptedAt: new Date(parsed.receivedAt),
+          reason: "checksum_mismatch",
+          payloadRef: parsed.payloadRef,
+          details: buildSourceEvidenceQuarantineDetails(parsed)
+        });
+
+        return {
+          outcome: "conflict",
+          incoming: parsed,
+          conflictingRecords: [inserted],
+          reason: "idempotency_key_mismatch"
+        };
+      }
+
+      if (!sameSourceEvidenceRecord(parsed, inserted)) {
+        return {
+          outcome: "duplicate",
+          record: inserted
+        };
+      }
 
       return {
         outcome: "inserted",

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -54,6 +54,35 @@ export interface SourceEvidenceRepository {
   }): Promise<readonly SourceEvidenceRecord[]>;
 }
 
+export interface SourceEvidenceQuarantineInput {
+  readonly provider: Provider;
+  readonly idempotencyKey: string;
+  readonly checksum: string;
+  readonly attemptedAt: Date;
+  readonly reason: "checksum_mismatch";
+  readonly payloadRef: string;
+  readonly details: Readonly<Record<string, unknown>>;
+}
+
+export interface SourceEvidenceQuarantineRecord
+  extends SourceEvidenceQuarantineInput {
+  readonly id: string;
+  readonly createdAt: Date;
+}
+
+export interface SourceEvidenceQuarantineRepository {
+  record(
+    input: SourceEvidenceQuarantineInput,
+  ): Promise<SourceEvidenceQuarantineRecord>;
+  listRecent(input: {
+    readonly limit: number;
+    readonly beforeTimestamp?: Date;
+  }): Promise<{
+    readonly entries: readonly SourceEvidenceQuarantineRecord[];
+    readonly hasMore: boolean;
+  }>;
+}
+
 export interface SourceEvidenceCollisionEntry {
   readonly provider: Provider;
   readonly idempotencyKey: string;
@@ -64,9 +93,9 @@ export interface SourceEvidenceCollisionEntry {
     readonly receivedAt: Date;
   };
   readonly losing: readonly {
-    readonly sourceEvidenceId: string;
+    readonly quarantineId: string;
     readonly checksum: string;
-    readonly receivedAt: Date;
+    readonly attemptedAt: Date;
   }[];
 }
 
@@ -459,6 +488,7 @@ export interface AuditEvidenceRepository {
 
 export interface Stage1RepositoryBundle {
   readonly sourceEvidence: SourceEvidenceRepository;
+  readonly sourceEvidenceQuarantine: SourceEvidenceQuarantineRepository;
   readonly canonicalEvents: CanonicalEventRepository;
   readonly aiKnowledge: AiKnowledgeRepository;
   readonly projectKnowledge: ProjectKnowledgeRepository;

--- a/packages/domain/test/normalization.test.ts
+++ b/packages/domain/test/normalization.test.ts
@@ -238,6 +238,17 @@ function buildContext(input: {
   );
   const timelineRowsByCanonicalEventId = new Map<string, TimelineProjectionRow>();
   const gmailDetailsBySourceEvidenceId = new Map<string, GmailMessageDetailRecord>();
+  const sourceEvidenceQuarantineEntries = new Array<{
+    id: string;
+    provider: SourceEvidenceRecord["provider"];
+    idempotencyKey: string;
+    checksum: string;
+    attemptedAt: Date;
+    reason: "checksum_mismatch";
+    payloadRef: string;
+    details: Readonly<Record<string, unknown>>;
+    createdAt: Date;
+  }>();
   let inboxProjection = input.existingProjection ?? null;
   let inboxSaveCount = 0;
 
@@ -269,6 +280,31 @@ function buildContext(input: {
               record.providerRecordId === providerRecordId,
           ),
         ),
+    },
+    sourceEvidenceQuarantine: {
+      record: (input) => {
+        const record = {
+          id: `source_evidence_quarantine:${String(sourceEvidenceQuarantineEntries.length + 1)}`,
+          ...input,
+          createdAt: input.attemptedAt,
+        };
+        sourceEvidenceQuarantineEntries.push(record);
+        return Promise.resolve(record);
+      },
+      listRecent: ({ limit, beforeTimestamp }) => {
+        const entries = [...sourceEvidenceQuarantineEntries]
+          .filter((entry) =>
+            beforeTimestamp === undefined
+              ? true
+              : entry.attemptedAt < beforeTimestamp,
+          )
+          .sort((left, right) => right.attemptedAt.getTime() - left.attemptedAt.getTime());
+
+        return Promise.resolve({
+          entries: entries.slice(0, limit),
+          hasMore: entries.length > limit,
+        });
+      },
     },
     canonicalEvents: {
       findById: (id) => Promise.resolve(canonicalEventsById.get(id) ?? null),

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -31,6 +31,15 @@ describe("defineStage1RepositoryBundle", () => {
         countByProvider: () => Promise.resolve(0),
         listByProviderRecord: () => Promise.resolve([]),
       },
+      sourceEvidenceQuarantine: {
+        record: (input) =>
+          Promise.resolve({
+            id: "source_evidence_quarantine:test",
+            ...input,
+            createdAt: new Date(0),
+          }),
+        listRecent: () => Promise.resolve({ entries: [], hasMore: false }),
+      },
       canonicalEvents: {
         findById: () => Promise.resolve(null),
         findByIdempotencyKey: () => Promise.resolve(null),

--- a/packages/domain/test/stage3-last-inbound-alias.test.ts
+++ b/packages/domain/test/stage3-last-inbound-alias.test.ts
@@ -40,6 +40,15 @@ function buildRepositoryBundle(input: {
       countByProvider: () => Promise.resolve(0),
       listByProviderRecord: () => Promise.resolve([]),
     },
+    sourceEvidenceQuarantine: {
+      record: (input) =>
+        Promise.resolve({
+          id: "source_evidence_quarantine:last-inbound-alias",
+          ...input,
+          createdAt: new Date(0),
+        }),
+      listRecent: () => Promise.resolve({ entries: [], hasMore: false }),
+    },
     canonicalEvents: {
       findById: () => Promise.resolve(null),
       findByIdempotencyKey: () => Promise.resolve(null),

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -107,6 +107,15 @@ function createRepositoryBundle(input: {
       countByProvider: () => Promise.resolve(0),
       listByProviderRecord: () => Promise.resolve([]),
     },
+    sourceEvidenceQuarantine: {
+      record: (input) =>
+        Promise.resolve({
+          id: "source_evidence_quarantine:timeline",
+          ...input,
+          createdAt: new Date(0),
+        }),
+      listRecent: () => Promise.resolve({ entries: [], hasMore: false }),
+    },
     canonicalEvents: {
       findById: (id) => Promise.resolve(canonicalEventsById.get(id) ?? null),
       findByIdempotencyKey: () => Promise.resolve(null),


### PR DESCRIPTION
## Summary

Slice 5 P1 #9 + Slice 1 idempotency race fix. Today the table has UNIQUE `(provider, idempotency_key, checksum)` — meaning two ingests with the same idempotency key but different checksums BOTH succeed silently. Per locked decision: **tighten + quarantine + log**.

## Schema (migration `0043`)

- **DROP** old `source_evidence_log_replay_unique` on `(provider, idempotency_key, checksum)`
- **ADD** tighter `source_evidence_log_provider_idempotency_unique` on `(provider, idempotency_key)`
- **CREATE** `source_evidence_quarantine` (id, provider, idempotency_key, checksum, attempted_at, reason, payload_ref, details_jsonb, created_at) with index on `(provider, idempotency_key)` for Logs page joins

## Persistence

`recordSourceEvidence`:
- **Pre-read path**: existing row with different checksum → write to quarantine with `reason: 'checksum_mismatch'`. No log insert attempted.
- **Post-append race path**: concurrent insert hits new UNIQUE → retry read, quarantine the loser.
- Same-checksum replays remain a no-op.

## Repository

- `SourceEvidenceQuarantineRepository` interface (`record`, `listRecent`)
- Drizzle impl + in-memory test impl + mappers
- Stage 1 bundle test fixtures updated across 6+ test files

## Logs page

`listIdempotencyChecksumCollisions` (#208) now joins log ⨝ quarantine rather than self-grouping. Same view-model shape with `winning` + `losing[]`, plus new `quarantineId` and `attemptedAt` per losing entry. UI renders the new fields.

## Pre-existing collision rows

Architect-handled out-of-band. Migration assumes clean dataset; pre-deploy audit:

```sql
SELECT provider, idempotency_key, COUNT(DISTINCT checksum)
FROM source_evidence_log
GROUP BY provider, idempotency_key
HAVING COUNT(DISTINCT checksum) > 1;
```

If any rows return, the architect resolves by moving older losers to quarantine before applying the migration.

## Test plan

- [x] `pnpm typecheck && pnpm lint` clean (VALIDATION_PASSED)
- [ ] CI green
- [ ] Architect runs the audit query before applying migration to prod
- [ ] Apply migration `0043` after audit clean
- [ ] Verify Logs page renders quarantine entries (artificial test: insert a duplicate via the persistence service in a pre-prod env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)