### PR TITLE
feat(ops): merge email-only duplicate contacts into SF-anchored

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -26,6 +26,7 @@
     "ops:migrate-notion-child-dbs-to-project-knowledge": "tsx src/ops/migrate-notion-child-dbs-to-project-knowledge.ts",
     "ops:enqueue": "tsx src/ops/cli.ts enqueue",
     "ops:import-gmail-mbox": "tsx src/ops/cli.ts import-gmail-mbox",
+    "ops:merge-email-only-into-sf-anchored": "tsx src/ops/merge-email-only-into-sf-anchored.ts",
     "ops:reclassify-sf-direction": "tsx src/ops/cli.ts reclassify-sf-direction",
     "ops:reclassify-salesforce-tasks": "tsx src/ops/reclassify-salesforce-tasks.ts",
     "ops:inspect": "tsx src/ops/cli.ts inspect",

--- a/apps/worker/src/ops/cli.ts
+++ b/apps/worker/src/ops/cli.ts
@@ -36,6 +36,7 @@ import { runBackfillGarbledMessageBodiesCommand } from "./backfill-garbled-messa
 import { runBackfillMailchimpCampaignBodyCommand } from "./backfill-mailchimp-campaign-body.js";
 import { runCleanupGmailDraftEventsCommand } from "./cleanup-gmail-draft-events.js";
 import { runCleanupSalesforceOwnerScopeCommand } from "./cleanup-salesforce-owner-scope.js";
+import { main as runMergeEmailOnlyIntoSfAnchoredCommand } from "./merge-email-only-into-sf-anchored.js";
 import { reconcileIdentityQueue } from "./reconcile-identity-queue.js";
 import { reconcileRoutingReviewQueue } from "./reconcile-routing-review-queue.js";
 import { runDedupHistoricalLedgerCommand } from "./dedup-historical-ledger.js";
@@ -397,6 +398,9 @@ async function main(): Promise<void> {
     case "dedup-historical-ledger":
       await runDedupHistoricalLedgerCommand(rest, process.env);
       return;
+    case "merge-email-only-into-sf-anchored":
+      await runMergeEmailOnlyIntoSfAnchoredCommand(rest, process.env);
+      return;
     case "reconcile-identity-queue":
       await runReconcileIdentityQueue(rest);
       return;
@@ -408,7 +412,7 @@ async function main(): Promise<void> {
       return;
     default:
       throw new Error(
-        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-membership-sf-ids, backfill-gmail-mbox-bodies, backfill-content-fingerprint, backfill-garbled-message-bodies, backfill-mailchimp-campaign-body, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, dedup-historical-ledger, reconcile-identity-queue, reconcile-routing-review-queue, reclassify-sf-direction.",
+        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-membership-sf-ids, backfill-gmail-mbox-bodies, backfill-content-fingerprint, backfill-garbled-message-bodies, backfill-mailchimp-campaign-body, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, dedup-historical-ledger, merge-email-only-into-sf-anchored, reconcile-identity-queue, reconcile-routing-review-queue, reclassify-sf-direction.",
       );
   }
 }

--- a/apps/worker/src/ops/merge-email-only-into-sf-anchored.ts
+++ b/apps/worker/src/ops/merge-email-only-into-sf-anchored.ts
@@ -1,0 +1,645 @@
+#!/usr/bin/env tsx
+import process from "node:process";
+
+import {
+  closeDatabaseConnection,
+  createDatabaseConnection,
+  type Stage1Database,
+} from "@as-comms/db";
+import { sql as drizzleSql } from "drizzle-orm";
+
+import {
+  parseCliFlags,
+  readOptionalBooleanFlag,
+  readOptionalIntegerFlag,
+} from "./helpers.js";
+
+interface Logger {
+  log(...args: readonly unknown[]): void;
+  error(...args: readonly unknown[]): void;
+}
+
+interface SqlRunner {
+  unsafe<T extends readonly object[]>(query: string): Promise<T>;
+}
+
+interface IdRow {
+  readonly id: string;
+}
+
+interface DupePairRow {
+  readonly email_only_id: string;
+  readonly primary_email: string;
+  readonly sf_anchored_id: string;
+}
+
+interface MergeDupePair {
+  readonly emailOnlyId: string;
+  readonly sfAnchoredId: string;
+  readonly primaryEmail: string;
+}
+
+interface MergePlan {
+  readonly pair: MergeDupePair;
+  readonly canonicalEventIds: readonly string[];
+  readonly timelineRowIds: readonly string[];
+  readonly noteIds: readonly string[];
+  readonly routingRowIds: readonly string[];
+  readonly identityCaseIds: readonly string[];
+  readonly inboxProjectionContactIds: readonly string[];
+}
+
+interface MergeExecutionResult {
+  readonly canonicalEventsRepointed: number;
+  readonly timelineRowsRepointed: number;
+  readonly notesRepointed: number;
+  readonly routingRepointed: number;
+  readonly identityCasesResolved: number;
+  readonly contactsDeleted: number;
+}
+
+interface MergeSummary {
+  readonly pairsProcessed: number;
+  readonly pairsSkippedOnError: number;
+  readonly canonicalEventsRepointed: number;
+  readonly timelineRowsRepointed: number;
+  readonly notesRepointed: number;
+  readonly routingRepointed: number;
+  readonly identityCasesResolved: number;
+  readonly contactsDeleted: number;
+  readonly errors: readonly {
+    readonly emailOnlyId: string;
+    readonly sfAnchoredId: string;
+    readonly message: string;
+  }[];
+}
+
+class DryRunRollback extends Error {
+  constructor() {
+    super("Dry run rollback");
+  }
+}
+
+function chunkValues<TValue>(
+  values: readonly TValue[],
+  chunkSize: number,
+): TValue[][] {
+  const chunks: TValue[][] = [];
+
+  for (let index = 0; index < values.length; index += chunkSize) {
+    chunks.push(values.slice(index, index + chunkSize));
+  }
+
+  return chunks;
+}
+
+function quoteSqlLiteral(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function buildInClause(values: readonly string[]): string {
+  return `(${values.map((value) => quoteSqlLiteral(value)).join(", ")})`;
+}
+
+function buildTextArray(values: readonly string[]): string {
+  return `array[${values.map((value) => quoteSqlLiteral(value)).join(", ")}]::text[]`;
+}
+
+function normalizeQueryRows(result: unknown): readonly object[] {
+  if (Array.isArray(result)) {
+    return result as readonly object[];
+  }
+
+  return (result as { readonly rows: readonly object[] }).rows;
+}
+
+function createDbSqlRunner(db: Stage1Database): SqlRunner {
+  return {
+    async unsafe<T extends readonly object[]>(query: string): Promise<T> {
+      const result = await db.execute(drizzleSql.raw(query));
+      return normalizeQueryRows(result) as unknown as T;
+    },
+  };
+}
+
+function buildResolutionExplanation(pair: MergeDupePair): string {
+  return `merged duplicate contact ${pair.emailOnlyId} into ${pair.sfAnchoredId} (architect cleanup 2026-05-02)`;
+}
+
+function readConnectionString(env: NodeJS.ProcessEnv): string {
+  const value =
+    env.WORKER_DATABASE_URL ?? env.DATABASE_URL ?? env.DATABASE_PUBLIC_URL;
+
+  if (value === undefined || value.trim().length === 0) {
+    throw new Error(
+      "DATABASE_PUBLIC_URL, DATABASE_URL, or WORKER_DATABASE_URL is required for this ops command.",
+    );
+  }
+
+  return value.trim();
+}
+
+async function selectIds(sql: SqlRunner, query: string): Promise<string[]> {
+  const rows = await sql.unsafe<readonly IdRow[]>(query);
+  return rows.map((row) => row.id);
+}
+
+export async function loadDupePairs(
+  sql: SqlRunner,
+): Promise<readonly MergeDupePair[]> {
+  const rows = await sql.unsafe<readonly DupePairRow[]>(`
+    select
+      eo.id as email_only_id,
+      eo.primary_email,
+      sf.id as sf_anchored_id
+    from contacts eo
+    join contacts sf
+      on sf.primary_email = eo.primary_email
+     and sf.id like 'contact:salesforce:%'
+    where eo.id like 'contact:email:%'
+      and eo.primary_email is not null
+    order by eo.id
+  `);
+
+  return rows.map((row) => ({
+    emailOnlyId: row.email_only_id,
+    sfAnchoredId: row.sf_anchored_id,
+    primaryEmail: row.primary_email,
+  }));
+}
+
+export async function planMergeForPair(input: {
+  readonly pair: MergeDupePair;
+  readonly sql: SqlRunner;
+}): Promise<MergePlan> {
+  const emailOnlyId = quoteSqlLiteral(input.pair.emailOnlyId);
+  const emailOnlyInClause = buildInClause([input.pair.emailOnlyId]);
+  const emailOnlyArray = buildTextArray([input.pair.emailOnlyId]);
+
+  const [canonicalEventIds, timelineRowIds, noteIds, routingRowIds, identityCaseIds] =
+    await Promise.all([
+      selectIds(
+        input.sql,
+        `
+          select id
+          from canonical_event_ledger
+          where contact_id in ${emailOnlyInClause}
+          order by id
+        `,
+      ),
+      selectIds(
+        input.sql,
+        `
+          select id
+          from contact_timeline_projection
+          where contact_id in ${emailOnlyInClause}
+          order by id
+        `,
+      ),
+      selectIds(
+        input.sql,
+        `
+          select id
+          from internal_notes
+          where contact_id in ${emailOnlyInClause}
+          order by id
+        `,
+      ),
+      selectIds(
+        input.sql,
+        `
+          select id
+          from routing_review_queue
+          where contact_id in ${emailOnlyInClause}
+          order by id
+        `,
+      ),
+      selectIds(
+        input.sql,
+        `
+          select id
+          from identity_resolution_queue
+          where anchored_contact_id = ${emailOnlyId}
+             or candidate_contact_ids && ${emailOnlyArray}
+          order by id
+        `,
+      ),
+    ]);
+
+  const inboxProjectionContactIds = await selectIds(
+    input.sql,
+    `
+      select contact_id as id
+      from contact_inbox_projection
+      where contact_id in ${emailOnlyInClause}
+    `,
+  );
+
+  return {
+    pair: input.pair,
+    canonicalEventIds,
+    timelineRowIds,
+    noteIds,
+    routingRowIds,
+    identityCaseIds,
+    inboxProjectionContactIds,
+  };
+}
+
+function createEmptySummary(): MergeSummary {
+  return {
+    pairsProcessed: 0,
+    pairsSkippedOnError: 0,
+    canonicalEventsRepointed: 0,
+    timelineRowsRepointed: 0,
+    notesRepointed: 0,
+    routingRepointed: 0,
+    identityCasesResolved: 0,
+    contactsDeleted: 0,
+    errors: [],
+  };
+}
+
+function addPairSuccess(
+  summary: MergeSummary,
+  result: MergeExecutionResult,
+): MergeSummary {
+  return {
+    ...summary,
+    pairsProcessed: summary.pairsProcessed + 1,
+    canonicalEventsRepointed:
+      summary.canonicalEventsRepointed + result.canonicalEventsRepointed,
+    timelineRowsRepointed:
+      summary.timelineRowsRepointed + result.timelineRowsRepointed,
+    notesRepointed: summary.notesRepointed + result.notesRepointed,
+    routingRepointed: summary.routingRepointed + result.routingRepointed,
+    identityCasesResolved:
+      summary.identityCasesResolved + result.identityCasesResolved,
+    contactsDeleted: summary.contactsDeleted + result.contactsDeleted,
+  };
+}
+
+function addPairError(
+  summary: MergeSummary,
+  input: {
+    readonly pair: MergeDupePair;
+    readonly error: Error;
+  },
+): MergeSummary {
+  return {
+    ...summary,
+    pairsSkippedOnError: summary.pairsSkippedOnError + 1,
+    errors: [
+      ...summary.errors,
+      {
+        emailOnlyId: input.pair.emailOnlyId,
+        sfAnchoredId: input.pair.sfAnchoredId,
+        message: input.error.message,
+      },
+    ],
+  };
+}
+
+function buildPlanResult(plan: MergePlan): MergeExecutionResult {
+  return {
+    canonicalEventsRepointed: plan.canonicalEventIds.length,
+    timelineRowsRepointed: plan.timelineRowIds.length,
+    notesRepointed: plan.noteIds.length,
+    routingRepointed: plan.routingRowIds.length,
+    identityCasesResolved: plan.identityCaseIds.length,
+    contactsDeleted: 1,
+  };
+}
+
+async function updateRowsAndReturnIds(
+  sql: SqlRunner,
+  query: string,
+): Promise<string[]> {
+  const rows = await sql.unsafe<readonly IdRow[]>(query);
+  return rows.map((row) => row.id);
+}
+
+export async function applyMergeForPair(input: {
+  readonly db: Stage1Database;
+  readonly pair: MergeDupePair;
+  readonly plan: MergePlan;
+  readonly dryRun: boolean;
+}): Promise<MergeExecutionResult> {
+  const resolutionExplanation = buildResolutionExplanation(input.pair);
+  const emailOnlyId = quoteSqlLiteral(input.pair.emailOnlyId);
+  const sfAnchoredId = quoteSqlLiteral(input.pair.sfAnchoredId);
+  const emailOnlyArray = buildTextArray([input.pair.emailOnlyId]);
+  const explanationLiteral = quoteSqlLiteral(resolutionExplanation);
+
+  const runInTransaction = async (tx: Stage1Database) => {
+    const sql = createDbSqlRunner(tx);
+    const canonicalEventIds = await updateRowsAndReturnIds(
+      sql,
+      `
+        update canonical_event_ledger
+        set
+          contact_id = ${sfAnchoredId},
+          updated_at = timezone('utc', now())
+        where contact_id = ${emailOnlyId}
+        returning id
+      `,
+    );
+    const timelineRowIds = await updateRowsAndReturnIds(
+      sql,
+      `
+        update contact_timeline_projection
+        set
+          contact_id = ${sfAnchoredId},
+          updated_at = timezone('utc', now())
+        where contact_id = ${emailOnlyId}
+        returning id
+      `,
+    );
+    const noteIds = await updateRowsAndReturnIds(
+      sql,
+      `
+        update internal_notes
+        set
+          contact_id = ${sfAnchoredId},
+          updated_at = timezone('utc', now())
+        where contact_id = ${emailOnlyId}
+        returning id
+      `,
+    );
+    const routingRowIds = await updateRowsAndReturnIds(
+      sql,
+      `
+        update routing_review_queue
+        set
+          contact_id = ${sfAnchoredId},
+          updated_at = timezone('utc', now())
+        where contact_id = ${emailOnlyId}
+        returning id
+      `,
+    );
+    const identityCaseIds = await updateRowsAndReturnIds(
+      sql,
+      `
+        update identity_resolution_queue
+        set
+          anchored_contact_id = case
+            when anchored_contact_id = ${emailOnlyId} then ${sfAnchoredId}
+            else anchored_contact_id
+          end,
+          candidate_contact_ids = (
+            select coalesce(
+              array_agg(candidate_id order by candidate_id),
+              array[]::text[]
+            )
+            from (
+              select distinct candidate_id
+              from unnest(
+                case
+                  when candidate_contact_ids && ${emailOnlyArray}
+                    then array_replace(
+                      candidate_contact_ids,
+                      ${emailOnlyId},
+                      ${sfAnchoredId}
+                    )
+                  else candidate_contact_ids
+                end
+              ) as candidate_id
+              where candidate_id <> ${emailOnlyId}
+            ) deduped_candidates
+          ),
+          status = 'resolved',
+          resolved_at = coalesce(resolved_at, timezone('utc', now())),
+          explanation = case
+            when position(${explanationLiteral} in explanation) > 0 then explanation
+            else explanation || ' ' || ${explanationLiteral}
+          end,
+          updated_at = timezone('utc', now())
+        where anchored_contact_id = ${emailOnlyId}
+           or candidate_contact_ids && ${emailOnlyArray}
+        returning id
+      `,
+    );
+    const deletedContactIds = await updateRowsAndReturnIds(
+      sql,
+      `
+        delete from contacts
+        where id = ${emailOnlyId}
+        returning id
+      `,
+    );
+
+    if (deletedContactIds.length !== 1) {
+      throw new Error(
+        `Expected to delete exactly one contact for ${input.pair.emailOnlyId}; deleted ${deletedContactIds.length.toString()}.`,
+      );
+    }
+
+    if (input.dryRun) {
+      throw new DryRunRollback();
+    }
+
+    return {
+      canonicalEventsRepointed: canonicalEventIds.length,
+      timelineRowsRepointed: timelineRowIds.length,
+      notesRepointed: noteIds.length,
+      routingRepointed: routingRowIds.length,
+      identityCasesResolved: identityCaseIds.length,
+      contactsDeleted: deletedContactIds.length,
+    };
+  };
+
+  if (input.dryRun) {
+    try {
+      await input.db.transaction(runInTransaction);
+    } catch (error) {
+      if (!(error instanceof DryRunRollback)) {
+        throw error;
+      }
+    }
+
+    return buildPlanResult(input.plan);
+  }
+
+  return input.db.transaction(runInTransaction);
+}
+
+function printPlanHeader(input: {
+  readonly logger: Logger;
+  readonly dryRun: boolean;
+  readonly pairs: readonly MergeDupePair[];
+}): void {
+  input.logger.log("merge-email-only-into-sf-anchored");
+  input.logger.log(`Mode: ${input.dryRun ? "dry-run" : "execute"}`);
+  input.logger.log(
+    `Found ${input.pairs.length.toString()} email-only / Salesforce-anchored dupe pairs.`,
+  );
+}
+
+function printPairAudit(input: {
+  readonly logger: Logger;
+  readonly dryRun: boolean;
+  readonly plan: MergePlan;
+  readonly status: "planned" | "applied" | "error";
+  readonly errorMessage?: string;
+}): void {
+  input.logger.log(
+    JSON.stringify({
+      event: "merge_email_only_into_sf_anchored.pair",
+      dryRun: input.dryRun,
+      status: input.status,
+      emailOnlyId: input.plan.pair.emailOnlyId,
+      sfAnchoredId: input.plan.pair.sfAnchoredId,
+      primaryEmail: input.plan.pair.primaryEmail,
+      canonicalEventIds: input.plan.canonicalEventIds,
+      timelineRowIds: input.plan.timelineRowIds,
+      noteIds: input.plan.noteIds,
+      routingRowIds: input.plan.routingRowIds,
+      identityCaseIds: input.plan.identityCaseIds,
+      inboxProjectionContactIds: input.plan.inboxProjectionContactIds,
+      counts: {
+        canonicalEvents: input.plan.canonicalEventIds.length,
+        timelineRows: input.plan.timelineRowIds.length,
+        notes: input.plan.noteIds.length,
+        routingRows: input.plan.routingRowIds.length,
+        identityCases: input.plan.identityCaseIds.length,
+        inboxRows: input.plan.inboxProjectionContactIds.length,
+      },
+      ...(input.errorMessage === undefined
+        ? {}
+        : {
+            error: input.errorMessage,
+          }),
+    }),
+  );
+}
+
+function printSummary(input: {
+  readonly logger: Logger;
+  readonly dryRun: boolean;
+  readonly summary: MergeSummary;
+}): void {
+  input.logger.log(
+    JSON.stringify({
+      event: "merge_email_only_into_sf_anchored.completed",
+      dryRun: input.dryRun,
+      pairsProcessed: input.summary.pairsProcessed,
+      pairsSkippedOnError: input.summary.pairsSkippedOnError,
+      canonicalEventsRepointed: input.summary.canonicalEventsRepointed,
+      timelineRowsRepointed: input.summary.timelineRowsRepointed,
+      notesRepointed: input.summary.notesRepointed,
+      routingRepointed: input.summary.routingRepointed,
+      identityCasesResolved: input.summary.identityCasesResolved,
+      contactsDeleted: input.summary.contactsDeleted,
+      errors: input.summary.errors,
+    }),
+  );
+}
+
+export async function main(
+  args: readonly string[] = process.argv.slice(2),
+  env: NodeJS.ProcessEnv = process.env,
+  logger: Logger = console,
+): Promise<void> {
+  const flags = parseCliFlags(args);
+  const dryRun = !readOptionalBooleanFlag(flags, "execute", false);
+  const limit = readOptionalIntegerFlag(flags, "limit", 0);
+  const connection = createDatabaseConnection({
+    connectionString: readConnectionString(env),
+  });
+
+  try {
+    const sql = connection.sql as unknown as SqlRunner;
+    const allPairs = await loadDupePairs(sql);
+    const pairs =
+      limit === 0 ? allPairs : allPairs.slice(0, Math.min(limit, allPairs.length));
+    let summary = createEmptySummary();
+
+    printPlanHeader({
+      logger,
+      dryRun,
+      pairs,
+    });
+
+    if (pairs.length === 0) {
+      printSummary({
+        logger,
+        dryRun,
+        summary,
+      });
+      return;
+    }
+
+    for (const pairChunk of chunkValues(pairs, 1)) {
+      const pair = pairChunk[0];
+
+      if (pair === undefined) {
+        continue;
+      }
+
+      try {
+        const plan = await planMergeForPair({
+          pair,
+          sql,
+        });
+        const result = await applyMergeForPair({
+          db: connection.db,
+          pair,
+          plan,
+          dryRun,
+        });
+
+        printPairAudit({
+          logger,
+          dryRun,
+          plan,
+          status: dryRun ? "planned" : "applied",
+        });
+        summary = addPairSuccess(summary, result);
+      } catch (error) {
+        const resolvedError =
+          error instanceof Error ? error : new Error(String(error));
+        const plan = {
+          pair,
+          canonicalEventIds: [],
+          timelineRowIds: [],
+          noteIds: [],
+          routingRowIds: [],
+          identityCaseIds: [],
+          inboxProjectionContactIds: [],
+        } satisfies MergePlan;
+
+        printPairAudit({
+          logger,
+          dryRun,
+          plan,
+          status: "error",
+          errorMessage: resolvedError.message,
+        });
+        logger.error(
+          `Failed merging ${pair.emailOnlyId} into ${pair.sfAnchoredId}: ${resolvedError.message}`,
+        );
+        summary = addPairError(summary, {
+          pair,
+          error: resolvedError,
+        });
+      }
+    }
+
+    printSummary({
+      logger,
+      dryRun,
+      summary,
+    });
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}
+
+void main().catch((error: unknown) => {
+  console.error(
+    error instanceof Error
+      ? error.message
+      : "merge-email-only-into-sf-anchored failed.",
+  );
+  process.exitCode = 1;
+});

--- a/apps/worker/test/merge-email-only-into-sf-anchored.test.ts
+++ b/apps/worker/test/merge-email-only-into-sf-anchored.test.ts
@@ -1,0 +1,442 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  contactTimelineProjection,
+  type Stage1Database,
+} from "@as-comms/db";
+import { sql } from "drizzle-orm";
+
+import { createTestStage1Context } from "../../../packages/db/test/helpers.js";
+import {
+  applyMergeForPair,
+  loadDupePairs,
+  planMergeForPair,
+} from "../src/ops/merge-email-only-into-sf-anchored.js";
+
+interface SqlRunner {
+  unsafe<T extends readonly object[]>(query: string): Promise<T>;
+}
+
+function buildSqlRunner(db: Stage1Database): SqlRunner {
+  return {
+    async unsafe<T extends readonly object[]>(query: string): Promise<T> {
+      const result = await db.execute(sql.raw(query));
+      return Array.isArray(result)
+        ? (result as unknown as T)
+        : (result as { readonly rows: T }).rows;
+    },
+  };
+}
+
+function buildCanonicalProvenance(input: {
+  readonly sourceEvidenceId: string;
+  readonly providerRecordId: string;
+}) {
+  return {
+    primaryProvider: "gmail" as const,
+    primarySourceEvidenceId: input.sourceEvidenceId,
+    supportingSourceEvidenceIds: [],
+    winnerReason: "single_source" as const,
+    sourceRecordType: "message",
+    sourceRecordId: input.providerRecordId,
+    messageKind: "one_to_one" as const,
+    campaignRef: null,
+    threadRef: {
+      crossProviderCollapseKey: `rfc822:<${input.providerRecordId}@example.org>`,
+      providerThreadId: "gmail-thread-1",
+    },
+    direction: "inbound" as const,
+    notes: null,
+  };
+}
+
+async function seedContact(
+  db: Awaited<ReturnType<typeof createTestStage1Context>>["repositories"],
+  input: {
+    readonly id: string;
+    readonly salesforceContactId: string | null;
+    readonly displayName: string;
+    readonly primaryEmail: string | null;
+  },
+): Promise<void> {
+  await db.contacts.upsert({
+    id: input.id,
+    salesforceContactId: input.salesforceContactId,
+    displayName: input.displayName,
+    primaryEmail: input.primaryEmail,
+    primaryPhone: null,
+    createdAt: "2026-05-02T01:00:00.000Z",
+    updatedAt: "2026-05-02T01:00:00.000Z",
+  });
+}
+
+async function seedMergePair(
+  context: Awaited<ReturnType<typeof createTestStage1Context>>,
+): Promise<{
+  readonly emailOnlyId: string;
+  readonly sfAnchoredId: string;
+}> {
+  const emailOnlyId = "contact:email:dupe@example.org";
+  const sfAnchoredId = "contact:salesforce:003DUPE";
+
+  await seedContact(context.repositories, {
+    id: emailOnlyId,
+    salesforceContactId: null,
+    displayName: "Email Only",
+    primaryEmail: "dupe@example.org",
+  });
+  await seedContact(context.repositories, {
+    id: sfAnchoredId,
+    salesforceContactId: "003DUPE",
+    displayName: "Salesforce Contact",
+    primaryEmail: "dupe@example.org",
+  });
+
+  await context.repositories.sourceEvidence.append({
+    id: "source-evidence:gmail:message:dupe-1",
+    provider: "gmail",
+    providerRecordType: "message",
+    providerRecordId: "dupe-1",
+    receivedAt: "2026-05-02T01:01:00.000Z",
+    occurredAt: "2026-05-02T01:01:00.000Z",
+    payloadRef: "gmail://message/dupe-1",
+    idempotencyKey: "source-evidence:gmail:message:dupe-1",
+    checksum: "checksum:dupe-1",
+  });
+  await context.repositories.sourceEvidence.append({
+    id: "source-evidence:gmail:message:dupe-case-1",
+    provider: "gmail",
+    providerRecordType: "message",
+    providerRecordId: "dupe-case-1",
+    receivedAt: "2026-05-02T01:02:00.000Z",
+    occurredAt: "2026-05-02T01:02:00.000Z",
+    payloadRef: "gmail://message/dupe-case-1",
+    idempotencyKey: "source-evidence:gmail:message:dupe-case-1",
+    checksum: "checksum:dupe-case-1",
+  });
+  await context.repositories.sourceEvidence.append({
+    id: "source-evidence:gmail:message:dupe-case-2",
+    provider: "gmail",
+    providerRecordType: "message",
+    providerRecordId: "dupe-case-2",
+    receivedAt: "2026-05-02T01:03:00.000Z",
+    occurredAt: "2026-05-02T01:03:00.000Z",
+    payloadRef: "gmail://message/dupe-case-2",
+    idempotencyKey: "source-evidence:gmail:message:dupe-case-2",
+    checksum: "checksum:dupe-case-2",
+  });
+
+  await context.repositories.canonicalEvents.upsert({
+    id: "canonical-event:dupe-1",
+    contactId: emailOnlyId,
+    eventType: "communication.email.inbound",
+    channel: "email",
+    occurredAt: "2026-05-02T01:01:00.000Z",
+    contentFingerprint: null,
+    sourceEvidenceId: "source-evidence:gmail:message:dupe-1",
+    idempotencyKey: "canonical-event:dupe-1",
+    provenance: buildCanonicalProvenance({
+      sourceEvidenceId: "source-evidence:gmail:message:dupe-1",
+      providerRecordId: "dupe-1",
+    }),
+    reviewState: "clear",
+  });
+
+  await context.db.insert(contactTimelineProjection).values({
+    id: "timeline:dupe-1",
+    contactId: emailOnlyId,
+    canonicalEventId: "canonical-event:dupe-1",
+    occurredAt: new Date("2026-05-02T01:01:00.000Z"),
+    sortKey: "2026-05-02T01:01:00.000Z#canonical-event:dupe-1",
+    eventType: "communication.email.inbound",
+    summary: "Inbound email",
+    channel: "email",
+    primaryProvider: "gmail",
+    reviewState: "clear",
+  });
+
+  await context.repositories.identityResolutionQueue.upsert({
+    id: "identity-review:dupe-anchored",
+    sourceEvidenceId: "source-evidence:gmail:message:dupe-case-1",
+    candidateContactIds: [emailOnlyId],
+    reasonCode: "identity_anchor_mismatch",
+    status: "open",
+    openedAt: "2026-05-02T01:02:00.000Z",
+    resolvedAt: null,
+    normalizedIdentityValues: ["dupe@example.org"],
+    anchoredContactId: emailOnlyId,
+    explanation: "Anchor mismatch before cleanup.",
+  });
+  await context.repositories.identityResolutionQueue.upsert({
+    id: "identity-review:dupe-candidate",
+    sourceEvidenceId: "source-evidence:gmail:message:dupe-case-2",
+    candidateContactIds: [emailOnlyId, sfAnchoredId],
+    reasonCode: "identity_multi_candidate",
+    status: "open",
+    openedAt: "2026-05-02T01:03:00.000Z",
+    resolvedAt: null,
+    normalizedIdentityValues: ["dupe@example.org"],
+    anchoredContactId: null,
+    explanation: "Multiple candidates before cleanup.",
+  });
+
+  return {
+    emailOnlyId,
+    sfAnchoredId,
+  };
+}
+
+async function selectRows<TRow extends readonly object[]>(
+  db: Stage1Database,
+  query: ReturnType<typeof sql<unknown>>,
+): Promise<TRow> {
+  const result = await db.execute(query);
+  return Array.isArray(result)
+    ? (result as unknown as TRow)
+    : (result as { readonly rows: TRow }).rows;
+}
+
+function requireValue<TValue>(
+  value: TValue | undefined,
+  message: string,
+): TValue {
+  if (value === undefined) {
+    throw new Error(message);
+  }
+
+  return value;
+}
+
+describe("merge-email-only-into-sf-anchored", () => {
+  it("loads only email-only to Salesforce duplicate pairs", async () => {
+    const context = await createTestStage1Context();
+
+    try {
+      await seedContact(context.repositories, {
+        id: "contact:email:dupe@example.org",
+        salesforceContactId: null,
+        displayName: "Email Only",
+        primaryEmail: "dupe@example.org",
+      });
+      await seedContact(context.repositories, {
+        id: "contact:salesforce:003DUPE",
+        salesforceContactId: "003DUPE",
+        displayName: "Salesforce Contact",
+        primaryEmail: "dupe@example.org",
+      });
+      await seedContact(context.repositories, {
+        id: "contact:email:no-match@example.org",
+        salesforceContactId: null,
+        displayName: "No Match",
+        primaryEmail: "no-match@example.org",
+      });
+      await seedContact(context.repositories, {
+        id: "contact:salesforce:003SOLO",
+        salesforceContactId: "003SOLO",
+        displayName: "Solo Salesforce",
+        primaryEmail: "solo@example.org",
+      });
+
+      await expect(loadDupePairs(buildSqlRunner(context.db))).resolves.toEqual([
+        {
+          emailOnlyId: "contact:email:dupe@example.org",
+          sfAnchoredId: "contact:salesforce:003DUPE",
+          primaryEmail: "dupe@example.org",
+        },
+      ]);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("does not mutate the database in dry-run mode", async () => {
+    const context = await createTestStage1Context();
+
+    try {
+      const pairIds = await seedMergePair(context);
+      const sqlRunner = buildSqlRunner(context.db);
+      const pair = (
+        await loadDupePairs(sqlRunner)
+      ).find((entry) => entry.emailOnlyId === pairIds.emailOnlyId);
+
+      const targetPair = requireValue(
+        pair,
+        `Expected dupe pair for ${pairIds.emailOnlyId}.`,
+      );
+
+      const plan = await planMergeForPair({
+        pair: targetPair,
+        sql: sqlRunner,
+      });
+      const result = await applyMergeForPair({
+        db: context.db,
+        pair: targetPair,
+        plan,
+        dryRun: true,
+      });
+
+      expect(result).toMatchObject({
+        canonicalEventsRepointed: 1,
+        timelineRowsRepointed: 1,
+        identityCasesResolved: 2,
+        contactsDeleted: 1,
+      });
+
+      await expect(
+        context.repositories.contacts.findById(pairIds.emailOnlyId),
+      ).resolves.not.toBeNull();
+      await expect(
+        selectRows<
+          readonly {
+            readonly contactId: string;
+          }[]
+        >(
+          context.db,
+          sql`
+            select contact_id as "contactId"
+            from canonical_event_ledger
+            where id = 'canonical-event:dupe-1'
+          `,
+        ),
+      ).resolves.toEqual([{ contactId: pairIds.emailOnlyId }]);
+      await expect(
+        selectRows<
+          readonly {
+            readonly status: string;
+            readonly anchoredContactId: string | null;
+          }[]
+        >(
+          context.db,
+          sql`
+            select
+              status,
+              anchored_contact_id as "anchoredContactId"
+            from identity_resolution_queue
+            where id = 'identity-review:dupe-anchored'
+          `,
+        ),
+      ).resolves.toEqual([
+        {
+          status: "open",
+          anchoredContactId: pairIds.emailOnlyId,
+        },
+      ]);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("repoints dependent rows, resolves queue cases, and deletes the email-only contact in execute mode", async () => {
+    const context = await createTestStage1Context();
+
+    try {
+      const pairIds = await seedMergePair(context);
+      const sqlRunner = buildSqlRunner(context.db);
+      const pair = (
+        await loadDupePairs(sqlRunner)
+      ).find((entry) => entry.emailOnlyId === pairIds.emailOnlyId);
+
+      const targetPair = requireValue(
+        pair,
+        `Expected dupe pair for ${pairIds.emailOnlyId}.`,
+      );
+
+      const plan = await planMergeForPair({
+        pair: targetPair,
+        sql: sqlRunner,
+      });
+
+      await expect(
+        applyMergeForPair({
+          db: context.db,
+          pair: targetPair,
+          plan,
+          dryRun: false,
+        }),
+      ).resolves.toMatchObject({
+        canonicalEventsRepointed: 1,
+        timelineRowsRepointed: 1,
+        identityCasesResolved: 2,
+        contactsDeleted: 1,
+      });
+
+      await expect(
+        selectRows<
+          readonly {
+            readonly contactId: string;
+          }[]
+        >(
+          context.db,
+          sql`
+            select contact_id as "contactId"
+            from canonical_event_ledger
+            where id = 'canonical-event:dupe-1'
+          `,
+        ),
+      ).resolves.toEqual([{ contactId: pairIds.sfAnchoredId }]);
+      await expect(
+        selectRows<
+          readonly {
+            readonly contactId: string;
+          }[]
+        >(
+          context.db,
+          sql`
+            select contact_id as "contactId"
+            from contact_timeline_projection
+            where id = 'timeline:dupe-1'
+          `,
+        ),
+      ).resolves.toEqual([{ contactId: pairIds.sfAnchoredId }]);
+
+      const queueRows = await selectRows<
+        readonly {
+          readonly id: string;
+          readonly status: string;
+          readonly anchoredContactId: string | null;
+          readonly candidateContactIds: readonly string[];
+          readonly explanation: string;
+        }[]
+      >(
+        context.db,
+        sql`
+          select
+            id,
+            status,
+            anchored_contact_id as "anchoredContactId",
+            candidate_contact_ids as "candidateContactIds",
+            explanation
+          from identity_resolution_queue
+          where id in ('identity-review:dupe-anchored', 'identity-review:dupe-candidate')
+          order by id
+        `,
+      );
+
+      expect(queueRows).toHaveLength(2);
+      expect(queueRows[0]).toMatchObject({
+        id: "identity-review:dupe-anchored",
+        status: "resolved",
+        anchoredContactId: pairIds.sfAnchoredId,
+        candidateContactIds: [pairIds.sfAnchoredId],
+      });
+      expect(queueRows[0]?.explanation).toContain(
+        `merged duplicate contact ${pairIds.emailOnlyId} into ${pairIds.sfAnchoredId} (architect cleanup 2026-05-02)`,
+      );
+      expect(queueRows[1]).toMatchObject({
+        id: "identity-review:dupe-candidate",
+        status: "resolved",
+        anchoredContactId: null,
+        candidateContactIds: [pairIds.sfAnchoredId],
+      });
+      expect(queueRows[1]?.explanation).toContain(
+        `merged duplicate contact ${pairIds.emailOnlyId} into ${pairIds.sfAnchoredId} (architect cleanup 2026-05-02)`,
+      );
+
+      await expect(
+        context.repositories.contacts.findById(pairIds.emailOnlyId),
+      ).resolves.toBeNull();
+    } finally {
+      await context.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Why

Step B's historical SF backfill on 2026-05-01 (1,570 net-new SF email events captured for 346 contacts) surfaced 33 open `identity_resolution_queue` cases — 29 `identity_anchor_mismatch` + 4 `identity_multi_candidate` — all rooted in **5 email-only contacts** (`contact:email:*`) that share `primary_email` with an SF-anchored contact (`contact:salesforce:*`).

Architect investigation in `.identity-dupe-investigation-2026-05-02.md` confirms these are stub records auto-created from inbound email before SF Contact records arrived. They need merging on the DB side; nothing to fix in Salesforce.

## What

New ops script `apps/worker/src/ops/merge-email-only-into-sf-anchored.ts` with explicit `--execute` opt-in. For each email-only/SF-anchored pair found via `primary_email` collision:

- Repoints `canonical_event_ledger.contact_id`, `contact_timeline_projection.contact_id`, `internal_notes.contact_id`, `routing_review_queue.contact_id`, and `identity_resolution_queue.anchored_contact_id`/`candidate_contact_ids` from email-only → SF-anchored.
- Resolves affected queue cases with explanation `merged duplicate contact <email-only-id> into <sf-anchored-id> (architect cleanup 2026-05-02)`.
- Deletes the email-only contact (cascade clears identities, memberships, inbox projection).
- Each pair wrapped in a single transaction; failures skip the pair and continue.

Mirrors the dry-run + bucket-summary patterns from PR #229 and `cleanup-non-volunteer-contacts.ts`.

## Architect runs `--execute` after dry-run review

⚠️ **Manual review of dry-run output recommended** — particularly the
`jerry.tarvin@usda.gov` / "Nick Tarvin" pair (different first name; possibly a real mismatch rather than a duplicate). All 5 pairs are listed in the investigation doc.

🤖 Generated by Codex; reviewed by architect.