### PR TITLE
fix(integrations): bump SF capture task snippet cap to 100K (P0 follow-up)

### DIFF
--- a/packages/integrations/src/capture-services/salesforce.ts
+++ b/packages/integrations/src/capture-services/salesforce.ts
@@ -47,7 +47,7 @@ import {
   uniqueValues,
 } from "./shared.js";
 
-const SALESFORCE_CAPTURE_TASK_SNIPPET_MAX = 10_000;
+const SALESFORCE_CAPTURE_TASK_SNIPPET_MAX = 100_000;
 
 const salesforceCaptureServiceResponseSchema =
   createCapturedBatchResponseSchema(salesforceRecordSchema);

--- a/packages/integrations/test/stage1-salesforce-capture-service.test.ts
+++ b/packages/integrations/test/stage1-salesforce-capture-service.test.ts
@@ -341,7 +341,7 @@ describe("Salesforce capture service", () => {
                   },
                   TaskSubtype: "Email",
                   Subject: "Outbound follow-up",
-                  Description: "x".repeat(10_001),
+                  Description: "x".repeat(100_001),
                   CreatedDate: "2026-01-05T00:02:00.000Z",
                   LastModifiedDate: "2026-01-05T00:03:00.000Z"
                 }


### PR DESCRIPTION
## Summary

Follow-up to [#211](https://github.com/nico-kneler-as/as-comms-platform/pull/211). The previous hotfix bumped Gmail body preview to 100K and Salesforce provider snippet to 100K, but only bumped `SALESFORCE_CAPTURE_TASK_SNIPPET_MAX` from 2K to **10K** — well under the Salesforce `Description` column max of 32K. Real SF Tasks with long descriptions still trigger the same 400 `invalid_request` response that #211 was meant to fix.

## Diagnosis

Production observation post-#211 deploy: SF live capture continued 400-ing every cycle. Tracing:
- `salesforceLiveCaptureBatchPayloadSchema.parse(payload)` succeeds (request shape valid)
- The capture service then calls `captureLiveBatch` which iterates Salesforce records
- Inside, line 1232: `z.string().max(SALESFORCE_CAPTURE_TASK_SNIPPET_MAX).parse(description)` rejects when description > 10K
- Top-level handler catches the ZodError and returns 400 invalid_request

## Fix

`SALESFORCE_CAPTURE_TASK_SNIPPET_MAX`: 10K → **100K** (matches the provider-side cap).

Test fixture updated to use 100_001 for the over-cap rejection assertion.

## Test plan

- [x] `pnpm typecheck && pnpm lint` clean
- [ ] CI green
- [ ] Post-merge: `salesforce-capture` deploy + first SF poll succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)