### PR TITLE
fix(inbox): preserve search params on row navigation

### DIFF
--- a/apps/web/app/inbox/_components/inbox-row.tsx
+++ b/apps/web/app/inbox/_components/inbox-row.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useRef } from "react";
 
 import type { InboxListItemViewModel } from "../_lib/view-models";
@@ -18,13 +18,23 @@ interface RowProps {
  * List row for a contact. The left accent bar is sky when the row has
  * bucket === "new" and rose when needsFollowUp is set. If both apply,
  * both colors remain visible via stacked segments.
+ *
+ * The href preserves the current URL search params (`q=`, `filter=`,
+ * `projectId=`) so navigating into a thread doesn't reset the search
+ * bar. The InboxList view-model URL sync keeps the input populated
+ * because the param survives the navigation. Operators can still clear
+ * the search via the input's X button.
  */
 export function InboxRow({ item, isActive }: RowProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const prefetchedRef = useRef(false);
   const isUnread = item.isUnread;
   const ChannelIcon = item.latestChannel === "email" ? MailIcon : PhoneIcon;
-  const href = `/inbox/${encodeURIComponent(item.contactId)}`;
+  const queryString = searchParams.toString();
+  const href = queryString.length > 0
+    ? `/inbox/${encodeURIComponent(item.contactId)}?${queryString}`
+    : `/inbox/${encodeURIComponent(item.contactId)}`;
 
   const showBadges = Boolean(item.projectLabel) || item.needsFollowUp;
 


### PR DESCRIPTION
## Summary

When you searched, clicked a row, the conversation opened — but the search bar reset. URL went from `/inbox?q=robert` to `/inbox/<contactId>`, the InboxList URL→state sync saw `q=` disappear, and cleared `search.query`.

Now `InboxRow` appends the current `searchParams.toString()` to the href, so navigating into a thread keeps `?q=`, `?filter=`, and `?projectId=` in the URL. Search input stays populated; back button returns to the filtered list as expected. The X button remains the explicit clear affordance.

Closes round-2 item **F**.

## Test plan
- [ ] CI green
- [ ] Architect verifies in dev preview: search "robert" → click result → search bar still shows "robert" → back button → list still filtered

🤖 Generated with [Claude Code](https://claude.com/claude-code)