### PR TITLE
fix(attachments): RFC 5987-encode Content-Disposition for non-ASCII filenames

### DIFF
--- a/apps/gmail-capture/src/index.ts
+++ b/apps/gmail-capture/src/index.ts
@@ -275,20 +275,41 @@ export async function handleGmailHealthRequest(
   return integrationHealthCheckResponseSchema.parse(health);
 }
 
+/**
+ * RFC 5987 / 6266-compliant Content-Disposition builder.
+ *
+ * The legacy `filename=` parameter is a quoted-string per RFC 7230, which
+ * only permits printable ASCII (0x20-0x7E) — non-ASCII bytes throw on
+ * Node's strict header validator. We provide both an ASCII-sanitized
+ * fallback and a UTF-8 percent-encoded `filename*=` for full Unicode
+ * support per RFC 5987. Browsers prefer `filename*` when both are present.
+ */
+function encodeRfc5987(value: string): string {
+  return encodeURIComponent(value).replace(
+    /['()*]/g,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
 function buildAttachmentContentDisposition(input: {
   readonly mimeType: string;
   readonly filename: string | null;
 }): string {
   const trimmed = input.filename?.trim();
-  const filename = (trimmed && trimmed.length > 0 ? trimmed : "Attachment").replaceAll(
-    '"',
-    "",
-  );
+  const rawName = trimmed && trimmed.length > 0 ? trimmed : "Attachment";
+  // Strip non-printable-ASCII (covers Unicode, CR, LF, control chars) and
+  // characters that would break the quoted-string format.
+  const asciiFallback = rawName
+    .replace(/[^\x20-\x7e]/g, "_")
+    .replaceAll('"', "")
+    .replaceAll("\\", "");
+  const safeFallback = asciiFallback.length > 0 ? asciiFallback : "Attachment";
+  const utf8Encoded = encodeRfc5987(rawName);
   const disposition = input.mimeType.startsWith("image/")
     ? "inline"
     : "attachment";
 
-  return `${disposition}; filename="${filename}"`;
+  return `${disposition}; filename="${safeFallback}"; filename*=UTF-8''${utf8Encoded}`;
 }
 
 async function handleInternalAttachmentRequest(

--- a/apps/gmail-capture/test/internal-attachments-route.test.ts
+++ b/apps/gmail-capture/test/internal-attachments-route.test.ts
@@ -267,9 +267,113 @@ describe("gmail-capture internal attachments route", () => {
       expect(response.headers.get("Content-Type")).toBe("image/jpeg");
       expect(response.headers.get("Content-Length")).toBe(String(bytes.length));
       expect(response.headers.get("Content-Disposition")).toBe(
-        'inline; filename="field-photo.jpg"',
+        "inline; filename=\"field-photo.jpg\"; filename*=UTF-8''field-photo.jpg",
       );
       await expect(response.text()).resolves.toBe("image");
+    } finally {
+      await closeServer(server);
+      await context.dispose();
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("RFC 5987-encodes Content-Disposition for non-ASCII filenames", async () => {
+    const context = await createTestStage1Context();
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "gmail-internal-attachments-"));
+    const server = await startGmailCaptureServer(createConfig(tempDir), {
+      connection: createTestConnection(context),
+    });
+
+    try {
+      const attachmentId = "att:gmail:non-ascii:0/1";
+      const storageKey = "gmail/aa/att:gmail:non-ascii:0/1";
+      const attachmentPath = path.join(tempDir, storageKey);
+      const bytes = Buffer.from("image", "utf8");
+
+      await seedAttachment({
+        context,
+        id: attachmentId,
+        storageKey,
+        sizeBytes: bytes.length,
+        mimeType: "image/png",
+        filename: "café — déjà vu.png",
+      });
+      await mkdir(path.dirname(attachmentPath), { recursive: true });
+      await writeFile(attachmentPath, bytes);
+
+      const address = server.address() as AddressInfo;
+      const response = await fetch(
+        new URL(
+          `/internal/attachments/${encodeURIComponent(attachmentId)}`,
+          `http://127.0.0.1:${String(address.port)}`,
+        ),
+        {
+          headers: {
+            authorization: "Bearer gmail-token",
+          },
+        },
+      );
+
+      expect(response.status).toBe(200);
+      const header = response.headers.get("Content-Disposition") ?? "";
+      // ASCII fallback replaces non-ASCII with `_` and preserves the
+      // extension; the UTF-8 form percent-encodes the original.
+      expect(header).toMatch(/^inline; filename="caf_ _ d_j_ vu\.png"; /);
+      expect(header).toContain(
+        "filename*=UTF-8''caf%C3%A9%20%E2%80%94%20d%C3%A9j%C3%A0%20vu.png",
+      );
+    } finally {
+      await closeServer(server);
+      await context.dispose();
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("strips quotes and CR/LF from the ASCII fallback", async () => {
+    const context = await createTestStage1Context();
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "gmail-internal-attachments-"));
+    const server = await startGmailCaptureServer(createConfig(tempDir), {
+      connection: createTestConnection(context),
+    });
+
+    try {
+      const attachmentId = "att:gmail:dangerous-name:0/1";
+      const storageKey = "gmail/dd/att:gmail:dangerous-name:0/1";
+      const attachmentPath = path.join(tempDir, storageKey);
+      const bytes = Buffer.from("image", "utf8");
+
+      await seedAttachment({
+        context,
+        id: attachmentId,
+        storageKey,
+        sizeBytes: bytes.length,
+        mimeType: "image/png",
+        // Embedded quote, backslash, CR, LF — would otherwise either
+        // inject a header or break the quoted-string format.
+        filename: 'a"b\\c\r\nd.png',
+      });
+      await mkdir(path.dirname(attachmentPath), { recursive: true });
+      await writeFile(attachmentPath, bytes);
+
+      const address = server.address() as AddressInfo;
+      const response = await fetch(
+        new URL(
+          `/internal/attachments/${encodeURIComponent(attachmentId)}`,
+          `http://127.0.0.1:${String(address.port)}`,
+        ),
+        {
+          headers: {
+            authorization: "Bearer gmail-token",
+          },
+        },
+      );
+
+      expect(response.status).toBe(200);
+      const header = response.headers.get("Content-Disposition") ?? "";
+      expect(header).toMatch(/^inline; filename="abc__d\.png"; /);
+      expect(header).not.toContain('"b');
+      expect(header).not.toContain("\r");
+      expect(header).not.toContain("\n");
     } finally {
       await closeServer(server);
       await context.dispose();

--- a/apps/web/app/api/attachments/[id]/route.ts
+++ b/apps/web/app/api/attachments/[id]/route.ts
@@ -4,20 +4,42 @@ import { fetchAttachmentUpstream } from "@/src/server/attachments/upstream";
 
 export const dynamic = "force-dynamic";
 
+/**
+ * RFC 5987 / 6266-compliant Content-Disposition builder.
+ *
+ * The legacy `filename=` parameter is a quoted-string per RFC 7230, which
+ * only permits printable ASCII — non-ASCII bytes throw on Node's strict
+ * header validator. We provide both an ASCII-sanitized fallback and a
+ * UTF-8 percent-encoded `filename*=` for full Unicode support per RFC
+ * 5987. Browsers prefer `filename*` when both are present.
+ *
+ * Mirrored in `apps/gmail-capture/src/index.ts`. If you change this,
+ * change that one too — they format the same wire bytes.
+ */
+function encodeRfc5987(value: string): string {
+  return encodeURIComponent(value).replace(
+    /['()*]/g,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
 function contentDisposition(input: {
   readonly mimeType: string;
   readonly filename: string | null;
 }): string {
   const trimmed = input.filename?.trim();
-  const filename = (trimmed && trimmed.length > 0 ? trimmed : "Attachment").replaceAll(
-    '"',
-    ""
-  );
+  const rawName = trimmed && trimmed.length > 0 ? trimmed : "Attachment";
+  const asciiFallback = rawName
+    .replace(/[^\x20-\x7e]/g, "_")
+    .replaceAll('"', "")
+    .replaceAll("\\", "");
+  const safeFallback = asciiFallback.length > 0 ? asciiFallback : "Attachment";
+  const utf8Encoded = encodeRfc5987(rawName);
   const disposition = input.mimeType.startsWith("image/")
     ? "inline"
     : "attachment";
 
-  return `${disposition}; filename="${filename}"`;
+  return `${disposition}; filename="${safeFallback}"; filename*=UTF-8''${utf8Encoded}`;
 }
 
 export async function GET(

--- a/apps/web/tests/unit/attachments-route.test.ts
+++ b/apps/web/tests/unit/attachments-route.test.ts
@@ -101,7 +101,7 @@ describe("attachment proxy route", () => {
       expect(response.headers.get("Content-Type")).toBe("image/jpeg");
       expect(response.headers.get("Content-Length")).toBe("5");
       expect(response.headers.get("Content-Disposition")).toBe(
-        'inline; filename="field-photo.jpg"',
+        "inline; filename=\"field-photo.jpg\"; filename*=UTF-8''field-photo.jpg",
       );
       await expect(response.text()).resolves.toBe("image");
     } finally {


### PR DESCRIPTION
## Summary

Hotfix for the production gmail-capture log spam introduced by #254:

```
Gmail capture request failed.
Invalid character in header content ["Content-Disposition"]
```

Node's strict header validator rejects any byte outside the printable ASCII range (0x20-0x7E) inside a quoted-string. Several captured filenames contain non-ASCII characters (Unicode em-dashes, accented letters, emoji), which made the affected attachment fetches fail with a 500.

Both the gmail-capture internal route (`apps/gmail-capture/src/index.ts`) and the web proxy (`apps/web/app/api/attachments/[id]/route.ts`) now emit RFC 5987 / 6266-compliant headers:

```
Content-Disposition: inline; filename="ASCII fallback"; filename*=UTF-8''<percent-encoded>
```

- **ASCII fallback** strips non-printable bytes, embedded quotes, and backslashes — also closes a latent header-injection vector if a future filename contained CR/LF
- **`filename*=UTF-8''…`** is the modern parameter; all current browsers prefer it when both are present (RFC 6266 §4.3)

The two functions are now duplicated across services (10 lines each). I considered hoisting to `packages/integrations` but the duplication is small, stable, and avoids a cross-service contract for what is purely a wire-format helper.

## Tests

New cases in both test suites:

- `apps/gmail-capture/test/internal-attachments-route.test.ts` — non-ASCII filename (`café — déjà vu.png`) and dangerous-byte filename (embedded `"`, `\\`, CR, LF)
- `apps/web/tests/unit/attachments-route.test.ts` — assertion updated for the new header format

## Test plan
- [ ] CI green
- [ ] After deploy: tail gmail-capture logs; "Invalid character in header content" should stop firing
- [ ] Image attachments with Unicode filenames render in the inbox bubble + dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)