### PR TITLE
fix(inbox): server-resolve participant rows for the email bubble header

### DIFF
--- a/apps/web/app/inbox/_components/email-participant-header.tsx
+++ b/apps/web/app/inbox/_components/email-participant-header.tsx
@@ -10,7 +10,10 @@ import {
 import { cn } from "@/lib/utils";
 import { FOCUS_RING, TRANSITION, TYPE } from "@/app/_lib/design-tokens-v2";
 
-import type { InboxTimelineEntryViewModel } from "../_lib/view-models";
+import type {
+  InboxTimelineEntryParticipantRowViewModel,
+  InboxTimelineEntryViewModel,
+} from "../_lib/view-models";
 import { ArrowRightIcon, ChevronDownIcon, MailIcon } from "./icons";
 
 const WRAP_ANYWHERE = "break-words [overflow-wrap:anywhere]";
@@ -28,42 +31,25 @@ function formatExactTimestamp(timestamp: string): string {
   return EXACT_TIMESTAMP_FORMATTER.format(new Date(timestamp));
 }
 
-function normalizeHeaderValue(value: string | null): string | null {
-  if (value === null) {
-    return null;
+/**
+ * Pick the compact-row label for the `<sender> → <recipient>` summary
+ * line. Falls through `name` → `email` so we never blank a half. The
+ * server-side resolver in `selectors.ts` already nulls `name` out when
+ * we'd otherwise render `email <email>`.
+ */
+function compactLabel(
+  row: InboxTimelineEntryParticipantRowViewModel | undefined,
+): string {
+  if (row === undefined) {
+    return "";
   }
-
-  const trimmed = value.trim();
-  return trimmed.length === 0 ? null : trimmed;
-}
-
-function splitHeaderValue(value: string): {
-  readonly primary: string;
-  readonly subdued: string | null;
-} {
-  const match = /^(.*?)(\s*<[^>]+>)$/u.exec(value);
-
-  if (!match) {
-    return { primary: value, subdued: null };
+  if (row.name !== null && row.name.length > 0) {
+    return row.name;
   }
-
-  const primary = match[1] ?? value;
-  const subdued = match[2] ?? null;
-  return {
-    primary: primary.trimEnd(),
-    subdued: subdued?.trimStart() ?? null,
-  };
-}
-
-function extractDisplayName(value: string | null): string | null {
-  const normalized = normalizeHeaderValue(value);
-
-  if (normalized === null) {
-    return null;
+  if (row.email !== null && row.email.length > 0) {
+    return row.email;
   }
-
-  const stripped = normalized.replace(/\s*<[^>]+>\s*/g, "").trim();
-  return stripped.length === 0 ? normalized : stripped;
+  return "";
 }
 
 function RelativeTimestamp({
@@ -94,20 +80,15 @@ function RelativeTimestamp({
 
 export function EmailParticipantHeader({
   entry,
-  direction = "inbound",
   tone = "slate",
 }: {
   readonly entry: InboxTimelineEntryViewModel;
   /**
-   * Drives the bubble-header label swap:
-   *   outbound → "<projectAlias> → <volunteer>"
-   *   inbound  → "<volunteer> → <projectAlias>"
-   *
-   * The MessageBubble already knows the direction; passing it here keeps
-   * the header dumb (no tone-as-direction guessing) and lets the
-   * pre-resolved labels from `selectors.ts` fall through.
+   * Tone drives the border / Cc-pill background colors. Direction is
+   * NOT passed any more — the server-side `participantRows` already
+   * bake direction into the From/To resolution, so the component just
+   * renders `[0].name → [1].name`.
    */
-  readonly direction?: "inbound" | "outbound";
   readonly tone?: "slate" | "sky";
 }) {
   const [expanded, setExpanded] = useState(false);
@@ -117,54 +98,13 @@ export function EmailParticipantHeader({
     return null;
   }
 
-  const projectLabel = entry.headerProjectLabel ?? null;
-  const recipientLabelFallback =
-    entry.recipientLabel ??
-    extractDisplayName(entry.toHeader) ??
-    normalizeHeaderValue(entry.toHeader);
-  const fromHeaderName = extractDisplayName(entry.fromHeader);
+  const rows = entry.participantRows ?? [];
+  const fromRow = rows[0];
+  const toRow = rows[1];
+  const sender = compactLabel(fromRow);
+  const recipient = compactLabel(toRow);
+  const hasCc = rows.some((row) => row.label === "Cc");
 
-  // Outbound: projectAlias on the left (us, sending FROM the alias),
-  // volunteer name on the right.
-  // Inbound:  volunteer name on the left, projectAlias on the right
-  // (the operator inbox the volunteer wrote TO).
-  // Outbound: prefer the resolved project alias (e.g. "PNW Biodiversity"),
-  // then the From-header's display name (handles legacy / non-aliased
-  // sends), then the operator's actorLabel as a final fallback.
-  // Inbound: actorLabel was already normalized server-side (canonical
-  // contact display name in Title Case), so use it directly. The raw
-  // From-header is only consulted if actorLabel is empty.
-  const sender =
-    direction === "outbound"
-      ? (projectLabel ?? fromHeaderName ?? entry.actorLabel)
-      : entry.actorLabel.length > 0
-        ? entry.actorLabel
-        : (fromHeaderName ?? entry.actorLabel);
-  const recipient =
-    direction === "outbound"
-      ? recipientLabelFallback
-      : (projectLabel ?? recipientLabelFallback);
-
-  const rows = [
-    {
-      label: "From",
-      value: normalizeHeaderValue(entry.fromHeader) ?? entry.actorLabel,
-    },
-    {
-      label: "To",
-      value: normalizeHeaderValue(entry.toHeader) ?? recipientLabelFallback,
-    },
-    { label: "Cc", value: entry.ccHeader },
-  ].filter(
-    (
-      row,
-    ): row is {
-      readonly label: "From" | "To" | "Cc";
-      readonly value: string;
-    } => row.value !== null,
-  );
-
-  const hasCc = entry.ccHeader !== null && entry.ccHeader.trim().length > 0;
   const headerBorderClass =
     tone === "sky" ? "border-sky-100/60" : "border-slate-100";
   const detailBorderClass =
@@ -236,29 +176,47 @@ export function EmailParticipantHeader({
         className={cn("border-b px-4 py-2", detailBorderClass)}
       >
         <dl className="space-y-0.5 text-[11.5px] leading-relaxed text-slate-600">
-          {rows.map((row) => {
-            const parts = splitHeaderValue(row.value);
-
-            return (
-              <div
-                key={row.label}
-                className="grid grid-cols-[2.5rem_minmax(0,1fr)] gap-2"
-              >
-                <dt className="text-slate-400">{row.label}</dt>
-                <dd className={cn("min-w-0 text-slate-700", WRAP_ANYWHERE)}>
-                  <span>{parts.primary}</span>
-                  {parts.subdued ? (
-                    <>
-                      {parts.primary.length > 0 ? " " : null}
-                      <span className="text-slate-400">{parts.subdued}</span>
-                    </>
-                  ) : null}
-                </dd>
-              </div>
-            );
-          })}
+          {rows.map((row) => (
+            <ParticipantRowDetail key={row.label} row={row} />
+          ))}
         </dl>
       </CollapsibleContent>
     </Collapsible>
+  );
+}
+
+/**
+ * Expanded debug-row renderer. Format: `<name> <email>`. When `name`
+ * is null or equals the email, render only `<email>`. When `email` is
+ * null, render only the `name`. Cc rows currently arrive as a single
+ * verbatim header string in `name` with `email = null` — per-address
+ * parsing is a follow-up.
+ */
+function ParticipantRowDetail({
+  row,
+}: {
+  readonly row: InboxTimelineEntryParticipantRowViewModel;
+}) {
+  const name = row.name?.trim() ?? "";
+  const email = row.email?.trim() ?? "";
+  const showName = name.length > 0 && name !== email;
+  const showEmail = email.length > 0;
+
+  return (
+    <div className="grid grid-cols-[2.5rem_minmax(0,1fr)] gap-2">
+      <dt className="text-slate-400">{row.label}</dt>
+      <dd className={cn("min-w-0 text-slate-700", WRAP_ANYWHERE)}>
+        {showName ? <span>{name}</span> : null}
+        {showEmail ? (
+          <>
+            {showName ? " " : null}
+            <span className="text-slate-400">{`<${email}>`}</span>
+          </>
+        ) : null}
+        {!showName && !showEmail ? (
+          <span className="text-slate-400">—</span>
+        ) : null}
+      </dd>
+    </div>
   );
 }

--- a/apps/web/app/inbox/_components/email-participant-header.tsx
+++ b/apps/web/app/inbox/_components/email-participant-header.tsx
@@ -52,6 +52,88 @@ function compactLabel(
   return "";
 }
 
+const HEADER_EMAIL_PATTERN = /<\s*([^>\s]+@[^>\s]+)\s*>/u;
+const PLAIN_EMAIL_PATTERN = /^[^\s<>"]+@[^\s<>"]+\.[^\s<>"]+$/u;
+
+function extractDisplayNameRaw(value: string | null): string | null {
+  if (value === null) {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  const stripped = trimmed.replace(/\s*<[^>]+>\s*/g, "").trim();
+  if (stripped.length === 0) {
+    return null;
+  }
+  if (PLAIN_EMAIL_PATTERN.test(stripped)) {
+    return null;
+  }
+  return stripped.replace(/^["']|["']$/g, "").trim() || null;
+}
+
+function extractEmailFromHeader(value: string | null): string | null {
+  if (value === null) {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  const angle = HEADER_EMAIL_PATTERN.exec(trimmed)?.[1];
+  if (angle !== undefined && angle.length > 0) {
+    return angle;
+  }
+  if (PLAIN_EMAIL_PATTERN.test(trimmed)) {
+    return trimmed;
+  }
+  return null;
+}
+
+/**
+ * When the view-model didn't supply pre-resolved `participantRows`
+ * (e.g. test fixtures, hand-rolled entries, or in-flight optimistic
+ * outbound entries before the selector has touched them), build the
+ * minimum viable rows from the raw header fields so the bubble still
+ * renders something. This is a defense-in-depth fallback — production
+ * entries always come with `participantRows` populated.
+ */
+function deriveParticipantRowsFromRawHeaders(
+  entry: InboxTimelineEntryViewModel,
+): readonly InboxTimelineEntryParticipantRowViewModel[] {
+  const rows: InboxTimelineEntryParticipantRowViewModel[] = [];
+
+  const fromName = extractDisplayNameRaw(entry.fromHeader) ?? entry.actorLabel;
+  rows.push({
+    label: "From",
+    name: fromName.length > 0 ? fromName : null,
+    email: extractEmailFromHeader(entry.fromHeader),
+  });
+
+  const toName =
+    entry.recipientLabel ??
+    extractDisplayNameRaw(entry.toHeader) ??
+    entry.headerProjectLabel ??
+    null;
+  rows.push({
+    label: "To",
+    name: toName !== null && toName.length > 0 ? toName : null,
+    email:
+      extractEmailFromHeader(entry.toHeader) ?? entry.mailbox ?? null,
+  });
+
+  if (entry.ccHeader !== null && entry.ccHeader.trim().length > 0) {
+    rows.push({
+      label: "Cc",
+      name: entry.ccHeader.trim(),
+      email: null,
+    });
+  }
+
+  return rows;
+}
+
 function RelativeTimestamp({
   timestamp,
   label,
@@ -98,7 +180,10 @@ export function EmailParticipantHeader({
     return null;
   }
 
-  const rows = entry.participantRows ?? [];
+  const rows =
+    entry.participantRows !== undefined && entry.participantRows.length > 0
+      ? entry.participantRows
+      : deriveParticipantRowsFromRawHeaders(entry);
   const fromRow = rows[0];
   const toRow = rows[1];
   const sender = compactLabel(fromRow);

--- a/apps/web/app/inbox/_components/inbox-timeline-bubble.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-bubble.tsx
@@ -422,7 +422,6 @@ export function MessageBubble({
           {isEmail ? (
             <EmailParticipantHeader
               entry={entry}
-              direction={isOutbound ? "outbound" : "inbound"}
               tone={isOutbound ? "sky" : "slate"}
             />
           ) : null}

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -34,6 +34,7 @@ import type {
   InboxRecentActivityViewModel,
   InboxTimelineCampaignActivityViewModel,
   InboxTimelineEntryKind,
+  InboxTimelineEntryParticipantRowViewModel,
   InboxTimelineEntryViewModel,
   InboxVolunteerStage,
   InboxWelcomeWorkloadViewModel,
@@ -1853,7 +1854,14 @@ function timelineActorLabel(
         ? ""
         : normalizeDisplayName(canonicalContactDisplayName);
 
-    if (normalizedCanonicalContactName.length > 0) {
+    // Skip the canonical lookup when the stored displayName is just the
+    // email itself (placeholder for email-only contacts). The From
+    // header on inbound usually carries the sender's real name —
+    // prefer that over a degraded stored value.
+    if (
+      normalizedCanonicalContactName.length > 0 &&
+      !isEmailLikeName(normalizedCanonicalContactName)
+    ) {
       return normalizedCanonicalContactName;
     }
 
@@ -1862,12 +1870,17 @@ function timelineActorLabel(
       const normalizedSenderLabel =
         senderLabel === null ? "" : normalizeDisplayName(senderLabel);
 
-      if (normalizedSenderLabel.length > 0) {
+      if (
+        normalizedSenderLabel.length > 0 &&
+        !isEmailLikeName(normalizedSenderLabel)
+      ) {
         return normalizedSenderLabel;
       }
     }
 
-    return normalizeDisplayName(contactDisplayName) || contactDisplayName;
+    const fallback =
+      normalizeDisplayName(contactDisplayName) || contactDisplayName;
+    return fallback;
   }
 
   if (kind === "inbound-sms") {
@@ -1929,6 +1942,27 @@ function titleCaseSimpleToken(token: string): string {
   }
 
   return `${token[0]?.toUpperCase() ?? ""}${token.slice(1).toLowerCase()}`;
+}
+
+/**
+ * Treats `local@host.tld`-shaped strings as "we don't actually have a
+ * real name for this person" — used so we never render `email <email>`
+ * in the bubble header AND so a contact whose stored displayName
+ * happens to be the email itself doesn't short-circuit the From-header
+ * fallback chain. Conservative on whitespace: any space disqualifies.
+ */
+function isEmailLikeName(value: string | null | undefined): boolean {
+  if (value === null || value === undefined) {
+    return false;
+  }
+
+  const trimmed = value.trim();
+
+  if (trimmed.length === 0) {
+    return false;
+  }
+
+  return /^\S+@\S+\.\S+$/u.test(trimmed);
 }
 
 function normalizeDisplayName(raw: string): string {
@@ -2448,10 +2482,177 @@ function buildTimelineEntry(input: {
             projectLabelByAlias: input.projectLabelByAlias,
           })
         : null,
+    ...(input.item.family === "one_to_one_email"
+      ? {
+          participantRows: buildParticipantRows({
+            item: input.item,
+            contactDisplayName: input.contactDisplayName,
+            contactDisplayNameByEmail: input.contactDisplayNameByEmail,
+            projectLabelByAlias: input.projectLabelByAlias,
+            operatorDisplayName: input.operatorDisplayName,
+            headerProjectLabel: resolveHeaderProjectLabel({
+              item: input.item,
+              projectLabelByAlias: input.projectLabelByAlias,
+            }),
+          }),
+        }
+      : {}),
     noteId: input.item.family === "internal_note" ? input.item.noteId : null,
     authorId:
       input.item.family === "internal_note" ? input.item.authorId : null,
   };
+}
+
+/**
+ * Resolve a single bubble-header participant slot ("From"/"To"
+ * volunteer side, never the project side) to a `name` (or null when
+ * we have nothing better than the email itself). Order: known-contact
+ * lookup by email, header display name, conversation-contact display
+ * name. Each candidate is rejected when it looks like a bare email
+ * (`isEmailLikeName`) so we never echo `email <email>` in the UI.
+ */
+function resolveVolunteerParticipantName(input: {
+  readonly emailAddress: string | null;
+  readonly headerDisplayName: string | null;
+  readonly contactDisplayNameByEmail: ReadonlyMap<string, string>;
+  readonly conversationContactDisplayName: string;
+}): string | null {
+  if (input.emailAddress !== null) {
+    const lookup = input.contactDisplayNameByEmail.get(input.emailAddress);
+    if (
+      lookup !== undefined &&
+      lookup.length > 0 &&
+      !isEmailLikeName(lookup)
+    ) {
+      const normalized = normalizeDisplayName(lookup);
+      if (normalized.length > 0) {
+        return normalized;
+      }
+    }
+  }
+
+  if (input.headerDisplayName !== null) {
+    const normalized = normalizeDisplayName(input.headerDisplayName);
+    if (normalized.length > 0 && !isEmailLikeName(normalized)) {
+      return normalized;
+    }
+  }
+
+  if (
+    input.conversationContactDisplayName.length > 0 &&
+    !isEmailLikeName(input.conversationContactDisplayName)
+  ) {
+    const normalized = normalizeDisplayName(
+      input.conversationContactDisplayName,
+    );
+    if (normalized.length > 0) {
+      return normalized;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Build the From / To / (optional Cc) rows that drive both the
+ * compact bubble header and the expanded debug view. Direction is
+ * baked in so the component can render
+ * `participantRows[0].name → participantRows[1].name` without
+ * branching: the From slot for outbound is the project alias, for
+ * inbound it is the volunteer's resolved name (and vice versa for
+ * To). When toHeader is missing on an inbound capture the To row
+ * falls back to `item.mailbox` so we never render an empty right
+ * side.
+ */
+function buildParticipantRows(input: {
+  readonly item: Extract<TimelineItem, { family: "one_to_one_email" }>;
+  readonly contactDisplayName: string;
+  readonly contactDisplayNameByEmail: ReadonlyMap<string, string>;
+  readonly projectLabelByAlias: ReadonlyMap<string, string>;
+  readonly operatorDisplayName: string;
+  readonly headerProjectLabel: string | null;
+}): readonly InboxTimelineEntryParticipantRowViewModel[] {
+  const fromEmail = participantHeaderEmail(input.item.fromHeader ?? null);
+  const toEmail = participantHeaderEmail(input.item.toHeader ?? null);
+  const fromHeaderDisplayName = participantHeaderLabel(
+    input.item.fromHeader ?? null,
+  );
+  const toHeaderDisplayName = participantHeaderLabel(
+    input.item.toHeader ?? null,
+  );
+  const normalizedOperator = normalizeDisplayName(input.operatorDisplayName);
+  const operatorLabel =
+    normalizedOperator.length > 0 ? normalizedOperator : "Adventure Scientists";
+
+  const rows: InboxTimelineEntryParticipantRowViewModel[] = [];
+
+  if (input.item.direction === "outbound") {
+    // For outbound the From slot holds whatever the operator was
+    // sending AS. Order: resolved project alias → whatever display
+    // name appears on the wire (handles legacy / non-aliased sends
+    // like "PNW Project <pnwbio@…>") → operator name → fallback.
+    const fromHeaderName =
+      fromHeaderDisplayName !== null &&
+      !isEmailLikeName(fromHeaderDisplayName)
+        ? normalizeDisplayName(fromHeaderDisplayName) || fromHeaderDisplayName
+        : null;
+    rows.push({
+      label: "From",
+      name: input.headerProjectLabel ?? fromHeaderName ?? operatorLabel,
+      email: fromEmail,
+    });
+    rows.push({
+      label: "To",
+      name: resolveVolunteerParticipantName({
+        emailAddress: toEmail,
+        headerDisplayName:
+          toHeaderDisplayName !== null && !isEmailLikeName(toHeaderDisplayName)
+            ? toHeaderDisplayName
+            : null,
+        contactDisplayNameByEmail: input.contactDisplayNameByEmail,
+        conversationContactDisplayName: input.contactDisplayName,
+      }),
+      email: toEmail,
+    });
+  } else {
+    rows.push({
+      label: "From",
+      name: resolveVolunteerParticipantName({
+        emailAddress: fromEmail,
+        headerDisplayName:
+          fromHeaderDisplayName !== null &&
+          !isEmailLikeName(fromHeaderDisplayName)
+            ? fromHeaderDisplayName
+            : null,
+        contactDisplayNameByEmail: input.contactDisplayNameByEmail,
+        conversationContactDisplayName: input.contactDisplayName,
+      }),
+      email: fromEmail,
+    });
+    // Inbound captures sometimes drop the To header (older
+    // Salesforce-derived items, mbox imports). Fall back to the
+    // captured `mailbox` so the compact header always has a right
+    // side and the expanded view always shows a To row.
+    const inboundToEmail = toEmail ?? input.item.mailbox ?? null;
+    rows.push({
+      label: "To",
+      name: input.headerProjectLabel,
+      email: inboundToEmail,
+    });
+  }
+
+  if (
+    input.item.ccHeader !== null &&
+    input.item.ccHeader.trim().length > 0
+  ) {
+    rows.push({
+      label: "Cc",
+      name: input.item.ccHeader.trim(),
+      email: null,
+    });
+  }
+
+  return rows;
 }
 
 /**

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -183,6 +183,12 @@ export interface InboxTimelineCampaignActivityViewModel {
   readonly label: string;
 }
 
+export interface InboxTimelineEntryParticipantRowViewModel {
+  readonly label: "From" | "To" | "Cc";
+  readonly name: string | null;
+  readonly email: string | null;
+}
+
 export interface InboxTimelineEntryViewModel {
   readonly id: string;
   readonly kind: InboxTimelineEntryKind;
@@ -209,6 +215,21 @@ export interface InboxTimelineEntryViewModel {
    * without the bubble component needing access to the alias map.
    */
   readonly headerProjectLabel?: string | null;
+  /**
+   * Pre-resolved bubble-header rows for email entries. Always emits a
+   * From and a To row even when one side of the captured header is
+   * missing — the bubble's compact header reads
+   * `participantRows[0].name → participantRows[1].name` regardless of
+   * direction; the expanded debug view renders each row as
+   * `<name> <email>` (or just `<email>` when the resolver couldn't
+   * find a real name). `email` is null when only a label is known
+   * (e.g. a project alias without a captured alias address).
+   *
+   * Cc, when present, is appended as a single row with the raw
+   * comma-separated header in `name` and `email = null`. Per-address
+   * parsing is a future follow-up.
+   */
+  readonly participantRows?: readonly InboxTimelineEntryParticipantRowViewModel[];
   readonly ccHeader: string | null;
   readonly mailbox: string | null;
   readonly threadId: string | null;


### PR DESCRIPTION
## Summary

Three issues the user surfaced after #267 landed:

1. **`nicolaskneler@gmail.com` rendered instead of "Nicolás Kneler".** Email-only contacts have their email stored as `displayName` as a placeholder. `timelineActorLabel` saw a non-empty canonical name and stopped — the From-header's real display name was never consulted.
2. **Inbound bubbles with no `toHeader`** rendered an empty right side in the compact header AND dropped the To row from the expanded view (mbox imports, some Salesforce-derived items).
3. **Expanded From/To/Cc rows passed raw header strings.** Either "Adventure Scientists" with no email, or `<naico777ml@gmail.com>` with no name. Spec calls for `<name> <email>` per participant.

## Approach

- New `isEmailLikeName(v)` helper. `timelineActorLabel` skips a stored displayName when it matches the email shape, falling through to the From-header.
- New `participantRows` field on email view-models, server-resolved by `buildParticipantRows`. Direction is **baked into** the rows: outbound `[From=projectAlias, To=volunteer]`, inbound `[From=volunteer, To=projectAlias]`. Compact header just reads `[0].name → [1].name` regardless of direction. To row falls back to `item.mailbox` when `toHeader` is missing on inbound.
- `EmailParticipantHeader` rewritten to read `participantRows`. Compact header and expanded debug rows share the same data. Expanded format: `<name> <email>` per row; `<email>` alone when no real name is known; `name` alone when no email is captured. `direction` prop dropped — no longer needed in the component.

## Decisions locked (per architect-user thread)

- Outbound to email-only recipients with no resolvable name → bare email. Contact-displayName backfill on inbound capture is a follow-up.
- Outbound from non-aliased shared mailbox keeps "Adventure Scientists" / operator name.
- Email-as-name heuristic: `^\S+@\S+\.\S+$`.
- Cc renders as a single verbatim row; per-address parsing is a follow-up.

## Files changed
- `apps/web/app/inbox/_lib/view-models.ts` — new `InboxTimelineEntryParticipantRowViewModel` + `participantRows` field
- `apps/web/app/inbox/_lib/selectors.ts` — `isEmailLikeName`, updated `timelineActorLabel`, new `resolveVolunteerParticipantName` + `buildParticipantRows`, threading `participantRows` into the entry build
- `apps/web/app/inbox/_components/email-participant-header.tsx` — rewritten to render `participantRows`
- `apps/web/app/inbox/_components/inbox-timeline-bubble.tsx` — drops the no-longer-needed `direction` prop

## Test plan
- [ ] CI green
- [ ] Open Daniel Locke's thread → inbound bubble shows `Daniel Locke → PNW Biodiversity` (or whatever alias is resolved); expanded view has both From and To rows with `<email>`
- [ ] Open the nicolaskneler@gmail.com self-test thread → inbound bubble shows `Nicolás Kneler → Adventure Scientists` (or project alias if email was sent to one), expanded shows the email next to each name
- [ ] Outbound bubble from a project alias → `<projectAlias> → <Recipient Name>`; bare email when recipient is email-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)