### PR TITLE
fix(composer): show attachment chip on pending outbound bubble before reconciliation

### DIFF
--- a/apps/web/app/inbox/_components/inbox-timeline-bubble.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-bubble.tsx
@@ -118,21 +118,28 @@ function MessageAttachments({
   }
 
   const imageAttachments = attachments.filter((attachment) =>
-    attachment.mimeType.startsWith("image/"),
+    attachment.proxyUrl !== null && attachment.mimeType.startsWith("image/"),
   );
   const fileAttachments = attachments.filter(
-    (attachment) => !attachment.mimeType.startsWith("image/"),
+    (attachment) =>
+      attachment.proxyUrl === null || !attachment.mimeType.startsWith("image/"),
   );
 
   return (
     <div className="mt-3 flex flex-col gap-3">
       {imageAttachments.length > 0 ? (
         <div className="flex flex-wrap gap-2">
-          {imageAttachments.map((attachment) => {
+          {imageAttachments.map((attachment, index) => {
             const label = attachmentLabel(attachment.filename);
+            const attachmentKey = attachment.id ?? `pending-${String(index)}`;
+            const proxyUrl = attachment.proxyUrl;
+
+            if (proxyUrl === null) {
+              return null;
+            }
 
             return (
-              <Dialog key={attachment.id}>
+              <Dialog key={attachmentKey}>
                 <DialogTrigger asChild>
                   <button
                     type="button"
@@ -140,7 +147,7 @@ function MessageAttachments({
                   >
                     {/* eslint-disable-next-line @next/next/no-img-element -- proxy serves authenticated bytes; next/image optimizer cannot fetch through cookie auth */}
                     <img
-                      src={attachment.proxyUrl}
+                      src={proxyUrl}
                       alt={label}
                       loading="lazy"
                       className="h-[160px] w-[240px] object-cover"
@@ -151,7 +158,7 @@ function MessageAttachments({
                   <DialogTitle className="px-8 text-sm">{label}</DialogTitle>
                   {/* eslint-disable-next-line @next/next/no-img-element -- same reason as the trigger thumbnail above */}
                   <img
-                    src={attachment.proxyUrl}
+                    src={proxyUrl}
                     alt={label}
                     className="max-h-[80vh] w-full rounded-md object-contain"
                   />
@@ -164,12 +171,28 @@ function MessageAttachments({
 
       {fileAttachments.length > 0 ? (
         <div className="flex flex-wrap gap-2">
-          {fileAttachments.map((attachment) => {
+          {fileAttachments.map((attachment, index) => {
             const label = attachmentLabel(attachment.filename);
+            const attachmentKey = attachment.id ?? `pending-${String(index)}`;
+
+            if (attachment.proxyUrl === null) {
+              return (
+                <span
+                  key={attachmentKey}
+                  className="inline-flex cursor-default items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-500"
+                >
+                  <FileDocIcon className="size-3.5 shrink-0" />
+                  <span className="max-w-[16rem] truncate">{label}</span>
+                  <span className="text-slate-400">
+                    {formatBytes(attachment.sizeBytes)}
+                  </span>
+                </span>
+              );
+            }
 
             return (
               <a
-                key={attachment.id}
+                key={attachmentKey}
                 href={attachment.proxyUrl}
                 target="_blank"
                 rel="noreferrer"

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -2432,18 +2432,13 @@ function buildTimelineEntry(input: {
     (finalKind === "inbound-email" || finalKind === "inbound-sms");
   const attachments =
     input.item.family === "one_to_one_email"
-      ? (
-          input.attachmentsByCanonicalEventId.get(input.item.canonicalEventId) ??
-          []
-        )
-          .filter((attachment) => !attachment.isInline)
-          .map((attachment) => ({
-            id: attachment.id,
-            mimeType: attachment.mimeType,
-            filename: attachment.filename,
-            sizeBytes: attachment.sizeBytes,
-            proxyUrl: `/api/attachments/${encodeURIComponent(attachment.id)}`,
-          }))
+      ? buildEmailAttachmentsForEntry({
+          canonical:
+            input.attachmentsByCanonicalEventId.get(
+              input.item.canonicalEventId,
+            ) ?? [],
+          pending: input.item.pendingAttachmentMetadata ?? [],
+        })
       : [];
   const headerProjectLabel =
     input.item.family === "one_to_one_email"
@@ -2559,6 +2554,41 @@ function buildTimelineEntry(input: {
     authorId:
       input.item.family === "internal_note" ? input.item.authorId : null,
   };
+}
+
+function buildEmailAttachmentsForEntry(input: {
+  readonly canonical: readonly MessageAttachmentRecord[];
+  readonly pending: readonly {
+    readonly filename: string | null;
+    readonly contentType: string;
+    readonly sizeBytes: number;
+  }[];
+}): InboxTimelineEntryViewModel["attachments"] {
+  const canonicalAttachments = input.canonical
+    .filter((attachment) => !attachment.isInline)
+    .map((attachment) => ({
+      id: attachment.id,
+      mimeType: attachment.mimeType,
+      filename: attachment.filename,
+      sizeBytes: attachment.sizeBytes,
+      proxyUrl: `/api/attachments/${encodeURIComponent(attachment.id)}`,
+    }));
+
+  if (canonicalAttachments.length > 0) {
+    return canonicalAttachments;
+  }
+
+  if (input.pending.length > 0) {
+    return input.pending.map((attachment) => ({
+      id: null,
+      mimeType: attachment.contentType,
+      filename: attachment.filename,
+      sizeBytes: attachment.sizeBytes,
+      proxyUrl: null,
+    }));
+  }
+
+  return [];
 }
 
 /**

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -240,11 +240,11 @@ export interface InboxTimelineEntryViewModel {
   readonly failedDetail: string | null;
   readonly attachmentCount: number;
   readonly attachments: readonly {
-    readonly id: string;
+    readonly id: string | null;
     readonly mimeType: string;
     readonly filename: string | null;
     readonly sizeBytes: number;
-    readonly proxyUrl: string;
+    readonly proxyUrl: string | null;
   }[];
   readonly campaignActivity: readonly InboxTimelineCampaignActivityViewModel[];
   readonly noteId?: string | null;

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -5143,4 +5143,147 @@ describe("real inbox selectors", () => {
       },
     ]);
   });
+
+  it("falls back to pending attachment metadata when pending outbounds have no canonical attachments yet", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:pending-attachment-test",
+      salesforceContactId: null,
+      displayName: "Pending Attachment Test",
+      primaryEmail: "pending@example.org",
+      primaryPhone: null,
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:pending-attachment-test",
+      bucket: "Opened",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: null,
+      lastOutboundAt: "2026-04-20T12:05:00.000Z",
+      lastActivityAt: "2026-04-20T12:05:00.000Z",
+      snippet: "Pending outbound with attachment.",
+      lastCanonicalEventId: "pending-outbound:pending-attachment-1",
+      lastEventType: "communication.email.outbound",
+    });
+    await runtime.context.repositories.pendingOutbounds.insert({
+      id: "pending-attachment-1",
+      fingerprint: "fp:pending-attachment-1",
+      actorId: "user:operator",
+      canonicalContactId: "contact:pending-attachment-test",
+      projectId: null,
+      fromAlias: "field@adventuresci.org",
+      toEmailNormalized: "pending@example.org",
+      subject: "Packet attached",
+      bodyPlaintext: "See attached.",
+      bodyHtml: "<p>See attached.</p>",
+      bodySha256: "sha256:pending-attachment-1",
+      attachmentMetadata: [
+        {
+          filename: "x.zip",
+          contentType: "application/zip",
+          size: 1234,
+        },
+      ],
+      gmailThreadId: null,
+      inReplyToRfc822: null,
+      attemptedAt: "2026-04-20T12:05:00.000Z",
+    });
+
+    const detail = await getInboxDetail("contact:pending-attachment-test");
+
+    expect(detail?.timeline[0]?.attachmentCount).toBe(1);
+    expect(detail?.timeline[0]?.attachments).toEqual([
+      {
+        id: null,
+        mimeType: "application/zip",
+        filename: "x.zip",
+        sizeBytes: 1234,
+        proxyUrl: null,
+      },
+    ]);
+  });
+
+  it("prefers canonical attachments over pending metadata after reconciliation", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:canonical-attachment-preferred",
+      salesforceContactId: "003-canonical-attachment",
+      displayName: "Canonical Attachment Preferred",
+      primaryEmail: "canonical@example.org",
+      primaryPhone: null,
+    });
+    const latest = await seedInboxEmailEvent(runtime.context, {
+      id: "canonical-attachment-email-1",
+      contactId: "contact:canonical-attachment-preferred",
+      occurredAt: "2026-04-20T13:00:00.000Z",
+      direction: "outbound",
+      subject: "Canonical packet",
+      snippet: "See canonical attachment.",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:canonical-attachment-preferred",
+      bucket: "Opened",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: null,
+      lastOutboundAt: "2026-04-20T13:00:00.000Z",
+      lastActivityAt: "2026-04-20T13:00:00.000Z",
+      snippet: "See canonical attachment.",
+      lastCanonicalEventId: latest.canonicalEventId,
+      lastEventType: "communication.email.outbound",
+    });
+    await seedInboxMessageAttachment(runtime.context, {
+      sourceEvidenceId: "source:canonical-attachment-email-1",
+      id: "att:gmail:canonical-attachment-email-1:0/1",
+      mimeType: "application/pdf",
+      filename: "canonical.pdf",
+      sizeBytes: 4567,
+      storageKey: "gmail/ef/att:gmail:canonical-attachment-email-1:0/1",
+    });
+    await runtime.context.repositories.pendingOutbounds.insert({
+      id: "pending-canonical-attachment-1",
+      fingerprint: "fp:pending-canonical-attachment-1",
+      actorId: "user:operator",
+      canonicalContactId: "contact:canonical-attachment-preferred",
+      projectId: null,
+      fromAlias: "field@adventuresci.org",
+      toEmailNormalized: "canonical@example.org",
+      subject: "Canonical packet",
+      bodyPlaintext: "See canonical attachment.",
+      bodyHtml: "<p>See canonical attachment.</p>",
+      bodySha256: "sha256:pending-canonical-attachment-1",
+      attachmentMetadata: [
+        {
+          filename: "pending.zip",
+          contentType: "application/zip",
+          size: 1234,
+        },
+      ],
+      gmailThreadId: null,
+      inReplyToRfc822: null,
+      attemptedAt: "2026-04-20T12:59:00.000Z",
+    });
+
+    const detail = await getInboxDetail("contact:canonical-attachment-preferred");
+
+    const canonicalEntry = detail?.timeline.find((entry) =>
+      entry.attachments.some((attachment) => attachment.proxyUrl !== null),
+    );
+    expect(canonicalEntry?.attachments).toEqual([
+      {
+        id: "att:gmail:canonical-attachment-email-1:0/1",
+        mimeType: "application/pdf",
+        filename: "canonical.pdf",
+        sizeBytes: 4567,
+        proxyUrl:
+          "/api/attachments/att%3Agmail%3Acanonical-attachment-email-1%3A0%2F1",
+      },
+    ]);
+  });
 });

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -5218,8 +5218,11 @@ describe("real inbox selectors", () => {
 
     const detail = await getInboxDetail("contact:pending-attachment-test");
 
-    expect(detail?.timeline[0]?.attachmentCount).toBe(1);
-    expect(detail?.timeline[0]?.attachments).toEqual([
+    const pendingEntry = detail?.timeline.find((entry) =>
+      entry.attachments.some((attachment) => attachment.proxyUrl === null),
+    );
+    expect(pendingEntry?.attachmentCount).toBe(1);
+    expect(pendingEntry?.attachments).toEqual([
       {
         id: null,
         mimeType: "application/zip",

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -236,6 +236,21 @@ function buildMembership(
   };
 }
 
+async function seedOperatorUser(runtime: InboxTestRuntime): Promise<void> {
+  const now = new Date("2026-04-20T10:00:00.000Z");
+  await runtime.context.settings.users.upsert({
+    id: "user:operator",
+    email: "operator@test.local",
+    name: "Operator",
+    emailVerified: now,
+    image: null,
+    role: "operator",
+    deactivatedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
 async function seedInboxFixture(runtime: InboxTestRuntime): Promise<void> {
   await seedInboxContact(runtime.context, {
     contactId: "contact:lisa-zhang",
@@ -5149,6 +5164,7 @@ describe("real inbox selectors", () => {
       throw new Error("Expected inbox test runtime");
     }
 
+    await seedOperatorUser(runtime);
     await seedInboxContact(runtime.context, {
       contactId: "contact:pending-attachment-test",
       salesforceContactId: null,
@@ -5156,17 +5172,25 @@ describe("real inbox selectors", () => {
       primaryEmail: "pending@example.org",
       primaryPhone: null,
     });
+    const priorInbound = await seedInboxEmailEvent(runtime.context, {
+      id: "pending-attachment-inbound-1",
+      contactId: "contact:pending-attachment-test",
+      occurredAt: "2026-04-20T11:00:00.000Z",
+      direction: "inbound",
+      subject: "Question about volunteering",
+      snippet: "Hi, I would like to know more.",
+    });
     await seedInboxProjection(runtime.context, {
       contactId: "contact:pending-attachment-test",
       bucket: "Opened",
       needsFollowUp: false,
       hasUnresolved: false,
-      lastInboundAt: null,
+      lastInboundAt: "2026-04-20T11:00:00.000Z",
       lastOutboundAt: "2026-04-20T12:05:00.000Z",
       lastActivityAt: "2026-04-20T12:05:00.000Z",
       snippet: "Pending outbound with attachment.",
-      lastCanonicalEventId: "pending-outbound:pending-attachment-1",
-      lastEventType: "communication.email.outbound",
+      lastCanonicalEventId: priorInbound.canonicalEventId,
+      lastEventType: "communication.email.inbound",
     });
     await runtime.context.repositories.pendingOutbounds.insert({
       id: "pending-attachment-1",
@@ -5211,6 +5235,7 @@ describe("real inbox selectors", () => {
       throw new Error("Expected inbox test runtime");
     }
 
+    await seedOperatorUser(runtime);
     await seedInboxContact(runtime.context, {
       contactId: "contact:canonical-attachment-preferred",
       salesforceContactId: "003-canonical-attachment",

--- a/packages/contracts/src/stage1-timeline.ts
+++ b/packages/contracts/src/stage1-timeline.ts
@@ -107,6 +107,15 @@ export const oneToOneEmailTimelineItemSchema = timelineItemBaseSchema.extend({
   failedReason: z.string().nullable().optional(),
   failedDetail: z.string().nullable().optional(),
   attachmentCount: z.number().int().nonnegative().optional(),
+  pendingAttachmentMetadata: z
+    .array(
+      z.object({
+        filename: nullableStringSchema,
+        contentType: z.string(),
+        sizeBytes: z.number().int().nonnegative(),
+      }),
+    )
+    .optional(),
 });
 export type OneToOneEmailTimelineItem = z.infer<
   typeof oneToOneEmailTimelineItemSchema

--- a/packages/domain/src/timeline.ts
+++ b/packages/domain/src/timeline.ts
@@ -289,6 +289,11 @@ function buildPendingTimelineItems(
       failedReason: row.failedReason,
       failedDetail: row.failedDetail,
       attachmentCount: row.attachmentMetadata.length,
+      pendingAttachmentMetadata: row.attachmentMetadata.map((meta) => ({
+        filename: meta.filename,
+        contentType: meta.contentType,
+        sizeBytes: meta.size,
+      })),
     })),
   );
 }

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -827,7 +827,13 @@ describe("Stage 1 timeline presenter", () => {
           bodyPlaintext: "Pending outbound body",
           bodyHtml: "<p>Pending outbound body</p>",
           bodySha256: "sha256:pending",
-          attachmentMetadata: [],
+          attachmentMetadata: [
+            {
+              filename: "x.zip",
+              contentType: "application/zip",
+              size: 1234,
+            },
+          ],
           gmailThreadId: null,
           inReplyToRfc822: null,
           attemptedAt: "2026-01-01T00:02:00.000Z",
@@ -856,7 +862,14 @@ describe("Stage 1 timeline presenter", () => {
       subject: "Pending outbound",
       bodyPreview: "Pending outbound body",
       sendStatus: "pending",
-      attachmentCount: 0,
+      attachmentCount: 1,
+      pendingAttachmentMetadata: [
+        {
+          filename: "x.zip",
+          contentType: "application/zip",
+          sizeBytes: 1234,
+        },
+      ],
     });
   });
 


### PR DESCRIPTION
## Symptom

When an operator sends an email with an attachment via the composer, the send succeeds and the recipient confirms they got the file, but the platform's own timeline bubble for the just-sent email shows **no attachment chip** for the 1–5 minute window before gmail-capture polls the Sent folder. The attachment metadata is already in the DB on the `pending_composer_outbounds` row — it just never reaches the bubble.

## Root cause

Pending bubble's data path drops the metadata it already has:

- `buildPendingTimelineItems` at [`packages/domain/src/timeline.ts`](packages/domain/src/timeline.ts) only reads `row.attachmentMetadata.length` for `attachmentCount` — the per-attachment fields are never put on the `TimelineItem`.
- `buildTimelineEntry` at [`apps/web/app/inbox/_lib/selectors.ts`](apps/web/app/inbox/_lib/selectors.ts) builds `attachmentsByCanonicalEventId` strictly from canonical events' source-evidence IDs. Pending items use `canonicalEventId = "pending-outbound:{id}"` and miss the lookup → empty array → no chip.

Once gmail-capture re-ingests, the canonical event lands and the canonical `message_attachments` row drives the chip render normally — which is why the chip *eventually* appears. This PR closes the visibility window.

## Fix (4 surfaces)

1. **Schema** ([`packages/contracts/src/stage1-timeline.ts`](packages/contracts/src/stage1-timeline.ts)) — add optional `pendingAttachmentMetadata: { filename, contentType, sizeBytes }[]` on `oneToOneEmailTimelineItemSchema`.
2. **Domain** ([`packages/domain/src/timeline.ts`](packages/domain/src/timeline.ts)) — `buildPendingTimelineItems` populates the new field from `row.attachmentMetadata` (mapping `size` → `sizeBytes`).
3. **Selectors** ([`apps/web/app/inbox/_lib/selectors.ts`](apps/web/app/inbox/_lib/selectors.ts)) — extracted `buildEmailAttachmentsForEntry(canonical, pending)` helper; canonical wins, otherwise falls back to pending with `id: null` and `proxyUrl: null`.
4. **View-model + UI** ([`apps/web/app/inbox/_lib/view-models.ts`](apps/web/app/inbox/_lib/view-models.ts) + [`apps/web/app/inbox/_components/inbox-timeline-bubble.tsx`](apps/web/app/inbox/_components/inbox-timeline-bubble.tsx)) — attachment shape's `id` and `proxyUrl` become nullable; bubble renders pending file chips as non-clickable `<span>` (muted slate-500, no `ArrowUpRightIcon`); pending image attachments fall through to the file path so a chip still appears.

## Out of scope

- Gmail-capture pipeline / `message_attachments` writes — already work correctly post-reconciliation.
- Optimistic client-side bubble (it already shows the attachment from the in-memory FileList).
- Attachment size / count caps.

## Test plan

- [x] `pnpm typecheck && pnpm lint` clean across all 14 packages.
- [x] New unit test in `apps/web/tests/unit/inbox-selectors.test.ts` asserts pending fallback (`id: null`, `proxyUrl: null`, correct mimeType/filename/sizeBytes) and that `attachmentCount` reflects pending metadata length.
- [x] New assertion in `packages/domain/test/timeline.test.ts` covers the pending → timeline-item field mapping.
- [ ] Post-merge: send a fresh email with an attachment in prod and verify the chip appears immediately on the bubble (greyed out / non-clickable) instead of waiting 1–5 min for capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)