### PR TITLE
fix(db): enforce non-empty project_alias on active project_dimensions

### DIFF
--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -1314,18 +1314,21 @@ describe("real inbox selectors", () => {
     await runtime.context.repositories.projectDimensions.upsert({
       projectId: "project:amazon-basin",
       projectName: "Amazon Basin Research",
+      projectAlias: "Amazon Basin",
       source: "salesforce",
       isActive: true,
     });
     await runtime.context.repositories.projectDimensions.upsert({
       projectId: "project:whitebark-pine",
       projectName: "Tracking Whitebark Pine",
+      projectAlias: "Whitebark Pine",
       source: "salesforce",
       isActive: true,
     });
     await runtime.context.repositories.projectDimensions.upsert({
       projectId: "project:river-cleanup",
       projectName: "River Cleanup",
+      projectAlias: "River Cleanup",
       source: "salesforce",
       isActive: true,
     });
@@ -1379,12 +1382,14 @@ describe("real inbox selectors", () => {
     await runtime.context.repositories.projectDimensions.upsert({
       projectId: "project:amazon-basin",
       projectName: "Amazon Basin Research",
+      projectAlias: "Amazon Basin",
       source: "salesforce",
       isActive: true,
     });
     await runtime.context.repositories.projectDimensions.upsert({
       projectId: "project:whitebark-pine",
       projectName: "Tracking Whitebark Pine",
+      projectAlias: "Whitebark Pine",
       source: "salesforce",
       isActive: true,
     });

--- a/apps/web/tests/unit/inbox-stage1-helpers.ts
+++ b/apps/web/tests/unit/inbox-stage1-helpers.ts
@@ -37,10 +37,14 @@ export async function seedInboxContact(
   });
 
   if (input.projectId !== undefined) {
+    const fallbackAlias = input.projectName ?? input.projectId;
     await context.repositories.projectDimensions.upsert({
       projectId: input.projectId,
       projectName: input.projectName ?? input.projectId,
-      projectAlias: input.projectAlias ?? null,
+      // Migration 0045 enforces a CHECK that active projects have a
+      // non-empty alias. Default to projectName/projectId so legacy
+      // fixtures that don't pass projectAlias continue to seed successfully.
+      projectAlias: input.projectAlias ?? fallbackAlias,
       source: "salesforce",
       // Default fixture projects to active so tests don't have to opt in. Tests
       // that need a specific project to be inactive should call setActive(id,false)

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "ops:cleanup-non-volunteer-contacts": "tsx scripts/ops/cleanup-non-volunteer-contacts.ts",
     "ops:reclassify-salesforce-tasks": "pnpm --filter @as-comms/worker ops:reclassify-salesforce-tasks",
     "ops:worker:seed-aliases-from-env": "tsx scripts/ops/seed-aliases-from-env.ts",
+    "ops:backfill-project-aliases": "tsx scripts/ops/backfill-project-aliases.ts",
     "ops:promote-admin": "tsx scripts/ops/promote-admin.ts",
     "build": "turbo build && node scripts/verify-runtime-exports.mjs",
     "lint": "turbo lint",

--- a/packages/db/drizzle/0045_project_dimensions_active_alias_required.sql
+++ b/packages/db/drizzle/0045_project_dimensions_active_alias_required.sql
@@ -1,0 +1,28 @@
+-- Active projects must have a non-empty project_alias.
+--
+-- Background: project_dimensions.project_alias is the operator-friendly short
+-- name (e.g. "PNW Biodiversity") used in the inbox sidebar chip and the
+-- Settings → Projects subtitle. The display layer falls back to project_name
+-- when alias is null; production has 3 active rows with alias = NULL, so the
+-- UI shows the long marketing name. The Settings UI guards against this
+-- (apps/web/app/settings/actions.ts:711) but the DB has no enforcement, so
+-- any non-action-layer write could land an active row without an alias.
+--
+-- Step 1: backfill active rows missing an alias with a mechanical default
+--         derived from project_name. Operator can edit through the existing
+--         /settings/projects/{projectId} UI (or the new ops:backfill script)
+--         to override with operator-chosen aliases.
+-- Step 2: add a CHECK constraint so the same gap can't reopen.
+
+UPDATE "project_dimensions"
+   SET "project_alias" = LEFT(BTRIM("project_name"), 40),
+       "updated_at" = NOW()
+ WHERE "is_active" = true
+   AND ("project_alias" IS NULL OR BTRIM("project_alias") = '');
+
+ALTER TABLE "project_dimensions"
+  ADD CONSTRAINT "project_dimensions_active_alias_required"
+  CHECK (
+    "is_active" = false
+    OR ("project_alias" IS NOT NULL AND BTRIM("project_alias") <> '')
+  );

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -113,6 +113,29 @@ import {
 
 export type Stage1Database = PgDatabase<PgQueryResultHKT, DatabaseSchema>;
 
+/**
+ * Thrown by the projects repository when an attempt is made to flip
+ * `is_active` to `true` on a project_dimensions row whose `project_alias`
+ * is null or empty/whitespace.
+ *
+ * The Settings action layer (apps/web/app/settings/actions.ts) already
+ * validates this before calling setActive, so this error is defense-in-depth
+ * against any future code path that bypasses the action layer. The DB also
+ * enforces the same invariant via a CHECK constraint
+ * (migration 0045_project_dimensions_active_alias_required.sql).
+ */
+export class ProjectAliasRequiredError extends Error {
+  readonly projectId: string;
+
+  constructor(projectId: string) {
+    super(
+      `Cannot activate project ${projectId}: project_alias must be set and non-empty.`,
+    );
+    this.name = "ProjectAliasRequiredError";
+    this.projectId = projectId;
+  }
+}
+
 interface SalesforceCommunicationDetailRecord {
   readonly sourceEvidenceId: string;
   readonly providerRecordId: string;
@@ -3314,6 +3337,26 @@ function createStage2RepositoriesInternal(
       },
 
       async setActive(projectId: string, isActive: boolean) {
+        if (isActive) {
+          // Defense-in-depth: action-layer callers already validate alias
+          // before this point (apps/web/app/settings/actions.ts:711, :1290).
+          // The DB CHECK constraint (migration 0045) is the ultimate
+          // backstop. This pre-flight check turns the constraint violation
+          // into a typed error any future caller can handle.
+          const [aliasRow] = await db
+            .select({ projectAlias: projectDimensions.projectAlias })
+            .from(projectDimensions)
+            .where(eq(projectDimensions.projectId, projectId))
+            .limit(1);
+
+          if (aliasRow !== undefined) {
+            const trimmed = aliasRow.projectAlias?.trim() ?? "";
+            if (trimmed.length === 0) {
+              throw new ProjectAliasRequiredError(projectId);
+            }
+          }
+        }
+
         const [row] = await db
           .update(projectDimensions)
           .set({

--- a/packages/db/src/schema/tables.ts
+++ b/packages/db/src/schema/tables.ts
@@ -215,20 +215,29 @@ export const contactMemberships = pgTable(
   ],
 );
 
-export const projectDimensions = pgTable("project_dimensions", {
-  projectId: text("project_id").primaryKey(),
-  projectName: text("project_name").notNull(),
-  projectAlias: text("project_alias"),
-  isActive: boolean("is_active").notNull().default(false),
-  aiKnowledgeUrl: text("ai_knowledge_url"),
-  aiKnowledgeSyncedAt: timestamp("ai_knowledge_synced_at", {
-    mode: "date",
-    withTimezone: true,
-  }),
-  source: recordSourceEnum("source").notNull(),
-  createdAt: createdAtColumn,
-  updatedAt: updatedAtColumn,
-});
+export const projectDimensions = pgTable(
+  "project_dimensions",
+  {
+    projectId: text("project_id").primaryKey(),
+    projectName: text("project_name").notNull(),
+    projectAlias: text("project_alias"),
+    isActive: boolean("is_active").notNull().default(false),
+    aiKnowledgeUrl: text("ai_knowledge_url"),
+    aiKnowledgeSyncedAt: timestamp("ai_knowledge_synced_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    source: recordSourceEnum("source").notNull(),
+    createdAt: createdAtColumn,
+    updatedAt: updatedAtColumn,
+  },
+  (table) => [
+    check(
+      "project_dimensions_active_alias_required",
+      sql`${table.isActive} = false OR (${table.projectAlias} IS NOT NULL AND BTRIM(${table.projectAlias}) <> '')`,
+    ),
+  ],
+);
 
 export const expeditionDimensions = pgTable(
   "expedition_dimensions",

--- a/packages/db/test/projects-repository-active-alias.test.ts
+++ b/packages/db/test/projects-repository-active-alias.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import { ProjectAliasRequiredError } from "../src/repositories.js";
+import { createTestStage1Context } from "./helpers.js";
+
+describe("settings.projects.setActive — alias requirement", () => {
+  it("throws ProjectAliasRequiredError when activating a project with NULL alias", async () => {
+    const context = await createTestStage1Context();
+    try {
+      await context.repositories.projectDimensions.upsert({
+        projectId: "project_no_alias",
+        projectName: "Long Marketing Project Name",
+        source: "salesforce",
+      });
+
+      await expect(
+        context.settings.projects.setActive("project_no_alias", true),
+      ).rejects.toBeInstanceOf(ProjectAliasRequiredError);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("throws ProjectAliasRequiredError when activating a project with whitespace-only alias", async () => {
+    const context = await createTestStage1Context();
+    try {
+      await context.repositories.projectDimensions.upsert({
+        projectId: "project_blank_alias",
+        projectName: "Long Marketing Project Name",
+        projectAlias: "   ",
+        source: "salesforce",
+      });
+
+      await expect(
+        context.settings.projects.setActive("project_blank_alias", true),
+      ).rejects.toBeInstanceOf(ProjectAliasRequiredError);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("activates a project successfully when alias is set", async () => {
+    const context = await createTestStage1Context();
+    try {
+      await context.repositories.projectDimensions.upsert({
+        projectId: "project_with_alias",
+        projectName: "Long Marketing Project Name",
+        projectAlias: "Short Name",
+        source: "salesforce",
+      });
+
+      const activated = await context.settings.projects.setActive(
+        "project_with_alias",
+        true,
+      );
+
+      expect(activated).not.toBeNull();
+      expect(activated?.isActive).toBe(true);
+      expect(activated?.projectAlias).toBe("Short Name");
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("deactivates a project regardless of alias state (NULL alias allowed)", async () => {
+    const context = await createTestStage1Context();
+    try {
+      // Seed an inactive row with NULL alias — represents the "stale row"
+      // shape (active=false, alias=null) that the CHECK constraint allows.
+      await context.repositories.projectDimensions.upsert({
+        projectId: "project_inactive_no_alias",
+        projectName: "Long Marketing Project Name",
+        source: "salesforce",
+      });
+
+      // Deactivating an already-inactive row should succeed (no-op semantics).
+      const deactivated = await context.settings.projects.setActive(
+        "project_inactive_no_alias",
+        false,
+      );
+
+      expect(deactivated).not.toBeNull();
+      expect(deactivated?.isActive).toBe(false);
+      expect(deactivated?.projectAlias).toBeNull();
+    } finally {
+      await context.dispose();
+    }
+  });
+});

--- a/packages/db/test/stage1-repositories.test.ts
+++ b/packages/db/test/stage1-repositories.test.ts
@@ -1002,6 +1002,8 @@ describe("Stage 1 DB repositories", () => {
     await repositories.projectDimensions.upsert({
       projectId: "project_1",
       projectName: "Project Antarctica",
+      // Alias required for setActive(true) per migration 0045 CHECK constraint.
+      projectAlias: "Antarctica",
       isActive: false,
       source: "salesforce",
     });
@@ -1016,6 +1018,7 @@ describe("Stage 1 DB repositories", () => {
     await repositories.projectDimensions.upsert({
       projectId: "project_1",
       projectName: "Project Antarctica Resynced",
+      projectAlias: "Antarctica",
       isActive: false,
       source: "salesforce",
     });
@@ -1318,21 +1321,25 @@ describe("Stage 1 DB repositories", () => {
   it("matches project filters against any active membership and excludes inactive project memberships", async () => {
     const { repositories, settings } = await createTestStage1Context();
 
+    // Alias required for active rows per migration 0045 CHECK constraint.
     await repositories.projectDimensions.upsert({
       projectId: "project:pnw-bio",
       projectName: "PNW Biodiversity",
+      projectAlias: "PNW Biodiversity",
       source: "salesforce",
       isActive: true,
     });
     await repositories.projectDimensions.upsert({
       projectId: "project:whitebark-pine",
       projectName: "Tracking Whitebark Pine",
+      projectAlias: "Whitebark Pine",
       source: "salesforce",
       isActive: true,
     });
     await repositories.projectDimensions.upsert({
       projectId: "project:inactive-c",
       projectName: "Inactive Project",
+      projectAlias: "Inactive",
       source: "salesforce",
       isActive: true,
     });

--- a/scripts/ops/backfill-project-aliases.ts
+++ b/scripts/ops/backfill-project-aliases.ts
@@ -1,0 +1,147 @@
+#!/usr/bin/env tsx
+/**
+ * pnpm ops:backfill-project-aliases
+ *
+ * Backfills `project_dimensions.project_alias` for one or more projects from
+ * a JSON map provided via the `PROJECT_ALIAS_MAP` environment variable.
+ *
+ * Background: migration 0045 enforces a CHECK constraint requiring active
+ * projects to have a non-empty alias, and includes a mechanical backfill
+ * that derives a default from `project_name`. This script lets the
+ * architect override that mechanical default with operator-chosen aliases
+ * (e.g. "PNW Biodiversity") after the migration lands.
+ *
+ * Idempotent: skips rows whose current alias already matches the target.
+ *
+ * Usage:
+ *   PROJECT_ALIAS_MAP='{"<projectId1>":"<alias1>","<projectId2>":"<alias2>"}' \
+ *     DATABASE_URL=postgres://... \
+ *     pnpm ops:backfill-project-aliases
+ *
+ * Requires: DATABASE_URL, PROJECT_ALIAS_MAP env vars.
+ */
+import {
+  createDatabaseConnection,
+  createStage2RepositoryBundleFromConnection
+} from "@as-comms/db";
+
+interface AliasOverride {
+  readonly projectId: string;
+  readonly alias: string;
+}
+
+function parseAliasMap(raw: string): readonly AliasOverride[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `PROJECT_ALIAS_MAP is not valid JSON: ${(error as Error).message}`
+    );
+  }
+
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    Array.isArray(parsed)
+  ) {
+    throw new Error(
+      "PROJECT_ALIAS_MAP must be a JSON object mapping projectId → alias."
+    );
+  }
+
+  const overrides: AliasOverride[] = [];
+  for (const [projectId, value] of Object.entries(parsed)) {
+    if (typeof value !== "string") {
+      throw new Error(
+        `PROJECT_ALIAS_MAP value for ${projectId} must be a string.`
+      );
+    }
+    const trimmedId = projectId.trim();
+    const trimmedAlias = value.trim();
+    if (trimmedId.length === 0) {
+      throw new Error("PROJECT_ALIAS_MAP keys must be non-empty.");
+    }
+    if (trimmedAlias.length === 0) {
+      throw new Error(
+        `PROJECT_ALIAS_MAP alias for ${projectId} must be non-empty.`
+      );
+    }
+    overrides.push({ projectId: trimmedId, alias: trimmedAlias });
+  }
+  return overrides;
+}
+
+async function main(): Promise<void> {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    console.error("DATABASE_URL is required");
+    process.exitCode = 1;
+    return;
+  }
+
+  const aliasMapEnv = process.env.PROJECT_ALIAS_MAP;
+  if (!aliasMapEnv?.trim()) {
+    console.error(
+      'PROJECT_ALIAS_MAP is required (JSON map of {"projectId":"alias",...})'
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  let overrides: readonly AliasOverride[];
+  try {
+    overrides = parseAliasMap(aliasMapEnv);
+  } catch (error) {
+    console.error((error as Error).message);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (overrides.length === 0) {
+    console.error("PROJECT_ALIAS_MAP must contain at least one entry.");
+    process.exitCode = 1;
+    return;
+  }
+
+  const connection = createDatabaseConnection({ connectionString });
+  try {
+    const { projects } = createStage2RepositoryBundleFromConnection(connection);
+
+    let updated = 0;
+    let skipped = 0;
+    let notFound = 0;
+
+    for (const { projectId, alias } of overrides) {
+      const project = await projects.findById(projectId);
+      if (project === null) {
+        console.log(`Not found: ${projectId}`);
+        notFound++;
+        continue;
+      }
+
+      if ((project.projectAlias ?? "").trim() === alias) {
+        console.log(`Skipping (already matches): ${projectId} = "${alias}"`);
+        skipped++;
+        continue;
+      }
+
+      await projects.setProjectAlias(projectId, alias);
+      console.log(
+        `Updated: ${projectId} "${project.projectAlias ?? "(null)"}" → "${alias}"`
+      );
+      updated++;
+    }
+
+    console.log(
+      `Done. Updated: ${updated.toString()}, Skipped: ${skipped.toString()}, Not found: ${notFound.toString()}`
+    );
+  } finally {
+    const sql = (connection as { sql?: { end?: () => Promise<void> } }).sql;
+    if (sql && typeof sql.end === "function") {
+      await sql.end();
+    }
+  }
+}
+
+await main();


### PR DESCRIPTION
## Summary

- **Migration 0045** adds a CHECK constraint on `project_dimensions` requiring `is_active=false OR project_alias non-empty`, with an inline backfill that derives a mechanical default (`LEFT(BTRIM(project_name), 40)`) for any active row missing an alias.
- **`setActive(id, true)`** now pre-flight-checks the alias and throws a new typed `ProjectAliasRequiredError` (defense-in-depth backstop matching the DB constraint).
- **`scripts/ops/backfill-project-aliases.ts`** lets the operator override the mechanical default with operator-chosen aliases via a `PROJECT_ALIAS_MAP` JSON env var. Idempotent. Wired as `pnpm ops:backfill-project-aliases`.

## Why

The inbox sidebar chip and Settings → Projects subtitle prefer `project_alias` and fall back to `project_name`. Production has 3 active rows with `project_alias = NULL`, so the long marketing name shows in place of the operator-friendly short label. The Settings UI guards activation (`activateProjectAction`, `activateProjectFromWizardAction`) but no DB-level invariant enforced it — any non-action-layer write could land an active row with NULL alias.

## Visible behaviour change

After this lands and is deployed:

1. Active rows that had `project_alias = NULL` now have a mechanical default derived from the project name. The long marketing name still shows but truncated to 40 chars.
2. To set the operator-chosen aliases (e.g. "PNW Biodiversity"), either:
   - Edit each project via `/settings/projects/{projectId}` in the UI, or
   - Run `PROJECT_ALIAS_MAP='{"<id>":"<alias>",...}' DATABASE_URL=... pnpm ops:backfill-project-aliases` against production.
3. Any future activation path (UI, ops, direct DB) is forced to set a non-empty alias before flipping `is_active = true`.

## Test plan

- [x] `pnpm typecheck` (full repo, 14 tasks green)
- [x] `pnpm lint` (full repo, 14 tasks green)
- [ ] CI runs `pnpm test:unit` (skipped locally due to known macOS rollup native-module gotcha; CI is authoritative)
- [ ] After merge + deploy: confirm the inbox sidebar chip on production shows non-empty short labels for the 3 projects.
- [ ] After merge + deploy: run `ops:backfill-project-aliases` with operator-chosen aliases and confirm the chip updates.

## Out of scope

- Display logic (already correct).
- Activation wizard UI.
- `project_aliases` table (separate concept — email routing addresses).
- Capture apps (gmail-capture, salesforce-capture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)