### PR TITLE
fix(inbox): unify font for campaign/auto bubbles with 1:1

### DIFF
--- a/apps/web/app/inbox/_components/inbox-timeline-automated-row.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-automated-row.tsx
@@ -317,7 +317,7 @@ export function TimelineAutomatedRow({
                   {!hideCollapsedBody && body.length > 0 ? (
                     <p
                       className={cn(
-                        "mt-0.5 line-clamp-1 font-message-body text-[13.5px] leading-relaxed text-slate-700",
+                        "mt-0.5 line-clamp-1 text-[13.5px] leading-relaxed text-slate-700",
                         WRAP_ANYWHERE,
                       )}
                     >
@@ -342,7 +342,7 @@ export function TimelineAutomatedRow({
               <div className="border-t border-slate-200 bg-white px-4 py-3">
                 <p
                   className={cn(
-                    "whitespace-pre-wrap text-pretty font-message-body text-[13.5px] leading-relaxed text-slate-700",
+                    "whitespace-pre-wrap text-pretty text-[13.5px] leading-relaxed text-slate-700",
                     WRAP_ANYWHERE,
                   )}
                 >


### PR DESCRIPTION
## Summary
- Remove `font-message-body` class from automated/campaign bubble bodies so they inherit the same default sans stack as 1:1 email bubbles
- Internal notes and welcome quote-card retain `font-message-body` (intentionally distinct surfaces)

Closes sprint item #7 (font consistency).

## Test plan
- [ ] CI green (`pnpm typecheck`, `pnpm lint`)
- [ ] Architect verifies in dev preview: campaign + auto rows visually match 1:1 email font
- [ ] Internal note + welcome quote unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)