### PR TITLE
fix(dedup): drop preview from computeContentFingerprint (Path C, cross-provider symmetry)

### DIFF
--- a/packages/db/test/stage1-normalization.test.ts
+++ b/packages/db/test/stage1-normalization.test.ts
@@ -1380,7 +1380,7 @@ describe("Stage 1 normalization service", () => {
     expect(canonicalEvent.contentFingerprint).toMatch(/^fp:/);
   });
 
-  it("does not collapse distinct same-minute Gmail and Salesforce emails when the body content differs", async () => {
+  it("does not collapse distinct same-minute Gmail and Salesforce emails when the normalized subject differs", async () => {
     const context = await seedContactWithEmail("monica@example.org", {
       contactId: "contact_monica",
       salesforceContactId: "003-monica",
@@ -1402,7 +1402,7 @@ describe("Stage 1 normalization service", () => {
       salesforceContactId: "003-monica",
       occurredAt: "2026-04-20T21:27:45.000Z",
       receivedAt: "2026-04-20T21:28:30.000Z",
-      subject: "→ Email: Re: Hex 12345",
+      subject: "→ Email: Re: Hex 67890",
       snippet: "Second draft with a different call to action and follow-up wording.",
       messageKind: "auto"
     });

--- a/packages/domain/src/outbound-email-dedup.ts
+++ b/packages/domain/src/outbound-email-dedup.ts
@@ -59,6 +59,9 @@ export interface ContentFingerprintInput {
   readonly contactId: string | null;
   readonly channel: CanonicalEventRecord["channel"];
   readonly direction: "inbound" | "outbound" | null;
+  // Kept for caller compatibility. computeContentFingerprint intentionally
+  // ignores preview/body text so Gmail and Salesforce can converge on the same
+  // cross-provider key for the same outbound email.
   readonly previewText?: string | null;
 }
 
@@ -300,6 +303,14 @@ function buildMinuteBucket(occurredAt: string): string | null {
   return new Date(occurredAtMs).toISOString().slice(0, 16);
 }
 
+/**
+ * Computes the cross-provider content fingerprint for outbound email dedup.
+ *
+ * Path C intentionally excludes preview/body text from the hash so Gmail
+ * plaintext and Salesforce HTML-derived snippets converge on the same
+ * fingerprint for the same outbound email. Keep previewText in the input for
+ * caller compatibility, but do not add it back into this hash.
+ */
 export function computeContentFingerprint(
   input: ContentFingerprintInput
 ): string | null {
@@ -312,26 +323,22 @@ export function computeContentFingerprint(
   }
 
   const normalizedSubject = normalizeContentFingerprintSubject(input.subject);
-  const normalizedPreview = normalizeContentFingerprintPreview(
-    input.previewText
-  );
   const minuteBucket = buildMinuteBucket(input.occurredAt);
 
-  if (
-    normalizedSubject === null ||
-    normalizedPreview === null ||
-    minuteBucket === null
-  ) {
+  if (normalizedSubject === null || minuteBucket === null) {
     return null;
   }
 
+  // Subject-only fingerprint. Preview/body text is intentionally excluded per
+  // Path C so Gmail plaintext and Salesforce stripped HTML can share the same
+  // cross-provider key for the same outbound email. Keep L2/L4 exact-body
+  // matching unchanged in buildOutboundEmailDuplicateFingerprint.
   const key = [
     input.contactId,
     input.channel,
     input.direction,
     minuteBucket,
-    normalizedSubject,
-    sha256Text(normalizedPreview)
+    normalizedSubject
   ].join("|");
 
   return `fp:${sha256Text(key)}`;

--- a/packages/domain/test/outbound-email-dedup.test.ts
+++ b/packages/domain/test/outbound-email-dedup.test.ts
@@ -51,7 +51,7 @@ describe("content fingerprint helpers", () => {
     expect(third).not.toBe(first);
   });
 
-  it("keeps distinct same-subject messages apart when the preview text differs", () => {
+  it("ignores preview text so Gmail and Salesforce share the same fingerprint", () => {
     const first = computeContentFingerprint({
       subject: "Re: Hex 12345",
       occurredAt: "2026-04-20T21:27:03.000Z",
@@ -61,7 +61,7 @@ describe("content fingerprint helpers", () => {
       previewText: "First draft with the pickup link and meeting notes."
     });
     const second = computeContentFingerprint({
-      subject: "Re: Hex 12345",
+      subject: "→ Email: Re: Hex 12345",
       occurredAt: "2026-04-20T21:27:45.000Z",
       contactId: "contact_1",
       channel: "email",
@@ -70,7 +70,72 @@ describe("content fingerprint helpers", () => {
         "Second draft with a different call to action and follow-up wording."
     });
 
+    expect(first).toBe(second);
+  });
+
+  it("keeps distinct same-minute messages apart when the normalized subject differs", () => {
+    const first = computeContentFingerprint({
+      subject: "Re: Hex 12345",
+      occurredAt: "2026-04-20T21:27:03.000Z",
+      contactId: "contact_1",
+      channel: "email",
+      direction: "outbound",
+      previewText: "First draft with the pickup link and meeting notes."
+    });
+    const second = computeContentFingerprint({
+      subject: "Re: Hex 67890",
+      occurredAt: "2026-04-20T21:27:45.000Z",
+      contactId: "contact_1",
+      channel: "email",
+      direction: "outbound",
+      previewText:
+        "First draft with the pickup link and meeting notes."
+    });
+
     expect(first).not.toBe(second);
+  });
+
+  it("returns a fingerprint when the preview text is empty or null", () => {
+    const emptyPreview = computeContentFingerprint({
+      subject: "Field logistics",
+      occurredAt: "2026-04-20T21:27:03.000Z",
+      contactId: "contact_1",
+      channel: "email",
+      direction: "outbound",
+      previewText: ""
+    });
+    const nullPreview = computeContentFingerprint({
+      subject: "Field logistics",
+      occurredAt: "2026-04-20T21:27:45.000Z",
+      contactId: "contact_1",
+      channel: "email",
+      direction: "outbound",
+      previewText: null
+    });
+
+    expect(emptyPreview).toBeTruthy();
+    expect(nullPreview).toBe(emptyPreview);
+  });
+
+  it("keeps subject normalization symmetric across providers", () => {
+    const gmail = computeContentFingerprint({
+      subject: "[External Email] Re: ARU pickup details",
+      occurredAt: "2026-04-20T21:27:03.000Z",
+      contactId: "contact_1",
+      channel: "email",
+      direction: "outbound",
+      previewText: "Gmail plaintext body"
+    });
+    const salesforce = computeContentFingerprint({
+      subject: "→ Email: ARU pickup details",
+      occurredAt: "2026-04-20T21:27:41.000Z",
+      contactId: "contact_1",
+      channel: "email",
+      direction: "outbound",
+      previewText: null
+    });
+
+    expect(gmail).toBe(salesforce);
   });
 
   it("keeps the pending composer fingerprint aligned with Gmail outbound ingest", () => {


### PR DESCRIPTION
## Summary
Path C of the dedup-architecture consolidation. Path A-prime eliminated by SOQL probe 2026-04-30; Path C is the only viable cross-provider symmetric key.

### Live prod data (108 active gmail+SF dup clusters, 2026-04-30)

| provider | events_in_dup_clusters | has_fingerprint | null_fingerprint |
|---|---|---|---|
| gmail | 171 | 127 (74%) | 44 |
| salesforce | 141 | **4 (3%)** | **137** |

L3's preview requirement is the operational root cause of cluster persistence. SF-stored Marketing Cloud / Pardot HTML body content normalizes to empty after the existing strip pipeline, so the fingerprint computation returns null. L4 can't collapse cross-provider pairs without fingerprints, even when subject + minute + contact unambiguously identify the same email.

## Algorithm change
`computeContentFingerprint` now hashes only `(contactId, channel, direction, minuteBucket, normalizedSubject)`. Preview component dropped entirely.

- Symmetric across providers regardless of body rendering.
- Existing rows with old fingerprints stay valid; backfill ops command (follow-up PR) recomputes them.
- L1, L2, L4, L5 untouched (no new dedup layer per architect's "consolidate, don't extend" decision).

## Path A-prime is permanently dead
SOQL probe (2026-04-30):
- SF EmailMessage rows: 292 (vs 5,022 admin+1@ Tasks / 180d → 4.5% coverage)
- `MessageIdentifier` format: `<XXX@sfdc.net>` — Salesforce-internal email-tracking IDs, NOT rfc822 envelope IDs from the actual message envelope
- Even at 100% coverage these would never match Gmail-side rfc822 IDs (`@mail.gmail.com`, sender-system-generated)

Path C is the only viable consolidation route.

## Tests added
- Cross-provider symmetry: same minute + same subject + same contact across two providers → same fingerprint
- Distinct-subject divergence
- Empty/null preview still returns a fingerprint (the bug we just fixed)
- Subject-prefix normalization convergence

## Validation
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] CI green

## Out of scope
- Backfill of existing rows (follow-up PR `.codex-dedup-step3-pathC-phase2-backfill-2026-04-30.md`)
- Touching L1/L2/L4/L5
- Adding a new dedup layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)