### PR TITLE
feat(attachments): hide inline/signature images from the attachment rail

### DIFF
--- a/apps/gmail-capture/src/attachments.ts
+++ b/apps/gmail-capture/src/attachments.ts
@@ -55,6 +55,50 @@ const attachmentLogger: AttachmentLogger = {
   },
 };
 
+function normalizeContentId(value: string | null | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const normalized = trimmed.replace(/^<|>$/gu, "").toLowerCase();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function hasInlineContentDisposition(
+  contentDisposition: string | null | undefined,
+): boolean {
+  if (typeof contentDisposition !== "string") {
+    return false;
+  }
+
+  const dispositionType = contentDisposition.split(";")[0]?.trim().toLowerCase();
+  return dispositionType === "inline";
+}
+
+function isInlineAttachment(input: {
+  readonly attachment: {
+    readonly contentDisposition?: string | null;
+    readonly contentId?: string | null;
+  };
+  readonly htmlBodyCidReferences: ReadonlySet<string>;
+}): boolean {
+  if (hasInlineContentDisposition(input.attachment.contentDisposition)) {
+    return true;
+  }
+
+  const normalizedContentId = normalizeContentId(input.attachment.contentId);
+  return (
+    normalizedContentId !== null &&
+    input.htmlBodyCidReferences.has(normalizedContentId)
+  );
+}
+
 function decodeBase64Url(value: string): Buffer {
   const paddedValue =
     value.replace(/-/gu, "+").replace(/_/gu, "/") +
@@ -249,6 +293,12 @@ export async function syncGmailMessageAttachments(input: {
     const existingAttachmentIds = new Set(
       existingAttachments.map((attachment) => attachment.id),
     );
+    const htmlBodyCidReferences = new Set(
+      parsedRecord.data.htmlBodyCidReferences.flatMap((value) => {
+        const normalized = normalizeContentId(value);
+        return normalized === null ? [] : [normalized];
+      }),
+    );
     const rowsToInsert: {
       readonly id: string;
       readonly provider: "gmail";
@@ -257,6 +307,7 @@ export async function syncGmailMessageAttachments(input: {
       readonly filename: string | null;
       readonly sizeBytes: number;
       readonly storageKey: string;
+      readonly isInline: boolean;
     }[] = [];
 
     for (const attachment of parsedRecord.data.attachmentMetadata) {
@@ -333,6 +384,10 @@ export async function syncGmailMessageAttachments(input: {
         filename: attachment.filename,
         sizeBytes: cachedAttachment.sizeBytes,
         storageKey,
+        isInline: isInlineAttachment({
+          attachment,
+          htmlBodyCidReferences,
+        }),
       });
     }
 

--- a/apps/gmail-capture/test/attachments.test.ts
+++ b/apps/gmail-capture/test/attachments.test.ts
@@ -17,6 +17,9 @@ function buildGmailRecord(input: {
   readonly direction: "inbound" | "outbound";
   readonly recordId: string;
   readonly attachmentSizeBytes: number;
+  readonly contentDisposition?: string | null;
+  readonly contentId?: string | null;
+  readonly htmlBodyCidReferences?: readonly string[];
 }): GmailRecord {
   return {
     recordType: "message",
@@ -59,9 +62,47 @@ function buildGmailRecord(input: {
         filename: "field-photo.jpg",
         sizeBytes: input.attachmentSizeBytes,
         gmailAttachmentId: "gmail-attachment-1",
+        contentDisposition: input.contentDisposition ?? null,
+        contentId: input.contentId ?? null,
       },
     ],
+    htmlBodyCidReferences: [...(input.htmlBodyCidReferences ?? [])],
   };
+}
+
+function buildSuccessfulFetchImplementation(
+  attachmentBytes: Buffer,
+): typeof fetch {
+  return vi.fn((url: string | URL | Request) => {
+    const resolvedUrl =
+      typeof url === "string"
+        ? url
+        : url instanceof URL
+          ? url.toString()
+          : url.url;
+
+    if (resolvedUrl === "https://oauth2.googleapis.com/token") {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            access_token: "access-token",
+            expires_in: 3600,
+          }),
+          { status: 200 },
+        ),
+      );
+    }
+
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({
+          data: attachmentBytes.toString("base64url"),
+          size: attachmentBytes.length,
+        }),
+        { status: 200 },
+      ),
+    );
+  }) as unknown as typeof fetch;
 }
 
 describe("gmail attachment sync", () => {
@@ -160,6 +201,7 @@ describe("gmail attachment sync", () => {
           filename: "field-photo.jpg",
           sizeBytes: attachmentBytes.length,
           storageKey: buildGmailMessageAttachmentStorageKey(attachmentId),
+          isInline: false,
         },
       ]);
       await expect(
@@ -222,6 +264,158 @@ describe("gmail attachment sync", () => {
           buildSourceEvidenceId("gmail", "message", "gmail-inbound-oversize"),
         ]),
       ).resolves.toEqual([]);
+    } finally {
+      await context.dispose();
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("marks Content-Disposition inline attachments as inline", async () => {
+    const context = await createTestStage1Context();
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "gmail-attachments-"));
+    const attachmentBytes = Buffer.from("inline-image", "utf8");
+
+    try {
+      const record = buildGmailRecord({
+        direction: "inbound",
+        recordId: "gmail-inline-disposition-1",
+        attachmentSizeBytes: attachmentBytes.length,
+        contentDisposition: "inline; filename=\"image001.png\"",
+      });
+      const sourceEvidenceId = buildSourceEvidenceId(
+        "gmail",
+        "message",
+        "gmail-inline-disposition-1",
+      );
+
+      await syncGmailMessageAttachments({
+        records: [record],
+        repositories: context.repositories,
+        serviceConfig: {
+          liveAccount: "volunteers@example.org",
+          oauthClientId: "gmail-oauth-client-id",
+          oauthClientSecret: "gmail-oauth-client-secret",
+          oauthRefreshToken: "gmail-oauth-refresh-token",
+          tokenUri: "https://oauth2.googleapis.com/token",
+          timeoutMs: 15_000,
+        },
+        runtimeConfig: {
+          attachmentVolumePath: tempDir,
+          maxAttachmentBytesPerAttachment: 52_428_800,
+        },
+        fetchImplementation: buildSuccessfulFetchImplementation(attachmentBytes),
+      });
+
+      await expect(
+        context.repositories.messageAttachments.findByMessageIds([sourceEvidenceId]),
+      ).resolves.toMatchObject([
+        {
+          sourceEvidenceId,
+          isInline: true,
+        },
+      ]);
+    } finally {
+      await context.dispose();
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("marks Content-ID attachments referenced by sibling HTML as inline", async () => {
+    const context = await createTestStage1Context();
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "gmail-attachments-"));
+    const attachmentBytes = Buffer.from("cid-image", "utf8");
+
+    try {
+      const record = buildGmailRecord({
+        direction: "inbound",
+        recordId: "gmail-inline-cid-1",
+        attachmentSizeBytes: attachmentBytes.length,
+        contentId: "<abc@x>",
+        htmlBodyCidReferences: ["abc@x"],
+      });
+      const sourceEvidenceId = buildSourceEvidenceId(
+        "gmail",
+        "message",
+        "gmail-inline-cid-1",
+      );
+
+      await syncGmailMessageAttachments({
+        records: [record],
+        repositories: context.repositories,
+        serviceConfig: {
+          liveAccount: "volunteers@example.org",
+          oauthClientId: "gmail-oauth-client-id",
+          oauthClientSecret: "gmail-oauth-client-secret",
+          oauthRefreshToken: "gmail-oauth-refresh-token",
+          tokenUri: "https://oauth2.googleapis.com/token",
+          timeoutMs: 15_000,
+        },
+        runtimeConfig: {
+          attachmentVolumePath: tempDir,
+          maxAttachmentBytesPerAttachment: 52_428_800,
+        },
+        fetchImplementation: buildSuccessfulFetchImplementation(attachmentBytes),
+      });
+
+      await expect(
+        context.repositories.messageAttachments.findByMessageIds([sourceEvidenceId]),
+      ).resolves.toMatchObject([
+        {
+          sourceEvidenceId,
+          isInline: true,
+        },
+      ]);
+    } finally {
+      await context.dispose();
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps plain attachments non-inline when no inline MIME signals are present", async () => {
+    const context = await createTestStage1Context();
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "gmail-attachments-"));
+    const attachmentBytes = Buffer.from("plain-attachment", "utf8");
+
+    try {
+      const record = buildGmailRecord({
+        direction: "inbound",
+        recordId: "gmail-plain-attachment-1",
+        attachmentSizeBytes: attachmentBytes.length,
+        contentDisposition: "attachment; filename=\"field-photo.jpg\"",
+        contentId: "<not-referenced@example.org>",
+      });
+      const sourceEvidenceId = buildSourceEvidenceId(
+        "gmail",
+        "message",
+        "gmail-plain-attachment-1",
+      );
+
+      await syncGmailMessageAttachments({
+        records: [record],
+        repositories: context.repositories,
+        serviceConfig: {
+          liveAccount: "volunteers@example.org",
+          oauthClientId: "gmail-oauth-client-id",
+          oauthClientSecret: "gmail-oauth-client-secret",
+          oauthRefreshToken: "gmail-oauth-refresh-token",
+          tokenUri: "https://oauth2.googleapis.com/token",
+          timeoutMs: 15_000,
+        },
+        runtimeConfig: {
+          attachmentVolumePath: tempDir,
+          maxAttachmentBytesPerAttachment: 52_428_800,
+        },
+        fetchImplementation: buildSuccessfulFetchImplementation(attachmentBytes),
+      });
+
+      await expect(
+        context.repositories.messageAttachments.findByMessageIds([sourceEvidenceId]),
+      ).resolves.toMatchObject([
+        {
+          sourceEvidenceId,
+          isInline: false,
+        },
+      ]);
     } finally {
       await context.dispose();
       await rm(tempDir, { recursive: true, force: true });

--- a/apps/gmail-capture/test/internal-attachments-route.test.ts
+++ b/apps/gmail-capture/test/internal-attachments-route.test.ts
@@ -90,6 +90,7 @@ async function seedAttachment(input: {
         filename: input.filename ?? "field-photo.jpg",
         sizeBytes: input.sizeBytes,
         storageKey: input.storageKey,
+        isInline: false,
       },
     ],
   );

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -2240,13 +2240,15 @@ function buildTimelineEntry(input: {
       ? (
           input.attachmentsByCanonicalEventId.get(input.item.canonicalEventId) ??
           []
-        ).map((attachment) => ({
-          id: attachment.id,
-          mimeType: attachment.mimeType,
-          filename: attachment.filename,
-          sizeBytes: attachment.sizeBytes,
-          proxyUrl: `/api/attachments/${encodeURIComponent(attachment.id)}`,
-        }))
+        )
+          .filter((attachment) => !attachment.isInline)
+          .map((attachment) => ({
+            id: attachment.id,
+            mimeType: attachment.mimeType,
+            filename: attachment.filename,
+            sizeBytes: attachment.sizeBytes,
+            proxyUrl: `/api/attachments/${encodeURIComponent(attachment.id)}`,
+          }))
       : [];
 
   return {

--- a/apps/web/tests/unit/attachments-route.test.ts
+++ b/apps/web/tests/unit/attachments-route.test.ts
@@ -39,6 +39,7 @@ async function seedAttachmentFixture() {
     filename: "field-photo.jpg",
     sizeBytes: 5,
     storageKey: "gmail/ab/att:gmail:attachment-image-1:0/1",
+    isInline: false,
   });
 
   return runtime;

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -4796,6 +4796,7 @@ describe("real inbox selectors", () => {
       filename: "field-photo.jpg",
       sizeBytes: 1234,
       storageKey: "gmail/ab/att:gmail:attachment-email-1:0/1",
+      isInline: true,
     });
     await seedInboxMessageAttachment(runtime.context, {
       sourceEvidenceId: "source:attachment-email-1",
@@ -4820,15 +4821,8 @@ describe("real inbox selectors", () => {
     // (see packages/domain/src/timeline.ts loadTimelinePresentationContext)
     // so the selector — which already loads attachments — is the canonical
     // home for this assertion.
-    expect(detail?.timeline[0]?.attachmentCount).toBe(2);
+    expect(detail?.timeline[0]?.attachmentCount).toBe(1);
     expect(detail?.timeline[0]?.attachments).toEqual([
-      {
-        id: "att:gmail:attachment-email-1:0/1",
-        mimeType: "image/jpeg",
-        filename: "field-photo.jpg",
-        sizeBytes: 1234,
-        proxyUrl: "/api/attachments/att%3Agmail%3Aattachment-email-1%3A0%2F1",
-      },
       {
         id: "att:gmail:attachment-email-1:0/2",
         mimeType: "application/pdf",

--- a/apps/web/tests/unit/inbox-stage1-helpers.ts
+++ b/apps/web/tests/unit/inbox-stage1-helpers.ts
@@ -185,6 +185,7 @@ export async function seedInboxMessageAttachment(
     readonly sizeBytes: number;
     readonly storageKey: string;
     readonly gmailAttachmentId?: string;
+    readonly isInline?: boolean;
   },
 ): Promise<void> {
   await context.repositories.messageAttachments.upsertManyForMessage(
@@ -198,6 +199,7 @@ export async function seedInboxMessageAttachment(
         filename: input.filename,
         sizeBytes: input.sizeBytes,
         storageKey: input.storageKey,
+        isInline: input.isInline ?? false,
       },
     ],
   );

--- a/packages/contracts/src/stage1-records.ts
+++ b/packages/contracts/src/stage1-records.ts
@@ -309,6 +309,7 @@ export const messageAttachmentSchema = z.object({
   filename: nullableStringSchema,
   sizeBytes: z.number().int().nonnegative(),
   storageKey: z.string().min(1),
+  isInline: z.boolean(),
   createdAt: timestampSchema,
 });
 export type MessageAttachmentRecord = z.infer<typeof messageAttachmentSchema>;

--- a/packages/db/drizzle/0049_inline_attachments.sql
+++ b/packages/db/drizzle/0049_inline_attachments.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "message_attachments"
+ADD COLUMN "is_inline" boolean DEFAULT false NOT NULL;

--- a/packages/db/src/mappers.ts
+++ b/packages/db/src/mappers.ts
@@ -567,6 +567,7 @@ export function mapMessageAttachmentRow(
     filename: row.filename,
     sizeBytes: row.sizeBytes,
     storageKey: row.storageKey,
+    isInline: row.isInline,
     createdAt: row.createdAt.toISOString(),
   });
 }
@@ -585,6 +586,7 @@ export function mapMessageAttachmentToInsert(
     filename: parsed.filename,
     sizeBytes: parsed.sizeBytes,
     storageKey: parsed.storageKey,
+    isInline: parsed.isInline,
     createdAt: toDate(parsed.createdAt),
   };
 }

--- a/packages/db/src/schema/tables.ts
+++ b/packages/db/src/schema/tables.ts
@@ -297,6 +297,7 @@ export const messageAttachments = pgTable(
     filename: text("filename"),
     sizeBytes: bigint("size_bytes", { mode: "number" }).notNull(),
     storageKey: text("storage_key").notNull(),
+    isInline: boolean("is_inline").notNull().default(false),
     createdAt: createdAtColumn,
   },
   (table) => [index("message_attachments_source_idx").on(table.sourceEvidenceId)],

--- a/packages/db/test/stage1-repositories.test.ts
+++ b/packages/db/test/stage1-repositories.test.ts
@@ -465,6 +465,7 @@ describe("Stage 1 DB repositories", () => {
           filename: "field-photo.jpg",
           sizeBytes: 2048,
           storageKey: "gmail/ab/att:gmail:gmail-message-1:0",
+          isInline: false,
         },
       ],
     );
@@ -480,6 +481,7 @@ describe("Stage 1 DB repositories", () => {
         filename: "field-photo.jpg",
         sizeBytes: 2048,
         storageKey: "gmail/ab/att:gmail:gmail-message-1:0",
+        isInline: false,
       },
     ]);
     await expect(

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -221,6 +221,7 @@ export interface MessageAttachmentInsert {
   readonly filename: string | null;
   readonly sizeBytes: number;
   readonly storageKey: string;
+  readonly isInline: boolean;
 }
 
 export interface MessageAttachmentRepository {

--- a/packages/integrations/src/capture-services/gmail.ts
+++ b/packages/integrations/src/capture-services/gmail.ts
@@ -21,6 +21,7 @@ import {
 } from "../providers/gmail-record-builder.js";
 import {
   collectGmailAttachmentMetadata,
+  collectGmailHtmlCidReferences,
   extractDsnOriginalMessageId,
   extractGmailBodyPreviewFromPayloadResult,
   type GmailApiMessagePart
@@ -434,6 +435,12 @@ export async function mapLiveGmailMessageToRecord(input: {
     }
   );
   const attachmentMetadata = collectGmailAttachmentMetadata(input.message.payload);
+  const htmlBodyCidReferences = collectGmailHtmlCidReferences(
+    input.message.payload,
+    {
+      messageIdentifier: input.message.id,
+    }
+  );
   const previewMessageIdPattern =
     /Message-ID:\s*(<\d+\.[a-f0-9-]+@[a-z.]+>)/iu;
   const dsnOriginalMessageIdFromParts = isPossiblyDsn
@@ -453,6 +460,7 @@ export async function mapLiveGmailMessageToRecord(input: {
     snippetClean: input.message.snippet,
     ...bodyPreviewResult,
     attachmentMetadata,
+    htmlBodyCidReferences,
     internalDate: input.message.internalDate,
     headers,
     payloadRef: `gmail://${encodeURIComponent(input.capturedMailbox)}/messages/${encodeURIComponent(input.message.id)}`,

--- a/packages/integrations/src/providers/gmail-body.ts
+++ b/packages/integrations/src/providers/gmail-body.ts
@@ -83,6 +83,8 @@ export interface GmailAttachmentMetadata {
   readonly filename: string | null;
   readonly sizeBytes: number;
   readonly gmailAttachmentId: string;
+  readonly contentDisposition: string | null;
+  readonly contentId: string | null;
 }
 
 const ENCRYPTED_MESSAGE_PLACEHOLDER =
@@ -714,6 +716,8 @@ export function collectGmailAttachmentMetadata(
             part.filename?.trim().length ? part.filename.trim() : null,
           sizeBytes: Math.max(0, part.body?.size ?? 0),
           gmailAttachmentId,
+          contentDisposition: getPartHeader(part, "Content-Disposition"),
+          contentId: getPartHeader(part, "Content-ID"),
         });
       }
     }
@@ -728,6 +732,62 @@ export function collectGmailAttachmentMetadata(
   }
 
   return attachments;
+}
+
+function normalizeContentIdReference(value: string): string | null {
+  const trimmed = value.trim();
+
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const withoutAngleBrackets = trimmed.replace(/^<|>$/gu, "");
+  return withoutAngleBrackets.length > 0
+    ? withoutAngleBrackets.toLowerCase()
+    : null;
+}
+
+export function collectGmailHtmlCidReferences(
+  payload: GmailApiMessagePart,
+  options?: {
+    readonly messageIdentifier?: string | null;
+  },
+): readonly string[] {
+  const references = new Set<string>();
+  const context = createGmailMimeBudgetContext(options?.messageIdentifier);
+  const decodeState: GmailMimeDecodeState = {
+    decodedBytes: 0,
+    budgetExceeded: false,
+  };
+
+  function walk(part: GmailApiMessagePart, depth: number): void {
+    if (depth > context.bounds.maxDepth || decodeState.budgetExceeded) {
+      return;
+    }
+
+    const mimeType = normalizeMimeType(part.mimeType);
+
+    if (mimeType === "text/html" && !isAttachmentPart(part)) {
+      const decodedHtml = decodePartBodyToString(part, context, decodeState);
+
+      if (decodedHtml !== null) {
+        for (const match of decodedHtml.matchAll(/cid:([^"'\\\s>]+)/giu)) {
+          const normalized = normalizeContentIdReference(match[1] ?? "");
+
+          if (normalized !== null) {
+            references.add(normalized);
+          }
+        }
+      }
+    }
+
+    for (const childPart of part.parts ?? []) {
+      walk(childPart, depth + 1);
+    }
+  }
+
+  walk(payload, 0);
+  return [...references].sort((left, right) => left.localeCompare(right));
 }
 
 function collectCandidateBodyPartsInternal(

--- a/packages/integrations/src/providers/gmail-record-builder.ts
+++ b/packages/integrations/src/providers/gmail-record-builder.ts
@@ -30,6 +30,7 @@ export interface GmailProviderCloseMessageInput {
   readonly internalAddresses: readonly string[];
   readonly projectInboxAliases: readonly string[];
   readonly attachmentMetadata?: readonly GmailAttachmentMetadata[];
+  readonly htmlBodyCidReferences?: readonly string[];
   readonly projectInboxAliasOverride?: string | null;
   readonly treatCapturedMailboxAsProjectInbox?: boolean;
 }
@@ -273,5 +274,6 @@ export function buildGmailMessageRecord(
     crossProviderCollapseKey:
       rfc822MessageId === null ? null : `rfc822:${rfc822MessageId.toLowerCase()}`,
     attachmentMetadata: input.attachmentMetadata ?? [],
+    htmlBodyCidReferences: input.htmlBodyCidReferences ?? [],
   });
 }

--- a/packages/integrations/src/providers/gmail.ts
+++ b/packages/integrations/src/providers/gmail.ts
@@ -67,9 +67,12 @@ export const gmailMessageRecordSchema = z.object({
         filename: nullableStringSchema,
         sizeBytes: z.number().int().nonnegative(),
         gmailAttachmentId: z.string().min(1),
+        contentDisposition: nullableStringSchema.default(null),
+        contentId: nullableStringSchema.default(null),
       }),
     )
     .default([]),
+  htmlBodyCidReferences: stringArraySchema.default([]),
 });
 export type GmailMessageRecord = z.infer<typeof gmailMessageRecordSchema>;
 

--- a/packages/integrations/test/gmail-body-extraction.test.ts
+++ b/packages/integrations/test/gmail-body-extraction.test.ts
@@ -40,6 +40,7 @@ vi.mock("mailparser", async () => {
 import {
   cleanGmailBodyPreviewText,
   collectGmailAttachmentMetadata,
+  collectGmailHtmlCidReferences,
   extractDsnOriginalMessageId,
   extractGmailBodyPreviewFromMimeMessageResult,
   extractGmailBodyPreviewFromPayloadResult,
@@ -279,6 +280,8 @@ describe("Gmail body extraction", () => {
         filename: "field-photo.jpg",
         sizeBytes: 12_345,
         gmailAttachmentId: "att-image",
+        contentDisposition: null,
+        contentId: null,
       },
       {
         partIndexPath: "2",
@@ -286,8 +289,29 @@ describe("Gmail body extraction", () => {
         filename: "packet.pdf",
         sizeBytes: 98_765,
         gmailAttachmentId: "att-pdf",
+        contentDisposition: null,
+        contentId: null,
       },
     ]);
+  });
+
+  it("collects normalized cid references from html body parts", () => {
+    const payload: GmailApiMessagePart = {
+      mimeType: "multipart/alternative",
+      parts: [
+        {
+          mimeType: "text/html",
+          body: {
+            data: Buffer.from(
+              '<html><body><img src="cid:<ABC@x>"><img src="CID:def@x"></body></html>',
+              "utf8",
+            ).toString("base64url"),
+          },
+        },
+      ],
+    };
+
+    expect(collectGmailHtmlCidReferences(payload)).toEqual(["abc@x", "def@x"]);
   });
 
   it("treats a text/plain part containing decoded binary noise as a binary fallback", async () => {


### PR DESCRIPTION
## Summary

Inbound emails with HTML signatures (e.g. `image001.png` embedded as a `cid:` reference) currently render the signature image as a thumbnail in the attachment rail. That's not what operators mean by "this email has an attachment" — it's part of the body. This filters those out using a proper schema flag rather than a forever-fragile filename/size heuristic.

- **Schema:** new `message_attachments.is_inline` column (default `false`); migration `0049_inline_attachments.sql`. Existing rows stay false → render as today; the filter applies to messages re-captured after this lands
- **Capture (gmail-capture):** detects inline by either `Content-Disposition: inline` OR a `Content-ID` referenced via `cid:` in any sibling `text/html` part. Salesforce-captured rows stay `is_inline=false` (SF doesn't expose the same MIME structure cleanly)
- **View-model:** filters `is_inline=true` rows from `entry.attachments`; the proxy route still serves them on demand for future inline-rendering work
- **Contracts + repositories:** threaded the new field through `messageAttachmentSchema` and the Stage 1 repository

Closes round-2 item **B**.

## Migration

Auto-applies on next worker deploy (per #237). Forward-only; no backfill in this PR — opportunistic re-capture covers most live-Gmail messages over time. A one-off backfill ops script is a viable follow-up if older signature images keep showing up.

## Test plan
- [ ] CI green (`pnpm typecheck`, `pnpm lint`, `pnpm test:unit`)
- [ ] After deploy: receive a fresh email with an HTML signature → signature image no longer appears as a thumbnail; explicit attachment still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)