### PR TITLE
feat(worker): daily dedup-historical-ledger dry-run cron

### DIFF
--- a/apps/worker/src/jobs/dedup-historical-ledger.ts
+++ b/apps/worker/src/jobs/dedup-historical-ledger.ts
@@ -1,0 +1,38 @@
+import type { Task } from "graphile-worker";
+
+import type { Stage1Database } from "@as-comms/db";
+import type { Stage1RepositoryBundle } from "@as-comms/domain";
+
+import { dedupHistoricalLedger } from "../ops/dedup-historical-ledger.js";
+
+export const dedupHistoricalLedgerJobName = "dedup-historical-ledger" as const;
+
+export interface DedupHistoricalLedgerTaskDependencies {
+  readonly db: Stage1Database;
+  readonly repositories: Stage1RepositoryBundle;
+  readonly logger?: Pick<Console, "log" | "error">;
+}
+
+export function createDedupHistoricalLedgerTask(
+  dependencies: DedupHistoricalLedgerTaskDependencies,
+): Task {
+  const logger = dependencies.logger ?? console;
+
+  return () =>
+    dedupHistoricalLedger({
+      db: dependencies.db,
+      repositories: dependencies.repositories,
+      dryRun: true,
+      logger,
+      auditWriter: { writeLine: () => undefined },
+    }).then((result) => {
+      logger.log(
+        JSON.stringify({
+          event: "dedup_historical_ledger.dry_run.completed",
+          scannedCandidates: result.scannedCandidateCount,
+          plannedClusters: result.plannedClusterCount,
+          plannedLosers: result.plannedLoserCount,
+        }),
+      );
+    });
+}

--- a/apps/worker/src/runtime.ts
+++ b/apps/worker/src/runtime.ts
@@ -31,6 +31,7 @@ import {
   type Stage1SafeRuntimeConfigSummary,
 } from "./ops/config.js";
 import { readNotionKnowledgeSyncConfig } from "./jobs/notion-knowledge-sync/index.js";
+import { dedupHistoricalLedgerJobName } from "./jobs/dedup-historical-ledger.js";
 import { reconcileRoutingReviewQueueJobName } from "./jobs/reconcile-routing-review-queue.js";
 import {
   createStage1SyncStateService,
@@ -105,6 +106,7 @@ export function buildWorkerCrontab(config: WorkerConfig): string {
     `*/5 * * * * ${sweepPendingOutboundsJobName} ?id=composer-orphan-sweep&max=1`,
     `* * * * * ${reconcileStaleRunningJobName} ?id=stale-running-sweep&max=1`,
     `*/15 * * * * ${reconcileIdentityQueueJobName} ?id=identity-queue-reconcile&max=1`,
+    `0 10 * * * ${dedupHistoricalLedgerJobName} ?id=dedup-historical-ledger&max=1`,
     `*/15 * * * * ${reconcileRoutingReviewQueueJobName} ?id=routing-review-queue-reconcile&max=1`,
   ].join("\n");
 }
@@ -348,6 +350,10 @@ export async function createStage1WorkerRuntimeServices(
       },
       pendingOutboundSweep: {
         pendingOutbounds: repositories.pendingOutbounds,
+      },
+      dedupHistoricalLedger: {
+        db: connection.db,
+        repositories,
       },
       reconcileIdentityQueue: {
         db: connection.db,

--- a/apps/worker/src/tasks.ts
+++ b/apps/worker/src/tasks.ts
@@ -3,6 +3,11 @@ import type { TaskList } from "graphile-worker";
 import { noopJobName } from "@as-comms/contracts";
 
 import {
+  createDedupHistoricalLedgerTask,
+  dedupHistoricalLedgerJobName,
+  type DedupHistoricalLedgerTaskDependencies,
+} from "./jobs/dedup-historical-ledger.js";
+import {
   createSweepPendingOutboundsTask,
   sweepPendingOutboundsJobName,
   type PendingOutboundSweepTaskDependencies,
@@ -37,6 +42,7 @@ import {
 export function createTaskList(
   orchestration?: Stage1WorkerOrchestrationService,
   input?: {
+    readonly dedupHistoricalLedger?: DedupHistoricalLedgerTaskDependencies;
     readonly integrationHealth?: IntegrationHealthTaskDependencies;
     readonly notionKnowledgeSync?: NotionKnowledgeSyncDependencies;
     readonly pendingOutboundSweep?: PendingOutboundSweepTaskDependencies;
@@ -52,6 +58,13 @@ export function createTaskList(
       : {
           [sweepPendingOutboundsJobName]: createSweepPendingOutboundsTask(
             input.pendingOutboundSweep,
+          ),
+        }),
+    ...(input?.dedupHistoricalLedger === undefined
+      ? {}
+      : {
+          [dedupHistoricalLedgerJobName]: createDedupHistoricalLedgerTask(
+            input.dedupHistoricalLedger,
           ),
         }),
     ...(input?.reconcileIdentityQueue === undefined

--- a/apps/worker/test/stage1-runtime.test.ts
+++ b/apps/worker/test/stage1-runtime.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@as-comms/contracts";
 
 import { buildWorkerCrontab, readWorkerConfig } from "../src/runtime.js";
+import { dedupHistoricalLedgerJobName } from "../src/jobs/dedup-historical-ledger.js";
 import {
   pollGmailLiveJobName,
   pollIntegrationHealthJobName,
@@ -150,6 +151,7 @@ describe("Stage 1 worker runtime task registration", () => {
         `*/5 * * * * ${sweepPendingOutboundsJobName} ?id=composer-orphan-sweep&max=1`,
         `* * * * * ${reconcileStaleRunningJobName} ?id=stale-running-sweep&max=1`,
         "*/15 * * * * reconcile-identity-queue ?id=identity-queue-reconcile&max=1",
+        `0 10 * * * ${dedupHistoricalLedgerJobName} ?id=dedup-historical-ledger&max=1`,
         "*/15 * * * * reconcile-routing-review-queue ?id=routing-review-queue-reconcile&max=1",
       ].join("\n"),
     );


### PR DESCRIPTION
## Why

Dedup subarchitect (Phase 4 note in `.SUBARCHITECT-STATUS-dedup-consolidation-2026-04-30.md`) recommends running the historical-ledger dedup analysis on a daily schedule so cross-provider duplicate clusters don't accumulate between manual ops sessions.

## What

New worker cron job at 10:00 UTC (3am Pacific) that calls `dedupHistoricalLedger(...)` with `dryRun: true` and a no-op `auditWriter` (per-loser audit lines suppressed; would otherwise flood worker logs). The job emits one structured `dedup_historical_ledger.dry_run.completed` event with cluster + loser counts each morning.

- New job module: `apps/worker/src/jobs/dedup-historical-ledger.ts`
- Wired into `tasks.ts` and `runtime.ts` mirroring `reconcile-identity-queue`
- Crontab regression test updated

**This is dry-run only.** Promote to `--execute` only after the architect reviews ~1 week of dry-run logs (separate brief).

🤖 Generated by Codex; reviewed by architect.