### PR TITLE
feat(inbox): hide pre-2025 events at UI read layer (cutover filter)

### DIFF
--- a/apps/web/app/_lib/cutover.ts
+++ b/apps/web/app/_lib/cutover.ts
@@ -1,0 +1,30 @@
+/**
+ * Platform "full capture" cutover line. Events with occurredAt before this
+ * timestamp are hidden from operator views (timeline, message-history, AI
+ * grounding) but remain in the database. Project memberships and other
+ * non-event data are NOT subject to this filter.
+ *
+ * To move the line: change this constant. To disable: remove the filter at
+ * each consumer (see callers).
+ */
+export const PLATFORM_FULL_CAPTURE_CUTOVER = "2025-01-01T00:00:00.000Z";
+
+export function occurredAtIsOnOrAfterPlatformFullCaptureCutover(
+  occurredAt: string,
+): boolean {
+  return occurredAt >= PLATFORM_FULL_CAPTURE_CUTOVER;
+}
+
+export function occurredAtIsBeforePlatformFullCaptureCutover(
+  occurredAt: string,
+): boolean {
+  return occurredAt < PLATFORM_FULL_CAPTURE_CUTOVER;
+}
+
+export function filterItemsAtOrAfterPlatformFullCaptureCutover<
+  T extends { readonly occurredAt: string },
+>(items: readonly T[]): readonly T[] {
+  return items.filter((item) =>
+    occurredAtIsOnOrAfterPlatformFullCaptureCutover(item.occurredAt),
+  );
+}

--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -597,6 +597,9 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
               entries={timelineEntries}
               volunteerFirstName={firstName}
               currentOperatorUserId={currentOperatorUserId}
+              showEarlierHistoryDivider={
+                timelinePage.hasHiddenEarlierHistory
+              }
               hasMore={timelinePage.hasMore}
               isLoadingOlder={isTimelineLoading}
               retryingEntryId={isRetryPending ? retryingEntryId : null}

--- a/apps/web/app/inbox/_components/inbox-timeline.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline.tsx
@@ -41,6 +41,7 @@ interface TimelineProps {
   readonly entries: readonly InboxTimelineEntryViewModel[];
   readonly volunteerFirstName: string;
   readonly currentOperatorUserId: string;
+  readonly showEarlierHistoryDivider?: boolean;
   readonly hasMore?: boolean;
   readonly isLoadingOlder?: boolean;
   readonly onLoadOlder?: () => void;
@@ -53,6 +54,7 @@ export function InboxTimeline({
   entries,
   volunteerFirstName,
   currentOperatorUserId,
+  showEarlierHistoryDivider = false,
   hasMore = false,
   isLoadingOlder = false,
   onLoadOlder,
@@ -110,6 +112,17 @@ export function InboxTimeline({
         ) : null}
 
         <ol className="mx-auto flex w-full max-w-[920px] flex-col gap-3">
+          {showEarlierHistoryDivider ? (
+            <li aria-label="Earlier history not shown" className="list-none">
+              <div className="flex items-center gap-3 py-1 text-xs text-muted-foreground">
+                <div className="h-px flex-1 bg-border" />
+                <span className="whitespace-nowrap">
+                  Earlier history not shown - full capture began Jan 1, 2025
+                </span>
+                <div className="h-px flex-1 bg-border" />
+              </div>
+            </li>
+          ) : null}
           {presentationItems.map((item) => (
             <TimelinePresentationItem
               key={item.id}

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -10,6 +10,10 @@ import type {
 
 import { recordSensitiveReadForCurrentUserDetached } from "@/src/server/security/audit";
 import { getStage1WebRuntime } from "../../../src/server/stage1-runtime";
+import {
+  occurredAtIsBeforePlatformFullCaptureCutover,
+  filterItemsAtOrAfterPlatformFullCaptureCutover,
+} from "@/app/_lib/cutover";
 
 import { INBOX_FILTERS } from "./filters";
 import type {
@@ -113,6 +117,7 @@ interface InboxDetailCacheData {
   >;
   readonly timelinePage: {
     readonly hasMore: boolean;
+    readonly hasHiddenEarlierHistory: boolean;
     readonly nextCursor: string | null;
     readonly total: number;
   };
@@ -2190,7 +2195,7 @@ function buildComposerReplyContext(input: {
   readonly timelineItems: readonly TimelineItem[];
   readonly defaultAlias: string | null;
 }): InboxComposerReplyContext | null {
-  const inboundEmails = [...input.timelineItems]
+  const inboundEmails = [...filterItemsAtOrAfterPlatformFullCaptureCutover(input.timelineItems)]
     .reverse()
     .filter(
       (item): item is Extract<TimelineItem, { family: "one_to_one_email" }> =>
@@ -2214,6 +2219,46 @@ function buildComposerReplyContext(input: {
     inReplyToRfc822: latestInboundEmail.rfc822MessageId ?? null,
     defaultAlias: input.defaultAlias,
     cc: extractEmailAddresses(latestInboundEmail.ccHeader),
+  };
+}
+
+function paginateTimelineItems(input: {
+  readonly timelineItems: readonly TimelineItem[];
+  readonly limit: number;
+  readonly beforeSortKey: string | null;
+}): {
+  readonly items: readonly TimelineItem[];
+  readonly hasMore: boolean;
+  readonly nextCursor: string | null;
+  readonly total: number;
+} {
+  const total = input.timelineItems.length;
+  const endIndex =
+    input.beforeSortKey === null
+      ? total
+      : input.timelineItems.findIndex(
+          (item) => item.sortKey === input.beforeSortKey,
+        );
+
+  if (endIndex <= 0) {
+    return {
+      items: [],
+      hasMore: false,
+      nextCursor: null,
+      total,
+    };
+  }
+
+  const sliceEnd = endIndex === -1 ? total : endIndex;
+  const sliceStart = Math.max(0, sliceEnd - input.limit);
+  const items = input.timelineItems.slice(sliceStart, sliceEnd);
+  const hasMore = sliceStart > 0;
+
+  return {
+    items,
+    hasMore,
+    nextCursor: hasMore ? items[0]?.sortKey ?? null : null,
+    total,
   };
 }
 
@@ -2793,7 +2838,6 @@ async function readInboxDetailCacheData(
     memberships,
     latestNote,
     activityTimelineItems,
-    timelinePage,
     inboxFreshness,
     timelineFreshness,
     canonicalEvents,
@@ -2817,10 +2861,6 @@ async function readInboxDetailCacheData(
             };
       }),
     runtime.timelinePresentation.listTimelineItemsByContactId(contactId),
-    runtime.timelinePresentation.listTimelineItemsPageByContactId(contactId, {
-      limit: input.timelineLimit,
-      beforeSortKey: input.timelineCursor,
-    }),
     runtime.repositories.inboxProjection.getFreshnessByContactId(contactId),
     runtime.repositories.timelineProjection.getFreshnessByContactId(contactId),
     runtime.repositories.canonicalEvents.listByContactId(contactId),
@@ -2853,6 +2893,17 @@ async function readInboxDetailCacheData(
     aliasesByProjectId.set(aliasRecord.projectId, aliases);
   }
 
+  const visibleTimelineItems = filterItemsAtOrAfterPlatformFullCaptureCutover(
+    activityTimelineItems,
+  );
+  const timelinePage = paginateTimelineItems({
+    timelineItems: visibleTimelineItems,
+    limit: input.timelineLimit,
+    beforeSortKey: input.timelineCursor,
+  });
+  const hasHiddenEarlierHistory = canonicalEvents.some((event) =>
+    occurredAtIsBeforePlatformFullCaptureCutover(event.occurredAt),
+  );
   const gmailSourceEvidenceIds = uniqueStrings(
     canonicalEvents
       .filter((event) => event.eventType === "communication.email.outbound")
@@ -2932,7 +2983,8 @@ async function readInboxDetailCacheData(
     ),
     timelinePage: {
       hasMore: timelinePage.hasMore,
-      nextCursor: timelinePage.hasMore ? timelinePage.nextBeforeSortKey : null,
+      hasHiddenEarlierHistory,
+      nextCursor: timelinePage.nextCursor,
       total: timelinePage.total,
     },
     freshness: {
@@ -2941,7 +2993,7 @@ async function readInboxDetailCacheData(
         timelineFreshness.latestUpdatedAt ??
         timelinePage.items[timelinePage.items.length - 1]?.occurredAt ??
         null,
-      timelineCount: timelinePage.total,
+      timelineCount: timelineFreshness.total,
     },
   };
 }

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -343,6 +343,7 @@ export interface InboxDetailViewModel {
   readonly composerReplyContext: InboxComposerReplyContext | null;
   readonly timelinePage: {
     readonly hasMore: boolean;
+    readonly hasHiddenEarlierHistory: boolean;
     readonly nextCursor: string | null;
     readonly total: number;
   };

--- a/apps/web/src/server/ai/retriever.ts
+++ b/apps/web/src/server/ai/retriever.ts
@@ -1,4 +1,5 @@
 import type { Stage1RepositoryBundle } from "@as-comms/domain";
+import { filterItemsAtOrAfterPlatformFullCaptureCutover } from "@/app/_lib/cutover";
 
 import type {
   AiDraftGrounding,
@@ -147,9 +148,9 @@ export async function retrieveGrounding(
     );
   }
 
-  const communicationEvents = canonicalEvents.filter((event) =>
-    isCommunicationEvent(event.eventType),
-  );
+  const communicationEvents = filterItemsAtOrAfterPlatformFullCaptureCutover(
+    canonicalEvents,
+  ).filter((event) => isCommunicationEvent(event.eventType));
   const sourceEvidenceIds = communicationEvents.map((event) => event.sourceEvidenceId);
   const [gmailDetails, salesforceDetails, simpleTextingDetails] =
     await Promise.all([

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -1870,9 +1870,138 @@ describe("real inbox selectors", () => {
     });
     expect(detail?.timelinePage).toEqual({
       hasMore: false,
+      hasHiddenEarlierHistory: false,
       nextCursor: null,
       total: 2,
     });
+  });
+
+  it("filters pre-cutover timeline entries while keeping the cutover boundary inclusive", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:cutover-boundary",
+      salesforceContactId: "003-cutover-boundary",
+      displayName: "Cutover Boundary",
+      primaryEmail: "cutover-boundary@example.org",
+      primaryPhone: null,
+      projectId: "project:cutover-boundary",
+      projectName: "Cutover Boundary Project",
+      membershipId: "membership:cutover-boundary",
+      membershipStatus: "active",
+    });
+    await seedInboxEmailEvent(runtime.context, {
+      id: "cutover-pre-outbound",
+      contactId: "contact:cutover-boundary",
+      occurredAt: "2024-12-31T23:59:59.999Z",
+      direction: "outbound",
+      subject: "Older hidden email",
+      snippet: "This email should be hidden from the timeline.",
+    });
+    const boundaryInbound = await seedInboxEmailEvent(runtime.context, {
+      id: "cutover-boundary-inbound",
+      contactId: "contact:cutover-boundary",
+      occurredAt: "2025-01-01T00:00:00.000Z",
+      direction: "inbound",
+      subject: "Boundary inbound email",
+      snippet: "This inbound message sits exactly on the cutover.",
+    });
+    const postCutoverOutbound = await seedInboxEmailEvent(runtime.context, {
+      id: "cutover-post-outbound",
+      contactId: "contact:cutover-boundary",
+      occurredAt: "2025-01-02T12:00:00.000Z",
+      direction: "outbound",
+      subject: "Visible post-cutover email",
+      snippet: "This email should remain visible.",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:cutover-boundary",
+      bucket: "Opened",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2025-01-01T00:00:00.000Z",
+      lastOutboundAt: "2025-01-02T12:00:00.000Z",
+      lastActivityAt: "2025-01-02T12:00:00.000Z",
+      snippet: "This email should remain visible.",
+      lastCanonicalEventId: postCutoverOutbound.canonicalEventId,
+      lastEventType: "communication.email.outbound",
+    });
+
+    const detail = await getInboxDetail("contact:cutover-boundary");
+
+    expect(detail?.timeline.map((entry) => entry.subject)).toEqual([
+      "Boundary inbound email",
+      "Visible post-cutover email",
+    ]);
+    expect(detail?.timeline.map((entry) => entry.occurredAt)).toEqual([
+      "2025-01-01T00:00:00.000Z",
+      "2025-01-02T12:00:00.000Z",
+    ]);
+    expect(detail?.timelinePage).toEqual({
+      hasMore: false,
+      hasHiddenEarlierHistory: true,
+      nextCursor: null,
+      total: 2,
+    });
+    expect(detail?.composerReplyContext).toMatchObject({
+      threadCursor: boundaryInbound.canonicalEventId,
+      subject: "Re: Boundary inbound email",
+    });
+  });
+
+  it("filters pre-cutover message history out of the composer reply context", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:cutover-reply",
+      salesforceContactId: "003-cutover-reply",
+      displayName: "Cutover Reply",
+      primaryEmail: "cutover-reply@example.org",
+      primaryPhone: null,
+      projectId: "project:cutover-reply",
+      projectName: "Cutover Reply Project",
+      membershipId: "membership:cutover-reply",
+      membershipStatus: "active",
+    });
+    await seedInboxEmailEvent(runtime.context, {
+      id: "cutover-reply-pre-inbound",
+      contactId: "contact:cutover-reply",
+      occurredAt: "2024-12-15T15:00:00.000Z",
+      direction: "inbound",
+      subject: "Only older inbound",
+      snippet: "This is the last inbound before full capture.",
+    });
+    const visibleOutbound = await seedInboxEmailEvent(runtime.context, {
+      id: "cutover-reply-visible-outbound",
+      contactId: "contact:cutover-reply",
+      occurredAt: "2025-02-01T15:00:00.000Z",
+      direction: "outbound",
+      subject: "Visible outbound",
+      snippet: "Visible outbound with no visible inbound to reply to.",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:cutover-reply",
+      bucket: "Opened",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2024-12-15T15:00:00.000Z",
+      lastOutboundAt: "2025-02-01T15:00:00.000Z",
+      lastActivityAt: "2025-02-01T15:00:00.000Z",
+      snippet: "Visible outbound with no visible inbound to reply to.",
+      lastCanonicalEventId: visibleOutbound.canonicalEventId,
+      lastEventType: "communication.email.outbound",
+    });
+
+    const detail = await getInboxDetail("contact:cutover-reply");
+
+    expect(detail?.timeline.map((entry) => entry.subject)).toEqual([
+      "Visible outbound",
+    ]);
+    expect(detail?.composerReplyContext).toBeNull();
   });
 
   it("renders the contact rail project row as a single expedition-member anchor with a hover affordance", async () => {
@@ -1932,6 +2061,53 @@ describe("real inbox selectors", () => {
       statusLabel: "Successful",
     });
     expect(detail?.contact.pastProjects).toHaveLength(0);
+  });
+
+  it("keeps all-time project memberships visible even when the membership predates the cutover", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:membership-all-time",
+      salesforceContactId: "003-membership-all-time",
+      displayName: "Membership All Time",
+      primaryEmail: "membership-all-time@example.org",
+      primaryPhone: null,
+      projectId: "project:all-time-membership",
+      projectName: "All-Time Membership Project",
+      membershipId: "membership:all-time-membership",
+      membershipStatus: "successful",
+      membershipCreatedAt: "2023-06-01T12:00:00.000Z",
+    });
+    const latest = await seedInboxEmailEvent(runtime.context, {
+      id: "membership-all-time-inbound",
+      contactId: "contact:membership-all-time",
+      occurredAt: "2025-03-01T12:00:00.000Z",
+      direction: "inbound",
+      subject: "Visible 2025 email",
+      snippet: "The timeline should filter events, not memberships.",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:membership-all-time",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2025-03-01T12:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2025-03-01T12:00:00.000Z",
+      snippet: "The timeline should filter events, not memberships.",
+      lastCanonicalEventId: latest.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+
+    const detail = await getInboxDetail("contact:membership-all-time");
+
+    expect(detail?.contact.activeProjects[0]).toMatchObject({
+      projectName: "All-Time Membership Project",
+      signupYear: 2023,
+      status: "successful",
+    });
   });
 
   it("places inactive memberships in Past Projects regardless of volunteer status", async () => {

--- a/apps/web/tests/unit/inbox-timeline.test.ts
+++ b/apps/web/tests/unit/inbox-timeline.test.ts
@@ -180,6 +180,35 @@ describe("InboxTimeline", () => {
     expect(markup).not.toContain("1 automated");
   });
 
+  it("renders the earlier-history divider when pre-cutover events exist", () => {
+    const markup = renderToStaticMarkup(
+      createElement(InboxTimeline, {
+        entries: [baseEntry],
+        volunteerFirstName: "Alice",
+        currentOperatorUserId: "user:operator",
+        showEarlierHistoryDivider: true,
+      }),
+    );
+
+    expect(markup).toContain(
+      "Earlier history not shown - full capture began Jan 1, 2025",
+    );
+  });
+
+  it("omits the earlier-history divider when no pre-cutover events exist", () => {
+    const markup = renderToStaticMarkup(
+      createElement(InboxTimeline, {
+        entries: [baseEntry],
+        volunteerFirstName: "Alice",
+        currentOperatorUserId: "user:operator",
+      }),
+    );
+
+    expect(markup).not.toContain(
+      "Earlier history not shown - full capture began Jan 1, 2025",
+    );
+  });
+
   it("shows one consolidated campaign state while keeping the row in the purple campaign treatment", () => {
     const markup = renderToStaticMarkup(
       createElement(InboxTimeline, {


### PR DESCRIPTION
## Summary
Architect decision 2026-04-30: keep full event history in DB, hide pre-2025 events at the UI read layer. Reversible by moving a single constant. No data destruction.

## Consumers filtered
- Inbox timeline selector (`apps/web/app/inbox/_lib/selectors.ts`)
- Composer reply-context / message-history selector (same file)
- AI grounding retriever (`apps/web/src/server/ai/retriever.ts`)

## Explicitly NOT filtered
- Contact rail project memberships (all-time visibility preserved)
- Database / projection writes
- Any ops scripts

## Constant
Single source of truth: `apps/web/app/_lib/cutover.ts` →
```
PLATFORM_FULL_CAPTURE_CUTOVER = "2025-01-01T00:00:00.000Z"
```
Move the constant to change the line; remove filter calls to disable.

## Visual marker
Conditional divider rendered at the bottom of the timeline if (and only if) the contact has at least one pre-cutover event:

```
--- Earlier history not shown - full capture began Jan 1, 2025 ---
```

## Tests
New cases cover: mixed-date filter behavior, boundary inclusivity (events exactly at 2025-01-01T00:00:00.000Z stay visible), memberships unfiltered, divider conditional rendering.

## Validation
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] CI green (verify, build, test:unit, lint, typecheck)

## Out of scope
- "View full history" toggle — explicitly deferred
- Database deletion — explicitly NOT happening
- Projection-write filtering — read-layer only

🤖 Generated with [Claude Code](https://claude.com/claude-code)