### PR TITLE
fix(salesforce): admit null-membership admin+1@ Task records (F.1 widen)

### DIFF
--- a/packages/integrations/src/capture-services/salesforce.ts
+++ b/packages/integrations/src/capture-services/salesforce.ts
@@ -1132,7 +1132,7 @@ export function resolveTaskChannel(input: {
 
   const subject = getStringField(input.row, "Subject")?.toLowerCase() ?? null;
 
-  if (normalizedChannelValue === "task" && input.relatedMembership !== null) {
+  if (normalizedChannelValue === "task") {
     const ownerUsername =
       getStringField(input.row, "Owner.Username")?.toLowerCase() ?? null;
     const isLaunchScopeOwner =

--- a/packages/integrations/test/resolve-task-channel-f1.test.ts
+++ b/packages/integrations/test/resolve-task-channel-f1.test.ts
@@ -37,14 +37,55 @@ describe("resolveTaskChannel F.1 owner-trust extension", () => {
     ).toBe("email");
   });
 
-  it("requires a related membership before trusting the launch-scope owner", () => {
+  it("trusts launch-scope owners on Task subtype rows without a related membership (F.1 widen)", () => {
     expect(
       resolveTaskChannel({
         row: makeRow(),
         relatedMembership: null,
         config: defaultChannelConfig,
       }),
+    ).toBe("email");
+  });
+
+  it("does not match Call subtype even for launch-scope owners with null membership", () => {
+    expect(
+      resolveTaskChannel({
+        row: makeRow({ TaskSubtype: "Call" }),
+        relatedMembership: null,
+        config: defaultChannelConfig,
+      }),
     ).toBeNull();
+  });
+
+  it("does not trust non-launch-scope owners on Task subtype with null membership", () => {
+    expect(
+      resolveTaskChannel({
+        row: makeRow({
+          Owner: {
+            Username: "ricky@adventurescientists.org",
+            Name: "Ricky",
+          },
+        }),
+        relatedMembership: null,
+        config: defaultChannelConfig,
+      }),
+    ).toBeNull();
+  });
+
+  it("preserves the legacy email subject heuristic with null membership", () => {
+    expect(
+      resolveTaskChannel({
+        row: makeRow({
+          Owner: {
+            Username: "ricky@adventurescientists.org",
+            Name: "Ricky",
+          },
+          Subject: "→ Email: Hello",
+        }),
+        relatedMembership: null,
+        config: defaultChannelConfig,
+      }),
+    ).toBe("email");
   });
 
   it("does not trust non-launch-scope owners without the legacy subject heuristic", () => {


### PR DESCRIPTION
## Why

Following PR #236 (F.1 — trust launch-scope owners on TaskSubtype=Task), 7 admin+1@-owned `→ Email:`-prefix Tasks were silently dropped today because their volunteer's `Expedition_Members__c` row had been rolled (membership null at task observation time). Both F.1 AND the legacy subject-prefix heuristic were gated on `relatedMembership !== null`, so neither branch matched.

Architect ran the SOQL probe 2026-05-02 to confirm widening is safe:

\`\`\`sql
SELECT Id, Subject, WhoId, Who.Type, OwnerId, Owner.Username, TaskSubtype, CreatedDate
FROM Task
WHERE Owner.Username = 'admin+1@adventurescientists.org'
  AND TaskSubtype = 'Task'
  AND CreatedDate = LAST_N_DAYS:30
  AND Who.Type != 'Contact'
LIMIT 50
\`\`\`

Result: **0 rows.** admin+1@ never points TaskSubtype=Task records at non-Contact entities.

## What

Drop the `relatedMembership !== null` gate from the TaskSubtype=Task branch in `resolveTaskChannel` (`packages/integrations/src/capture-services/salesforce.ts:1135`). The launch-scope owner trust + the legacy subject-prefix heuristic now both work for rolled-membership volunteers.

Test changes: replace the prior "requires a related membership" assertion with the new contract; add three guards — TaskSubtype=Call still doesn't match (regression), non-launch-scope owners with null membership still don't match, legacy `Email:` subject prefix with null membership now matches. Existing passing tests untouched.

`pnpm --filter @as-comms/integrations test:unit` hit the known macOS rollup-darwin-arm64 signing failure locally; `pnpm typecheck` + `pnpm lint` are clean. CI is authoritative.

🤖 Generated by Codex; reviewed by architect.