### PR TITLE
feat(sms): phase 5 polish — inline cost, MTD spend surface, send-and-save-for-AI

### DIFF
--- a/apps/web/app/inbox/_components/composer-detail-surfaces.tsx
+++ b/apps/web/app/inbox/_components/composer-detail-surfaces.tsx
@@ -20,6 +20,10 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { RADIUS, SHADOW, TYPE } from "@/app/_lib/design-tokens-v2";
+import {
+  estimateSmsCostUsd,
+  formatSmsEstimatedCostUsd,
+} from "@/src/lib/sms-pricing";
 
 import { ComposerAiDraftWindow } from "./composer-ai-draft-window";
 import {
@@ -645,12 +649,15 @@ export function ComposerSmsSurface({
   body,
   includeSignature,
   segmentMetrics,
+  outboundRateUsdPerSegment,
   aiDraft,
   aiDirective,
   repromptText,
   isGeneratingAi,
   runAiDraftDisabled,
   runAiDraftDisabledReason,
+  canSendAndSaveForAi,
+  sendAndSaveDisabledReason,
   sendDisabledReason,
   inlineError,
   recipientError,
@@ -681,12 +688,15 @@ export function ComposerSmsSurface({
   readonly body: string;
   readonly includeSignature: boolean;
   readonly segmentMetrics: SmsMetrics;
+  readonly outboundRateUsdPerSegment: number;
   readonly aiDraft: AiDraftState;
   readonly aiDirective: string;
   readonly repromptText: string;
   readonly isGeneratingAi: boolean;
   readonly runAiDraftDisabled: boolean;
   readonly runAiDraftDisabledReason: string | null;
+  readonly canSendAndSaveForAi: boolean;
+  readonly sendAndSaveDisabledReason: string | null;
   readonly sendDisabledReason: string | null;
   readonly inlineError: InlineComposerError | null;
   readonly recipientError?: ComposerValidationError;
@@ -707,20 +717,33 @@ export function ComposerSmsSurface({
   readonly onRepromptTextChange: (value: string) => void;
   readonly onReprompt: () => void;
   readonly onToggleSignature: () => void;
-  readonly onSend: () => void;
+  readonly onSend: (sendKind?: ComposerSendKind) => void;
   readonly onCancel: () => void;
 }) {
   const selectedSender =
     smsSenders.find((sender) => sender.id === selectedSenderId) ??
     smsSenders[0] ??
     null;
+  const estimatedCostUsd =
+    segmentMetrics.segments > 0
+      ? estimateSmsCostUsd(
+          segmentMetrics.segments,
+          outboundRateUsdPerSegment,
+        )
+      : null;
+  const sendAndSaveDisabled = !canSendAndSaveForAi || isSending;
+  const sendAndSaveTooltipMessage =
+    sendAndSaveDisabledReason ??
+    (!canSendAndSaveForAi ? "Project knowledge capture is unavailable." : null);
   const sendButton = (
     <div className="inline-flex items-stretch overflow-hidden rounded-md shadow-sm">
       <Button
         type="button"
         disabled={sendDisabledReason !== null || isSending}
         className="h-9 rounded-none rounded-l-md bg-slate-900 px-3 text-[12.5px] font-medium text-white shadow-none hover:bg-slate-800"
-        onClick={onSend}
+        onClick={() => {
+          onSend("send");
+        }}
       >
         {isSending ? (
           <>
@@ -745,11 +768,11 @@ export function ComposerSmsSurface({
             <ChevronDownIcon className="size-4" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-64 rounded-xl p-1.5">
+        <DropdownMenuContent align="end" className="w-72 rounded-xl p-1.5">
           <DropdownMenuItem
             className="rounded-md"
             onSelect={() => {
-              onSend();
+              onSend("send");
             }}
           >
             <div className="flex min-w-0 flex-col">
@@ -759,6 +782,13 @@ export function ComposerSmsSurface({
               </span>
             </div>
           </DropdownMenuItem>
+          <SendAndSaveMenuItem
+            disabled={sendAndSaveDisabled}
+            tooltipMessage={sendAndSaveTooltipMessage}
+            onSelect={() => {
+              onSend("send-and-save");
+            }}
+          />
         </DropdownMenuContent>
       </DropdownMenu>
     </div>
@@ -847,11 +877,16 @@ export function ComposerSmsSurface({
         ) : null}
 
         <div className="flex flex-wrap items-center gap-2">
-          <div className="text-[11.5px] text-slate-500">
+          <div className="flex flex-wrap items-center gap-1.5 text-[11.5px] text-slate-500">
             <span className="font-medium text-slate-700">
               {segmentMetrics.segments === 0 ? "0 segments" : `${String(segmentMetrics.segments)} segments`}
             </span>
             {` · ${segmentMetrics.encoding} · ${String(segmentMetrics.remaining)} remaining`}
+            {estimatedCostUsd === null ? null : (
+              <span className="font-medium tabular-nums text-slate-500">
+                · Est. ${formatSmsEstimatedCostUsd(estimatedCostUsd)}
+              </span>
+            )}
           </div>
 
           {recipientError?.message ? (

--- a/apps/web/app/inbox/_components/inbox-composer.tsx
+++ b/apps/web/app/inbox/_components/inbox-composer.tsx
@@ -15,6 +15,7 @@ import { cn } from "@/lib/utils";
 
 import {
   isComposerSendDisabled,
+  resolveSmsSendAndSaveForAiAvailability,
   resolveSendAndSaveForAiAvailability,
 } from "../_lib/composer-ui";
 import { ComposerCollapsedPill } from "./composer-collapsed-pill";
@@ -147,9 +148,11 @@ function ComposerModeTabs({
 }
 
 export function InboxComposerDetailPane({
+  outboundRateUsdPerSegment,
   smsEnabled = false,
   smsSenders = [],
 }: {
+  readonly outboundRateUsdPerSegment: number;
   readonly smsEnabled?: boolean;
   readonly smsSenders?: readonly InboxSmsSenderOption[];
 }) {
@@ -301,6 +304,11 @@ export function InboxComposerDetailPane({
     selectedAlias: state.selectedAlias,
     aliases: composerAliases,
   });
+  const smsSendAndSaveAvailability = resolveSmsSendAndSaveForAiAvailability({
+    selectedAlias: state.selectedAlias,
+    aliases: composerAliases,
+    smsRecipientKind: state.smsRecipient?.kind ?? null,
+  });
   const isSendDisabled = isComposerSendDisabled({
     activeTab: state.activeTab,
     recipient: state.recipient,
@@ -368,6 +376,7 @@ export function InboxComposerDetailPane({
     state,
     dispatch,
     draftKey,
+    composerAliases,
     isReplying,
     replyContext,
     operatorDisplayName,
@@ -597,12 +606,17 @@ export function InboxComposerDetailPane({
               body={state.smsBody}
               includeSignature={state.smsIncludeSignature}
               segmentMetrics={smsMetricsValue}
+              outboundRateUsdPerSegment={outboundRateUsdPerSegment}
               aiDraft={aiDraft}
               aiDirective={state.aiDirective}
               repromptText={state.repromptText}
               isGeneratingAi={isGeneratingAi}
               runAiDraftDisabled={runAiDraftDisabled}
               runAiDraftDisabledReason={runAiDraftDisabledReason}
+              canSendAndSaveForAi={smsSendAndSaveAvailability.enabled}
+              sendAndSaveDisabledReason={
+                smsSendAndSaveAvailability.disabledReason
+              }
               sendDisabledReason={smsSendDisabledReason}
               inlineError={state.inlineError}
               isSending={isSending}

--- a/apps/web/app/inbox/_components/inbox-shell.tsx
+++ b/apps/web/app/inbox/_components/inbox-shell.tsx
@@ -21,6 +21,7 @@ interface ShellProps {
   readonly initialList: InboxListViewModel;
   readonly initialFilterId: InboxFilterId;
   readonly composerAliases: readonly InboxComposerAliasOption[];
+  readonly outboundRateUsdPerSegment: number;
   readonly smsEnabled: boolean;
   readonly smsSenders: readonly InboxSmsSenderOption[];
   readonly healthBanner: InboxIntegrationHealthBannerViewModel | null;
@@ -46,6 +47,7 @@ export function InboxShell({
   initialList,
   initialFilterId,
   composerAliases,
+  outboundRateUsdPerSegment,
   smsEnabled,
   smsSenders,
   healthBanner,
@@ -75,7 +77,11 @@ export function InboxShell({
               initialFilterId={initialFilterId}
             />
 
-            <InboxWorkspace smsEnabled={smsEnabled} smsSenders={smsSenders}>
+            <InboxWorkspace
+              outboundRateUsdPerSegment={outboundRateUsdPerSegment}
+              smsEnabled={smsEnabled}
+              smsSenders={smsSenders}
+            >
               {children}
             </InboxWorkspace>
           </div>

--- a/apps/web/app/inbox/_components/inbox-workspace.tsx
+++ b/apps/web/app/inbox/_components/inbox-workspace.tsx
@@ -12,10 +12,12 @@ import { XIcon } from "./icons";
 
 export function InboxWorkspace({
   children,
+  outboundRateUsdPerSegment,
   smsEnabled = false,
   smsSenders = [],
 }: {
   readonly children: ReactNode;
+  readonly outboundRateUsdPerSegment: number;
   readonly smsEnabled?: boolean;
   readonly smsSenders?: readonly InboxSmsSenderOption[];
 }) {
@@ -40,6 +42,7 @@ export function InboxWorkspace({
       {children}
       {composerPane.mode === "closed" ? null : (
         <InboxComposerDetailPane
+          outboundRateUsdPerSegment={outboundRateUsdPerSegment}
           smsEnabled={smsEnabled}
           smsSenders={smsSenders}
         />

--- a/apps/web/app/inbox/_hooks/use-composer-submit.ts
+++ b/apps/web/app/inbox/_hooks/use-composer-submit.ts
@@ -12,6 +12,7 @@ import {
   type ComposerSendKind,
 } from "../_lib/composer-ui";
 import type {
+  InboxComposerAliasOption,
   InboxComposerReplyContext,
   OptimisticOutbound,
 } from "../_lib/view-models";
@@ -82,6 +83,7 @@ export function useComposerSubmit({
   state,
   dispatch,
   draftKey,
+  composerAliases,
   isReplying,
   replyContext,
   operatorDisplayName,
@@ -99,6 +101,7 @@ export function useComposerSubmit({
   readonly state: ComposerDraftState;
   readonly dispatch: Dispatch<ComposerDraftAction>;
   readonly draftKey: string | null;
+  readonly composerAliases: readonly InboxComposerAliasOption[];
   readonly isReplying: boolean;
   readonly replyContext: InboxComposerReplyContext | null;
   readonly operatorDisplayName: string;
@@ -313,7 +316,7 @@ export function useComposerSubmit({
     });
   };
 
-  const submitSms = () => {
+  const submitSms = (sendKind: ComposerSendKind = "send") => {
     if (state.activeTab !== "sms") {
       return;
     }
@@ -349,6 +352,11 @@ export function useComposerSubmit({
     const clientGeneratedId = crypto.randomUUID();
     const smsRecipient = state.smsRecipient;
     const smsSenderId = state.smsSelectedSenderId;
+    const selectedAliasRecord =
+      state.selectedAlias === null
+        ? null
+        : (composerAliases.find((alias) => alias.alias === state.selectedAlias) ??
+          null);
     const occurredAt = new Date().toISOString();
     const recipientLabel =
       smsRecipient.kind === "contact"
@@ -409,6 +417,11 @@ export function useComposerSubmit({
           senderId: smsSenderId,
           body,
           clientGeneratedId,
+          projectId:
+            sendKind === "send-and-save"
+              ? selectedAliasRecord?.projectId ?? null
+              : null,
+          saveAsKnowledge: sendKind === "send-and-save",
         });
 
         if (result.ok) {

--- a/apps/web/app/inbox/_lib/composer-ui.ts
+++ b/apps/web/app/inbox/_lib/composer-ui.ts
@@ -199,3 +199,25 @@ export function resolveSendAndSaveForAiAvailability(input: {
       : "AI is not configured for this project.",
   };
 }
+
+export function resolveSmsSendAndSaveForAiAvailability(input: {
+  readonly selectedAlias: string | null;
+  readonly aliases: readonly InboxComposerAliasOption[];
+  readonly smsRecipientKind: "contact" | "phone" | null;
+}): {
+  readonly enabled: boolean;
+  readonly disabledReason: string | null;
+} {
+  if (input.smsRecipientKind === "phone") {
+    return {
+      enabled: false,
+      disabledReason:
+        "Project knowledge capture requires a known contact with project context.",
+    };
+  }
+
+  return resolveSendAndSaveForAiAvailability({
+    selectedAlias: input.selectedAlias,
+    aliases: input.aliases,
+  });
+}

--- a/apps/web/app/inbox/actions.ts
+++ b/apps/web/app/inbox/actions.ts
@@ -107,6 +107,8 @@ const sendSmsActionInputSchema = z.object({
   senderId: z.string().min(1),
   body: z.string().min(1),
   clientGeneratedId: z.string().min(1),
+  projectId: z.string().min(1).nullable().optional(),
+  saveAsKnowledge: z.boolean().optional(),
 });
 
 export type SendSmsActionInput = z.input<typeof sendSmsActionInputSchema>;
@@ -206,39 +208,68 @@ function maskKnowledgeExample(value: string): string {
 async function captureKnowledgeFromSend(input: {
   readonly runtime: Awaited<ReturnType<typeof getStage1WebRuntime>>;
   readonly projectId: string;
-  readonly subject: string;
   readonly bodyPlaintext: string;
-  readonly pendingOutboundId: string;
-  readonly gmailMessageId: string;
-  readonly gmailThreadId: string | null;
-  readonly rfc822MessageId: string | null;
   readonly createdAt: Date;
   readonly createdByUserId: string;
+  readonly source:
+    | {
+        readonly channel: "email";
+        readonly subject: string;
+        readonly pendingOutboundId: string;
+        readonly gmailMessageId: string;
+        readonly gmailThreadId: string | null;
+        readonly rfc822MessageId: string | null;
+      }
+    | {
+        readonly channel: "sms";
+        readonly smsMessageId: string;
+        readonly twilioMessageSid: string | null;
+        readonly summary: string;
+      };
 }): Promise<void> {
   const nowIso = input.createdAt.toISOString();
+  const questionSummary =
+    input.source.channel === "email"
+      ? input.source.subject
+      : input.source.summary;
+  const entryId =
+    input.source.channel === "email"
+      ? `project_knowledge:captured:${input.source.pendingOutboundId}`
+      : `project_knowledge:captured:${input.source.smsMessageId}`;
+  const metadataJson =
+    input.source.channel === "email"
+      ? {
+          subject: input.source.subject,
+          bodyPlaintext: input.bodyPlaintext,
+          createdByUserId: input.createdByUserId,
+          pendingOutboundId: input.source.pendingOutboundId,
+          gmailMessageId: input.source.gmailMessageId,
+          gmailThreadId: input.source.gmailThreadId,
+          rfc822MessageId: input.source.rfc822MessageId,
+          maskedExample: maskKnowledgeExample(input.bodyPlaintext),
+        }
+      : {
+          channel: "sms" as const,
+          bodyPlaintext: input.bodyPlaintext,
+          createdByUserId: input.createdByUserId,
+          smsMessageId: input.source.smsMessageId,
+          twilioMessageSid: input.source.twilioMessageSid,
+          maskedExample: maskKnowledgeExample(input.bodyPlaintext),
+        };
 
   await input.runtime.repositories.projectKnowledge.upsert({
-    id: `project_knowledge:captured:${input.pendingOutboundId}`,
+    id: entryId,
     projectId: input.projectId,
     kind: "canonical_reply",
     issueType: null,
     volunteerStage: null,
-    questionSummary: input.subject,
+    questionSummary,
     replyStrategy: null,
     maskedExample: input.bodyPlaintext,
     sourceKind: "captured_from_send",
     approvedForAi: false,
     sourceEventId: null,
-    metadataJson: {
-      subject: input.subject,
-      bodyPlaintext: input.bodyPlaintext,
-      createdByUserId: input.createdByUserId,
-      pendingOutboundId: input.pendingOutboundId,
-      gmailMessageId: input.gmailMessageId,
-      gmailThreadId: input.gmailThreadId,
-      rfc822MessageId: input.rfc822MessageId,
-      maskedExample: maskKnowledgeExample(input.bodyPlaintext),
-    },
+    metadataJson,
     lastReviewedAt: null,
     createdAt: nowIso,
     updatedAt: nowIso,
@@ -246,9 +277,12 @@ async function captureKnowledgeFromSend(input: {
 }
 
 function readSaveAsKnowledgeFlag(
-  input: ComposerSendActionParsedInput,
+  input: {
+    readonly saveAsKnowledge?: boolean | undefined;
+    readonly captureAsKnowledge?: boolean | undefined;
+  },
 ): boolean {
-  return input.saveAsKnowledge ?? input.captureAsKnowledge;
+  return input.saveAsKnowledge ?? input.captureAsKnowledge ?? false;
 }
 
 function beginAiDraftRequest(userId: string): boolean {
@@ -1034,6 +1068,8 @@ export async function sendSmsAction(
       message: "SMS send input is invalid.",
     };
   }
+  const saveAsKnowledge = readSaveAsKnowledgeFlag(parsedInput.data);
+  const knowledgeProjectId = parsedInput.data.projectId ?? null;
 
   let currentUser;
   try {
@@ -1137,6 +1173,7 @@ export async function sendSmsAction(
       retryable: false,
     };
   }
+  const contact = await runtime.repositories.contacts.findById(contactId);
 
   const messageId = randomUUID();
   await runtime.repositories.smsMessages.insert({
@@ -1172,6 +1209,41 @@ export async function sendSmsAction(
       status: "sent",
       sentAt: attemptedAt,
     });
+
+    if (saveAsKnowledge && knowledgeProjectId !== null) {
+      try {
+        const contactDisplayName = (contact?.displayName ?? "").trim();
+        const contactLabel =
+          contactDisplayName.length > 0 ? contactDisplayName : phoneE164;
+        const trimmedBody = body.trim();
+        const fallbackSummary =
+          trimmedBody.length <= 60
+            ? trimmedBody
+            : `${trimmedBody.slice(0, 57).trimEnd()}...`;
+
+        await captureKnowledgeFromSend({
+          runtime,
+          projectId: knowledgeProjectId,
+          bodyPlaintext: body,
+          createdAt: attemptedAt,
+          createdByUserId: currentUser.id,
+          source: {
+            channel: "sms",
+            smsMessageId: messageId,
+            twilioMessageSid: sendResult.messageSid,
+            summary:
+              contactLabel.length > 0 ? `SMS to ${contactLabel}` : fallbackSummary,
+          },
+        });
+      } catch (error) {
+        console.warn("SMS send succeeded but knowledge capture failed.", {
+          messageId,
+          projectId: knowledgeProjectId,
+          error,
+        });
+      }
+    }
+
     revalidateInboxContact(contactId);
 
     return {
@@ -1914,14 +1986,17 @@ export async function sendComposerAction(
           await captureKnowledgeFromSend({
             runtime,
             projectId: alias.projectId,
-            subject: parsedInput.data.subject,
             bodyPlaintext,
-            pendingOutboundId,
-            gmailMessageId: sendResult.gmailMessageId,
-            gmailThreadId: sendResult.gmailThreadId,
-            rfc822MessageId: sendResult.rfc822MessageId,
             createdAt: attemptedAt,
             createdByUserId: currentUser.id,
+            source: {
+              channel: "email",
+              subject: parsedInput.data.subject,
+              pendingOutboundId,
+              gmailMessageId: sendResult.gmailMessageId,
+              gmailThreadId: sendResult.gmailThreadId,
+              rfc822MessageId: sendResult.rfc822MessageId,
+            },
           });
         } catch (error) {
           console.warn("Composer send succeeded but knowledge capture failed.", {

--- a/apps/web/app/inbox/layout.tsx
+++ b/apps/web/app/inbox/layout.tsx
@@ -61,6 +61,7 @@ export default async function InboxLayout({
       initialList={list}
       initialFilterId="all"
       composerAliases={composerAliases}
+      outboundRateUsdPerSegment={env.TWILIO_OUTBOUND_RATE_USD_PER_SEGMENT}
       smsEnabled={env.SMS_ENABLED}
       smsSenders={smsSenders}
       healthBanner={healthBanner}

--- a/apps/web/app/settings/_components/integrations-section.tsx
+++ b/apps/web/app/settings/_components/integrations-section.tsx
@@ -17,6 +17,10 @@ import {
   TooltipTrigger
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import {
+  formatSmsEstimatedCostUsd,
+  formatUsdAmount
+} from "@/src/lib/sms-pricing";
 import type {
   IntegrationHealthViewModel,
   IntegrationsSettingsViewModel
@@ -85,6 +89,34 @@ function formatRelative(iso: string | null): string {
   if (months < 12) return `${String(months)}mo ago`;
   const years = Math.floor(days / 365);
   return `${String(years)}y ago`;
+}
+
+function buildTwilioUsageState(input: {
+  readonly spendUsd: number | null;
+  readonly capUsd: number | null;
+}): null | {
+  readonly label: string;
+  readonly className: string;
+} {
+  if (input.spendUsd === null || input.capUsd === null || input.capUsd <= 0) {
+    return null;
+  }
+
+  if (input.spendUsd >= input.capUsd) {
+    return {
+      label: "Cap exceeded — sends still allowed in v1, no hard enforcement",
+      className: "bg-rose-50 text-rose-700 ring-rose-200"
+    };
+  }
+
+  if (input.spendUsd >= input.capUsd * 0.8) {
+    return {
+      label: "Approaching cap",
+      className: "bg-amber-50 text-amber-800 ring-amber-200"
+    };
+  }
+
+  return null;
 }
 
 export function IntegrationsSection({ viewModel }: IntegrationsSectionProps) {
@@ -230,6 +262,14 @@ function TwilioConnectorCard({
       colorClasses: "bg-amber-50 text-amber-800 ring-amber-200",
     },
   }[viewModel.status];
+  const usageState = buildTwilioUsageState({
+    spendUsd: viewModel.monthToDateSpendUsd,
+    capUsd: viewModel.monthlyCapUsd
+  });
+  const showUsageRows =
+    viewModel.smsEnabled &&
+    viewModel.monthToDateSpendUsd !== null &&
+    viewModel.monthToDateSegments !== null;
 
   return (
     <div
@@ -280,6 +320,44 @@ function TwilioConnectorCard({
           <dd>{formatRelative(viewModel.lastStatusCallbackAt)}</dd>
         </div>
       </dl>
+
+      {showUsageRows ? (
+        <div className="border-t border-slate-200 pt-3">
+          <dl className="grid gap-2 text-[12px] text-slate-600">
+            <div className="flex items-start justify-between gap-3">
+              <dt className="font-medium text-slate-900">Spend MTD</dt>
+              <dd className="text-right">
+                <span className="font-medium tabular-nums text-slate-900">
+                  ${formatUsdAmount(viewModel.monthToDateSpendUsd)}
+                </span>
+              </dd>
+            </div>
+            <div className="-mt-1 text-right text-[11.5px] text-slate-500 tabular-nums">
+              (${formatSmsEstimatedCostUsd(viewModel.outboundRateUsdPerSegment)} /
+              {" "}
+              segment, {String(viewModel.monthToDateSegments)} segments)
+            </div>
+            <div className="flex items-start justify-between gap-3">
+              <dt className="font-medium text-slate-900">Monthly cap</dt>
+              <dd className="font-medium tabular-nums text-slate-900">
+                {viewModel.monthlyCapUsd === null
+                  ? "—"
+                  : `$${formatUsdAmount(viewModel.monthlyCapUsd)}`}
+              </dd>
+            </div>
+          </dl>
+
+          {usageState ? (
+            <div className="mt-3">
+              <StatusBadge
+                label={usageState.label}
+                colorClasses={usageState.className}
+                variant="soft"
+              />
+            </div>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/lib/sms-pricing.ts
+++ b/apps/web/src/lib/sms-pricing.ts
@@ -1,0 +1,18 @@
+export function estimateSmsCostUsd(
+  segments: number,
+  outboundRateUsdPerSegment: number,
+): number {
+  if (segments <= 0) {
+    return 0;
+  }
+
+  return segments * outboundRateUsdPerSegment;
+}
+
+export function formatSmsEstimatedCostUsd(value: number): string {
+  return value.toFixed(4);
+}
+
+export function formatUsdAmount(value: number): string {
+  return value.toFixed(2);
+}

--- a/apps/web/src/server/env.ts
+++ b/apps/web/src/server/env.ts
@@ -8,8 +8,24 @@ function parseBooleanEnv(value: unknown): boolean {
   return ["1", "true", "yes", "on"].includes(value.trim().toLowerCase());
 }
 
+function parsePositiveNumberEnv(value: unknown): number | undefined {
+  if (typeof value === "number") {
+    return Number.isFinite(value) && value > 0 ? value : undefined;
+  }
+
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const parsed = Number(value.trim());
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
 export const webEnvSchema = z.object({
   SMS_ENABLED: z.preprocess(parseBooleanEnv, z.boolean()).default(false),
+  TWILIO_OUTBOUND_RATE_USD_PER_SEGMENT: z
+    .preprocess(parsePositiveNumberEnv, z.number().positive())
+    .default(0.0079),
 });
 
 export type WebEnv = z.infer<typeof webEnvSchema>;
@@ -17,5 +33,7 @@ export type WebEnv = z.infer<typeof webEnvSchema>;
 export function readWebEnv(env: NodeJS.ProcessEnv = process.env): WebEnv {
   return webEnvSchema.parse({
     SMS_ENABLED: env.SMS_ENABLED,
+    TWILIO_OUTBOUND_RATE_USD_PER_SEGMENT:
+      env.TWILIO_OUTBOUND_RATE_USD_PER_SEGMENT,
   });
 }

--- a/apps/web/src/server/settings/selectors.ts
+++ b/apps/web/src/server/settings/selectors.ts
@@ -8,6 +8,7 @@ import type {
 
 import { getCurrentUser } from "../auth/session";
 import { readWebEnv } from "../env";
+import { estimateSmsCostUsd } from "@/src/lib/sms-pricing";
 import { recordSensitiveReadForCurrentUserDetached } from "../security/audit";
 import { getStage1WebRuntime } from "../stage1-runtime";
 
@@ -84,6 +85,10 @@ export interface IntegrationsSettingsViewModel {
     readonly smsEnabled: boolean;
     readonly hasActiveSender: boolean;
     readonly lastStatusCallbackAt: string | null;
+    readonly outboundRateUsdPerSegment: number;
+    readonly monthToDateSpendUsd: number | null;
+    readonly monthToDateSegments: number | null;
+    readonly monthlyCapUsd: number | null;
   };
 }
 
@@ -443,14 +448,20 @@ async function readIntegrationHealth(): Promise<
 > {
   const runtime = await getStage1WebRuntime();
   const env = readWebEnv();
+  const monthStart = new Date();
+  monthStart.setUTCDate(1);
+  monthStart.setUTCHours(0, 0, 0, 0);
 
   await runtime.settings.integrationHealth.seedDefaults();
-  const [rows, activeSmsSenders, latestCallback, latestDelivered] =
+  const [rows, activeSmsSenders, latestCallback, latestDelivered, usageSnapshot] =
     await Promise.all([
       runtime.settings.integrationHealth.listAll(),
       runtime.settings.smsSenders.listActive(),
       runtime.settings.smsMessages.findLatestByStatuses(["delivered", "failed"]),
       runtime.settings.smsMessages.findLatestByStatuses(["delivered"]),
+      runtime.settings.smsSenders.getActiveUsageSnapshot({
+        monthStart,
+      }),
     ]);
 
   const integrationById = new Map(rows.map((row) => [row.id, row] as const));
@@ -485,6 +496,14 @@ async function readIntegrationHealth(): Promise<
       : deliveredWithinLastDay
         ? "active"
         : "degraded";
+  const monthToDateSegments = usageSnapshot?.monthToDateSegments ?? null;
+  const monthToDateSpendUsd =
+    monthToDateSegments === null
+      ? null
+      : estimateSmsCostUsd(
+          monthToDateSegments,
+          env.TWILIO_OUTBOUND_RATE_USD_PER_SEGMENT,
+        );
 
   return {
     integrations,
@@ -493,6 +512,10 @@ async function readIntegrationHealth(): Promise<
       smsEnabled: env.SMS_ENABLED,
       hasActiveSender,
       lastStatusCallbackAt: latestCallback?.updatedAt.toISOString() ?? null,
+      outboundRateUsdPerSegment: env.TWILIO_OUTBOUND_RATE_USD_PER_SEGMENT,
+      monthToDateSpendUsd,
+      monthToDateSegments,
+      monthlyCapUsd: usageSnapshot?.monthlyCap ?? null,
     },
   };
 }

--- a/apps/web/tests/unit/composer-canonical-modal.test.tsx
+++ b/apps/web/tests/unit/composer-canonical-modal.test.tsx
@@ -629,7 +629,7 @@ function TestApp() {
       currentActorId="user:operator"
     >
       <InboxKeyboardProvider>
-        <InboxWorkspace>
+        <InboxWorkspace outboundRateUsdPerSegment={0.0079}>
           <section data-testid="underlying-conversation">
             Conversation remains visible
           </section>

--- a/apps/web/tests/unit/send-sms-action.test.ts
+++ b/apps/web/tests/unit/send-sms-action.test.ts
@@ -244,4 +244,94 @@ describe("sendSmsAction", () => {
       sendStatus: "sent",
     });
   });
+
+  it("captures project knowledge for SMS when saveAsKnowledge is true", async () => {
+    if (!runtime) {
+      throw new Error("Expected runtime.");
+    }
+
+    sendSmsViaTwilio.mockResolvedValue({
+      messageSid: "SM456",
+      segments: 1,
+    });
+    await runtime.context.repositories.consentRecords.insert({
+      id: "consent-4",
+      contactId: "contact-1",
+      phoneE164: "+14065550123",
+      status: "opted_in",
+      source: "operator_attestation",
+      sourceDetail: null,
+      consentedAt: new Date("2026-05-03T12:00:00.000Z"),
+      revokedAt: null,
+      recordedByUserId: "user:operator",
+      notes: null,
+      createdAt: new Date("2026-05-03T12:00:00.000Z"),
+      updatedAt: new Date("2026-05-03T12:00:00.000Z"),
+    });
+
+    const result = await sendSmsAction({
+      ...buildInput(),
+      projectId: "project:antarctica",
+      saveAsKnowledge: true,
+    });
+
+    expect(result.ok).toBe(true);
+
+    const entries = await runtime.context.repositories.projectKnowledge.list({
+      projectId: "project:antarctica",
+    });
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      kind: "canonical_reply",
+      sourceKind: "captured_from_send",
+      approvedForAi: false,
+      questionSummary: "SMS to Maya Lee",
+      maskedExample: "Field update confirmed.",
+    });
+    expect(entries[0]?.metadataJson).toMatchObject({
+      channel: "sms",
+      bodyPlaintext: "Field update confirmed.",
+      createdByUserId: "user:operator",
+      twilioMessageSid: "SM456",
+    });
+  });
+
+  it("does not capture project knowledge for SMS when saveAsKnowledge is false", async () => {
+    if (!runtime) {
+      throw new Error("Expected runtime.");
+    }
+
+    sendSmsViaTwilio.mockResolvedValue({
+      messageSid: "SM789",
+      segments: 1,
+    });
+    await runtime.context.repositories.consentRecords.insert({
+      id: "consent-5",
+      contactId: "contact-1",
+      phoneE164: "+14065550123",
+      status: "opted_in",
+      source: "operator_attestation",
+      sourceDetail: null,
+      consentedAt: new Date("2026-05-03T12:00:00.000Z"),
+      revokedAt: null,
+      recordedByUserId: "user:operator",
+      notes: null,
+      createdAt: new Date("2026-05-03T12:00:00.000Z"),
+      updatedAt: new Date("2026-05-03T12:00:00.000Z"),
+    });
+
+    const result = await sendSmsAction({
+      ...buildInput(),
+      projectId: "project:antarctica",
+      saveAsKnowledge: false,
+    });
+
+    expect(result.ok).toBe(true);
+    await expect(
+      runtime.context.repositories.projectKnowledge.list({
+        projectId: "project:antarctica",
+      }),
+    ).resolves.toEqual([]);
+  });
 });

--- a/apps/web/tests/unit/settings-selectors.test.ts
+++ b/apps/web/tests/unit/settings-selectors.test.ts
@@ -184,6 +184,8 @@ async function seedSourceEvidenceCollision(
 
 describe("settings selectors", () => {
   let runtime: Stage1WebTestRuntime | null = null;
+  const originalSmsEnabled = process.env.SMS_ENABLED;
+  const originalTwilioRate = process.env.TWILIO_OUTBOUND_RATE_USD_PER_SEGMENT;
 
   beforeEach(async () => {
     runtime = await createStage1WebTestRuntime();
@@ -192,9 +194,21 @@ describe("settings selectors", () => {
       id: "user:admin",
       role: "admin"
     });
+    process.env.SMS_ENABLED = "true";
+    process.env.TWILIO_OUTBOUND_RATE_USD_PER_SEGMENT = "0.0079";
   });
 
   afterEach(async () => {
+    if (originalSmsEnabled === undefined) {
+      delete process.env.SMS_ENABLED;
+    } else {
+      process.env.SMS_ENABLED = originalSmsEnabled;
+    }
+    if (originalTwilioRate === undefined) {
+      delete process.env.TWILIO_OUTBOUND_RATE_USD_PER_SEGMENT;
+    } else {
+      process.env.TWILIO_OUTBOUND_RATE_USD_PER_SEGMENT = originalTwilioRate;
+    }
     await waitForPendingSecurityAuditTasksForTests();
     await runtime?.dispose();
     runtime = null;
@@ -446,6 +460,122 @@ describe("settings selectors", () => {
         "not_configured"
       ]
     );
+  });
+
+  it("aggregates Twilio MTD spend and monthly cap from outbound SMS usage", async () => {
+    if (!runtime) {
+      throw new Error("runtime not initialized");
+    }
+
+    await runtime.context.client.exec(`
+      insert into sms_senders (
+        id,
+        phone_e164,
+        display_name,
+        monthly_cap,
+        is_active,
+        created_at,
+        updated_at
+      ) values (
+        'sender-1',
+        '+14065550142',
+        'Adventure Scientists',
+        40,
+        true,
+        '2026-05-01T00:00:00.000Z',
+        '2026-05-01T00:00:00.000Z'
+      );
+    `);
+
+    await runtime.context.repositories.contacts.upsert({
+      id: "contact:settings:sms",
+      salesforceContactId: null,
+      displayName: "SMS Volunteer",
+      primaryEmail: null,
+      primaryPhone: "+14065550123",
+      createdAt: "2026-05-01T00:00:00.000Z",
+      updatedAt: "2026-05-01T00:00:00.000Z"
+    });
+
+    await runtime.context.repositories.smsMessages.insert({
+      id: "sms:outbound:current-month",
+      twilioMessageSid: "SM-current",
+      direction: "outbound",
+      contactId: "contact:settings:sms",
+      phoneE164: "+14065550123",
+      senderId: "sender-1",
+      body: "Current month outbound",
+      segments: 547,
+      encoding: "GSM-7",
+      mediaUrls: null,
+      sendStatus: "sent",
+      failedReason: null,
+      failedDetail: null,
+      sentAt: new Date("2026-05-02T12:00:00.000Z"),
+      receivedAt: null,
+      actorId: "user:admin",
+      createdAt: new Date("2026-05-02T12:00:00.000Z"),
+      updatedAt: new Date("2026-05-02T12:00:00.000Z"),
+    });
+    await runtime.context.repositories.smsMessages.insert({
+      id: "sms:outbound:previous-month",
+      twilioMessageSid: "SM-previous",
+      direction: "outbound",
+      contactId: "contact:settings:sms",
+      phoneE164: "+14065550123",
+      senderId: "sender-1",
+      body: "Previous month outbound",
+      segments: 100,
+      encoding: "GSM-7",
+      mediaUrls: null,
+      sendStatus: "sent",
+      failedReason: null,
+      failedDetail: null,
+      sentAt: new Date("2026-04-20T12:00:00.000Z"),
+      receivedAt: null,
+      actorId: "user:admin",
+      createdAt: new Date("2026-04-20T12:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T12:00:00.000Z"),
+    });
+
+    const viewModel = await loadIntegrationHealth();
+
+    expect(viewModel.twilioCard.monthToDateSegments).toBe(547);
+    expect(viewModel.twilioCard.monthToDateSpendUsd).toBeCloseTo(4.3213, 4);
+    expect(viewModel.twilioCard.monthlyCapUsd).toBe(40);
+    expect(viewModel.twilioCard.outboundRateUsdPerSegment).toBe(0.0079);
+  });
+
+  it("returns a null Twilio monthly cap when the active sender has no cap", async () => {
+    if (!runtime) {
+      throw new Error("runtime not initialized");
+    }
+
+    await runtime.context.client.exec(`
+      insert into sms_senders (
+        id,
+        phone_e164,
+        display_name,
+        monthly_cap,
+        is_active,
+        created_at,
+        updated_at
+      ) values (
+        'sender-uncapped',
+        '+14065550143',
+        'Uncapped Sender',
+        null,
+        true,
+        '2026-05-01T00:00:00.000Z',
+        '2026-05-01T00:00:00.000Z'
+      );
+    `);
+
+    const viewModel = await loadIntegrationHealth();
+
+    expect(viewModel.twilioCard.monthToDateSegments).toBe(0);
+    expect(viewModel.twilioCard.monthToDateSpendUsd).toBe(0);
+    expect(viewModel.twilioCard.monthlyCapUsd).toBeNull();
   });
 
   it("maps source-evidence collisions into the logs settings view model", async () => {

--- a/apps/web/tests/unit/settings-selectors.test.ts
+++ b/apps/web/tests/unit/settings-selectors.test.ts
@@ -497,6 +497,12 @@ describe("settings selectors", () => {
       updatedAt: "2026-05-01T00:00:00.000Z"
     });
 
+    await runtime.context.settings.users.upsert(buildUser({
+      id: "user:admin",
+      email: "admin@example.org",
+      role: "admin"
+    }));
+
     await runtime.context.repositories.smsMessages.insert({
       id: "sms:outbound:current-month",
       twilioMessageSid: "SM-current",

--- a/apps/web/tests/unit/sms-segment-cost.test.ts
+++ b/apps/web/tests/unit/sms-segment-cost.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  estimateSmsCostUsd,
+  formatSmsEstimatedCostUsd,
+} from "../../src/lib/sms-pricing";
+
+describe("sms pricing", () => {
+  it("treats zero segments as no cost", () => {
+    expect(estimateSmsCostUsd(0, 0.0079)).toBe(0);
+  });
+
+  it("computes one segment at the default Twilio rate", () => {
+    expect(formatSmsEstimatedCostUsd(estimateSmsCostUsd(1, 0.0079))).toBe(
+      "0.0079",
+    );
+  });
+
+  it("computes multiple segments at the default Twilio rate", () => {
+    expect(formatSmsEstimatedCostUsd(estimateSmsCostUsd(4, 0.0079))).toBe(
+      "0.0316",
+    );
+  });
+
+  it("uses a custom per-segment rate when configured", () => {
+    expect(formatSmsEstimatedCostUsd(estimateSmsCostUsd(3, 0.0125))).toBe(
+      "0.0375",
+    );
+  });
+});

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -696,6 +696,39 @@ function createSmsRepositorySlices(db: Stage1Database) {
 
         return row === undefined ? null : mapSmsSenderRow(row);
       },
+
+      async getActiveUsageSnapshot(input) {
+        const [row] = await db
+          .select({
+            monthlyCap: smsSenders.monthlyCap,
+            monthToDateSegments:
+              sql<number>`coalesce(sum(${smsMessages.segments}), 0)`.mapWith(
+                Number,
+              ),
+          })
+          .from(smsSenders)
+          .leftJoin(
+            smsMessages,
+            and(
+              eq(smsMessages.senderId, smsSenders.id),
+              eq(smsMessages.direction, "outbound"),
+              sql`${smsMessages.createdAt} >= ${input.monthStart}`,
+            ),
+          )
+          .where(eq(smsSenders.isActive, true))
+          .groupBy(smsSenders.id)
+          .orderBy(asc(smsSenders.createdAt), asc(smsSenders.id))
+          .limit(1);
+
+        if (row === undefined) {
+          return null;
+        }
+
+        return {
+          monthlyCap: row.monthlyCap,
+          monthToDateSegments: row.monthToDateSegments,
+        };
+      },
     },
   } satisfies Pick<
     Stage1RepositoryBundle,

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -231,6 +231,15 @@ export interface SmsSenderRepository {
   listActive(): Promise<readonly SmsSenderRecord[]>;
   findById(id: string): Promise<SmsSenderRecord | null>;
   findByPhone(phoneE164: string): Promise<SmsSenderRecord | null>;
+  getActiveUsageSnapshot(input: {
+    readonly monthStart: Date;
+  }): Promise<
+    | {
+        readonly monthlyCap: number | null;
+        readonly monthToDateSegments: number;
+      }
+    | null
+  >;
 }
 
 export interface ProjectDimensionRepository {

--- a/packages/domain/test/normalization.test.ts
+++ b/packages/domain/test/normalization.test.ts
@@ -414,6 +414,7 @@ function buildContext(input: {
       listActive: () => Promise.resolve([]),
       findById: () => Promise.resolve(null),
       findByPhone: () => Promise.resolve(null),
+      getActiveUsageSnapshot: () => Promise.resolve(null),
     },
     projectDimensions: {
       listAll: () => Promise.resolve([]),

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -102,6 +102,7 @@ describe("defineStage1RepositoryBundle", () => {
         listActive: () => Promise.resolve([]),
         findById: () => Promise.resolve(null),
         findByPhone: () => Promise.resolve(null),
+        getActiveUsageSnapshot: () => Promise.resolve(null),
       },
       projectDimensions: {
         listAll: () => Promise.resolve([]),

--- a/packages/domain/test/stage3-last-inbound-alias.test.ts
+++ b/packages/domain/test/stage3-last-inbound-alias.test.ts
@@ -116,6 +116,7 @@ function buildRepositoryBundle(input: {
       listActive: () => Promise.resolve([]),
       findById: () => Promise.resolve(null),
       findByPhone: () => Promise.resolve(null),
+      getActiveUsageSnapshot: () => Promise.resolve(null),
     },
     projectDimensions: {
       listAll: () => Promise.resolve([]),

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -189,6 +189,7 @@ function createRepositoryBundle(input: {
       listActive: () => Promise.resolve([]),
       findById: () => Promise.resolve(null),
       findByPhone: () => Promise.resolve(null),
+      getActiveUsageSnapshot: () => Promise.resolve(null),
     },
     projectDimensions: {
       listAll: () => Promise.resolve([]),


### PR DESCRIPTION
PRD: https://github.com/nico-kneler-as/as-comms-platform/issues/277
Phase 5 of 5 — final phase. Builds on Phases 1–4 (#278, #279, #280, #281).

## Summary

After this lands, all v1 SMS architecture is in place. Remaining work is A2P 10DLC carrier review (architect-side), the four parked product inputs from the PRD, and the launch flag flip.

## What's in

### Inline cost in SMS composer
- `TWILIO_OUTBOUND_RATE_USD_PER_SEGMENT` env var (default `0.0079`).
- `apps/web/src/lib/sms-pricing.ts` shared helper — `formatSmsCost(segments, rate)` etc.
- `ComposerSmsSurface` shows `Est. $X.XXXX` next to the segment counter (hidden at segments=0).
- Rate threaded server boundary → `InboxShell` → `InboxWorkspace` → composer as a prop. No React context.

### Settings: MTD spend + monthly cap
- New `smsSenders.getActiveUsageSnapshot` repo method — one-query aggregation of outbound `sms_messages.segments` for the current UTC month.
- Settings → Twilio card surfaces:
  - MTD spend (`segments × rate`)
  - MTD segment count
  - Monthly cap (or "—")
  - Soft cap-state indicator: amber at ≥80%, red at ≥100%
- **No hard send-blocking** per PRD ("visibility-only").

### "Send & save for AI" for SMS
- `captureKnowledgeFromSend` refactored into a channel-aware helper with discriminated metadata. Email's existing `metadataJson` shape (gmailMessageId / gmailThreadId / rfc822MessageId) preserved exactly; SMS branch adds `twilioMessageSid` + `smsMessageId`.
- `sourceKind: "captured_from_send"` reused for both channels — **no schema migration**.
- `sendSmsAction` accepts `saveAsKnowledge: boolean`; SMS split-button menu adds the "Send and save for AI" option, disabled for raw-phone recipients and senders without project association.

## Validation
- `pnpm typecheck`: green
- `pnpm lint`: green
- `pnpm boundaries`: green (no rule changes)
- `pnpm build`: green

## Tests
- New: `apps/web/tests/unit/sms-segment-cost.test.ts` — pure pricing helper coverage.
- Extended: `apps/web/tests/unit/send-sms-action.test.ts` — `saveAsKnowledge` flag drives capture.
- Extended: `apps/web/tests/unit/settings-selectors.test.ts` — Twilio MTD spend + cap selector.
- Updated: `composer-canonical-modal.test.tsx` for new required `outboundRateUsdPerSegment` prop on `InboxWorkspace`.
- Updated: `packages/domain/test/{normalization,repositories,stage3-last-inbound-alias,timeline}.test.ts` — added `getActiveUsageSnapshot` stub to repo bundle fixtures.

## `captureKnowledgeFromSend` refactor decision

Channel-aware helper with discriminated `source` parameter:
```ts
source: { channel: "email"; subject; pendingOutboundId; gmailMessageId; gmailThreadId; rfc822MessageId }
      | { channel: "sms"; smsMessageId; twilioMessageSid }
```
`metadataJson` gets a `channel` discriminator. Existing email rows in production have no `channel` field; treated as `"email"` implicitly when reading. **No row migration needed.**

## Out of scope (untouched)
- Hard cap enforcement (PRD: visibility-only in v1).
- Per-message cost stored in DB (computed at read time).
- Per-project monthly caps (defers to v2 with per-project numbers).
- Inbound SMS save-for-AI (only outbound, mirrors email).
- "Last N SMS" knowledge tier (v2).
- Schema migrations.

## Behavior preservation
- [x] Email send + save-for-AI produces identical `project_knowledge_entries` rows.
- [x] Email composer cost behavior unchanged (no email cost UI).
- [x] AI Draft (Phase 4) unchanged.
- [x] `SMS_ENABLED=false` hides all Phase 5 surfaces (cost in composer, Settings card additions).
- [x] No hard send-blocking from cap exceedance.
- [x] `captureKnowledgeFromSend` email branch preserves the exact prior metadata shape and id pattern (`project_knowledge:captured:{pendingOutboundId}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)