### PR TITLE
fix(composer): snapshot attachments before clearing live FileList

### DIFF
--- a/apps/web/app/inbox/_components/inbox-composer.tsx
+++ b/apps/web/app/inbox/_components/inbox-composer.tsx
@@ -615,13 +615,18 @@ export function InboxComposerDetailPane() {
 
   const handleFilesSelected = async (event: ChangeEvent<HTMLInputElement>) => {
     const files = event.currentTarget.files;
-    event.currentTarget.value = "";
-
     if (files === null || files.length === 0) {
+      // Picker dispatched change with no selection — treat as cancel.
+      event.currentTarget.value = "";
       return;
     }
 
+    // HTMLInputElement.files is a *live* FileList: resetting `.value`
+    // empties it. Snapshot to a real array before the reset so the rest
+    // of the handler keeps its file references and the user's selection
+    // actually arrives in the attachment list.
     const selectedFiles = Array.from(files);
+    event.currentTarget.value = "";
     const nextTotalBytes =
       attachmentBytes +
       selectedFiles.reduce((total, file) => total + file.size, 0);


### PR DESCRIPTION
## Summary

The composer's attach-button opened the OS picker, the user selected a file, and **nothing happened** — no attachment row, no send-side bytes. Root cause is a subtle live-DOM gotcha:

```ts
// Before
const files = event.currentTarget.files;
event.currentTarget.value = "";   // (1) empties the live FileList
if (files === null || files.length === 0) return;  // (2) now-empty → returns
```

`HTMLInputElement.files` returns a **live** `FileList`. Resetting `value = ""` immediately empties that list — even on the captured reference — so the length check returned 0 and `setAttachments` was never called. Frontend state never got the file, the AttachmentRow stayed empty, and submit sent zero attachments.

Fix: validate first, snapshot via `Array.from(files)`, then clear the input. Same shape as the recommended pattern for file inputs that need to accept the same file twice.

Closes round-2 item **D** (outbound attachments not appearing or sending).

## Why no test caught this

The unit tests for the composer mock `attachmentInputRef.current?.click()` and inject `AttachmentDraft` directly into state — they never exercise the real DOM path. JSDOM doesn't model the live FileList behavior accurately enough for this to surface without an e2e test. Worth a follow-up: a Playwright spec that uploads a fixture and asserts the AttachmentRow renders, but out of scope for this hotfix.

## Test plan
- [ ] CI green
- [ ] Architect verifies in dev preview: open composer, click Attach, pick a file → AttachmentRow shows the filename + size, X button removes it, Send actually transmits the bytes (verify via inbox-self test send to nicolaskneler@gmail.com)

🤖 Generated with [Claude Code](https://claude.com/claude-code)