### PR TITLE
fix(timeline): drop reconciled pending outbounds from inbox view-model

### DIFF
--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -171,6 +171,7 @@ export type InboxTimelineEntryKind =
 
 export type InboxTimelineEntrySendStatus =
   | "pending"
+  | "confirmed"
   | "failed"
   | "orphaned"
   | null;

--- a/packages/contracts/src/stage1-timeline.ts
+++ b/packages/contracts/src/stage1-timeline.ts
@@ -102,7 +102,7 @@ export const oneToOneEmailTimelineItemSchema = timelineItemBaseSchema.extend({
   threadId: nullableStringSchema,
   rfc822MessageId: nullableStringSchema.optional(),
   inReplyToRfc822: nullableStringSchema.optional(),
-  sendStatus: z.enum(["pending", "failed", "orphaned"]).nullable().optional(),
+  sendStatus: z.enum(["pending", "confirmed", "failed", "orphaned"]).nullable().optional(),
   failedReason: z.string().nullable().optional(),
   failedDetail: z.string().nullable().optional(),
   attachmentCount: z.number().int().nonnegative().optional(),

--- a/packages/domain/src/timeline.ts
+++ b/packages/domain/src/timeline.ts
@@ -281,6 +281,7 @@ function buildPendingTimelineItems(
       inReplyToRfc822: row.inReplyToRfc822,
       sendStatus:
         row.status === "pending" ||
+        row.status === "confirmed" ||
         row.status === "failed" ||
         row.status === "orphaned"
           ? row.status

--- a/packages/domain/src/timeline.ts
+++ b/packages/domain/src/timeline.ts
@@ -737,10 +737,20 @@ function mergeTimelineItems(input: {
   readonly canonicalItems: readonly TimelineItem[];
   readonly pendingRows: readonly PendingComposerOutboundRecord[];
 }): readonly TimelineItem[] {
+  // Keep unreconciled rows visible, but suppress pending rows once their
+  // reconciled canonical event is present in the current page.
+  const canonicalIds = new Set(
+    input.canonicalItems.map((item) => item.canonicalEventId),
+  );
+  const filteredPending = input.pendingRows.filter(
+    (row) =>
+      row.reconciledEventId === null ||
+      !canonicalIds.has(row.reconciledEventId),
+  );
   return timelineItemListSchema.parse(
     [
       ...input.canonicalItems,
-      ...buildPendingTimelineItems(input.pendingRows),
+      ...buildPendingTimelineItems(filteredPending),
     ].sort((left, right) => left.sortKey.localeCompare(right.sortKey)),
   );
 }

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -860,6 +860,178 @@ describe("Stage 1 timeline presenter", () => {
     });
   });
 
+  it("drops reconciled pending outbounds once the canonical event is present", async () => {
+    const outbound = buildGmailOutboundEmailEvent({
+      id: "canonical-event:gmail%3Amessage%3Atest123",
+      sourceEvidenceId: "sev_gmail_outbound_reconciled",
+      occurredAt: "2026-01-01T00:03:00.000Z",
+      subject: "Reconciled outbound",
+      snippet: "Reconciled outbound body",
+      bodyPreview: "Reconciled outbound body",
+    });
+    const repositories = createRepositoryBundle({
+      canonicalEvents: [outbound.canonicalEvent],
+      sourceEvidence: [
+        buildSourceEvidence({
+          id: "sev_gmail_outbound_reconciled",
+          provider: "gmail",
+          providerRecordType: "gmail_message",
+          providerRecordId: "gmail-message-test123",
+        }),
+      ],
+      gmailMessageDetails: [outbound.detail],
+      timelineRows: [outbound.timelineRow],
+      salesforceCommunicationDetails: [],
+      pendingOutbounds: [
+        {
+          id: "pending:reconciled",
+          fingerprint: "fp:pending:reconciled",
+          status: "confirmed",
+          actorId: "user:operator",
+          canonicalContactId: "contact_1",
+          projectId: null,
+          fromAlias: "antarctica@example.org",
+          toEmailNormalized: "volunteer@example.org",
+          subject: "Reconciled outbound",
+          bodyPlaintext: "Reconciled outbound body",
+          bodyHtml: "<p>Reconciled outbound body</p>",
+          bodySha256: "sha256:reconciled",
+          attachmentMetadata: [],
+          gmailThreadId: null,
+          inReplyToRfc822: null,
+          sentAt: "2026-01-01T00:03:00.000Z",
+          reconciledEventId: "canonical-event:gmail%3Amessage%3Atest123",
+          reconciledAt: "2026-01-01T00:03:24.000Z",
+          failedReason: null,
+          sentRfc822MessageId: null,
+          failedDetail: null,
+          orphanedAt: null,
+          createdAt: "2026-01-01T00:03:00.000Z",
+          updatedAt: "2026-01-01T00:03:24.000Z",
+        },
+      ],
+    });
+    const presenter = createStage1TimelinePresentationService(repositories);
+
+    const items = await presenter.listTimelineItemsByContactId("contact_1");
+
+    expect(items.filter((item) => item.family === "one_to_one_email")).toHaveLength(1);
+    expect(items.map((item) => item.canonicalEventId)).toEqual([
+      "canonical-event:gmail%3Amessage%3Atest123",
+    ]);
+  });
+
+  it("preserves unreconciled pending outbounds", async () => {
+    const repositories = createRepositoryBundle({
+      canonicalEvents: [],
+      sourceEvidence: [],
+      salesforceCommunicationDetails: [],
+      timelineRows: [],
+      pendingOutbounds: [
+        {
+          id: "pending:null-reconcile",
+          fingerprint: "fp:pending:null-reconcile",
+          status: "pending",
+          actorId: "user:operator",
+          canonicalContactId: "contact_1",
+          projectId: null,
+          fromAlias: "antarctica@example.org",
+          toEmailNormalized: "volunteer@example.org",
+          subject: "Pending outbound",
+          bodyPlaintext: "Pending outbound body",
+          bodyHtml: "<p>Pending outbound body</p>",
+          bodySha256: "sha256:pending-null",
+          attachmentMetadata: [],
+          gmailThreadId: null,
+          inReplyToRfc822: null,
+          sentAt: "2026-01-01T00:04:00.000Z",
+          reconciledEventId: null,
+          reconciledAt: null,
+          failedReason: null,
+          sentRfc822MessageId: null,
+          failedDetail: null,
+          orphanedAt: null,
+          createdAt: "2026-01-01T00:04:00.000Z",
+          updatedAt: "2026-01-01T00:04:00.000Z",
+        },
+      ],
+    });
+    const presenter = createStage1TimelinePresentationService(repositories);
+
+    const items = await presenter.listTimelineItemsByContactId("contact_1");
+
+    expect(items.map((item) => item.canonicalEventId)).toEqual([
+      "pending-outbound:pending:null-reconcile",
+    ]);
+    expect(items[0]).toMatchObject({
+      sendStatus: "pending",
+      subject: "Pending outbound",
+    });
+  });
+
+  it("preserves reconciled pending outbounds when the canonical event is not in the current page", async () => {
+    const outbound = buildSalesforceEmailEvent({
+      id: "evt_salesforce_one_to_one_page_only",
+      sourceEvidenceId: "sev_salesforce_one_to_one_page_only",
+      occurredAt: "2026-01-01T00:05:00.000Z",
+      direction: "outbound",
+      canonicalMessageKind: "one_to_one",
+      subject: "Page event",
+      snippet: "Page event body",
+    });
+    const repositories = createRepositoryBundle({
+      canonicalEvents: [outbound.canonicalEvent],
+      sourceEvidence: [
+        buildSourceEvidence({
+          id: "sev_salesforce_one_to_one_page_only",
+          providerRecordId: "salesforce-page-only",
+        }),
+      ],
+      salesforceCommunicationDetails: [outbound.detail],
+      timelineRows: [outbound.timelineRow],
+      pendingOutbounds: [
+        {
+          id: "pending:lag-window",
+          fingerprint: "fp:pending:lag-window",
+          status: "confirmed",
+          actorId: "user:operator",
+          canonicalContactId: "contact_1",
+          projectId: null,
+          fromAlias: "antarctica@example.org",
+          toEmailNormalized: "volunteer@example.org",
+          subject: "Lag window outbound",
+          bodyPlaintext: "Lag window outbound body",
+          bodyHtml: "<p>Lag window outbound body</p>",
+          bodySha256: "sha256:lag-window",
+          attachmentMetadata: [],
+          gmailThreadId: null,
+          inReplyToRfc822: null,
+          sentAt: "2026-01-01T00:06:00.000Z",
+          reconciledEventId: "canonical-event:something-not-in-the-page",
+          reconciledAt: "2026-01-01T00:06:24.000Z",
+          failedReason: null,
+          sentRfc822MessageId: null,
+          failedDetail: null,
+          orphanedAt: null,
+          createdAt: "2026-01-01T00:06:00.000Z",
+          updatedAt: "2026-01-01T00:06:24.000Z",
+        },
+      ],
+    });
+    const presenter = createStage1TimelinePresentationService(repositories);
+
+    const items = await presenter.listTimelineItemsByContactId("contact_1");
+
+    expect(items.map((item) => item.canonicalEventId)).toEqual([
+      "evt_salesforce_one_to_one_page_only",
+      "pending-outbound:pending:lag-window",
+    ]);
+    expect(items[1]).toMatchObject({
+      sendStatus: "confirmed",
+      subject: "Lag window outbound",
+    });
+  });
+
   // The "hydrates attachmentCount from message_attachments rows" assertion
   // moved to the inbox selector tests — the domain timeline presenter
   // intentionally returns attachmentCount: 0 to avoid a duplicate


### PR DESCRIPTION
## Summary
- A successful composer send rendered as **two bubbles** in the inbox: pending-lane (alias-labeled "Adventure Scientists →") + canonical-lane (OAuth-identity-labeled "You →"). Reproduced in prod 2026-04-30.
- Reconciliation was working correctly — `pending_composer_outbounds.reconciled_event_id` populated ~24s after send. The bug was purely in `mergeTimelineItems`: straight concatenation of canonical + pending lanes with no cross-lane dedup pass.
- Fix at the merge step: drop pending rows whose `reconciledEventId` matches a canonical item already on the page. Keeps unreconciled rows and lag-window rows visible.
- 3 unit tests added (drop-when-matched, preserve-when-null, preserve-when-canonical-not-yet-in-page).

## Test plan
- [x] `pnpm typecheck` passes (per Codex sandbox)
- [x] `pnpm lint` passes
- [x] `pnpm boundaries` passes
- [ ] CI green on `pnpm build` (sandbox: Google Fonts unreachable — local-only)
- [ ] CI green on `pnpm test:unit` (sandbox: macOS rollup gotcha — local-only)
- [ ] Manual after merge + deploy: send a composer message; confirm exactly one bubble in the inbox timeline once the canonical event materializes.

## Context
- Investigation: `.OVERNIGHT-composer-duplication-investigation-2026-04-30.md`
- This is the targeted patch flagged for the duplication symptom — independent of the broader 5-layer dedup-architecture consolidation, which still belongs on the roadmap.
- Independent of [#227](https://github.com/nico-kneler-as/as-comms-platform/pull/227) (composer thread_id resolution); both can ship in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)