### PR TITLE
feat(inbox): bubble author normalization + conversation-derived project pill

### DIFF
--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -306,7 +306,7 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
     });
   }, [contact.contactId, router]);
 
-  const activeProject = contact.activeProjects[0] ?? null;
+  const headerProject = contact.activeProjects[0] ?? detail.conversationProject;
   const firstName = contact.displayName.split(" ")[0] ?? contact.displayName;
   const isFollowUp = followUpToggle.value;
   const existingReminder = reminders.get(contact.contactId) ?? null;
@@ -436,19 +436,29 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
             </h1>
             <div className="hidden h-5 w-px bg-slate-200 sm:block" />
             <div className="hidden min-w-0 flex-1 sm:block">
-              {activeProject ? (
+              {headerProject ? (
                 <div className="flex min-w-0 items-center gap-2 text-xs">
-                  <span className="min-w-0 truncate font-medium text-slate-700">
-                    {activeProject.projectName}
-                  </span>
                   <span
-                    className={cn(
-                      "shrink-0 text-[11px] font-semibold uppercase tracking-wider",
-                      PROJECT_STATUS_TEXT[activeProject.status],
-                    )}
+                    className="min-w-0 truncate font-medium text-slate-700"
+                    title={
+                      "source" in headerProject &&
+                      headerProject.source === "conversation"
+                        ? "Via project alias"
+                        : undefined
+                    }
                   >
-                    {activeProject.statusLabel}
+                    {headerProject.projectName}
                   </span>
+                  {"status" in headerProject ? (
+                    <span
+                      className={cn(
+                        "shrink-0 text-[11px] font-semibold uppercase tracking-wider",
+                        PROJECT_STATUS_TEXT[headerProject.status],
+                      )}
+                    >
+                      {headerProject.statusLabel}
+                    </span>
+                  ) : null}
                 </div>
               ) : (
                 <span className="text-xs text-slate-400">

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -2535,6 +2535,14 @@ function pickPrimaryActiveProjectName(input: {
 
 async function loadProjectMetadataById(
   memberships: readonly ContactMembershipRecord[],
+  /**
+   * Additional project IDs to look up beyond what the contact's memberships
+   * surface. The conversation-derived project pill needs the metadata for
+   * any project_id that appears in salesforce_event_context for this
+   * contact's events, even when no membership exists (external contacts
+   * sent FROM a project alias).
+   */
+  extraProjectIds: readonly (string | null | undefined)[] = [],
 ): Promise<
   Readonly<
     Record<
@@ -2546,9 +2554,10 @@ async function loadProjectMetadataById(
     >
   >
 > {
-  const projectIds = uniqueStrings(
-    memberships.map((membership) => membership.projectId),
-  );
+  const projectIds = uniqueStrings([
+    ...memberships.map((membership) => membership.projectId),
+    ...extraProjectIds,
+  ]);
 
   if (projectIds.length === 0) {
     return {};
@@ -3265,7 +3274,10 @@ async function readInboxDetailCacheData(
         canonicalEvents,
       }),
     canonicalEventById: new Map(canonicalEvents.map((event) => [event.id, event])),
-    projectMetadataById: await loadProjectMetadataById(memberships),
+    projectMetadataById: await loadProjectMetadataById(
+      memberships,
+      salesforceEventContexts.map((context) => context.projectId),
+    ),
     salesforceEventContextBySourceEvidenceId: new Map(
       salesforceEventContexts.map((context) => [
         context.sourceEvidenceId,

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -8,6 +8,7 @@ import type {
   TimelineItem,
 } from "@as-comms/contracts";
 
+import { getCurrentUser } from "@/src/server/auth/session";
 import { recordSensitiveReadForCurrentUserDetached } from "@/src/server/security/audit";
 import { getStage1WebRuntime } from "../../../src/server/stage1-runtime";
 import {
@@ -101,6 +102,7 @@ interface InboxDetailCacheData {
   readonly campaignActivitySummaryByCampaignId: Readonly<
     Record<string, CampaignActivitySummary>
   >;
+  readonly canonicalEventById: ReadonlyMap<string, CanonicalEventRecord>;
   readonly projectMetadataById: Readonly<
     Record<
       string,
@@ -110,6 +112,13 @@ interface InboxDetailCacheData {
       }
     >
   >;
+  readonly salesforceEventContextBySourceEvidenceId: ReadonlyMap<
+    string,
+    {
+      readonly projectId: string | null;
+    }
+  >;
+  readonly contactDisplayNameByEmail: ReadonlyMap<string, string>;
   readonly projectLabelByAlias: ReadonlyMap<string, string>;
   readonly attachmentsByCanonicalEventId: ReadonlyMap<
     string,
@@ -1835,25 +1844,38 @@ function timelineActorLabel(
   item: TimelineItem,
   contactDisplayName: string,
   kind: InboxTimelineEntryKind,
+  operatorDisplayName: string,
+  canonicalContactDisplayName: string | null = null,
 ): string {
   if (kind === "inbound-email") {
+    const normalizedCanonicalContactName =
+      canonicalContactDisplayName === null
+        ? ""
+        : normalizeDisplayName(canonicalContactDisplayName);
+
+    if (normalizedCanonicalContactName.length > 0) {
+      return normalizedCanonicalContactName;
+    }
+
     if (item.family === "one_to_one_email") {
       const senderLabel = participantHeaderLabel(item.fromHeader ?? null);
+      const normalizedSenderLabel =
+        senderLabel === null ? "" : normalizeDisplayName(senderLabel);
 
-      if (senderLabel !== null) {
-        return senderLabel;
+      if (normalizedSenderLabel.length > 0) {
+        return normalizedSenderLabel;
       }
     }
 
-    return contactDisplayName;
+    return normalizeDisplayName(contactDisplayName) || contactDisplayName;
   }
 
   if (kind === "inbound-sms") {
-    return contactDisplayName;
+    return normalizeDisplayName(contactDisplayName) || contactDisplayName;
   }
 
   if (kind === "outbound-email" || kind === "outbound-sms") {
-    return "You";
+    return normalizeDisplayName(operatorDisplayName) || "Adventure Scientists";
   }
 
   if (kind === "email-activity") {
@@ -1863,7 +1885,7 @@ function timelineActorLabel(
   switch (item.family) {
     case "one_to_one_email":
     case "one_to_one_sms":
-      return "You";
+      return normalizeDisplayName(operatorDisplayName) || "Adventure Scientists";
     case "auto_email":
     case "auto_sms":
       return item.sourceLabel;
@@ -1884,6 +1906,57 @@ const PLACEHOLDER_BODY_PREVIEWS = new Set([
   "[Encrypted message — open in Gmail to read]",
   "[Message body could not be extracted — open in Gmail]",
 ]);
+
+function hasUppercaseBeyondFirst(token: string): boolean {
+  for (let index = 1; index < token.length; index += 1) {
+    const character = token[index];
+
+    if (character !== undefined && /[A-Z]/u.test(character)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function titleCaseSimpleToken(token: string): string {
+  if (token.length === 0) {
+    return token;
+  }
+
+  if (/[.'’-]/u.test(token) && hasUppercaseBeyondFirst(token)) {
+    return token;
+  }
+
+  return `${token[0]?.toUpperCase() ?? ""}${token.slice(1).toLowerCase()}`;
+}
+
+function normalizeDisplayName(raw: string): string {
+  const trimmed = raw.trim();
+
+  if (trimmed.length === 0) {
+    return "";
+  }
+
+  if (/^[a-z0-9._-]+$/iu.test(trimmed)) {
+    return trimmed;
+  }
+
+  const reversedNameMatch = /^([^,]+),\s*([^,]+)$/u.exec(trimmed);
+
+  if (reversedNameMatch !== null) {
+    return [reversedNameMatch[2], reversedNameMatch[1]]
+      .flatMap((part) => (part ?? "").trim().split(/\s+/u))
+      .filter((part) => part.length > 0)
+      .map(titleCaseSimpleToken)
+      .join(" ");
+  }
+
+  return trimmed
+    .split(/\s+/u)
+    .map(titleCaseSimpleToken)
+    .join(" ");
+}
 
 function participantHeaderLabel(headerValue: string | null): string | null {
   if (headerValue === null) {
@@ -1910,6 +1983,16 @@ function participantHeaderLabel(headerValue: string | null): string | null {
   }
 
   return trimmed;
+}
+
+function participantHeaderEmail(headerValue: string | null): string | null {
+  if (headerValue === null) {
+    return null;
+  }
+
+  return normalizeEmailAddress(
+    PARTICIPANT_HEADER_EMAIL_PATTERN.exec(headerValue)?.[0] ?? null,
+  );
 }
 
 const OUTBOUND_SUBJECT_PREFIX_PATTERN =
@@ -2150,6 +2233,8 @@ function isPreviewTimelineItem(item: TimelineItem): boolean {
 function buildTimelineEntry(input: {
   readonly contactDisplayName: string;
   readonly contactPrimaryEmail: string | null;
+  readonly contactDisplayNameByEmail: ReadonlyMap<string, string>;
+  readonly operatorDisplayName: string;
   readonly inboxProjection: InboxProjectionRow;
   readonly item: TimelineItem;
   readonly campaignActivitySummaryByCampaignId: Readonly<
@@ -2248,6 +2333,12 @@ function buildTimelineEntry(input: {
           proxyUrl: `/api/attachments/${encodeURIComponent(attachment.id)}`,
         }))
       : [];
+  const canonicalSenderDisplayName =
+    input.item.family === "one_to_one_email"
+      ? input.contactDisplayNameByEmail.get(
+          participantHeaderEmail(input.item.fromHeader ?? null) ?? "",
+        ) ?? null
+      : null;
 
   return {
     id: input.item.id,
@@ -2262,6 +2353,8 @@ function buildTimelineEntry(input: {
       input.item,
       input.contactDisplayName,
       finalKind,
+      input.operatorDisplayName,
+      canonicalSenderDisplayName,
     ),
     subject,
     body: resolvedBody,
@@ -3050,11 +3143,20 @@ async function readInboxDetailCacheData(
       .filter((event) => event.eventType === "communication.email.outbound")
       .map((event) => event.sourceEvidenceId),
   );
+  const canonicalSourceEvidenceIds = uniqueStrings(
+    canonicalEvents.map((event) => event.sourceEvidenceId),
+  );
   const gmailDetails =
     gmailSourceEvidenceIds.length === 0
       ? []
       : await runtime.repositories.gmailMessageDetails.listBySourceEvidenceIds(
           gmailSourceEvidenceIds,
+        );
+  const salesforceEventContexts =
+    canonicalSourceEvidenceIds.length === 0
+      ? []
+      : await runtime.repositories.salesforceEventContext.listBySourceEvidenceIds(
+          canonicalSourceEvidenceIds,
         );
   const gmailDetailBySourceEvidenceId = new Map(
     gmailDetails.map((detail) => [detail.sourceEvidenceId, detail]),
@@ -3076,12 +3178,62 @@ async function readInboxDetailCacheData(
       .map((item) => sourceEvidenceIdByCanonicalEventId.get(item.canonicalEventId))
       .filter((value): value is string => typeof value === "string"),
   );
+  const senderEmails = uniqueStrings(
+    timelinePage.items
+      .flatMap((item) =>
+        item.family === "one_to_one_email"
+          ? [participantHeaderEmail(item.fromHeader ?? null)]
+          : [],
+      )
+      .filter((value): value is string => value !== null),
+  );
   const attachments =
     timelineSourceEvidenceIds.length === 0
       ? []
       : await runtime.repositories.messageAttachments.findByMessageIds(
           timelineSourceEvidenceIds,
         );
+  const contactIdentityMatches = await Promise.all(
+    senderEmails.map(async (email) => ({
+      email,
+      identities:
+        await runtime.repositories.contactIdentities.listByNormalizedValue({
+          kind: "email",
+          normalizedValue: email,
+        }),
+    })),
+  );
+  const matchedContactIds = uniqueStrings(
+    contactIdentityMatches.flatMap(({ identities }) =>
+      identities.map((identity) => identity.contactId),
+    ),
+  );
+  const matchedContacts =
+    matchedContactIds.length === 0
+      ? []
+      : await runtime.repositories.contacts.listByIds(matchedContactIds);
+  const contactById = new Map(matchedContacts.map((row) => [row.id, row]));
+  const contactDisplayNameByEmail = new Map<string, string>();
+
+  if (
+    contact.primaryEmail !== null &&
+    normalizeEmailAddress(contact.primaryEmail) !== null
+  ) {
+    contactDisplayNameByEmail.set(
+      normalizeEmailAddress(contact.primaryEmail) ?? "",
+      contact.displayName,
+    );
+  }
+
+  for (const match of contactIdentityMatches) {
+    const contactId = match.identities[0]?.contactId;
+    const matchedContact =
+      contactId === undefined ? null : (contactById.get(contactId) ?? null);
+
+    if (matchedContact !== null) {
+      contactDisplayNameByEmail.set(match.email, matchedContact.displayName);
+    }
+  }
   const attachmentsBySourceEvidenceId = new Map<
     string,
     MessageAttachmentRecord[]
@@ -3112,7 +3264,17 @@ async function readInboxDetailCacheData(
         runtime,
         canonicalEvents,
       }),
+    canonicalEventById: new Map(canonicalEvents.map((event) => [event.id, event])),
     projectMetadataById: await loadProjectMetadataById(memberships),
+    salesforceEventContextBySourceEvidenceId: new Map(
+      salesforceEventContexts.map((context) => [
+        context.sourceEvidenceId,
+        {
+          projectId: context.projectId,
+        },
+      ]),
+    ),
+    contactDisplayNameByEmail,
     projectLabelByAlias: await loadProjectLabelByAlias(projectAliasRecords),
     attachmentsByCanonicalEventId: new Map(
       timelinePage.items.map((item) => [
@@ -3425,6 +3587,70 @@ function buildContactSummary(input: {
   };
 }
 
+function buildConversationProject(input: {
+  readonly contact: InboxContactSummaryViewModel;
+  readonly timelineItems: readonly TimelineItem[];
+  readonly canonicalEventById: ReadonlyMap<string, CanonicalEventRecord>;
+  readonly salesforceEventContextBySourceEvidenceId: ReadonlyMap<
+    string,
+    {
+      readonly projectId: string | null;
+    }
+  >;
+  readonly projectMetadataById: Readonly<
+    Record<
+      string,
+      {
+        readonly projectName: string;
+        readonly isActive: boolean;
+      }
+    >
+  >;
+}): InboxDetailViewModel["conversationProject"] {
+  const membershipProject = input.contact.activeProjects[0];
+
+  if (membershipProject !== undefined) {
+    return {
+      projectId: membershipProject.projectId,
+      projectName: membershipProject.projectName,
+      source: "membership",
+    };
+  }
+
+  for (const item of [...input.timelineItems].sort((left, right) =>
+    right.occurredAt.localeCompare(left.occurredAt),
+  )) {
+    const sourceEvidenceId =
+      input.canonicalEventById.get(item.canonicalEventId)?.sourceEvidenceId;
+
+    if (sourceEvidenceId === undefined) {
+      continue;
+    }
+
+    const projectId =
+      input.salesforceEventContextBySourceEvidenceId.get(sourceEvidenceId)
+        ?.projectId ?? null;
+
+    if (projectId === null) {
+      continue;
+    }
+
+    const projectName = input.projectMetadataById[projectId]?.projectName;
+
+    if (typeof projectName !== "string" || projectName.length === 0) {
+      continue;
+    }
+
+    return {
+      projectId,
+      projectName,
+      source: "conversation",
+    };
+  }
+
+  return null;
+}
+
 function matchesServerFilter(
   item: InboxListItemViewModel,
   filterId: InboxFilterId,
@@ -3540,12 +3766,15 @@ export async function getInboxTimelinePage(
   }
 
   const referenceNowIso = new Date().toISOString();
+  const operatorDisplayName = "Adventure Scientists";
 
   return {
     entries: cachedData.timelineItems.map((item) =>
       buildTimelineEntry({
         contactDisplayName: cachedData.contact.displayName,
         contactPrimaryEmail: cachedData.contact.primaryEmail,
+        contactDisplayNameByEmail: cachedData.contactDisplayNameByEmail,
+        operatorDisplayName,
         inboxProjection: cachedData.inboxProjection,
         item,
         campaignActivitySummaryByCampaignId:
@@ -3622,6 +3851,18 @@ export async function getInboxDetail(
 
   const runtime = await getStage1WebRuntime();
   const referenceNowIso = new Date().toISOString();
+  const currentUser = await getCurrentUser();
+  const operatorDisplayName =
+    normalizeDisplayName(currentUser?.name ?? "") || "Adventure Scientists";
+  const contactSummary = buildContactSummary({
+    contact: cachedData.contact,
+    inboxProjection: cachedData.inboxProjection,
+    memberships: cachedData.memberships,
+    latestNote: cachedData.latestNote,
+    activityTimelineItems: cachedData.activityTimelineItems,
+    projectMetadataById: cachedData.projectMetadataById,
+    referenceNowIso,
+  });
   const composerReplyContext = buildComposerReplyContext({
     contact: cachedData.contact,
     timelineItems: cachedData.timelineItems,
@@ -3632,14 +3873,14 @@ export async function getInboxDetail(
   });
 
   return {
-    contact: buildContactSummary({
-      contact: cachedData.contact,
-      inboxProjection: cachedData.inboxProjection,
-      memberships: cachedData.memberships,
-      latestNote: cachedData.latestNote,
-      activityTimelineItems: cachedData.activityTimelineItems,
+    contact: contactSummary,
+    conversationProject: buildConversationProject({
+      contact: contactSummary,
+      timelineItems: cachedData.activityTimelineItems,
+      canonicalEventById: cachedData.canonicalEventById,
+      salesforceEventContextBySourceEvidenceId:
+        cachedData.salesforceEventContextBySourceEvidenceId,
       projectMetadataById: cachedData.projectMetadataById,
-      referenceNowIso,
     }),
     initials: toInitials(cachedData.contact.displayName),
     avatarTone: avatarToneForContact(cachedData.contact.id),
@@ -3647,6 +3888,8 @@ export async function getInboxDetail(
       buildTimelineEntry({
         contactDisplayName: cachedData.contact.displayName,
         contactPrimaryEmail: cachedData.contact.primaryEmail,
+        contactDisplayNameByEmail: cachedData.contactDisplayNameByEmail,
+        operatorDisplayName,
         inboxProjection: cachedData.inboxProjection,
         item,
         campaignActivitySummaryByCampaignId:

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -336,6 +336,11 @@ export interface InboxComposerReplyContext {
 
 export interface InboxDetailViewModel {
   readonly contact: InboxContactSummaryViewModel;
+  readonly conversationProject: {
+    readonly projectId: string;
+    readonly projectName: string;
+    readonly source: "membership" | "conversation";
+  } | null;
   readonly initials: string;
   readonly avatarTone: InboxAvatarTone;
   readonly timeline: readonly InboxTimelineEntryViewModel[];

--- a/apps/web/tests/unit/inbox-actions.test.ts
+++ b/apps/web/tests/unit/inbox-actions.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const requireSession = vi.hoisted(() => vi.fn());
+const getCurrentUser = vi.hoisted(() => vi.fn().mockResolvedValue(null));
 const generateAiDraft = vi.hoisted(() => vi.fn());
 
 vi.mock("next/cache", () => ({
@@ -9,6 +10,7 @@ vi.mock("next/cache", () => ({
 
 vi.mock("@/src/server/auth/session", () => ({
   requireSession,
+  getCurrentUser,
 }));
 
 vi.mock("@/src/server/ai", async (importOriginal) => {

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -1931,6 +1931,118 @@ describe("real inbox selectors", () => {
     });
   });
 
+  it("sets conversationProject from membership when the contact has an active project membership", async () => {
+    const detail = await getInboxDetail("contact:sarah-martinez");
+
+    expect(detail?.conversationProject).toEqual({
+      projectId: "project:amazon-basin",
+      projectName: "Amazon Basin Research",
+      source: "membership",
+    });
+  });
+
+  it("falls back to a conversation-derived project when there is no membership project", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await runtime.context.repositories.projectDimensions.upsert({
+      projectId: "project:orcas",
+      projectName: "Orca Listening Network",
+      projectAlias: "Orcas",
+      source: "salesforce",
+      isActive: true,
+    });
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:external-orcas",
+      salesforceContactId: null,
+      displayName: "External Orcas",
+      primaryEmail: "external-orcas@example.org",
+      primaryPhone: null,
+    });
+    const latest = await seedInboxEmailEvent(runtime.context, {
+      id: "external-orcas-outbound",
+      contactId: "contact:external-orcas",
+      occurredAt: "2026-04-19T16:00:00.000Z",
+      direction: "outbound",
+      subject: "Project alias send",
+      snippet: "Sent from the orcas alias.",
+      bodyTextPreview: "Sent from the orcas alias.",
+      fromHeader: "Orcas <orcas@adventurescientists.org>",
+      toHeader: "External Orcas <external-orcas@example.org>",
+      projectInboxAlias: "orcas@adventurescientists.org",
+    });
+    await runtime.context.repositories.salesforceEventContext.upsert({
+      sourceEvidenceId: "source:external-orcas-outbound",
+      salesforceContactId: null,
+      projectId: "project:orcas",
+      expeditionId: null,
+      sourceField: null,
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:external-orcas",
+      bucket: "Opened",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: null,
+      lastOutboundAt: "2026-04-19T16:00:00.000Z",
+      lastActivityAt: "2026-04-19T16:00:00.000Z",
+      snippet: "Sent from the orcas alias.",
+      lastCanonicalEventId: latest.canonicalEventId,
+      lastEventType: "communication.email.outbound",
+    });
+
+    const detail = await getInboxDetail("contact:external-orcas");
+
+    expect(detail?.contact.activeProjects).toHaveLength(0);
+    expect(detail?.conversationProject).toEqual({
+      projectId: "project:orcas",
+      projectName: "Orca Listening Network",
+      source: "conversation",
+    });
+  });
+
+  it("leaves conversationProject null when there is no membership or project-linked event context", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:no-project-context",
+      salesforceContactId: null,
+      displayName: "No Project Context",
+      primaryEmail: "no-project-context@example.org",
+      primaryPhone: null,
+    });
+    const latest = await seedInboxEmailEvent(runtime.context, {
+      id: "no-project-context-inbound",
+      contactId: "contact:no-project-context",
+      occurredAt: "2026-04-19T17:00:00.000Z",
+      direction: "inbound",
+      subject: "No project context",
+      snippet: "No project-linked event context.",
+      bodyTextPreview: "No project-linked event context.",
+      fromHeader: "No Project Context <no-project-context@example.org>",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:no-project-context",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-19T17:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-04-19T17:00:00.000Z",
+      snippet: "No project-linked event context.",
+      lastCanonicalEventId: latest.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+
+    const detail = await getInboxDetail("contact:no-project-context");
+
+    expect(detail?.contact.activeProjects).toHaveLength(0);
+    expect(detail?.conversationProject).toBeNull();
+  });
+
   it("filters pre-cutover timeline entries while keeping the cutover boundary inclusive", async () => {
     if (runtime === null) {
       throw new Error("Expected inbox test runtime");
@@ -2862,6 +2974,151 @@ describe("real inbox selectors", () => {
     });
   });
 
+  it("normalizes canonical inbound contact names instead of using inconsistent From headers", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    const cases = [
+      {
+        contactId: "contact:normalized-last-first",
+        displayName: "RUTLEDGE, JOE",
+        primaryEmail: "last-first@example.org",
+        fromHeader: "jrutle <last-first@example.org>",
+        expected: "Joe Rutledge",
+      },
+      {
+        contactId: "contact:normalized-all-caps",
+        displayName: "JOE RUTLEDGE",
+        primaryEmail: "all-caps@example.org",
+        fromHeader: "Joe rutledge <all-caps@example.org>",
+        expected: "Joe Rutledge",
+      },
+      {
+        contactId: "contact:normalized-lowercase",
+        displayName: "Joe rutledge",
+        primaryEmail: "lowercase@example.org",
+        fromHeader: "JOE RUTLEDGE <lowercase@example.org>",
+        expected: "Joe Rutledge",
+      },
+      {
+        contactId: "contact:normalized-username",
+        displayName: "jrutle",
+        primaryEmail: "username@example.org",
+        fromHeader: "JOE RUTLEDGE <username@example.org>",
+        expected: "jrutle",
+      },
+    ] as const;
+
+    for (const entry of cases) {
+      await seedInboxContact(runtime.context, {
+        contactId: entry.contactId,
+        salesforceContactId: null,
+        displayName: entry.displayName,
+        primaryEmail: entry.primaryEmail,
+        primaryPhone: null,
+      });
+      const latest = await seedInboxEmailEvent(runtime.context, {
+        id: `${entry.contactId}-latest`,
+        contactId: entry.contactId,
+        occurredAt: "2026-04-23T12:00:00.000Z",
+        direction: "inbound",
+        subject: "Author normalization",
+        snippet: "Testing author normalization.",
+        bodyTextPreview: "Testing author normalization.",
+        fromHeader: entry.fromHeader,
+      });
+      await seedInboxProjection(runtime.context, {
+        contactId: entry.contactId,
+        bucket: "New",
+        needsFollowUp: false,
+        hasUnresolved: false,
+        lastInboundAt: "2026-04-23T12:00:00.000Z",
+        lastOutboundAt: null,
+        lastActivityAt: "2026-04-23T12:00:00.000Z",
+        snippet: "Testing author normalization.",
+        lastCanonicalEventId: latest.canonicalEventId,
+        lastEventType: "communication.email.inbound",
+      });
+    }
+
+    const detailByContactId = new Map<string, Awaited<ReturnType<typeof getInboxDetail>>>(
+      await Promise.all(
+        cases.map(async (entry) => {
+          const detail = await getInboxDetail(entry.contactId);
+          return [entry.contactId, detail] as const;
+        }),
+      ),
+    );
+
+    expect(detailByContactId.get("contact:normalized-last-first")?.timeline.at(-1))
+      .toMatchObject({ actorLabel: "Joe Rutledge" });
+    expect(detailByContactId.get("contact:normalized-all-caps")?.timeline.at(-1))
+      .toMatchObject({ actorLabel: "Joe Rutledge" });
+    expect(detailByContactId.get("contact:normalized-lowercase")?.timeline.at(-1))
+      .toMatchObject({ actorLabel: "Joe Rutledge" });
+    expect(detailByContactId.get("contact:normalized-username")?.timeline.at(-1))
+      .toMatchObject({ actorLabel: "jrutle" });
+  });
+
+  it("uses a known sender contact record for inbound actor labels when the sender already exists", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:primary-thread",
+      salesforceContactId: null,
+      displayName: "Primary Thread",
+      primaryEmail: "primary-thread@example.org",
+      primaryPhone: null,
+    });
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:known-sender",
+      salesforceContactId: null,
+      displayName: "RUTLEDGE, JOE",
+      primaryEmail: "joe.sender@example.org",
+      primaryPhone: null,
+    });
+    await runtime.context.repositories.contactIdentities.upsert({
+      id: "identity:known-sender-email",
+      contactId: "contact:known-sender",
+      kind: "email",
+      normalizedValue: "joe.sender@example.org",
+      isPrimary: true,
+      source: "gmail",
+      verifiedAt: null,
+    });
+    const latest = await seedInboxEmailEvent(runtime.context, {
+      id: "known-sender-inbound",
+      contactId: "contact:primary-thread",
+      occurredAt: "2026-04-23T13:00:00.000Z",
+      direction: "inbound",
+      subject: "Known sender",
+      snippet: "Known sender body.",
+      bodyTextPreview: "Known sender body.",
+      fromHeader: "JOE RUTLEDGE <joe.sender@example.org>",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:primary-thread",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-23T13:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-04-23T13:00:00.000Z",
+      snippet: "Known sender body.",
+      lastCanonicalEventId: latest.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+
+    const detail = await getInboxDetail("contact:primary-thread");
+
+    expect(detail?.timeline.at(-1)).toMatchObject({
+      actorLabel: "Joe Rutledge",
+    });
+  });
+
   it("preserves Stage 1 timeline families instead of flattening them into generic system events", async () => {
     if (runtime === null) {
       throw new Error("Expected inbox test runtime");
@@ -3248,13 +3505,13 @@ describe("real inbox selectors", () => {
 
     expect(nullClassifiedEntry).toMatchObject({
       kind: "outbound-email",
-      actorLabel: "You",
+      actorLabel: "Adventure Scientists",
       channel: "email",
       body: "Logged Salesforce follow-up body.",
     });
     expect(explicitOneToOneEntry).toMatchObject({
       kind: "outbound-email",
-      actorLabel: "You",
+      actorLabel: "Adventure Scientists",
       channel: "email",
       body: "Explicit Salesforce one-to-one body.",
     });

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -8,6 +8,13 @@ vi.mock("next/cache", () => ({
   revalidateTag: vi.fn(),
 }));
 
+// Stub the session module so importing selectors.ts does not pull in
+// next-auth (and therefore `next/server`, which Node ESM cannot resolve
+// from inside next-auth's package layout in the test environment).
+vi.mock("@/src/server/auth/session", () => ({
+  getCurrentUser: vi.fn().mockResolvedValue(null),
+}));
+
 Object.assign(globalThis, { React });
 
 vi.mock("@/components/ui/button", () => ({

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -2002,9 +2002,11 @@ describe("real inbox selectors", () => {
     const detail = await getInboxDetail("contact:external-orcas");
 
     expect(detail?.contact.activeProjects).toHaveLength(0);
+    // loadProjectMetadataById prefers projectAlias over projectName
+    // (system convention — the alias is the operator-facing label).
     expect(detail?.conversationProject).toEqual({
       projectId: "project:orcas",
-      projectName: "Orca Listening Network",
+      projectName: "Orcas",
       source: "conversation",
     });
   });


### PR DESCRIPTION
## Summary

Two view-model fixes that share `selectors.ts`:

### C — Author labels (`Firstname Lastname` everywhere)

The same person was rendering as `Joe rutledge`, `jrutle`, `JOE RUTLEDGE` across messages because the From-header is operator-uncontrolled. Now:

- **Inbound 1:1 bubbles** prefer the canonical contact's `displayName`; fall back to a Title Cased form of the From-header (`LASTNAME, FIRSTNAME` → `Firstname Lastname`, `JOE RUTLEDGE` → `Joe Rutledge`)
- **Outbound 1:1 bubbles** use the operator's `displayName`; fall back to `Adventure Scientists`
- Automated/campaign labels untouched — those are system-generated and intentionally distinct

### G — Conversation project pill for external contacts

Sending FROM `orcas@adventurescientists.org` TO `nicolaskneler@gmail.com` showed "No active project" because the recipient has no SF membership. Now:

- New `conversationProject` field on `InboxContactDetailViewModel`, derived from the most recent canonical event's `project_id` when membership is empty
- Header pill prefers `activeProjects[0]` (membership) and falls back to `conversationProject`
- Conversation-derived pills render project name only with a `Via project alias` tooltip and no membership status (no membership = no status)

Closes round-2 items **C, G**.

## Test plan
- [ ] CI green
- [ ] Architect verifies in dev preview:
  - Same volunteer's bubbles in different forms now render as one Title Cased name
  - Send from orcas@ to nicolaskneler@gmail.com → conversation header shows "Orcas Project" pill (or whatever the project name is) with the via-alias tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)