### PR TITLE
feat(composer): optimistic outbound bubble until thread switch

### DIFF
--- a/apps/web/app/inbox/_components/inbox-client-provider.tsx
+++ b/apps/web/app/inbox/_components/inbox-client-provider.tsx
@@ -13,6 +13,7 @@ import type { AiDraftRequestPayload, AiDraftResponseVm } from "../actions";
 import type {
   InboxComposerAliasOption,
   InboxComposerReplyContext,
+  OptimisticOutbound,
 } from "../_lib/view-models";
 import {
   reduceComposerPane,
@@ -123,9 +124,19 @@ export interface InboxToastState {
 
 interface InboxClientState {
   readonly currentActorId: string;
+  readonly operatorDisplayName: string;
   readonly reminders: ReadonlyMap<string, Reminder>;
   readonly setReminder: (contactId: string, reminder: Reminder) => void;
   readonly clearReminder: (contactId: string) => void;
+  readonly optimisticOutbounds: readonly OptimisticOutbound[];
+  readonly addOptimisticOutbound: (entry: OptimisticOutbound) => void;
+  readonly markOptimisticSettled: (clientGeneratedId: string) => void;
+  readonly markOptimisticFailed: (
+    clientGeneratedId: string,
+    reason: string,
+  ) => void;
+  readonly removeOptimisticOutbound: (clientGeneratedId: string) => void;
+  readonly clearOptimisticForContact: (contactId: string) => void;
 
   readonly search: SearchState;
   readonly setSearchQuery: (query: string) => void;
@@ -198,10 +209,12 @@ export function InboxClientProvider({
   children,
   composerAliases,
   currentActorId,
+  operatorDisplayName = currentActorId,
 }: {
   readonly children: ReactNode;
   readonly composerAliases: readonly InboxComposerAliasOption[];
   readonly currentActorId: string;
+  readonly operatorDisplayName?: string;
 }) {
   const [reminders, setReminders] = useState<ReadonlyMap<string, Reminder>>(
     () => new Map<string, Reminder>(),
@@ -219,6 +232,9 @@ export function InboxClientProvider({
   >([]);
   const [toast, setToast] = useState<InboxToastState | null>(null);
   const [aiDraft, setAiDraft] = useState(INITIAL_AI_DRAFT);
+  const [optimisticOutbounds, setOptimisticOutbounds] = useState<
+    readonly OptimisticOutbound[]
+  >([]);
 
   const setReminder = useCallback((contactId: string, reminder: Reminder) => {
     setReminders((previous) => {
@@ -257,6 +273,54 @@ export function InboxClientProvider({
 
   const clearSearch = useCallback(() => {
     setSearch(INITIAL_SEARCH);
+  }, []);
+
+  const addOptimisticOutbound = useCallback((entry: OptimisticOutbound) => {
+    setOptimisticOutbounds((previous) => [...previous, entry]);
+  }, []);
+
+  const markOptimisticSettled = useCallback((clientGeneratedId: string) => {
+    setOptimisticOutbounds((previous) =>
+      previous.map((entry) =>
+        entry.clientGeneratedId === clientGeneratedId
+          ? {
+              ...entry,
+              settledAt: Date.now(),
+            }
+          : entry,
+      ),
+    );
+  }, []);
+
+  const markOptimisticFailed = useCallback(
+    (clientGeneratedId: string, reason: string) => {
+      setOptimisticOutbounds((previous) =>
+        previous.map((entry) =>
+          entry.clientGeneratedId === clientGeneratedId
+            ? {
+                ...entry,
+                sendStatus: "failed",
+                failedReason: "send_failed",
+                failedDetail: reason,
+                settledAt: null,
+              }
+            : entry,
+        ),
+      );
+    },
+    [],
+  );
+
+  const removeOptimisticOutbound = useCallback((clientGeneratedId: string) => {
+    setOptimisticOutbounds((previous) =>
+      previous.filter((entry) => entry.clientGeneratedId !== clientGeneratedId),
+    );
+  }, []);
+
+  const clearOptimisticForContact = useCallback((contactId: string) => {
+    setOptimisticOutbounds((previous) =>
+      previous.filter((entry) => entry.contactId !== contactId),
+    );
   }, []);
 
   const openNewDraft = useCallback(() => {
@@ -507,9 +571,16 @@ export function InboxClientProvider({
   const value = useMemo<InboxClientState>(
     () => ({
       currentActorId,
+      operatorDisplayName,
       reminders,
       setReminder,
       clearReminder,
+      optimisticOutbounds,
+      addOptimisticOutbound,
+      markOptimisticSettled,
+      markOptimisticFailed,
+      removeOptimisticOutbound,
+      clearOptimisticForContact,
       search,
       setSearchQuery,
       setSearchResults,
@@ -550,9 +621,16 @@ export function InboxClientProvider({
     }),
     [
       currentActorId,
+      operatorDisplayName,
       reminders,
       setReminder,
       clearReminder,
+      optimisticOutbounds,
+      addOptimisticOutbound,
+      markOptimisticSettled,
+      markOptimisticFailed,
+      removeOptimisticOutbound,
+      clearOptimisticForContact,
       search,
       setSearchQuery,
       setSearchResults,

--- a/apps/web/app/inbox/_components/inbox-composer.tsx
+++ b/apps/web/app/inbox/_components/inbox-composer.tsx
@@ -34,6 +34,7 @@ import {
   resolveSendAndSaveForAiAvailability,
   type ComposerSendKind,
 } from "../_lib/composer-ui";
+import type { OptimisticOutbound } from "../_lib/view-models";
 import {
   clearDraft,
   loadDraft,
@@ -103,6 +104,19 @@ function resolveSupplementaryRecipientEmails(input: {
   return {
     ok: true,
     emails,
+  };
+}
+
+function toOptimisticAttachment(attachment: AttachmentDraft, index: number) {
+  return {
+    id: `optimistic-attachment:${attachment.id}:${String(index)}`,
+    mimeType: attachment.contentType,
+    filename: attachment.filename,
+    sizeBytes: attachment.size,
+    proxyUrl:
+      attachment.contentBase64 === null
+        ? ""
+        : `data:${attachment.contentType};base64,${attachment.contentBase64}`,
   };
 }
 
@@ -184,6 +198,7 @@ export function InboxComposerDetailPane() {
   const router = useRouter();
   const {
     currentActorId,
+    operatorDisplayName,
     composerAliases,
     composerPane,
     composerView,
@@ -204,6 +219,9 @@ export function InboxComposerDetailPane() {
     cancelReprompt,
     resetAiDraft,
     setAiError,
+    addOptimisticOutbound,
+    markOptimisticSettled,
+    markOptimisticFailed,
   } = useInboxClient();
   const [activeTab, setActiveTab] = useState<"email" | "note">("email");
   const [recipient, setRecipient] = useState<ComposerRecipientValue | null>(
@@ -765,34 +783,89 @@ export function InboxComposerDetailPane() {
         ? { inReplyToRfc822: replyContext.inReplyToRfc822 }
         : {}),
     };
+    const clientGeneratedId = crypto.randomUUID();
+    const recipientLabel = resolveRecipientLabel(recipient);
+    const occurredAt = new Date().toISOString();
+    const optimisticEntry: OptimisticOutbound = {
+      id: `optimistic:${clientGeneratedId}`,
+      clientGeneratedId,
+      contactId: recipient.kind === "contact" ? recipient.contactId : null,
+      settledAt: null,
+      kind: "outbound-email",
+      occurredAt,
+      occurredAtLabel: "Just now",
+      actorLabel: operatorDisplayName,
+      subject: subject.trim(),
+      body: body.trim(),
+      channel: "email",
+      isUnread: false,
+      isPreview: false,
+      fromHeader: selectedAlias,
+      toHeader: recipientLabel,
+      recipientLabel,
+      ccHeader:
+        resolvedCc.emails.length > 0 ? resolvedCc.emails.join(", ") : null,
+      mailbox: selectedAlias,
+      threadId: replyContext?.threadId ?? null,
+      rfc822MessageId: null,
+      inReplyToRfc822: replyContext?.inReplyToRfc822 ?? null,
+      sendStatus: "pending",
+      failedReason: null,
+      failedDetail: null,
+      attachmentCount: attachments.length,
+      attachments: attachments.map(toOptimisticAttachment),
+      campaignActivity: [],
+    };
 
     setInlineError(null);
     setComposerErrors([]);
     setComposerStatus("sending");
+    addOptimisticOutbound(optimisticEntry);
+
+    if (draftKey !== null) {
+      clearDraft(draftKey);
+    }
+    closeComposer();
 
     startSendTransition(async () => {
-      const result = await sendComposerAction(payload);
+      try {
+        const result = await sendComposerAction({
+          ...payload,
+          clientGeneratedId,
+        });
 
-      if (result.ok) {
-        if (draftKey !== null) {
-          clearDraft(draftKey);
+        if (result.ok) {
+          if (result.data.clientGeneratedId !== null) {
+            markOptimisticSettled(result.data.clientGeneratedId);
+          }
+          setComposerStatus("sent-success");
+          showToast(`Sent to ${recipientLabel}`, "success");
+          router.refresh();
+          return;
         }
-        setComposerStatus("sent-success");
-        showToast(`Sent to ${resolveRecipientLabel(recipient)}`, "success");
-        closeComposer();
-        return;
-      }
 
-      setComposerErrors(mapFieldErrors(result));
-      setComposerStatus(
-        result.code === "validation_error"
-          ? "validation-error"
-          : "send-failure",
-      );
-      setInlineError({
-        message: result.message,
-        retryable: result.retryable === true,
-      });
+        markOptimisticFailed(clientGeneratedId, result.message);
+        setComposerErrors(mapFieldErrors(result));
+        setComposerStatus(
+          result.code === "validation_error"
+            ? "validation-error"
+            : "send-failure",
+        );
+        setInlineError({
+          message: result.message,
+          retryable: result.retryable === true,
+        });
+      } catch {
+        markOptimisticFailed(
+          clientGeneratedId,
+          "We could not send that message right now.",
+        );
+        setComposerStatus("send-failure");
+        setInlineError({
+          message: "We could not send that message right now.",
+          retryable: true,
+        });
+      }
     });
   };
 

--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import {
   useCallback,
   useEffect,
+  useMemo,
   useOptimistic,
   useRef,
   useState,
@@ -38,6 +39,7 @@ import type {
   InboxComposerReplyContext,
   InboxDetailViewModel,
   InboxTimelineEntryViewModel,
+  OptimisticOutbound,
 } from "../_lib/view-models";
 import type { UiError, UiResult } from "@/src/server/ui-result";
 import { InboxFreshnessPoller } from "./inbox-freshness-poller";
@@ -131,6 +133,37 @@ function buildTimelineReplyContext(input: {
   };
 }
 
+function sortTimelineEntries(
+  entries: readonly InboxTimelineEntryViewModel[],
+): readonly InboxTimelineEntryViewModel[] {
+  return [...entries].sort((left, right) =>
+    left.occurredAt.localeCompare(right.occurredAt),
+  );
+}
+
+function realEntryMatchesOptimistic(
+  realEntry: InboxTimelineEntryViewModel,
+  optimisticEntry: OptimisticOutbound,
+): boolean {
+  if (realEntry.id === optimisticEntry.id) {
+    return false;
+  }
+
+  if (realEntry.kind !== optimisticEntry.kind) {
+    return false;
+  }
+
+  if (realEntry.subject !== optimisticEntry.subject) {
+    return false;
+  }
+
+  if (realEntry.mailbox !== optimisticEntry.mailbox) {
+    return false;
+  }
+
+  return realEntry.occurredAt >= optimisticEntry.occurredAt;
+}
+
 export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
   const { contact } = detail;
   const timelineScrollRef = useRef<HTMLDivElement>(null);
@@ -143,6 +176,9 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
     clearReminder,
     isTimelineLoading,
     setTimelineLoading,
+    optimisticOutbounds,
+    clearOptimisticForContact,
+    removeOptimisticOutbound,
     openReplyDraft,
     showToast,
   } = useInboxClient();
@@ -163,10 +199,12 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
     setTimelinePage(detail.timelinePage);
 
     if (previousContactIdRef.current !== detail.contact.contactId) {
+      clearOptimisticForContact(previousContactIdRef.current);
       shouldScrollToLatestRef.current = true;
       previousContactIdRef.current = detail.contact.contactId;
     }
   }, [
+    clearOptimisticForContact,
     detail.contact.contactId,
     detail.freshness.inboxUpdatedAt,
     detail.freshness.timelineCount,
@@ -175,6 +213,39 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
     detail.timelinePage,
     setTimelineLoading,
   ]);
+
+  const activeOptimisticOutbounds = useMemo(
+    () =>
+      optimisticOutbounds.filter(
+        (entry) => entry.contactId === detail.contact.contactId,
+      ),
+    [detail.contact.contactId, optimisticOutbounds],
+  );
+
+  const mergedTimelineEntries = useMemo(
+    () => sortTimelineEntries([...timelineEntries, ...activeOptimisticOutbounds]),
+    [activeOptimisticOutbounds, timelineEntries],
+  );
+
+  useEffect(() => {
+    const matchedSettledIds = activeOptimisticOutbounds
+      .filter(
+        (entry) =>
+          entry.settledAt !== null &&
+          timelineEntries.some((realEntry) =>
+            realEntryMatchesOptimistic(realEntry, entry),
+          ),
+      )
+      .map((entry) => entry.clientGeneratedId);
+
+    if (matchedSettledIds.length === 0) {
+      return;
+    }
+
+    for (const clientGeneratedId of matchedSettledIds) {
+      removeOptimisticOutbound(clientGeneratedId);
+    }
+  }, [activeOptimisticOutbounds, removeOptimisticOutbound, timelineEntries]);
 
   useEffect(() => {
     if (!shouldScrollToLatestRef.current) {
@@ -195,7 +266,7 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
     return () => {
       window.cancelAnimationFrame(frame);
     };
-  }, [detail.contact.contactId, timelineEntries]);
+  }, [detail.contact.contactId, mergedTimelineEntries]);
 
   const loadOlderTimeline = useCallback(async () => {
     if (!timelinePage.hasMore || timelinePage.nextCursor === null) {
@@ -313,7 +384,7 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
   const composerReplyContext = detail.composerReplyContext;
   const handleReply = useCallback(
     (entryId: string) => {
-      const entry = timelineEntries.find((item) => item.id === entryId);
+      const entry = mergedTimelineEntries.find((item) => item.id === entryId);
 
       if (entry === undefined) {
         if (composerReplyContext !== null) {
@@ -338,8 +409,8 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
       composerReplyContext,
       contact.contactId,
       contact.displayName,
+      mergedTimelineEntries,
       openReplyDraft,
-      timelineEntries,
     ],
   );
 
@@ -358,7 +429,7 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
 
   const handleRetryPending = useCallback(
     (entryId: string) => {
-      const entry = timelineEntries.find((item) => item.id === entryId);
+      const entry = mergedTimelineEntries.find((item) => item.id === entryId);
 
       if (
         entry?.sendStatus === undefined ||
@@ -372,9 +443,11 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
 
       const pendingId = entry.id.startsWith("pending-outbound:")
         ? entry.id.slice("pending-outbound:".length)
-        : null;
+        : entry.id.startsWith("optimistic:")
+          ? null
+          : null;
 
-      if (pendingId === null) {
+      if (!entry.id.startsWith("pending-outbound:") && !entry.id.startsWith("optimistic:")) {
         return;
       }
 
@@ -397,7 +470,9 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
             ...(entry.inReplyToRfc822 === null
               ? {}
               : { inReplyToRfc822: entry.inReplyToRfc822 }),
-            supersedesPendingId: pendingId,
+            ...(pendingId === null
+              ? {}
+              : { supersedesPendingId: pendingId }),
           });
 
           if (result.ok) {
@@ -411,7 +486,7 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
         setRetryingEntryId(null);
       });
     },
-    [contact.contactId, contact.displayName, showToast, timelineEntries],
+    [contact.contactId, contact.displayName, mergedTimelineEntries, showToast],
   );
 
   return (
@@ -587,11 +662,11 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
           ref={timelineScrollRef}
           className={`min-h-0 flex-1 overflow-y-auto ${TONE_CLASSES.slate.subtle} ${SPACING.container}`}
         >
-          {isTimelineLoading && timelineEntries.length === 0 ? (
+          {isTimelineLoading && mergedTimelineEntries.length === 0 ? (
             <TimelineSkeleton />
           ) : (
             <InboxTimeline
-              entries={timelineEntries}
+              entries={mergedTimelineEntries}
               volunteerFirstName={firstName}
               currentOperatorUserId={currentOperatorUserId}
               showEarlierHistoryDivider={

--- a/apps/web/app/inbox/_components/inbox-shell.tsx
+++ b/apps/web/app/inbox/_components/inbox-shell.tsx
@@ -52,6 +52,7 @@ export function InboxShell({
     <InboxClientProvider
       composerAliases={composerAliases}
       currentActorId={currentActorId}
+      operatorDisplayName={operator.displayName}
     >
       <InboxKeyboardProvider>
         <InboxFreshnessPoller listFreshness={initialList.freshness} />

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -218,6 +218,12 @@ export interface InboxTimelineEntryViewModel {
   readonly authorId?: string | null;
 }
 
+export type OptimisticOutbound = InboxTimelineEntryViewModel & {
+  readonly contactId: string | null;
+  readonly clientGeneratedId: string;
+  readonly settledAt: number | null;
+};
+
 export interface InboxTimelineSystemGroupViewModel {
   readonly id: string;
   readonly kind: "system-message-group";

--- a/apps/web/app/inbox/actions.ts
+++ b/apps/web/app/inbox/actions.ts
@@ -41,6 +41,7 @@ import type { UiResult } from "../../src/server/ui-result";
 const composerSendActionInputSchema = composerSendInputSchema.extend({
   saveAsKnowledge: z.boolean().optional(),
   captureAsKnowledge: z.boolean().optional().default(false),
+  clientGeneratedId: z.string().min(1).optional(),
 });
 
 type ComposerSendActionParsedInput = z.output<
@@ -75,6 +76,7 @@ export type ComposerSendActionData = {
   readonly pendingOutboundId: string;
   readonly canonicalContactId: string;
   readonly threadId: string | null;
+  readonly clientGeneratedId: string | null;
 };
 
 export type ComposerSendActionInput = z.input<
@@ -1529,6 +1531,7 @@ export async function sendComposerAction(
           pendingOutboundId,
           canonicalContactId,
           threadId: sendResult.gmailThreadId,
+          clientGeneratedId: parsedInput.data.clientGeneratedId ?? null,
         },
         requestId,
       };

--- a/apps/web/tests/unit/inbox-optimistic-send.test.tsx
+++ b/apps/web/tests/unit/inbox-optimistic-send.test.tsx
@@ -1,0 +1,321 @@
+import { createRequire } from "node:module";
+import React, { act, createElement, useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+
+Object.assign(globalThis, { React });
+
+import { InboxClientProvider, useInboxClient } from "../../app/inbox/_components/inbox-client-provider";
+import type {
+  InboxTimelineEntryViewModel,
+  OptimisticOutbound,
+} from "../../app/inbox/_lib/view-models";
+
+const workerRequire = createRequire(
+  new URL("../../../worker/package.json", import.meta.url),
+);
+const { JSDOM } = workerRequire("jsdom") as {
+  readonly JSDOM: new (
+    html: string,
+    options: { readonly url: string },
+  ) => {
+    readonly window: Window &
+      typeof globalThis & {
+        close: () => void;
+      };
+  };
+};
+
+beforeAll(() => {
+  const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+    url: "http://localhost/inbox",
+  });
+  const w = dom.window;
+  const entries = {
+    document: w.document,
+    Element: w.Element,
+    Event: w.Event,
+    HTMLElement: w.HTMLElement,
+    Node: w.Node,
+    navigator: w.navigator,
+    self: w,
+    window: w,
+  } as const;
+  for (const [key, value] of Object.entries(entries)) {
+    Object.defineProperty(globalThis, key, {
+      configurable: true,
+      value,
+      writable: true,
+    });
+  }
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+});
+
+function buildEntry(
+  overrides: Partial<InboxTimelineEntryViewModel> = {},
+): InboxTimelineEntryViewModel {
+  return {
+    id: "timeline:1",
+    kind: "outbound-email",
+    occurredAt: "2026-05-01T10:00:00.000Z",
+    occurredAtLabel: "Just now",
+    actorLabel: "Operator",
+    subject: "Subject",
+    body: "Body",
+    channel: "email",
+    isUnread: false,
+    isPreview: false,
+    fromHeader: "operator@example.org",
+    toHeader: "Volunteer",
+    recipientLabel: "Volunteer",
+    ccHeader: null,
+    mailbox: "operator@example.org",
+    threadId: null,
+    rfc822MessageId: null,
+    inReplyToRfc822: null,
+    sendStatus: "confirmed",
+    failedReason: null,
+    failedDetail: null,
+    attachmentCount: 0,
+    attachments: [],
+    campaignActivity: [],
+    ...overrides,
+  };
+}
+
+function buildOptimistic(
+  overrides: Partial<OptimisticOutbound> = {},
+): OptimisticOutbound {
+  return {
+    ...buildEntry({
+      id: "optimistic:1",
+      sendStatus: "pending",
+      occurredAt: "2026-05-01T10:00:01.000Z",
+      occurredAtLabel: "Just now",
+    }),
+    contactId: "contact-1",
+    clientGeneratedId: "client-1",
+    settledAt: null,
+    ...overrides,
+  };
+}
+
+function mergeTimeline(
+  serverEntries: readonly InboxTimelineEntryViewModel[],
+  optimisticOutbounds: readonly OptimisticOutbound[],
+  activeContactId: string,
+) {
+  const activeOptimistic = optimisticOutbounds.filter(
+    (entry) => entry.contactId === activeContactId,
+  );
+
+  const visibleOptimistic = activeOptimistic.filter(
+    (entry) =>
+      !(
+        entry.settledAt !== null &&
+        serverEntries.some(
+          (serverEntry) =>
+            serverEntry.kind === entry.kind &&
+            serverEntry.subject === entry.subject &&
+            serverEntry.mailbox === entry.mailbox &&
+            serverEntry.occurredAt >= entry.occurredAt,
+        )
+      ),
+  );
+
+  return [...serverEntries, ...visibleOptimistic].sort((left, right) =>
+    left.occurredAt.localeCompare(right.occurredAt),
+  );
+}
+
+type ClientApi = ReturnType<typeof useInboxClient>;
+
+let latestClient: ClientApi | null = null;
+
+function Harness({
+  activeContactId,
+  serverEntries,
+}: {
+  readonly activeContactId: string;
+  readonly serverEntries: readonly InboxTimelineEntryViewModel[];
+}) {
+  const client = useInboxClient();
+  latestClient = client;
+
+  useEffect(() => {
+    return () => {
+      latestClient = null;
+    };
+  }, []);
+
+  const mergedEntries = mergeTimeline(
+    serverEntries,
+    client.optimisticOutbounds,
+    activeContactId,
+  );
+
+  return createElement(
+    "div",
+    null,
+    createElement(
+      "ul",
+      { "data-testid": "timeline" },
+      mergedEntries.map((entry) =>
+        createElement(
+          "li",
+          {
+            key: entry.id,
+            "data-entry-id": entry.id,
+            "data-send-status": entry.sendStatus ?? "none",
+          },
+          `${entry.subject ?? "(no subject)"}|${entry.sendStatus ?? "none"}`,
+        ),
+      ),
+    ),
+  );
+}
+
+interface RenderSession {
+  readonly container: HTMLElement;
+  readonly root: Root;
+  readonly rerender: (props: {
+    readonly activeContactId: string;
+    readonly serverEntries: readonly InboxTimelineEntryViewModel[];
+  }) => Promise<void>;
+  readonly cleanup: () => Promise<void>;
+}
+
+let activeSession: RenderSession | null = null;
+
+async function renderHarness(props: {
+  readonly activeContactId: string;
+  readonly serverEntries: readonly InboxTimelineEntryViewModel[];
+}): Promise<RenderSession> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  const render = async (nextProps: {
+    readonly activeContactId: string;
+    readonly serverEntries: readonly InboxTimelineEntryViewModel[];
+  }) => {
+    await act(async () => {
+      root.render(
+        createElement(
+          InboxClientProvider,
+          {
+            composerAliases: [],
+            currentActorId: "user-1",
+            operatorDisplayName: "Operator Name",
+            children: createElement(Harness, nextProps),
+          },
+        ),
+      );
+      await Promise.resolve();
+    });
+  };
+
+  await render(props);
+
+  const cleanup = async () => {
+    await act(async () => {
+      root.unmount();
+      await Promise.resolve();
+    });
+    container.remove();
+  };
+
+  activeSession = {
+    container,
+    root,
+    rerender: render,
+    cleanup,
+  };
+
+  return activeSession;
+}
+
+afterEach(async () => {
+  await activeSession?.cleanup();
+  activeSession = null;
+  latestClient = null;
+});
+
+describe("Inbox optimistic send provider", () => {
+  it("shows an optimistic bubble after addOptimisticOutbound", async () => {
+    const session = await renderHarness({
+      activeContactId: "contact-1",
+      serverEntries: [],
+    });
+
+    await act(async () => {
+      latestClient?.addOptimisticOutbound(buildOptimistic());
+      await Promise.resolve();
+    });
+
+    expect(session.container.textContent).toContain("Subject|pending");
+  });
+
+  it("hides the settled optimistic bubble once the real entry arrives", async () => {
+    const session = await renderHarness({
+      activeContactId: "contact-1",
+      serverEntries: [],
+    });
+
+    await act(async () => {
+      latestClient?.addOptimisticOutbound(buildOptimistic());
+      latestClient?.markOptimisticSettled("client-1");
+      await Promise.resolve();
+    });
+
+    await session.rerender({
+      activeContactId: "contact-1",
+      serverEntries: [
+        buildEntry({
+          id: "timeline:real",
+          occurredAt: "2026-05-01T10:00:02.000Z",
+        }),
+      ],
+    });
+
+    const text = session.container.textContent;
+    expect(text).toContain("Subject|confirmed");
+    expect(text).not.toContain("Subject|pending");
+  });
+
+  it('keeps the bubble visible and failed after markOptimisticFailed', async () => {
+    await renderHarness({
+      activeContactId: "contact-1",
+      serverEntries: [],
+    });
+
+    await act(async () => {
+      latestClient?.addOptimisticOutbound(buildOptimistic());
+      latestClient?.markOptimisticFailed("client-1", "Mailbox unavailable");
+      await Promise.resolve();
+    });
+
+    expect(latestClient?.optimisticOutbounds[0]?.sendStatus).toBe("failed");
+  });
+
+  it("clears optimistic outbounds for the previous contact", async () => {
+    const session = await renderHarness({
+      activeContactId: "contact-1",
+      serverEntries: [],
+    });
+
+    await act(async () => {
+      latestClient?.addOptimisticOutbound(buildOptimistic());
+      latestClient?.clearOptimisticForContact("contact-1");
+      await Promise.resolve();
+    });
+
+    await session.rerender({
+      activeContactId: "contact-2",
+      serverEntries: [],
+    });
+
+    expect(session.container.textContent).not.toContain("Subject|pending");
+  });
+});


### PR DESCRIPTION
## Summary

Sent messages now appear immediately in the timeline as a `pending` bubble and stay visible until the server settles them or the operator navigates to a different thread. Closes the visual gap between Send-click and the freshness-poll refresh.

- `inbox-client-provider`: new `optimisticOutbounds` slice + actions
- `inbox-composer`: drops a synthetic OutboundEntry into the provider, awaits the action, marks settled on `ok` or `failed` on error
- `inbox-detail`: merges optimistic entries scoped to active contact with `detail.timeline.entries`; clears prior thread's entries on `contactId` change
- `actions.ts`: round-trips `clientGeneratedId` in the result so the client can settle precisely
- New unit coverage in `inbox-optimistic-send.test.tsx`

Closes round-2 item **E**.

## Locked decisions
- In-memory only; no localStorage persistence
- Scope = active contact; switching threads clears the previous thread's optimistic entries
- DB `pending_outbounds` is the durable source — optimistic state is purely a UX bridge
- Failed bubbles stay (existing retry banner handles them)

## Test plan
- [ ] CI green
- [ ] Architect verifies in dev preview: send to nicolaskneler@gmail.com → bubble appears immediately with "Sending..." → real bubble takes over after refresh → switching threads clears the pending bubble

🤖 Generated with [Claude Code](https://claude.com/claude-code)