### PR TITLE
fix(db): migrator honors -- migrate:no-transaction directive

### DIFF
--- a/packages/db/drizzle/0050_twilio_provider_taxonomy.sql
+++ b/packages/db/drizzle/0050_twilio_provider_taxonomy.sql
@@ -1,2 +1,5 @@
+-- migrate:no-transaction
+-- Postgres forbids ALTER TYPE ... ADD VALUE inside a transaction block.
+-- The migrator honors this directive and runs the file outside sql.begin().
 ALTER TYPE "provider" ADD VALUE IF NOT EXISTS 'twilio';
 ALTER TYPE "record_source" ADD VALUE IF NOT EXISTS 'twilio';

--- a/packages/db/drizzle/0052_contacts_primary_phone_unique.sql
+++ b/packages/db/drizzle/0052_contacts_primary_phone_unique.sql
@@ -1,2 +1,13 @@
-CREATE UNIQUE INDEX contacts_primary_phone_unique
+-- Originally drafted as a UNIQUE INDEX (filename retained to match the
+-- applied_migrations row id seeded during the 2026-05-03 incident
+-- remediation). At apply time we discovered shared org/family phones in
+-- the live data (1 known case as of 2026-05-03 — California Botanic
+-- Garden main line shared by two contacts), so we landed a non-UNIQUE
+-- partial index instead.
+--
+-- Tracking issue: phone↔contact must move to a many-to-many relation via
+-- contact_identities before SMS routing goes live, at which point the
+-- uniqueness invariant can be re-established at the right grain.
+-- See https://github.com/nico-kneler-as/as-comms-platform/issues/285
+CREATE INDEX IF NOT EXISTS contacts_primary_phone_index
   ON contacts (primary_phone) WHERE primary_phone IS NOT NULL;

--- a/packages/db/scripts/migrate.mjs
+++ b/packages/db/scripts/migrate.mjs
@@ -137,15 +137,40 @@ async function bootstrap(sql, migrations) {
   `;
 }
 
+// Migrations may opt out of the per-migration transaction by including the
+// directive `-- migrate:no-transaction` anywhere in the file. Required for
+// statements Postgres forbids inside transaction blocks — most commonly
+// `ALTER TYPE ... ADD VALUE` and `CREATE INDEX CONCURRENTLY`.
+//
+// The trade-off: a partial-failure mid-migration leaves the DB in an
+// intermediate state. Keep no-transaction migrations narrow (ideally a
+// single statement) so partial failure is recoverable.
+const NO_TRANSACTION_DIRECTIVE = /^[ \t]*--[ \t]*migrate:no-transaction\b/mu;
+
+function migrationOptsOutOfTransaction(migration) {
+  return NO_TRANSACTION_DIRECTIVE.test(migration.sql);
+}
+
 async function applyMigration(sql, migration) {
-  log(`applying ${migration.id}`);
-  await sql.begin(async (tx) => {
-    await tx.unsafe(migration.sql);
-    await tx`
-      INSERT INTO ${tx(TRACKING_TABLE)} (id, hash)
+  const noTransaction = migrationOptsOutOfTransaction(migration);
+  log(`applying ${migration.id}${noTransaction ? " (no-transaction)" : ""}`);
+
+  if (noTransaction) {
+    await sql.unsafe(migration.sql);
+    await sql`
+      INSERT INTO ${sql(TRACKING_TABLE)} (id, hash)
       VALUES (${migration.id}, ${migration.hash})
     `;
-  });
+  } else {
+    await sql.begin(async (tx) => {
+      await tx.unsafe(migration.sql);
+      await tx`
+        INSERT INTO ${tx(TRACKING_TABLE)} (id, hash)
+        VALUES (${migration.id}, ${migration.hash})
+      `;
+    });
+  }
+
   log(`applied ${migration.id}`);
 }
 


### PR DESCRIPTION
## Summary

Today's incident: SMS phase 1 migration `0050_twilio_provider_taxonomy.sql` has `ALTER TYPE ... ADD VALUE`, which **Postgres forbids inside a transaction block**. The custom migrator at `packages/db/scripts/migrate.mjs:142` (PR #263) wraps every migration in `sql.begin()`. Worker preDeployCommand failed → rolled back to the previous image → web service deployed independently with code that referenced `sms_messages` → every inbox detail render 500'd.

**This PR fixes the structural bug.** Live remediation (manual SQL apply on prod) was completed during the incident; this PR brings disk truth back into alignment with prod state and prevents the next enum-add migration from triggering the same outage.

## Changes

### `packages/db/scripts/migrate.mjs`
Migrator detects `-- migrate:no-transaction` directive in the SQL file and runs those statements outside `sql.begin()`. Default behavior unchanged for transactional migrations. The directive is also required for `CREATE INDEX CONCURRENTLY` whenever we need it.

### `packages/db/drizzle/0050_twilio_provider_taxonomy.sql`
Added the directive header so future green-field deploys apply cleanly.

### `packages/db/drizzle/0052_contacts_primary_phone_unique.sql`
Replaced the intended `UNIQUE INDEX` with a non-UNIQUE partial index matching the actual prod state. The UNIQUE invariant could not be applied because of a legitimately shared org phone (California Botanic Garden line, two volunteers). Filename retained so the `applied_migrations` row id seeded during incident remediation lines up. Issue #285 tracks the proper m:n data-model fix.

## Live state on prod (already remediated today)

- ✅ `applied_migrations` table bootstrapped, 39 prior migrations seeded
- ✅ 0050 applied (twilio in `provider` and `record_source` enums)
- ✅ 0051 applied (sms_messages, sms_senders, consent_records tables)
- ✅ 0052 applied as non-UNIQUE index (`contacts_primary_phone_index`)
- ✅ Inbox detail loads (verified by Nico in browser)

This PR is recovery-after-the-fact: when the next deploy runs the migrator, it will see 0050/0051/0052 already in `applied_migrations` and skip them. Disk + prod stay aligned.

## Validation

- `pnpm --filter @as-comms/db typecheck` ✅
- `pnpm --filter @as-comms/db lint` ✅
- `node --check packages/db/scripts/migrate.mjs` ✅
- Directive detection regex unit-tested via inline script ✅

## Test plan

- [ ] CI green
- [ ] After merge: next worker deploy logs `[migrate] OK — 0 applied this run, 42 total` (no surprise re-apply)
- [ ] Independent investigation #286: confirm whether the migrator actually invokes on Railway preDeployCommand, since it apparently never did between #263 merging and today

## Companion issues

- #285 — Data model: support shared phones (m:n) before SMS goes live
- #286 — Migrator: investigate why preDeployCommand never created applied_migrations

## Risks

- **Partial-failure semantics for no-transaction migrations.** If a no-transaction migration fails mid-statement, the DB is left in an intermediate state. Acceptable — the only current use case (ALTER TYPE ADD VALUE) is single-statement and idempotent. Future no-transaction migrations should keep the same discipline; lint-style enforcement could be added later if abused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)