### PR TITLE
chore(db): index gmail_message_details.rfc822_message_id (dedup step 1)

### DIFF
--- a/packages/db/drizzle/0048_gmail_message_details_rfc822_index.sql
+++ b/packages/db/drizzle/0048_gmail_message_details_rfc822_index.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS gmail_message_details_rfc822_idx
+  ON gmail_message_details (rfc822_message_id)
+  WHERE rfc822_message_id IS NOT NULL;

--- a/packages/db/src/schema/tables.ts
+++ b/packages/db/src/schema/tables.ts
@@ -278,6 +278,9 @@ export const gmailMessageDetails = pgTable(
   (table) => [
     index("gmail_message_details_record_idx").on(table.providerRecordId),
     index("gmail_message_details_thread_idx").on(table.gmailThreadId),
+    index("gmail_message_details_rfc822_idx")
+      .on(table.rfc822MessageId)
+      .where(sql`${table.rfc822MessageId} IS NOT NULL`),
   ],
 );
 


### PR DESCRIPTION
## Summary
- Pure additive: partial index on `gmail_message_details.rfc822_message_id` (`WHERE rfc822_message_id IS NOT NULL`)
- Path-agnostic prep for the dedup-architecture consolidation — useful regardless of whether we land on Path A-prime (rfc822 from SF EmailMessage) or Path C (content-fingerprint hardening)
- Migration uses `0048_` prefix (`0047_` is taken by [#230](https://github.com/nico-kneler-as/as-comms-platform/pull/230))

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] CI green
- [ ] After merge + apply: `\d gmail_message_details` shows `gmail_message_details_rfc822_idx` as a partial index

## Context
- Dedup consolidation PRD: `.dedup-consolidation-PRD-2026-04-30.md`
- Decision gate (Path A-prime vs C) still pending architect's SF EmailMessage SOQL probe
- Step 1 is path-agnostic — it ships regardless of what the gate resolves to

🤖 Generated with [Claude Code](https://claude.com/claude-code)