### PR TITLE
[codex] Polish inbox header interactions

### DIFF
--- a/apps/web/app/inbox/_components/icons.tsx
+++ b/apps/web/app/inbox/_components/icons.tsx
@@ -28,6 +28,7 @@ export {
   Clock as ClockIcon,
   PanelRightOpen as PanelRightOpenIcon,
   PanelRightClose as PanelRightCloseIcon,
+  UserRound as UserRoundIcon,
   CornerUpLeft as CornerUpLeftIcon,
   ArrowRight as ArrowRightIcon,
   X as XIcon,

--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -9,6 +9,8 @@ import {
   useRef,
   useState,
   useTransition,
+  type ButtonHTMLAttributes,
+  type ReactNode,
 } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -17,12 +19,6 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 import {
@@ -47,13 +43,13 @@ import { InboxFreshnessPoller } from "./inbox-freshness-poller";
 import { useInboxClient, type Reminder } from "./inbox-client-provider";
 import { InboxAvatar } from "./inbox-avatar";
 import { SectionLabel } from "@/components/ui/section-label";
-import { PROJECT_STATUS_TEXT } from "@/app/_lib/design-tokens";
+import { StatusBadge } from "@/components/ui/status-badge";
+import { PROJECT_STATUS_BADGE } from "@/app/_lib/design-tokens";
 import {
   LAYOUT,
   SPACING,
   TONE_CLASSES,
   TRANSITION,
-  TYPE,
 } from "@/app/_lib/design-tokens-v2";
 import { InboxComposerReplyBar } from "./inbox-composer";
 import { InboxContactRail } from "./inbox-contact-rail";
@@ -68,7 +64,7 @@ import {
   ClockIcon,
   FlagIcon,
   MailOpenIcon,
-  PanelRightOpenIcon,
+  UserRoundIcon,
   XIcon,
 } from "./icons";
 
@@ -524,13 +520,13 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
               className="size-7 text-[11px]"
             />
             <div className="min-w-0">
-              <h1 className={`truncate ${TYPE.headingMd}`}>
+              <h1 className="truncate text-base font-semibold leading-tight text-slate-900 text-balance">
                 {contact.displayName}
               </h1>
               {headerProject ? (
-                <div className="mt-0.5 flex min-w-0 items-center gap-2 text-xs">
+                <div className="mt-0.5 flex min-w-0 items-center gap-2">
                   <span
-                    className="min-w-0 truncate font-medium text-slate-700"
+                    className="min-w-0 truncate text-[13px] font-medium leading-none text-slate-500"
                     title={
                       "source" in headerProject &&
                       headerProject.source === "conversation"
@@ -541,14 +537,12 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
                     {headerProject.projectName}
                   </span>
                   {"status" in headerProject ? (
-                    <span
-                      className={cn(
-                        "shrink-0 text-[11px] font-semibold uppercase tracking-wider",
-                        PROJECT_STATUS_TEXT[headerProject.status],
-                      )}
-                    >
-                      {headerProject.statusLabel}
-                    </span>
+                    <StatusBadge
+                      variant="subtle"
+                      colorClasses={PROJECT_STATUS_BADGE[headerProject.status]}
+                      label={headerProject.statusLabel}
+                      className="shrink-0"
+                    />
                   ) : null}
                 </div>
               ) : (
@@ -566,132 +560,99 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
             </div>
           </div>
 
-          <TooltipProvider>
-            <div className="flex shrink-0 items-center gap-2">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div>
-                    <FollowUpToggleControl
-                      needsFollowUp={isFollowUp}
-                      isPending={followUpToggle.isPending}
-                      error={followUpToggle.error}
-                      onToggle={followUpToggle.toggle}
-                    />
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent>Needs Follow-Up</TooltipContent>
-              </Tooltip>
+          <div className="flex shrink-0 items-center gap-2">
+            <FollowUpToggleControl
+              needsFollowUp={isFollowUp}
+              isPending={followUpToggle.isPending}
+              error={followUpToggle.error}
+              onToggle={followUpToggle.toggle}
+            />
 
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    disabled={isMarkUnreadPending}
-                    onClick={handleMarkUnread}
-                    aria-label="Mark as unread"
-                    className="size-8 text-slate-800 hover:bg-slate-100 hover:text-slate-950"
-                    data-inbox-mark-unread="true"
-                  >
-                    <MailOpenIcon className="size-4" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Mark as unread</TooltipContent>
-              </Tooltip>
+            <HeaderActionButton
+              label="Mark Unread"
+              aria-label="Mark unread"
+              disabled={isMarkUnreadPending}
+              onClick={handleMarkUnread}
+              data-inbox-mark-unread="true"
+              widthClassName="w-32"
+            >
+              <MailOpenIcon className="size-4" />
+            </HeaderActionButton>
 
-              <Popover open={reminderOpen} onOpenChange={setReminderOpen}>
-                <PopoverTrigger asChild>
-                  {existingReminder ? (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      aria-label="Set reminder"
-                      title="Set reminder"
-                      className="gap-1.5 bg-sky-50 text-sky-800 hover:bg-sky-100 hover:text-sky-800"
-                    >
-                      <ClockIcon className="size-3.5" />
-                      Reminder · {formatShortReminder(existingReminder)}
-                    </Button>
-                  ) : (
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="size-8 text-slate-800 hover:bg-slate-100 hover:text-slate-950"
-                      aria-label="Set reminder"
-                      title="Set reminder"
-                    >
-                      <ClockIcon className="size-4" />
-                    </Button>
-                  )}
-                </PopoverTrigger>
-                <PopoverContent align="end" className="w-72">
-                  <ReminderPopoverBody
-                    existing={existingReminder}
-                    value={reminderValue}
-                    unit={reminderUnit}
-                    onChangeValue={setReminderValue}
-                    onChangeUnit={setReminderUnit}
-                    onClose={() => {
-                      setReminderOpen(false);
-                    }}
-                    onSet={handleSetReminder}
-                    onClear={handleClearReminder}
-                  />
-                </PopoverContent>
-              </Popover>
+            <Popover open={reminderOpen} onOpenChange={setReminderOpen}>
+              <PopoverTrigger asChild>
+                <HeaderActionButton
+                  label="Set Reminder"
+                  aria-label={
+                    existingReminder
+                      ? `Set reminder, current reminder ${formatShortReminder(existingReminder)}`
+                      : "Set reminder"
+                  }
+                  title="Set reminder"
+                  widthClassName="w-32"
+                  surfaceClassName={
+                    existingReminder
+                      ? "scale-x-[0.24] bg-sky-50 opacity-100 group-hover/header-action:bg-sky-100 group-focus-visible/header-action:bg-sky-100"
+                      : undefined
+                  }
+                  iconClassName={
+                    existingReminder
+                      ? "text-sky-800"
+                      : undefined
+                  }
+                >
+                  <ClockIcon className="size-4" />
+                </HeaderActionButton>
+              </PopoverTrigger>
+              <PopoverContent align="end" className="w-72">
+                <ReminderPopoverBody
+                  existing={existingReminder}
+                  value={reminderValue}
+                  unit={reminderUnit}
+                  onChangeValue={setReminderValue}
+                  onChangeUnit={setReminderUnit}
+                  onClose={() => {
+                    setReminderOpen(false);
+                  }}
+                  onSet={handleSetReminder}
+                  onClear={handleClearReminder}
+                />
+              </PopoverContent>
+            </Popover>
 
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    className="size-8 text-slate-800 hover:bg-slate-100 hover:text-slate-950"
-                    aria-label={
-                      detail.isArchived
-                        ? "Move back to inbox"
-                        : "Archive conversation"
-                    }
-                    disabled={isArchivePending}
-                    onClick={detail.isArchived ? handleUnarchive : handleArchive}
-                  >
-                    {detail.isArchived ? (
-                      <ArchiveRestoreIcon className="size-4" />
-                    ) : (
-                      <ArchiveBoxIcon className="size-4" />
-                    )}
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {detail.isArchived
-                    ? "Move back to inbox"
-                    : "Archive conversation"}
-                </TooltipContent>
-              </Tooltip>
+            <HeaderActionButton
+              label={detail.isArchived ? "Unarchive" : "Archive"}
+              aria-label={
+                detail.isArchived
+                  ? "Move back to inbox"
+                  : "Archive conversation"
+              }
+              disabled={isArchivePending}
+              onClick={detail.isArchived ? handleUnarchive : handleArchive}
+              widthClassName={detail.isArchived ? "w-28" : "w-24"}
+            >
+              {detail.isArchived ? (
+                <ArchiveRestoreIcon className="size-4" />
+              ) : (
+                <ArchiveBoxIcon className="size-4" />
+              )}
+            </HeaderActionButton>
 
-              {!railOpen ? (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="size-8 text-slate-800 hover:bg-slate-100 hover:text-slate-950"
-                      aria-label="Toggle contact details"
-                      aria-expanded={false}
-                      aria-controls="inbox-contact-rail"
-                      onClick={() => {
-                        setRailOpen(true);
-                      }}
-                    >
-                      <PanelRightOpenIcon className="size-4" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>Toggle contact details</TooltipContent>
-                </Tooltip>
-              ) : null}
-            </div>
-          </TooltipProvider>
+            {!railOpen ? (
+              <HeaderActionButton
+                label="Volunteer Details"
+                aria-label="Open volunteer details"
+                aria-expanded={false}
+                aria-controls="inbox-contact-rail"
+                onClick={() => {
+                  setRailOpen(true);
+                }}
+                widthClassName="w-40"
+              >
+                <UserRoundIcon className="size-4" />
+              </HeaderActionButton>
+            ) : null}
+          </div>
         </header>
 
         {contact.hasUnresolved ? <UnresolvedBanner /> : null}
@@ -799,23 +760,95 @@ function FollowUpToggleButton({
   readonly onToggle: () => void;
 }) {
   return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon"
+    <HeaderActionButton
+      label="Needs Follow-Up"
       disabled={pending}
       aria-pressed={needsFollowUp}
       aria-label="Needs Follow-Up"
       aria-keyshortcuts="f"
       data-inbox-follow-up-toggle="true"
       onClick={onToggle}
+      widthClassName="w-36"
       className={cn(
-        "size-8 text-slate-800 hover:bg-slate-100 hover:text-slate-950",
         needsFollowUp &&
-          "bg-rose-50 text-rose-800 hover:bg-rose-100 hover:text-rose-800",
+          "text-rose-800",
       )}
+      surfaceClassName={
+        needsFollowUp
+          ? "scale-x-[0.24] bg-rose-50 opacity-100 group-hover/header-action:bg-rose-100 group-focus-visible/header-action:bg-rose-100"
+          : undefined
+      }
     >
       <FlagIcon className="size-4" />
+    </HeaderActionButton>
+  );
+}
+
+interface HeaderActionButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
+  readonly label: string;
+  readonly children: ReactNode;
+  readonly widthClassName?: string;
+  readonly surfaceClassName?: string | undefined;
+  readonly iconClassName?: string | undefined;
+}
+
+function HeaderActionButton({
+  label,
+  children,
+  widthClassName = "w-32",
+  surfaceClassName,
+  iconClassName,
+  className,
+  type = "button",
+  ...props
+}: HeaderActionButtonProps) {
+  return (
+    <Button
+      {...props}
+      type={type}
+      variant="ghost"
+      size="icon"
+      title={props.title ?? label}
+      className={cn(
+        "group/header-action relative size-8 overflow-visible rounded-md px-0 text-slate-900 hover:z-20 hover:bg-transparent hover:text-slate-950 focus-visible:z-20 focus-visible:bg-transparent",
+        "transition-[color,transform] duration-150 ease-out active:scale-[0.96] motion-reduce:transition-none",
+        className,
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "pointer-events-none absolute right-0 top-0 z-0 flex h-8 origin-right scale-x-[0.24] items-center rounded-md bg-slate-100/0 pl-2 pr-8 opacity-0",
+          "transition-[transform,opacity,background-color] duration-150 ease-out",
+          "group-hover/header-action:scale-x-100 group-hover/header-action:bg-slate-100 group-hover/header-action:opacity-100",
+          "group-focus-visible/header-action:scale-x-100 group-focus-visible/header-action:bg-slate-100 group-focus-visible/header-action:opacity-100",
+          "motion-reduce:transition-none",
+          widthClassName,
+          surfaceClassName,
+        )}
+      >
+        <span
+          className={cn(
+            "translate-x-1 whitespace-nowrap text-[11px] font-medium text-slate-700 opacity-0",
+            "transition-[transform,opacity] duration-150 ease-out",
+            "group-hover/header-action:translate-x-0 group-hover/header-action:opacity-100",
+            "group-focus-visible/header-action:translate-x-0 group-focus-visible/header-action:opacity-100",
+            "motion-reduce:transition-none",
+          )}
+        >
+          {label}
+        </span>
+      </span>
+      <span
+        aria-hidden="true"
+        className={cn(
+          "relative z-10 flex size-8 items-center justify-center rounded-md",
+          iconClassName,
+        )}
+      >
+        {children}
+      </span>
     </Button>
   );
 }

--- a/apps/web/app/inbox/_components/inbox-list.tsx
+++ b/apps/web/app/inbox/_components/inbox-list.tsx
@@ -544,7 +544,7 @@ export function InboxList({
             aria-keyshortcuts="c"
             title="Compose"
             onClick={openNewDraft}
-            className="size-8 shrink-0 text-slate-500 hover:bg-slate-100 hover:text-slate-900"
+            className="size-8 shrink-0 text-slate-900 hover:bg-slate-100 hover:text-slate-950"
           >
             <PencilIcon aria-hidden="true" data-icon="inline-start" />
           </Button>
@@ -563,7 +563,7 @@ export function InboxList({
                 ? "bg-slate-900 text-white hover:bg-slate-900 hover:text-white"
                 : hasActiveFilters
                   ? "bg-slate-100 text-slate-900 hover:bg-slate-100 hover:text-slate-900"
-                  : "text-slate-500 hover:bg-slate-100 hover:text-slate-900",
+                  : "text-slate-900 hover:bg-slate-100 hover:text-slate-950",
             )}
           >
             <FilterIcon aria-hidden="true" data-icon="inline-start" />

--- a/apps/web/tests/unit/inbox-list-shell.test.tsx
+++ b/apps/web/tests/unit/inbox-list-shell.test.tsx
@@ -462,7 +462,7 @@ describe("Inbox list shell", () => {
 
     const filterButton = findButtonByLabel(session.container, "Filters");
     expect(filterButton.getAttribute("aria-expanded")).toBe("false");
-    expect(filterButton.className).toContain("text-slate-500");
+    expect(filterButton.className).toContain("text-slate-900");
 
     act(() => {
       filterButton.click();


### PR DESCRIPTION
## Summary
- Uses the right-rail `StatusBadge` treatment in the detail header status label.
- Replaces the compressed volunteer details opener with a person icon while keeping the existing collapse icon behavior.
- Adds lightweight hover/focus expansion labels for the detail header actions without adding a new animation dependency.
- Darkens the list header compose/filter icon resting state to better match the model reference.

## Validation
- `pnpm --filter @as-comms/web typecheck`
- `pnpm --filter @as-comms/web lint`
- `pnpm --filter @as-comms/web exec vitest run --config ../../vitest.config.ts --passWithNoTests tests/unit/inbox-list-shell.test.tsx tests/unit/inbox-welcome-workload-component.test.tsx`
