### PR TITLE
feat(ui): EmptyState action slot + wire follow-up/clear-filter CTAs

### DIFF
--- a/apps/web/app/design-system/page.tsx
+++ b/apps/web/app/design-system/page.tsx
@@ -19,6 +19,7 @@ import { StatusBadge } from "@/components/ui/status-badge";
 import { Chip } from "@/components/ui/chip";
 import { ToneAvatar } from "@/components/ui/tone-avatar";
 import { DividerLabel } from "@/components/ui/divider-label";
+import { Button } from "@/components/ui/button";
 import {
   InboxIcon,
   SearchIcon,
@@ -551,6 +552,21 @@ export default function DesignSystemPage() {
                   }
                 />
               </div>
+              <div className="rounded-lg border border-slate-200 bg-white">
+                <p className="border-b border-slate-100 px-4 py-2 text-xs font-medium text-slate-500">
+                  size=&quot;sm&quot; with action
+                </p>
+                <EmptyState
+                  icon={<InboxIcon className="h-6 w-6" />}
+                  title="All caught up"
+                  description="No conversations match the current filter."
+                  action={
+                    <Button variant="outline" size="sm">
+                      Switch to follow-ups
+                    </Button>
+                  }
+                />
+              </div>
             </div>
             <div className="mt-4 rounded-lg border border-slate-200 bg-white">
               <p className="border-b border-slate-100 px-4 py-2 text-xs font-medium text-slate-500">
@@ -566,7 +582,7 @@ export default function DesignSystemPage() {
               </div>
             </div>
             <CodeBlock>
-              {`<EmptyState\n  icon={<InboxIcon className="h-6 w-6" />}\n  title="All caught up"\n  description="No conversations match the current filter."\n/>\n\n<EmptyState\n  size="lg"\n  icon={<InboxIcon className="h-7 w-7" />}\n  title="Select a person"\n  description="Choose anyone to view their history."\n/>`}
+              {`<EmptyState\n  icon={<InboxIcon className="h-6 w-6" />}\n  title="All caught up"\n  description="No conversations match the current filter."\n/>\n\n<EmptyState\n  icon={<InboxIcon className="h-6 w-6" />}\n  title="All caught up"\n  description="No conversations match the current filter."\n  action={\n    <Button variant="outline" size="sm">\n      Switch to follow-ups\n    </Button>\n  }\n/>\n\n<EmptyState\n  size="lg"\n  icon={<InboxIcon className="h-7 w-7" />}\n  title="Select a person"\n  description="Choose anyone to view their history."\n/>`}
             </CodeBlock>
           </CatalogSection>
 

--- a/apps/web/app/inbox/_components/inbox-list.tsx
+++ b/apps/web/app/inbox/_components/inbox-list.tsx
@@ -676,9 +676,13 @@ export function InboxList({
         ) : shouldShowInitialSkeleton ? (
           <QueueLoadingSkeleton />
         ) : shouldShowSearchSummary && displayItems.length === 0 ? (
-          <SearchEmptyState query={search.query} />
+          <SearchEmptyState query={search.query} onClearSearch={clearSearch} />
         ) : displayItems.length === 0 ? (
-          <QueueEmptyState />
+          <QueueEmptyState
+            onSwitchToFollowUp={() => {
+              handleFilterChange("follow-up");
+            }}
+          />
         ) : (
           <>
             <ul className="divide-y divide-slate-100">
@@ -712,17 +716,37 @@ export function InboxList({
   );
 }
 
-function QueueEmptyState() {
+function QueueEmptyState({
+  onSwitchToFollowUp,
+}: {
+  readonly onSwitchToFollowUp: () => void;
+}) {
   return (
     <EmptyState
       icon={<InboxIcon className="h-6 w-6" />}
       title="All caught up"
       description="No conversations match the current filter."
+      action={
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onSwitchToFollowUp}
+        >
+          Switch to follow-ups
+        </Button>
+      }
     />
   );
 }
 
-function SearchEmptyState({ query }: { readonly query: string }) {
+function SearchEmptyState({
+  query,
+  onClearSearch,
+}: {
+  readonly query: string;
+  readonly onClearSearch: () => void;
+}) {
   return (
     <EmptyState
       icon={<SearchXIcon className="h-6 w-6" />}
@@ -732,6 +756,16 @@ function SearchEmptyState({ query }: { readonly query: string }) {
           Nothing in the inbox matches &ldquo;{query}&rdquo;. Try a different
           search.
         </>
+      }
+      action={
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onClearSearch}
+        >
+          Clear filter
+        </Button>
       }
     />
   );

--- a/apps/web/components/ui/empty-state.tsx
+++ b/apps/web/components/ui/empty-state.tsx
@@ -5,6 +5,7 @@ interface EmptyStateProps {
   readonly icon: React.ReactNode;
   readonly title: string;
   readonly description: React.ReactNode;
+  readonly action?: React.ReactNode;
   /** `sm` for inline/list contexts, `lg` for full-page empty states */
   readonly size?: "sm" | "lg";
   readonly className?: string;
@@ -17,6 +18,7 @@ const SIZE_CONFIG = {
     iconClass: "h-6 w-6 text-slate-400",
     title: "mt-4 text-sm font-medium text-slate-700",
     description: `mt-1 ${TEXT.caption}`,
+    actionWrapper: "mt-4 flex justify-center",
   },
   lg: {
     wrapper: "flex h-full flex-col items-center justify-center px-10 text-center",
@@ -24,6 +26,7 @@ const SIZE_CONFIG = {
     iconClass: "h-7 w-7",
     title: "mt-5 text-base font-semibold text-slate-900",
     description: "mt-1 max-w-sm text-sm leading-6 text-slate-500",
+    actionWrapper: "mt-5 flex justify-center",
   },
 } as const;
 
@@ -31,6 +34,7 @@ export function EmptyState({
   icon,
   title,
   description,
+  action,
   size = "sm",
   className,
 }: EmptyStateProps) {
@@ -43,6 +47,7 @@ export function EmptyState({
       </div>
       <p className={cfg.title}>{title}</p>
       <p className={cfg.description}>{description}</p>
+      {action ? <div className={cfg.actionWrapper}>{action}</div> : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Adds `action?: React.ReactNode` slot to `EmptyState`, rendered below the description with size-aware spacing (`mt-4` on `sm`, `mt-5` on `lg`).
- Wires the two reachable production empty states with real CTAs:
  - **"All caught up"** → **"Switch to follow-ups"** (calls `handleFilterChange("follow-up")`).
  - **"No results"** → **"Clear filter"** (calls the existing `clearSearch` handler).
- Updates the `/design-system` showcase to demo the new slot.
- Leaves the dead `InboxEmptyState` untouched (the `/inbox` route renders `<InboxWelcomeWorkload>` now, not the "Select a person to begin" state — confirmed with `grep`).

## Why

`/baseline-ui` audit on 2026-05-01 (Section 8 of `.UI-AUDIT-baseline-2026-05-01.md`) flagged: "MUST give empty states one clear next action." Verified empirically at `/design-system` that both rendered cards had `hasButton: false`. This PR closes that gap on the two empty states an operator can actually reach.

## Why this is safe

- `action` is optional and defaults to `undefined` — every existing call site that doesn't pass it renders identically to before.
- The CTA handlers reuse code paths that already exist in `inbox-list.tsx` (`handleFilterChange` and `clearSearch`); no new state primitive introduced.
- No visual change to `EmptyState`'s padding, radius, or typography scale.

## Test plan

- [x] `pnpm typecheck` — pass
- [x] `pnpm lint` — pass
- [x] `pnpm --filter @as-comms/web build` — pass
- [ ] Manual: trigger "All caught up" by filtering to a project with no conversations; confirm "Switch to follow-ups" lands you in the follow-up filter.
- [ ] Manual: search for a non-existent string; confirm "Clear filter" empties the search input and restores the queue.
- [ ] CI green

## Out of scope

- Cleanup of dead `inbox-empty-state.tsx` (only used in the `/inbox/states` showcase). Will be its own decision later.
- Other baseline-ui violations: cn-bypass via template literals, `tracking-*` removal, `prefers-reduced-motion` rollout, AlertDialog primitive, multicolor gradient. Tracked in the audit report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)