### PR TITLE
feat(ops): backfill canonical_event_ledger.content_fingerprint under new algorithm (Path C phase 2)

### DIFF
--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -57,3 +57,5 @@ pnpm ops:worker:import-gmail-mbox -- \
 ```
 
 Leave `--overwrite-bodies` off to preserve the existing Gmail detail preview fields on duplicate re-imports. Enable it when a duplicate-safe re-import should refresh `subject`, `snippetClean`, and `bodyTextPreview` from the current `.mbox` parse.
+
+`pnpm --filter @as-comms/worker ops backfill-content-fingerprint [--execute] [--limit N] [--event-types <comma-list>]`

--- a/apps/worker/src/ops/backfill-content-fingerprint.ts
+++ b/apps/worker/src/ops/backfill-content-fingerprint.ts
@@ -1,68 +1,96 @@
 #!/usr/bin/env tsx
+/**
+ * backfill-content-fingerprint
+ *
+ * Usage:
+ *   pnpm --filter @as-comms/worker ops backfill-content-fingerprint
+ *   pnpm --filter @as-comms/worker ops backfill-content-fingerprint --limit 100
+ *   pnpm --filter @as-comms/worker ops backfill-content-fingerprint --execute
+ *
+ * Dry-run by default. Recomputes canonical_event_ledger.content_fingerprint
+ * using the current persisted fingerprint-source builder plus the current
+ * computeContentFingerprint algorithm. Emits JSONL audit rows to stdout and
+ * writes summary counts to stderr.
+ */
 import process from "node:process";
 
-import {
-  asc,
-  eq,
-  sql
-} from "drizzle-orm";
+import { asc, eq, inArray } from "drizzle-orm";
 
 import {
-  canonicalEventSchema
+  canonicalEventSchema,
+  type CanonicalEventRecord,
 } from "@as-comms/contracts";
 import {
   canonicalEventLedger,
   closeDatabaseConnection,
   createDatabaseConnection,
   createStage1RepositoryBundleFromConnection,
-  gmailMessageDetails,
-  salesforceCommunicationDetails,
-  type Stage1Database
+  type Stage1Database,
 } from "@as-comms/db";
+import type { createStage1RepositoryBundle } from "@as-comms/db";
 import {
+  buildPersistedContentFingerprintSource,
   computeContentFingerprint,
-  type ContentFingerprintInput
 } from "@as-comms/domain";
+import { toIsoTimestamp } from "@as-comms/integrations";
 
 import {
   parseCliFlags,
-  readOptionalIntegerFlag
+  readOptionalBooleanFlag,
+  readOptionalIntegerFlag,
+  readOptionalStringArrayFlag,
 } from "./helpers.js";
 
-const updateChunkSize = 500;
+const detailBatchSize = 500;
+const updateBatchSize = 500;
+const defaultEventTypes = [
+  "communication.email.outbound",
+  "communication.email.inbound",
+] as const satisfies readonly CanonicalEventRecord["eventType"][];
+
+type Stage1Repositories = ReturnType<typeof createStage1RepositoryBundle>;
 
 interface Logger {
-  log(...args: readonly unknown[]): void;
+  error(...args: readonly unknown[]): void;
 }
 
-interface ContentFingerprintBackfillRow {
-  readonly canonicalEventId: string;
+interface AuditWriter {
+  writeLine(line: string): void;
+}
+
+type SupportedFingerprintProvider = "gmail" | "salesforce";
+type BackfillCategory = "unchanged" | "new_value" | "cleared" | "still_null";
+
+interface BackfillContentFingerprintAuditLine {
+  readonly id: string;
   readonly contactId: string;
-  readonly occurredAt: Date;
-  readonly contentFingerprint: string | null;
-  readonly primaryProvider: string;
-  readonly direction: "inbound" | "outbound" | null;
-  readonly gmailSubject: string | null;
-  readonly gmailBodyTextPreview: string | null;
-  readonly gmailSnippetClean: string | null;
-  readonly salesforceSubject: string | null;
-  readonly salesforceSnippet: string | null;
+  readonly provider: SupportedFingerprintProvider;
+  readonly oldFingerprint: string | null;
+  readonly newFingerprint: string | null;
+  readonly occurredAt: string;
+  readonly eventType: CanonicalEventRecord["eventType"];
 }
 
-interface ContentFingerprintBackfillCandidate {
-  readonly canonicalEventId: string;
-  readonly currentContentFingerprint: string | null;
-  readonly nextContentFingerprint: string | null;
+interface BackfillContentFingerprintCandidate {
+  readonly id: string;
+  readonly contactId: string;
+  readonly provider: SupportedFingerprintProvider;
+  readonly eventType: CanonicalEventRecord["eventType"];
+  readonly occurredAt: string;
+  readonly oldFingerprint: string | null;
+  readonly newFingerprint: string | null;
+  readonly category: BackfillCategory;
 }
 
 export interface BackfillContentFingerprintResult {
   readonly dryRun: boolean;
+  readonly eventTypes: readonly CanonicalEventRecord["eventType"][];
   readonly scannedCount: number;
-  readonly computedCount: number;
-  readonly unchangedCount: number;
-  readonly updateCount: number;
+  readonly categoryCounts: Readonly<Record<BackfillCategory, number>>;
   readonly updatedCount: number;
-  readonly sample: readonly ContentFingerprintBackfillCandidate[];
+  readonly runtimeMs: number;
+  readonly warningCount: number;
+  readonly auditLines: readonly BackfillContentFingerprintAuditLine[];
 }
 
 function readConnectionString(env: NodeJS.ProcessEnv): string {
@@ -70,7 +98,7 @@ function readConnectionString(env: NodeJS.ProcessEnv): string {
 
   if (connectionString === undefined || connectionString.trim().length === 0) {
     throw new Error(
-      "DATABASE_URL or WORKER_DATABASE_URL is required for this ops command."
+      "DATABASE_URL or WORKER_DATABASE_URL is required for this ops command.",
     );
   }
 
@@ -79,7 +107,7 @@ function readConnectionString(env: NodeJS.ProcessEnv): string {
 
 function chunkValues<TValue>(
   values: readonly TValue[],
-  chunkSize: number
+  chunkSize: number,
 ): TValue[][] {
   const chunks: TValue[][] = [];
 
@@ -90,205 +118,309 @@ function chunkValues<TValue>(
   return chunks;
 }
 
-function buildContentFingerprintInput(
-  row: ContentFingerprintBackfillRow
-): ContentFingerprintInput | null {
-  if (row.primaryProvider === "gmail") {
-    return {
-      subject: row.gmailSubject,
-      occurredAt: row.occurredAt.toISOString(),
-      contactId: row.contactId,
-      channel: "email",
-      direction: row.direction,
-      previewText: row.gmailBodyTextPreview ?? row.gmailSnippetClean
-    };
+function parseBackfillEventTypes(
+  args: readonly CanonicalEventRecord["eventType"][],
+): CanonicalEventRecord["eventType"][] {
+  const allowed = new Set<CanonicalEventRecord["eventType"]>([
+    "communication.email.outbound",
+    "communication.email.inbound",
+  ]);
+  const eventTypes = args.length === 0 ? [...defaultEventTypes] : [...new Set(args)];
+
+  for (const eventType of eventTypes) {
+    if (!allowed.has(eventType)) {
+      throw new Error(
+        `Unsupported --event-types value "${eventType}". Allowed values: communication.email.outbound, communication.email.inbound.`,
+      );
+    }
   }
 
-  if (row.primaryProvider === "salesforce") {
-    return {
-      subject: row.salesforceSubject,
-      occurredAt: row.occurredAt.toISOString(),
-      contactId: row.contactId,
-      channel: "email",
-      direction: row.direction,
-      previewText: row.salesforceSnippet
-    };
-  }
-
-  return null;
+  return eventTypes;
 }
 
-async function loadBackfillRows(input: {
-  readonly db: Stage1Database;
-  readonly limit: number | null;
-}): Promise<readonly ContentFingerprintBackfillRow[]> {
-  const rows = await input.db
-    .select({
-      canonicalEventId: canonicalEventLedger.id,
-      contactId: canonicalEventLedger.contactId,
-      occurredAt: canonicalEventLedger.occurredAt,
-      contentFingerprint: canonicalEventLedger.contentFingerprint,
-      primaryProvider:
-        sql<string>`${canonicalEventLedger.provenance} ->> 'primaryProvider'`,
-      direction:
-        sql<"inbound" | "outbound" | null>`${canonicalEventLedger.provenance} ->> 'direction'`,
-      gmailSubject: gmailMessageDetails.subject,
-      gmailBodyTextPreview: gmailMessageDetails.bodyTextPreview,
-      gmailSnippetClean: gmailMessageDetails.snippetClean,
-      salesforceSubject: salesforceCommunicationDetails.subject,
-      salesforceSnippet: salesforceCommunicationDetails.snippet
-    })
-    .from(canonicalEventLedger)
-    .leftJoin(
-      gmailMessageDetails,
-      eq(gmailMessageDetails.sourceEvidenceId, canonicalEventLedger.sourceEvidenceId)
-    )
-    .leftJoin(
-      salesforceCommunicationDetails,
-      eq(
-        salesforceCommunicationDetails.sourceEvidenceId,
-        canonicalEventLedger.sourceEvidenceId
-      )
-    )
-    .where(eq(canonicalEventLedger.channel, "email"))
-    .orderBy(
-      asc(canonicalEventLedger.occurredAt),
-      asc(canonicalEventLedger.id)
-    );
+function normalizeOccurredAt(value: Date | string): string {
+  const normalized = toIsoTimestamp(value);
 
-  return input.limit === null ? rows : rows.slice(0, input.limit);
+  if (normalized === null) {
+    throw new Error("Expected canonical_event_ledger.occurred_at to be a valid timestamp.");
+  }
+
+  return normalized;
+}
+
+function toCanonicalEventRecord(row: typeof canonicalEventLedger.$inferSelect): CanonicalEventRecord {
+  return canonicalEventSchema.parse({
+    id: row.id,
+    contactId: row.contactId,
+    eventType: row.eventType,
+    channel: row.channel,
+    occurredAt: normalizeOccurredAt(row.occurredAt),
+    contentFingerprint: row.contentFingerprint,
+    sourceEvidenceId: row.sourceEvidenceId,
+    idempotencyKey: row.idempotencyKey,
+    provenance: row.provenance,
+    reviewState: row.reviewState,
+  });
+}
+
+function categorizeFingerprintChange(input: {
+  readonly oldFingerprint: string | null;
+  readonly newFingerprint: string | null;
+}): BackfillCategory {
+  if (input.oldFingerprint === input.newFingerprint) {
+    return input.oldFingerprint === null ? "still_null" : "unchanged";
+  }
+
+  if (input.newFingerprint === null) {
+    return "cleared";
+  }
+
+  return "new_value";
+}
+
+async function loadCandidates(input: {
+  readonly db: Stage1Database;
+  readonly repositories: Stage1Repositories;
+  readonly eventTypes: readonly CanonicalEventRecord["eventType"][];
+  readonly limit: number | null;
+}): Promise<readonly BackfillContentFingerprintCandidate[]> {
+  const rows = await input.db
+    .select()
+    .from(canonicalEventLedger)
+    .where(inArray(canonicalEventLedger.eventType, [...input.eventTypes]))
+    .orderBy(
+      asc(canonicalEventLedger.contactId),
+      asc(canonicalEventLedger.occurredAt),
+      asc(canonicalEventLedger.id),
+    );
+  const limitedRows =
+    input.limit === null ? rows : rows.slice(0, input.limit);
+  const parsedEvents = limitedRows.map(toCanonicalEventRecord);
+  const sourceEvidenceIds = Array.from(
+    new Set(parsedEvents.map((event) => event.sourceEvidenceId)),
+  ).sort((left, right) => left.localeCompare(right));
+
+  const gmailMessageDetailBySourceEvidenceId = new Map();
+  const salesforceCommunicationDetailBySourceEvidenceId = new Map();
+
+  for (const sourceEvidenceIdChunk of chunkValues(sourceEvidenceIds, detailBatchSize)) {
+    const [gmailDetails, salesforceDetails] = await Promise.all([
+      input.repositories.gmailMessageDetails.listBySourceEvidenceIds(
+        sourceEvidenceIdChunk,
+      ),
+      input.repositories.salesforceCommunicationDetails.listBySourceEvidenceIds(
+        sourceEvidenceIdChunk,
+      ),
+    ]);
+
+    for (const detail of gmailDetails) {
+      gmailMessageDetailBySourceEvidenceId.set(detail.sourceEvidenceId, detail);
+    }
+
+    for (const detail of salesforceDetails) {
+      salesforceCommunicationDetailBySourceEvidenceId.set(
+        detail.sourceEvidenceId,
+        detail,
+      );
+    }
+  }
+
+  const candidates: BackfillContentFingerprintCandidate[] = [];
+
+  for (const event of parsedEvents) {
+    const provider = event.provenance.primaryProvider;
+
+    if (provider !== "gmail" && provider !== "salesforce") {
+      continue;
+    }
+
+    const fingerprintSource = buildPersistedContentFingerprintSource({
+      event,
+      sourceEvidenceId: event.sourceEvidenceId,
+      gmailMessageDetailBySourceEvidenceId,
+      salesforceCommunicationDetailBySourceEvidenceId,
+    });
+    const newFingerprint =
+      fingerprintSource === null
+        ? null
+        : computeContentFingerprint(fingerprintSource);
+
+    candidates.push({
+      id: event.id,
+      contactId: event.contactId,
+      provider,
+      eventType: event.eventType,
+      occurredAt: event.occurredAt,
+      oldFingerprint: event.contentFingerprint ?? null,
+      newFingerprint,
+      category: categorizeFingerprintChange({
+        oldFingerprint: event.contentFingerprint ?? null,
+        newFingerprint,
+      }),
+    });
+  }
+
+  return candidates;
+}
+
+async function applyUpdates(input: {
+  readonly db: Stage1Database;
+  readonly candidates: readonly BackfillContentFingerprintCandidate[];
+}): Promise<number> {
+  let updatedCount = 0;
+
+  for (const batch of chunkValues(input.candidates, updateBatchSize)) {
+    await input.db.transaction(async (tx) => {
+      for (const candidate of batch) {
+        await tx
+          .update(canonicalEventLedger)
+          .set({
+            contentFingerprint: candidate.newFingerprint,
+            updatedAt: new Date(),
+          })
+          .where(eq(canonicalEventLedger.id, candidate.id));
+      }
+    });
+    updatedCount += batch.length;
+  }
+
+  return updatedCount;
 }
 
 export async function backfillContentFingerprint(input: {
   readonly db: Stage1Database;
-  readonly repositories?: ReturnType<typeof createStage1RepositoryBundleFromConnection>;
+  readonly repositories: Stage1Repositories;
   readonly dryRun?: boolean;
   readonly limit?: number | null;
+  readonly eventTypes?: readonly CanonicalEventRecord["eventType"][];
   readonly logger?: Logger;
+  readonly auditWriter?: AuditWriter;
 }): Promise<BackfillContentFingerprintResult> {
+  const startedAt = Date.now();
   const dryRun = input.dryRun ?? true;
   const logger = input.logger ?? console;
-  const rows = await loadBackfillRows({
+  const auditWriter = input.auditWriter ?? {
+    writeLine(line: string) {
+      process.stdout.write(`${line}\n`);
+    },
+  };
+  const eventTypes = parseBackfillEventTypes([
+    ...(input.eventTypes ?? defaultEventTypes),
+  ]);
+  const candidates = await loadCandidates({
     db: input.db,
-    limit: input.limit ?? null
+    repositories: input.repositories,
+    eventTypes,
+    limit: input.limit ?? null,
   });
-  const candidates: ContentFingerprintBackfillCandidate[] = [];
-  let computedCount = 0;
-  let unchangedCount = 0;
+  const categoryCounts: Record<BackfillCategory, number> = {
+    unchanged: 0,
+    new_value: 0,
+    cleared: 0,
+    still_null: 0,
+  };
+  const auditLines: BackfillContentFingerprintAuditLine[] = [];
+  const updates = candidates.filter(
+    (candidate) =>
+      candidate.category === "new_value" || candidate.category === "cleared",
+  );
 
-  for (const row of rows) {
-    const fingerprintInput = buildContentFingerprintInput(row);
-    const nextContentFingerprint =
-      fingerprintInput === null
-        ? null
-        : computeContentFingerprint(fingerprintInput);
+  for (const candidate of candidates) {
+    categoryCounts[candidate.category] += 1;
 
-    if (nextContentFingerprint !== null) {
-      computedCount += 1;
-    }
-
-    if (row.contentFingerprint === nextContentFingerprint) {
-      unchangedCount += 1;
+    if (candidate.category !== "new_value" && candidate.category !== "cleared") {
       continue;
     }
 
-    candidates.push({
-      canonicalEventId: row.canonicalEventId,
-      currentContentFingerprint: row.contentFingerprint,
-      nextContentFingerprint
-    });
+    const auditLine: BackfillContentFingerprintAuditLine = {
+      id: candidate.id,
+      contactId: candidate.contactId,
+      provider: candidate.provider,
+      oldFingerprint: candidate.oldFingerprint,
+      newFingerprint: candidate.newFingerprint,
+      occurredAt: candidate.occurredAt,
+      eventType: candidate.eventType,
+    };
+    auditLines.push(auditLine);
+    auditWriter.writeLine(JSON.stringify(auditLine));
   }
 
-  if (!dryRun && candidates.length > 0) {
-    if (input.repositories === undefined) {
-      throw new Error("repositories are required when --execute is used.");
-    }
+  const updatedCount = dryRun ? 0 : await applyUpdates({ db: input.db, candidates: updates });
+  const runtimeMs = Date.now() - startedAt;
+  const warningCount = categoryCounts.cleared;
 
-    const events = await input.repositories.canonicalEvents.listByIds(
-      candidates.map((candidate) => candidate.canonicalEventId)
+  logger.error("backfill-content-fingerprint");
+  logger.error(`Mode: ${dryRun ? "dry-run" : "execute"}`);
+  logger.error(`Event types: ${eventTypes.join(", ")}`);
+  logger.error(`- scanned rows: ${String(candidates.length)}`);
+  logger.error(`- unchanged: ${String(categoryCounts.unchanged)}`);
+  logger.error(`- new_value: ${String(categoryCounts.new_value)}`);
+  logger.error(`- cleared: ${String(categoryCounts.cleared)}`);
+  logger.error(`- still_null: ${String(categoryCounts.still_null)}`);
+  logger.error(`- updated: ${String(updatedCount)}`);
+  logger.error(`- runtime_ms: ${String(runtimeMs)}`);
+
+  if (warningCount > 0) {
+    logger.error(
+      `WARNING: ${String(warningCount)} rows would clear or cleared content_fingerprint. Investigate normalization regressions before trusting this run.`,
     );
-    const eventById = new Map(events.map((event) => [event.id, event] as const));
-
-    for (const chunk of chunkValues(candidates, updateChunkSize)) {
-      for (const candidate of chunk) {
-        const event = eventById.get(candidate.canonicalEventId);
-
-        if (event === undefined) {
-          continue;
-        }
-
-        await input.repositories.canonicalEvents.upsert(
-          canonicalEventSchema.parse({
-            ...event,
-            contentFingerprint: candidate.nextContentFingerprint
-          })
-        );
-      }
-    }
   }
-
-  logger.log(
-    JSON.stringify(
-      {
-        dryRun,
-        scannedCount: rows.length,
-        computedCount,
-        unchangedCount,
-        updateCount: candidates.length,
-        updatedCount: dryRun ? 0 : candidates.length,
-        sample: candidates.slice(0, 10)
-      },
-      null,
-      2
-    )
-  );
 
   return {
     dryRun,
-    scannedCount: rows.length,
-    computedCount,
-    unchangedCount,
-    updateCount: candidates.length,
-    updatedCount: dryRun ? 0 : candidates.length,
-    sample: candidates.slice(0, 10)
+    eventTypes,
+    scannedCount: candidates.length,
+    categoryCounts,
+    updatedCount,
+    runtimeMs,
+    warningCount,
+    auditLines,
   };
 }
 
 export async function runBackfillContentFingerprintCommand(
   args: readonly string[],
-  env: NodeJS.ProcessEnv
-): Promise<void> {
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<BackfillContentFingerprintResult> {
   const flags = parseCliFlags(args);
   const connection = createDatabaseConnection({
-    connectionString: readConnectionString(env)
+    connectionString: readConnectionString(env),
   });
 
   try {
     const repositories = createStage1RepositoryBundleFromConnection(connection);
-
-    await backfillContentFingerprint({
+    const result = await backfillContentFingerprint({
       db: connection.db,
       repositories,
-      dryRun: !args.includes("--execute"),
-      limit: readOptionalIntegerFlag(flags, "limit", 0) || null
+      dryRun: !readOptionalBooleanFlag(flags, "execute", false),
+      limit: readOptionalIntegerFlag(flags, "limit", 0) || null,
+      eventTypes: parseBackfillEventTypes(
+        readOptionalStringArrayFlag(flags, "event-types") as CanonicalEventRecord["eventType"][],
+      ),
     });
+
+    if (!result.dryRun && result.categoryCounts.cleared > 0) {
+      throw new Error(
+        `backfill-content-fingerprint completed with ${String(result.categoryCounts.cleared)} cleared rows.`,
+      );
+    }
+
+    return result;
   } finally {
     await closeDatabaseConnection(connection);
   }
 }
 
-const entrypointPath = process.argv[1];
-
-if (
-  entrypointPath !== undefined &&
-  import.meta.url === `file://${entrypointPath}`
-) {
-  void runBackfillContentFingerprintCommand(process.argv.slice(2), process.env).catch(
+if (import.meta.url === `file://${process.argv[1] ?? ""}`) {
+  void runBackfillContentFingerprintCommand(process.argv.slice(2)).catch(
     (error: unknown) => {
-      console.error(
-        error instanceof Error ? error.message : "backfill-content-fingerprint failed."
-      );
+      const message =
+        error instanceof Error
+          ? error.message
+          : "backfill-content-fingerprint failed.";
+
+      console.error(message);
       process.exitCode = 1;
-    }
+    },
   );
 }

--- a/apps/worker/test/backfill-content-fingerprint.test.ts
+++ b/apps/worker/test/backfill-content-fingerprint.test.ts
@@ -1,0 +1,373 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canonicalEventSchema,
+  resolveCanonicalChannel,
+} from "@as-comms/contracts";
+import { computeContentFingerprint } from "@as-comms/domain";
+
+import { backfillContentFingerprint } from "../src/ops/backfill-content-fingerprint.js";
+import { createTestWorkerContext } from "./helpers.js";
+
+const silentLogger = {
+  error: (...args: readonly unknown[]) => void args.length,
+};
+
+const silentAuditWriter = {
+  writeLine: (line: string) => void line.length,
+};
+
+async function seedContact(input: {
+  readonly context: Awaited<ReturnType<typeof createTestWorkerContext>>;
+  readonly contactId: string;
+  readonly salesforceContactId: string;
+  readonly email: string;
+}): Promise<void> {
+  await input.context.normalization.upsertNormalizedContactGraph({
+    contact: {
+      id: input.contactId,
+      salesforceContactId: input.salesforceContactId,
+      displayName: input.contactId,
+      primaryEmail: input.email,
+      primaryPhone: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    },
+    identities: [
+      {
+        id: `identity:${input.contactId}:email`,
+        contactId: input.contactId,
+        kind: "email",
+        normalizedValue: input.email,
+        isPrimary: true,
+        source: "salesforce",
+        verifiedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ],
+    memberships: [
+      {
+        id: `membership:${input.contactId}:default`,
+        contactId: input.contactId,
+        salesforceMembershipId: `membership:${input.contactId}:default:sf`,
+        projectId: "project_default",
+        expeditionId: "expedition_default",
+        role: "volunteer",
+        status: "active",
+        source: "salesforce",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    ],
+  });
+}
+
+async function seedEmailEvent(input: {
+  readonly context: Awaited<ReturnType<typeof createTestWorkerContext>>;
+  readonly key: string;
+  readonly contactId: string;
+  readonly provider: "gmail" | "salesforce";
+  readonly eventType: "communication.email.outbound" | "communication.email.inbound";
+  readonly occurredAt: string;
+  readonly subject: string;
+  readonly previewText: string | null;
+  readonly persistedFingerprint: string | null;
+}): Promise<string> {
+  const sourceEvidenceId = `sev_${input.key}`;
+
+  await input.context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: input.provider,
+    providerRecordType:
+      input.provider === "gmail" ? "message" : "task_communication",
+    providerRecordId: `${input.provider}-${input.key}`,
+    receivedAt: input.occurredAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `payloads/${input.provider}/${input.key}.json`,
+    idempotencyKey: `${input.provider}:${input.key}`,
+    checksum: `checksum:${input.key}`,
+  });
+
+  if (input.provider === "gmail") {
+    await input.context.repositories.gmailMessageDetails.upsert({
+      sourceEvidenceId,
+      providerRecordId: `gmail-${input.key}`,
+      gmailThreadId: `thread-${input.key}`,
+      rfc822MessageId: `<${input.key}@example.org>`,
+      direction: input.eventType === "communication.email.inbound" ? "inbound" : "outbound",
+      subject: input.subject,
+      fromHeader: "sender@example.org",
+      toHeader: "recipient@example.org",
+      ccHeader: null,
+      snippetClean: input.previewText ?? "",
+      bodyTextPreview: input.previewText ?? "",
+      capturedMailbox: "volunteers@example.org",
+      projectInboxAlias: null,
+    });
+  } else {
+    await input.context.repositories.salesforceCommunicationDetails.upsert({
+      sourceEvidenceId,
+      providerRecordId: `salesforce-${input.key}`,
+      channel: "email",
+      messageKind: "one_to_one",
+      subject: input.subject,
+      snippet: input.previewText ?? "",
+      sourceLabel: "Salesforce Task",
+    });
+  }
+
+  const canonicalEvent = canonicalEventSchema.parse({
+    id: `evt_${input.key}`,
+    contactId: input.contactId,
+    eventType: input.eventType,
+    channel: resolveCanonicalChannel(input.eventType),
+    occurredAt: input.occurredAt,
+    contentFingerprint: input.persistedFingerprint,
+    sourceEvidenceId,
+    idempotencyKey: `canonical:${input.key}`,
+    provenance: {
+      primaryProvider: input.provider,
+      primarySourceEvidenceId: sourceEvidenceId,
+      supportingSourceEvidenceIds: [],
+      winnerReason:
+        input.provider === "gmail" ? "single_source" : "salesforce_only_best_evidence",
+      sourceRecordType:
+        input.provider === "gmail" ? "message" : "task_communication",
+      sourceRecordId: `${input.provider}-${input.key}`,
+      messageKind: "one_to_one",
+      campaignRef: null,
+      threadRef: null,
+      direction: input.eventType === "communication.email.inbound" ? "inbound" : "outbound",
+      notes: null,
+    },
+    reviewState: "clear",
+  });
+  await input.context.repositories.canonicalEvents.upsert(canonicalEvent);
+
+  return canonicalEvent.id;
+}
+
+describe("backfill-content-fingerprint", () => {
+  it("dry-run emits audit lines but does not write", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact({
+        context,
+        contactId: "contact_1",
+        salesforceContactId: "003-1",
+        email: "one@example.org",
+      });
+
+      const expectedNewFingerprint = computeContentFingerprint({
+        subject: "Re: Field logistics",
+        occurredAt: "2026-04-20T21:27:03.000Z",
+        contactId: "contact_1",
+        channel: "email",
+        direction: "outbound",
+        previewText: "Different old preview text",
+      });
+      const eventId = await seedEmailEvent({
+        context,
+        key: "dry-run-change",
+        contactId: "contact_1",
+        provider: "gmail",
+        eventType: "communication.email.outbound",
+        occurredAt: "2026-04-20T21:27:03.000Z",
+        subject: "Re: Field logistics",
+        previewText: "Current persisted preview text",
+        persistedFingerprint: "fp:legacy:different",
+      });
+
+      const writtenAuditLines: string[] = [];
+      const result = await backfillContentFingerprint({
+        db: context.db,
+        repositories: context.repositories,
+        dryRun: true,
+        auditWriter: {
+          writeLine(line: string) {
+            writtenAuditLines.push(line);
+          },
+        },
+        logger: silentLogger,
+      });
+
+      expect(result.categoryCounts.new_value).toBe(1);
+      expect(result.updatedCount).toBe(0);
+      expect(writtenAuditLines).toHaveLength(1);
+      expect(JSON.parse(writtenAuditLines[0] ?? "")).toEqual({
+        id: eventId,
+        contactId: "contact_1",
+        provider: "gmail",
+        oldFingerprint: "fp:legacy:different",
+        newFingerprint: expectedNewFingerprint,
+        occurredAt: "2026-04-20T21:27:03.000Z",
+        eventType: "communication.email.outbound",
+      });
+
+      const persisted = await context.repositories.canonicalEvents.findById(eventId);
+      expect(persisted?.contentFingerprint).toBe("fp:legacy:different");
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("execute writes only rows in new_value or cleared categories", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact({
+        context,
+        contactId: "contact_2",
+        salesforceContactId: "003-2",
+        email: "two@example.org",
+      });
+
+      const unchangedFingerprint = computeContentFingerprint({
+        subject: "Re: Same minute",
+        occurredAt: "2026-04-20T22:10:03.000Z",
+        contactId: "contact_2",
+        channel: "email",
+        direction: "inbound",
+        previewText: "Persisted preview",
+      });
+      const newValueFingerprint = computeContentFingerprint({
+        subject: "Re: Same minute",
+        occurredAt: "2026-04-20T22:11:03.000Z",
+        contactId: "contact_2",
+        channel: "email",
+        direction: "outbound",
+        previewText: "Anything here is ignored by the current algorithm",
+      });
+
+      const unchangedId = await seedEmailEvent({
+        context,
+        key: "execute-unchanged",
+        contactId: "contact_2",
+        provider: "gmail",
+        eventType: "communication.email.inbound",
+        occurredAt: "2026-04-20T22:10:03.000Z",
+        subject: "Re: Same minute",
+        previewText: "Persisted preview",
+        persistedFingerprint: unchangedFingerprint,
+      });
+      const changedId = await seedEmailEvent({
+        context,
+        key: "execute-changed",
+        contactId: "contact_2",
+        provider: "salesforce",
+        eventType: "communication.email.outbound",
+        occurredAt: "2026-04-20T22:11:03.000Z",
+        subject: "Re: Same minute",
+        previewText: "Salesforce snippet",
+        persistedFingerprint: "fp:legacy:stale",
+      });
+
+      const result = await backfillContentFingerprint({
+        db: context.db,
+        repositories: context.repositories,
+        dryRun: false,
+        auditWriter: silentAuditWriter,
+        logger: silentLogger,
+      });
+
+      expect(result.categoryCounts.unchanged).toBe(1);
+      expect(result.categoryCounts.new_value).toBe(1);
+      expect(result.updatedCount).toBe(1);
+
+      const unchanged = await context.repositories.canonicalEvents.findById(unchangedId);
+      const changed = await context.repositories.canonicalEvents.findById(changedId);
+      expect(unchanged?.contentFingerprint).toBe(unchangedFingerprint);
+      expect(changed?.contentFingerprint).toBe(newValueFingerprint);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("honors --limit semantics when selecting rows", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact({
+        context,
+        contactId: "contact_3",
+        salesforceContactId: "003-3",
+        email: "three@example.org",
+      });
+
+      for (let index = 0; index < 12; index += 1) {
+        await seedEmailEvent({
+          context,
+          key: `limit-${String(index)}`,
+          contactId: "contact_3",
+          provider: index % 2 === 0 ? "gmail" : "salesforce",
+          eventType: "communication.email.outbound",
+          occurredAt: `2026-04-21T10:${String(index).padStart(2, "0")}:00.000Z`,
+          subject: `Subject ${String(index)}`,
+          previewText: `Preview ${String(index)}`,
+          persistedFingerprint: `fp:legacy:${String(index)}`,
+        });
+      }
+
+      const result = await backfillContentFingerprint({
+        db: context.db,
+        repositories: context.repositories,
+        dryRun: true,
+        limit: 10,
+        auditWriter: silentAuditWriter,
+        logger: silentLogger,
+      });
+
+      expect(result.scannedCount).toBe(10);
+      expect(result.categoryCounts.new_value).toBe(10);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("is idempotent after execute", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact({
+        context,
+        contactId: "contact_4",
+        salesforceContactId: "003-4",
+        email: "four@example.org",
+      });
+
+      await seedEmailEvent({
+        context,
+        key: "idempotent",
+        contactId: "contact_4",
+        provider: "gmail",
+        eventType: "communication.email.outbound",
+        occurredAt: "2026-04-22T09:00:00.000Z",
+        subject: "Re: Idempotent run",
+        previewText: "Fresh preview",
+        persistedFingerprint: "fp:legacy:old",
+      });
+
+      const first = await backfillContentFingerprint({
+        db: context.db,
+        repositories: context.repositories,
+        dryRun: false,
+        auditWriter: silentAuditWriter,
+        logger: silentLogger,
+      });
+      const second = await backfillContentFingerprint({
+        db: context.db,
+        repositories: context.repositories,
+        dryRun: false,
+        auditWriter: silentAuditWriter,
+        logger: silentLogger,
+      });
+
+      expect(first.categoryCounts.new_value).toBe(1);
+      expect(first.updatedCount).toBe(1);
+      expect(second.categoryCounts.new_value).toBe(0);
+      expect(second.updatedCount).toBe(0);
+      expect(second.categoryCounts.unchanged).toBe(1);
+    } finally {
+      await context.dispose();
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "ops:reclassify-salesforce-tasks": "pnpm --filter @as-comms/worker ops:reclassify-salesforce-tasks",
     "ops:worker:seed-aliases-from-env": "tsx scripts/ops/seed-aliases-from-env.ts",
     "ops:backfill-project-aliases": "tsx scripts/ops/backfill-project-aliases.ts",
+    "ops:backfill-content-fingerprint": "tsx scripts/ops/backfill-content-fingerprint.ts",
     "ops:backfill-stuck-identity-anchors": "tsx scripts/ops/backfill-stuck-identity-anchors.ts",
     "ops:recover-orphan-task-details": "tsx scripts/ops/recover-orphan-task-details.ts",
     "ops:promote-admin": "tsx scripts/ops/promote-admin.ts",

--- a/scripts/ops/backfill-content-fingerprint.ts
+++ b/scripts/ops/backfill-content-fingerprint.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env tsx
+import process from "node:process";
+
+import { runBackfillContentFingerprintCommand } from "../../apps/worker/src/ops/backfill-content-fingerprint.js";
+
+await runBackfillContentFingerprintCommand(process.argv.slice(2), process.env);


### PR DESCRIPTION
## Summary
Path C Phase 2: backfill existing `canonical_event_ledger.content_fingerprint` values under the new algorithm shipped in #234.

Phase 1 (#234) dropped the preview component from `computeContentFingerprint`. Every existing row was fingerprinted under the OLD algorithm, so its hash is incompatible with new ingests. Until backfilled, L4 (`dedup-historical-ledger`) cannot cluster a fresh event with a pre-Phase-1 event — they hash to different strings.

## Architect-only post-merge sequence
1. Merge after CI green
2. Run `--dry-run` against prod, review counts + JSONL audit
3. Run `--execute` (architect manual operation, requires explicit user sign-off in chat)

**Timing:** within ~1 hour of this merge, before the auto-email Phase 2 historical backfill (which would mint 3,000-4,000 more SF events under the new algorithm, widening the gap if existing rows still have old hashes).

## Behavior
- DRY-RUN BY DEFAULT. `--execute` opt-in.
- `--limit <n>` for incremental rollout
- `--event-types <comma-list>` (default `communication.email.outbound,communication.email.inbound`)
- JSONL audit on stdout per `new_value`/`cleared` row
- Summary + warnings on stderr
- Idempotent: re-run is a no-op for rows already at the new value

## Categorization
- `unchanged` — new == existing
- `new_value` — existing was null OR new differs and is non-null (the main bucket)
- `cleared` — new is null, existing was non-null. Defensive: should be ~0; non-zero count exits non-zero in `--execute` mode
- `still_null` — new is null AND existing was null. Logged count only

## Validation
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] CI green
- [ ] Architect dry-run: review counts make sense
- [ ] Architect execute: queue updated, summary clean

## Out of scope
- Touching the L1/L2/L4/L5 dedup paths
- Running the L4 op (`dedup-historical-ledger`) — separate operation
- Auto-email Phase 2 backfill — separate operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)