### PR TITLE
fix(gmail): recover short garbled message bodies

### DIFF
--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -1100,6 +1100,57 @@ function sanitizePreviewText(value: string): string {
     .trim();
 }
 
+const PREVIEW_NOISE_THRESHOLD = 0.3;
+const PREVIEW_NOISE_MIN_LENGTH = 32;
+const SHORT_PREVIEW_NOISE_MIN_SUSPICIOUS = 3;
+const REPLACEMENT_CHARACTER = "�";
+
+function isLikelyPreviewNoise(value: string): boolean {
+  const normalized = value.trim();
+
+  if (normalized.length === 0) {
+    return false;
+  }
+
+  let suspicious = 0;
+  let total = 0;
+
+  for (const character of normalized) {
+    total += 1;
+
+    if (character === REPLACEMENT_CHARACTER) {
+      suspicious += 1;
+      continue;
+    }
+
+    const code = character.codePointAt(0) ?? 0;
+
+    if (
+      code < 0x20 &&
+      code !== 0x09 &&
+      code !== 0x0a &&
+      code !== 0x0d
+    ) {
+      suspicious += 1;
+    }
+  }
+
+  if (total === 0) {
+    return false;
+  }
+
+  const ratio = suspicious / total;
+
+  if (total < PREVIEW_NOISE_MIN_LENGTH) {
+    return (
+      suspicious >= SHORT_PREVIEW_NOISE_MIN_SUSPICIOUS &&
+      ratio >= PREVIEW_NOISE_THRESHOLD
+    );
+  }
+
+  return ratio >= PREVIEW_NOISE_THRESHOLD;
+}
+
 const STRUCTURED_EMAIL_TRANSLATION_MARKER_PATTERN =
   /\b(?:en|es|fr|de|pt):(?=[A-ZÀ-Ý])/g;
 const STRUCTURED_EMAIL_PARAGRAPH_STARTERS = [
@@ -1535,7 +1586,11 @@ function resolvePreferredMessagePreview(input: {
       subjectFromPreview = parsed.subject;
     }
 
-    if (body.length === 0 && parsed.body.length > 0) {
+    if (
+      body.length === 0 &&
+      parsed.body.length > 0 &&
+      !isLikelyPreviewNoise(parsed.body)
+    ) {
       body = parsed.body;
       continue;
     }
@@ -1543,7 +1598,7 @@ function resolvePreferredMessagePreview(input: {
     if (sanitizedFallback.length === 0) {
       const sanitized = sanitizePreviewText(rawCandidate);
 
-      if (sanitized.length > 0) {
+      if (sanitized.length > 0 && !isLikelyPreviewNoise(sanitized)) {
         sanitizedFallback = sanitized;
       }
     }

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -3931,6 +3931,51 @@ describe("real inbox selectors", () => {
     });
   });
 
+  it("skips short garbled Gmail bodies and renders the readable snippet instead", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:short-garbled",
+      salesforceContactId: "003-short-garbled",
+      displayName: "Joe Rutledge",
+      primaryEmail: "joe@example.org",
+      primaryPhone: null,
+    });
+
+    const latestEvent = await seedInboxEmailEvent(runtime.context, {
+      id: "short-garbled-latest",
+      contactId: "contact:short-garbled",
+      occurredAt: "2026-04-30T16:31:58.000Z",
+      direction: "inbound",
+      subject: "Re: Placement completed 28 April",
+      snippet: "Thanks. Will work on this. May take a day or two",
+      snippetClean: "Thanks. Will work on this. May take a day or two",
+      bodyTextPreview: "�٥�杙�Z��iz�����w/�i",
+      bodyKind: "plaintext",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:short-garbled",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-30T16:31:58.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-04-30T16:31:58.000Z",
+      snippet: "Thanks. Will work on this. May take a day or two",
+      lastCanonicalEventId: latestEvent.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+
+    const detail = await getInboxDetail("contact:short-garbled");
+
+    expect(detail?.timeline.at(-1)).toMatchObject({
+      kind: "inbound-email",
+      body: "Thanks. Will work on this. May take a day or two",
+    });
+  });
+
   it("falls back to provider communication details before projection snippets for Salesforce-backed latest rows", async () => {
     if (runtime === null) {
       throw new Error("Expected inbox test runtime");

--- a/apps/worker/src/ops/backfill-garbled-message-bodies.ts
+++ b/apps/worker/src/ops/backfill-garbled-message-bodies.ts
@@ -2,7 +2,7 @@
 import process from "node:process";
 import { pathToFileURL } from "node:url";
 
-import { and, asc, eq, gt, isNull, sql } from "drizzle-orm";
+import { and, asc, eq, gt, ne, or, sql } from "drizzle-orm";
 
 import {
   closeDatabaseConnection,
@@ -10,14 +10,16 @@ import {
   gmailMessageDetails,
   type Stage1Database,
 } from "@as-comms/db";
-import { isLikelyBinaryNoise } from "@as-comms/integrations";
+import {
+  isLikelyBinaryNoise,
+  isUsableGmailBodyPreviewText,
+} from "@as-comms/integrations";
 
 import { parseCliFlags, readOptionalIntegerFlag } from "./helpers.js";
 
 const BINARY_FALLBACK_PLACEHOLDER =
   "[Message body could not be extracted — open in Gmail]";
 const DEFAULT_BATCH_SIZE = 200;
-const BINARY_NOISE_MIN_LENGTH = 32;
 const REPLACEMENT_CHARACTER = "�";
 
 interface BackfillLogger {
@@ -26,7 +28,15 @@ interface BackfillLogger {
 
 interface GarbledMessageBodyCandidateRow {
   readonly sourceEvidenceId: string;
+  readonly snippetClean: string;
   readonly bodyTextPreview: string;
+  readonly bodyKind: "plaintext" | "encrypted_placeholder" | "binary_fallback" | null;
+}
+
+interface GarbledBodyRepair {
+  readonly bodyTextPreview: string;
+  readonly snippetClean: string;
+  readonly bodyKind: "plaintext" | "binary_fallback";
 }
 
 export interface GarbledMessageBodiesBackfillResult {
@@ -51,7 +61,7 @@ function readConnectionString(env: NodeJS.ProcessEnv): string {
 }
 
 function calculateReplacementRatio(text: string): number {
-  if (text.length < BINARY_NOISE_MIN_LENGTH) {
+  if (text.trim().length === 0) {
     return 0;
   }
 
@@ -86,16 +96,21 @@ async function loadCandidateBatch(input: {
   readonly afterSourceEvidenceId: string | null;
   readonly batchSize: number;
 }): Promise<readonly GarbledMessageBodyCandidateRow[]> {
-  return input.db
+  const rows = await input.db
     .select({
       sourceEvidenceId: gmailMessageDetails.sourceEvidenceId,
+      snippetClean: gmailMessageDetails.snippetClean,
       bodyTextPreview: gmailMessageDetails.bodyTextPreview,
+      bodyKind: gmailMessageDetails.bodyKind,
     })
     .from(gmailMessageDetails)
     .where(
       and(
-        isNull(gmailMessageDetails.bodyKind),
-        sql<boolean>`length(${gmailMessageDetails.bodyTextPreview}) >= ${BINARY_NOISE_MIN_LENGTH}`,
+        or(
+          sql`${gmailMessageDetails.bodyKind} is null`,
+          ne(gmailMessageDetails.bodyKind, "binary_fallback"),
+        ),
+        sql<boolean>`position(chr(65533) in ${gmailMessageDetails.bodyTextPreview}) > 0`,
         input.afterSourceEvidenceId === null
           ? undefined
           : gt(gmailMessageDetails.sourceEvidenceId, input.afterSourceEvidenceId),
@@ -103,21 +118,50 @@ async function loadCandidateBatch(input: {
     )
     .orderBy(asc(gmailMessageDetails.sourceEvidenceId))
     .limit(input.batchSize);
+
+  return rows.map((row) => ({
+    ...row,
+    bodyKind:
+      row.bodyKind === "plaintext" ||
+      row.bodyKind === "encrypted_placeholder" ||
+      row.bodyKind === "binary_fallback"
+        ? row.bodyKind
+        : null,
+  }));
 }
 
 async function updateGarbledBodyRow(input: {
   readonly db: Stage1Database;
   readonly sourceEvidenceId: string;
+  readonly repair: GarbledBodyRepair;
 }): Promise<void> {
   await input.db
     .update(gmailMessageDetails)
     .set({
-      bodyTextPreview: BINARY_FALLBACK_PLACEHOLDER,
-      snippetClean: BINARY_FALLBACK_PLACEHOLDER,
-      bodyKind: "binary_fallback",
+      bodyTextPreview: input.repair.bodyTextPreview,
+      snippetClean: input.repair.snippetClean,
+      bodyKind: input.repair.bodyKind,
       updatedAt: new Date(),
     })
     .where(eq(gmailMessageDetails.sourceEvidenceId, input.sourceEvidenceId));
+}
+
+function resolveGarbledBodyRepair(
+  candidate: GarbledMessageBodyCandidateRow,
+): GarbledBodyRepair {
+  if (isUsableGmailBodyPreviewText(candidate.snippetClean)) {
+    return {
+      bodyTextPreview: candidate.snippetClean,
+      snippetClean: candidate.snippetClean,
+      bodyKind: "plaintext",
+    };
+  }
+
+  return {
+    bodyTextPreview: BINARY_FALLBACK_PLACEHOLDER,
+    snippetClean: BINARY_FALLBACK_PLACEHOLDER,
+    bodyKind: "binary_fallback",
+  };
 }
 
 export async function backfillGarbledMessageBodies(input: {
@@ -178,12 +222,15 @@ export async function backfillGarbledMessageBodies(input: {
 
       if (dryRun) {
         dryRunWouldUpdate += 1;
+        const repair = resolveGarbledBodyRepair(candidate);
         logger.info(
           JSON.stringify({
             source_evidence_id: candidate.sourceEvidenceId,
             body_len: candidate.bodyTextPreview.length,
             replacement_ratio: Number(replacementRatio.toFixed(4)),
             sample: candidate.bodyTextPreview.slice(0, 80),
+            repair_body_kind: repair.bodyKind,
+            repair_sample: repair.bodyTextPreview.slice(0, 80),
           }),
         );
         continue;
@@ -192,6 +239,7 @@ export async function backfillGarbledMessageBodies(input: {
       await updateGarbledBodyRow({
         db: input.db,
         sourceEvidenceId: candidate.sourceEvidenceId,
+        repair: resolveGarbledBodyRepair(candidate),
       });
       updated += 1;
     }

--- a/apps/worker/test/stage1-backfill-garbled-message-bodies.test.ts
+++ b/apps/worker/test/stage1-backfill-garbled-message-bodies.test.ts
@@ -10,6 +10,10 @@ function buildGarbledBody(): string {
   return "A�".repeat(20);
 }
 
+function buildShortGarbledBody(): string {
+  return "�٥�杙�Z��iz�����w/�i";
+}
+
 function buildCleanBody(): string {
   return "Hello there.\n\nThis message is readable and should stay untouched.";
 }
@@ -19,7 +23,8 @@ async function seedGmailMessageDetail(input: {
   readonly sourceEvidenceId: string;
   readonly providerRecordId: string;
   readonly bodyTextPreview: string;
-  readonly bodyKind?: "binary_fallback" | null;
+  readonly snippetClean?: string;
+  readonly bodyKind?: "plaintext" | "binary_fallback" | null;
 }): Promise<void> {
   await input.context.repositories.sourceEvidence.append({
     id: input.sourceEvidenceId,
@@ -44,7 +49,7 @@ async function seedGmailMessageDetail(input: {
     toHeader: "Volunteer <volunteer@example.org>",
     ccHeader: null,
     labelIds: null,
-    snippetClean: input.bodyTextPreview,
+    snippetClean: input.snippetClean ?? input.bodyTextPreview,
     bodyTextPreview: input.bodyTextPreview,
     bodyKind: input.bodyKind ?? null,
     capturedMailbox: "volunteers@example.org",
@@ -130,6 +135,85 @@ describe("Stage 1 garbled Gmail message body backfill", () => {
     }
   });
 
+  it("repairs short garbled bodies from a readable snippet", async () => {
+    const context = await createTestWorkerContext();
+    const sourceEvidenceId =
+      "source-evidence:gmail:message:garbled-short-snippet";
+    const readableSnippet =
+      "Thanks. Will work on this. May take a day or two Sent from my Galaxy";
+
+    try {
+      await seedGmailMessageDetail({
+        context,
+        sourceEvidenceId,
+        providerRecordId: "garbled-short-snippet",
+        bodyTextPreview: buildShortGarbledBody(),
+        snippetClean: readableSnippet,
+      });
+
+      const result = await backfillGarbledMessageBodies({
+        db: context.db,
+        dryRun: false,
+      });
+      const [persisted] =
+        await context.repositories.gmailMessageDetails.listBySourceEvidenceIds([
+          sourceEvidenceId,
+        ]);
+
+      expect(result).toMatchObject({
+        dryRun: false,
+        scanned: 1,
+        garbled: 1,
+        updated: 1,
+      });
+      expect(persisted).toMatchObject({
+        bodyTextPreview: readableSnippet,
+        snippetClean: readableSnippet,
+        bodyKind: "plaintext",
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("repairs plaintext-classified short garbled rows", async () => {
+    const context = await createTestWorkerContext();
+    const sourceEvidenceId =
+      "source-evidence:gmail:message:garbled-short-plaintext";
+
+    try {
+      await seedGmailMessageDetail({
+        context,
+        sourceEvidenceId,
+        providerRecordId: "garbled-short-plaintext",
+        bodyTextPreview: buildShortGarbledBody(),
+        bodyKind: "plaintext",
+      });
+
+      const result = await backfillGarbledMessageBodies({
+        db: context.db,
+        dryRun: false,
+      });
+      const [persisted] =
+        await context.repositories.gmailMessageDetails.listBySourceEvidenceIds([
+          sourceEvidenceId,
+        ]);
+
+      expect(result).toMatchObject({
+        scanned: 1,
+        garbled: 1,
+        updated: 1,
+      });
+      expect(persisted).toMatchObject({
+        bodyTextPreview: BINARY_FALLBACK_PLACEHOLDER,
+        snippetClean: BINARY_FALLBACK_PLACEHOLDER,
+        bodyKind: "binary_fallback",
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
   it("leaves readable bodies untouched", async () => {
     const context = await createTestWorkerContext();
     const sourceEvidenceId = "source-evidence:gmail:message:garbled-clean";
@@ -153,7 +237,7 @@ describe("Stage 1 garbled Gmail message body backfill", () => {
         ]);
 
       expect(result).toMatchObject({
-        scanned: 1,
+        scanned: 0,
         garbled: 0,
         dryRunWouldUpdate: 0,
         updated: 0,

--- a/packages/integrations/src/capture-services/gmail.ts
+++ b/packages/integrations/src/capture-services/gmail.ts
@@ -22,8 +22,10 @@ import {
 import {
   collectGmailAttachmentMetadata,
   collectGmailHtmlCidReferences,
+  cleanGmailBodyPreviewText,
   extractDsnOriginalMessageId,
   extractGmailBodyPreviewFromPayloadResult,
+  isUsableGmailBodyPreviewText,
   type GmailApiMessagePart
 } from "../providers/gmail-body.js";
 import {
@@ -434,6 +436,12 @@ export async function mapLiveGmailMessageToRecord(input: {
       messageIdentifier: input.message.id
     }
   );
+  const cleanedGmailSnippet = cleanGmailBodyPreviewText(input.message.snippet);
+  const usableSnippetFallback =
+    bodyPreviewResult.bodyKind === "binary_fallback" &&
+    isUsableGmailBodyPreviewText(cleanedGmailSnippet)
+      ? cleanedGmailSnippet
+      : null;
   const attachmentMetadata = collectGmailAttachmentMetadata(input.message.payload);
   const htmlBodyCidReferences = collectGmailHtmlCidReferences(
     input.message.payload,
@@ -458,7 +466,8 @@ export async function mapLiveGmailMessageToRecord(input: {
     labelIds: input.message.labelIds,
     snippet: input.message.snippet,
     snippetClean: input.message.snippet,
-    ...bodyPreviewResult,
+    bodyTextPreview: usableSnippetFallback ?? bodyPreviewResult.bodyTextPreview,
+    bodyKind: usableSnippetFallback === null ? bodyPreviewResult.bodyKind : "plaintext",
     attachmentMetadata,
     htmlBodyCidReferences,
     internalDate: input.message.internalDate,

--- a/packages/integrations/src/providers/gmail-body.ts
+++ b/packages/integrations/src/providers/gmail-body.ts
@@ -113,6 +113,7 @@ const REPLACEMENT_CHARACTER = "�";
 // in production sit at ~50%.
 const BINARY_NOISE_THRESHOLD = 0.3;
 const BINARY_NOISE_MIN_LENGTH = 32;
+const SHORT_BINARY_NOISE_MIN_SUSPICIOUS = 3;
 const DEFAULT_GMAIL_MIME_MAX_DEPTH = 64;
 const DEFAULT_GMAIL_MIME_MAX_PARTS = 512;
 const DEFAULT_GMAIL_MIME_MAX_DECODED_BYTES = 20 * 1024 * 1024;
@@ -230,7 +231,7 @@ function visitChildPart(
 }
 
 export function isLikelyBinaryNoise(text: string): boolean {
-  if (text.length < BINARY_NOISE_MIN_LENGTH) {
+  if (text.trim().length === 0) {
     return false;
   }
 
@@ -259,7 +260,20 @@ export function isLikelyBinaryNoise(text: string): boolean {
     }
   }
 
-  return total > 0 && suspicious / total >= BINARY_NOISE_THRESHOLD;
+  if (total === 0) {
+    return false;
+  }
+
+  const ratio = suspicious / total;
+
+  if (total < BINARY_NOISE_MIN_LENGTH) {
+    return (
+      suspicious >= SHORT_BINARY_NOISE_MIN_SUSPICIOUS &&
+      ratio >= BINARY_NOISE_THRESHOLD
+    );
+  }
+
+  return ratio >= BINARY_NOISE_THRESHOLD;
 }
 
 function normalizeLineEndings(value: string): string {
@@ -411,6 +425,12 @@ export function cleanGmailBodyPreviewText(value: string): string {
       : sanitizePreviewText(value);
 
   return normalized;
+}
+
+export function isUsableGmailBodyPreviewText(value: string): boolean {
+  const normalized = cleanGmailBodyPreviewText(value);
+
+  return normalized.length > 0 && !isLikelyBinaryNoise(normalized);
 }
 
 function decodeBase64Url(value: string): Buffer {

--- a/packages/integrations/test/gmail-body-extraction.test.ts
+++ b/packages/integrations/test/gmail-body-extraction.test.ts
@@ -352,6 +352,70 @@ describe("Gmail body extraction", () => {
     });
   });
 
+  it("treats a short replacement-heavy text/plain part as a binary fallback", async () => {
+    const payload: GmailApiMessagePart = {
+      mimeType: "text/plain",
+      headers: [{ name: "Content-Type", value: "text/plain; charset=utf-8" }],
+      body: {
+        data: encodeBase64Url(Buffer.from([0x80, 0x81, 0x82, 0x83, 0x84, 0x85])),
+        size: 6,
+      },
+    };
+
+    await expect(
+      extractGmailBodyPreviewFromPayloadResult(payload),
+    ).resolves.toEqual({
+      bodyTextPreview: "[Message body could not be extracted — open in Gmail]",
+      bodyKind: "binary_fallback",
+    });
+  });
+
+  it("uses a readable Gmail snippet when live body extraction returns a short binary fallback", async () => {
+    const binaryPart: GmailApiMessagePart = {
+      mimeType: "text/plain",
+      headers: [{ name: "Content-Type", value: "text/plain; charset=utf-8" }],
+      body: {
+        data: encodeBase64Url(Buffer.from([0x80, 0x81, 0x82, 0x83, 0x84, 0x85])),
+        size: 6,
+      },
+    };
+
+    const record = await mapLiveGmailMessageToRecord({
+      message: {
+        id: "gmail-short-binary-snippet",
+        threadId: "thread-short-binary-snippet",
+        labelIds: ["INBOX"],
+        snippet: "Thanks. Will work on this. May take a day or two",
+        internalDate: "1777566721000",
+        payload: {
+          mimeType: "multipart/mixed",
+          headers: [
+            { name: "From", value: "Joe <joe@example.org>" },
+            { name: "To", value: "PNW Biodiversity <pnwbio@example.org>" },
+            { name: "Subject", value: "Re: Placement completed 28 April" },
+            { name: "Date", value: "Thu, 30 Apr 2026 09:31:58 -0800" },
+            {
+              name: "Message-ID",
+              value: "<gmail-short-binary-snippet@example.org>",
+            },
+          ],
+          parts: [binaryPart],
+        },
+      },
+      capturedMailbox: "pnwbio@example.org",
+      liveAccount: "pnwbio@example.org",
+      projectInboxAliases: ["pnwbio@example.org"],
+      receivedAt: "2026-04-30T16:33:00.147Z",
+    });
+
+    expect(record).toMatchObject({
+      recordType: "message",
+      bodyTextPreview: "Thanks. Will work on this. May take a day or two",
+      bodyKind: "plaintext",
+      snippetClean: "Thanks. Will work on this. May take a day or two",
+    });
+  });
+
   it("preserves a normal email body that contains a handful of stray control characters", async () => {
     // Mirrors the OpenAI marketing-email shape from production: ~7%
     // replacement-or-control chars in an otherwise readable body. These must


### PR DESCRIPTION
## Summary
- tighten Gmail binary-noise detection so short replacement-heavy bodies like the Joe Rutledge example are treated as unusable
- use the Gmail API clean snippet as a plaintext fallback when extraction only finds short binary/noisy body text
- make inbox rendering skip legacy garbled body candidates and fall through to readable snippets immediately
- broaden the garbled-body backfill so existing polluted Gmail detail rows can be repaired to readable snippets or binary placeholders

## Root cause
Previous PRs handled MIME decoding, RFC 2047 subjects, binary/encrypted placeholders, and longer garbled bodies, but the binary-noise detector had a 32-character minimum. The example body was only 19 characters with many replacement/control-like characters, so it slipped through as a preferred body candidate and hid the readable Gmail snippet.

## Verification
Clean detached worktree at `f1a4aa39`:
- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm boundaries`
- `pnpm test:unit`

Focused coverage added for Gmail extraction, live Gmail mapping, inbox selectors, and the worker backfill.

Note: the main local worktree has unrelated pre-existing untracked scratch files, including a Notion ops script that makes local full `pnpm typecheck`/`pnpm lint` noisy there. The clean detached worktree verification above passed.