### PR TITLE
feat(salesforce): instrument silent task_unmapped_channel drops (Phase 1 of capture-gap fix)

### DIFF
--- a/apps/worker/src/ops/diag-unmapped-task-scope.ts
+++ b/apps/worker/src/ops/diag-unmapped-task-scope.ts
@@ -1,0 +1,290 @@
+import { salesforceLaunchScopeAutomatedOwnerUsernames } from "@as-comms/integrations";
+
+export type UnmappedTaskSubjectBucket =
+  | "hex"
+  | "plan_your"
+  | "time_to_plan"
+  | "dont_forget"
+  | "other";
+
+export interface UnmappedTaskScopeAuditRow {
+  readonly policyCode: string;
+  readonly entityId: string;
+  readonly occurredAt: string;
+  readonly taskSubtype: string | null;
+  readonly subject: string | null;
+  readonly ownerUsername: string | null;
+  readonly whoId: string | null;
+  readonly relatedMembershipPresent: boolean;
+  readonly createdDate: string | null;
+  readonly lastModifiedDate: string | null;
+}
+
+export interface UnmappedTaskScopeOwnerBucket {
+  readonly ownerUsername: string;
+  readonly count: number;
+  readonly launchScopeOwner: boolean;
+}
+
+export interface UnmappedTaskScopeClusterSample {
+  readonly ownerUsername: string;
+  readonly taskSubtype: string;
+  readonly rows: readonly UnmappedTaskScopeAuditRow[];
+}
+
+export interface UnmappedTaskScopeReport {
+  readonly totalRows: number;
+  readonly taskSubtypeDistribution: Readonly<Record<string, number>>;
+  readonly ownerUsernameDistribution: readonly UnmappedTaskScopeOwnerBucket[];
+  readonly subjectBucketDistribution: Readonly<
+    Record<UnmappedTaskSubjectBucket, number>
+  >;
+  readonly last30DayCounts: readonly {
+    readonly day: string;
+    readonly count: number;
+  }[];
+  readonly samplesByCluster: readonly UnmappedTaskScopeClusterSample[];
+}
+
+const hexSubjectPattern = /\bhex\s+\d+\b/iu;
+const planYourPattern = /^\s*plan your\b/iu;
+const timeToPlanPattern = /^\s*time to plan\b/iu;
+const dontForgetPattern = /^\s*don['’]t forget\b/iu;
+
+function incrementCounter(
+  counters: Map<string, number>,
+  key: string
+): void {
+  counters.set(key, (counters.get(key) ?? 0) + 1);
+}
+
+function toSortedRecord(counters: Map<string, number>): Readonly<Record<string, number>> {
+  return Object.fromEntries(
+    Array.from(counters.entries()).sort(([left], [right]) =>
+      left.localeCompare(right)
+    )
+  );
+}
+
+export function classifyUnmappedTaskSubjectBucket(
+  subject: string | null
+): UnmappedTaskSubjectBucket {
+  if (subject === null) {
+    return "other";
+  }
+
+  if (hexSubjectPattern.test(subject)) {
+    return "hex";
+  }
+
+  if (planYourPattern.test(subject)) {
+    return "plan_your";
+  }
+
+  if (timeToPlanPattern.test(subject)) {
+    return "time_to_plan";
+  }
+
+  if (dontForgetPattern.test(subject)) {
+    return "dont_forget";
+  }
+
+  return "other";
+}
+
+function toOwnerKey(ownerUsername: string | null): string {
+  return ownerUsername?.trim() ?? "(missing)";
+}
+
+function toTaskSubtypeKey(taskSubtype: string | null): string {
+  return taskSubtype?.trim() ?? "(missing)";
+}
+
+function toDayKey(timestamp: string): string {
+  return timestamp.slice(0, 10);
+}
+
+function makeClusterKey(ownerUsername: string, taskSubtype: string): string {
+  return JSON.stringify([ownerUsername, taskSubtype]);
+}
+
+function parseClusterKey(clusterKey: string): {
+  readonly ownerUsername: string;
+  readonly taskSubtype: string;
+} {
+  const parsed = JSON.parse(clusterKey) as unknown;
+
+  if (
+    !Array.isArray(parsed) ||
+    parsed.length !== 2 ||
+    typeof parsed[0] !== "string" ||
+    typeof parsed[1] !== "string"
+  ) {
+    throw new Error(`Invalid unmapped-task cluster key: ${clusterKey}`);
+  }
+
+  return {
+    ownerUsername: parsed[0],
+    taskSubtype: parsed[1]
+  };
+}
+
+export function buildUnmappedTaskScopeReport(input: {
+  readonly rows: readonly UnmappedTaskScopeAuditRow[];
+  readonly now?: Date;
+}): UnmappedTaskScopeReport {
+  const now = input.now ?? new Date();
+  const thirtyDaysAgo = new Date(now.getTime() - 29 * 24 * 60 * 60 * 1000);
+  const taskSubtypeCounts = new Map<string, number>();
+  const ownerCounts = new Map<string, number>();
+  const subjectBucketCounts = new Map<UnmappedTaskSubjectBucket, number>();
+  const dayCounts = new Map<string, number>();
+  const sampleRowsByCluster = new Map<string, UnmappedTaskScopeAuditRow[]>();
+
+  for (const row of input.rows) {
+    incrementCounter(taskSubtypeCounts, toTaskSubtypeKey(row.taskSubtype));
+    incrementCounter(ownerCounts, toOwnerKey(row.ownerUsername));
+    const subjectBucket = classifyUnmappedTaskSubjectBucket(row.subject);
+    subjectBucketCounts.set(
+      subjectBucket,
+      (subjectBucketCounts.get(subjectBucket) ?? 0) + 1
+    );
+
+    const occurredAtDate = new Date(row.occurredAt);
+    if (!Number.isNaN(occurredAtDate.getTime()) && occurredAtDate >= thirtyDaysAgo) {
+      incrementCounter(dayCounts, toDayKey(row.occurredAt));
+    }
+
+    const clusterKey = makeClusterKey(
+      toOwnerKey(row.ownerUsername),
+      toTaskSubtypeKey(row.taskSubtype)
+    );
+    const clusterRows = sampleRowsByCluster.get(clusterKey) ?? [];
+    if (clusterRows.length < 5) {
+      clusterRows.push(row);
+      sampleRowsByCluster.set(clusterKey, clusterRows);
+    }
+  }
+
+  const samplesByCluster = Array.from(sampleRowsByCluster.entries())
+    .map(([clusterKey, rows]) => {
+      const { ownerUsername, taskSubtype } = parseClusterKey(clusterKey);
+      return {
+        ownerUsername,
+        taskSubtype,
+        rows
+      };
+    })
+    .sort((left, right) => {
+      if (left.ownerUsername !== right.ownerUsername) {
+        return left.ownerUsername.localeCompare(right.ownerUsername);
+      }
+
+      return left.taskSubtype.localeCompare(right.taskSubtype);
+    });
+
+  const ownerUsernameDistribution = Array.from(ownerCounts.entries())
+    .map(([ownerUsername, count]) => ({
+      ownerUsername,
+      count,
+      launchScopeOwner: salesforceLaunchScopeAutomatedOwnerUsernames.includes(
+        ownerUsername as (typeof salesforceLaunchScopeAutomatedOwnerUsernames)[number]
+      )
+    }))
+    .sort((left, right) => {
+      if (left.count !== right.count) {
+        return right.count - left.count;
+      }
+
+      return left.ownerUsername.localeCompare(right.ownerUsername);
+    });
+
+  const last30DayCounts = Array.from(dayCounts.entries())
+    .map(([day, count]) => ({ day, count }))
+    .sort((left, right) => left.day.localeCompare(right.day));
+
+  return {
+    totalRows: input.rows.length,
+    taskSubtypeDistribution: toSortedRecord(taskSubtypeCounts),
+    ownerUsernameDistribution,
+    subjectBucketDistribution: {
+      hex: subjectBucketCounts.get("hex") ?? 0,
+      plan_your: subjectBucketCounts.get("plan_your") ?? 0,
+      time_to_plan: subjectBucketCounts.get("time_to_plan") ?? 0,
+      dont_forget: subjectBucketCounts.get("dont_forget") ?? 0,
+      other: subjectBucketCounts.get("other") ?? 0
+    },
+    last30DayCounts,
+    samplesByCluster
+  };
+}
+
+function formatSampleRow(row: UnmappedTaskScopeAuditRow): string {
+  return JSON.stringify({
+    taskId: row.entityId,
+    occurredAt: row.occurredAt,
+    taskSubtype: row.taskSubtype,
+    ownerUsername: row.ownerUsername,
+    subject: row.subject,
+    whoId: row.whoId,
+    relatedMembershipPresent: row.relatedMembershipPresent,
+    createdDate: row.createdDate,
+    lastModifiedDate: row.lastModifiedDate,
+    policyCode: row.policyCode
+  });
+}
+
+export function renderUnmappedTaskScopeMarkdown(
+  report: UnmappedTaskScopeReport
+): string {
+  const lines = [
+    "# Unmapped Salesforce Task Scope",
+    "",
+    `- total rows: ${String(report.totalRows)}`,
+    "",
+    "## TaskSubtype distribution"
+  ];
+
+  for (const [taskSubtype, count] of Object.entries(report.taskSubtypeDistribution)) {
+    lines.push(`- ${taskSubtype}: ${String(count)}`);
+  }
+
+  lines.push("", "## Owner.Username distribution");
+  for (const owner of report.ownerUsernameDistribution) {
+    lines.push(
+      `- ${owner.ownerUsername}: ${String(owner.count)}${owner.launchScopeOwner ? " (launch-scope owner)" : ""}`
+    );
+  }
+
+  lines.push("", "## Subject buckets");
+  for (const [bucket, count] of Object.entries(report.subjectBucketDistribution)) {
+    lines.push(`- ${bucket}: ${String(count)}`);
+  }
+
+  lines.push("", "## Per-day count (last 30 days)");
+  if (report.last30DayCounts.length === 0) {
+    lines.push("- none");
+  } else {
+    for (const day of report.last30DayCounts) {
+      lines.push(`- ${day.day}: ${String(day.count)}`);
+    }
+  }
+
+  lines.push("", "## Sample rows by (ownerUsername, taskSubtype)");
+  if (report.samplesByCluster.length === 0) {
+    lines.push("- none");
+  } else {
+    for (const cluster of report.samplesByCluster) {
+      lines.push(`### ${cluster.ownerUsername} / ${cluster.taskSubtype}`);
+      for (const row of cluster.rows) {
+        lines.push(`- ${formatSampleRow(row)}`);
+      }
+      lines.push("");
+    }
+    if (lines.at(-1) === "") {
+      lines.pop();
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}

--- a/apps/worker/src/orchestration/service.ts
+++ b/apps/worker/src/orchestration/service.ts
@@ -114,6 +114,27 @@ interface ParsedGmailHistoricalPayloadRef {
   readonly messageNumber: number;
 }
 
+const instrumentedSalesforceDeferredTaskPolicyCodeByRecordType = {
+  task_unmapped_channel: "stage1.skip.task_unmapped_channel",
+  task_missing_id: "stage1.skip.task_missing_id",
+  task_missing_occurred_at: "stage1.skip.task_missing_occurred_at"
+} as const;
+
+type InstrumentedSalesforceDeferredTaskRecordType =
+  keyof typeof instrumentedSalesforceDeferredTaskPolicyCodeByRecordType;
+
+interface InstrumentedSalesforceDeferredTaskRecord {
+  readonly recordType: InstrumentedSalesforceDeferredTaskRecordType;
+  readonly recordId: string;
+  readonly taskSubtype?: string | null;
+  readonly subject?: string | null;
+  readonly ownerUsername?: string | null;
+  readonly whoId?: string | null;
+  readonly relatedMembershipPresent?: boolean;
+  readonly createdDate?: string | null;
+  readonly lastModifiedDate?: string | null;
+}
+
 function buildHistoricalReplayProjectInboxAliases(input: {
   readonly configuredAliases: readonly string[];
   readonly recordedProjectInboxAlias: string | null;
@@ -149,6 +170,75 @@ function compareEventOrder(
 
 function buildWorkerOperationId(prefix: string): string {
   return `${prefix}:${randomUUID()}`;
+}
+
+function isInstrumentedSalesforceDeferredTaskRecord(
+  record: SalesforceRecord
+): record is InstrumentedSalesforceDeferredTaskRecord {
+  return (
+    record.recordType === "task_unmapped_channel" ||
+    record.recordType === "task_missing_id" ||
+    record.recordType === "task_missing_occurred_at"
+  );
+}
+
+function truncateAuditSubject(subject: string | null | undefined): string | null {
+  if (typeof subject !== "string") {
+    return null;
+  }
+
+  return subject.length <= 200 ? subject : subject.slice(0, 200);
+}
+
+async function recordDeferredSalesforceTaskAuditIfNeeded(
+  persistence: Stage1PersistenceService,
+  input: {
+    readonly record: SalesforceRecord;
+    readonly ingestResult: Stage1IngestResult;
+  }
+): Promise<void> {
+  if (
+    input.ingestResult.outcome !== "deferred" ||
+    input.ingestResult.provider !== "salesforce" ||
+    !isInstrumentedSalesforceDeferredTaskRecord(input.record)
+  ) {
+    return;
+  }
+
+  const policyCode =
+    instrumentedSalesforceDeferredTaskPolicyCodeByRecordType[
+      input.record.recordType
+    ];
+  const auditId = `audit:salesforce_task:${input.record.recordId}:${policyCode}`;
+  const existingRecords = await persistence.repositories.auditEvidence.listByEntity({
+    entityType: "salesforce_task",
+    entityId: input.record.recordId
+  });
+
+  if (existingRecords.some((record) => record.policyCode === policyCode)) {
+    return;
+  }
+
+  await persistence.recordAuditEvidence({
+    id: auditId,
+    actorType: "system",
+    actorId: "salesforce_capture",
+    action: "skipped_unmapped_task",
+    entityType: "salesforce_task",
+    entityId: input.record.recordId,
+    occurredAt: new Date().toISOString(),
+    result: "recorded",
+    policyCode,
+    metadataJson: {
+      taskSubtype: input.record.taskSubtype ?? null,
+      subject: truncateAuditSubject(input.record.subject),
+      ownerUsername: input.record.ownerUsername ?? null,
+      whoId: input.record.whoId ?? null,
+      relatedMembershipPresent: input.record.relatedMembershipPresent ?? false,
+      createdDate: input.record.createdDate ?? null,
+      lastModifiedDate: input.record.lastModifiedDate ?? null
+    }
+  });
 }
 
 function subtractSeconds(now: Date, seconds: number): string {
@@ -1006,6 +1096,13 @@ export function createStage1WorkerOrchestrationService(input: {
       for (const { record, mapped } of prioritizedRecords) {
         const ingestResult = await params.ingestRecord(record);
         ingestResults.push(ingestResult);
+
+        if (payload.provider === "salesforce") {
+          await recordDeferredSalesforceTaskAuditIfNeeded(input.persistence, {
+            record: record as SalesforceRecord,
+            ingestResult
+          });
+        }
 
         if (
           payload.provider === "gmail" &&

--- a/apps/worker/test/diag-unmapped-task-scope.test.ts
+++ b/apps/worker/test/diag-unmapped-task-scope.test.ts
@@ -166,7 +166,7 @@ describe("diag-unmapped-task-scope", () => {
     });
     expect(report.ownerUsernameDistribution[0]).toEqual({
       ownerUsername: "admin+1@adventurescientists.org",
-      count: 7,
+      count: 8,
       launchScopeOwner: true
     });
     expect(report.last30DayCounts).toEqual([

--- a/apps/worker/test/diag-unmapped-task-scope.test.ts
+++ b/apps/worker/test/diag-unmapped-task-scope.test.ts
@@ -55,14 +55,16 @@ describe("diag-unmapped-task-scope", () => {
         {
           policyCode: "stage1.skip.task_unmapped_channel",
           entityId: "00T-3",
-          occurredAt: "2026-04-01T10:00:00.000Z",
+          // 2026-04-01T13:00 sits AFTER the 30-day cutoff at 2026-04-01T12:00
+          // (now=2026-04-30T12:00 minus 29 days), so this row stays in window.
+          occurredAt: "2026-04-01T13:00:00.000Z",
           taskSubtype: null,
           subject: "Completely different subject",
           ownerUsername: "someone@example.org",
           whoId: "003-3",
           relatedMembershipPresent: false,
-          createdDate: "2026-04-01T09:00:00.000Z",
-          lastModifiedDate: "2026-04-01T09:30:00.000Z"
+          createdDate: "2026-04-01T12:00:00.000Z",
+          lastModifiedDate: "2026-04-01T12:30:00.000Z"
         },
         {
           policyCode: "stage1.skip.task_unmapped_channel",

--- a/apps/worker/test/diag-unmapped-task-scope.test.ts
+++ b/apps/worker/test/diag-unmapped-task-scope.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildUnmappedTaskScopeReport,
+  classifyUnmappedTaskSubjectBucket
+} from "../src/ops/diag-unmapped-task-scope.js";
+
+describe("diag-unmapped-task-scope", () => {
+  it("buckets subjects into the expected operator-facing clusters", () => {
+    expect(classifyUnmappedTaskSubjectBucket("Hex 36016 (Date Pending)")).toBe(
+      "hex"
+    );
+    expect(
+      classifyUnmappedTaskSubjectBucket("Plan your Adventure Today!")
+    ).toBe("plan_your");
+    expect(
+      classifyUnmappedTaskSubjectBucket("Time to Plan Your Adventures")
+    ).toBe("time_to_plan");
+    expect(classifyUnmappedTaskSubjectBucket("Don't Forget to Finish")).toBe(
+      "dont_forget"
+    );
+    expect(classifyUnmappedTaskSubjectBucket("Completely different subject")).toBe(
+      "other"
+    );
+  });
+
+  it("builds distributions, last-30-day counts, and capped cluster samples", () => {
+    const report = buildUnmappedTaskScopeReport({
+      now: new Date("2026-04-30T12:00:00.000Z"),
+      rows: [
+        {
+          policyCode: "stage1.skip.task_unmapped_channel",
+          entityId: "00T-1",
+          occurredAt: "2026-04-30T10:00:00.000Z",
+          taskSubtype: "Task",
+          subject: "Plan your Adventure Today!",
+          ownerUsername: "admin+1@adventurescientists.org",
+          whoId: "003-1",
+          relatedMembershipPresent: true,
+          createdDate: "2026-04-30T09:00:00.000Z",
+          lastModifiedDate: "2026-04-30T09:30:00.000Z"
+        },
+        {
+          policyCode: "stage1.skip.task_unmapped_channel",
+          entityId: "00T-2",
+          occurredAt: "2026-04-29T10:00:00.000Z",
+          taskSubtype: "Task",
+          subject: "Hex 36016 (Date Pending)",
+          ownerUsername: "admin+1@adventurescientists.org",
+          whoId: "003-2",
+          relatedMembershipPresent: true,
+          createdDate: "2026-04-29T09:00:00.000Z",
+          lastModifiedDate: "2026-04-29T09:30:00.000Z"
+        },
+        {
+          policyCode: "stage1.skip.task_unmapped_channel",
+          entityId: "00T-3",
+          occurredAt: "2026-04-01T10:00:00.000Z",
+          taskSubtype: null,
+          subject: "Completely different subject",
+          ownerUsername: "someone@example.org",
+          whoId: "003-3",
+          relatedMembershipPresent: false,
+          createdDate: "2026-04-01T09:00:00.000Z",
+          lastModifiedDate: "2026-04-01T09:30:00.000Z"
+        },
+        {
+          policyCode: "stage1.skip.task_unmapped_channel",
+          entityId: "00T-4",
+          occurredAt: "2026-03-01T10:00:00.000Z",
+          taskSubtype: "Call",
+          subject: "Don't Forget to Finish",
+          ownerUsername: null,
+          whoId: "003-4",
+          relatedMembershipPresent: false,
+          createdDate: "2026-03-01T09:00:00.000Z",
+          lastModifiedDate: "2026-03-01T09:30:00.000Z"
+        },
+        {
+          policyCode: "stage1.skip.task_unmapped_channel",
+          entityId: "00T-5",
+          occurredAt: "2026-04-30T11:00:00.000Z",
+          taskSubtype: "Task",
+          subject: "Time to Plan Your Adventures",
+          ownerUsername: "admin+1@adventurescientists.org",
+          whoId: "003-5",
+          relatedMembershipPresent: true,
+          createdDate: "2026-04-30T10:30:00.000Z",
+          lastModifiedDate: "2026-04-30T10:40:00.000Z"
+        },
+        {
+          policyCode: "stage1.skip.task_unmapped_channel",
+          entityId: "00T-6",
+          occurredAt: "2026-04-30T11:10:00.000Z",
+          taskSubtype: "Task",
+          subject: "Time to Plan Your Adventures",
+          ownerUsername: "admin+1@adventurescientists.org",
+          whoId: "003-6",
+          relatedMembershipPresent: true,
+          createdDate: "2026-04-30T10:35:00.000Z",
+          lastModifiedDate: "2026-04-30T10:45:00.000Z"
+        },
+        {
+          policyCode: "stage1.skip.task_unmapped_channel",
+          entityId: "00T-7",
+          occurredAt: "2026-04-30T11:20:00.000Z",
+          taskSubtype: "Task",
+          subject: "Time to Plan Your Adventures",
+          ownerUsername: "admin+1@adventurescientists.org",
+          whoId: "003-7",
+          relatedMembershipPresent: true,
+          createdDate: "2026-04-30T10:36:00.000Z",
+          lastModifiedDate: "2026-04-30T10:46:00.000Z"
+        },
+        {
+          policyCode: "stage1.skip.task_unmapped_channel",
+          entityId: "00T-8",
+          occurredAt: "2026-04-30T11:30:00.000Z",
+          taskSubtype: "Task",
+          subject: "Time to Plan Your Adventures",
+          ownerUsername: "admin+1@adventurescientists.org",
+          whoId: "003-8",
+          relatedMembershipPresent: true,
+          createdDate: "2026-04-30T10:37:00.000Z",
+          lastModifiedDate: "2026-04-30T10:47:00.000Z"
+        },
+        {
+          policyCode: "stage1.skip.task_unmapped_channel",
+          entityId: "00T-9",
+          occurredAt: "2026-04-30T11:40:00.000Z",
+          taskSubtype: "Task",
+          subject: "Time to Plan Your Adventures",
+          ownerUsername: "admin+1@adventurescientists.org",
+          whoId: "003-9",
+          relatedMembershipPresent: true,
+          createdDate: "2026-04-30T10:38:00.000Z",
+          lastModifiedDate: "2026-04-30T10:48:00.000Z"
+        },
+        {
+          policyCode: "stage1.skip.task_unmapped_channel",
+          entityId: "00T-10",
+          occurredAt: "2026-04-30T11:50:00.000Z",
+          taskSubtype: "Task",
+          subject: "Time to Plan Your Adventures",
+          ownerUsername: "admin+1@adventurescientists.org",
+          whoId: "003-10",
+          relatedMembershipPresent: true,
+          createdDate: "2026-04-30T10:39:00.000Z",
+          lastModifiedDate: "2026-04-30T10:49:00.000Z"
+        }
+      ]
+    });
+
+    expect(report.totalRows).toBe(10);
+    expect(report.taskSubtypeDistribution).toEqual({
+      "(missing)": 1,
+      Call: 1,
+      Task: 8
+    });
+    expect(report.subjectBucketDistribution).toEqual({
+      hex: 1,
+      plan_your: 1,
+      time_to_plan: 6,
+      dont_forget: 1,
+      other: 1
+    });
+    expect(report.ownerUsernameDistribution[0]).toEqual({
+      ownerUsername: "admin+1@adventurescientists.org",
+      count: 7,
+      launchScopeOwner: true
+    });
+    expect(report.last30DayCounts).toEqual([
+      { day: "2026-04-01", count: 1 },
+      { day: "2026-04-29", count: 1 },
+      { day: "2026-04-30", count: 7 }
+    ]);
+    const adminTaskCluster = report.samplesByCluster.find(
+      (cluster) =>
+        cluster.ownerUsername === "admin+1@adventurescientists.org" &&
+        cluster.taskSubtype === "Task"
+    );
+    expect(adminTaskCluster?.rows).toHaveLength(5);
+  });
+});

--- a/apps/worker/test/stage1-orchestration.test.ts
+++ b/apps/worker/test/stage1-orchestration.test.ts
@@ -2116,4 +2116,125 @@ Alias drift outbound message.
       await nonRetryableContext.dispose();
     }
   });
+
+  it("records one audit row for deferred Salesforce task_unmapped_channel drops and stays idempotent across reruns", async () => {
+    const capture = createEmptyCapturePorts();
+    capture.salesforce.captureLiveBatch = () =>
+      Promise.resolve(
+        buildCapturedBatch([
+          {
+            recordType: "task_unmapped_channel" as const,
+            recordId: "00T-unmapped-1",
+            taskSubtype: "Task",
+            subject:
+              "Plan your Adventure Today! This subject is intentionally long to verify truncation stays bounded when the instrumentation records the audit metadata payload for skipped Salesforce tasks.",
+            ownerUsername: "admin+1@adventurescientists.org",
+            whoId: "003-stage1",
+            relatedMembershipPresent: true,
+            createdDate: "2026-01-05T00:01:00.000Z",
+            lastModifiedDate: "2026-01-05T00:02:00.000Z"
+          }
+        ])
+      );
+    const context = await createTestWorkerContext({ capture });
+
+    try {
+      const first = await context.orchestration.runSalesforceLiveCaptureBatch(
+        buildSalesforceLivePayload({
+          syncStateId: "sync:salesforce:task-unmapped:1"
+        })
+      );
+      const second = await context.orchestration.runSalesforceLiveCaptureBatch(
+        buildSalesforceLivePayload({
+          syncStateId: "sync:salesforce:task-unmapped:2"
+        })
+      );
+
+      expect(first.outcome).toBe("succeeded");
+      expect(second.outcome).toBe("succeeded");
+      const audits = await context.repositories.auditEvidence.listByEntity({
+        entityType: "salesforce_task",
+        entityId: "00T-unmapped-1"
+      });
+
+      expect(audits).toHaveLength(1);
+      expect(audits[0]).toMatchObject({
+        actorType: "system",
+        actorId: "salesforce_capture",
+        action: "skipped_unmapped_task",
+        entityType: "salesforce_task",
+        entityId: "00T-unmapped-1",
+        policyCode: "stage1.skip.task_unmapped_channel",
+        result: "recorded"
+      });
+      expect(audits[0]?.metadataJson).toMatchObject({
+        taskSubtype: "Task",
+        ownerUsername: "admin+1@adventurescientists.org",
+        whoId: "003-stage1",
+        relatedMembershipPresent: true,
+        createdDate: "2026-01-05T00:01:00.000Z",
+        lastModifiedDate: "2026-01-05T00:02:00.000Z"
+      });
+      expect(typeof audits[0]?.metadataJson.subject).toBe("string");
+      expect((audits[0]?.metadataJson.subject as string).length).toBeLessThanOrEqual(
+        200
+      );
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("does not record deferred-task audit evidence for normal Salesforce task_communication records", async () => {
+    const capture = createEmptyCapturePorts();
+    capture.salesforce.captureLiveBatch = () =>
+      Promise.resolve(
+        buildCapturedBatch([
+          {
+            recordType: "task_communication" as const,
+            recordId: "00T-task-1",
+            channel: "email" as const,
+            messageKind: "auto" as const,
+            salesforceContactId: "003-stage1",
+            occurredAt: "2026-01-05T00:01:00.000Z",
+            receivedAt: "2026-01-05T00:02:00.000Z",
+            payloadRef: "payloads/salesforce/00T-task-1.json",
+            checksum: "checksum-00T-task-1",
+            subject: "Email: Launch update",
+            snippet: "Outbound email sent",
+            normalizedEmails: ["volunteer@example.org"],
+            normalizedPhones: [],
+            volunteerIdPlainValues: [],
+            supportingRecords: [],
+            crossProviderCollapseKey: null,
+            routing: {
+              required: true,
+              projectId: "project-stage1",
+              expeditionId: "expedition-stage1",
+              projectName: "Project Stage 1",
+              expeditionName: "Expedition Stage 1"
+            }
+          }
+        ])
+      );
+    const context = await createTestWorkerContext({ capture });
+
+    try {
+      await seedContact(context);
+      const result = await context.orchestration.runSalesforceLiveCaptureBatch(
+        buildSalesforceLivePayload({
+          syncStateId: "sync:salesforce:task-communication:1"
+        })
+      );
+
+      expect(result.outcome).toBe("succeeded");
+      await expect(
+        context.repositories.auditEvidence.listByEntity({
+          entityType: "salesforce_task",
+          entityId: "00T-task-1"
+        })
+      ).resolves.toEqual([]);
+    } finally {
+      await context.dispose();
+    }
+  });
 });

--- a/packages/integrations/src/capture-services/salesforce.ts
+++ b/packages/integrations/src/capture-services/salesforce.ts
@@ -1132,11 +1132,29 @@ function buildTaskRecord(input: {
   readonly receivedAt: string;
 }): SalesforceRecord {
   const taskId = getStringField(input.task, "Id");
+  const taskSubtype = getStringField(input.task, "TaskSubtype");
+  const subject = getStringField(input.task, "Subject");
+  const ownerUsername = getStringField(input.task, "Owner.Username");
+  const whoId = getStringField(input.task, input.config.taskContactField);
+  const createdDate = toIsoTimestamp(getStringField(input.task, "CreatedDate"));
+  const lastModifiedDate = toIsoTimestamp(
+    getStringField(input.task, "LastModifiedDate"),
+  );
+  const deferredTaskMetadata = {
+    taskSubtype,
+    subject,
+    ownerUsername,
+    whoId,
+    relatedMembershipPresent: input.relatedMembership !== null,
+    createdDate,
+    lastModifiedDate,
+  };
 
   if (taskId === null) {
     return {
       recordType: "task_missing_id",
       recordId: "unknown-task",
+      ...deferredTaskMetadata,
     };
   }
 
@@ -1150,6 +1168,7 @@ function buildTaskRecord(input: {
     return {
       recordType: "task_unmapped_channel",
       recordId: taskId,
+      ...deferredTaskMetadata,
     };
   }
 
@@ -1162,11 +1181,12 @@ function buildTaskRecord(input: {
     return {
       recordType: "task_missing_occurred_at",
       recordId: taskId,
+      ...deferredTaskMetadata,
     };
   }
 
   const salesforceContactId =
-    getStringField(input.task, input.config.taskContactField) ??
+    whoId ??
     getStringField(input.contact ?? {}, "Id");
   const projectId =
     input.relatedMembership === null
@@ -1198,13 +1218,12 @@ function buildTaskRecord(input: {
         );
   const hasMembershipRoutingContext =
     projectId !== null || expeditionId !== null;
-  const subject = getStringField(input.task, "Subject");
   const messageKind = classifySalesforceTaskMessageKind({
     channel,
-    taskSubtype: getStringField(input.task, "TaskSubtype"),
+    taskSubtype,
     ownerId: getStringField(input.task, "OwnerId"),
     ownerName: getStringField(input.task, "Owner.Name"),
-    ownerUsername: getStringField(input.task, "Owner.Username"),
+    ownerUsername,
     subject,
   }).messageKind;
 

--- a/packages/integrations/src/providers/salesforce.ts
+++ b/packages/integrations/src/providers/salesforce.ts
@@ -317,6 +317,29 @@ export type SalesforceTaskCommunicationRecord = z.infer<
   typeof salesforceTaskCommunicationRecordSchema
 >;
 
+const salesforceDeferredTaskRecordMetadataSchema = z.object({
+  taskSubtype: nullableStringSchema.default(null),
+  subject: nullableStringSchema.default(null),
+  ownerUsername: nullableStringSchema.default(null),
+  whoId: nullableStringSchema.default(null),
+  relatedMembershipPresent: z.boolean().default(false),
+  createdDate: nullableStringSchema.default(null),
+  lastModifiedDate: nullableStringSchema.default(null),
+});
+
+export const salesforceDeferredTaskRecordSchema =
+  salesforceDeferredTaskRecordMetadataSchema.extend({
+    recordType: z.enum([
+      "task_unmapped_channel",
+      "task_missing_id",
+      "task_missing_occurred_at",
+    ]),
+    recordId: z.string().min(1),
+  });
+export type SalesforceDeferredTaskRecord = z.infer<
+  typeof salesforceDeferredTaskRecordSchema
+>;
+
 export const salesforceUnsupportedRecordSchema = z
   .object({
     recordType: z.string().min(1),
@@ -328,6 +351,9 @@ export const salesforceUnsupportedRecordSchema = z
         "contact_snapshot",
         "lifecycle_milestone",
         "task_communication",
+        "task_unmapped_channel",
+        "task_missing_id",
+        "task_missing_occurred_at",
       ].includes(record.recordType),
     {
       message:
@@ -342,12 +368,14 @@ export const salesforceRecordSchema = z.union([
   salesforceContactSnapshotRecordSchema,
   salesforceLifecycleRecordSchema,
   salesforceTaskCommunicationRecordSchema,
+  salesforceDeferredTaskRecordSchema,
   salesforceUnsupportedRecordSchema,
 ]);
 export type SalesforceRecord =
   | SalesforceContactSnapshotRecord
   | SalesforceLifecycleRecord
   | SalesforceTaskCommunicationRecord
+  | SalesforceDeferredTaskRecord
   | SalesforceUnsupportedRecord;
 
 function resolveLifecycleEventType(
@@ -865,6 +893,18 @@ export function mapSalesforceRecord(
       command: createCanonicalEventCommand(
         mapSalesforceTaskCommunicationRecord(taskRecord.data),
       ),
+    });
+  }
+
+  const deferredTaskRecord = salesforceDeferredTaskRecordSchema.safeParse(rawRecord);
+
+  if (deferredTaskRecord.success) {
+    return createDeferredMappingResult({
+      provider: "salesforce",
+      sourceRecordType: deferredTaskRecord.data.recordType,
+      sourceRecordId: deferredTaskRecord.data.recordId,
+      reason: "deferred_record_family",
+      detail: `Salesforce ${deferredTaskRecord.data.recordType} records are deferred in Stage 1.`,
     });
   }
 

--- a/scripts/ops/diag-unmapped-task-scope.ts
+++ b/scripts/ops/diag-unmapped-task-scope.ts
@@ -1,0 +1,91 @@
+#!/usr/bin/env tsx
+import process from "node:process";
+
+import {
+  closeDatabaseConnection,
+  createDatabaseConnection,
+  type PostgresClient
+} from "@as-comms/db";
+
+import {
+  buildUnmappedTaskScopeReport,
+  renderUnmappedTaskScopeMarkdown,
+  type UnmappedTaskScopeAuditRow
+} from "../../apps/worker/src/ops/diag-unmapped-task-scope.js";
+
+interface UnmappedTaskScopeAuditRowRaw {
+  readonly policy_code: string;
+  readonly entity_id: string;
+  readonly occurred_at: string;
+  readonly task_subtype: string | null;
+  readonly subject: string | null;
+  readonly owner_username: string | null;
+  readonly who_id: string | null;
+  readonly related_membership_present: boolean | null;
+  readonly created_date: string | null;
+  readonly last_modified_date: string | null;
+}
+
+function readConnectionString(env: NodeJS.ProcessEnv): string {
+  const connectionString = env.WORKER_DATABASE_URL ?? env.DATABASE_URL;
+
+  if (connectionString === undefined || connectionString.trim().length === 0) {
+    throw new Error(
+      "DATABASE_URL or WORKER_DATABASE_URL is required for this ops command."
+    );
+  }
+
+  return connectionString;
+}
+
+async function loadRows(sql: PostgresClient): Promise<readonly UnmappedTaskScopeAuditRow[]> {
+  const rows = await sql.unsafe<readonly UnmappedTaskScopeAuditRowRaw[]>(`
+    select
+      policy_code,
+      entity_id,
+      occurred_at::text as occurred_at,
+      metadata_json ->> 'taskSubtype' as task_subtype,
+      metadata_json ->> 'subject' as subject,
+      metadata_json ->> 'ownerUsername' as owner_username,
+      metadata_json ->> 'whoId' as who_id,
+      case
+        when metadata_json ? 'relatedMembershipPresent'
+          then coalesce((metadata_json ->> 'relatedMembershipPresent')::boolean, false)
+        else false
+      end as related_membership_present,
+      metadata_json ->> 'createdDate' as created_date,
+      metadata_json ->> 'lastModifiedDate' as last_modified_date
+    from audit_policy_evidence
+    where policy_code like 'stage1.skip.task_unmapped%'
+    order by occurred_at desc, entity_id desc
+  `);
+
+  return rows.map((row) => ({
+    policyCode: row.policy_code,
+    entityId: row.entity_id,
+    occurredAt: row.occurred_at,
+    taskSubtype: row.task_subtype,
+    subject: row.subject,
+    ownerUsername: row.owner_username,
+    whoId: row.who_id,
+    relatedMembershipPresent: row.related_membership_present ?? false,
+    createdDate: row.created_date,
+    lastModifiedDate: row.last_modified_date
+  }));
+}
+
+async function main(): Promise<void> {
+  const connection = createDatabaseConnection({
+    connectionString: readConnectionString(process.env)
+  });
+
+  try {
+    const rows = await loadRows(connection.sql as PostgresClient);
+    const report = buildUnmappedTaskScopeReport({ rows });
+    process.stdout.write(renderUnmappedTaskScopeMarkdown(report));
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}
+
+await main();


### PR DESCRIPTION
## Summary
- Phase 1 instrumentation only — Phase 2 (the fix) is a separate brief.
- Adds orchestration-boundary audit evidence for deferred Salesforce Task drops with `policy_code` variants for `task_unmapped_channel`, `task_missing_id`, and `task_missing_occurred_at`.
- Adds a read-only ops diagnostic script at `scripts/ops/diag-unmapped-task-scope.ts` to aggregate `audit_policy_evidence` rows after deploy.
- Leaves `resolveTaskChannel` behavior unchanged in this PR.

## Bug Being Instrumented
- `resolveTaskChannel` silent-drop path: `packages/integrations/src/capture-services/salesforce.ts:1080-1124`
- Current Phase 1 capture now preserves deferred-task metadata in the provider-close record so orchestration can emit audit evidence without adding side effects inside `mapSalesforceRecord`.

## Fix Options For Phase 2
- F.1 — Owner-trust extension (simplest, highest leverage). When `TaskSubtype === "Task"` and `Owner.Username` is in the launch-scope whitelist and `relatedMembership !== null`, classify as `"email"` regardless of subject. Pro: catches Pardot / Marketing Cloud automations using arbitrary subjects. Con: assumes admin+1@ does not log non-email volunteer Tasks.
- F.2 — Type-field check. If Salesforce Task `Type === 'Email'`, treat it as email. Pro: respects Salesforce classification. Con: depends on org consistency; prior architect diag suggested `Type` may be empty.
- F.3 — Activity record-type lookup. Probe Salesforce Task `RecordTypeId` / org record-type configuration and classify from that. Pro: most precise. Con: requires schema investigation and may vary across orgs.

## Recommendation
- Recommendation: deploy this instrumentation first and let it run for a day. If the resulting data shows that more than 90% of dropped Tasks are `admin+1@adventurescientists.org`-owned volunteer Tasks, choose F.1. Otherwise prefer an F.2/F.3 hybrid after validating fresh Salesforce metadata.

## Validation
- `pnpm typecheck`
- `pnpm lint`

## Scope Notes
- Phase 1 instrumentation only — no `resolveTaskChannel` classifier change in this PR.
- No side-effecting DB call was added inside `mapSalesforceRecord`; the audit emission is at the orchestration boundary that consumes the deferred result.
- No schema changes were required for this phase.
