### PR TITLE
feat(sms): phase 3 inbound — webhook processing, contact resolution, timeline integration

### DIFF
--- a/apps/sms-capture/src/server.ts
+++ b/apps/sms-capture/src/server.ts
@@ -4,12 +4,18 @@ import {
   type Server,
   type ServerResponse,
 } from "node:http";
+import { createHash, randomUUID } from "node:crypto";
 
 import {
   createDatabaseConnection,
-  createStage1RepositoryBundleFromConnection,
+  createStage1RepositoryBundle,
+  type Stage1Database,
 } from "@as-comms/db";
-import type { Stage1RepositoryBundle } from "@as-comms/domain";
+import {
+  resolveContactByPhone,
+  smsMetrics,
+  type Stage1RepositoryBundle,
+} from "@as-comms/domain";
 import { createTwilioProvider, type TwilioProvider } from "@as-comms/integrations";
 import { z } from "zod";
 
@@ -149,6 +155,14 @@ function paramsFromBody(bodyText: string): Record<string, string> {
   return params;
 }
 
+function isUniqueViolation(error: unknown): boolean {
+  if (typeof error !== "object" || error === null || !("code" in error)) {
+    return false;
+  }
+
+  return (error as { readonly code?: unknown }).code === "23505";
+}
+
 function readWebhookUrl(request: IncomingMessage): string {
   const host = request.headers.host ?? "sms-capture.local";
   const protoHeader = request.headers["x-forwarded-proto"];
@@ -163,7 +177,8 @@ async function handleWebhookRequest(input: {
   readonly request: IncomingMessage;
   readonly response: ServerResponse;
   readonly provider: TwilioProvider;
-  readonly repositories: Pick<Stage1RepositoryBundle, "smsMessages">;
+  readonly repositories: Stage1RepositoryBundle;
+  readonly db: Stage1Database | null;
   readonly path: string;
 }): Promise<void> {
   const bodyText = await readRequestBody(input.request);
@@ -184,6 +199,12 @@ async function handleWebhookRequest(input: {
   }
 
   if (input.path === "/webhooks/inbound") {
+    await handleInboundWebhook({
+      params,
+      provider: input.provider,
+      repositories: input.repositories,
+      db: input.db,
+    });
     writeJson(input.response, 200, { ok: true });
     return;
   }
@@ -244,23 +265,36 @@ async function handleWebhookRequest(input: {
     return;
   }
 
+  if (input.path === "/webhooks/opt-out") {
+    await handleOptOutWebhook({
+      params,
+      repositories: input.repositories,
+      db: input.db,
+    });
+    writeJson(input.response, 200, { ok: true });
+    return;
+  }
+
   writeJson(input.response, 200, { ok: true });
 }
 
 export function createSmsCaptureServer(input: {
   readonly config: SmsCaptureRuntimeConfig;
   readonly provider?: TwilioProvider;
-  readonly repositories?: Pick<Stage1RepositoryBundle, "smsMessages">;
+  readonly db?: Stage1Database;
+  readonly repositories?: Stage1RepositoryBundle;
 }): Server {
   const provider =
     input.provider ?? createTwilioProvider(input.config.service);
+  const db =
+    input.db ??
+    (input.repositories === undefined
+      ? createDatabaseConnection({
+          connectionString: input.config.databaseUrl,
+        }).db
+      : null);
   const repositories =
-    input.repositories ??
-    createStage1RepositoryBundleFromConnection(
-      createDatabaseConnection({
-        connectionString: input.config.databaseUrl,
-      }),
-    );
+    input.repositories ?? createStage1RepositoryBundle(requireDatabase(db));
 
   return createServer((request, response) => {
     void (async () => {
@@ -278,6 +312,7 @@ export function createSmsCaptureServer(input: {
           response,
           provider,
           repositories,
+          db,
           path,
         });
       } catch (error) {
@@ -305,5 +340,302 @@ export function startSmsCaptureServer(
       server.off("error", reject);
       resolve(server);
     });
+  });
+}
+
+function sha256Json(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+function isInboundProjectionLatest(input: {
+  readonly existingLastActivityAt: string | null;
+  readonly occurredAtIso: string;
+}): boolean {
+  return (
+    input.existingLastActivityAt === null ||
+    input.occurredAtIso >= input.existingLastActivityAt
+  );
+}
+
+async function withRepositories<T>(input: {
+  readonly db: Stage1Database | null;
+  readonly repositories: Stage1RepositoryBundle;
+  readonly transactional: boolean;
+  readonly run: (repositories: Stage1RepositoryBundle) => Promise<T>;
+}): Promise<T> {
+  if (!input.transactional || input.db === null) {
+    return input.run(input.repositories);
+  }
+
+  return input.db.transaction(async (tx) =>
+    input.run(createStage1RepositoryBundle(tx)),
+  );
+}
+
+function requireDatabase(db: Stage1Database | null): Stage1Database {
+  if (db === null) {
+    throw new Error("Database handle is required for repository creation.");
+  }
+
+  return db;
+}
+
+async function handleInboundWebhook(input: {
+  readonly params: Record<string, string>;
+  readonly provider: TwilioProvider;
+  readonly repositories: Stage1RepositoryBundle;
+  readonly db: Stage1Database | null;
+}): Promise<void> {
+  const parsed = input.provider.parseInbound(input.params);
+
+  try {
+    await withRepositories({
+      db: input.db,
+      repositories: input.repositories,
+      transactional: true,
+      run: async (repositories) => {
+        const existingMessage = await repositories.smsMessages.findByTwilioSid(
+          parsed.messageSid,
+        );
+
+        if (existingMessage !== null) {
+          return;
+        }
+
+        const sender = await repositories.smsSenders.findByPhone(parsed.toE164);
+
+        if (sender === null) {
+          console.warn(
+            `Inbound SMS ignored for unknown sender number ${parsed.toE164}`,
+          );
+          return;
+        }
+
+        const now = new Date();
+        const occurredAtIso = now.toISOString();
+        const resolution = await resolveContactByPhone({
+          phoneE164: parsed.fromE164,
+          readContacts: {
+            findByPrimaryPhone: (phoneE164) =>
+              repositories.contacts.findByPrimaryPhone(phoneE164),
+          },
+          writeContacts: {
+            upsert: (record) => repositories.contacts.upsert(record),
+          },
+          clock: {
+            now: () => now,
+          },
+          idGenerator: () => randomUUID(),
+        });
+        const sourceEvidenceId = randomUUID();
+        const canonicalEventId = randomUUID();
+        const inboundMessageId = randomUUID();
+        const metrics = smsMetrics(parsed.body);
+        const payloadRef = `twilio:webhooks/inbound:${parsed.messageSid}`;
+        const checksum = sha256Json({
+          body: parsed.body,
+          fromE164: parsed.fromE164,
+          mediaUrls: parsed.mediaUrls,
+          messageSid: parsed.messageSid,
+          numMediaUrls: parsed.numMediaUrls,
+          toE164: parsed.toE164,
+        });
+
+        await repositories.sourceEvidence.append({
+          id: sourceEvidenceId,
+          provider: "twilio",
+          providerRecordType: "message",
+          providerRecordId: parsed.messageSid,
+          receivedAt: occurredAtIso,
+          occurredAt: occurredAtIso,
+          payloadRef,
+          idempotencyKey: `twilio:message:${parsed.messageSid}`,
+          checksum,
+        });
+        await repositories.canonicalEvents.upsert({
+          id: canonicalEventId,
+          contactId: resolution.contact.id,
+          eventType: "communication.sms.inbound",
+          channel: "sms",
+          occurredAt: occurredAtIso,
+          contentFingerprint: null,
+          sourceEvidenceId,
+          idempotencyKey: `twilio:message:${parsed.messageSid}:communication.sms.inbound`,
+          provenance: {
+            primaryProvider: "twilio",
+            primarySourceEvidenceId: sourceEvidenceId,
+            supportingSourceEvidenceIds: [],
+            winnerReason: "single_source",
+            sourceRecordType: "message",
+            sourceRecordId: parsed.messageSid,
+            messageKind: "one_to_one",
+            campaignRef: null,
+            threadRef: {
+              crossProviderCollapseKey: parsed.fromE164,
+              providerThreadId: parsed.fromE164,
+            },
+            direction: "inbound",
+            notes: null,
+            inboxProjectionExclusionReason: null,
+          },
+          reviewState: "clear",
+        });
+        await repositories.smsMessages.insert({
+          id: inboundMessageId,
+          twilioMessageSid: parsed.messageSid,
+          direction: "inbound",
+          contactId: resolution.contact.id,
+          phoneE164: parsed.fromE164,
+          senderId: sender.id,
+          body: parsed.body,
+          segments: metrics.segments,
+          encoding: metrics.encoding,
+          mediaUrls: parsed.mediaUrls.length > 0 ? parsed.mediaUrls : null,
+          sendStatus: "received",
+          failedReason: null,
+          failedDetail: null,
+          sentAt: null,
+          receivedAt: now,
+          actorId: null,
+          createdAt: now,
+          updatedAt: now,
+        });
+
+        const existingInboxProjection =
+          await repositories.inboxProjection.findByContactId(resolution.contact.id);
+        const isLatest = isInboundProjectionLatest({
+          existingLastActivityAt:
+            existingInboxProjection?.lastActivityAt ?? null,
+          occurredAtIso,
+        });
+        const nextLastOutboundAt =
+          existingInboxProjection?.lastOutboundAt ?? null;
+
+        await repositories.inboxProjection.upsert({
+          contactId: resolution.contact.id,
+          bucket: "New",
+          needsFollowUp: existingInboxProjection?.needsFollowUp ?? false,
+          hasUnresolved: existingInboxProjection?.hasUnresolved ?? false,
+          lastInboundAt: isLatest
+            ? occurredAtIso
+            : existingInboxProjection?.lastInboundAt ?? occurredAtIso,
+          lastOutboundAt: nextLastOutboundAt,
+          lastActivityAt: isLatest
+            ? occurredAtIso
+            : existingInboxProjection?.lastActivityAt ?? occurredAtIso,
+          snippet: isLatest
+            ? parsed.body
+            : existingInboxProjection?.snippet ?? parsed.body,
+          archivedAt: existingInboxProjection?.archivedAt ?? null,
+          lastCanonicalEventId: isLatest
+            ? canonicalEventId
+            : existingInboxProjection?.lastCanonicalEventId ?? canonicalEventId,
+          lastEventType: isLatest
+            ? "communication.sms.inbound"
+            : existingInboxProjection?.lastEventType ??
+              "communication.sms.inbound",
+        });
+
+        const latestConsent = await repositories.consentRecords.findLatestByPhone(
+          parsed.fromE164,
+        );
+
+        if (latestConsent?.status !== "opted_in") {
+          await repositories.consentRecords.insert({
+            id: randomUUID(),
+            contactId: resolution.contact.id,
+            phoneE164: parsed.fromE164,
+            status: "opted_in",
+            source: "inbound_thread",
+            sourceDetail: null,
+            consentedAt: now,
+            revokedAt: null,
+            recordedByUserId: null,
+            notes: null,
+            createdAt: now,
+            updatedAt: now,
+          });
+        }
+      },
+    });
+  } catch (error) {
+    if (!isUniqueViolation(error)) {
+      throw error;
+    }
+
+    const duplicate = await input.repositories.smsMessages.findByTwilioSid(
+      parsed.messageSid,
+    );
+
+    if (duplicate === null) {
+      throw error;
+    }
+  }
+}
+
+async function handleOptOutWebhook(input: {
+  readonly params: Record<string, string>;
+  readonly repositories: Stage1RepositoryBundle;
+  readonly db: Stage1Database | null;
+}): Promise<void> {
+  const parsed = z
+    .object({
+      From: z.string().min(1),
+      OptOutType: z.string().min(1),
+    })
+    .safeParse(input.params);
+
+  if (!parsed.success) {
+    return;
+  }
+
+  const optOutType = parsed.data.OptOutType.toUpperCase();
+
+  await withRepositories({
+    db: input.db,
+    repositories: input.repositories,
+    transactional: true,
+    run: async (repositories) => {
+      const contact = await repositories.contacts.findByPrimaryPhone(
+        parsed.data.From,
+      );
+      const now = new Date();
+
+      if (optOutType === "HELP") {
+        console.info(`SMS HELP webhook acknowledged for ${parsed.data.From}`);
+        return;
+      }
+
+      if (optOutType !== "STOP" && optOutType !== "START" && optOutType !== "UNSTOP") {
+        console.info(
+          `SMS opt-out webhook ignored unsupported OptOutType ${optOutType}`,
+        );
+        return;
+      }
+
+      await repositories.consentRecords.insert({
+        id: randomUUID(),
+        contactId: contact?.id ?? null,
+        phoneE164: parsed.data.From,
+        status:
+          optOutType === "STOP"
+            ? "revoked"
+            : "opted_in",
+        source: "sms_reply_yes",
+        sourceDetail: optOutType,
+        consentedAt:
+          optOutType === "STOP"
+            ? null
+            : now,
+        revokedAt:
+          optOutType === "STOP"
+            ? now
+            : null,
+        recordedByUserId: null,
+        notes: null,
+        createdAt: now,
+        updatedAt: now,
+      });
+    },
   });
 }

--- a/apps/sms-capture/test/server.test.ts
+++ b/apps/sms-capture/test/server.test.ts
@@ -1,7 +1,18 @@
 import type { Server } from "node:http";
 
-import { smsSenders } from "@as-comms/db";
-import { createTestStage1Context, type TestStage1Context } from "@as-comms/db/test-helpers";
+import {
+  canonicalEventLedger,
+  consentRecords,
+  contactInboxProjection,
+  contacts,
+  smsMessages,
+  smsSenders,
+  sourceEvidenceLog,
+} from "@as-comms/db";
+import {
+  createTestStage1Context,
+  type TestStage1Context,
+} from "@as-comms/db/test-helpers";
 import type { TwilioProvider } from "@as-comms/integrations";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -59,6 +70,53 @@ function buildConfig() {
   });
 }
 
+function buildProvider(input?: {
+  readonly inbound?: ReturnType<TwilioProvider["parseInbound"]>;
+}): TwilioProvider {
+  return {
+    sendSms() {
+      return Promise.resolve({
+        messageSid: "SMignored",
+        segments: 1,
+      });
+    },
+    verifyWebhookSignature() {
+      return true;
+    },
+    parseInbound() {
+      return (
+        input?.inbound ?? {
+          messageSid: "SM00000000000000000000000000000000",
+          fromE164: "+14065550143",
+          toE164: "+14065550142",
+          body: "hello from inbound",
+          numMediaUrls: 0,
+          mediaUrls: [],
+        }
+      );
+    },
+  };
+}
+
+async function createContext() {
+  const context = await createTestStage1Context();
+  contexts.push(context);
+  return context;
+}
+
+async function seedSender(context: TestStage1Context) {
+  const timestamp = new Date("2026-05-03T12:00:00.000Z");
+  await context.db.insert(smsSenders).values({
+    id: "sender-1",
+    phoneE164: "+14065550142",
+    displayName: "AS Test Sender",
+    monthlyCap: null,
+    isActive: true,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  });
+}
+
 describe("SMS capture server", () => {
   it("rejects unsigned inbound webhook requests", async () => {
     const baseUrl = await listen(createSmsCaptureServer({ config: buildConfig() }));
@@ -81,9 +139,7 @@ describe("SMS capture server", () => {
   });
 
   it("updates the sms message row on a signed status callback", async () => {
-    const context = await createTestStage1Context();
-    contexts.push(context);
-
+    const context = await createContext();
     const seedTimestamp = new Date("2026-05-03T12:00:00.000Z");
     await context.settings.users.upsert({
       id: "user-1",
@@ -105,15 +161,7 @@ describe("SMS capture server", () => {
       createdAt: seedTimestamp.toISOString(),
       updatedAt: seedTimestamp.toISOString(),
     });
-    await context.db.insert(smsSenders).values({
-      id: "sender-1",
-      phoneE164: "+14065550142",
-      displayName: "AS Test Sender",
-      monthlyCap: null,
-      isActive: true,
-      createdAt: seedTimestamp,
-      updatedAt: seedTimestamp,
-    });
+    await seedSender(context);
 
     await context.repositories.smsMessages.insert({
       id: "sms-message-1",
@@ -136,32 +184,11 @@ describe("SMS capture server", () => {
       updatedAt: new Date("2026-05-03T12:00:00.000Z"),
     });
 
-    const provider: TwilioProvider = {
-      sendSms() {
-        return Promise.resolve({
-          messageSid: "SMignored",
-          segments: 1,
-        });
-      },
-      verifyWebhookSignature() {
-        return true;
-      },
-      parseInbound() {
-        return {
-          messageSid: "SMignored",
-          fromE164: "+14065550142",
-          toE164: "+14065550143",
-          body: "",
-          numMediaUrls: 0,
-          mediaUrls: [],
-        };
-      },
-    };
     const baseUrl = await listen(
       createSmsCaptureServer({
         config: buildConfig(),
-        provider,
-        repositories: context.repositories,
+        provider: buildProvider(),
+        db: context.db,
       }),
     );
 
@@ -184,6 +211,332 @@ describe("SMS capture server", () => {
       ),
     ).resolves.toMatchObject({
       sendStatus: "delivered",
+    });
+  });
+
+  it("creates a contact, inbound sms row, auto-consent, source evidence, canonical event, and inbox projection", async () => {
+    const context = await createContext();
+    await seedSender(context);
+    const provider = buildProvider({
+      inbound: {
+        messageSid: "SMinbound-1",
+        fromE164: "+14065550143",
+        toE164: "+14065550142",
+        body: "Need help with my trip",
+        numMediaUrls: 0,
+        mediaUrls: [],
+      },
+    });
+    const baseUrl = await listen(
+      createSmsCaptureServer({
+        config: buildConfig(),
+        provider,
+        db: context.db,
+      }),
+    );
+
+    const response = await fetch(`${baseUrl}/webhooks/inbound`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        "x-twilio-signature": "signed",
+      },
+      body: new URLSearchParams({
+        MessageSid: "SMinbound-1",
+        From: "+14065550143",
+        To: "+14065550142",
+        Body: "Need help with my trip",
+        NumMedia: "0",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    const contactRows = await context.db.select().from(contacts);
+    expect(contactRows).toHaveLength(1);
+    expect(contactRows[0]).toMatchObject({
+      primaryPhone: "+14065550143",
+      displayName: "Unknown (+1 406 555 0143)",
+    });
+
+    const smsRows = await context.db.select().from(smsMessages);
+    expect(smsRows).toHaveLength(1);
+    expect(smsRows[0]).toMatchObject({
+      twilioMessageSid: "SMinbound-1",
+      direction: "inbound",
+      phoneE164: "+14065550143",
+      body: "Need help with my trip",
+      sendStatus: "received",
+    });
+
+    const consentRows = await context.db.select().from(consentRecords);
+    expect(consentRows).toHaveLength(1);
+    expect(consentRows[0]).toMatchObject({
+      phoneE164: "+14065550143",
+      status: "opted_in",
+      source: "inbound_thread",
+    });
+
+    const sourceEvidenceRows = await context.db.select().from(sourceEvidenceLog);
+    expect(sourceEvidenceRows).toHaveLength(1);
+    expect(sourceEvidenceRows[0]).toMatchObject({
+      provider: "twilio",
+      providerRecordType: "message",
+      providerRecordId: "SMinbound-1",
+    });
+
+    const canonicalRows = await context.db.select().from(canonicalEventLedger);
+    expect(canonicalRows).toHaveLength(1);
+    expect(canonicalRows[0]).toMatchObject({
+      contactId: contactRows[0]?.id,
+      eventType: "communication.sms.inbound",
+      channel: "sms",
+    });
+
+    const projectionRows = await context.db.select().from(contactInboxProjection);
+    expect(projectionRows).toHaveLength(1);
+    expect(projectionRows[0]).toMatchObject({
+      contactId: contactRows[0]?.id,
+      bucket: "New",
+      snippet: "Need help with my trip",
+      lastCanonicalEventId: canonicalRows[0]?.id,
+      lastEventType: "communication.sms.inbound",
+    });
+  });
+
+  it("reuses an existing contact for signed inbound sms", async () => {
+    const context = await createContext();
+    await seedSender(context);
+    await context.repositories.contacts.upsert({
+      id: "contact-existing",
+      salesforceContactId: null,
+      displayName: "Existing Contact",
+      primaryEmail: null,
+      primaryPhone: "+14065550143",
+      createdAt: "2026-05-03T12:00:00.000Z",
+      updatedAt: "2026-05-03T12:00:00.000Z",
+    });
+
+    const baseUrl = await listen(
+      createSmsCaptureServer({
+        config: buildConfig(),
+        provider: buildProvider({
+          inbound: {
+            messageSid: "SMinbound-existing",
+            fromE164: "+14065550143",
+            toE164: "+14065550142",
+            body: "hello again",
+            numMediaUrls: 0,
+            mediaUrls: [],
+          },
+        }),
+        db: context.db,
+      }),
+    );
+
+    const response = await fetch(`${baseUrl}/webhooks/inbound`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        "x-twilio-signature": "signed",
+      },
+      body: new URLSearchParams({
+        MessageSid: "SMinbound-existing",
+        From: "+14065550143",
+        To: "+14065550142",
+        Body: "hello again",
+        NumMedia: "0",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const contactRows = await context.db.select().from(contacts);
+    expect(contactRows).toHaveLength(1);
+    expect(contactRows[0]?.id).toBe("contact-existing");
+  });
+
+  it("tolerates inbound message sid retries without double-writing", async () => {
+    const context = await createContext();
+    await seedSender(context);
+    const provider = buildProvider({
+      inbound: {
+        messageSid: "SMinbound-duplicate",
+        fromE164: "+14065550143",
+        toE164: "+14065550142",
+        body: "retry me once",
+        numMediaUrls: 0,
+        mediaUrls: [],
+      },
+    });
+    const baseUrl = await listen(
+      createSmsCaptureServer({
+        config: buildConfig(),
+        provider,
+        db: context.db,
+      }),
+    );
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const response = await fetch(`${baseUrl}/webhooks/inbound`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          "x-twilio-signature": "signed",
+        },
+        body: new URLSearchParams({
+          MessageSid: "SMinbound-duplicate",
+          From: "+14065550143",
+          To: "+14065550142",
+          Body: "retry me once",
+          NumMedia: "0",
+        }),
+      });
+
+      expect(response.status).toBe(200);
+    }
+
+    expect((await context.db.select().from(smsMessages)).length).toBe(1);
+    expect((await context.db.select().from(sourceEvidenceLog)).length).toBe(1);
+    expect((await context.db.select().from(canonicalEventLedger)).length).toBe(1);
+  });
+
+  it("returns 200 and skips writes for an unknown sender number", async () => {
+    const context = await createContext();
+    const baseUrl = await listen(
+      createSmsCaptureServer({
+        config: buildConfig(),
+        provider: buildProvider({
+          inbound: {
+            messageSid: "SMinbound-unknown-sender",
+            fromE164: "+14065550143",
+            toE164: "+14065559999",
+            body: "wrong route",
+            numMediaUrls: 0,
+            mediaUrls: [],
+          },
+        }),
+        db: context.db,
+      }),
+    );
+
+    const response = await fetch(`${baseUrl}/webhooks/inbound`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        "x-twilio-signature": "signed",
+      },
+      body: new URLSearchParams({
+        MessageSid: "SMinbound-unknown-sender",
+        From: "+14065550143",
+        To: "+14065559999",
+        Body: "wrong route",
+        NumMedia: "0",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect((await context.db.select().from(smsMessages)).length).toBe(0);
+  });
+
+  it("records STOP as revoked consent", async () => {
+    const context = await createContext();
+    await context.repositories.contacts.upsert({
+      id: "contact-stop",
+      salesforceContactId: null,
+      displayName: "Contact Stop",
+      primaryEmail: null,
+      primaryPhone: "+14065550143",
+      createdAt: "2026-05-03T12:00:00.000Z",
+      updatedAt: "2026-05-03T12:00:00.000Z",
+    });
+    const baseUrl = await listen(
+      createSmsCaptureServer({
+        config: buildConfig(),
+        provider: buildProvider(),
+        db: context.db,
+      }),
+    );
+
+    const response = await fetch(`${baseUrl}/webhooks/opt-out`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        "x-twilio-signature": "signed",
+      },
+      body: new URLSearchParams({
+        From: "+14065550143",
+        OptOutType: "STOP",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const consentRows = await context.db.select().from(consentRecords);
+    expect(consentRows).toHaveLength(1);
+    expect(consentRows[0]).toMatchObject({
+      contactId: "contact-stop",
+      phoneE164: "+14065550143",
+      status: "revoked",
+      source: "sms_reply_yes",
+      sourceDetail: "STOP",
+    });
+  });
+
+  it("treats HELP as a no-op", async () => {
+    const context = await createContext();
+    const baseUrl = await listen(
+      createSmsCaptureServer({
+        config: buildConfig(),
+        provider: buildProvider(),
+        db: context.db,
+      }),
+    );
+
+    const response = await fetch(`${baseUrl}/webhooks/opt-out`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        "x-twilio-signature": "signed",
+      },
+      body: new URLSearchParams({
+        From: "+14065550143",
+        OptOutType: "HELP",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect((await context.db.select().from(consentRecords)).length).toBe(0);
+  });
+
+  it("records START as re-consent", async () => {
+    const context = await createContext();
+    const baseUrl = await listen(
+      createSmsCaptureServer({
+        config: buildConfig(),
+        provider: buildProvider(),
+        db: context.db,
+      }),
+    );
+
+    const response = await fetch(`${baseUrl}/webhooks/opt-out`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        "x-twilio-signature": "signed",
+      },
+      body: new URLSearchParams({
+        From: "+14065550143",
+        OptOutType: "START",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const consentRows = await context.db.select().from(consentRecords);
+    expect(consentRows).toHaveLength(1);
+    expect(consentRows[0]).toMatchObject({
+      phoneE164: "+14065550143",
+      status: "opted_in",
+      source: "sms_reply_yes",
+      sourceDetail: "START",
     });
   });
 });

--- a/apps/web/app/inbox/_components/inbox-timeline.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline.tsx
@@ -24,6 +24,7 @@ import { TRANSITION } from "@/app/_lib/design-tokens-v2";
 import { TimelineAutomatedRow } from "./inbox-timeline-automated-row";
 import { MessageBubble } from "./inbox-timeline-bubble";
 import { TimelineNoteEntry } from "./inbox-timeline-note-entry";
+import { SmsMessage } from "./sms-message";
 import { SystemDivider } from "./inbox-timeline-system-divider";
 
 export { shouldHideAutomatedRowBody } from "./inbox-timeline-automated-row";
@@ -279,6 +280,16 @@ function TimelineEntry({
 
   switch (role) {
     case "inbound":
+      if (entry.kind === "inbound-sms") {
+        return (
+          <SmsMessage
+            entry={entry}
+            direction="inbound"
+            {...(onReply === undefined ? {} : { onReply })}
+          />
+        );
+      }
+
       return (
         <MessageBubble
           entry={entry}
@@ -287,6 +298,18 @@ function TimelineEntry({
         />
       );
     case "outbound":
+      if (entry.kind === "outbound-sms") {
+        return (
+          <SmsMessage
+            entry={entry}
+            direction="outbound"
+            isRetrying={retryingEntryId === entry.id}
+            {...(onReply === undefined ? {} : { onReply })}
+            {...(onRetryPending === undefined ? {} : { onRetryPending })}
+          />
+        );
+      }
+
       return (
         <MessageBubble
           entry={entry}

--- a/apps/web/app/inbox/_components/sms-message.tsx
+++ b/apps/web/app/inbox/_components/sms-message.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+import type { InboxTimelineEntryViewModel } from "../_lib/view-models";
+import { autolinkText } from "./_autolink";
+import {
+  CornerUpLeftIcon,
+  LoaderIcon,
+  RefreshCwIcon,
+} from "./icons";
+
+function StatusBanner({
+  entry,
+  isRetrying,
+  onRetryPending,
+}: {
+  readonly entry: InboxTimelineEntryViewModel;
+  readonly isRetrying: boolean;
+  readonly onRetryPending?: (entryId: string) => void;
+}) {
+  if (entry.sendStatus === "pending") {
+    return (
+      <div className="mb-2 inline-flex items-center gap-1 rounded-full bg-white/20 px-2 py-1 text-[11px] font-medium text-white/90">
+        <LoaderIcon className="size-3 animate-spin" />
+        Sending...
+      </div>
+    );
+  }
+
+  if (entry.sendStatus !== "failed" && entry.sendStatus !== "orphaned") {
+    return null;
+  }
+
+  return (
+    <div className="mb-2 flex items-center justify-between gap-2 rounded-lg bg-white/12 px-2.5 py-2 text-[11px] text-white/90">
+      <span>
+        {entry.sendStatus === "failed" ? "Send failed." : "Send stalled."}
+      </span>
+      {onRetryPending === undefined ? null : (
+        <button
+          type="button"
+          onClick={() => {
+            onRetryPending(entry.id);
+          }}
+          disabled={isRetrying}
+          className="inline-flex items-center gap-1 rounded-full bg-white/90 px-2 py-1 font-medium text-sky-700 disabled:opacity-60"
+        >
+          {isRetrying ? (
+            <LoaderIcon className="size-3 animate-spin" />
+          ) : (
+            <RefreshCwIcon className="size-3" />
+          )}
+          Retry
+        </button>
+      )}
+    </div>
+  );
+}
+
+export function SmsMessage({
+  entry,
+  direction,
+  onReply,
+  isRetrying = false,
+  onRetryPending,
+}: {
+  readonly entry: InboxTimelineEntryViewModel;
+  readonly direction: "inbound" | "outbound";
+  readonly onReply?: (entryId: string) => void;
+  readonly isRetrying?: boolean;
+  readonly onRetryPending?: (entryId: string) => void;
+}) {
+  const isOutbound = direction === "outbound";
+
+  return (
+    <li
+      className={cn(
+        "flex w-full flex-col",
+        isOutbound ? "items-end pl-16" : "items-start pr-16",
+      )}
+    >
+      <div className="mb-1 px-1">
+        <span
+          className={cn(
+            "text-[10px] font-semibold uppercase tracking-wider",
+            isOutbound ? "text-sky-600" : "text-emerald-700",
+          )}
+        >
+          SMS
+        </span>
+      </div>
+
+      <div
+        className={cn(
+          "w-full max-w-[440px] rounded-2xl border px-4 py-3 shadow-sm",
+          isOutbound
+            ? "rounded-br-md border-sky-600 bg-sky-600 text-white"
+            : "rounded-bl-md border-slate-200 bg-white text-slate-900",
+        )}
+      >
+        {isOutbound ? (
+          <StatusBanner
+            entry={entry}
+            isRetrying={isRetrying}
+            {...(onRetryPending === undefined ? {} : { onRetryPending })}
+          />
+        ) : null}
+
+        {entry.body.trim().length > 0 ? (
+          <p
+            className={cn(
+              "whitespace-pre-wrap text-[13px] leading-relaxed [overflow-wrap:anywhere]",
+              isOutbound ? "text-white" : "text-slate-700",
+            )}
+          >
+            {autolinkText(entry.body)}
+          </p>
+        ) : null}
+
+        <div
+          className={cn(
+            "mt-2 text-[11px]",
+            isOutbound ? "text-white/75" : "text-slate-500",
+          )}
+        >
+          {entry.occurredAtLabel}
+        </div>
+      </div>
+
+      {isOutbound ? (
+        <div className="mt-1 px-1 text-[11px] text-slate-500">
+          {entry.actorLabel}
+        </div>
+      ) : null}
+
+      {onReply === undefined ? null : (
+        <button
+          type="button"
+          onClick={() => {
+            onReply(entry.id);
+          }}
+          className="mt-2 inline-flex items-center gap-1 px-1 text-[11px] text-slate-500 hover:text-slate-800"
+        >
+          <CornerUpLeftIcon className="size-3" />
+          Reply
+        </button>
+      )}
+    </li>
+  );
+}

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -3668,7 +3668,7 @@ async function readInboxDetailCacheData(
     isUnread,
     memberships,
     latestNote,
-    activityTimelineItems: visibleTimelineItems,
+    activityTimelineItems,
     timelineItems: timelinePage.items,
     campaignActivitySummaryByCampaignId:
       await loadCampaignActivitySummaryByCampaignId({

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -9,6 +9,7 @@ import type {
 } from "@as-comms/contracts";
 
 import { getCurrentUser } from "@/src/server/auth/session";
+import { readWebEnv } from "@/src/server/env";
 import { recordSensitiveReadForCurrentUserDetached } from "@/src/server/security/audit";
 import { getStage1WebRuntime } from "../../../src/server/stage1-runtime";
 import {
@@ -40,6 +41,17 @@ import type {
   InboxWelcomeWorkloadViewModel,
 } from "./view-models";
 export { groupInboxTimelineSystemMessages } from "./view-models";
+
+function filterSmsTimelineItems(
+  items: readonly TimelineItem[],
+  smsEnabled: boolean,
+): readonly TimelineItem[] {
+  if (smsEnabled) {
+    return items;
+  }
+
+  return items.filter((item) => item.family !== "one_to_one_sms");
+}
 
 interface InboxListCacheRow {
   readonly contact: ContactRecord;
@@ -2426,10 +2438,14 @@ function buildTimelineEntry(input: {
         })
       : [];
   const isUnread =
-    input.inboxProjection.bucket === "New" &&
-    input.item.canonicalEventId ===
-      input.inboxProjection.lastCanonicalEventId &&
-    (finalKind === "inbound-email" || finalKind === "inbound-sms");
+    finalKind === "inbound-sms"
+      ? input.inboxProjection.bucket === "New" &&
+        input.inboxProjection.lastEventType === "communication.sms.inbound" &&
+        input.inboxProjection.lastInboundAt === input.item.occurredAt
+      : input.inboxProjection.bucket === "New" &&
+        input.item.canonicalEventId ===
+          input.inboxProjection.lastCanonicalEventId &&
+        finalKind === "inbound-email";
   const attachments =
     input.item.family === "one_to_one_email"
       ? buildEmailAttachmentsForEntry({
@@ -3460,6 +3476,7 @@ async function readInboxDetailCacheData(
   },
 ): Promise<InboxDetailCacheData | null> {
   const runtime = await getStage1WebRuntime();
+  const env = readWebEnv();
   const [
     contact,
     inboxProjection,
@@ -3522,7 +3539,7 @@ async function readInboxDetailCacheData(
   }
 
   const visibleTimelineItems = filterItemsAtOrAfterPlatformFullCaptureCutover(
-    activityTimelineItems,
+    filterSmsTimelineItems(activityTimelineItems, env.SMS_ENABLED),
   );
   const timelinePage = paginateTimelineItems({
     timelineItems: visibleTimelineItems,
@@ -3651,7 +3668,7 @@ async function readInboxDetailCacheData(
     isUnread,
     memberships,
     latestNote,
-    activityTimelineItems,
+    activityTimelineItems: visibleTimelineItems,
     timelineItems: timelinePage.items,
     campaignActivitySummaryByCampaignId:
       await loadCampaignActivitySummaryByCampaignId({

--- a/packages/db/drizzle/0052_contacts_primary_phone_unique.sql
+++ b/packages/db/drizzle/0052_contacts_primary_phone_unique.sql
@@ -1,0 +1,2 @@
+CREATE UNIQUE INDEX contacts_primary_phone_unique
+  ON contacts (primary_phone) WHERE primary_phone IS NOT NULL;

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -1628,6 +1628,16 @@ function createStage1RepositoriesInternal(
         return row === undefined ? null : mapContactRow(row);
       },
 
+      async findByPrimaryPhone(phoneE164) {
+        const [row] = await db
+          .select()
+          .from(contacts)
+          .where(eq(contacts.primaryPhone, phoneE164))
+          .limit(1);
+
+        return row === undefined ? null : mapContactRow(row);
+      },
+
       async listAll() {
         const rows = await db.select().from(contacts).orderBy(asc(contacts.id));
 

--- a/packages/domain/src/contact-resolution.ts
+++ b/packages/domain/src/contact-resolution.ts
@@ -1,0 +1,90 @@
+import type { ContactRecord } from "@as-comms/contracts";
+
+export type ContactInsertRecord = ContactRecord;
+
+export interface ContactResolutionInput {
+  readonly phoneE164: string;
+  readonly readContacts: {
+    readonly findByPrimaryPhone: (
+      phoneE164: string,
+    ) => Promise<ContactRecord | null>;
+  };
+  readonly writeContacts: {
+    readonly upsert: (record: ContactInsertRecord) => Promise<ContactRecord>;
+  };
+  readonly clock: { readonly now: () => Date };
+  readonly idGenerator: () => string;
+}
+
+export interface ContactResolutionResult {
+  readonly contact: ContactRecord;
+  readonly isNewlyCreated: boolean;
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  if (typeof error !== "object" || error === null || !("code" in error)) {
+    return false;
+  }
+
+  return (error as { readonly code?: unknown }).code === "23505";
+}
+
+export function formatUnknownPhoneDisplayName(phoneE164: string): string {
+  const match = /^\+1(\d{3})(\d{3})(\d{4})$/.exec(phoneE164);
+
+  if (match === null) {
+    return `Unknown (${phoneE164})`;
+  }
+
+  const area = match[1] ?? "";
+  const prefix = match[2] ?? "";
+  const line = match[3] ?? "";
+  return `Unknown (+1 ${area} ${prefix} ${line})`;
+}
+
+export async function resolveContactByPhone(
+  input: ContactResolutionInput,
+): Promise<ContactResolutionResult> {
+  const existing = await input.readContacts.findByPrimaryPhone(input.phoneE164);
+
+  if (existing !== null) {
+    return {
+      contact: existing,
+      isNewlyCreated: false,
+    };
+  }
+
+  const nowIso = input.clock.now().toISOString();
+
+  try {
+    const created = await input.writeContacts.upsert({
+      id: input.idGenerator(),
+      salesforceContactId: null,
+      displayName: formatUnknownPhoneDisplayName(input.phoneE164),
+      primaryEmail: null,
+      primaryPhone: input.phoneE164,
+      createdAt: nowIso,
+      updatedAt: nowIso,
+    });
+
+    return {
+      contact: created,
+      isNewlyCreated: true,
+    };
+  } catch (error) {
+    if (!isUniqueViolation(error)) {
+      throw error;
+    }
+
+    const raced = await input.readContacts.findByPrimaryPhone(input.phoneE164);
+
+    if (raced === null) {
+      throw error;
+    }
+
+    return {
+      contact: raced,
+      isNewlyCreated: false,
+    };
+  }
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./contact-resolution.js";
 export * from "./consent.js";
 export * from "./inbox-driving.js";
 export * from "./notes.js";

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -164,6 +164,7 @@ export interface ContactRepository {
   findBySalesforceContactId(
     salesforceContactId: string,
   ): Promise<ContactRecord | null>;
+  findByPrimaryPhone(phoneE164: string): Promise<ContactRecord | null>;
   listAll(): Promise<readonly ContactRecord[]>;
   listByIds(ids: readonly string[]): Promise<readonly ContactRecord[]>;
   searchByQuery(input: {

--- a/packages/domain/src/timeline.ts
+++ b/packages/domain/src/timeline.ts
@@ -829,6 +829,16 @@ function isDisplayableCommunicationEvent(input: {
     return false;
   }
 
+  // Twilio inbound SMS is anchored in the canonical ledger for inbox
+  // projection/rebuild truth, but the visible chat bubble is intentionally
+  // sourced from `sms_messages` rather than timeline projection rows.
+  if (
+    input.event.provenance.primaryProvider === "twilio" &&
+    input.event.channel === "sms"
+  ) {
+    return false;
+  }
+
   try {
     resolveFamily(
       input.event,

--- a/packages/domain/test/contact-resolution.test.ts
+++ b/packages/domain/test/contact-resolution.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  formatUnknownPhoneDisplayName,
+  resolveContactByPhone,
+  type ContactInsertRecord,
+} from "../src/contact-resolution.js";
+
+describe("contact resolution", () => {
+  it("formats unknown phone display names", () => {
+    expect(formatUnknownPhoneDisplayName("+14065550142")).toBe(
+      "Unknown (+1 406 555 0142)",
+    );
+    expect(formatUnknownPhoneDisplayName("+442071838750")).toBe(
+      "Unknown (+442071838750)",
+    );
+  });
+
+  it("returns an existing contact when the phone already exists", async () => {
+    const existing: ContactInsertRecord = {
+      id: "contact-existing",
+      salesforceContactId: null,
+      displayName: "Existing Contact",
+      primaryEmail: null,
+      primaryPhone: "+14065550142",
+      createdAt: "2026-05-03T12:00:00.000Z",
+      updatedAt: "2026-05-03T12:00:00.000Z",
+    };
+    const upsert = vi.fn();
+
+    const result = await resolveContactByPhone({
+      phoneE164: "+14065550142",
+      readContacts: {
+        findByPrimaryPhone: vi.fn().mockResolvedValue(existing),
+      },
+      writeContacts: {
+        upsert,
+      },
+      clock: {
+        now: () => new Date("2026-05-03T12:30:00.000Z"),
+      },
+      idGenerator: () => "unused",
+    });
+
+    expect(result).toEqual({
+      contact: existing,
+      isNewlyCreated: false,
+    });
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it("creates a new phone-only contact when none exists", async () => {
+    const upsert = vi
+      .fn<(_: ContactInsertRecord) => Promise<ContactInsertRecord>>()
+      .mockImplementation((record) => Promise.resolve(record));
+
+    const result = await resolveContactByPhone({
+      phoneE164: "+14065550142",
+      readContacts: {
+        findByPrimaryPhone: vi.fn().mockResolvedValue(null),
+      },
+      writeContacts: {
+        upsert,
+      },
+      clock: {
+        now: () => new Date("2026-05-03T12:30:00.000Z"),
+      },
+      idGenerator: () => "contact-new",
+    });
+
+    expect(upsert).toHaveBeenCalledWith({
+      id: "contact-new",
+      salesforceContactId: null,
+      displayName: "Unknown (+1 406 555 0142)",
+      primaryEmail: null,
+      primaryPhone: "+14065550142",
+      createdAt: "2026-05-03T12:30:00.000Z",
+      updatedAt: "2026-05-03T12:30:00.000Z",
+    });
+    expect(result).toEqual({
+      contact: {
+        id: "contact-new",
+        salesforceContactId: null,
+        displayName: "Unknown (+1 406 555 0142)",
+        primaryEmail: null,
+        primaryPhone: "+14065550142",
+        createdAt: "2026-05-03T12:30:00.000Z",
+        updatedAt: "2026-05-03T12:30:00.000Z",
+      },
+      isNewlyCreated: true,
+    });
+  });
+
+  it("re-queries the contact on a unique race", async () => {
+    const raced: ContactInsertRecord = {
+      id: "contact-raced",
+      salesforceContactId: null,
+      displayName: "Unknown (+1 406 555 0142)",
+      primaryEmail: null,
+      primaryPhone: "+14065550142",
+      createdAt: "2026-05-03T12:30:00.000Z",
+      updatedAt: "2026-05-03T12:30:00.000Z",
+    };
+    const findByPrimaryPhone = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(raced);
+    const uniqueViolation = Object.assign(new Error("duplicate key"), {
+      code: "23505",
+    });
+
+    const result = await resolveContactByPhone({
+      phoneE164: "+14065550142",
+      readContacts: {
+        findByPrimaryPhone,
+      },
+      writeContacts: {
+        upsert: vi.fn().mockRejectedValue(uniqueViolation),
+      },
+      clock: {
+        now: () => new Date("2026-05-03T12:30:00.000Z"),
+      },
+      idGenerator: () => "contact-new",
+    });
+
+    expect(findByPrimaryPhone).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({
+      contact: raced,
+      isNewlyCreated: false,
+    });
+  });
+});

--- a/packages/domain/test/normalization.test.ts
+++ b/packages/domain/test/normalization.test.ts
@@ -358,6 +358,10 @@ function buildContext(input: {
       findById: (id) => Promise.resolve(contactsById.get(id) ?? null),
       findBySalesforceContactId: (salesforceContactId) =>
         Promise.resolve(contactsBySalesforceContactId.get(salesforceContactId) ?? null),
+      findByPrimaryPhone: (phoneE164) =>
+        Promise.resolve(
+          contacts.find((contact) => contact.primaryPhone === phoneE164) ?? null,
+        ),
       listAll: () => Promise.resolve([...contacts]),
       listByIds: (ids) =>
         Promise.resolve(

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -68,6 +68,7 @@ describe("defineStage1RepositoryBundle", () => {
       contacts: {
         findById: () => Promise.resolve(contact),
         findBySalesforceContactId: () => Promise.resolve(contact),
+        findByPrimaryPhone: () => Promise.resolve(contact),
         listAll: () => Promise.resolve([contact]),
         listByIds: () => Promise.resolve([contact]),
         searchByQuery: () => Promise.resolve([contact]),

--- a/packages/domain/test/stage3-last-inbound-alias.test.ts
+++ b/packages/domain/test/stage3-last-inbound-alias.test.ts
@@ -82,6 +82,7 @@ function buildRepositoryBundle(input: {
     contacts: {
       findById: () => Promise.resolve(contact),
       findBySalesforceContactId: () => Promise.resolve(contact),
+      findByPrimaryPhone: () => Promise.resolve(contact),
       listAll: () => Promise.resolve([contact]),
       listByIds: () => Promise.resolve([contact]),
       searchByQuery: () => Promise.resolve([contact]),

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -155,6 +155,7 @@ function createRepositoryBundle(input: {
     contacts: {
       findById: () => Promise.resolve(contact),
       findBySalesforceContactId: () => Promise.resolve(contact),
+      findByPrimaryPhone: () => Promise.resolve(contact),
       listAll: () => Promise.resolve([contact]),
       listByIds: () => Promise.resolve([contact]),
       searchByQuery: () => Promise.resolve([contact]),


### PR DESCRIPTION
PRD: https://github.com/nico-kneler-as/as-comms-platform/issues/277
Phase 3 of 5 in the SMS rollout. Builds on Phase 1 (#278) + Phase 2 (#279).

## Summary

Closes the inbound side. Volunteer texts our number → arrives in the per-contact timeline → operator sees it and replies via the existing SMS composer (Phase 2). All gated by `SMS_ENABLED`. AI Draft and cost surface still out of scope (Phases 4 & 5).

## What's in

- **`/webhooks/inbound` real processing** in `apps/sms-capture`. Signature verify, MessageSid idempotency dedupe, sender lookup, phone-keyed contact find-or-create, `sms_messages` persist, auto-consent on first inbound from a phone, source-evidence/canonical-event anchor so `contact_inbox_projection` stays authoritative.
- **`/webhooks/opt-out` real processing**. Twilio Advanced Opt-Out Management auto-detects STOP/HELP/UNSTOP keywords; we mirror events into `consent_records` (revoke on STOP, re-opt-in on START/UNSTOP, no-op on HELP).
- **`packages/domain/src/contact-resolution.ts`** — deep, pure, unit-testable module with injected IO slices. `resolveContactByPhone` handles find-or-create with race safety (partial unique index + 23505 retry/re-query path).
- **Migration `0052_contacts_primary_phone_unique.sql`** — partial unique index on `contacts.primary_phone WHERE primary_phone IS NOT NULL` for the race-safe insert path.
- **`contacts.findByPrimaryPhone`** repo method added.
- **Timeline projection in `selectors.ts`** extended with `'sms'` kind rows. Surgical change — the audit's I2 god-module is not refactored here.
- **`SmsMessage` bubble component** — chat-style, sky-600 outbound / white inbound, distinct from `EmailMessage`.
- **Inbox-list SMS integration** — unread SMS contributes to per-contact unread count via the existing shared bucket model. No new schema for mark-as-read; reuses existing inbox bucket/opened flow.
- **`SMS_ENABLED` flag gates everything** including inbound timeline row rendering — flag off = invisible.

## Validation
- `pnpm typecheck`: green
- `pnpm lint`: green
- `pnpm boundaries`: green (no rule changes)
- `pnpm build`: green

## Tests added
- `packages/domain/test/contact-resolution.test.ts` — table-driven find-or-create, including 23505 race-condition path with mocked upsert throwing → expect re-query returns existing.
- `apps/sms-capture/test/server.test.ts` (extended) — signed inbound full flow, idempotency, unknown-sender no-op, STOP/HELP/START opt-out webhook handling.
- Existing domain tests updated for new repo bundle slices (mock fixtures).

## Out of scope (untouched)
- Composer behavior (Phase 2 territory).
- AI Draft channel parameter (Phase 4).
- Cost reporting / "Send & store for AI" (Phase 5).
- SimpleTexting scaffolding.
- I2 god-module refactor — `selectors.ts` extended surgically only.
- MMS, templates, schedule send, quiet hours (v2).
- `getPhoneField` SF capture path (PRD says v2 polish).

## Race-condition handling

Codex implemented the requested partial unique index + try/catch on Postgres `23505` unique violation. The `resolveContactByPhone` flow:

1. `findByPrimaryPhone(phone)` — returns existing if hit.
2. Otherwise insert new contact with phone.
3. On `23505` (race-loser): re-query by phone, return existing as `isNewlyCreated: false`.

This is the standard double-checked locking idiom for Postgres find-or-create.

## Mark-as-read decision

Codex used the existing inbox bucket/opened flow without schema change. SMS rows participate in the same `contact_inbox_projection` mechanism that drives email read state. Mirrors the platform's existing pattern rather than introducing a parallel SMS-only mechanism.

## Behavior preservation
- [x] Phase 2 outbound send + status callback unchanged.
- [x] Email send pipeline unchanged.
- [x] Note save pipeline unchanged.
- [x] AI Draft confirm-on-overwrite preserved.
- [x] No boundary rule changes.
- [x] No composer action mock allowlist updates needed.
- [x] SMS surfaces (composer tab + timeline rows + inbox unread) hidden when `SMS_ENABLED=false`.

## Notes
- macOS rollup native-module signing issue prevented local Vitest runs (memory `project_macos_rollup_gotcha`). The required workspace validations are green; CI is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)