### PR TITLE
feat(inbox): add follow-up rail to welcome dashboard

### DIFF
--- a/apps/web/app/inbox/_components/inbox-list.tsx
+++ b/apps/web/app/inbox/_components/inbox-list.tsx
@@ -17,6 +17,7 @@ import type {
   InboxListViewModel,
 } from "../_lib/view-models";
 import { fetchInboxListPage } from "../_lib/client-api";
+import { parseInboxFilterId } from "../_lib/view-models";
 import { shouldApplyUrlSearchQuery } from "../_lib/search-sync";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
@@ -133,6 +134,7 @@ export function InboxList({
     openNewDraft,
   } = useInboxClient();
   const urlQuery = searchParams.get("q") ?? "";
+  const urlFilter = searchParams.get("filter");
   const urlProjectId = searchParams.get("projectId");
   const urlProjectIds = searchParams.getAll("projectId");
   const rawSearchQuery = search.query.trim();
@@ -161,6 +163,7 @@ export function InboxList({
     urlProjectId ?? initialList.selectedProjectId ?? null,
   );
   const previousUrlQueryRef = useRef(urlQuery);
+  const previousUrlFilterRef = useRef(urlFilter);
   const previousUrlProjectIdRef = useRef(urlProjectId);
   const latestShellStateRef = useRef({
     activeFilter: initialFilterId,
@@ -210,6 +213,19 @@ export function InboxList({
     previousUrlProjectIdRef.current = urlProjectId;
     setSelectedProjectId(urlProjectId);
   }, [urlProjectId]);
+
+  useEffect(() => {
+    if (urlFilter === previousUrlFilterRef.current) {
+      return;
+    }
+
+    previousUrlFilterRef.current = urlFilter;
+    const parsedFilter = parseInboxFilterId(urlFilter);
+
+    if (parsedFilter !== null) {
+      setActiveFilter(parsedFilter);
+    }
+  }, [urlFilter]);
 
   useEffect(() => {
     const currentUrlQuery = urlQuery.trim();

--- a/apps/web/app/inbox/_components/inbox-welcome-workload.tsx
+++ b/apps/web/app/inbox/_components/inbox-welcome-workload.tsx
@@ -12,11 +12,13 @@ import {
 import { cn } from "@/lib/utils";
 
 import type {
+  InboxWelcomeFollowUpEntryViewModel,
   InboxWelcomeProjectWorkloadViewModel,
   InboxWelcomeWorkloadViewModel,
 } from "../_lib/view-models";
 import { FIELD_QUOTES } from "../_lib/field-quotes";
 import { projectToneFromName } from "../_lib/project-tone";
+import { InboxAvatar } from "./inbox-avatar";
 import { ArrowUpRightIcon, QuoteIcon, RefreshCwIcon } from "./icons";
 
 interface InboxWelcomeWorkloadProps {
@@ -77,6 +79,18 @@ export function InboxWelcomeWorkload({
           projects={workload.projects}
           onOpenProject={openProject}
         />
+
+        {workload.followUpRail.totalCount > 0 ? (
+          <FollowUpRail
+            rail={workload.followUpRail}
+            onOpenContact={(contactId) => {
+              router.push(`/inbox/${encodeURIComponent(contactId)}`);
+            }}
+            onViewAll={() => {
+              router.push("/inbox?filter=follow-up");
+            }}
+          />
+        ) : null}
       </div>
     </section>
   );
@@ -202,6 +216,103 @@ function ProjectMiniDashboard({
         })}
       </div>
     </div>
+  );
+}
+
+interface FollowUpRailProps {
+  readonly rail: InboxWelcomeWorkloadViewModel["followUpRail"];
+  readonly onOpenContact: (contactId: string) => void;
+  readonly onViewAll: () => void;
+}
+
+function FollowUpRail({
+  rail,
+  onOpenContact,
+  onViewAll,
+}: FollowUpRailProps) {
+  return (
+    <div>
+      <div className="flex items-baseline justify-between gap-4">
+        <SectionLabel as="h2">
+          {`\u{1F6A9} These need follow-up · ${rail.totalCount.toString()}`}
+        </SectionLabel>
+        <button
+          type="button"
+          onClick={onViewAll}
+          className="text-xs font-medium text-slate-500 transition-colors hover:text-slate-900"
+        >
+          View all →
+        </button>
+      </div>
+
+      <div className="mt-3 overflow-hidden rounded-xl border border-slate-200 bg-white">
+        <div className="divide-y divide-slate-100">
+          {rail.entries.map((entry) => (
+            <FollowUpRailRow
+              key={entry.contactId}
+              entry={entry}
+              onOpenContact={onOpenContact}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface FollowUpRailRowProps {
+  readonly entry: InboxWelcomeFollowUpEntryViewModel;
+  readonly onOpenContact: (contactId: string) => void;
+}
+
+function FollowUpRailRow({ entry, onOpenContact }: FollowUpRailRowProps) {
+  const tone =
+    entry.projectLabel === null
+      ? null
+      : TONE_CLASSES[projectToneFromName(entry.projectLabel)];
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        onOpenContact(entry.contactId);
+      }}
+      aria-label={`Open conversation with ${entry.displayName}`}
+      className="group relative flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-slate-50/80"
+    >
+      <InboxAvatar
+        initials={entry.initials}
+        tone={entry.avatarTone}
+        size="sm"
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-sm font-semibold text-slate-900">
+            {entry.displayName}
+          </span>
+          {entry.projectLabel !== null && tone !== null ? (
+            <span
+              className={cn(
+                "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
+                tone.subtle,
+                tone.subtleText,
+              )}
+            >
+              <span
+                aria-hidden="true"
+                className={cn("h-1.5 w-1.5 rounded-full", tone.dot)}
+              />
+              {entry.projectLabel}
+            </span>
+          ) : null}
+        </div>
+        <p className={cn(TYPE.caption, "truncate")}>{entry.latestSubject}</p>
+      </div>
+      <span className={cn(TYPE.micro, "shrink-0 whitespace-nowrap")}>
+        {entry.lastActivityLabel}
+      </span>
+      <ArrowUpRightIcon className="h-3.5 w-3.5 shrink-0 text-slate-300 transition-colors group-hover:text-slate-600" />
+    </button>
   );
 }
 

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -126,11 +126,13 @@ interface InboxDetailCacheData {
 interface InboxWelcomeWorkloadCacheData {
   readonly projects: InboxWelcomeWorkloadViewModel["projects"];
   readonly totals: InboxWelcomeWorkloadViewModel["totals"];
+  readonly followUpRail: InboxWelcomeWorkloadViewModel["followUpRail"];
 }
 
 const DEFAULT_INBOX_LIST_PAGE_SIZE = 50;
 const DEFAULT_INBOX_TIMELINE_PAGE_SIZE = 40;
 const INBOX_LIST_SCAN_LIMIT = 5_000;
+const WELCOME_FOLLOW_UP_INLINE_LIMIT = 3;
 
 type CampaignActivityType = Extract<
   TimelineItem,
@@ -2234,6 +2236,24 @@ function groupMembershipsByContactId(
   return grouped;
 }
 
+function pickPrimaryActiveProjectName(input: {
+  readonly memberships: readonly ContactMembershipRecord[];
+  readonly activeProjectIds: ReadonlySet<string>;
+  readonly projectLabelById: ReadonlyMap<string, string>;
+}): string | null {
+  const membership =
+    sortMembershipsByCreatedAt(input.memberships).find(
+      (record) =>
+        record.projectId !== null &&
+        input.activeProjectIds.has(record.projectId) &&
+        input.projectLabelById.has(record.projectId),
+    ) ?? null;
+
+  return membership?.projectId == null
+    ? null
+    : input.projectLabelById.get(membership.projectId) ?? null;
+}
+
 async function loadProjectMetadataById(
   memberships: readonly ContactMembershipRecord[],
 ): Promise<
@@ -2977,6 +2997,30 @@ async function readInboxWelcomeWorkloadCacheData(): Promise<InboxWelcomeWorkload
         activeProjectIds.has(membership.projectId),
     ),
   );
+  const followUpRows = activeWorkloadRows.filter((row) => row.needsFollowUp);
+  const orderedFollowUpRows = [...followUpRows].sort((left, right) => {
+    const timestampDifference = left.lastActivityAt.localeCompare(
+      right.lastActivityAt,
+    );
+
+    return timestampDifference !== 0
+      ? timestampDifference
+      : left.contactId.localeCompare(right.contactId);
+  });
+  const inlineRows = orderedFollowUpRows.slice(
+    0,
+    WELCOME_FOLLOW_UP_INLINE_LIMIT,
+  );
+  const inlineContactIds = inlineRows.map((row) => row.contactId);
+  const inlineContacts =
+    inlineContactIds.length === 0
+      ? []
+      : await runtime.repositories.contacts.listByIds(inlineContactIds);
+  const contactById = new Map(inlineContacts.map((contact) => [contact.id, contact]));
+  const projectLabelById = new Map(
+    activeProjects.map((project) => [project.projectId, project.projectName]),
+  );
+  const referenceNowIso = new Date().toISOString();
 
   return {
     projects: activeProjects.map((project, index) => {
@@ -3001,6 +3045,32 @@ async function readInboxWelcomeWorkloadCacheData(): Promise<InboxWelcomeWorkload
       unread: activeWorkloadRows.filter((row) => row.bucket === "New").length,
       needsFollowUp: activeWorkloadRows.filter((row) => row.needsFollowUp)
         .length,
+    },
+    followUpRail: {
+      totalCount: orderedFollowUpRows.length,
+      entries: inlineRows.map((row) => {
+        const contact = contactById.get(row.contactId);
+        const displayName = contact?.displayName ?? "Unknown contact";
+        const membershipsForContact =
+          membershipsByContactId.get(row.contactId) ?? [];
+
+        return {
+          contactId: row.contactId,
+          displayName,
+          initials: toInitials(displayName),
+          avatarTone: avatarToneForContact(row.contactId),
+          projectLabel: pickPrimaryActiveProjectName({
+            memberships: membershipsForContact,
+            activeProjectIds,
+            projectLabelById,
+          }),
+          latestSubject: fallbackLatestSubject(row.lastEventType),
+          lastActivityLabel: formatRelativeTimestamp(
+            row.lastActivityAt,
+            referenceNowIso,
+          ),
+        };
+      }),
     },
   };
 }
@@ -3235,6 +3305,7 @@ export async function getInboxWelcomeWorkload(): Promise<InboxWelcomeWorkloadVie
   return {
     projects: cachedData.projects,
     totals: cachedData.totals,
+    followUpRail: cachedData.followUpRail,
   };
 }
 

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -30,6 +30,22 @@ export type InboxFilterId =
   | "sent"
   | "archived";
 
+export const INBOX_FILTER_IDS: readonly InboxFilterId[] = [
+  "all",
+  "unread",
+  "follow-up",
+  "unresolved",
+  "sent",
+];
+
+export function parseInboxFilterId(
+  value: string | null | undefined,
+): InboxFilterId | null {
+  return INBOX_FILTER_IDS.includes(value as InboxFilterId)
+    ? (value as InboxFilterId)
+    : null;
+}
+
 export type InboxChannel = "email" | "sms";
 
 export type InboxVolunteerStage =
@@ -356,12 +372,26 @@ export interface InboxWelcomeProjectWorkloadViewModel {
   readonly needsFollowUpCount: number;
 }
 
+export interface InboxWelcomeFollowUpEntryViewModel {
+  readonly contactId: string;
+  readonly displayName: string;
+  readonly initials: string;
+  readonly avatarTone: InboxAvatarTone;
+  readonly projectLabel: string | null;
+  readonly latestSubject: string;
+  readonly lastActivityLabel: string;
+}
+
 export interface InboxWelcomeWorkloadViewModel {
   readonly projects: readonly InboxWelcomeProjectWorkloadViewModel[];
   readonly totals: {
     readonly activeProjects: number;
     readonly unread: number;
     readonly needsFollowUp: number;
+  };
+  readonly followUpRail: {
+    readonly totalCount: number;
+    readonly entries: readonly InboxWelcomeFollowUpEntryViewModel[];
   };
 }
 

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -1720,6 +1720,7 @@ describe("real inbox selectors", () => {
     await runtime.context.repositories.projectDimensions.upsert({
       projectId: "project:whitebark-pine",
       projectName: "Tracking Whitebark Pine",
+      projectAlias: "Whitebark Pine",
       source: "salesforce",
       isActive: true,
     });

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -1436,6 +1436,405 @@ describe("real inbox selectors", () => {
     });
   });
 
+  it("returns an empty follow-up rail when no active workload row needs follow-up", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:sarah-martinez",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-14T13:00:00.000Z",
+      lastOutboundAt: "2026-04-13T12:00:00.000Z",
+      lastActivityAt: "2026-04-14T13:00:00.000Z",
+      snippet:
+        "Following up on the field study logistics for the Amazon basin project.",
+      lastCanonicalEventId: "event:sarah-inbound-1",
+      lastEventType: "communication.email.inbound",
+    });
+
+    const workload = await getInboxWelcomeWorkload();
+
+    expect(workload.followUpRail).toEqual({
+      totalCount: 0,
+      entries: [],
+    });
+  });
+
+  it("excludes follow-up rows whose memberships only touch inactive projects", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await runtime.context.settings.projects.setActive(
+      "project:killer-whales",
+      false,
+    );
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:sarah-martinez",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-14T13:00:00.000Z",
+      lastOutboundAt: "2026-04-13T12:00:00.000Z",
+      lastActivityAt: "2026-04-14T13:00:00.000Z",
+      snippet:
+        "Following up on the field study logistics for the Amazon basin project.",
+      lastCanonicalEventId: "event:sarah-inbound-1",
+      lastEventType: "communication.email.inbound",
+    });
+
+    const hiddenLatest = await seedInboxEmailEvent(runtime.context, {
+      id: "hidden-follow-up-1",
+      contactId: "contact:hidden-follow-up",
+      occurredAt: "2026-04-10T10:00:00.000Z",
+      direction: "inbound",
+      subject: "Killer whales check-in",
+      snippet: "Checking in from the inactive project.",
+    });
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:hidden-follow-up",
+      salesforceContactId: "003-hidden-follow-up",
+      displayName: "Hidden Follow Up",
+      primaryEmail: "hidden-follow-up@example.org",
+      primaryPhone: null,
+      projectId: "project:killer-whales",
+      projectName: "Searching for Killer Whales",
+      membershipId: "membership:hidden-follow-up",
+      membershipStatus: "active",
+      membershipCreatedAt: "2026-04-10T10:00:00.000Z",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:hidden-follow-up",
+      bucket: "New",
+      needsFollowUp: true,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-10T10:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-04-10T10:00:00.000Z",
+      snippet: "Checking in from the inactive project.",
+      lastCanonicalEventId: hiddenLatest.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+
+    const workload = await getInboxWelcomeWorkload();
+
+    expect(workload.followUpRail.totalCount).toBe(0);
+    expect(workload.followUpRail.entries).toEqual([]);
+  });
+
+  it("caps the follow-up rail inline list at three rows while preserving the full count", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:sarah-martinez",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-14T13:00:00.000Z",
+      lastOutboundAt: "2026-04-13T12:00:00.000Z",
+      lastActivityAt: "2026-04-14T13:00:00.000Z",
+      snippet:
+        "Following up on the field study logistics for the Amazon basin project.",
+      lastCanonicalEventId: "event:sarah-inbound-1",
+      lastEventType: "communication.email.inbound",
+    });
+
+    const contacts = [
+      {
+        contactId: "contact:follow-up-a",
+        displayName: "Follow Up A",
+        occurredAt: "2026-04-09T09:00:00.000Z",
+      },
+      {
+        contactId: "contact:follow-up-b",
+        displayName: "Follow Up B",
+        occurredAt: "2026-04-10T09:00:00.000Z",
+      },
+      {
+        contactId: "contact:follow-up-c",
+        displayName: "Follow Up C",
+        occurredAt: "2026-04-11T09:00:00.000Z",
+      },
+      {
+        contactId: "contact:follow-up-d",
+        displayName: "Follow Up D",
+        occurredAt: "2026-04-12T09:00:00.000Z",
+      },
+      {
+        contactId: "contact:follow-up-e",
+        displayName: "Follow Up E",
+        occurredAt: "2026-04-13T09:00:00.000Z",
+      },
+    ] as const;
+
+    for (const contact of contacts) {
+      await seedInboxContact(runtime.context, {
+        contactId: contact.contactId,
+        salesforceContactId: contact.contactId.replace("contact:", "003-"),
+        displayName: contact.displayName,
+        primaryEmail: `${contact.contactId}@example.org`,
+        primaryPhone: null,
+        projectId: "project:amazon-basin",
+        projectName: "Amazon Basin Research",
+        membershipId: `membership:${contact.contactId}`,
+        membershipStatus: "active",
+        membershipCreatedAt: contact.occurredAt,
+      });
+      const latest = await seedInboxEmailEvent(runtime.context, {
+        id: `${contact.contactId}-follow-up`,
+        contactId: contact.contactId,
+        occurredAt: contact.occurredAt,
+        direction: "inbound",
+        subject: `${contact.displayName} subject`,
+        snippet: `${contact.displayName} snippet`,
+      });
+      await seedInboxProjection(runtime.context, {
+        contactId: contact.contactId,
+        bucket: "New",
+        needsFollowUp: true,
+        hasUnresolved: false,
+        lastInboundAt: contact.occurredAt,
+        lastOutboundAt: null,
+        lastActivityAt: contact.occurredAt,
+        snippet: `${contact.displayName} snippet`,
+        lastCanonicalEventId: latest.canonicalEventId,
+        lastEventType: "communication.email.inbound",
+      });
+    }
+
+    const workload = await getInboxWelcomeWorkload();
+
+    expect(workload.followUpRail.totalCount).toBe(5);
+    expect(workload.followUpRail.entries).toHaveLength(3);
+    expect(workload.followUpRail.entries.map((entry) => entry.contactId)).toEqual([
+      "contact:follow-up-a",
+      "contact:follow-up-b",
+      "contact:follow-up-c",
+    ]);
+  });
+
+  it("orders follow-up rail rows by oldest lastActivityAt first with contactId tiebreaks", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:sarah-martinez",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-14T13:00:00.000Z",
+      lastOutboundAt: "2026-04-13T12:00:00.000Z",
+      lastActivityAt: "2026-04-14T13:00:00.000Z",
+      snippet:
+        "Following up on the field study logistics for the Amazon basin project.",
+      lastCanonicalEventId: "event:sarah-inbound-1",
+      lastEventType: "communication.email.inbound",
+    });
+
+    const contacts = [
+      {
+        contactId: "contact:zeta",
+        displayName: "Zeta Contact",
+        occurredAt: "2026-04-10T09:00:00.000Z",
+      },
+      {
+        contactId: "contact:alpha",
+        displayName: "Alpha Contact",
+        occurredAt: "2026-04-10T09:00:00.000Z",
+      },
+      {
+        contactId: "contact:middle",
+        displayName: "Middle Contact",
+        occurredAt: "2026-04-11T09:00:00.000Z",
+      },
+    ] as const;
+
+    for (const contact of contacts) {
+      await seedInboxContact(runtime.context, {
+        contactId: contact.contactId,
+        salesforceContactId: contact.contactId.replace("contact:", "003-"),
+        displayName: contact.displayName,
+        primaryEmail: `${contact.contactId}@example.org`,
+        primaryPhone: null,
+        projectId: "project:amazon-basin",
+        projectName: "Amazon Basin Research",
+        membershipId: `membership:${contact.contactId}`,
+        membershipStatus: "active",
+        membershipCreatedAt: contact.occurredAt,
+      });
+      const latest = await seedInboxEmailEvent(runtime.context, {
+        id: `${contact.contactId}-order`,
+        contactId: contact.contactId,
+        occurredAt: contact.occurredAt,
+        direction: "inbound",
+        subject: `${contact.displayName} subject`,
+        snippet: `${contact.displayName} snippet`,
+      });
+      await seedInboxProjection(runtime.context, {
+        contactId: contact.contactId,
+        bucket: "New",
+        needsFollowUp: true,
+        hasUnresolved: false,
+        lastInboundAt: contact.occurredAt,
+        lastOutboundAt: null,
+        lastActivityAt: contact.occurredAt,
+        snippet: `${contact.displayName} snippet`,
+        lastCanonicalEventId: latest.canonicalEventId,
+        lastEventType: "communication.email.inbound",
+      });
+    }
+
+    const workload = await getInboxWelcomeWorkload();
+
+    expect(workload.followUpRail.entries.map((entry) => entry.contactId)).toEqual([
+      "contact:alpha",
+      "contact:zeta",
+      "contact:middle",
+    ]);
+  });
+
+  it("uses one active project label per row based on the newest active membership", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:sarah-martinez",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-14T13:00:00.000Z",
+      lastOutboundAt: "2026-04-13T12:00:00.000Z",
+      lastActivityAt: "2026-04-14T13:00:00.000Z",
+      snippet:
+        "Following up on the field study logistics for the Amazon basin project.",
+      lastCanonicalEventId: "event:sarah-inbound-1",
+      lastEventType: "communication.email.inbound",
+    });
+    await runtime.context.repositories.projectDimensions.upsert({
+      projectId: "project:whitebark-pine",
+      projectName: "Tracking Whitebark Pine",
+      source: "salesforce",
+      isActive: true,
+    });
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:multi-membership",
+      salesforceContactId: "003-multi-membership",
+      displayName: "Multi Membership",
+      primaryEmail: "multi-membership@example.org",
+      primaryPhone: null,
+      projectId: "project:amazon-basin",
+      projectName: "Amazon Basin Research",
+      membershipId: "membership:multi-membership:amazon",
+      membershipStatus: "lead",
+      membershipCreatedAt: "2026-04-08T09:00:00.000Z",
+    });
+    await runtime.context.repositories.contactMemberships.upsert({
+      id: "membership:multi-membership:whitebark",
+      contactId: "contact:multi-membership",
+      projectId: "project:whitebark-pine",
+      expeditionId: null,
+      salesforceMembershipId: "membership:multi-membership:whitebark:sf",
+      role: "volunteer",
+      status: "active",
+      source: "salesforce",
+      createdAt: "2026-04-12T09:00:00.000Z",
+    });
+    const latest = await seedInboxEmailEvent(runtime.context, {
+      id: "multi-membership-follow-up",
+      contactId: "contact:multi-membership",
+      occurredAt: "2026-04-12T09:00:00.000Z",
+      direction: "inbound",
+      subject: "Multi membership subject",
+      snippet: "Multi membership snippet",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:multi-membership",
+      bucket: "New",
+      needsFollowUp: true,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-12T09:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-04-12T09:00:00.000Z",
+      snippet: "Multi membership snippet",
+      lastCanonicalEventId: latest.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+
+    const workload = await getInboxWelcomeWorkload();
+    const entry = workload.followUpRail.entries.find(
+      (item) => item.contactId === "contact:multi-membership",
+    );
+
+    expect(entry?.projectLabel).toBe("Tracking Whitebark Pine");
+  });
+
+  it("uses the event-type fallback subject for follow-up rows", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:sarah-martinez",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-14T13:00:00.000Z",
+      lastOutboundAt: "2026-04-13T12:00:00.000Z",
+      lastActivityAt: "2026-04-14T13:00:00.000Z",
+      snippet:
+        "Following up on the field study logistics for the Amazon basin project.",
+      lastCanonicalEventId: "event:sarah-inbound-1",
+      lastEventType: "communication.email.inbound",
+    });
+    const latest = await seedInboxEmailEvent(runtime.context, {
+      id: "fallback-follow-up",
+      contactId: "contact:fallback-follow-up",
+      occurredAt: "2026-04-09T08:00:00.000Z",
+      direction: "outbound",
+      subject: "Ignored explicit subject",
+      snippet: "",
+    });
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:fallback-follow-up",
+      salesforceContactId: "003-fallback-follow-up",
+      displayName: "Fallback Follow Up",
+      primaryEmail: "fallback-follow-up@example.org",
+      primaryPhone: null,
+      projectId: "project:amazon-basin",
+      projectName: "Amazon Basin Research",
+      membershipId: "membership:fallback-follow-up",
+      membershipStatus: "active",
+      membershipCreatedAt: "2026-04-09T08:00:00.000Z",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:fallback-follow-up",
+      bucket: "Opened",
+      needsFollowUp: true,
+      hasUnresolved: false,
+      lastInboundAt: null,
+      lastOutboundAt: "2026-04-09T08:00:00.000Z",
+      lastActivityAt: "2026-04-09T08:00:00.000Z",
+      snippet: "",
+      lastCanonicalEventId: latest.canonicalEventId,
+      lastEventType: "communication.email.outbound",
+    });
+
+    const workload = await getInboxWelcomeWorkload();
+    const entry = workload.followUpRail.entries.find(
+      (item) => item.contactId === "contact:fallback-follow-up",
+    );
+
+    expect(entry?.latestSubject).toBe("Outbound email sent");
+  });
+
   it("assembles selected-contact detail from real contact, membership, timeline, and projection data", async () => {
     const detail = await getInboxDetail("contact:sarah-martinez");
 

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -1486,15 +1486,6 @@ describe("real inbox selectors", () => {
       lastEventType: "communication.email.inbound",
     });
 
-    const hiddenLatest = await seedInboxEmailEvent(runtime.context, {
-      id: "hidden-follow-up-1",
-      contactId: "contact:hidden-follow-up",
-      occurredAt: "2026-04-10T10:00:00.000Z",
-      direction: "inbound",
-      subject: "Killer whales check-in",
-      snippet: "Checking in from the inactive project.",
-    });
-
     await seedInboxContact(runtime.context, {
       contactId: "contact:hidden-follow-up",
       salesforceContactId: "003-hidden-follow-up",
@@ -1506,6 +1497,14 @@ describe("real inbox selectors", () => {
       membershipId: "membership:hidden-follow-up",
       membershipStatus: "active",
       membershipCreatedAt: "2026-04-10T10:00:00.000Z",
+    });
+    const hiddenLatest = await seedInboxEmailEvent(runtime.context, {
+      id: "hidden-follow-up-1",
+      contactId: "contact:hidden-follow-up",
+      occurredAt: "2026-04-10T10:00:00.000Z",
+      direction: "inbound",
+      subject: "Killer whales check-in",
+      snippet: "Checking in from the inactive project.",
     });
     await seedInboxProjection(runtime.context, {
       contactId: "contact:hidden-follow-up",
@@ -1794,14 +1793,6 @@ describe("real inbox selectors", () => {
       lastCanonicalEventId: "event:sarah-inbound-1",
       lastEventType: "communication.email.inbound",
     });
-    const latest = await seedInboxEmailEvent(runtime.context, {
-      id: "fallback-follow-up",
-      contactId: "contact:fallback-follow-up",
-      occurredAt: "2026-04-09T08:00:00.000Z",
-      direction: "outbound",
-      subject: "Ignored explicit subject",
-      snippet: "",
-    });
     await seedInboxContact(runtime.context, {
       contactId: "contact:fallback-follow-up",
       salesforceContactId: "003-fallback-follow-up",
@@ -1813,6 +1804,14 @@ describe("real inbox selectors", () => {
       membershipId: "membership:fallback-follow-up",
       membershipStatus: "active",
       membershipCreatedAt: "2026-04-09T08:00:00.000Z",
+    });
+    const latest = await seedInboxEmailEvent(runtime.context, {
+      id: "fallback-follow-up",
+      contactId: "contact:fallback-follow-up",
+      occurredAt: "2026-04-09T08:00:00.000Z",
+      direction: "outbound",
+      subject: "Ignored explicit subject",
+      snippet: "",
     });
     await seedInboxProjection(runtime.context, {
       contactId: "contact:fallback-follow-up",

--- a/apps/web/tests/unit/inbox-welcome-workload-component.test.tsx
+++ b/apps/web/tests/unit/inbox-welcome-workload-component.test.tsx
@@ -1,0 +1,243 @@
+import { createRequire } from "node:module";
+import React, { act, createElement } from "react";
+
+Object.assign(globalThis, { React });
+
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { InboxWelcomeWorkloadViewModel } from "../../app/inbox/_lib/view-models";
+
+const routerPushMock = vi.hoisted(() => vi.fn());
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: routerPushMock,
+  }),
+}));
+
+function iconMock(name: string) {
+  return (props: Record<string, unknown>) =>
+    createElement("svg", { "data-icon": name, ...props });
+}
+
+vi.mock("../../app/inbox/_components/icons", () => ({
+  ArrowUpRightIcon: iconMock("ArrowUpRightIcon"),
+  QuoteIcon: iconMock("QuoteIcon"),
+  RefreshCwIcon: iconMock("RefreshCwIcon"),
+}));
+
+vi.mock("../../app/inbox/_components/inbox-avatar", () => ({
+  InboxAvatar: ({
+    initials,
+  }: {
+    readonly initials: string;
+  }) => createElement("span", null, initials),
+}));
+
+import { InboxWelcomeWorkload } from "../../app/inbox/_components/inbox-welcome-workload";
+
+const workerRequire = createRequire(
+  new URL("../../../worker/package.json", import.meta.url),
+);
+const { JSDOM } = workerRequire("jsdom") as {
+  readonly JSDOM: new (
+    html: string,
+    options: { readonly url: string },
+  ) => {
+    readonly window: Window &
+      typeof globalThis & {
+        close: () => void;
+      };
+  };
+};
+
+interface RenderSession {
+  readonly container: HTMLElement;
+  readonly root: Root;
+  readonly cleanup: () => void;
+}
+
+let activeSession: RenderSession | null = null;
+
+function setDomGlobals(window: Window & typeof globalThis) {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: window,
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: window.document,
+  });
+  Object.defineProperty(globalThis, "HTMLElement", {
+    configurable: true,
+    value: window.HTMLElement,
+  });
+  Object.defineProperty(globalThis, "Node", {
+    configurable: true,
+    value: window.Node,
+  });
+  Object.defineProperty(globalThis, "Event", {
+    configurable: true,
+    value: window.Event,
+  });
+  Object.defineProperty(globalThis, "MouseEvent", {
+    configurable: true,
+    value: window.MouseEvent,
+  });
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: window.navigator,
+  });
+  Object.defineProperty(globalThis, "requestAnimationFrame", {
+    configurable: true,
+    value: (callback: FrameRequestCallback) => {
+      return window.setTimeout(callback, 16);
+    },
+  });
+  Object.defineProperty(globalThis, "cancelAnimationFrame", {
+    configurable: true,
+    value: (id: number) => {
+      window.clearTimeout(id);
+    },
+  });
+}
+
+function renderComponent(workload: InboxWelcomeWorkloadViewModel): RenderSession {
+  const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+    url: "http://localhost/inbox",
+  });
+  setDomGlobals(dom.window);
+
+  const container = dom.window.document.createElement("div");
+  dom.window.document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <InboxWelcomeWorkload workload={workload} firstName="Nicolas" />,
+    );
+  });
+
+  return {
+    container,
+    root,
+    cleanup: () => {
+      act(() => {
+        root.unmount();
+      });
+      dom.window.close();
+    },
+  };
+}
+
+function buildWorkload(
+  totalCount: number,
+): InboxWelcomeWorkloadViewModel {
+  const entries =
+    totalCount === 0
+      ? []
+      : [
+          {
+            contactId: "contact:alpha",
+            displayName: "Alpha Rowan",
+            initials: "AR",
+            avatarTone: "indigo" as const,
+            projectLabel: "Amazon Basin Research",
+            latestSubject: "Inbound email received",
+            lastActivityLabel: "3d ago",
+          },
+          {
+            contactId: "contact:bravo",
+            displayName: "Bravo Stone",
+            initials: "BS",
+            avatarTone: "emerald" as const,
+            projectLabel: "Tracking Whitebark Pine",
+            latestSubject: "Outbound email sent",
+            lastActivityLabel: "2d ago",
+          },
+          {
+            contactId: "contact:charlie",
+            displayName: "Charlie Vale",
+            initials: "CV",
+            avatarTone: "amber" as const,
+            projectLabel: null,
+            latestSubject: "Inbound SMS received",
+            lastActivityLabel: "yesterday",
+          },
+        ].slice(0, Math.min(totalCount, 3));
+
+  return {
+    projects: [],
+    totals: {
+      activeProjects: 0,
+      unread: 0,
+      needsFollowUp: totalCount,
+    },
+    followUpRail: {
+      totalCount,
+      entries,
+    },
+  };
+}
+
+afterEach(() => {
+  routerPushMock.mockReset();
+
+  if (activeSession !== null) {
+    activeSession.cleanup();
+    activeSession = null;
+  }
+});
+
+describe("InboxWelcomeWorkload follow-up rail", () => {
+  it("renders follow-up rows with conversation aria labels", () => {
+    activeSession = renderComponent(buildWorkload(3));
+
+    const buttons = Array.from(
+      activeSession.container.querySelectorAll("button[aria-label]"),
+    ).map((element) => element.getAttribute("aria-label"));
+
+    expect(
+      activeSession.container.textContent.includes(
+        "🚩 These need follow-up · 3",
+      ),
+    ).toBe(true);
+    expect(buttons).toEqual([
+      "Open conversation with Alpha Rowan",
+      "Open conversation with Bravo Stone",
+      "Open conversation with Charlie Vale",
+    ]);
+  });
+
+  it("hides the follow-up rail entirely when the total count is zero", () => {
+    activeSession = renderComponent(buildWorkload(0));
+
+    expect(activeSession.container.textContent).not.toContain(
+      "These need follow-up",
+    );
+    expect(activeSession.container.textContent).not.toContain("View all");
+  });
+
+  it("routes View all clicks to the follow-up inbox filter", () => {
+    activeSession = renderComponent(buildWorkload(3));
+
+    const viewAllButton = Array.from(
+      activeSession.container.querySelectorAll("button"),
+    ).find((element) => element.textContent.includes("View all"));
+
+    expect(viewAllButton).toBeTruthy();
+
+    if (viewAllButton === undefined) {
+      throw new Error("Expected View all button");
+    }
+
+    act(() => {
+      viewAllButton.dispatchEvent(
+        new window.MouseEvent("click", { bubbles: true }),
+      );
+    });
+
+    expect(routerPushMock).toHaveBeenCalledWith("/inbox?filter=follow-up");
+  });
+});

--- a/apps/web/tests/unit/inbox-welcome-workload-component.test.tsx
+++ b/apps/web/tests/unit/inbox-welcome-workload-component.test.tsx
@@ -195,7 +195,9 @@ describe("InboxWelcomeWorkload follow-up rail", () => {
     activeSession = renderComponent(buildWorkload(3));
 
     const buttons = Array.from(
-      activeSession.container.querySelectorAll("button[aria-label]"),
+      activeSession.container.querySelectorAll(
+        'button[aria-label^="Open conversation with"]',
+      ),
     ).map((element) => element.getAttribute("aria-label"));
 
     expect(


### PR DESCRIPTION
## Summary

Adds the **🚩 These need follow-up** rail to the inbox welcome dashboard, beneath the project workload cards. Surfaces the conversations the operator has manually flagged for follow-up so they don't slip when working through `/inbox`.

Brief: [.codex-welcome-follow-up-rail-2026-04-29.md](https://github.com/nico-kneler-as/as-comms-platform/blob/feat/welcome-follow-up-rail/.codex-welcome-follow-up-rail-2026-04-29.md) (committed alongside the change is fine, but the brief lives at repo root pre-merge — link is for review).

## Decisions locked in the brief

| | |
|---|---|
| Source | `inboxProjection.needsFollowUp === true` AND contact has ≥1 membership in an active project |
| Order | `lastActivityAt ASC` (oldest pending first), tiebreak by `contactId` |
| Inline cap | 3 rows (`WELCOME_FOLLOW_UP_INLINE_LIMIT`) |
| Empty state | Rail returns `null` — no header, no card, no placeholder copy |
| "View all" | Routes to `/inbox?filter=follow-up` (new client-side URL→state mirror in `inbox-list.tsx`) |
| Click row | Navigates to `/inbox/[contactId]` |

## Surfaces touched

- **View models** ([apps/web/app/inbox/_lib/view-models.ts](https://github.com/nico-kneler-as/as-comms-platform/blob/feat/welcome-follow-up-rail/apps/web/app/inbox/_lib/view-models.ts)) — adds `InboxWelcomeFollowUpEntryViewModel`, extends `InboxWelcomeWorkloadViewModel.followUpRail`, and adds the shared `parseInboxFilterId` helper.
- **Selector** ([apps/web/app/inbox/_lib/selectors.ts](https://github.com/nico-kneler-as/as-comms-platform/blob/feat/welcome-follow-up-rail/apps/web/app/inbox/_lib/selectors.ts)) — extends the existing `readInboxWelcomeWorkloadCacheData` pipeline (no second projection scan); resolves contacts via `contacts.listByIds`; uses `fallbackLatestSubject(lastEventType)` for the subject (rail doesn't load full message previews).
- **Welcome component** ([apps/web/app/inbox/_components/inbox-welcome-workload.tsx](https://github.com/nico-kneler-as/as-comms-platform/blob/feat/welcome-follow-up-rail/apps/web/app/inbox/_components/inbox-welcome-workload.tsx)) — colocated `FollowUpRail` + `FollowUpRailRow` subcomponents; reuses `InboxAvatar`, `projectToneFromName`, `TONE_CLASSES`, `ArrowUpRightIcon`.
- **List URL mirror** ([apps/web/app/inbox/_components/inbox-list.tsx](https://github.com/nico-kneler-as/as-comms-platform/blob/feat/welcome-follow-up-rail/apps/web/app/inbox/_components/inbox-list.tsx)) — client-side `?filter=` → `activeFilter` mirror, parallel to the existing `?projectId=` mirror. Layout untouched.

## Tests

- 6 new cases in [apps/web/tests/unit/inbox-selectors.test.ts](https://github.com/nico-kneler-as/as-comms-platform/blob/feat/welcome-follow-up-rail/apps/web/tests/unit/inbox-selectors.test.ts): empty rail, active-project gating, inline cap with full count preserved, order by oldest `lastActivityAt`, multi-membership project label resolution, event-type subject fallback.
- 3 new cases in [apps/web/tests/unit/inbox-welcome-workload-component.test.tsx](https://github.com/nico-kneler-as/as-comms-platform/blob/feat/welcome-follow-up-rail/apps/web/tests/unit/inbox-welcome-workload-component.test.tsx): renders rows + ARIA labels, hides entire rail when total count is 0, "View all" routes to `/inbox?filter=follow-up`.

## Validation

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm --filter @as-comms/web test:unit` — local macOS run blocked by the documented `rollup-darwin-arm64 ERR_DLOPEN` (per `project_macos_rollup_gotcha`); CI authoritative.

## Out of scope (explicit)

- No new follow-up state — reuses the existing `inboxProjection.needsFollowUp` toggle.
- No `needsFollowUpAt` column or schema migration.
- Project workload cards, quote card, timeline, inbox row untouched.
- Layout (`apps/web/app/inbox/layout.tsx`) untouched — URL filter mirror is client-side only.

## Test plan

- [ ] CI green
- [ ] Manual: dashboard renders the rail when ≥1 contact in an active project has `needsFollowUp=true`
- [ ] Manual: rail is hidden entirely when no flagged conversations exist
- [ ] Manual: clicking a row navigates to `/inbox/[contactId]`
- [ ] Manual: clicking "View all →" lands on `/inbox?filter=follow-up` with the follow-up filter chip active