### PR TITLE
docs(ops): annotate underscore-prefixed retention reasoning

### DIFF
--- a/apps/worker/src/ops/_reconcile-from-stored-evidence.ts
+++ b/apps/worker/src/ops/_reconcile-from-stored-evidence.ts
@@ -1,3 +1,11 @@
+/**
+ * Underscore-prefixed because this is an internal helper, not a standalone ops entrypoint.
+ * Invoked manually through `src/ops/cli.ts reconcile-identity-queue`, which calls
+ * `reconcile-identity-queue.ts`, which imports `buildEventFromStoredData`.
+ * Retained because identity-queue recovery still reconstructs canonical events from stored rows.
+ * Git history still shows active maintenance through 2026-04-29 (`fix(worker): reconcile lifecycle_milestone + close gmail-orphan cases`).
+ * Remove only after `reconcile-identity-queue.ts` stops rebuilding from stored evidence or inlines/replaces this helper.
+ */
 import type {
   ContactIdentityKind,
   ExpeditionDimensionRecord,

--- a/apps/worker/src/ops/_salesforce-task-audit.ts
+++ b/apps/worker/src/ops/_salesforce-task-audit.ts
@@ -1,3 +1,10 @@
+/**
+ * Underscore-prefixed because this is a helper module behind a targeted ops audit, not a general runtime surface.
+ * Invoked manually by `src/ops/audit-salesforce-task-ingest.ts`, shipped via the `ops:audit-salesforce-task-ingest` package script.
+ * Retained because that audit entrypoint and its unit test still import these helpers directly.
+ * Git history still shows follow-up maintenance through 2026-04-23 (`Fix inbox welcome workload totals and invalidation`).
+ * Remove only after retiring `audit-salesforce-task-ingest.ts` and its test or moving this logic into a non-underscore module.
+ */
 export interface SalesforceTaskAuditRow {
   readonly canonicalEventId: string;
   readonly sourceEvidenceId: string;


### PR DESCRIPTION
## Summary

Architecture audit C2 — verified that `apps/worker/src/ops/_reconcile-from-stored-evidence.ts` and `apps/worker/src/ops/_salesforce-task-audit.ts` are still load-bearing despite the underscore prefix. Adds top-of-file comment blocks to each documenting the invocation chain and retention condition. No logic changes.

## Verification report

`_reconcile-from-stored-evidence.ts`:
- act101 `references` on `buildEventFromStoredData`: imported by `apps/worker/src/ops/reconcile-identity-queue.ts`.
- `reconcile-identity-queue` is dispatched from `apps/worker/src/ops/cli.ts`.
- No matching `package.json` script handle (uses the cli.ts subcommand pattern).
- Recent git activity through 2026-04-29 (last commit: identity-queue reconciliation hardening).
- Conclusion: live, retain.

`_salesforce-task-audit.ts`:
- act101 `references` on its exports: imported by `apps/worker/src/ops/audit-salesforce-task-ingest.ts` and its unit test.
- Dispatched via `pnpm op:audit-salesforce-task-ingest` (script in `apps/worker/package.json`).
- Recent git activity through 2026-04-23.
- Conclusion: live, retain.

## Test plan

- [x] `pnpm typecheck` green
- [x] `pnpm lint` green
- [x] `pnpm boundaries` green
- [ ] CI verifies `pnpm test:unit`

## Refs

- `.STATE-2026-05-02-architecture-audit.md` C2

🤖 Generated with [Claude Code](https://claude.com/claude-code)