### PR TITLE
feat(ui): pixel-perfect inbox thread surfaces (S6-B)

### DIFF
--- a/apps/web/app/inbox/_components/email-participant-header.tsx
+++ b/apps/web/app/inbox/_components/email-participant-header.tsx
@@ -37,6 +37,24 @@ function normalizeHeaderValue(value: string | null): string | null {
   return trimmed.length === 0 ? null : trimmed;
 }
 
+function splitHeaderValue(value: string): {
+  readonly primary: string;
+  readonly subdued: string | null;
+} {
+  const match = /^(.*?)(\s*<[^>]+>)$/u.exec(value);
+
+  if (!match) {
+    return { primary: value, subdued: null };
+  }
+
+  const primary = match[1] ?? value;
+  const subdued = match[2] ?? null;
+  return {
+    primary: primary.trimEnd(),
+    subdued: subdued?.trimStart() ?? null,
+  };
+}
+
 function extractDisplayName(value: string | null): string | null {
   const normalized = normalizeHeaderValue(value);
 
@@ -180,18 +198,28 @@ export function EmailParticipantHeader({
         id={contentId}
         className={cn("border-b px-4 py-2", detailBorderClass)}
       >
-        <dl className="space-y-1 text-[11.5px] leading-relaxed text-slate-600">
-          {rows.map((row) => (
-            <div
-              key={row.label}
-              className="grid grid-cols-[2rem_minmax(0,1fr)] gap-2"
-            >
-              <dt className="font-medium text-slate-400">{row.label}</dt>
-              <dd className={cn("min-w-0 text-slate-700", WRAP_ANYWHERE)}>
-                {row.value}
-              </dd>
-            </div>
-          ))}
+        <dl className="space-y-0.5 text-[11.5px] leading-relaxed text-slate-600">
+          {rows.map((row) => {
+            const parts = splitHeaderValue(row.value);
+
+            return (
+              <div
+                key={row.label}
+                className="grid grid-cols-[2.5rem_minmax(0,1fr)] gap-2"
+              >
+                <dt className="text-slate-400">{row.label}</dt>
+                <dd className={cn("min-w-0 text-slate-700", WRAP_ANYWHERE)}>
+                  <span>{parts.primary}</span>
+                  {parts.subdued ? (
+                    <>
+                      {parts.primary.length > 0 ? " " : null}
+                      <span className="text-slate-400">{parts.subdued}</span>
+                    </>
+                  ) : null}
+                </dd>
+              </div>
+            );
+          })}
         </dl>
       </CollapsibleContent>
     </Collapsible>

--- a/apps/web/app/inbox/_components/inbox-timeline-automated-row.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-automated-row.tsx
@@ -71,6 +71,7 @@ interface EventRowDescriptor {
   readonly label: string;
   readonly Icon: ComponentType<{ className?: string }>;
   readonly shellClassName: string;
+  readonly hoverClassName: string;
   readonly iconClassName: string;
   readonly labelClassName: string;
 }
@@ -83,9 +84,9 @@ function describeEventRow(input: {
     return {
       label: input.isEmail ? "Campaign" : "Campaign SMS",
       Icon: MegaphoneIcon,
-      shellClassName:
-        "border-violet-200/70 bg-violet-50/30 hover:bg-violet-50/60",
-      iconClassName: "border-violet-100 bg-violet-100 text-violet-700",
+      shellClassName: "border-violet-200/70 bg-violet-50/30",
+      hoverClassName: "hover:bg-violet-50/60",
+      iconClassName: "bg-violet-100 text-violet-700",
       labelClassName: "text-violet-700",
     };
   }
@@ -94,8 +95,9 @@ function describeEventRow(input: {
     return {
       label: input.isEmail ? "Activity" : "SMS Activity",
       Icon: input.isEmail ? MailIcon : PhoneIcon,
-      shellClassName: "border-violet-200 bg-violet-50/75 hover:bg-violet-50",
-      iconClassName: "border-violet-200 text-violet-700",
+      shellClassName: "border-violet-200 bg-violet-50/75",
+      hoverClassName: "hover:bg-violet-50",
+      iconClassName: "bg-violet-100 text-violet-700",
       labelClassName: "text-violet-700",
     };
   }
@@ -103,8 +105,9 @@ function describeEventRow(input: {
   return {
     label: input.isEmail ? "Automated" : "Automated SMS",
     Icon: input.isEmail ? ZapIcon : WandIcon,
-    shellClassName: "border-slate-200 bg-slate-50/40 hover:bg-slate-100/60",
-    iconClassName: "border-slate-100 bg-slate-100 text-slate-600",
+    shellClassName: "border-slate-200 bg-slate-50/40",
+    hoverClassName: "hover:bg-slate-100/60",
+    iconClassName: "bg-slate-100 text-slate-600",
     labelClassName: "text-slate-500",
   };
 }
@@ -246,86 +249,102 @@ export function TimelineAutomatedRow({
     <li className="flex w-full flex-col items-end pl-16">
       <Tooltip>
         <TooltipTrigger asChild>
-          <button
-            type="button"
-            aria-expanded={isExpanded}
-            title={formatExactTimestamp(entry.occurredAt)}
-            onClick={onToggle}
-            data-event-role={role}
-            data-campaign-state={campaignState}
+          <div
             className={cn(
-              "group flex w-full max-w-[560px] items-start gap-2.5 rounded-xl border px-4 py-2.5 text-left",
-              "transition-[color,background-color,transform] duration-150 ease-out",
-              "active:scale-[0.96]",
-              TRANSITION.reduceMotion,
+              "w-full max-w-[560px] overflow-hidden rounded-xl border",
               descriptor.shellClassName,
             )}
           >
-            <div
+            <button
+              type="button"
+              aria-expanded={isExpanded}
+              title={formatExactTimestamp(entry.occurredAt)}
+              onClick={onToggle}
+              data-event-role={role}
+              data-campaign-state={campaignState}
               className={cn(
-                "mt-0.5 inline-flex size-6 shrink-0 items-center justify-center rounded-md border bg-white/90",
-                descriptor.iconClassName,
+                "group flex w-full items-center justify-between gap-3 px-4 py-2.5 text-left",
+                "transition-[background-color,transform] duration-150 ease-out active:scale-[0.99]",
+                descriptor.hoverClassName,
+                TRANSITION.reduceMotion,
               )}
             >
-              {role === "campaign" ? (
-                <CampaignStateIcon state={campaignState ?? "sent"} />
-              ) : (
-                <descriptor.Icon className="size-4" />
-              )}
-            </div>
-            <div className="min-w-0 flex-1">
-              <div className="flex flex-wrap items-center gap-2">
-                <span
+              <div className="flex min-w-0 items-center gap-2.5">
+                <div
                   className={cn(
-                    "text-[9.5px] font-semibold uppercase tracking-wider",
-                    descriptor.labelClassName,
+                    "inline-flex size-6 shrink-0 items-center justify-center rounded-md",
+                    descriptor.iconClassName,
                   )}
                 >
-                  {descriptor.label}
-                </span>
-                <RelativeTimestamp
-                  timestamp={entry.occurredAt}
-                  label={entry.occurredAtLabel}
-                  className="text-[11px] text-slate-500"
+                  {role === "campaign" ? (
+                    <CampaignStateIcon state={campaignState ?? "sent"} />
+                  ) : (
+                    <descriptor.Icon className="size-4" />
+                  )}
+                </div>
+                <div className="min-w-0">
+                  <div className="flex items-center gap-1.5">
+                    <span
+                      className={cn(
+                        "text-[9.5px] font-semibold uppercase tracking-wider",
+                        descriptor.labelClassName,
+                      )}
+                    >
+                      {descriptor.label}
+                    </span>
+                    <RelativeTimestamp
+                      timestamp={entry.occurredAt}
+                      label={`· ${entry.occurredAtLabel}`}
+                      className="text-[11px] text-slate-400"
+                    />
+                  </div>
+                  {headline ? (
+                    <p
+                      className={cn(
+                        "mt-0.5 truncate text-[12.5px] font-medium text-slate-800",
+                        WRAP_ANYWHERE,
+                      )}
+                    >
+                      {headline}
+                    </p>
+                  ) : null}
+                  {!hideCollapsedBody && body.length > 0 ? (
+                    <p
+                      className={cn(
+                        "mt-0.5 line-clamp-1 font-message-body text-[13.5px] leading-relaxed text-slate-700",
+                        WRAP_ANYWHERE,
+                      )}
+                    >
+                      {body}
+                    </p>
+                  ) : null}
+                </div>
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                {role === "campaign" && campaignState !== undefined ? (
+                  <CampaignStateBadge state={campaignState} />
+                ) : null}
+                <ChevronRightIcon
+                  className={cn(
+                    "h-3.5 w-3.5 text-slate-500 transition-transform duration-150",
+                    isExpanded && "rotate-90",
+                  )}
                 />
               </div>
-              {headline ? (
+            </button>
+            {isExpanded && body.length > 0 ? (
+              <div className="border-t border-slate-200 bg-white px-4 py-3">
                 <p
                   className={cn(
-                    "mt-0.5 text-pretty text-[12.5px] font-medium leading-snug text-slate-800",
+                    "whitespace-pre-wrap text-pretty font-message-body text-[13.5px] leading-relaxed text-slate-700",
                     WRAP_ANYWHERE,
                   )}
                 >
-                  {headline}
+                  {autolinkText(body, "text-sky-600")}
                 </p>
-              ) : null}
-              {!hideCollapsedBody && body.length > 0 ? (
-                <p
-                  className={cn(
-                    "font-message-body text-[13.5px] leading-relaxed text-slate-700",
-                    WRAP_ANYWHERE,
-                    (headline !== null || role === "campaign") && "mt-1.5",
-                    isExpanded
-                      ? "whitespace-pre-wrap text-pretty"
-                      : "line-clamp-1",
-                  )}
-                >
-                  {isExpanded ? autolinkText(body, "text-sky-600") : body}
-                </p>
-              ) : null}
-            </div>
-            <div className="flex shrink-0 items-center gap-2 pt-1">
-              {role === "campaign" && campaignState !== undefined ? (
-                <CampaignStateBadge state={campaignState} />
-              ) : null}
-              <ChevronRightIcon
-                className={cn(
-                  "h-3.5 w-3.5 text-slate-500 transition-transform duration-150",
-                  isExpanded && "rotate-90",
-                )}
-              />
-            </div>
-          </button>
+              </div>
+            ) : null}
+          </div>
         </TooltipTrigger>
         <TooltipContent side="top">
           <p>{formatExactTimestamp(entry.occurredAt)}</p>

--- a/apps/web/app/inbox/_components/inbox-timeline-automated-row.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-automated-row.tsx
@@ -292,10 +292,16 @@ export function TimelineAutomatedRow({
                     >
                       {descriptor.label}
                     </span>
+                    <span
+                      aria-hidden="true"
+                      className="text-[11px] text-slate-400 tabular-nums"
+                    >
+                      ·
+                    </span>
                     <RelativeTimestamp
                       timestamp={entry.occurredAt}
-                      label={`· ${entry.occurredAtLabel}`}
-                      className="text-[11px] text-slate-400"
+                      label={entry.occurredAtLabel}
+                      className="text-[11px] text-slate-400 tabular-nums"
                     />
                   </div>
                   {headline ? (

--- a/apps/web/app/inbox/_components/inbox-timeline-bubble.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-bubble.tsx
@@ -35,7 +35,7 @@ import {
 const WRAP_ANYWHERE = "break-words [overflow-wrap:anywhere]";
 const HTML_TAG_PATTERN = /<\/?[a-zA-Z][^>]*>/u;
 const EMAIL_HTML_BODY_CLASS =
-  "text-pretty text-[14px] leading-relaxed text-slate-700 [&_a]:text-sky-700 [&_a]:underline [&_blockquote]:border-l-2 [&_blockquote]:border-slate-200 [&_blockquote]:pl-3 [&_blockquote]:text-slate-600 [&_code]:rounded-sm [&_code]:bg-slate-100 [&_code]:px-1 [&_code]:py-0.5 [&_h1]:text-lg [&_h1]:font-semibold [&_h2]:text-base [&_h2]:font-semibold [&_h3]:text-sm [&_h3]:font-semibold [&_ol]:ml-5 [&_ol]:list-decimal [&_pre]:overflow-x-auto [&_pre]:rounded-md [&_pre]:bg-slate-100 [&_pre]:p-3 [&_table]:my-2 [&_table]:border-collapse [&_td]:border [&_td]:border-slate-200 [&_td]:px-2 [&_td]:py-1 [&_th]:border [&_th]:border-slate-200 [&_th]:px-2 [&_th]:py-1 [&_ul]:ml-5 [&_ul]:list-disc";
+  "text-pretty text-[13px] leading-relaxed text-slate-700 [&_a]:text-sky-700 [&_a]:underline [&_blockquote]:border-l-2 [&_blockquote]:border-slate-200 [&_blockquote]:pl-3 [&_blockquote]:text-slate-600 [&_code]:rounded-sm [&_code]:bg-slate-100 [&_code]:px-1 [&_code]:py-0.5 [&_h1]:text-lg [&_h1]:font-semibold [&_h2]:text-base [&_h2]:font-semibold [&_h3]:text-sm [&_h3]:font-semibold [&_ol]:ml-5 [&_ol]:list-decimal [&_pre]:overflow-x-auto [&_pre]:rounded-md [&_pre]:bg-slate-100 [&_pre]:p-3 [&_table]:my-2 [&_table]:border-collapse [&_td]:border [&_td]:border-slate-200 [&_td]:px-2 [&_td]:py-1 [&_th]:border [&_th]:border-slate-200 [&_th]:px-2 [&_th]:py-1 [&_ul]:ml-5 [&_ul]:list-disc";
 
 function bodyContainsHtml(body: string): boolean {
   return HTML_TAG_PATTERN.test(body);
@@ -150,11 +150,9 @@ function MessageAttachments({
 
 function ReplyFooter({
   entryId,
-  tone,
   onReply,
 }: {
   readonly entryId: string;
-  readonly tone: "slate" | "sky" | "sky-inverse";
   readonly onReply?: (entryId: string) => void;
 }) {
   if (onReply === undefined) {
@@ -162,28 +160,16 @@ function ReplyFooter({
   }
 
   return (
-    <div
-      className={cn(
-        "flex items-center justify-end border-t px-4 py-2",
-        tone === "sky-inverse"
-          ? "border-sky-500/40"
-          : tone === "sky"
-            ? "border-sky-100/60"
-            : "border-slate-100",
-      )}
-    >
+    <div className="flex items-center justify-end border-t border-slate-100 px-4 py-1.5">
       <button
         type="button"
         onClick={() => {
           onReply(entryId);
         }}
         className={cn(
-          "inline-flex items-center gap-1 text-[12px]",
+          "inline-flex items-center gap-1 text-[11px] text-slate-500 hover:text-slate-800",
           TRANSITION.fast,
           TRANSITION.reduceMotion,
-          tone === "sky-inverse"
-            ? "text-sky-100 hover:text-white hover:underline"
-            : "text-sky-700 hover:underline",
         )}
       >
         <CornerUpLeftIcon className="h-3 w-3" />
@@ -359,12 +345,11 @@ export function MessageBubble({
 
   const bubbleClassName = isEmail
     ? isOutbound
-      ? "border border-sky-100 bg-sky-50"
+      ? "border border-sky-200 bg-sky-50/40"
       : "border border-slate-200 bg-white"
     : isOutbound
       ? "border border-sky-600 bg-sky-600 text-white"
       : "border border-slate-200 bg-white";
-  const replyTone = isOutbound ? (isEmail ? "sky" : "sky-inverse") : "slate";
 
   return (
     <li
@@ -427,7 +412,7 @@ export function MessageBubble({
             ) : body.length > 0 ? (
               <p
                 className={cn(
-                  "whitespace-pre-wrap text-pretty text-[14px] leading-relaxed",
+                  "whitespace-pre-wrap text-pretty text-[13px] leading-relaxed",
                   isOutbound && !isEmail ? "text-white" : "text-slate-700",
                   WRAP_ANYWHERE,
                 )}
@@ -441,7 +426,6 @@ export function MessageBubble({
 
           <ReplyFooter
             entryId={entry.id}
-            tone={replyTone}
             {...(onReply === undefined ? {} : { onReply })}
           />
         </div>

--- a/apps/web/app/inbox/_components/inbox-timeline-system-divider.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-system-divider.tsx
@@ -103,7 +103,7 @@ export function classifySystemDivider(body: string): SystemDividerCategory {
 
   return {
     label: "LIFECYCLE",
-    tone: "amber",
+    tone: "violet",
     Icon: CalendarIcon,
   };
 }
@@ -138,10 +138,13 @@ export function SystemDivider({
         </span>
         <span className={cn(TYPE.label, tone.text)}>{category.label}</span>
         <span className="text-[11.5px] text-slate-600">{body}</span>
+        <span className="text-[11px] text-slate-400 tabular-nums" aria-hidden="true">
+          ·
+        </span>
         <time
           dateTime={entry.occurredAt}
           title={formatExactTimestamp(entry.occurredAt)}
-          className="cursor-help text-[11px] text-slate-400"
+          className="cursor-help text-[11px] text-slate-400 tabular-nums"
         >
           {entry.occurredAtLabel}
         </time>


### PR DESCRIPTION
## Summary

Pixel-fidelity pass on the conversation thread surfaces — message bubbles, lifecycle dividers, and automated/campaign event rows — sampled directly from the Claude Design v2 reference HTML on 2026-04-29. Pure CSS/markup tightening — no IA, view-model, or data changes.

## Reference-sampled values (now in production)

**Outbound email bubble:** `border-sky-200 bg-sky-50/40` (was `border-sky-100 bg-sky-50` — slightly heavier).

**Bubble body text:** `text-[13px]` (was `text-[14px]`) for both plaintext and HTML email render paths.

**Reply footer:** `px-4 py-1.5 border-t border-slate-100` (uniform — dropped the per-tone border variants). Reply button: `text-[11px] text-slate-500 hover:text-slate-800` (was `text-[12px] text-sky-700`).

**Email participant header detail block:** `space-y-0.5` (was `space-y-1`); label column tightened to `w-10`.

**Lifecycle divider:**
- Default tone: `amber` → `violet` (matches reference's purple Lifecycle pill).
- Timestamp: added `· ` separator span between body and timestamp.
- Timestamp class: now `tabular-nums` so the time digit doesn't wiggle on re-render.

**Automated / campaign / activity row:**
- Restructured: outer `<div>` carries the bordered shell, inner `<button>` becomes the borderless click target with hover tint. This matches the reference's split and lets hover/active states animate without affecting the border.
- Icon container: dropped `border` class (now just `bg-slate-100` etc).
- `active:scale-[0.96]` softened to `active:scale-[0.99]` — the previous scale was too aggressive for a simple expander.
- Expanded body now lives in a separate `<div class="border-t border-slate-200 bg-white px-4 py-3">` block to mirror the reference's "shell tinted, body white" pattern.

## Notes

- The bubble participant header keeps **sender → recipient** in the chevron position (not sender → project). The architect's brief speculated about a project-alias swap, but the reference also shows recipient — production was already correct.
- The collapsed system-message-group bubble is **untouched** in this pass. We didn't have a reference DOM sample of that variant; queued for a follow-up brief.

## Files changed

4 files, +137/-103:
- `apps/web/app/inbox/_components/email-participant-header.tsx`
- `apps/web/app/inbox/_components/inbox-timeline-automated-row.tsx`
- `apps/web/app/inbox/_components/inbox-timeline-bubble.tsx`
- `apps/web/app/inbox/_components/inbox-timeline-system-divider.tsx`

## Test plan

- [x] `pnpm --filter @as-comms/web typecheck`
- [x] `pnpm --filter @as-comms/web lint`
- [ ] Visual check on /inbox/{contact} at 1456×827 against the reference (architect to confirm).
- [ ] Confirm the lifecycle tone change amber → violet is desirable (it matches the reference, but the architect may prefer keeping amber for consistency with status indicators elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code) and Codex GPT-5.4 (medium)