### PR TITLE
fix(ops): normalize SF datetime offset in backfill-stuck-identity-anchors

### DIFF
--- a/apps/worker/src/ops/backfill-stuck-identity-anchors.ts
+++ b/apps/worker/src/ops/backfill-stuck-identity-anchors.ts
@@ -19,6 +19,7 @@ import {
   normalizeEmail,
   normalizePhone,
   salesforceContactSnapshotRecordSchema,
+  toIsoTimestamp,
   type SalesforceCaptureServiceConfig,
 } from "@as-comms/integrations";
 import type {
@@ -590,8 +591,16 @@ async function probeSalesforceContacts(input: {
     for (const rawContactRow of contactRows) {
       const contactRow = rawContactRow as Record<string, unknown>;
       const salesforceContactId = readRowStringField(contactRow, "Id");
-      const createdAt = readRowStringField(contactRow, "CreatedDate");
-      const updatedAt = readRowStringField(contactRow, "LastModifiedDate");
+      // Salesforce returns datetimes like "2026-04-30T13:40:34.000+0000",
+      // which Zod's z.string().datetime() rejects (offset disallowed by default).
+      // Normalize to "...Z" via the existing helper, matching the pattern in
+      // packages/integrations/src/capture-services/salesforce.ts.
+      const createdAt = toIsoTimestamp(
+        readRowStringField(contactRow, "CreatedDate"),
+      );
+      const updatedAt = toIsoTimestamp(
+        readRowStringField(contactRow, "LastModifiedDate"),
+      );
 
       if (
         salesforceContactId === null ||


### PR DESCRIPTION
## Summary
Follow-up to #224. Surfaced when running the dry-run from #224 against prod for the first time.

Salesforce returns datetimes like \`2026-04-30T13:40:34.000+0000\` (offset-form), which Zod's \`z.string().datetime()\` rejects by default. The script in #224 passes \`CreatedDate\` / \`LastModifiedDate\` directly to \`salesforceContactSnapshotRecordSchema.parse(...)\` and the parse fails on every contact.

Wrap both reads in the existing \`toIsoTimestamp\` helper (\`packages/integrations/src/capture-services/shared.ts:153\`) — same pattern already used in \`capture-services/salesforce.ts\` for live capture.

## Test plan
- [x] Local \`pnpm typecheck\` clean
- [x] Local \`pnpm lint\` clean
- [ ] CI green
- [ ] After merge, architect re-runs the dry-run against prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)