### PR TITLE
feat(ops): backfill stuck-identity-anchor SF contacts (drains 1,558 queue cases)

### DIFF
--- a/apps/worker/src/ops/backfill-stuck-identity-anchors.ts
+++ b/apps/worker/src/ops/backfill-stuck-identity-anchors.ts
@@ -1,0 +1,1142 @@
+#!/usr/bin/env tsx
+import process from "node:process";
+
+import {
+  closeDatabaseConnection,
+  createDatabaseConnection,
+  createStage1RepositoryBundle,
+  type DatabaseConnection,
+  type Stage1Database,
+} from "@as-comms/db";
+import {
+  createStage1NormalizationService,
+  createStage1PersistenceService,
+  type Stage1RepositoryBundle,
+} from "@as-comms/domain";
+import {
+  createSalesforceApiClient,
+  mapSalesforceContactSnapshot,
+  normalizeEmail,
+  normalizePhone,
+  salesforceContactSnapshotRecordSchema,
+  type SalesforceCaptureServiceConfig,
+} from "@as-comms/integrations";
+import type {
+  IdentityResolutionCase,
+  NormalizedContactGraphUpsertInput,
+} from "@as-comms/contracts";
+
+import {
+  parseCliFlags,
+  readOptionalBooleanFlag,
+  readOptionalIntegerFlag,
+} from "./helpers.js";
+
+const defaultProbeBatchSize = 200;
+const defaultSampleLimit = 5;
+const topContactLimit = 10;
+
+export const stuckIdentityAnchorCountsSql = `WITH stuck AS (
+  SELECT q.id AS queue_id,
+         (regexp_match(q.explanation, 'Salesforce Contact ID ([A-Za-z0-9]+)'))[1] AS sf_contact_id,
+         q.source_evidence_id,
+         q.opened_at
+  FROM identity_resolution_queue q
+  JOIN source_evidence_log sel ON sel.id = q.source_evidence_id
+  WHERE q.status = 'open'
+    AND q.reason_code = 'identity_missing_anchor'
+    AND sel.provider_record_type = 'task_communication'
+)
+SELECT sf_contact_id, COUNT(*) AS stuck_count
+FROM stuck
+WHERE sf_contact_id IS NOT NULL
+GROUP BY sf_contact_id
+ORDER BY stuck_count DESC;`;
+
+const stuckIdentityAnchorCaseRowsSql = `WITH stuck AS (
+  SELECT q.id AS queue_id,
+         (regexp_match(q.explanation, 'Salesforce Contact ID ([A-Za-z0-9]+)'))[1] AS sf_contact_id,
+         q.source_evidence_id,
+         q.opened_at
+  FROM identity_resolution_queue q
+  JOIN source_evidence_log sel ON sel.id = q.source_evidence_id
+  WHERE q.status = 'open'
+    AND q.reason_code = 'identity_missing_anchor'
+    AND sel.provider_record_type = 'task_communication'
+)
+SELECT queue_id, sf_contact_id, source_evidence_id, opened_at
+FROM stuck
+WHERE sf_contact_id IS NOT NULL
+ORDER BY opened_at ASC, queue_id ASC;`;
+
+interface Logger {
+  log(...args: readonly unknown[]): void;
+  error(...args: readonly unknown[]): void;
+}
+
+interface SqlRunner {
+  unsafe<T extends readonly object[]>(query: string): Promise<T>;
+}
+
+interface StuckCountRow {
+  readonly sf_contact_id: string;
+  readonly stuck_count: string | number;
+}
+
+interface StuckCaseRow {
+  readonly queue_id: string;
+  readonly sf_contact_id: string;
+  readonly source_evidence_id: string;
+  readonly opened_at: string;
+}
+
+export interface StuckIdentityAnchorTarget {
+  readonly salesforceContactId: string;
+  readonly stuckCount: number;
+  readonly queueCaseIds: readonly string[];
+  readonly sourceEvidenceIds: readonly string[];
+  readonly oldestOpenedAt: string;
+}
+
+interface SalesforceMembershipProbeRow {
+  readonly Id?: unknown;
+  readonly Contact__c?: unknown;
+  readonly Project__c?: unknown;
+  readonly Expedition__c?: unknown;
+  readonly Status__c?: unknown;
+  readonly attributes?: unknown;
+  readonly [key: string]: unknown;
+}
+
+interface SalesforceContactProbeSnapshot {
+  readonly salesforceContactId: string;
+  readonly graphInput: NormalizedContactGraphUpsertInput;
+  readonly hasMemberships: boolean;
+  readonly primaryEmail: string | null;
+  readonly normalizedPhones: readonly string[];
+}
+
+export type BucketName = "A" | "B" | "C";
+
+export interface BucketedIdentityAnchorTarget {
+  readonly bucket: BucketName;
+  readonly target: StuckIdentityAnchorTarget;
+  readonly snapshot: SalesforceContactProbeSnapshot | null;
+}
+
+export interface BucketClassification {
+  readonly bucketA: readonly BucketedIdentityAnchorTarget[];
+  readonly bucketB: readonly BucketedIdentityAnchorTarget[];
+  readonly bucketC: readonly BucketedIdentityAnchorTarget[];
+}
+
+interface ProbeConfig {
+  readonly membershipObjectName: string;
+  readonly membershipContactField: string;
+  readonly membershipProjectField: string;
+  readonly membershipProjectNameField: string;
+  readonly membershipExpeditionField: string;
+  readonly membershipExpeditionNameField: string;
+  readonly membershipRoleField: string | null;
+  readonly membershipStatusField: string;
+}
+
+interface ProcessTargetResult {
+  readonly bucket: BucketName;
+  readonly action:
+    | "would_ingest"
+    | "ingested"
+    | "would_terminal_skip"
+    | "terminal_skipped"
+    | "noop_already_anchored"
+    | "noop_cases_already_closed";
+  readonly resolvedCaseCount: number;
+}
+
+interface ExecutionSummary {
+  readonly bucketAIngested: number;
+  readonly bucketANoOp: number;
+  readonly bucketBIngested: number;
+  readonly bucketBNoOp: number;
+  readonly bucketCTerminalSkipped: number;
+  readonly bucketCNoOp: number;
+  readonly errorCount: number;
+  readonly errors: readonly {
+    readonly key: string;
+    readonly salesforceContactId: string;
+    readonly message: string;
+  }[];
+}
+
+class DryRunRollback extends Error {
+  constructor() {
+    super("Dry run rollback");
+  }
+}
+
+function readConnectionString(env: NodeJS.ProcessEnv): string {
+  const value =
+    env.WORKER_DATABASE_URL ?? env.DATABASE_URL ?? env.DATABASE_PUBLIC_URL;
+
+  if (value === undefined || value.trim().length === 0) {
+    throw new Error(
+      "DATABASE_PUBLIC_URL, DATABASE_URL, or WORKER_DATABASE_URL is required for this ops command.",
+    );
+  }
+
+  return value.trim();
+}
+
+function readRequiredEnv(env: NodeJS.ProcessEnv, key: string): string {
+  const value = env[key]?.trim();
+
+  if (value === undefined || value.length === 0) {
+    throw new Error(`${key} is required for this ops command.`);
+  }
+
+  return value;
+}
+
+function readOptionalStringEnv(
+  env: NodeJS.ProcessEnv,
+  key: string,
+  defaultValue: string,
+): string {
+  const value = env[key]?.trim();
+  return value === undefined || value.length === 0 ? defaultValue : value;
+}
+
+function readOptionalNullableStringEnv(
+  env: NodeJS.ProcessEnv,
+  key: string,
+): string | null {
+  const value = env[key]?.trim();
+  return value === undefined || value.length === 0 ? null : value;
+}
+
+function readOptionalPositiveIntegerEnv(
+  env: NodeJS.ProcessEnv,
+  key: string,
+  defaultValue: number,
+): number {
+  const rawValue = env[key]?.trim();
+
+  if (rawValue === undefined || rawValue.length === 0) {
+    return defaultValue;
+  }
+
+  const parsed = Number.parseInt(rawValue, 10);
+
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${key} must be a positive integer.`);
+  }
+
+  return parsed;
+}
+
+function readSalesforceCaptureConfig(
+  env: NodeJS.ProcessEnv,
+): SalesforceCaptureServiceConfig {
+  return {
+    bearerToken: readRequiredEnv(env, "SALESFORCE_CAPTURE_TOKEN"),
+    loginUrl: readRequiredEnv(env, "SALESFORCE_LOGIN_URL"),
+    clientId: readRequiredEnv(env, "SALESFORCE_CLIENT_ID"),
+    username: readRequiredEnv(env, "SALESFORCE_USERNAME"),
+    jwtPrivateKey: readRequiredEnv(env, "SALESFORCE_JWT_PRIVATE_KEY"),
+    jwtExpirationSeconds: readOptionalPositiveIntegerEnv(
+      env,
+      "SALESFORCE_JWT_EXPIRATION_SECONDS",
+      180,
+    ),
+    apiVersion: readOptionalStringEnv(env, "SALESFORCE_API_VERSION", "61.0"),
+    contactCaptureMode: readOptionalStringEnv(
+      env,
+      "SALESFORCE_CONTACT_CAPTURE_MODE",
+      "delta_polling",
+    ) as "delta_polling" | "cdc_compatible",
+    membershipCaptureMode: readOptionalStringEnv(
+      env,
+      "SALESFORCE_MEMBERSHIP_CAPTURE_MODE",
+      "delta_polling",
+    ) as "delta_polling" | "cdc_compatible",
+    membershipObjectName: readOptionalStringEnv(
+      env,
+      "SALESFORCE_EXPEDITION_MEMBER_OBJECT",
+      "Expedition_Members__c",
+    ),
+    membershipContactField: readOptionalStringEnv(
+      env,
+      "SALESFORCE_EXPEDITION_MEMBER_CONTACT_FIELD",
+      "Contact__c",
+    ),
+    membershipProjectField: readOptionalStringEnv(
+      env,
+      "SALESFORCE_EXPEDITION_MEMBER_PROJECT_FIELD",
+      "Project__c",
+    ),
+    membershipProjectNameField: readOptionalStringEnv(
+      env,
+      "SALESFORCE_EXPEDITION_MEMBER_PROJECT_NAME_FIELD",
+      "Project__r.Name",
+    ),
+    membershipExpeditionField: readOptionalStringEnv(
+      env,
+      "SALESFORCE_EXPEDITION_MEMBER_EXPEDITION_FIELD",
+      "Expedition__c",
+    ),
+    membershipExpeditionNameField: readOptionalStringEnv(
+      env,
+      "SALESFORCE_EXPEDITION_MEMBER_EXPEDITION_NAME_FIELD",
+      "Expedition__r.Name",
+    ),
+    membershipRoleField: readOptionalNullableStringEnv(
+      env,
+      "SALESFORCE_EXPEDITION_MEMBER_ROLE_FIELD",
+    ),
+    membershipStatusField: readOptionalStringEnv(
+      env,
+      "SALESFORCE_EXPEDITION_MEMBER_STATUS_FIELD",
+      "Status__c",
+    ),
+    taskContactField: readOptionalStringEnv(
+      env,
+      "SALESFORCE_TASK_CONTACT_FIELD",
+      "WhoId",
+    ),
+    taskChannelField: readOptionalStringEnv(
+      env,
+      "SALESFORCE_TASK_CHANNEL_FIELD",
+      "TaskSubtype",
+    ),
+    taskEmailChannelValues: ["Email"],
+    taskSmsChannelValues: ["SMS", "Text"],
+    taskSnippetField: readOptionalStringEnv(
+      env,
+      "SALESFORCE_TASK_SNIPPET_FIELD",
+      "Description",
+    ),
+    taskOccurredAtField: readOptionalStringEnv(
+      env,
+      "SALESFORCE_TASK_OCCURRED_AT_FIELD",
+      "CreatedDate",
+    ),
+    taskCrossProviderKeyField: readOptionalNullableStringEnv(
+      env,
+      "SALESFORCE_TASK_CROSS_PROVIDER_KEY_FIELD",
+    ),
+    timeoutMs: readOptionalPositiveIntegerEnv(
+      env,
+      "SALESFORCE_CAPTURE_TIMEOUT_MS",
+      30000,
+    ),
+  };
+}
+
+function readProbeConfig(env: NodeJS.ProcessEnv): ProbeConfig {
+  return {
+    membershipObjectName: readOptionalStringEnv(
+      env,
+      "SALESFORCE_EXPEDITION_MEMBER_OBJECT",
+      "Expedition_Members__c",
+    ),
+    membershipContactField: readOptionalStringEnv(
+      env,
+      "SALESFORCE_EXPEDITION_MEMBER_CONTACT_FIELD",
+      "Contact__c",
+    ),
+    membershipProjectField: readOptionalStringEnv(
+      env,
+      "SALESFORCE_EXPEDITION_MEMBER_PROJECT_FIELD",
+      "Project__c",
+    ),
+    membershipProjectNameField: readOptionalStringEnv(
+      env,
+      "SALESFORCE_EXPEDITION_MEMBER_PROJECT_NAME_FIELD",
+      "Project__r.Name",
+    ),
+    membershipExpeditionField: readOptionalStringEnv(
+      env,
+      "SALESFORCE_EXPEDITION_MEMBER_EXPEDITION_FIELD",
+      "Expedition__c",
+    ),
+    membershipExpeditionNameField: readOptionalStringEnv(
+      env,
+      "SALESFORCE_EXPEDITION_MEMBER_EXPEDITION_NAME_FIELD",
+      "Expedition__r.Name",
+    ),
+    membershipRoleField: readOptionalNullableStringEnv(
+      env,
+      "SALESFORCE_EXPEDITION_MEMBER_ROLE_FIELD",
+    ),
+    membershipStatusField: readOptionalStringEnv(
+      env,
+      "SALESFORCE_EXPEDITION_MEMBER_STATUS_FIELD",
+      "Status__c",
+    ),
+  };
+}
+
+function chunkValues<TValue>(
+  values: readonly TValue[],
+  chunkSize: number,
+): TValue[][] {
+  const chunks: TValue[][] = [];
+
+  for (let index = 0; index < values.length; index += chunkSize) {
+    chunks.push(values.slice(index, index + chunkSize));
+  }
+
+  return chunks;
+}
+
+function quoteSoqlString(value: string): string {
+  return `'${value.replaceAll("\\", "\\\\").replaceAll("'", "\\'")}'`;
+}
+
+function readRowStringField(
+  row: Record<string, unknown>,
+  fieldName: string,
+): string | null {
+  const value = fieldName.split(".").reduce<unknown>((current, part) => {
+    if (current === null || typeof current !== "object") {
+      return undefined;
+    }
+
+    return (current as Record<string, unknown>)[part];
+  }, row);
+
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+function fallbackDisplayName(input: {
+  readonly name: string | null;
+  readonly firstName: string | null;
+  readonly lastName: string | null;
+  readonly salesforceContactId: string;
+}): string {
+  if (input.name !== null) {
+    return input.name;
+  }
+
+  const parts = [input.firstName, input.lastName].filter(
+    (value): value is string => value !== null,
+  );
+
+  if (parts.length > 0) {
+    return parts.join(" ");
+  }
+
+  return input.salesforceContactId;
+}
+
+export function buildContactProbeSoql(
+  salesforceContactIds: readonly string[],
+): string {
+  return [
+    "SELECT Id, Email, Phone, MobilePhone, FirstName, LastName, Name, CreatedDate, LastModifiedDate, Volunteer_ID_Plain__c",
+    "FROM Contact",
+    `WHERE Id IN (${salesforceContactIds.map((id) => quoteSoqlString(id)).join(", ")})`,
+  ].join(" ");
+}
+
+export function buildMembershipProbeSoql(
+  salesforceContactIds: readonly string[],
+  config: ProbeConfig,
+): string {
+  const fields = [
+    "Id",
+    config.membershipContactField,
+    config.membershipProjectField,
+    config.membershipProjectNameField,
+    config.membershipExpeditionField,
+    config.membershipExpeditionNameField,
+    ...(config.membershipRoleField === null ? [] : [config.membershipRoleField]),
+    config.membershipStatusField,
+  ];
+
+  return [
+    `SELECT ${fields.join(", ")}`,
+    `FROM ${config.membershipObjectName}`,
+    `WHERE ${config.membershipContactField} IN (${salesforceContactIds.map((id) => quoteSoqlString(id)).join(", ")})`,
+    `AND ${config.membershipProjectField} != null`,
+  ].join(" ");
+}
+
+export function classifyBucketedTargets(input: {
+  readonly targets: readonly StuckIdentityAnchorTarget[];
+  readonly snapshotsBySalesforceContactId: ReadonlyMap<
+    string,
+    SalesforceContactProbeSnapshot
+  >;
+}): BucketClassification {
+  const bucketA: BucketedIdentityAnchorTarget[] = [];
+  const bucketB: BucketedIdentityAnchorTarget[] = [];
+  const bucketC: BucketedIdentityAnchorTarget[] = [];
+
+  for (const target of input.targets) {
+    const snapshot = input.snapshotsBySalesforceContactId.get(
+      target.salesforceContactId,
+    );
+
+    if (snapshot === undefined) {
+      bucketC.push({
+        bucket: "C",
+        target,
+        snapshot: null,
+      });
+      continue;
+    }
+
+    if (snapshot.hasMemberships) {
+      bucketA.push({
+        bucket: "A",
+        target,
+        snapshot,
+      });
+      continue;
+    }
+
+    bucketB.push({
+      bucket: "B",
+      target,
+      snapshot,
+    });
+  }
+
+  return { bucketA, bucketB, bucketC };
+}
+
+async function loadStuckTargets(
+  sql: SqlRunner,
+): Promise<readonly StuckIdentityAnchorTarget[]> {
+  const [countRows, caseRows] = await Promise.all([
+    sql.unsafe<readonly StuckCountRow[]>(stuckIdentityAnchorCountsSql),
+    sql.unsafe<readonly StuckCaseRow[]>(stuckIdentityAnchorCaseRowsSql),
+  ]);
+  const caseIdsByContactId = new Map<string, string[]>();
+  const sourceEvidenceIdsByContactId = new Map<string, Set<string>>();
+  const oldestOpenedAtByContactId = new Map<string, string>();
+
+  for (const row of caseRows) {
+    const queueIds = caseIdsByContactId.get(row.sf_contact_id) ?? [];
+    queueIds.push(row.queue_id);
+    caseIdsByContactId.set(row.sf_contact_id, queueIds);
+
+    const sourceEvidenceIds =
+      sourceEvidenceIdsByContactId.get(row.sf_contact_id) ?? new Set<string>();
+    sourceEvidenceIds.add(row.source_evidence_id);
+    sourceEvidenceIdsByContactId.set(row.sf_contact_id, sourceEvidenceIds);
+
+    const currentOldest = oldestOpenedAtByContactId.get(row.sf_contact_id);
+    if (currentOldest === undefined || row.opened_at < currentOldest) {
+      oldestOpenedAtByContactId.set(row.sf_contact_id, row.opened_at);
+    }
+  }
+
+  return countRows.map((row) => ({
+    salesforceContactId: row.sf_contact_id,
+    stuckCount:
+      typeof row.stuck_count === "number"
+        ? row.stuck_count
+        : Number.parseInt(row.stuck_count, 10),
+    queueCaseIds: caseIdsByContactId.get(row.sf_contact_id) ?? [],
+    sourceEvidenceIds: Array.from(
+      sourceEvidenceIdsByContactId.get(row.sf_contact_id) ?? new Set<string>(),
+    ).sort((left, right) => left.localeCompare(right)),
+    oldestOpenedAt:
+      oldestOpenedAtByContactId.get(row.sf_contact_id) ??
+      "1970-01-01T00:00:00.000Z",
+  }));
+}
+
+async function probeSalesforceContacts(input: {
+  readonly salesforceContactIds: readonly string[];
+  readonly probeBatchSize: number;
+  readonly salesforceConfig: SalesforceCaptureServiceConfig;
+  readonly probeConfig: ProbeConfig;
+}): Promise<ReadonlyMap<string, SalesforceContactProbeSnapshot>> {
+  const apiClient = createSalesforceApiClient(input.salesforceConfig);
+  const contactSnapshots = new Map<string, SalesforceContactProbeSnapshot>();
+
+  for (const batch of chunkValues(input.salesforceContactIds, input.probeBatchSize)) {
+    const [contactRows, membershipRows] = await Promise.all([
+      apiClient.queryAll(buildContactProbeSoql(batch)),
+      apiClient.queryAll(buildMembershipProbeSoql(batch, input.probeConfig)),
+    ]);
+
+    const membershipsByContactId = new Map<string, SalesforceMembershipProbeRow[]>();
+
+    for (const rawRow of membershipRows) {
+      const membershipRow = rawRow as SalesforceMembershipProbeRow;
+      const salesforceContactId = readRowStringField(
+        membershipRow as Record<string, unknown>,
+        input.probeConfig.membershipContactField,
+      );
+
+      if (salesforceContactId === null) {
+        continue;
+      }
+
+      const rows = membershipsByContactId.get(salesforceContactId) ?? [];
+      rows.push(membershipRow);
+      membershipsByContactId.set(salesforceContactId, rows);
+    }
+
+    for (const rawContactRow of contactRows) {
+      const contactRow = rawContactRow as Record<string, unknown>;
+      const salesforceContactId = readRowStringField(contactRow, "Id");
+      const createdAt = readRowStringField(contactRow, "CreatedDate");
+      const updatedAt = readRowStringField(contactRow, "LastModifiedDate");
+
+      if (
+        salesforceContactId === null ||
+        createdAt === null ||
+        updatedAt === null
+      ) {
+        continue;
+      }
+
+      const phone = normalizePhone(readRowStringField(contactRow, "Phone"));
+      const mobilePhone = normalizePhone(
+        readRowStringField(contactRow, "MobilePhone"),
+      );
+      const primaryEmail = normalizeEmail(readRowStringField(contactRow, "Email"));
+      const normalizedPhones = Array.from(
+        new Set(
+          [phone, mobilePhone].filter(
+            (value): value is string => value !== null,
+          ),
+        ),
+      ).sort((left, right) => left.localeCompare(right));
+      const volunteerIdPlain = readRowStringField(
+        contactRow,
+        "Volunteer_ID_Plain__c",
+      );
+      const memberships = (
+        membershipsByContactId.get(salesforceContactId) ?? []
+      ).map((membership) => ({
+        salesforceId: readRowStringField(
+          membership as Record<string, unknown>,
+          "Id",
+        ),
+        projectId: readRowStringField(
+          membership as Record<string, unknown>,
+          input.probeConfig.membershipProjectField,
+        ),
+        projectName: readRowStringField(
+          membership as Record<string, unknown>,
+          input.probeConfig.membershipProjectNameField,
+        ),
+        expeditionId: readRowStringField(
+          membership as Record<string, unknown>,
+          input.probeConfig.membershipExpeditionField,
+        ),
+        expeditionName: readRowStringField(
+          membership as Record<string, unknown>,
+          input.probeConfig.membershipExpeditionNameField,
+        ),
+        role:
+          input.probeConfig.membershipRoleField === null
+            ? null
+            : readRowStringField(
+                membership as Record<string, unknown>,
+                input.probeConfig.membershipRoleField,
+              ),
+        status: readRowStringField(
+          membership as Record<string, unknown>,
+          input.probeConfig.membershipStatusField,
+        ),
+      }));
+      const snapshotRecord = salesforceContactSnapshotRecordSchema.parse({
+        recordType: "contact_snapshot",
+        recordId: salesforceContactId,
+        salesforceContactId,
+        displayName: fallbackDisplayName({
+          name: readRowStringField(contactRow, "Name"),
+          firstName: readRowStringField(contactRow, "FirstName"),
+          lastName: readRowStringField(contactRow, "LastName"),
+          salesforceContactId,
+        }),
+        primaryEmail,
+        primaryPhone: phone ?? mobilePhone,
+        normalizedEmails: primaryEmail === null ? [] : [primaryEmail],
+        normalizedPhones,
+        volunteerIdPlainValues:
+          volunteerIdPlain === null ? [] : [volunteerIdPlain],
+        createdAt,
+        updatedAt,
+        memberships,
+      });
+
+      contactSnapshots.set(salesforceContactId, {
+        salesforceContactId,
+        graphInput: mapSalesforceContactSnapshot(snapshotRecord),
+        hasMemberships: memberships.length > 0,
+        primaryEmail,
+        normalizedPhones,
+      });
+    }
+  }
+
+  return contactSnapshots;
+}
+
+function redactEmail(value: string | null): string | null {
+  if (value === null) {
+    return null;
+  }
+
+  const atIndex = value.indexOf("@");
+
+  if (atIndex <= 1) {
+    return "***";
+  }
+
+  return `${value[0] ?? "*"}***${value.slice(atIndex)}`;
+}
+
+function redactPhone(value: string | null): string | null {
+  if (value === null) {
+    return null;
+  }
+
+  const suffix = value.slice(-2);
+  return `***${suffix}`;
+}
+
+function buildSampleRows(
+  targets: readonly BucketedIdentityAnchorTarget[],
+  sampleLimit: number,
+): readonly Record<string, unknown>[] {
+  return targets.slice(0, sampleLimit).map(({ bucket, target, snapshot }) => ({
+    bucket,
+    salesforceContactId: target.salesforceContactId,
+    stuckCount: target.stuckCount,
+    displayName: snapshot?.graphInput.contact.displayName ?? null,
+    email: redactEmail(snapshot?.primaryEmail ?? null),
+    phones: snapshot?.normalizedPhones.map((phone) => redactPhone(phone)) ?? [],
+    membershipCount: (snapshot?.graphInput.memberships ?? []).length,
+  }));
+}
+
+function buildTopOffenderRows(
+  classification: BucketClassification,
+): readonly Record<string, unknown>[] {
+  return [
+    ...classification.bucketA,
+    ...classification.bucketB,
+    ...classification.bucketC,
+  ]
+    .sort((left, right) => right.target.stuckCount - left.target.stuckCount)
+    .slice(0, topContactLimit)
+    .map(({ bucket, target }) => ({
+      salesforceContactId: target.salesforceContactId,
+      stuckCount: target.stuckCount,
+      bucket,
+    }));
+}
+
+function createExecutionSummary(): ExecutionSummary {
+  return {
+    bucketAIngested: 0,
+    bucketANoOp: 0,
+    bucketBIngested: 0,
+    bucketBNoOp: 0,
+    bucketCTerminalSkipped: 0,
+    bucketCNoOp: 0,
+    errorCount: 0,
+    errors: [],
+  };
+}
+
+function addExecutionResult(
+  summary: ExecutionSummary,
+  result: ProcessTargetResult,
+): ExecutionSummary {
+  switch (result.bucket) {
+    case "A":
+      return result.action === "ingested" || result.action === "would_ingest"
+        ? {
+            ...summary,
+            bucketAIngested: summary.bucketAIngested + 1,
+          }
+        : {
+            ...summary,
+            bucketANoOp: summary.bucketANoOp + 1,
+          };
+    case "B":
+      return result.action === "ingested" || result.action === "would_ingest"
+        ? {
+            ...summary,
+            bucketBIngested: summary.bucketBIngested + 1,
+          }
+        : {
+            ...summary,
+            bucketBNoOp: summary.bucketBNoOp + 1,
+          };
+    case "C":
+      return result.action === "terminal_skipped" ||
+        result.action === "would_terminal_skip"
+        ? {
+            ...summary,
+            bucketCTerminalSkipped:
+              summary.bucketCTerminalSkipped + result.resolvedCaseCount,
+          }
+        : {
+            ...summary,
+            bucketCNoOp: summary.bucketCNoOp + 1,
+          };
+  }
+}
+
+function addExecutionError(
+  summary: ExecutionSummary,
+  input: {
+    readonly salesforceContactId: string;
+    readonly error: Error;
+  },
+): ExecutionSummary {
+  const key = `${input.error.name}:${input.error.message}`;
+
+  return {
+    ...summary,
+    errorCount: summary.errorCount + 1,
+    errors: [
+      ...summary.errors,
+      {
+        key,
+        salesforceContactId: input.salesforceContactId,
+        message: input.error.message,
+      },
+    ],
+  };
+}
+
+export async function markIdentityCasesResolved(input: {
+  readonly repositories: Stage1RepositoryBundle;
+  readonly caseIds: readonly string[];
+  readonly resolvedAt: string;
+  readonly explanation: string;
+}): Promise<number> {
+  let resolvedCount = 0;
+
+  for (const caseId of input.caseIds) {
+    const currentCase = await input.repositories.identityResolutionQueue.findById(
+      caseId,
+    );
+
+    if (currentCase?.status !== "open") {
+      continue;
+    }
+
+    await markIdentityCaseResolved({
+      repositories: input.repositories,
+      caseRecord: currentCase,
+      resolvedAt: input.resolvedAt,
+      explanation: input.explanation,
+    });
+    resolvedCount += 1;
+  }
+
+  return resolvedCount;
+}
+
+async function markIdentityCaseResolved(input: {
+  readonly repositories: Stage1RepositoryBundle;
+  readonly caseRecord: IdentityResolutionCase;
+  readonly resolvedAt: string;
+  readonly explanation: string;
+}): Promise<void> {
+  await input.repositories.identityResolutionQueue.upsert({
+    ...input.caseRecord,
+    status: "resolved",
+    resolvedAt: input.resolvedAt,
+    explanation: `${input.caseRecord.explanation} ${input.explanation}`,
+  });
+}
+
+async function processBucketedTarget(input: {
+  readonly connection: DatabaseConnection;
+  readonly bucketedTarget: BucketedIdentityAnchorTarget;
+  readonly dryRun: boolean;
+}): Promise<ProcessTargetResult> {
+  let result: ProcessTargetResult | null = null;
+
+  const runInTransaction = async (tx: Stage1Database) => {
+    const repositories = createStage1RepositoryBundle(tx);
+    const persistence = createStage1PersistenceService(repositories);
+    const normalization = createStage1NormalizationService(persistence);
+    const existingContact = await repositories.contacts.findBySalesforceContactId(
+      input.bucketedTarget.target.salesforceContactId,
+    );
+
+    if (
+      input.bucketedTarget.bucket === "A" ||
+      input.bucketedTarget.bucket === "B"
+    ) {
+      const snapshot = input.bucketedTarget.snapshot;
+
+      if (snapshot === null) {
+        throw new Error(
+          `Expected Salesforce probe snapshot for bucket ${input.bucketedTarget.bucket}.`,
+        );
+      }
+
+      if (existingContact !== null) {
+        result = {
+          bucket: input.bucketedTarget.bucket,
+          action: "noop_already_anchored",
+          resolvedCaseCount: 0,
+        };
+      } else if (input.bucketedTarget.bucket === "A") {
+        await normalization.upsertNormalizedContactGraph(snapshot.graphInput);
+        result = {
+          bucket: "A",
+          action: input.dryRun ? "would_ingest" : "ingested",
+          resolvedCaseCount: 0,
+        };
+      } else {
+        await repositories.contacts.upsert(snapshot.graphInput.contact);
+        for (const identity of snapshot.graphInput.identities ?? []) {
+          await repositories.contactIdentities.upsert(identity);
+        }
+        result = {
+          bucket: "B",
+          action: input.dryRun ? "would_ingest" : "ingested",
+          resolvedCaseCount: 0,
+        };
+      }
+    } else {
+      const resolvedCaseCount = await markIdentityCasesResolved({
+        repositories,
+        caseIds: input.bucketedTarget.target.queueCaseIds,
+        resolvedAt: new Date().toISOString(),
+        explanation: `Salesforce contact ${input.bucketedTarget.target.salesforceContactId} not found in SF - terminally skipped`,
+      });
+
+      result = {
+        bucket: "C",
+        action:
+          resolvedCaseCount > 0
+            ? input.dryRun
+              ? "would_terminal_skip"
+              : "terminal_skipped"
+            : "noop_cases_already_closed",
+        resolvedCaseCount,
+      };
+    }
+
+    if (input.dryRun) {
+      throw new DryRunRollback();
+    }
+  };
+
+  if (input.dryRun) {
+    try {
+      await input.connection.db.transaction(runInTransaction);
+    } catch (error) {
+      if (!(error instanceof DryRunRollback)) {
+        throw error;
+      }
+    }
+  } else {
+    await input.connection.db.transaction(runInTransaction);
+  }
+
+  // The result is assigned inside the transaction closure before dry-run
+  // rollback is thrown, but TypeScript and ESLint do not track that flow.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (result === null) {
+    throw new Error(
+      `Expected processing result for Salesforce contact ${input.bucketedTarget.target.salesforceContactId}.`,
+    );
+  }
+
+  return result;
+}
+
+function printPlan(input: {
+  readonly logger: Logger;
+  readonly targets: readonly StuckIdentityAnchorTarget[];
+  readonly classification: BucketClassification;
+  readonly probeConfig: ProbeConfig;
+  readonly sampleLimit: number;
+  readonly probeBatchSize: number;
+}): void {
+  const { logger, targets, classification } = input;
+  const firstBatch = targets
+    .slice(0, input.probeBatchSize)
+    .map((target) => target.salesforceContactId);
+
+  logger.log("backfill-stuck-identity-anchors");
+  logger.log(
+    `Found ${targets.length.toString()} distinct Salesforce contacts across ${targets.reduce((total, target) => total + target.stuckCount, 0).toString()} stuck queue cases.`,
+  );
+  logger.log(
+    `Buckets: A=${classification.bucketA.length.toString()} B=${classification.bucketB.length.toString()} C=${classification.bucketC.length.toString()}`,
+  );
+  logger.log("Top 10 stuck contacts by bucket:");
+  logger.log(JSON.stringify(buildTopOffenderRows(classification), null, 2));
+  logger.log("Sample Bucket A rows:");
+  logger.log(
+    JSON.stringify(buildSampleRows(classification.bucketA, input.sampleLimit), null, 2),
+  );
+  logger.log("Sample Bucket B rows:");
+  logger.log(
+    JSON.stringify(buildSampleRows(classification.bucketB, input.sampleLimit), null, 2),
+  );
+  logger.log("Sample Bucket C rows:");
+  logger.log(
+    JSON.stringify(buildSampleRows(classification.bucketC, input.sampleLimit), null, 2),
+  );
+  logger.log("Read SQL:");
+  logger.log(stuckIdentityAnchorCountsSql);
+  logger.log("SOQL contact probe for first batch:");
+  logger.log(buildContactProbeSoql(firstBatch));
+  logger.log("SOQL membership probe for first batch:");
+  logger.log(buildMembershipProbeSoql(firstBatch, input.probeConfig));
+  logger.log("Write SQL templates:");
+  logger.log(
+    "contacts: INSERT ... ON CONFLICT (id) DO UPDATE; contact_identities: INSERT ... ON CONFLICT (contact_id, kind, normalized_value) DO UPDATE; identity_resolution_queue: INSERT ... ON CONFLICT (id) DO UPDATE;",
+  );
+}
+
+function printExecutionSummary(input: {
+  readonly logger: Logger;
+  readonly dryRun: boolean;
+  readonly summary: ExecutionSummary;
+  readonly classification: BucketClassification;
+}): void {
+  const bucketCaseDrain = [
+    ...input.classification.bucketA,
+    ...input.classification.bucketB,
+  ].reduce((total, item) => total + item.target.stuckCount, 0);
+  const estimatedDrain =
+    bucketCaseDrain +
+    input.summary.bucketCTerminalSkipped;
+
+  input.logger.log(
+    JSON.stringify(
+      {
+        event: "stuck_identity_anchor_backfill.completed",
+        dryRun: input.dryRun,
+        bucketA: {
+          count: input.classification.bucketA.length,
+          ingested: input.summary.bucketAIngested,
+          noOpAlreadyAnchored: input.summary.bucketANoOp,
+        },
+        bucketB: {
+          count: input.classification.bucketB.length,
+          ingested: input.summary.bucketBIngested,
+          noOpAlreadyAnchored: input.summary.bucketBNoOp,
+        },
+        bucketC: {
+          count: input.classification.bucketC.length,
+          terminalSkipped: input.summary.bucketCTerminalSkipped,
+          noOpAlreadyClosed: input.summary.bucketCNoOp,
+        },
+        errors: {
+          count: input.summary.errorCount,
+          examples: input.summary.errors.slice(0, 5),
+        },
+        estimatedStuckCaseDrainAfterNextCronTicks: estimatedDrain,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+export async function main(
+  args: readonly string[] = process.argv.slice(2),
+  env: NodeJS.ProcessEnv = process.env,
+  logger: Logger = console,
+): Promise<void> {
+  const flags = parseCliFlags(args);
+  const dryRun = !readOptionalBooleanFlag(flags, "execute", false);
+  const probeBatchSize = readOptionalIntegerFlag(
+    flags,
+    "batch-size",
+    defaultProbeBatchSize,
+  );
+  const sampleLimit = readOptionalIntegerFlag(
+    flags,
+    "sample-limit",
+    defaultSampleLimit,
+  );
+  const connection = createDatabaseConnection({
+    connectionString: readConnectionString(env),
+  });
+
+  try {
+    const targets = await loadStuckTargets(connection.sql as unknown as SqlRunner);
+
+    if (targets.length === 0) {
+      logger.log("No open stuck task_communication identity-anchor cases found.");
+      return;
+    }
+
+    const salesforceConfig = readSalesforceCaptureConfig(env);
+    const probeConfig = readProbeConfig(env);
+    const snapshotsBySalesforceContactId = await probeSalesforceContacts({
+      salesforceContactIds: targets.map((target) => target.salesforceContactId),
+      probeBatchSize,
+      salesforceConfig,
+      probeConfig,
+    });
+    const classification = classifyBucketedTargets({
+      targets,
+      snapshotsBySalesforceContactId,
+    });
+
+    printPlan({
+      logger,
+      targets,
+      classification,
+      probeConfig,
+      sampleLimit,
+      probeBatchSize,
+    });
+
+    let summary = createExecutionSummary();
+
+    for (const bucketedTarget of [
+      ...classification.bucketA,
+      ...classification.bucketB,
+      ...classification.bucketC,
+    ]) {
+      try {
+        const result = await processBucketedTarget({
+          connection,
+          bucketedTarget,
+          dryRun,
+        });
+        summary = addExecutionResult(summary, result);
+      } catch (error) {
+        const resolvedError =
+          error instanceof Error ? error : new Error(String(error));
+        summary = addExecutionError(summary, {
+          salesforceContactId: bucketedTarget.target.salesforceContactId,
+          error: resolvedError,
+        });
+        logger.error(
+          `Failed processing ${bucketedTarget.target.salesforceContactId}: ${resolvedError.message}`,
+        );
+      }
+    }
+
+    printExecutionSummary({
+      logger,
+      dryRun,
+      summary,
+      classification,
+    });
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}

--- a/apps/worker/test/stage1-backfill-stuck-identity-anchors.test.ts
+++ b/apps/worker/test/stage1-backfill-stuck-identity-anchors.test.ts
@@ -136,6 +136,20 @@ describe("backfill-stuck-identity-anchors helpers", () => {
     const context = await createTestStage1Context();
 
     try {
+      // FK parent: source_evidence_log row must exist before identity_resolution_queue
+      // can reference it (identity_resolution_queue_source_evidence_id_fkey, ON DELETE restrict).
+      await context.repositories.sourceEvidence.append({
+        id: "source-evidence:salesforce:task_communication:task-1",
+        provider: "salesforce",
+        providerRecordType: "task_communication",
+        providerRecordId: "task-1",
+        receivedAt: "2026-04-30T00:00:00.000Z",
+        occurredAt: "2026-04-30T00:00:00.000Z",
+        payloadRef: "salesforce://Task/task-1",
+        idempotencyKey: "salesforce:task_communication:task-1",
+        checksum: "checksum:task-1",
+      });
+
       await context.repositories.identityResolutionQueue.upsert({
         id: "identity-review:source-evidence:salesforce:task_communication:task-1:identity_missing_anchor",
         sourceEvidenceId: "source-evidence:salesforce:task_communication:task-1",

--- a/apps/worker/test/stage1-backfill-stuck-identity-anchors.test.ts
+++ b/apps/worker/test/stage1-backfill-stuck-identity-anchors.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+
+import { createTestStage1Context } from "../../../packages/db/test/helpers.js";
+import {
+  buildContactProbeSoql,
+  buildMembershipProbeSoql,
+  classifyBucketedTargets,
+  markIdentityCasesResolved,
+  type StuckIdentityAnchorTarget,
+} from "../src/ops/backfill-stuck-identity-anchors.js";
+
+describe("backfill-stuck-identity-anchors helpers", () => {
+  it("classifies probed contacts into buckets A, B, and C", () => {
+    const targets: readonly StuckIdentityAnchorTarget[] = [
+      {
+        salesforceContactId: "003-bucket-a",
+        stuckCount: 5,
+        queueCaseIds: ["case-a"],
+        sourceEvidenceIds: ["source-a"],
+        oldestOpenedAt: "2026-04-30T00:00:00.000Z",
+      },
+      {
+        salesforceContactId: "003-bucket-b",
+        stuckCount: 4,
+        queueCaseIds: ["case-b"],
+        sourceEvidenceIds: ["source-b"],
+        oldestOpenedAt: "2026-04-30T00:01:00.000Z",
+      },
+      {
+        salesforceContactId: "003-bucket-c",
+        stuckCount: 3,
+        queueCaseIds: ["case-c"],
+        sourceEvidenceIds: ["source-c"],
+        oldestOpenedAt: "2026-04-30T00:02:00.000Z",
+      },
+    ];
+
+    const classification = classifyBucketedTargets({
+      targets,
+      snapshotsBySalesforceContactId: new Map([
+        [
+          "003-bucket-a",
+          {
+            salesforceContactId: "003-bucket-a",
+            hasMemberships: true,
+            primaryEmail: "bucket-a@example.org",
+            normalizedPhones: [],
+            graphInput: {
+              contact: {
+                id: "contact:salesforce:003-bucket-a",
+                salesforceContactId: "003-bucket-a",
+                displayName: "Bucket A",
+                primaryEmail: "bucket-a@example.org",
+                primaryPhone: null,
+                createdAt: "2026-04-30T00:00:00.000Z",
+                updatedAt: "2026-04-30T00:00:00.000Z",
+              },
+              identities: [],
+              memberships: [
+                {
+                  id: "membership-a",
+                  contactId: "contact:salesforce:003-bucket-a",
+                  projectId: "project-a",
+                  expeditionId: "expedition-a",
+                  salesforceMembershipId: "a0B-a",
+                  role: null,
+                  status: "Active",
+                  source: "salesforce",
+                  createdAt: "2026-04-30T00:00:00.000Z",
+                },
+              ],
+              projectDimensions: [],
+              expeditionDimensions: [],
+            },
+          },
+        ],
+        [
+          "003-bucket-b",
+          {
+            salesforceContactId: "003-bucket-b",
+            hasMemberships: false,
+            primaryEmail: "bucket-b@example.org",
+            normalizedPhones: [],
+            graphInput: {
+              contact: {
+                id: "contact:salesforce:003-bucket-b",
+                salesforceContactId: "003-bucket-b",
+                displayName: "Bucket B",
+                primaryEmail: "bucket-b@example.org",
+                primaryPhone: null,
+                createdAt: "2026-04-30T00:00:00.000Z",
+                updatedAt: "2026-04-30T00:00:00.000Z",
+              },
+              identities: [],
+              memberships: [],
+              projectDimensions: [],
+              expeditionDimensions: [],
+            },
+          },
+        ],
+      ]),
+    });
+
+    expect(classification.bucketA.map((entry) => entry.target.salesforceContactId)).toEqual([
+      "003-bucket-a",
+    ]);
+    expect(classification.bucketB.map((entry) => entry.target.salesforceContactId)).toEqual([
+      "003-bucket-b",
+    ]);
+    expect(classification.bucketC.map((entry) => entry.target.salesforceContactId)).toEqual([
+      "003-bucket-c",
+    ]);
+  });
+
+  it("builds the contact and membership SOQL probes", () => {
+    expect(
+      buildContactProbeSoql(["003AAA0000001", "003AAA0000002"]),
+    ).toContain("SELECT Id, Email, Phone, MobilePhone, FirstName, LastName, Name, CreatedDate, LastModifiedDate, Volunteer_ID_Plain__c FROM Contact");
+    expect(
+      buildMembershipProbeSoql(["003AAA0000001"], {
+        membershipObjectName: "Expedition_Members__c",
+        membershipContactField: "Contact__c",
+        membershipProjectField: "Project__c",
+        membershipProjectNameField: "Project__r.Name",
+        membershipExpeditionField: "Expedition__c",
+        membershipExpeditionNameField: "Expedition__r.Name",
+        membershipRoleField: null,
+        membershipStatusField: "Status__c",
+      }),
+    ).toBe(
+      "SELECT Id, Contact__c, Project__c, Project__r.Name, Expedition__c, Expedition__r.Name, Status__c FROM Expedition_Members__c WHERE Contact__c IN ('003AAA0000001') AND Project__c != null",
+    );
+  });
+
+  it("terminally resolves open queue cases and appends the explanation", async () => {
+    const context = await createTestStage1Context();
+
+    try {
+      await context.repositories.identityResolutionQueue.upsert({
+        id: "identity-review:source-evidence:salesforce:task_communication:task-1:identity_missing_anchor",
+        sourceEvidenceId: "source-evidence:salesforce:task_communication:task-1",
+        candidateContactIds: [],
+        reasonCode: "identity_missing_anchor",
+        status: "open",
+        openedAt: "2026-04-30T00:00:00.000Z",
+        resolvedAt: null,
+        normalizedIdentityValues: [],
+        anchoredContactId: null,
+        explanation: "Salesforce Contact ID 003AAA0000001 could not anchor.",
+      });
+
+      const resolvedCount = await markIdentityCasesResolved({
+        repositories: context.repositories,
+        caseIds: [
+          "identity-review:source-evidence:salesforce:task_communication:task-1:identity_missing_anchor",
+        ],
+        resolvedAt: "2026-04-30T01:00:00.000Z",
+        explanation:
+          "Salesforce contact 003AAA0000001 not found in SF - terminally skipped",
+      });
+
+      const updatedCase = await context.repositories.identityResolutionQueue.findById(
+        "identity-review:source-evidence:salesforce:task_communication:task-1:identity_missing_anchor",
+      );
+
+      expect(resolvedCount).toBe(1);
+      expect(updatedCase?.status).toBe("resolved");
+      expect(updatedCase?.resolvedAt).toBe("2026-04-30T01:00:00.000Z");
+      expect(updatedCase?.explanation).toContain(
+        "Salesforce contact 003AAA0000001 not found in SF - terminally skipped",
+      );
+    } finally {
+      await context.dispose();
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "ops:reclassify-salesforce-tasks": "pnpm --filter @as-comms/worker ops:reclassify-salesforce-tasks",
     "ops:worker:seed-aliases-from-env": "tsx scripts/ops/seed-aliases-from-env.ts",
     "ops:backfill-project-aliases": "tsx scripts/ops/backfill-project-aliases.ts",
+    "ops:backfill-stuck-identity-anchors": "tsx scripts/ops/backfill-stuck-identity-anchors.ts",
     "ops:promote-admin": "tsx scripts/ops/promote-admin.ts",
     "build": "turbo build && node scripts/verify-runtime-exports.mjs",
     "lint": "turbo lint",

--- a/packages/integrations/src/providers/salesforce.ts
+++ b/packages/integrations/src/providers/salesforce.ts
@@ -429,7 +429,7 @@ export function parseSubjectDirection(rawSubject: string | null): {
   };
 }
 
-function mapSalesforceContactSnapshot(
+export function mapSalesforceContactSnapshot(
   record: SalesforceContactSnapshotRecord,
 ): NormalizedContactGraphUpsertInput {
   const contactId = buildContactIdFromSalesforceContactId(

--- a/scripts/ops/backfill-stuck-identity-anchors.ts
+++ b/scripts/ops/backfill-stuck-identity-anchors.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env tsx
+
+import process from "node:process";
+
+import { main } from "../../apps/worker/src/ops/backfill-stuck-identity-anchors.js";
+
+await main(process.argv.slice(2), process.env);


### PR DESCRIPTION
## Summary
Adds one-shot ops script that ingests the **693 SF volunteer contacts whose existence-as-anchor is the only thing blocking 1,558 task_communication records from being promoted from `source_evidence_log` to `canonical_event_ledger`**.

Architect-direct prod diag 2026-04-30 confirmed:
- 1,558 stuck task_communication cases reference 693 distinct SF contact ids
- All 1,588 cases are `identity_missing_anchor`/`open` and the cron sweep is hitting them every 15 min, resolving 0 (no anchor exists)
- Different bug from #186/#196 race-condition — these contacts were never ingested at all
- User-visible symptom: operators report "missing emails" for specific volunteers

## Changes
- New `apps/worker/src/ops/backfill-stuck-identity-anchors.ts` with three-bucket flow:
  - **Bucket A — exists in SF + has memberships**: ingest via canonical contact-graph path (reuses `mapSalesforceContactSnapshot`)
  - **Bucket B — exists in SF + zero memberships**: direct `contacts` + `contact_identities` upsert (skip memberships); D-034 mapper would otherwise defer
  - **Bucket C — does not exist in SF**: terminal-skip queue cases via `markIdentityCasesResolved`
- New thin wrapper at `scripts/ops/backfill-stuck-identity-anchors.ts`
- New root script entry: `pnpm ops:backfill-stuck-identity-anchors`
- Exports `mapSalesforceContactSnapshot` from `packages/integrations/src/providers/salesforce.ts` (no behavior change to normal capture; ops path reuses the existing mapping shape)
- Unit-test coverage: SOQL builders, bucket logic, terminal-skip helper

## B.1 vs B.2 decision (per brief)
**B.1 chosen** (direct `contacts` + `contact_identities` upsert for Bucket B). Rationale:
- Minimal blast radius: no change to the contact-graph mapper or the canon ingest pipeline
- Bucket B is an ops edge case, not a steady-state ingest path; B.2 would have widened the canon mapper's API surface for a one-shot operation
- The audit trail concern is mitigated by writing through the `repositoryBundle` interface (same boundary as other ops scripts like `cleanup-non-volunteer-contacts.ts`)

## Validation
- `pnpm typecheck` ✓ (in dispatch sandbox)
- `pnpm lint` ✓ (in dispatch sandbox)
- `pnpm test:unit` skipped per architect convention (macOS rollup gotcha; CI authoritative)

## Dry-run artifact
**Codex sandbox could not reach prod**, so `.diag-backfill-stuck-identity-anchors-2026-04-30.txt` was NOT committed to this PR. Architect will run dry-run after merge and post output as a PR comment.

## Architect-only post-merge sequence
1. Merge after CI green
2. Run dry-run against prod:
   ```sh
   railway run --service Postgres sh -c 'export DATABASE_PUBLIC_URL_FOR_DIAG="$DATABASE_PUBLIC_URL"; \
     exec railway run --service salesforce-capture sh -c \
     "export DATABASE_PUBLIC_URL=\$DATABASE_PUBLIC_URL_FOR_DIAG; \
      pnpm tsx scripts/ops/backfill-stuck-identity-anchors.ts"'
   ```
3. Review bucket distribution, confirm sample contacts look right
4. Run `--execute` against prod (architect manual operation, requires explicit user sign-off in chat per memory `feedback_merge_and_railway_authority.md`)
5. Wait 1-2 cron ticks (~30 min); confirm queue depth drops via `SELECT COUNT(*) FROM identity_resolution_queue WHERE status='open' AND reason_code='identity_missing_anchor' AND <task_communication only>`

## Test plan
- [ ] CI green (verify, build, test:unit, lint, typecheck)
- [ ] Architect dry-run: bucket counts make sense (expect ~693 total split A/B/C)
- [ ] Architect execute: queue depth decreases over next 1-2 cron ticks
- [ ] Architect spot-check: pick a top-stuck-count contact (e.g., `003VK00000CJ7EzYAL` — 59 stuck), confirm contact appears in `contacts` after `--execute`, then confirm canonical events appear after next cron tick

## Out of scope
- Capture-layer gap for Tasks like Ryan Davis's "Plan your Adventure Today" / "Time to Plan Your Adventures" — separate brief at `.codex-fix-task-channel-resolver-2026-04-30.md` (silent drop in `resolveTaskChannel`)
- Race-condition root fix in orchestration batch loop
- Backfill of stuck `lifecycle_milestone` / `gmail/message` cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)