### PR TITLE
fix(composer): raise server action body size limit for attachment sends

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -58,6 +58,14 @@ const nextConfig: NextConfig = {
     "@as-comms/domain",
     "@as-comms/ui",
   ],
+  experimental: {
+    // Composer send carries base64-encoded attachments inline; the gmail-send
+    // integration caps total raw bytes at 20 MB (≈27 MB after base64), so the
+    // server action body limit needs headroom above Next.js's 1 MB default.
+    serverActions: {
+      bodySizeLimit: "30mb",
+    },
+  },
   headers() {
     return Promise.resolve([
       {


### PR DESCRIPTION
## Symptom

Composer optimistic outbound bubble shows the attachment but the send fails with **\"Send failed.\"** in the UI. Repro: reply with any attachment > ~700 KB.

## Root cause

Next.js Server Actions enforce a **1 MB default body limit**. The composer transmits attachments inline as base64 inside the action payload, so a 2.4 MB file becomes a ~3.2 MB request and gets rejected before the action handler even runs.

Railway log:
\`\`\`
⨯ [Error: Body exceeded 1 MB limit.
To configure the body size limit for Server Actions, see: https://nextjs.org/docs/app/api-reference/next-config-js/serverActions#bodysizelimit]
statusCode: 413
\`\`\`

The 413 returns generically and the composer maps it to the catch-all \`send_failed\` UI state — that's why the error surfaces as \"Send failed.\" with no provider detail.

## Fix

Set \`experimental.serverActions.bodySizeLimit\` to \`30mb\` in \`apps/web/next.config.ts\`. The integrations layer already caps total raw attachment bytes at 20 MB (≈27 MB after base64), so 30 MB gives a small headroom for body/threading metadata while staying under Gmail's own 25 MB raw cap.

## Why not the other recent attachment PRs

- #257 (RFC 5987 Content-Disposition) — about *serving* attachments to the browser
- #254 (gmail-capture proxy) — about reading attachment bytes from the shared volume
- #259 (snapshot FileList) — about not dropping attachments before they reach the action
- #260 (optimistic bubble) — UI feedback only

None of those address the request-size ceiling at the action boundary, which is why the user thought the feature was fixed but real sends still failed.

## Test plan

- [ ] After merge, redeploy and try the composer send that just failed (reply to Carlos Malara with \`debug-skill-master.zip\` 2.4 MB).
- [ ] Confirm the optimistic bubble settles green instead of showing \"Send failed.\".
- [ ] Check Railway logs — no \`Body exceeded\` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)