### PR TITLE
feat(inbox): match canon header styling — uppercase status text + drop dup follow-up chip

### DIFF
--- a/apps/web/app/_lib/design-tokens.ts
+++ b/apps/web/app/_lib/design-tokens.ts
@@ -125,6 +125,16 @@ export const PROJECT_STATUS_BADGE = {
   successful: "bg-violet-50 text-violet-700",
 } as const;
 
+/** Project participation status — text-only color (for header context, no chip background) */
+export const PROJECT_STATUS_TEXT = {
+  lead: "text-slate-600",
+  applied: "text-sky-700",
+  "in-training": "text-indigo-700",
+  "trip-planning": "text-amber-700",
+  "in-field": "text-emerald-700",
+  successful: "text-violet-700",
+} as const;
+
 /** Chip tone classes (neutral/info/warn/success) */
 export const CHIP_TONE = {
   neutral: "bg-slate-100 text-slate-700 ring-slate-200",

--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -44,6 +44,7 @@ import { InboxFreshnessPoller } from "./inbox-freshness-poller";
 import { useInboxClient, type Reminder } from "./inbox-client-provider";
 import { InboxAvatar } from "./inbox-avatar";
 import { SectionLabel } from "@/components/ui/section-label";
+import { PROJECT_STATUS_TEXT } from "@/app/_lib/design-tokens";
 import {
   LAYOUT,
   SPACING,
@@ -52,10 +53,7 @@ import {
   TYPE,
 } from "@/app/_lib/design-tokens-v2";
 import { InboxComposerReplyBar } from "./inbox-composer";
-import {
-  InboxContactRail,
-  InboxProjectStatusBadge,
-} from "./inbox-contact-rail";
+import { InboxContactRail } from "./inbox-contact-rail";
 import { TimelineSkeleton } from "./inbox-loading";
 import { InboxTimeline } from "./inbox-timeline";
 import {
@@ -443,10 +441,14 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
                   <span className="min-w-0 truncate font-medium text-slate-700">
                     {activeProject.projectName}
                   </span>
-                  <InboxProjectStatusBadge
-                    status={activeProject.status}
-                    label={activeProject.statusLabel}
-                  />
+                  <span
+                    className={cn(
+                      "shrink-0 text-[11px] font-semibold uppercase tracking-wider",
+                      PROJECT_STATUS_TEXT[activeProject.status],
+                    )}
+                  >
+                    {activeProject.statusLabel}
+                  </span>
                 </div>
               ) : (
                 <span className="text-xs text-slate-400">
@@ -455,11 +457,6 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
               )}
             </div>
             <div className="hidden items-center gap-1.5 sm:flex">
-              {isFollowUp ? (
-                <span className="inline-flex items-center rounded-full border border-rose-200 bg-rose-50 px-2 py-0.5 text-[11px] font-medium text-rose-800">
-                  Needs Follow-Up
-                </span>
-              ) : null}
               {contact.hasUnresolved ? (
                 <span className="inline-flex items-center rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-800">
                   Unresolved


### PR DESCRIPTION
## Summary

Two small fixes in the inbox-detail conversation header:

1. **Project status renders as uppercase amber-700 text** (`tracking-wider`, no chip background) — matches the canon eyebrow-label pattern. The chip variant remains in the contact rail where it's correct.
2. **Removes the rose "Needs Follow-Up" inline chip** next to the volunteer name. The state is already conveyed by the right-side flag toggle button and the inbox-list row tag — three signifiers was redundant.

Adds a new `PROJECT_STATUS_TEXT` token in `design-tokens.ts` (sibling to `PROJECT_STATUS_BADGE`, same keys, text-only color values).

## Why

- (1) Canon reference shows status as uppercase amber text; prod shipped a soft amber chip. The chip competes visually with the volunteer name in this context. Architect-confirmed via canon screenshot 2026-05-01.
- (2) Architect-requested cleanup — duplicate signifier removal.

## Why this is safe

- `<InboxProjectStatusBadge>` and `<StatusBadge>` are untouched. Every other caller (the contact rail) renders identically.
- `<FollowUpToggleControl>` (right-side flag button) and the `isFollowUp` derivation are unchanged — only the inline render in the header is dropped.
- `Unresolved` chip is unchanged.
- New token is additive; no existing import breaks.

## Test plan

- [x] `pnpm typecheck` — pass
- [x] `pnpm lint` — pass
- [x] `pnpm --filter @as-comms/web build` — pass
- [ ] Visual: inbox-detail header for a contact with active project (canon match: uppercase amber `TRIP PLANNING`)
- [ ] Visual: inbox-detail header for a contact with `isFollowUp` (no rose chip; right-side flag toggle still tinted rose)
- [ ] Visual: contact rail still shows the chip variant (untouched)
- [ ] CI green

## Out of scope

- `PROJECT_STATUS_TEXT` is added to design-tokens v1, not v2. The v1→v2 migration is a separate concern; keeping the new token next to its sibling `PROJECT_STATUS_BADGE` for now.
- The "No active project" fallback text is unchanged. Polish on that empty case is a separate decision.
- Other baseline-ui audit items remain queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)