### PR TITLE
chore(scripts): extend boundary-check.mjs to all 9 workspaces

### DIFF
--- a/apps/worker/test/helpers.ts
+++ b/apps/worker/test/helpers.ts
@@ -8,7 +8,7 @@ import type {
 import {
   createTestStage1Context,
   type TestStage1Context
-} from "../../../packages/db/test/helpers.js";
+} from "@as-comms/db/test-helpers";
 import { createStage1IngestService, type Stage1IngestService } from "../src/ingest/index.js";
 import {
   createStage1SyncStateService,
@@ -18,6 +18,8 @@ import {
   type Stage1SyncStateService,
   type Stage1WorkerOrchestrationService
 } from "../src/orchestration/index.js";
+
+export { createTestStage1Context } from "@as-comms/db/test-helpers";
 
 export interface TestWorkerContext extends TestStage1Context {
   readonly ingest: Stage1IngestService;

--- a/apps/worker/test/merge-email-only-into-sf-anchored.test.ts
+++ b/apps/worker/test/merge-email-only-into-sf-anchored.test.ts
@@ -6,7 +6,7 @@ import {
 } from "@as-comms/db";
 import { sql } from "drizzle-orm";
 
-import { createTestStage1Context } from "../../../packages/db/test/helpers.js";
+import { createTestStage1Context } from "./helpers.js";
 import {
   applyMergeForPair,
   loadDupePairs,

--- a/apps/worker/test/stage1-backfill-stuck-identity-anchors.test.ts
+++ b/apps/worker/test/stage1-backfill-stuck-identity-anchors.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { createTestStage1Context } from "../../../packages/db/test/helpers.js";
+import { createTestStage1Context } from "./helpers.js";
 import {
   buildContactProbeSoql,
   buildMembershipProbeSoql,

--- a/apps/worker/test/stage1-recover-orphan-task-details.test.ts
+++ b/apps/worker/test/stage1-recover-orphan-task-details.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { createTestStage1Context } from "../../../packages/db/test/helpers.js";
+import { createTestStage1Context } from "./helpers.js";
 import {
   applyTaskRecoveryPlans,
   buildRecoveredDetailForCase,

--- a/scripts/boundary-check.mjs
+++ b/scripts/boundary-check.mjs
@@ -31,11 +31,37 @@ const workspaceRules = {
       "@as-comms/integrations"
     ])
   },
+  "apps/worker": {
+    allowedWorkspaceImports: new Set([
+      "@as-comms/contracts",
+      "@as-comms/domain",
+      "@as-comms/integrations",
+      "@as-comms/db"
+    ])
+  },
   "packages/contracts": {
     allowedWorkspaceImports: new Set()
   },
+  "packages/db": {
+    // db consumes contracts (table types) and domain (record shapes
+    // re-exported by repositories.ts). It does NOT consume integrations
+    // — that would be a layer inversion.
+    allowedWorkspaceImports: new Set([
+      "@as-comms/contracts",
+      "@as-comms/domain"
+    ])
+  },
   "packages/domain": {
     allowedWorkspaceImports: new Set(["@as-comms/contracts"])
+  },
+  "packages/integrations": {
+    // integrations consumes contracts (provider record schemas) and
+    // domain (capture-service types). The one test-only import of
+    // `@as-comms/db/test-helpers` gets a narrow per-file exception below.
+    allowedWorkspaceImports: new Set([
+      "@as-comms/contracts",
+      "@as-comms/domain"
+    ])
   },
   "packages/ui": {
     allowedWorkspaceImports: new Set()
@@ -63,6 +89,25 @@ function isAllowedWorkspaceImport(scope, relativeFile, specifier) {
     // Test-only split of the composition root. Keeps `@as-comms/db/test-helpers`
     // (which pulls in PGlite) off the production Edge Runtime bundle path.
     // Only test files may import this module.
+    return true;
+  }
+
+  if (
+    relativeFile === "apps/worker/test/helpers.ts" &&
+    specifier === "@as-comms/db/test-helpers"
+  ) {
+    // Worker tests centralize Stage 1 PGlite-backed db fixture wiring here.
+    // Keep the exception narrow to the single local test-helper module.
+    return true;
+  }
+
+  if (
+    relativeFile ===
+      "packages/integrations/test/stage3-gmail-reconciliation.test.ts" &&
+    specifier === "@as-comms/db/test-helpers"
+  ) {
+    // Test-only reconciliation coverage needs the Stage 1 db helper wiring.
+    // Keep this escape hatch narrow to the single spec and specifier.
     return true;
   }
 


### PR DESCRIPTION
## Summary

Architecture audit C1 — closes the layer-enforcement gap surfaced in the audit. `scripts/boundary-check.mjs`'s `workspaceRules` previously covered 6 of 9 workspaces, so `apps/worker`, `packages/db`, and `packages/integrations` slipped through silently. CI was running `pnpm boundaries`, but layer inversions in those three workspaces were not enforced.

- Adds rule entries for the 3 missing scopes with allow-lists matching their actual current imports.
- Adds 2 narrow per-file `@as-comms/db/test-helpers` exceptions (mirrors the existing pattern at `scripts/boundary-check.mjs:60-67`).
- Side fix: 3 worker tests previously reached into `packages/db/test/helpers.js` via relative cross-package imports (silently allowed because `apps/worker` had no scope entry). Routed them through the existing `apps/worker/test/helpers.ts` re-export, which uses the package-style `@as-comms/db/test-helpers` import. Single helper file is the canonical entry for worker tests now.

## Allow-lists added

- `apps/worker` → contracts, domain, integrations, db
- `packages/db` → contracts, domain (no integrations — would be a layer inversion)
- `packages/integrations` → contracts, domain

## Test plan

- [x] `pnpm boundaries` green
- [x] `pnpm typecheck` green
- [x] `pnpm lint` green
- [x] **Regression check (required by brief):** temporarily injected `import {} from \"@as-comms/integrations\"` into `packages/db/src/repositories.ts`; `pnpm boundaries` failed with `packages/db/src/repositories.ts: workspace import is outside the allowed packages/db boundary (@as-comms/integrations)`. Edit reverted; `pnpm boundaries` green again.
- [ ] CI verifies `pnpm test:unit` (skipped locally per macOS rollup memory)

## Refs

- `.STATE-2026-05-02-architecture-audit.md` C1

🤖 Generated with [Claude Code](https://claude.com/claude-code)