### PR TITLE
chore(railway): auto-apply Drizzle migrations on worker preDeploy

### DIFF
--- a/apps/worker/railway.json
+++ b/apps/worker/railway.json
@@ -6,6 +6,7 @@
   },
   "deploy": {
     "startCommand": "pnpm --filter @as-comms/worker start",
+    "preDeployCommand": "pnpm --filter @as-comms/db migrate",
     "healthcheckPath": null
   }
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "build": "node ../../scripts/clean-dist.mjs dist && tsc -p tsconfig.build.json",
     "lint": "eslint src test drizzle.config.ts --max-warnings=0",
+    "migrate": "drizzle-kit migrate",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test:unit": "vitest run --config ../../vitest.config.ts --passWithNoTests"
   },


### PR DESCRIPTION
## Why

Outages this week were both rooted in pending Drizzle migrations not being applied after merge:
- 2026-04-30: PR #218 (`project_dimensions` schema enforcement) → SF capture outage
- 2026-05-01: PR #230 (`sent_at` → `attempted_at` rename) → web inbox 500s

Manual Railway-terminal applies are fragile and easy to forget — the architect has been running them by hand each time.

## What

Worker-only `preDeployCommand` runs `drizzle-kit migrate` against the production DB before traffic switches:

- `packages/db/package.json` gets a `migrate` script (`drizzle-kit migrate`).
- `apps/worker/railway.json` calls `pnpm --filter @as-comms/db migrate` in `deploy.preDeployCommand`.

Worker is the single migration runner — adding the same hook to web would race two concurrent migrators (drizzle's `__drizzle_migrations` journal is idempotent but not lock-protected).

**After this merges, manual migration applies on Railway are no longer needed for routine deploys.**

🤖 Generated by Codex; reviewed by architect.