### PR TITLE
feat(ui): lazy-load skeleton on inbox list + drop avatar borders

### DIFF
--- a/apps/web/app/_lib/design-tokens.ts
+++ b/apps/web/app/_lib/design-tokens.ts
@@ -80,18 +80,18 @@ export type ToneName = keyof typeof TONE;
 // ─── Avatar Tone Classes ────────────────────────────────────────────────────
 //
 // Pre-composed class strings for avatar backgrounds. Slightly different from
-// the base tone (uses -100 bg, -800 text, -200 ring) to ensure legibility
-// on the small circular surface.
+// the base tone (uses -100 bg and -800 text) to ensure legibility on the
+// small circular surface.
 
 export const AVATAR_TONE = {
-  indigo: "bg-indigo-100 text-indigo-800 ring-indigo-200",
-  emerald: "bg-emerald-100 text-emerald-800 ring-emerald-200",
-  amber: "bg-amber-100 text-amber-800 ring-amber-200",
-  rose: "bg-rose-100 text-rose-800 ring-rose-200",
-  sky: "bg-sky-100 text-sky-800 ring-sky-200",
-  violet: "bg-violet-100 text-violet-800 ring-violet-200",
-  teal: "bg-teal-100 text-teal-800 ring-teal-200",
-  slate: "bg-slate-200 text-slate-700 ring-slate-300",
+  indigo: "bg-indigo-100 text-indigo-800",
+  emerald: "bg-emerald-100 text-emerald-800",
+  amber: "bg-amber-100 text-amber-800",
+  rose: "bg-rose-100 text-rose-800",
+  sky: "bg-sky-100 text-sky-800",
+  violet: "bg-violet-100 text-violet-800",
+  teal: "bg-teal-100 text-teal-800",
+  slate: "bg-slate-200 text-slate-700",
 } as const;
 
 // ─── Badge / Status Colors ──────────────────────────────────────────────────

--- a/apps/web/app/inbox/_components/inbox-list.tsx
+++ b/apps/web/app/inbox/_components/inbox-list.tsx
@@ -44,7 +44,7 @@ import {
   XIcon,
 } from "./icons";
 import { InboxFilterList } from "./inbox-filter-list";
-import { QueueLoadingSkeleton } from "./inbox-loading";
+import { QueueLoadingSkeleton, QueueLoadMoreSkeleton } from "./inbox-loading";
 import { InboxRow } from "./inbox-row";
 
 interface ListColumnProps {
@@ -703,9 +703,7 @@ export function InboxList({
                   className="h-px w-full"
                 />
                 {isLoadingMore ? (
-                  <p className="pt-3 text-center text-sm text-slate-500">
-                    Loading more conversations...
-                  </p>
+                  <QueueLoadMoreSkeleton />
                 ) : null}
               </div>
             ) : null}

--- a/apps/web/app/inbox/_components/inbox-loading.tsx
+++ b/apps/web/app/inbox/_components/inbox-loading.tsx
@@ -128,6 +128,29 @@ export function QueueLoadingSkeleton({
   );
 }
 
+export function QueueLoadMoreSkeleton({
+  rowCount = 3,
+}: {
+  readonly rowCount?: number;
+}) {
+  return (
+    <div className="pt-3" role="status" aria-label="Loading more conversations">
+      <div className="space-y-0">
+        {Array.from({ length: rowCount }).map((_, i) => (
+          <div key={i} className="flex gap-3 px-4 py-3">
+            <Skeleton className="h-9 w-9 shrink-0 rounded-full" />
+            <div className="min-w-0 flex-1 space-y-1.5">
+              <Skeleton className="h-3 w-32" />
+              <Skeleton className="h-3 w-48 max-w-full" />
+              <Skeleton className="h-3 w-40 max-w-full" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 /**
  * Timeline loading skeleton. Mirrors the alternating left/right bubble
  * pattern of the real timeline.

--- a/apps/web/components/ui/tone-avatar.tsx
+++ b/apps/web/components/ui/tone-avatar.tsx
@@ -25,10 +25,7 @@ export function ToneAvatar({
   className,
 }: ToneAvatarProps) {
   return (
-    <Avatar
-      className={cn(size === "xs" ? "" : "ring-1", SIZE_CLASSES[size], className)}
-      aria-hidden="true"
-    >
+    <Avatar className={cn(SIZE_CLASSES[size], className)} aria-hidden="true">
       <AvatarFallback className={cn("font-semibold", AVATAR_TONE[tone])}>
         {initials}
       </AvatarFallback>


### PR DESCRIPTION
## Summary
- Replace "Loading more conversations…" text with 2-3 compact skeleton rows that mirror `InboxRow` density (new `QueueLoadMoreSkeleton` in `inbox-loading.tsx`)
- Remove `ring-1` from `ToneAvatar` and prune the now-unused `AVATAR_TONE_RING` token

Closes sprint items **C1, C2**.

## Notes
- `inbox-timeline-bubble.tsx` intentionally NOT touched — Bundle B (`feat/inbox-bubble-polish-0502`) is already removing the `OutboundBrandAvatar` ring as part of the B3 inversion fix
- Codex flagged: `tone-avatar.tsx` size naming is confusing (`xs = h-9 w-9` is larger than `sm = h-8 w-8`). Not renamed in this PR — requires reviewer sign-off; downstream callers depend on the keys

## Test plan
- [ ] CI green (`pnpm typecheck`, `pnpm lint`)
- [ ] Architect verifies in dev preview: scroll-load shows skeleton rows; avatars render without rings in InboxRow + ContactRail

🤖 Generated with [Claude Code](https://claude.com/claude-code)