### PR TITLE
feat(sms): phase 4 AI Draft channel-awareness — channel param, SMS prompt, composer integration

### DIFF
--- a/apps/web/app/inbox/_components/composer-ai-draft-window.tsx
+++ b/apps/web/app/inbox/_components/composer-ai-draft-window.tsx
@@ -120,6 +120,7 @@ function DraftActionTrigger({
 }
 
 export function ComposerAiDraftWindow({
+  directivePlaceholder = 'Optional: nudge the draft (e.g. "keep it brief, offer May 14 slot"). Or just click Draft with AI.',
   aiDraft,
   directiveText,
   repromptText,
@@ -136,6 +137,7 @@ export function ComposerAiDraftWindow({
   onApprove,
   onAbout,
 }: {
+  readonly directivePlaceholder?: string;
   readonly aiDraft: AiDraftState;
   readonly directiveText: string;
   readonly repromptText: string;
@@ -196,7 +198,7 @@ export function ComposerAiDraftWindow({
                   onRunDraft();
                 }
               }}
-              placeholder='Optional: nudge the draft (e.g. "keep it brief, offer May 14 slot"). Or just click Draft with AI.'
+              placeholder={directivePlaceholder}
               rows={2}
               disabled={isGeneratingAi}
               className={`flex-1 resize-none rounded-md bg-slate-50/60 px-2.5 py-2 text-[12.5px] leading-relaxed text-slate-800 placeholder:text-slate-400 ring-1 ring-inset ring-slate-200 focus:outline-none focus:ring-violet-300 disabled:opacity-60 ${TRANSITION.reduceMotion}`}

--- a/apps/web/app/inbox/_components/composer-detail-surfaces.tsx
+++ b/apps/web/app/inbox/_components/composer-detail-surfaces.tsx
@@ -645,14 +645,31 @@ export function ComposerSmsSurface({
   body,
   includeSignature,
   segmentMetrics,
+  aiDraft,
+  aiDirective,
+  repromptText,
+  isGeneratingAi,
+  runAiDraftDisabled,
+  runAiDraftDisabledReason,
   sendDisabledReason,
   inlineError,
   recipientError,
   senderError,
   bodyError,
   isSending,
+  isAboutOpen,
+  onAboutOpenChange,
   onRecipientChange,
   onBodyChange,
+  onAiDirectiveChange,
+  onAiEdited,
+  onDiscardAi,
+  onOpenReprompt,
+  onCancelReprompt,
+  onApproveAi,
+  onRunAiDraft,
+  onRepromptTextChange,
+  onReprompt,
   onToggleSignature,
   onSend,
   onCancel,
@@ -664,14 +681,31 @@ export function ComposerSmsSurface({
   readonly body: string;
   readonly includeSignature: boolean;
   readonly segmentMetrics: SmsMetrics;
+  readonly aiDraft: AiDraftState;
+  readonly aiDirective: string;
+  readonly repromptText: string;
+  readonly isGeneratingAi: boolean;
+  readonly runAiDraftDisabled: boolean;
+  readonly runAiDraftDisabledReason: string | null;
   readonly sendDisabledReason: string | null;
   readonly inlineError: InlineComposerError | null;
   readonly recipientError?: ComposerValidationError;
   readonly senderError?: ComposerValidationError;
   readonly bodyError?: ComposerValidationError;
   readonly isSending: boolean;
+  readonly isAboutOpen: boolean;
+  readonly onAboutOpenChange: (open: boolean) => void;
   readonly onRecipientChange: (recipient: ComposerSmsRecipient | null) => void;
   readonly onBodyChange: (value: string) => void;
+  readonly onAiDirectiveChange: (value: string) => void;
+  readonly onAiEdited: () => void;
+  readonly onDiscardAi: () => void;
+  readonly onOpenReprompt: () => void;
+  readonly onCancelReprompt: () => void;
+  readonly onApproveAi: () => void;
+  readonly onRunAiDraft: () => void;
+  readonly onRepromptTextChange: (value: string) => void;
+  readonly onReprompt: () => void;
   readonly onToggleSignature: () => void;
   readonly onSend: () => void;
   readonly onCancel: () => void;
@@ -763,11 +797,34 @@ export function ComposerSmsSurface({
       </div>
 
       <div className="px-4 py-4">
+        <ComposerAiDraftWindow
+          directivePlaceholder='Optional: nudge the SMS draft (e.g. "remind them about Wed training, keep under 140 chars"). Or just click Draft with AI.'
+          aiDraft={aiDraft}
+          directiveText={aiDirective}
+          repromptText={repromptText}
+          isGeneratingAi={isGeneratingAi}
+          runDraftDisabled={runAiDraftDisabled}
+          runDraftDisabledReason={runAiDraftDisabledReason}
+          onDirectiveTextChange={onAiDirectiveChange}
+          onRepromptTextChange={onRepromptTextChange}
+          onRunDraft={onRunAiDraft}
+          onOpenReprompt={onOpenReprompt}
+          onSubmitReprompt={onReprompt}
+          onCancelReprompt={onCancelReprompt}
+          onDiscard={onDiscardAi}
+          onApprove={onApproveAi}
+          onAbout={() => {
+            onAboutOpenChange(true);
+          }}
+        />
         <textarea
           rows={8}
           value={body}
           onChange={(event) => {
             onBodyChange(event.currentTarget.value);
+            if (aiDraft.status === "inserted") {
+              onAiEdited();
+            }
           }}
           placeholder="Write an SMS reply"
           className={cn(
@@ -825,6 +882,11 @@ export function ComposerSmsSurface({
           </div>
         </div>
       </div>
+      <AboutThisDraft
+        aiDraft={aiDraft}
+        open={isAboutOpen}
+        onOpenChange={onAboutOpenChange}
+      />
     </TooltipProvider>
   );
 }

--- a/apps/web/app/inbox/_components/inbox-client-provider.tsx
+++ b/apps/web/app/inbox/_components/inbox-client-provider.tsx
@@ -68,6 +68,7 @@ export type AiDraftStatus =
 
 export interface AiDraftState {
   readonly status: AiDraftStatus;
+  readonly channel: "email" | "sms";
   readonly mode: AiDraftRequestPayload["mode"] | null;
   readonly responseMode: AiDraftResponseVm["mode"] | null;
   readonly prompt: string;
@@ -89,6 +90,7 @@ export interface AiDraftState {
 
 const INITIAL_AI_DRAFT: AiDraftState = {
   status: "idle",
+  channel: "email",
   mode: null,
   responseMode: null,
   prompt: "",
@@ -395,6 +397,7 @@ export function InboxClientProvider({
     }) => {
       setAiDraft({
         status: "generating",
+        channel: input.request.channel ?? "email",
         mode: input.request.mode,
         responseMode: null,
         prompt: input.prompt,
@@ -424,6 +427,7 @@ export function InboxClientProvider({
       setAiDraft((previous) => ({
         ...previous,
         status: "reviewable",
+        channel: input.request.channel ?? "email",
         mode: input.request.mode,
         responseMode: input.response.mode,
         prompt: input.prompt,
@@ -477,6 +481,7 @@ export function InboxClientProvider({
       setAiDraft((previous) => ({
         ...previous,
         status: "inserted",
+        channel: input.request.channel ?? "email",
         mode: input.request.mode,
         responseMode: input.response.mode,
         prompt: input.prompt,
@@ -539,6 +544,7 @@ export function InboxClientProvider({
       setAiDraft((previous) => ({
         ...previous,
         status: "reprompting",
+        channel: input.request.channel ?? previous.channel,
         mode: "reprompt",
         prompt: input.prompt,
         errorMessage: null,

--- a/apps/web/app/inbox/_components/inbox-composer.tsx
+++ b/apps/web/app/inbox/_components/inbox-composer.tsx
@@ -270,19 +270,32 @@ export function InboxComposerDetailPane({
         null);
   const selectedAliasAiConfigured =
     selectedAliasRecord?.isAiConfigured ?? selectedAliasRecord?.isAiReady ?? false;
+  const smsRecipientRequiresKnownContact =
+    state.activeTab === "sms" && state.smsRecipient?.kind === "phone";
+  const smsAiConfigured =
+    selectedAliasRecord !== null && selectedAliasAiConfigured;
   const runAiDraftDisabled =
-    selectedAliasRecord === null ||
-    !selectedAliasAiConfigured ||
+    (state.activeTab === "sms"
+      ? !smsAiConfigured || smsRecipientRequiresKnownContact
+      : selectedAliasRecord === null || !selectedAliasAiConfigured) ||
     isGeneratingAi ||
     aiDraft.status === "generating" ||
     aiDraft.status === "reviewable" ||
     aiDraft.status === "reprompting";
   const runAiDraftDisabledReason =
-    selectedAliasRecord === null
-      ? "Choose a sender alias first."
-      : !selectedAliasAiConfigured
-        ? "AI is not configured for this project. Set it up in Settings → Integrations."
-        : null;
+    state.activeTab === "sms"
+      ? smsRecipientRequiresKnownContact
+        ? "AI drafting requires a known volunteer contact."
+        : !smsAiConfigured
+          ? selectedAliasRecord === null
+            ? "Choose a sender alias first."
+            : "AI is not configured for this project. Set it up in Settings → Integrations."
+          : null
+      : selectedAliasRecord === null
+        ? "Choose a sender alias first."
+        : !selectedAliasAiConfigured
+          ? "AI is not configured for this project. Set it up in Settings → Integrations."
+          : null;
   const aiWarningMessage = resolveAiWarningMessage(aiDraft);
   const sendAndSaveAvailability = resolveSendAndSaveForAiAvailability({
     selectedAlias: state.selectedAlias,
@@ -584,9 +597,19 @@ export function InboxComposerDetailPane({
               body={state.smsBody}
               includeSignature={state.smsIncludeSignature}
               segmentMetrics={smsMetricsValue}
+              aiDraft={aiDraft}
+              aiDirective={state.aiDirective}
+              repromptText={state.repromptText}
+              isGeneratingAi={isGeneratingAi}
+              runAiDraftDisabled={runAiDraftDisabled}
+              runAiDraftDisabledReason={runAiDraftDisabledReason}
               sendDisabledReason={smsSendDisabledReason}
               inlineError={state.inlineError}
               isSending={isSending}
+              isAboutOpen={state.isAboutOpen}
+              onAboutOpenChange={(open) => {
+                dispatch({ type: "SET_ABOUT_OPEN", open });
+              }}
               onRecipientChange={(nextRecipient) => {
                 if (nextRecipient === null) {
                   dispatch({
@@ -624,6 +647,21 @@ export function InboxComposerDetailPane({
               onBodyChange={(value) => {
                 dispatch({ type: "SET_SMS_BODY", body: value });
               }}
+              onAiDirectiveChange={(value) => {
+                dispatch({ type: "SET_AI_DIRECTIVE", value });
+              }}
+              onAiEdited={markAiDraftEdited}
+              onDiscardAi={discardAi}
+              onOpenReprompt={openReprompt}
+              onCancelReprompt={cancelAiReprompt}
+              onApproveAi={approveAi}
+              onRunAiDraft={() => {
+                runAiDraft();
+              }}
+              onRepromptTextChange={(value) => {
+                dispatch({ type: "SET_REPROMPT_TEXT", value });
+              }}
+              onReprompt={regenerateAi}
               onToggleSignature={() => {
                 dispatch({ type: "TOGGLE_SMS_SIGNATURE" });
               }}

--- a/apps/web/app/inbox/_hooks/composer-draft-reducer.ts
+++ b/apps/web/app/inbox/_hooks/composer-draft-reducer.ts
@@ -90,7 +90,11 @@ export type ComposerDraftAction =
   | { readonly type: "ADD_ATTACHMENTS"; readonly attachments: readonly AttachmentDraft[] }
   | { readonly type: "REMOVE_ATTACHMENT"; readonly id: string }
   | { readonly type: "MARK_ATTACHMENTS_NEEDING_REUPLOAD" }
-  | { readonly type: "APPLY_AI_APPROVAL"; readonly approvedText: string }
+  | {
+      readonly type: "APPLY_AI_APPROVAL";
+      readonly channel: "email" | "sms";
+      readonly approvedText: string;
+    }
   | { readonly type: "SET_INLINE_ERROR"; readonly error: InlineComposerError }
   | { readonly type: "SET_FIELD_ERRORS"; readonly errors: ComposerFieldErrors }
   | {
@@ -329,8 +333,14 @@ export function reduceComposerDraft(
     case "APPLY_AI_APPROVAL":
       return {
         ...state,
-        body: action.approvedText,
-        bodyHtml: plaintextToComposerHtml(action.approvedText),
+        ...(action.channel === "sms"
+          ? {
+              smsBody: action.approvedText,
+            }
+          : {
+              body: action.approvedText,
+              bodyHtml: plaintextToComposerHtml(action.approvedText),
+            }),
         aiDirective: "",
         repromptText: "",
       };

--- a/apps/web/app/inbox/_hooks/use-ai-draft-run.ts
+++ b/apps/web/app/inbox/_hooks/use-ai-draft-run.ts
@@ -68,7 +68,7 @@ export function useAiDraftRun({
     readonly mode: "reprompt";
     readonly repromptDirection: string;
   }) => {
-    if (state.activeTab !== "email") {
+    if (state.activeTab !== "email" && state.activeTab !== "sms") {
       return;
     }
 
@@ -78,11 +78,22 @@ export function useAiDraftRun({
 
     clearComposerErrors();
 
-    if (state.recipient?.kind !== "contact") {
+    const isSms = state.activeTab === "sms";
+    const contactId =
+      isSms && state.smsRecipient?.kind === "contact"
+        ? state.smsRecipient.contactId
+        : !isSms && state.recipient?.kind === "contact"
+          ? state.recipient.contactId
+          : null;
+
+    if (contactId === null) {
       dispatch({
         type: "SET_INLINE_ERROR",
         error: {
-          message: "AI drafting is available only when replying to a contact.",
+          message:
+            state.activeTab === "sms"
+              ? "AI drafting requires a known volunteer contact."
+              : "AI drafting is available only when replying to a contact.",
           retryable: false,
         },
       });
@@ -90,9 +101,10 @@ export function useAiDraftRun({
     }
 
     const baseRequest = {
-      contactId: state.recipient.contactId,
+      contactId,
       projectId: selectedAliasRecord?.projectId ?? null,
       threadCursor: replyContext?.threadCursor ?? null,
+      channel: isSms ? ("sms" as const) : ("email" as const),
     } as const;
 
     const request =
@@ -188,7 +200,10 @@ export function useAiDraftRun({
   const approveAi = () => {
     const willOverwrite =
       aiDraft.status === "edited-after-generation" ||
-      (aiDraft.status === "reviewable" && state.body.trim().length > 0);
+      (aiDraft.status === "reviewable" &&
+        (aiDraft.channel === "sms"
+          ? state.smsBody.trim().length > 0
+          : state.body.trim().length > 0));
 
     if (willOverwrite && !window.confirm("Replace your current message with the AI draft?")) {
       return;
@@ -196,6 +211,7 @@ export function useAiDraftRun({
 
     dispatch({
       type: "APPLY_AI_APPROVAL",
+      channel: aiDraft.channel,
       approvedText: aiDraft.generatedText,
     });
     approveAiDraft();

--- a/apps/web/app/inbox/actions.ts
+++ b/apps/web/app/inbox/actions.ts
@@ -43,6 +43,8 @@ import { enforceRateLimit } from "@/src/server/security/rate-limit";
 
 import type { UiResult } from "../../src/server/ui-result";
 
+const SMS_AI_MAX_TOKENS = 120;
+
 const composerSendActionInputSchema = composerSendInputSchema.extend({
   saveAsKnowledge: z.boolean().optional(),
   captureAsKnowledge: z.boolean().optional().default(false),
@@ -1325,7 +1327,10 @@ export async function draftWithAiAction(
         estimateCostUsd: provider.estimateCostUsd,
         model: provider.model,
         temperature: provider.temperature,
-        maxTokens: provider.maxTokens,
+        maxTokens:
+          parsedInput.data.channel === "sms"
+            ? SMS_AI_MAX_TOKENS
+            : provider.maxTokens,
         dailyCapUsd: provider.dailyCapUsd,
       },
       parsedInput.data,

--- a/apps/web/src/server/ai/prompt-builder.ts
+++ b/apps/web/src/server/ai/prompt-builder.ts
@@ -58,7 +58,18 @@ function renderTier3Entries(bundle: GroundingBundle): string {
     .join("\n\n");
 }
 
-function buildSystemPrompt(bundle: GroundingBundle): string {
+function renderChannelInstructionBlock(channel: AiDraftRequest["channel"]): string {
+  if (channel === "sms") {
+    return "Write SMS replies. Be concise, plaintext, one thought, target ~140 characters and never exceed 320 (two segments). No markdown, no greetings if the volunteer is mid-thread, no signature unless the operator asked. Match the tone of prior thread messages if any. Use the volunteer's first name when natural; default to no salutation. Don't include 'Reply STOP to opt out' — Twilio appends compliance language automatically.";
+  }
+
+  return "You are drafting a reply to a volunteer. Use only the information above and the inbound message. Never invent facts.";
+}
+
+function buildSystemPrompt(
+  bundle: GroundingBundle,
+  request: Pick<AiDraftRequest, "channel">,
+): string {
   return [
     renderContextSection(
       "Tier 1 Voice Instructions",
@@ -80,7 +91,7 @@ function buildSystemPrompt(bundle: GroundingBundle): string {
     "",
     "The examples above are pattern support, not templates. Never copy any example verbatim. Adapt the style and structure to the current volunteer and project context.",
     "",
-    "You are drafting a reply to a volunteer. Use only the information above and the inbound message. Never invent facts.",
+    renderChannelInstructionBlock(request.channel),
   ].join("\n");
 }
 
@@ -108,7 +119,7 @@ export function buildDraftPrompt(
 ): BuiltPrompt {
   void input;
   return {
-    system: buildSystemPrompt(bundle),
+    system: buildSystemPrompt(bundle, input),
     messages: [
       {
         role: "user",
@@ -123,7 +134,7 @@ export function buildFillPrompt(
   input: Extract<AiDraftRequest, { mode: "fill" }>,
 ): BuiltPrompt {
   return {
-    system: buildSystemPrompt(bundle),
+    system: buildSystemPrompt(bundle, input),
     messages: [
       {
         role: "user",
@@ -145,7 +156,7 @@ export function buildRepromptPrompt(
   input: Extract<AiDraftRequest, { mode: "reprompt" }>,
 ): BuiltPrompt {
   return {
-    system: buildSystemPrompt(bundle),
+    system: buildSystemPrompt(bundle, input),
     messages: [
       {
         role: "user",

--- a/apps/web/src/server/ai/types.ts
+++ b/apps/web/src/server/ai/types.ts
@@ -67,6 +67,7 @@ const aiDraftBaseRequestSchema = z.object({
   projectId: z.string().min(1).nullable().optional().default(null),
   threadCursor: z.string().min(1).nullable().optional().default(null),
   repromptIndex: z.number().int().nonnegative().optional().default(0),
+  channel: z.enum(["email", "sms"]).default("email"),
 });
 
 export const aiDraftRequestSchema = z.discriminatedUnion("mode", [

--- a/apps/web/test/server/ai/draft-generator.test.ts
+++ b/apps/web/test/server/ai/draft-generator.test.ts
@@ -75,6 +75,7 @@ describe("generateAiDraft", () => {
       projectId: "project:whitebark",
       threadCursor: "event:thread-1-inbound",
       repromptIndex: 0,
+      channel: "email",
       mode: "draft",
     });
 
@@ -96,6 +97,7 @@ describe("generateAiDraft", () => {
       projectId: "project:whitebark",
       threadCursor: "event:thread-1-inbound",
       repromptIndex: 0,
+      channel: "email",
       mode: "fill",
       operatorPrompt: "Tell her the revised field kit will ship tomorrow.",
     });
@@ -114,6 +116,7 @@ describe("generateAiDraft", () => {
       projectId: "project:whitebark",
       threadCursor: "event:thread-1-inbound",
       repromptIndex: 1,
+      channel: "email",
       mode: "reprompt",
       previousDraft: "Thanks for checking in.",
       repromptDirection: "Make it shorter.",
@@ -137,6 +140,7 @@ describe("generateAiDraft", () => {
         projectId: "project:whitebark",
         threadCursor: "event:thread-1-inbound",
         repromptIndex: 0,
+        channel: "email",
         mode: "draft",
       },
     );
@@ -165,6 +169,7 @@ describe("generateAiDraft", () => {
         projectId: "project:whitebark",
         threadCursor: "event:thread-1-inbound",
         repromptIndex: 0,
+        channel: "email",
         mode: "draft",
       },
     );
@@ -186,6 +191,7 @@ describe("generateAiDraft", () => {
       projectId: "project:missing",
       threadCursor: "event:thread-1-inbound",
       repromptIndex: 0,
+      channel: "email",
       mode: "draft",
     });
 
@@ -209,6 +215,7 @@ describe("generateAiDraft", () => {
         projectId: "project:whitebark",
         threadCursor: "event:thread-1-inbound",
         repromptIndex: 0,
+        channel: "email",
         mode: "draft",
       },
     );
@@ -241,6 +248,7 @@ describe("generateAiDraft", () => {
         projectId: "project:whitebark",
         threadCursor: "event:thread-1-inbound",
         repromptIndex: 0,
+        channel: "email",
         mode: "draft",
       },
     );

--- a/apps/web/test/server/ai/prompt-builder.test.ts
+++ b/apps/web/test/server/ai/prompt-builder.test.ts
@@ -65,15 +65,16 @@ const baseBundle: GroundingBundle = {
 
 describe("prompt builder", () => {
   it("builds the draft prompt", () => {
-    expect(
-      buildDraftPrompt(baseBundle, {
-        contactId: "contact:maya",
-        projectId: "project:whitebark",
-        threadCursor: "event:inbound-1",
-        repromptIndex: 0,
-        mode: "draft",
-      }),
-    ).toMatchInlineSnapshot(`
+    const prompt = buildDraftPrompt(baseBundle, {
+      contactId: "contact:maya",
+      projectId: "project:whitebark",
+      threadCursor: "event:inbound-1",
+      repromptIndex: 0,
+      channel: "email",
+      mode: "draft",
+    });
+
+    expect(prompt).toMatchInlineSnapshot(`
       {
         "messages": [
           {
@@ -103,6 +104,9 @@ describe("prompt builder", () => {
       You are drafting a reply to a volunteer. Use only the information above and the inbound message. Never invent facts.",
       }
     `);
+    expect(prompt.system).toContain(
+      "You are drafting a reply to a volunteer. Use only the information above and the inbound message. Never invent facts.",
+    );
   });
 
   it("builds the fill prompt", () => {
@@ -112,6 +116,7 @@ describe("prompt builder", () => {
         projectId: "project:whitebark",
         threadCursor: "event:inbound-1",
         repromptIndex: 0,
+        channel: "email",
         mode: "fill",
         operatorPrompt: "Tell her the revised field kit will ship tomorrow.",
       }),
@@ -159,6 +164,7 @@ describe("prompt builder", () => {
         projectId: "project:whitebark",
         threadCursor: "event:inbound-1",
         repromptIndex: 1,
+        channel: "email",
         mode: "reprompt",
         previousDraft: "Thanks for checking in.",
         repromptDirection: "Make it warmer and add the ship date.",
@@ -216,6 +222,7 @@ describe("prompt builder", () => {
           projectId: null,
           threadCursor: null,
           repromptIndex: 0,
+          channel: "email",
           mode: "draft",
         },
       ),
@@ -282,11 +289,28 @@ describe("prompt builder", () => {
           projectId: "project:whitebark",
           threadCursor: "event:inbound-1",
           repromptIndex: 0,
+          channel: "email",
           mode: "draft",
         },
       ).system,
     ).toContain(
       "[Tier 3 Canonical Examples]\n• [Issue: Trip planning] Q: Current field kit list\n  Strategy: Confirm the latest kit source and invite follow-up.\n  Example: Hi {NAME}, the latest kit list is in the volunteer portal.",
     );
+  });
+
+  it("builds the sms system prompt variant", () => {
+    const prompt = buildDraftPrompt(baseBundle, {
+      contactId: "contact:maya",
+      projectId: "project:whitebark",
+      threadCursor: "event:inbound-1",
+      repromptIndex: 0,
+      channel: "sms",
+      mode: "draft",
+    });
+
+    expect(prompt.system).toContain("Write SMS replies. Be concise, plaintext");
+    expect(prompt.system).toContain("target ~140 characters");
+    expect(prompt.system).toContain("never exceed 320");
+    expect(prompt.system).toContain("Don't include 'Reply STOP to opt out'");
   });
 });

--- a/apps/web/tests/unit/about-this-draft-modal.test.tsx
+++ b/apps/web/tests/unit/about-this-draft-modal.test.tsx
@@ -9,6 +9,7 @@ import type { AiDraftState } from "../../app/inbox/_components/inbox-client-prov
 
 const aiDraft: AiDraftState = {
   status: "inserted",
+  channel: "email",
   mode: "reprompt",
   responseMode: "generated",
   prompt: "Make it shorter",
@@ -52,6 +53,7 @@ const aiDraft: AiDraftState = {
     projectId: "project:whitebark",
     threadCursor: "event:inbound-1",
     repromptIndex: 1,
+    channel: "email",
     mode: "reprompt",
     previousDraft: "Original draft",
     repromptDirection: "Make it shorter",

--- a/apps/web/tests/unit/ai-draft-preview-approve.test.tsx
+++ b/apps/web/tests/unit/ai-draft-preview-approve.test.tsx
@@ -71,6 +71,7 @@ const { JSDOM } = workerRequire("jsdom") as {
 
 const initialAiDraft: AiDraftState = {
   status: "idle",
+  channel: "email",
   mode: null,
   responseMode: null,
   prompt: "",

--- a/apps/web/tests/unit/composer-draft-reducer.test.ts
+++ b/apps/web/tests/unit/composer-draft-reducer.test.ts
@@ -131,6 +131,7 @@ describe("composer draft reducer", () => {
   it("applies AI approval and clears tab-scoped errors on tab switch", () => {
     const approved = reduceComposerDraft(INITIAL_COMPOSER_DRAFT_STATE, {
       type: "APPLY_AI_APPROVAL",
+      channel: "email",
       approvedText: "Generated reply",
     });
 
@@ -149,6 +150,25 @@ describe("composer draft reducer", () => {
     expect(switched.activeTab).toBe("note");
     expect(switched.inlineError).toBeNull();
     expect(switched.fieldErrors).toEqual([]);
+  });
+
+  it("applies sms AI approval without mutating email fields", () => {
+    const approved = reduceComposerDraft(
+      {
+        ...INITIAL_COMPOSER_DRAFT_STATE,
+        body: "Existing email body",
+        bodyHtml: "<p>Existing email body</p>",
+      },
+      {
+        type: "APPLY_AI_APPROVAL",
+        channel: "sms",
+        approvedText: "Generated SMS reply",
+      },
+    );
+
+    expect(approved.smsBody).toBe("Generated SMS reply");
+    expect(approved.body).toBe("Existing email body");
+    expect(approved.bodyHtml).toBe("<p>Existing email body</p>");
   });
 
   it("returns initial state when the pane closes", () => {

--- a/apps/web/tests/unit/inbox-composer-send-menu.test.tsx
+++ b/apps/web/tests/unit/inbox-composer-send-menu.test.tsx
@@ -276,6 +276,7 @@ const baseProps: ComposerEmailSurfaceProps = {
   attachments: [],
   aiDraft: {
     status: "idle",
+    channel: "email",
     mode: null,
     responseMode: null,
     prompt: "",

--- a/apps/web/tests/unit/use-ai-draft-run.test.ts
+++ b/apps/web/tests/unit/use-ai-draft-run.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TransitionStartFunction } from "react";
 
 vi.mock("../../app/inbox/actions", () => ({
   draftWithAiAction: vi.fn(),
@@ -10,6 +11,7 @@ import { INITIAL_COMPOSER_DRAFT_STATE } from "../../app/inbox/_hooks/composer-dr
 
 const baseAiDraft: AiDraftState = {
   status: "reviewable",
+  channel: "email",
   mode: "draft",
   responseMode: "generated",
   prompt: "Draft with AI",
@@ -29,20 +31,66 @@ const baseAiDraft: AiDraftState = {
 function setup(input?: {
   readonly aiDraft?: AiDraftState;
   readonly body?: string;
+  readonly smsBody?: string;
+  readonly activeTab?: "email" | "sms" | "note";
+  readonly recipient?: (typeof INITIAL_COMPOSER_DRAFT_STATE)["recipient"];
+  readonly smsRecipient?: (typeof INITIAL_COMPOSER_DRAFT_STATE)["smsRecipient"];
+  readonly selectedAliasAiConfigured?: boolean;
+  readonly startAiGeneration?: ReturnType<typeof vi.fn>;
+  readonly startAiTransition?: TransitionStartFunction;
 }) {
   const dispatch = vi.fn();
   const approveAiDraft = vi.fn();
+  const startAiGeneration = input?.startAiGeneration ?? vi.fn();
   const controls = useAiDraftRun({
     state: {
       ...INITIAL_COMPOSER_DRAFT_STATE,
+      activeTab: input?.activeTab ?? "email",
       body: input?.body ?? "",
+      smsBody: input?.smsBody ?? "",
+      recipient:
+        input?.recipient ??
+        ({
+          kind: "contact",
+          contactId: "contact-1",
+          displayName: "Ada Lovelace",
+          primaryEmail: "ada@example.org",
+          primaryProjectName: "Forest",
+          salesforceContactId: "sf-1",
+        } as const),
+      smsRecipient:
+        input?.smsRecipient ??
+        ({
+          kind: "contact",
+          contactId: "contact-sms-1",
+          displayName: "Maya Lee",
+          phoneE164: "+14065550123",
+        } as const),
     },
     dispatch,
     aiDraft: input?.aiDraft ?? baseAiDraft,
-    selectedAliasRecord: null,
-    selectedAliasAiConfigured: false,
-    replyContext: null,
-    startAiGeneration: vi.fn(),
+    selectedAliasRecord: {
+      id: "alias-1",
+      alias: "forest@adventuresci.org",
+      projectId: "project-1",
+      projectName: "Forest",
+      isAiReady: true,
+      isAiConfigured: true,
+      hasCachedContent: true,
+    },
+    selectedAliasAiConfigured: input?.selectedAliasAiConfigured ?? true,
+    replyContext: {
+      contactId: "contact-1",
+      contactDisplayName: "Ada Lovelace",
+      contactPrimaryPhone: "+14065550123",
+      subject: "Re: Forest dates",
+      threadCursor: "thread-cursor-1",
+      threadId: "thread-1",
+      inReplyToRfc822: "<message@example.org>",
+      defaultAlias: "forest@adventuresci.org",
+      cc: [],
+    },
+    startAiGeneration,
     markAiDraftReviewable: vi.fn(),
     approveAiDraft,
     discardAiDraft: vi.fn(),
@@ -51,12 +99,17 @@ function setup(input?: {
     cancelReprompt: vi.fn(),
     setAiError: vi.fn(),
     setComposerErrors: vi.fn(),
-    startAiTransition: vi.fn(),
+    startAiTransition:
+      input?.startAiTransition ??
+      ((callback) => {
+        void callback();
+      }),
   });
 
   return {
     dispatch,
     approveAiDraft,
+    startAiGeneration,
     controls,
   };
 }
@@ -73,6 +126,7 @@ describe("useAiDraftRun", () => {
 
     expect(dispatch).toHaveBeenCalledWith({
       type: "APPLY_AI_APPROVAL",
+      channel: "email",
       approvedText: "AI draft",
     });
     expect(approveAiDraft).toHaveBeenCalledOnce();
@@ -95,6 +149,7 @@ describe("useAiDraftRun", () => {
     );
     expect(dispatch).not.toHaveBeenCalledWith({
       type: "APPLY_AI_APPROVAL",
+      channel: "email",
       approvedText: "AI draft",
     });
     expect(approveAiDraft).not.toHaveBeenCalled();
@@ -118,8 +173,61 @@ describe("useAiDraftRun", () => {
     );
     expect(dispatch).not.toHaveBeenCalledWith({
       type: "APPLY_AI_APPROVAL",
+      channel: "email",
       approvedText: "AI draft",
     });
     expect(approveAiDraft).not.toHaveBeenCalled();
+  });
+
+  it("applies approval to sms without checking the email body", () => {
+    const { dispatch, approveAiDraft, controls } = setup({
+      activeTab: "sms",
+      body: "Existing email draft",
+      smsBody: "",
+      aiDraft: {
+        ...baseAiDraft,
+        channel: "sms",
+      },
+    });
+
+    controls.approveAi();
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "APPLY_AI_APPROVAL",
+      channel: "sms",
+      approvedText: "AI draft",
+    });
+    expect(approveAiDraft).toHaveBeenCalledOnce();
+  });
+
+  it("starts an sms AI draft with channel-aware request inputs", () => {
+    const startAiGeneration = vi.fn();
+    const startAiTransition = vi.fn();
+    const { controls } = setup({
+      activeTab: "sms",
+      startAiGeneration,
+      startAiTransition,
+      recipient: null,
+      smsRecipient: {
+        kind: "contact",
+        contactId: "contact-sms-42",
+        displayName: "Maya Lee",
+        phoneE164: "+14065550123",
+      },
+    });
+
+    controls.runAiDraft();
+
+    expect(startAiGeneration).toHaveBeenCalledWith({
+      request: {
+        contactId: "contact-sms-42",
+        projectId: "project-1",
+        threadCursor: "thread-cursor-1",
+        channel: "sms",
+        mode: "draft",
+      },
+      prompt: "Draft with AI",
+    });
+    expect(startAiTransition).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
PRD: https://github.com/nico-kneler-as/as-comms-platform/issues/277
Phase 4 of 5. Builds on Phases 1–3 (#278, #279, #280).

## Summary

Adds channel-awareness to AI Draft so the existing pipeline serves both email and SMS. Pure extension — no pipeline refactor, no new provider, no new model. Email behavior is preserved identically. SMS-specific prompt + token cap + UI integration land behind `SMS_ENABLED`.

## What's in

- **`channel: "email" | "sms"`** added to `aiDraftBaseRequestSchema` with default `"email"`. Backwards-compatible: existing callers without channel keep working unchanged.
- **Prompt builder branches on channel.** SMS gets a concise/plaintext system prompt block (~140 char target, no markdown, no signature, no STOP language since Twilio adds compliance language automatically). Email prompt unchanged.
- **`maxTokens` cap of 120 for SMS** (email cap unchanged).
- **`ComposerAiDraftWindow` mounted in `ComposerSmsSurface`** with channel-specific tweaks: SMS-flavored placeholder copy, disable when `smsRecipient.kind === "phone"` (raw phone with no contact match).
- **`useAiDraftRun` extended in-place.** Orchestration stays shared; only request inputs, approval target, and disable rules branch on `state.activeTab`.
- **`APPLY_AI_APPROVAL` reducer action gets a channel discriminator.** SMS approve writes `smsBody`; email approve writes `body` + `bodyHtml`. `aiDraft.channel` state field tracks the originating channel so approve still lands correctly after a tab switch.

## Validation
- `pnpm typecheck`: green
- `pnpm lint`: green
- `pnpm boundaries`: green (no rule changes)
- `pnpm build`: green

## Tests touched / added
- `apps/web/test/server/ai/prompt-builder.test.ts` — extended for channel="sms" SMS prompt assertions.
- `apps/web/test/server/ai/draft-generator.test.ts` — fixture updates for new `channel` field.
- `apps/web/tests/unit/composer-draft-reducer.test.ts` — `APPLY_AI_APPROVAL` channel-discriminator coverage.
- `apps/web/tests/unit/use-ai-draft-run.test.ts` — SMS-tab path passes `channel: "sms"` and uses `smsRecipient.contactId`.
- `apps/web/tests/unit/about-this-draft-modal.test.tsx`, `ai-draft-preview-approve.test.tsx`, `inbox-composer-send-menu.test.tsx` — fixture updates for the expanded `aiDraft` state shape.

## Out of scope (untouched)
- "Last N SMS with this volunteer" knowledge tier (PRD defers to v2).
- Cost reporting / inline cost in composer (Phase 5).
- "Send & store for AI" extending to SMS (Phase 5).
- The grounding/retriever pipeline — both channels share the same Notion knowledge cache and recent-events thread context.
- `selectors.ts` — Phase 3 territory.
- Schema migrations — none needed.
- A separate AI provider/model for SMS — PRD locks "same model as email" in v1.

## `useAiDraftRun` decision
Extended in place rather than split into a separate `useAiDraftRunSms`. The orchestration (request → action → response → reducer dispatch) is identical between channels; only request inputs, approval target, and disable rules differ. Splitting would have duplicated ~80% of the hook's logic. In-place branching costs ~30 LOC.

## Behavior preservation
- [x] Email AI Draft generation produces identical prompts and outputs.
- [x] Email AI Draft approval writes to `body` + `bodyHtml`.
- [x] `composer-canonical-modal.test.tsx` unmodified.
- [x] Existing AI tests still pass (extended only for new fixture fields, no behavioral changes).
- [x] SMS AI Draft window hidden when `SMS_ENABLED=false` (gated via the SMS tab).
- [x] SMS `maxTokens` cap (120) enforced; email cap unaffected.
- [x] Approve from SMS tab writes to `smsBody`; approve from email tab writes to `body`/`bodyHtml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)