### PR TITLE
fix(integrations): SF capture writes dimensions before memberships + restore FKs

### DIFF
--- a/packages/db/drizzle/0046_contact_memberships_fks_v2.sql
+++ b/packages/db/drizzle/0046_contact_memberships_fks_v2.sql
@@ -1,0 +1,15 @@
+-- Re-add the contact_memberships FKs introduced in 0039 and dropped in 0044.
+-- Salesforce capture now seeds project_dimensions / expedition_dimensions
+-- before contact_memberships, and the mapper always emits dimension rows when
+-- membership IDs are present, so the referential integrity checks are safe
+-- to restore.
+
+ALTER TABLE "contact_memberships"
+  ADD CONSTRAINT "contact_memberships_project_id_fkey"
+  FOREIGN KEY ("project_id") REFERENCES "project_dimensions" ("project_id")
+  ON DELETE RESTRICT;
+
+ALTER TABLE "contact_memberships"
+  ADD CONSTRAINT "contact_memberships_expedition_id_fkey"
+  FOREIGN KEY ("expedition_id") REFERENCES "expedition_dimensions" ("expedition_id")
+  ON DELETE RESTRICT;

--- a/packages/db/src/schema/tables.ts
+++ b/packages/db/src/schema/tables.ts
@@ -181,14 +181,16 @@ export const contactMemberships = pgTable(
     contactId: text("contact_id")
       .notNull()
       .references(() => contacts.id, { onDelete: "cascade" }),
-    // FKs to project_dimensions and expedition_dimensions were introduced in
-    // migration 0039 then immediately dropped in production after a P0:
-    // Salesforce live capture writes contact_memberships rows pointing at
-    // expedition IDs that haven't yet been ingested into expedition_dimensions.
-    // The capture pipeline needs to seed dimensions before memberships before
-    // these FKs can return. Until then, plain text columns.
-    projectId: text("project_id"),
-    expeditionId: text("expedition_id"),
+    // Migration 0039 added these FKs, 0044 dropped them to unblock a
+    // Salesforce capture P0, and 0046 restores them after the capture
+    // pipeline was fixed to seed dimensions before memberships.
+    projectId: text("project_id").references(() => projectDimensions.projectId, {
+      onDelete: "restrict"
+    }),
+    expeditionId: text("expedition_id").references(
+      () => expeditionDimensions.expeditionId,
+      { onDelete: "restrict" }
+    ),
     salesforceMembershipId: text("salesforce_membership_id"),
     role: text("role"),
     status: text("status"),

--- a/packages/domain/src/normalization.ts
+++ b/packages/domain/src/normalization.ts
@@ -1949,6 +1949,11 @@ export function createStage1NormalizationService(
         );
       }
 
+      await upsertProjectAndExpeditionDimensions(persistence, {
+        projectDimensions: parsed.projectDimensions,
+        expeditionDimensions: parsed.expeditionDimensions
+      });
+
       const memberships: ContactMembershipRecord[] = [];
       for (const membership of parsed.memberships) {
         const parsedMembership = contactMembershipSchema.parse(membership);
@@ -1966,11 +1971,6 @@ export function createStage1NormalizationService(
           })
         );
       }
-
-      await upsertProjectAndExpeditionDimensions(persistence, {
-        projectDimensions: parsed.projectDimensions,
-        expeditionDimensions: parsed.expeditionDimensions
-      });
       identityResolutionContext.clear();
 
       return {

--- a/packages/domain/test/normalization.test.ts
+++ b/packages/domain/test/normalization.test.ts
@@ -13,6 +13,7 @@ import type {
   MailchimpCampaignActivityDetailRecord,
   ManualNoteDetailRecord,
   NormalizedCanonicalEventIntake,
+  NormalizedContactGraphUpsertInput,
   ProjectDimensionRecord,
   RoutingReviewCase,
   SalesforceCommunicationDetailRecord,
@@ -201,6 +202,12 @@ function buildContext(input: {
   readonly contacts?: readonly ContactRecord[];
   readonly contactIdentities?: readonly ContactIdentityRecord[];
   readonly sourceProvider?: SourceEvidenceRecord["provider"];
+  readonly onContactIdentityUpsert?: (record: ContactIdentityRecord) => void;
+  readonly onContactMembershipUpsert?: (record: ContactMembershipRecord) => void;
+  readonly onProjectDimensionUpsert?: (record: ProjectDimensionRecord) => void;
+  readonly onExpeditionDimensionUpsert?: (
+    record: Parameters<Stage1RepositoryBundle["expeditionDimensions"]["upsert"]>[0],
+  ) => void;
 }): TestContext {
   const contacts = input.contacts ?? [contact];
   const contactIdentities = input.contactIdentities ?? [emailIdentity];
@@ -371,22 +378,34 @@ function buildContext(input: {
             (identity) => identity.normalizedValue === normalizedValue,
           ),
         ),
-      upsert: (record) => Promise.resolve(record),
+      upsert: (record) => {
+        input.onContactIdentityUpsert?.(record);
+        return Promise.resolve(record);
+      },
     },
     contactMemberships: {
       listByContactId: () => Promise.resolve([]),
       listByContactIds: () => Promise.resolve([]),
-      upsert: (record: ContactMembershipRecord) => Promise.resolve(record),
+      upsert: (record: ContactMembershipRecord) => {
+        input.onContactMembershipUpsert?.(record);
+        return Promise.resolve(record);
+      },
     },
     projectDimensions: {
       listAll: () => Promise.resolve([]),
       listActive: () => Promise.resolve([]),
       listByIds: () => Promise.resolve([]),
-      upsert: (record: ProjectDimensionRecord) => Promise.resolve(record),
+      upsert: (record: ProjectDimensionRecord) => {
+        input.onProjectDimensionUpsert?.(record);
+        return Promise.resolve(record);
+      },
     },
     expeditionDimensions: {
       listByIds: () => Promise.resolve([]),
-      upsert: (record) => Promise.resolve(record),
+      upsert: (record) => {
+        input.onExpeditionDimensionUpsert?.(record);
+        return Promise.resolve(record);
+      },
     },
     gmailMessageDetails: {
       listBySourceEvidenceIds: (ids) =>
@@ -783,6 +802,98 @@ describe("rebuildInboxProjectionForContact bucket semantics", () => {
       bucket: "New",
       lastInboundAt: latestInbound.occurredAt,
     });
+  });
+});
+
+describe("upsertNormalizedContactGraph write ordering", () => {
+  it("writes project and expedition dimensions before contact memberships for a new expedition", async () => {
+    const callOrder: { kind: string; id: string }[] = [];
+    const context = buildContext({
+      events: [],
+      contacts: [],
+      contactIdentities: [],
+      onContactIdentityUpsert: (record) => {
+        callOrder.push({ kind: "contactIdentity", id: record.id });
+      },
+      onProjectDimensionUpsert: (record) => {
+        callOrder.push({ kind: "projectDimension", id: record.projectId });
+      },
+      onExpeditionDimensionUpsert: (record) => {
+        callOrder.push({ kind: "expeditionDimension", id: record.expeditionId });
+      },
+      onContactMembershipUpsert: (record) => {
+        callOrder.push({ kind: "contactMembership", id: record.id });
+      }
+    });
+    const input: NormalizedContactGraphUpsertInput = {
+      contact: {
+        id: "contact:salesforce:003-new-expedition",
+        salesforceContactId: "003-new-expedition",
+        displayName: "New Expedition Volunteer",
+        primaryEmail: "new-expedition@example.org",
+        primaryPhone: null,
+        createdAt: "2026-04-29T00:00:00.000Z",
+        updatedAt: "2026-04-29T00:00:00.000Z"
+      },
+      identities: [
+        {
+          id: "identity:salesforce-contact-id:003-new-expedition",
+          contactId: "contact:salesforce:003-new-expedition",
+          kind: "salesforce_contact_id",
+          normalizedValue: "003-new-expedition",
+          isPrimary: true,
+          source: "salesforce",
+          verifiedAt: "2026-04-29T00:00:00.000Z"
+        }
+      ],
+      memberships: [
+        {
+          id: "membership:new-expedition",
+          contactId: "contact:salesforce:003-new-expedition",
+          projectId: "sf-project-NEW-1",
+          expeditionId: "sf-expedition-NEW-1",
+          salesforceMembershipId: "a0B-new-expedition",
+          role: "volunteer",
+          status: "active",
+          source: "salesforce",
+          createdAt: "2026-04-29T00:00:00.000Z"
+        }
+      ],
+      projectDimensions: [
+        {
+          projectId: "sf-project-NEW-1",
+          projectName: "New Project",
+          source: "salesforce",
+          isActive: false
+        }
+      ],
+      expeditionDimensions: [
+        {
+          expeditionId: "sf-expedition-NEW-1",
+          projectId: "sf-project-NEW-1",
+          expeditionName: "New Expedition",
+          source: "salesforce"
+        }
+      ]
+    };
+
+    await context.normalization.upsertNormalizedContactGraph(input);
+
+    const firstProjectDimensionIndex = callOrder.findIndex(
+      (entry) => entry.kind === "projectDimension"
+    );
+    const firstExpeditionDimensionIndex = callOrder.findIndex(
+      (entry) => entry.kind === "expeditionDimension"
+    );
+    const firstMembershipIndex = callOrder.findIndex(
+      (entry) => entry.kind === "contactMembership"
+    );
+
+    expect(firstProjectDimensionIndex).toBeGreaterThanOrEqual(0);
+    expect(firstExpeditionDimensionIndex).toBeGreaterThanOrEqual(0);
+    expect(firstMembershipIndex).toBeGreaterThanOrEqual(0);
+    expect(firstProjectDimensionIndex).toBeLessThan(firstMembershipIndex);
+    expect(firstExpeditionDimensionIndex).toBeLessThan(firstMembershipIndex);
   });
 });
 

--- a/packages/integrations/src/providers/salesforce.ts
+++ b/packages/integrations/src/providers/salesforce.ts
@@ -463,22 +463,19 @@ function mapSalesforceContactSnapshot(
   >();
 
   for (const membership of record.memberships) {
-    if (membership.projectId !== null && membership.projectName !== null) {
+    if (membership.projectId !== null) {
       projectDimensionsById.set(membership.projectId, {
         projectId: membership.projectId,
-        projectName: membership.projectName,
+        projectName: membership.projectName ?? membership.projectId,
         source: "salesforce",
       });
     }
 
-    if (
-      membership.expeditionId !== null &&
-      membership.expeditionName !== null
-    ) {
+    if (membership.expeditionId !== null) {
       expeditionDimensionsById.set(membership.expeditionId, {
         expeditionId: membership.expeditionId,
         projectId: membership.projectId,
-        expeditionName: membership.expeditionName,
+        expeditionName: membership.expeditionName ?? membership.expeditionId,
         source: "salesforce",
       });
     }
@@ -636,23 +633,24 @@ function mapSalesforceLifecycleRecord(
       sourceField: record.sourceField,
     },
     projectDimensions:
-      record.routing.projectId !== null && record.routing.projectName !== null
+      record.routing.projectId !== null
         ? [
             {
               projectId: record.routing.projectId,
-              projectName: record.routing.projectName,
+              projectName:
+                record.routing.projectName ?? record.routing.projectId,
               source: "salesforce" as const,
             },
           ]
         : [],
     expeditionDimensions:
-      record.routing.expeditionId !== null &&
-      record.routing.expeditionName !== null
+      record.routing.expeditionId !== null
         ? [
             {
               expeditionId: record.routing.expeditionId,
               projectId: record.routing.projectId,
-              expeditionName: record.routing.expeditionName,
+              expeditionName:
+                record.routing.expeditionName ?? record.routing.expeditionId,
               source: "salesforce" as const,
             },
           ]

--- a/packages/integrations/test/stage1-mappers.test.ts
+++ b/packages/integrations/test/stage1-mappers.test.ts
@@ -409,6 +409,65 @@ describe("Stage 1 provider-close mappers", () => {
     }
   });
 
+  it("emits placeholder dimensions when Salesforce membership names are missing", () => {
+    const result = mapSalesforceRecord({
+      recordType: "contact_snapshot",
+      recordId: "003-placeholder-dimensions",
+      salesforceContactId: "003-placeholder-dimensions",
+      displayName: "Placeholder Dimension Volunteer",
+      primaryEmail: "placeholder@example.org",
+      primaryPhone: null,
+      normalizedEmails: ["placeholder@example.org"],
+      normalizedPhones: [],
+      volunteerIdPlainValues: [],
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-02T00:00:00.000Z",
+      memberships: [
+        {
+          salesforceId: "a0B-placeholder-1",
+          projectId: "sf-project-X",
+          projectName: null,
+          expeditionId: "sf-expedition-X",
+          expeditionName: null,
+          role: "volunteer",
+          status: "active"
+        }
+      ]
+    });
+
+    expect(result.outcome).toBe("command");
+    if (result.outcome !== "command") {
+      throw new Error("Expected a contact graph command.");
+    }
+
+    expect(result.command.kind).toBe("contact_graph");
+    if (result.command.kind !== "contact_graph") {
+      throw new Error("Expected a contact graph command.");
+    }
+
+    expect(result.command.input.memberships).toEqual([
+      expect.objectContaining({
+        projectId: "sf-project-X",
+        expeditionId: "sf-expedition-X"
+      })
+    ]);
+    expect(result.command.input.projectDimensions).toEqual([
+      {
+        projectId: "sf-project-X",
+        projectName: "sf-project-X",
+        source: "salesforce"
+      }
+    ]);
+    expect(result.command.input.expeditionDimensions).toEqual([
+      {
+        expeditionId: "sf-expedition-X",
+        projectId: "sf-project-X",
+        expeditionName: "sf-expedition-X",
+        source: "salesforce"
+      }
+    ]);
+  });
+
   it("defers Salesforce contact snapshots that are not backed by expedition memberships", () => {
     const result = mapSalesforceRecord({
       recordType: "contact_snapshot",


### PR DESCRIPTION
## Summary

Closes the architectural loop on the 0039 → 0044 FK saga:

- **0039** ([#207](https://github.com/nico-kneler-as/as-comms-platform/pull/207)): added FKs from `contact_memberships.project_id/expedition_id` → dimensions tables
- **0044** ([#215](https://github.com/nico-kneler-as/as-comms-platform/pull/215)): dropped both FKs in prod after they blocked SF live capture (memberships were written before dimensions)
- **This PR**: fixes the write order + plugs the secondary mapper hole + re-adds the FKs

## Two fixes

### 1. `upsertNormalizedContactGraph` write order

`packages/domain/src/normalization.ts`: the function now upserts `projectDimensions` and `expeditionDimensions` BEFORE the `contact_memberships` loop. One-line reorder. Tests in `normalization.test.ts` prove dimensions land first.

### 2. SF mapper placeholder dimensions

`packages/integrations/src/providers/salesforce.ts`: when a Salesforce membership row carries a project/expedition id but no name (deleted/archived/cross-org refs), we now emit a stub dimension using the id as the placeholder name. Subsequent capture batches that carry the name overwrite the stub via `onConflictDoUpdate`. Test added in `stage1-mappers.test.ts`.

## Restore the FKs

- `packages/db/drizzle/0046_contact_memberships_fks_v2.sql` re-adds both FKs (`ON DELETE RESTRICT`)
- `packages/db/src/schema/tables.ts` restores `.references(...)` on `contactMemberships.projectId` and `expeditionId`. Comment updated to reflect the 0039 → 0044 → 0046 saga.

`0045` skipped as a buffer slot.

## Pre-deploy audit (mandatory)

Architect runs before applying `0046`:

```sql
SELECT COUNT(*) FROM contact_memberships m
LEFT JOIN project_dimensions p ON p.project_id = m.project_id
WHERE m.project_id IS NOT NULL AND p.project_id IS NULL;

SELECT COUNT(*) FROM contact_memberships m
LEFT JOIN expedition_dimensions e ON e.expedition_id = m.expedition_id
WHERE m.expedition_id IS NOT NULL AND e.expedition_id IS NULL;
```

Both must return **0** before applying. If non-zero (orphans accumulated since #215 dropped the FKs), backfill the missing dimension rows manually before applying.

## Test plan

- [x] `pnpm typecheck && pnpm lint` clean
- [ ] CI green
- [ ] Architect runs orphan audit and confirms 0 / 0 before applying 0046
- [ ] After deploy + migration: SF live capture remains healthy (the dimensions-first flip is in code; the FK is just defense-in-depth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)