### PR TITLE
fix(inbox): bubble header data fallbacks + match canon header sizing

### DIFF
--- a/apps/web/app/_lib/design-tokens-v2.ts
+++ b/apps/web/app/_lib/design-tokens-v2.ts
@@ -194,8 +194,10 @@ export const TRANSITION = {
 } as const;
 
 export const LAYOUT = {
-  /** Shared header height for list, detail, and rail */
-  headerHeight: "h-[65px]",
+  /** Compact title/header bar for list, detail, and rail */
+  headerHeight: "h-[54px]",
+  /** Welcome dashboard header spans the list title and search bands */
+  welcomeHeaderHeight: "h-[102px]",
   /** Inbox list column width */
   listWidth: "w-[22rem]",
   /** Contact rail width */

--- a/apps/web/app/inbox/_components/email-participant-header.tsx
+++ b/apps/web/app/inbox/_components/email-participant-header.tsx
@@ -115,7 +115,7 @@ function deriveParticipantRowsFromRawHeaders(
     entry.recipientLabel ??
     extractDisplayNameRaw(entry.toHeader) ??
     entry.headerProjectLabel ??
-    null;
+    (entry.kind === "inbound-email" ? "Adventure Scientists" : null);
   rows.push({
     label: "To",
     name: toName !== null && toName.length > 0 ? toName : null,

--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -514,21 +514,21 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
 
       <section className="flex min-w-0 flex-1 flex-col border-r border-slate-200 bg-white">
         <header
-          className={`flex ${LAYOUT.headerHeight} items-center justify-between gap-4 border-b border-slate-200 px-6`}
+          className={`flex ${LAYOUT.headerHeight} items-center justify-between gap-4 border-b border-slate-200 px-5`}
         >
-          <div className="flex min-w-0 items-center gap-4">
+          <div className="flex min-w-0 items-center gap-3.5">
             <InboxAvatar
               initials={detail.initials}
               tone={detail.avatarTone}
-              size="md"
+              size="sm"
+              className="size-7 text-[11px]"
             />
-            <h1 className={`truncate ${TYPE.headingLg}`}>
-              {contact.displayName}
-            </h1>
-            <div className="hidden h-5 w-px bg-slate-200 sm:block" />
-            <div className="hidden min-w-0 flex-1 sm:block">
+            <div className="min-w-0">
+              <h1 className={`truncate ${TYPE.headingMd}`}>
+                {contact.displayName}
+              </h1>
               {headerProject ? (
-                <div className="flex min-w-0 items-center gap-2 text-xs">
+                <div className="mt-0.5 flex min-w-0 items-center gap-2 text-xs">
                   <span
                     className="min-w-0 truncate font-medium text-slate-700"
                     title={
@@ -586,12 +586,12 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
                 <TooltipTrigger asChild>
                   <Button
                     type="button"
-                    variant="outline"
+                    variant="ghost"
                     size="icon"
                     disabled={isMarkUnreadPending}
                     onClick={handleMarkUnread}
                     aria-label="Mark as unread"
-                    className="size-8"
+                    className="size-8 text-slate-800 hover:bg-slate-100 hover:text-slate-950"
                     data-inbox-mark-unread="true"
                   >
                     <MailOpenIcon className="size-4" />
@@ -604,20 +604,20 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
                 <PopoverTrigger asChild>
                   {existingReminder ? (
                     <Button
-                      variant="outline"
+                      variant="ghost"
                       size="sm"
                       aria-label="Set reminder"
                       title="Set reminder"
-                      className="gap-1.5 border-sky-300 bg-sky-50 text-sky-800 hover:bg-sky-100 hover:text-sky-800"
+                      className="gap-1.5 bg-sky-50 text-sky-800 hover:bg-sky-100 hover:text-sky-800"
                     >
                       <ClockIcon className="size-3.5" />
                       Reminder · {formatShortReminder(existingReminder)}
                     </Button>
                   ) : (
                     <Button
-                      variant="outline"
+                      variant="ghost"
                       size="icon"
-                      className="size-8"
+                      className="size-8 text-slate-800 hover:bg-slate-100 hover:text-slate-950"
                       aria-label="Set reminder"
                       title="Set reminder"
                     >
@@ -645,9 +645,9 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
                 <TooltipTrigger asChild>
                   <Button
                     type="button"
-                    variant="outline"
+                    variant="ghost"
                     size="icon"
-                    className="size-8"
+                    className="size-8 text-slate-800 hover:bg-slate-100 hover:text-slate-950"
                     aria-label={
                       detail.isArchived
                         ? "Move back to inbox"
@@ -674,9 +674,9 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button
-                      variant="outline"
+                      variant="ghost"
                       size="icon"
-                      className="size-8"
+                      className="size-8 text-slate-800 hover:bg-slate-100 hover:text-slate-950"
                       aria-label="Toggle contact details"
                       aria-expanded={false}
                       aria-controls="inbox-contact-rail"
@@ -801,7 +801,7 @@ function FollowUpToggleButton({
   return (
     <Button
       type="button"
-      variant="outline"
+      variant="ghost"
       size="icon"
       disabled={pending}
       aria-pressed={needsFollowUp}
@@ -810,9 +810,9 @@ function FollowUpToggleButton({
       data-inbox-follow-up-toggle="true"
       onClick={onToggle}
       className={cn(
-        "size-8",
+        "size-8 text-slate-800 hover:bg-slate-100 hover:text-slate-950",
         needsFollowUp &&
-          "border-rose-300 bg-rose-50 text-rose-800 hover:bg-rose-100 hover:text-rose-800",
+          "bg-rose-50 text-rose-800 hover:bg-rose-100 hover:text-rose-800",
       )}
     >
       <FlagIcon className="size-4" />

--- a/apps/web/app/inbox/_components/inbox-list.tsx
+++ b/apps/web/app/inbox/_components/inbox-list.tsx
@@ -531,9 +531,9 @@ export function InboxList({
     >
       <div className="sticky top-0 z-10 bg-white/95 backdrop-blur">
         <div
-          className={`flex ${LAYOUT.headerHeight} items-center gap-2 border-b border-slate-200 px-5`}
+          className={`flex ${LAYOUT.headerHeight} items-center gap-2 border-b border-slate-200 px-4`}
         >
-          <h1 className={`min-w-0 flex-1 truncate ${TYPE.headingLg}`}>
+          <h1 className={`min-w-0 flex-1 truncate ${TYPE.headingMd}`}>
             {headerTitle}
           </h1>
           <Button
@@ -580,7 +580,7 @@ export function InboxList({
           </Button>
         </div>
 
-        <div className="px-5 pb-3 pt-3">
+        <div className="px-4 py-2.5">
           <label
             className={`flex items-center gap-2 ${RADIUS.md} border border-slate-200 bg-white px-3 py-1.5 text-sm ${SHADOW.sm} ${TRANSITION.fast} focus-within:border-slate-400 focus-within:ring-1 focus-within:ring-slate-300`}
           >

--- a/apps/web/app/inbox/_components/inbox-loading.tsx
+++ b/apps/web/app/inbox/_components/inbox-loading.tsx
@@ -1,5 +1,6 @@
 import { Skeleton } from "@/components/ui/skeleton";
-import { LAYOUT, SPACING, TONE } from "@/app/_lib/design-tokens";
+import { SPACING, TONE } from "@/app/_lib/design-tokens";
+import { LAYOUT } from "@/app/_lib/design-tokens-v2";
 
 /**
  * Full-screen app loading skeleton for the inbox home (`/inbox`).
@@ -23,13 +24,13 @@ export function InboxAppLoading() {
 
       {/* List column skeleton */}
       <div className={`flex ${LAYOUT.listWidth} shrink-0 flex-col border-r border-slate-200 bg-white`}>
-        <div className="border-b border-slate-200 px-5">
+        <div className="border-b border-slate-200 px-4">
           <div className={`flex ${LAYOUT.headerHeight} items-center gap-2`}>
             <Skeleton className="h-5 w-24" />
             <div className="flex-1" />
             <Skeleton className="size-8 rounded-lg" />
           </div>
-          <div className="pb-4 pt-1">
+          <div className="py-2.5">
             <Skeleton className="h-8 w-full rounded-lg" />
           </div>
         </div>
@@ -60,7 +61,7 @@ export function WelcomeWorkloadSkeleton() {
     >
       {/* Header strip — matches `Welcome back, X` + sync indicator */}
       <header
-        className={`flex ${LAYOUT.headerHeight} shrink-0 items-center border-b border-slate-200 bg-white px-10`}
+        className={`flex ${LAYOUT.welcomeHeaderHeight} shrink-0 items-center border-b border-slate-200 bg-white px-10`}
       >
         <div className="flex w-full items-baseline justify-between gap-4">
           <div className="min-w-0 space-y-2">

--- a/apps/web/app/inbox/_components/inbox-welcome-workload.tsx
+++ b/apps/web/app/inbox/_components/inbox-welcome-workload.tsx
@@ -55,7 +55,7 @@ export function InboxWelcomeWorkload({
   return (
     <section className="flex min-h-0 flex-1 flex-col overflow-y-auto bg-slate-50/40">
       <header
-        className={`flex ${LAYOUT.headerHeight} shrink-0 items-center border-b border-slate-200 bg-white px-10`}
+        className={`flex ${LAYOUT.welcomeHeaderHeight} shrink-0 items-center border-b border-slate-200 bg-white px-10`}
       >
         <div className="flex w-full items-baseline justify-between gap-4">
           <div className="min-w-0">

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -2293,6 +2293,8 @@ function buildTimelineEntry(input: {
   readonly campaignActivitySummaryByCampaignId: Readonly<
     Record<string, CampaignActivitySummary>
   >;
+  readonly memberships: readonly ContactMembershipRecord[];
+  readonly projectMetadataById: InboxDetailCacheData["projectMetadataById"];
   readonly projectLabelByAlias: ReadonlyMap<string, string>;
   readonly referenceNowIso: string;
   readonly attachmentsByCanonicalEventId: ReadonlyMap<
@@ -2388,6 +2390,15 @@ function buildTimelineEntry(input: {
             proxyUrl: `/api/attachments/${encodeURIComponent(attachment.id)}`,
           }))
       : [];
+  const headerProjectLabel =
+    input.item.family === "one_to_one_email"
+      ? resolveHeaderProjectLabel({
+          item: input.item,
+          memberships: input.memberships,
+          projectMetadataById: input.projectMetadataById,
+          projectLabelByAlias: input.projectLabelByAlias,
+        })
+      : null;
   const canonicalSenderDisplayName =
     input.item.family === "one_to_one_email"
       ? input.contactDisplayNameByEmail.get(
@@ -2475,25 +2486,17 @@ function buildTimelineEntry(input: {
         : 0,
     attachments,
     campaignActivity,
-    headerProjectLabel:
-      input.item.family === "one_to_one_email"
-        ? resolveHeaderProjectLabel({
-            item: input.item,
-            projectLabelByAlias: input.projectLabelByAlias,
-          })
-        : null,
+    headerProjectLabel,
     ...(input.item.family === "one_to_one_email"
       ? {
           participantRows: buildParticipantRows({
             item: input.item,
             contactDisplayName: input.contactDisplayName,
+            contactPrimaryEmail: input.contactPrimaryEmail,
             contactDisplayNameByEmail: input.contactDisplayNameByEmail,
             projectLabelByAlias: input.projectLabelByAlias,
             operatorDisplayName: input.operatorDisplayName,
-            headerProjectLabel: resolveHeaderProjectLabel({
-              item: input.item,
-              projectLabelByAlias: input.projectLabelByAlias,
-            }),
+            headerProjectLabel,
           }),
         }
       : {}),
@@ -2567,12 +2570,17 @@ function resolveVolunteerParticipantName(input: {
 function buildParticipantRows(input: {
   readonly item: Extract<TimelineItem, { family: "one_to_one_email" }>;
   readonly contactDisplayName: string;
+  readonly contactPrimaryEmail: string | null;
   readonly contactDisplayNameByEmail: ReadonlyMap<string, string>;
   readonly projectLabelByAlias: ReadonlyMap<string, string>;
   readonly operatorDisplayName: string;
   readonly headerProjectLabel: string | null;
 }): readonly InboxTimelineEntryParticipantRowViewModel[] {
-  const fromEmail = participantHeaderEmail(input.item.fromHeader ?? null);
+  const fromEmail =
+    participantHeaderEmail(input.item.fromHeader ?? null) ??
+    (input.item.direction === "inbound"
+      ? normalizeEmailAddress(input.contactPrimaryEmail)
+      : null);
   const toEmail = participantHeaderEmail(input.item.toHeader ?? null);
   const fromHeaderDisplayName = participantHeaderLabel(
     input.item.fromHeader ?? null,
@@ -2636,7 +2644,7 @@ function buildParticipantRows(input: {
     const inboundToEmail = toEmail ?? input.item.mailbox ?? null;
     rows.push({
       label: "To",
-      name: input.headerProjectLabel,
+      name: input.headerProjectLabel ?? "Adventure Scientists",
       email: inboundToEmail,
     });
   }
@@ -2666,6 +2674,8 @@ function buildParticipantRows(input: {
  */
 function resolveHeaderProjectLabel(input: {
   readonly item: Extract<TimelineItem, { family: "one_to_one_email" }>;
+  readonly memberships: readonly ContactMembershipRecord[];
+  readonly projectMetadataById: InboxDetailCacheData["projectMetadataById"];
   readonly projectLabelByAlias: ReadonlyMap<string, string>;
 }): string | null {
   const fromEmail = participantHeaderEmail(input.item.fromHeader ?? null);
@@ -2687,10 +2697,27 @@ function resolveHeaderProjectLabel(input: {
     return toMatch;
   }
 
-  return projectLabelForAlias({
+  const mailboxMatch = projectLabelForAlias({
     alias: input.item.mailbox,
     projectLabelByAlias: input.projectLabelByAlias,
   });
+  if (mailboxMatch !== null) {
+    return mailboxMatch;
+  }
+
+  const membershipProjects = input.memberships.flatMap((membership) => {
+    const metadata =
+      membership.projectId === null
+        ? undefined
+        : input.projectMetadataById[membership.projectId];
+    return metadata === undefined ? [] : [metadata];
+  });
+
+  return (
+    membershipProjects.find((metadata) => metadata.isActive)?.projectName ??
+    membershipProjects[0]?.projectName ??
+    null
+  );
 }
 
 function buildComposerReplyContext(input: {
@@ -4070,6 +4097,8 @@ export async function getInboxTimelinePage(
         item,
         campaignActivitySummaryByCampaignId:
           cachedData.campaignActivitySummaryByCampaignId,
+        memberships: cachedData.memberships,
+        projectMetadataById: cachedData.projectMetadataById,
         projectLabelByAlias: cachedData.projectLabelByAlias,
         referenceNowIso,
         attachmentsByCanonicalEventId: cachedData.attachmentsByCanonicalEventId,
@@ -4185,6 +4214,8 @@ export async function getInboxDetail(
         item,
         campaignActivitySummaryByCampaignId:
           cachedData.campaignActivitySummaryByCampaignId,
+        memberships: cachedData.memberships,
+        projectMetadataById: cachedData.projectMetadataById,
         projectLabelByAlias: cachedData.projectLabelByAlias,
         referenceNowIso,
         attachmentsByCanonicalEventId: cachedData.attachmentsByCanonicalEventId,


### PR DESCRIPTION
## Summary

Two parallel Codex passes I reviewed and bundled into one PR. Both pass typecheck + lint; the second also has Codex Playwright measurements confirming pixel match.

### 1. Bubble participantRows fall back to memberships + sane defaults

Inbound bubbles still rendered empty right-sides for events where `gmail_message_details` was missing entirely (mbox-imported / Salesforce-derived items). Diagnosis (Codex): the data is the primary problem, but the selector should also fall back through memberships before giving up.

- `resolveHeaderProjectLabel` extends its chain past alias-match attempts → any active membership's projectName (alias-preferred via `loadProjectMetadataById`) → first membership of any state.
- `buildParticipantRows` for inbound: falls back to `contactPrimaryEmail` when `fromHeader` email is null; falls back to "Adventure Scientists" for the To name when no project context is resolvable.
- Removes the duplicate `resolveHeaderProjectLabel` call in the entry build path (computed once + reused).
- Component-side `deriveParticipantRowsFromRawHeaders` mirrors the same fallback for entries that skip the selector path.

User-visible result on the two cases reported:
- Joe Rutledge thread (PNW Biodiversity membership) → `Joe Rutledge → PNW Biodiversity`
- nicolaskneler@gmail.com self-test (no membership) → `Nicolás Kneler → Adventure Scientists`

### 2. Header sizing pixel-match against the canon model

New layout tokens in `design-tokens-v2`:
- `headerHeight: h-[54px]` (compact bar — list, detail, rail)
- `welcomeHeaderHeight: h-[102px]` (spans list title + search bands on the home dashboard)

Touched: `inbox-list.tsx` (`headingMd`, `px-4 py-2.5`), `inbox-welcome-workload.tsx` (welcome height), `inbox-detail.tsx` (smaller avatar, stacked name + project, `px-5`, ghost-variant action buttons), `inbox-loading.tsx` (skeleton alignment + welcome height).

Codex Playwright measurements at hydration: `listHeader: 54px`, `searchBand: 54px`, `searchBox: 319x34`, `welcomeHeader: 102px`.

## Test plan
- [ ] CI green
- [ ] Joe Rutledge inbound bubble renders project alias on the right
- [ ] nicolaskneler@gmail.com inbound bubble renders "Adventure Scientists" on the right
- [ ] Inbox home: header takes the height of list-title + search band combined
- [ ] Detail view: header is the compact 54px bar; avatar smaller; name + project stacked
- [ ] No regression in skeleton heights between welcome → conversation transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)