### PR TITLE
feat(mailchimp): settings tile + gap-backfill ops + decommission runbook

### DIFF
--- a/apps/web/app/settings/_components/integrations-section.tsx
+++ b/apps/web/app/settings/_components/integrations-section.tsx
@@ -91,6 +91,34 @@ function formatRelative(iso: string | null): string {
   return `${String(years)}y ago`;
 }
 
+function formatMailchimpCount(value: number | null): string {
+  if (value === null) return "—";
+  return new Intl.NumberFormat("en-US").format(value);
+}
+
+function formatMailchimpStatus(
+  integration: Extract<IntegrationHealthViewModel, { mailchimp: unknown }>
+): { readonly label: string; readonly colorClasses: string } {
+  switch (integration.mailchimp?.status) {
+    case "connected":
+      return {
+        label: "✓ Connected",
+        colorClasses: "bg-emerald-50 text-emerald-700 ring-emerald-200"
+      };
+    case "stale":
+      return {
+        label: "✗ Stale",
+        colorClasses: "bg-rose-50 text-rose-700 ring-rose-200"
+      };
+    case "unconfigured":
+    default:
+      return {
+        label: "⚠ Unconfigured",
+        colorClasses: "bg-amber-50 text-amber-800 ring-amber-200"
+      };
+  }
+}
+
 function buildTwilioUsageState(input: {
   readonly spendUsd: number | null;
   readonly capUsd: number | null;
@@ -168,7 +196,10 @@ export function IntegrationsSection({ viewModel }: IntegrationsSectionProps) {
       >
         <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           {items.map((integration) => {
-            const statusMeta = STATUS_META[integration.status];
+            const statusMeta =
+              integration.serviceName === "mailchimp" && integration.mailchimp !== null
+                ? formatMailchimpStatus(integration)
+                : STATUS_META[integration.status];
             const isRowPending =
               pending && pendingId === integration.serviceName;
             const isSyncDisabled =
@@ -216,23 +247,27 @@ export function IntegrationsSection({ viewModel }: IntegrationsSectionProps) {
                   />
                 </div>
 
-                <div className="flex items-center justify-between gap-3 text-[11.5px] text-slate-500">
-                  <span className="min-w-0 truncate tabular-nums">
-                    Last checked · {formatRelative(integration.lastCheckedAt)}
-                  </span>
+                {integration.mailchimp !== null ? (
+                  <MailchimpTileDetails integration={integration} />
+                ) : (
+                  <div className="flex items-center justify-between gap-3 text-[11.5px] text-slate-500">
+                    <span className="min-w-0 truncate tabular-nums">
+                      Last checked · {formatRelative(integration.lastCheckedAt)}
+                    </span>
 
-                  {viewModel.isAdmin && (
-                    <SyncButton
-                      disabled={isSyncDisabled}
-                      supportsRefresh={integration.supportsRefresh}
-                      pending={isRowPending}
-                      integrationName={integration.displayName}
-                      onSync={() => {
-                        handleRefresh(integration);
-                      }}
-                    />
-                  )}
-                </div>
+                    {viewModel.isAdmin && (
+                      <SyncButton
+                        disabled={isSyncDisabled}
+                        supportsRefresh={integration.supportsRefresh}
+                        pending={isRowPending}
+                        integrationName={integration.displayName}
+                        onSync={() => {
+                          handleRefresh(integration);
+                        }}
+                      />
+                    )}
+                  </div>
+                )}
               </li>
             );
           })}
@@ -240,6 +275,45 @@ export function IntegrationsSection({ viewModel }: IntegrationsSectionProps) {
         <TwilioConnectorCard viewModel={viewModel.twilioCard} />
       </SettingsSection>
     </TooltipProvider>
+  );
+}
+
+function MailchimpTileDetails({
+  integration,
+}: {
+  readonly integration: IntegrationHealthViewModel;
+}) {
+  if (integration.mailchimp === null) {
+    return null;
+  }
+
+  return (
+    <div className="border-t border-slate-200 pt-3">
+      <dl className="grid gap-2 text-[12px] text-slate-600">
+        <div className="flex items-start justify-between gap-3">
+          <dt className="font-medium text-slate-900">Last sync</dt>
+          <dd className="text-right tabular-nums">
+            {formatRelative(integration.mailchimp.lastSuccessfulSyncAt)}
+          </dd>
+        </div>
+        <div className="flex items-start justify-between gap-3">
+          <dt className="font-medium text-slate-900">Last campaign</dt>
+          <dd className="max-w-[60%] text-right">
+            {integration.mailchimp.lastCampaignName === null
+              ? "—"
+              : `${integration.mailchimp.lastCampaignName} · ${formatRelative(
+                  integration.mailchimp.lastCampaignSentAt
+                )}`}
+          </dd>
+        </div>
+        <div className="flex items-start justify-between gap-3">
+          <dt className="font-medium text-slate-900">Last batch</dt>
+          <dd className="text-right tabular-nums">
+            {formatMailchimpCount(integration.mailchimp.lastBatchRecipientCount)} recipients
+          </dd>
+        </div>
+      </dl>
+    </div>
   );
 }
 

--- a/apps/web/src/server/settings/selectors.ts
+++ b/apps/web/src/server/settings/selectors.ts
@@ -1,4 +1,5 @@
 import { unstable_cache } from "next/cache";
+import { sql } from "drizzle-orm";
 
 import type {
   IntegrationHealthCategory,
@@ -75,7 +76,20 @@ export interface IntegrationHealthViewModel {
   readonly lastCheckedAt: string | null;
   readonly detail: string | null;
   readonly supportsRefresh: boolean;
+  readonly mailchimp:
+    | {
+        readonly status: "connected" | "stale" | "unconfigured";
+        readonly lastSuccessfulSyncAt: string | null;
+        readonly lastCampaignName: string | null;
+        readonly lastCampaignSentAt: string | null;
+        readonly lastBatchRecipientCount: number | null;
+      }
+    | null;
 }
+
+type MailchimpTileStatus = NonNullable<
+  IntegrationHealthViewModel["mailchimp"]
+>["status"];
 
 export interface IntegrationsSettingsViewModel {
   readonly isAdmin: boolean;
@@ -158,7 +172,7 @@ const INTEGRATION_META = {
   },
   mailchimp: {
     displayName: "Mailchimp",
-    description: "Historical campaign records",
+    description: "Transition-period campaign ingest",
     supportsRefresh: false
   },
   notion: {
@@ -197,10 +211,176 @@ const PROVIDER_LABEL: Record<Provider, string> = {
   simpletexting: "SimpleTexting",
   mailchimp: "Mailchimp"
 };
+const MAILCHIMP_HEALTHY_WINDOW_MS = 70 * 60 * 1000;
+const MAILCHIMP_AUTO_HIDE_WINDOW_MS = 60 * 24 * 60 * 60 * 1000;
+
+interface MailchimpSnapshotRow {
+  readonly latestActivityAt: Date | string | null;
+  readonly lastCampaignName: string | null;
+  readonly lastCampaignSentAt: Date | string | null;
+}
+
+interface MailchimpBatchCountRow {
+  readonly canonicalEventCount: number | string;
+}
 
 function normalizeSearch(value: string | null | undefined): string | null {
   const trimmed = value?.trim() ?? "";
   return trimmed.length === 0 ? null : trimmed.toLowerCase();
+}
+
+function normalizeSqlResultRows(result: unknown): readonly unknown[] {
+  if (Array.isArray(result)) {
+    return result;
+  }
+
+  return (result as { readonly rows?: readonly unknown[] }).rows ?? [];
+}
+
+function coerceIsoTimestamp(value: Date | string | null | undefined): string | null {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value.toISOString();
+  }
+
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const timestamp = new Date(value);
+  return Number.isNaN(timestamp.getTime()) ? null : timestamp.toISOString();
+}
+
+function readMailchimpCaptureBaseUrl(): string | null {
+  const baseUrl = process.env.MAILCHIMP_CAPTURE_BASE_URL?.trim();
+  return baseUrl && baseUrl.length > 0 ? baseUrl : null;
+}
+
+function getLatestSuccessfulMailchimpTransitionSync(
+  syncStates: readonly {
+    readonly scope: string;
+    readonly provider: string | null;
+    readonly jobType: string;
+    readonly status: string;
+    readonly lastSuccessfulAt: string | null;
+    readonly windowStart: string | null;
+    readonly windowEnd: string | null;
+  }[]
+) {
+  return syncStates
+    .filter(
+      (row) =>
+        row.scope === "provider" &&
+        row.provider === "mailchimp" &&
+        row.jobType === "live_ingest" &&
+        row.status === "succeeded"
+    )
+    .sort((left, right) => {
+      const leftTimestamp =
+        Date.parse(
+          left.lastSuccessfulAt ?? left.windowEnd ?? left.windowStart ?? "1970-01-01T00:00:00.000Z"
+        ) || 0;
+      const rightTimestamp =
+        Date.parse(
+          right.lastSuccessfulAt ??
+            right.windowEnd ??
+            right.windowStart ??
+            "1970-01-01T00:00:00.000Z"
+        ) || 0;
+      return rightTimestamp - leftTimestamp;
+    })
+    .at(0) ?? null;
+}
+
+async function readMailchimpSnapshot(runtime: Awaited<ReturnType<typeof getStage1WebRuntime>>) {
+  if (runtime.connection === null) {
+    return {
+      latestActivityAt: null,
+      lastCampaignName: null,
+      lastCampaignSentAt: null,
+    };
+  }
+
+  const snapshotResult = await runtime.connection.db.execute(
+    sql<MailchimpSnapshotRow>`
+      select
+        (
+          select max(cel.occurred_at)
+          from canonical_event_ledger cel
+          inner join source_evidence_log sel
+            on sel.id = cel.source_evidence_id
+          where sel.provider = 'mailchimp'
+        ) as "latestActivityAt",
+        (
+          select mcad.campaign_name
+          from canonical_event_ledger cel
+          inner join source_evidence_log sel
+            on sel.id = cel.source_evidence_id
+          left join mailchimp_campaign_activity_details mcad
+            on mcad.source_evidence_id = cel.source_evidence_id
+          where sel.provider = 'mailchimp'
+            and cel.event_type = 'campaign.email.sent'
+          order by cel.occurred_at desc, cel.created_at desc
+          limit 1
+        ) as "lastCampaignName",
+        (
+          select cel.occurred_at
+          from canonical_event_ledger cel
+          inner join source_evidence_log sel
+            on sel.id = cel.source_evidence_id
+          where sel.provider = 'mailchimp'
+            and cel.event_type = 'campaign.email.sent'
+          order by cel.occurred_at desc, cel.created_at desc
+          limit 1
+        ) as "lastCampaignSentAt"
+    `
+  );
+
+  const [row] = normalizeSqlResultRows(snapshotResult) as readonly MailchimpSnapshotRow[];
+  return {
+    latestActivityAt: coerceIsoTimestamp(row?.latestActivityAt ?? null),
+    lastCampaignName: row?.lastCampaignName ?? null,
+    lastCampaignSentAt: coerceIsoTimestamp(row?.lastCampaignSentAt ?? null),
+  };
+}
+
+async function readMailchimpLastBatchRecipientCount(
+  runtime: Awaited<ReturnType<typeof getStage1WebRuntime>>,
+  input: {
+    readonly windowStart: string | null;
+    readonly windowEnd: string | null;
+  }
+): Promise<number | null> {
+  if (
+    runtime.connection === null ||
+    input.windowStart === null ||
+    input.windowEnd === null
+  ) {
+    return null;
+  }
+
+  const countResult = await runtime.connection.db.execute(
+    sql<MailchimpBatchCountRow>`
+      select count(*)::int as "canonicalEventCount"
+      from canonical_event_ledger cel
+      inner join source_evidence_log sel
+        on sel.id = cel.source_evidence_id
+      where sel.provider = 'mailchimp'
+        and cel.occurred_at > ${input.windowStart}
+        and cel.occurred_at <= ${input.windowEnd}
+    `
+  );
+
+  const [row] = normalizeSqlResultRows(countResult) as readonly MailchimpBatchCountRow[];
+  if (row === undefined) {
+    return 0;
+  }
+
+  const parsed =
+    typeof row.canonicalEventCount === "number"
+      ? row.canonicalEventCount
+      : Number.parseInt(row.canonicalEventCount, 10);
+
+  return Number.isFinite(parsed) ? parsed : 0;
 }
 
 function normalizeLogStreamId(value: string | null | undefined): LogStreamId {
@@ -453,9 +633,11 @@ async function readIntegrationHealth(): Promise<
   monthStart.setUTCHours(0, 0, 0, 0);
 
   await runtime.settings.integrationHealth.seedDefaults();
-  const [rows, activeSmsSenders, latestCallback, latestDelivered, usageSnapshot] =
+  const [rows, syncStates, mailchimpSnapshot, activeSmsSenders, latestCallback, latestDelivered, usageSnapshot] =
     await Promise.all([
       runtime.settings.integrationHealth.listAll(),
+      runtime.repositories.syncState.listAll(),
+      readMailchimpSnapshot(runtime),
       runtime.settings.smsSenders.listActive(),
       runtime.settings.smsMessages.findLatestByStatuses(["delivered", "failed"]),
       runtime.settings.smsMessages.findLatestByStatuses(["delivered"]),
@@ -465,26 +647,81 @@ async function readIntegrationHealth(): Promise<
     ]);
 
   const integrationById = new Map(rows.map((row) => [row.id, row] as const));
-  const integrations = INTEGRATION_ORDER.flatMap((serviceName) => {
+  const latestMailchimpSync = getLatestSuccessfulMailchimpTransitionSync(syncStates);
+  const latestMailchimpSyncAt = latestMailchimpSync?.lastSuccessfulAt ?? null;
+  const mailchimpBaseUrl = readMailchimpCaptureBaseUrl();
+  const mailchimpActivityAgeMs =
+    mailchimpSnapshot.latestActivityAt === null
+      ? null
+      : Date.now() - Date.parse(mailchimpSnapshot.latestActivityAt);
+  const shouldHideMailchimp =
+    mailchimpBaseUrl === null &&
+    mailchimpSnapshot.latestActivityAt !== null &&
+    mailchimpActivityAgeMs !== null &&
+    mailchimpActivityAgeMs > MAILCHIMP_AUTO_HIDE_WINDOW_MS;
+  const mailchimpBatchRecipientCount = await readMailchimpLastBatchRecipientCount(
+    runtime,
+    {
+      windowStart: latestMailchimpSync?.windowStart ?? null,
+      windowEnd: latestMailchimpSync?.windowEnd ?? null,
+    }
+  );
+  const integrations: IntegrationHealthViewModel[] = [];
+
+  for (const serviceName of INTEGRATION_ORDER) {
     const record = integrationById.get(serviceName);
-    if (record === undefined) {
-      return [];
+    if (record === undefined || (serviceName === "mailchimp" && shouldHideMailchimp)) {
+      continue;
     }
 
     const meta = INTEGRATION_META[serviceName];
-    return [
-      {
+    if (serviceName === "mailchimp") {
+      const mailchimpStatus: MailchimpTileStatus =
+        mailchimpBaseUrl === null
+          ? "unconfigured"
+          : latestMailchimpSyncAt !== null &&
+              Date.now() - Date.parse(latestMailchimpSyncAt) <=
+                MAILCHIMP_HEALTHY_WINDOW_MS
+            ? "connected"
+            : "stale";
+
+      integrations.push({
         serviceName: record.serviceName,
         displayName: meta.displayName,
         description: meta.description,
         category: record.category,
-        status: record.status,
-        lastCheckedAt: record.lastCheckedAt,
-        detail: record.detail,
-        supportsRefresh: meta.supportsRefresh
-      }
-    ];
-  });
+        status:
+          mailchimpStatus === "connected"
+            ? "healthy"
+            : mailchimpStatus === "unconfigured"
+              ? "not_configured"
+              : "needs_attention",
+        lastCheckedAt: latestMailchimpSyncAt,
+        detail: null,
+        supportsRefresh: meta.supportsRefresh,
+        mailchimp: {
+          status: mailchimpStatus,
+          lastSuccessfulSyncAt: latestMailchimpSyncAt,
+          lastCampaignName: mailchimpSnapshot.lastCampaignName,
+          lastCampaignSentAt: mailchimpSnapshot.lastCampaignSentAt,
+          lastBatchRecipientCount: mailchimpBatchRecipientCount,
+        },
+      });
+      continue;
+    }
+
+    integrations.push({
+      serviceName: record.serviceName,
+      displayName: meta.displayName,
+      description: meta.description,
+      category: record.category,
+      status: record.status,
+      lastCheckedAt: record.lastCheckedAt,
+      detail: record.detail,
+      supportsRefresh: meta.supportsRefresh,
+      mailchimp: null,
+    });
+  }
 
   const hasActiveSender = activeSmsSenders.length > 0;
   const deliveredWithinLastDay =

--- a/apps/web/src/server/stage1-runtime.test-support.ts
+++ b/apps/web/src/server/stage1-runtime.test-support.ts
@@ -34,7 +34,10 @@ export async function createStage1WebTestRuntime(): Promise<Stage1WebTestRuntime
   const context = await createTestStage1Context();
 
   const runtime: Stage1WebRuntime = {
-    connection: null,
+    connection: {
+      db: context.db as unknown as NonNullable<Stage1WebRuntime["connection"]>["db"],
+      sql: null as never,
+    },
     repositories: context.repositories,
     settings: context.settings,
     normalization: context.normalization,

--- a/apps/web/tests/unit/settings-selectors.test.ts
+++ b/apps/web/tests/unit/settings-selectors.test.ts
@@ -182,12 +182,72 @@ async function seedSourceEvidenceCollision(
   });
 }
 
+async function seedMailchimpCampaignEvent(
+  runtime: Stage1WebTestRuntime,
+  input: {
+    readonly sourceEvidenceId: string;
+    readonly providerRecordId: string;
+    readonly canonicalEventId: string;
+    readonly activityType: "sent" | "opened" | "clicked" | "unsubscribed";
+    readonly eventType:
+      | "campaign.email.sent"
+      | "campaign.email.opened"
+      | "campaign.email.clicked"
+      | "campaign.email.unsubscribed";
+    readonly campaignId: string;
+    readonly campaignName: string;
+    readonly occurredAt: string;
+  }
+): Promise<void> {
+  await runtime.context.normalization.applyNormalizedCanonicalEvent({
+    sourceEvidence: {
+      id: input.sourceEvidenceId,
+      provider: "mailchimp",
+      providerRecordType: "campaign_member_activity",
+      providerRecordId: input.providerRecordId,
+      receivedAt: input.occurredAt,
+      occurredAt: input.occurredAt,
+      payloadRef: `payloads/mailchimp/${input.providerRecordId}.json`,
+      idempotencyKey: `mailchimp:${input.providerRecordId}`,
+      checksum: `checksum:${input.providerRecordId}`
+    },
+    canonicalEvent: {
+      id: input.canonicalEventId,
+      eventType: input.eventType,
+      occurredAt: input.occurredAt,
+      idempotencyKey: `canonical:${input.providerRecordId}`,
+      summary: `Mailchimp ${input.activityType}`,
+      snippet: ""
+    },
+    identity: {
+      salesforceContactId: null,
+      volunteerIdPlainValues: [],
+      normalizedEmails: ["volunteer@example.org"],
+      normalizedPhones: [],
+    },
+    supportingSources: [],
+    mailchimpCampaignActivityDetail: {
+      sourceEvidenceId: input.sourceEvidenceId,
+      providerRecordId: input.providerRecordId,
+      activityType: input.activityType,
+      campaignId: input.campaignId,
+      audienceId: "audience-1",
+      memberId: `member:${input.providerRecordId}`,
+      campaignName: input.campaignName,
+      snippet: "",
+    },
+  });
+}
+
 describe("settings selectors", () => {
   let runtime: Stage1WebTestRuntime | null = null;
   const originalSmsEnabled = process.env.SMS_ENABLED;
   const originalTwilioRate = process.env.TWILIO_OUTBOUND_RATE_USD_PER_SEGMENT;
+  const originalMailchimpCaptureBaseUrl = process.env.MAILCHIMP_CAPTURE_BASE_URL;
 
   beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-03T12:00:00.000Z"));
     runtime = await createStage1WebTestRuntime();
     getCurrentUser.mockReset();
     getCurrentUser.mockResolvedValue({
@@ -209,6 +269,12 @@ describe("settings selectors", () => {
     } else {
       process.env.TWILIO_OUTBOUND_RATE_USD_PER_SEGMENT = originalTwilioRate;
     }
+    if (originalMailchimpCaptureBaseUrl === undefined) {
+      delete process.env.MAILCHIMP_CAPTURE_BASE_URL;
+    } else {
+      process.env.MAILCHIMP_CAPTURE_BASE_URL = originalMailchimpCaptureBaseUrl;
+    }
+    vi.useRealTimers();
     await waitForPendingSecurityAuditTasksForTests();
     await runtime?.dispose();
     runtime = null;
@@ -460,6 +526,109 @@ describe("settings selectors", () => {
         "not_configured"
       ]
     );
+  });
+
+  it("derives Mailchimp connected health from the latest successful transition sync and canonical events", async () => {
+    if (!runtime) {
+      throw new Error("runtime not initialized");
+    }
+
+    process.env.MAILCHIMP_CAPTURE_BASE_URL = "https://mailchimp-capture.internal";
+
+    await seedMailchimpCampaignEvent(runtime, {
+      sourceEvidenceId: "sev-mailchimp-sent",
+      providerRecordId: "campaign-1:member-1:sent",
+      canonicalEventId: "evt-mailchimp-sent",
+      activityType: "sent",
+      eventType: "campaign.email.sent",
+      campaignId: "campaign-1",
+      campaignName: "Spring Update",
+      occurredAt: "2026-05-03T11:15:00.000Z",
+    });
+    await seedMailchimpCampaignEvent(runtime, {
+      sourceEvidenceId: "sev-mailchimp-opened",
+      providerRecordId: "campaign-1:member-1:opened",
+      canonicalEventId: "evt-mailchimp-opened",
+      activityType: "opened",
+      eventType: "campaign.email.opened",
+      campaignId: "campaign-1",
+      campaignName: "Spring Update",
+      occurredAt: "2026-05-03T11:20:00.000Z",
+    });
+    await runtime.context.repositories.syncState.upsert({
+      id: "sync:mailchimp:transition:latest",
+      scope: "provider",
+      provider: "mailchimp",
+      jobType: "live_ingest",
+      cursor: "cursor:mailchimp",
+      windowStart: "2026-05-03T11:00:00.000Z",
+      windowEnd: "2026-05-03T11:30:00.000Z",
+      status: "succeeded",
+      parityPercent: null,
+      freshnessP95Seconds: null,
+      freshnessP99Seconds: null,
+      lastSuccessfulAt: "2026-05-03T11:30:00.000Z",
+      consecutiveFailureCount: 0,
+      leaseOwner: null,
+      heartbeatAt: null,
+      deadLetterCount: 0,
+    });
+
+    const viewModel = await loadIntegrationHealth();
+    const mailchimp = viewModel.integrations.find(
+      (integration) => integration.serviceName === "mailchimp"
+    );
+
+    expect(mailchimp).toMatchObject({
+      status: "healthy",
+      lastCheckedAt: "2026-05-03T11:30:00.000Z",
+      mailchimp: {
+        status: "connected",
+        lastSuccessfulSyncAt: "2026-05-03T11:30:00.000Z",
+        lastCampaignName: "Spring Update",
+        lastCampaignSentAt: "2026-05-03T11:15:00.000Z",
+        lastBatchRecipientCount: 2,
+      },
+    });
+  });
+
+  it("marks Mailchimp stale when the last successful transition sync is older than 70 minutes", async () => {
+    if (!runtime) {
+      throw new Error("runtime not initialized");
+    }
+
+    process.env.MAILCHIMP_CAPTURE_BASE_URL = "https://mailchimp-capture.internal";
+
+    await runtime.context.repositories.syncState.upsert({
+      id: "sync:mailchimp:transition:stale",
+      scope: "provider",
+      provider: "mailchimp",
+      jobType: "live_ingest",
+      cursor: null,
+      windowStart: "2026-05-03T09:00:00.000Z",
+      windowEnd: "2026-05-03T09:10:00.000Z",
+      status: "succeeded",
+      parityPercent: null,
+      freshnessP95Seconds: null,
+      freshnessP99Seconds: null,
+      lastSuccessfulAt: "2026-05-03T09:10:00.000Z",
+      consecutiveFailureCount: 0,
+      leaseOwner: null,
+      heartbeatAt: null,
+      deadLetterCount: 0,
+    });
+
+    const viewModel = await loadIntegrationHealth();
+    const mailchimp = viewModel.integrations.find(
+      (integration) => integration.serviceName === "mailchimp"
+    );
+
+    expect(mailchimp).toMatchObject({
+      status: "needs_attention",
+      mailchimp: {
+        status: "stale",
+      },
+    });
   });
 
   it("aggregates Twilio MTD spend and monthly cap from outbound SMS usage", async () => {

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -17,6 +17,7 @@
     "ops:backfill-gmail-mbox-bodies": "tsx src/ops/cli.ts backfill-gmail-mbox-bodies",
     "ops:cleanup-gmail-draft-events": "tsx src/ops/cleanup-gmail-draft-events.ts",
     "ops:backfill-mailchimp-campaign-body": "tsx src/ops/backfill-mailchimp-campaign-body.ts",
+    "ops:mailchimp-capture-historical": "tsx src/ops/mailchimp-capture-historical.ts",
     "ops:backfill-membership-sf-ids": "tsx src/ops/cli.ts backfill-membership-sf-ids",
     "ops:backfill-salesforce-communication-details": "tsx src/ops/backfill-salesforce-communication-details.ts",
     "ops:audit-salesforce-task-ingest": "tsx src/ops/audit-salesforce-task-ingest.ts",

--- a/apps/worker/src/ops/cli.ts
+++ b/apps/worker/src/ops/cli.ts
@@ -34,6 +34,7 @@ import { runBackfillGmailMboxBodiesCommand } from "./backfill-gmail-mbox-bodies.
 import { runBackfillContentFingerprintCommand } from "./backfill-content-fingerprint.js";
 import { runBackfillGarbledMessageBodiesCommand } from "./backfill-garbled-message-bodies.js";
 import { runBackfillMailchimpCampaignBodyCommand } from "./backfill-mailchimp-campaign-body.js";
+import { runMailchimpHistoricalCaptureCommand } from "./mailchimp-capture-historical.js";
 import { runCleanupGmailDraftEventsCommand } from "./cleanup-gmail-draft-events.js";
 import { runCleanupSalesforceOwnerScopeCommand } from "./cleanup-salesforce-owner-scope.js";
 import { main as runMergeEmailOnlyIntoSfAnchoredCommand } from "./merge-email-only-into-sf-anchored.js";
@@ -390,6 +391,9 @@ async function main(): Promise<void> {
     case "backfill-mailchimp-campaign-body":
       await runBackfillMailchimpCampaignBodyCommand(rest, process.env);
       return;
+    case "mailchimp-capture-historical":
+      await runMailchimpHistoricalCaptureCommand(rest, process.env);
+      return;
     case "cleanup-salesforce-owner-scope":
       await runCleanupSalesforceOwnerScopeCommand(rest, process.env);
       return;
@@ -416,7 +420,7 @@ async function main(): Promise<void> {
       return;
     default:
       throw new Error(
-        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-membership-sf-ids, backfill-gmail-mbox-bodies, backfill-content-fingerprint, backfill-garbled-message-bodies, backfill-mailchimp-campaign-body, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, recover-orphan-gmail-details, dedup-historical-ledger, merge-email-only-into-sf-anchored, reconcile-identity-queue, reconcile-routing-review-queue, reclassify-sf-direction.",
+        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-membership-sf-ids, backfill-gmail-mbox-bodies, backfill-content-fingerprint, backfill-garbled-message-bodies, backfill-mailchimp-campaign-body, mailchimp-capture-historical, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, recover-orphan-gmail-details, dedup-historical-ledger, merge-email-only-into-sf-anchored, reconcile-identity-queue, reconcile-routing-review-queue, reclassify-sf-direction.",
       );
   }
 }

--- a/apps/worker/src/ops/mailchimp-capture-historical.ts
+++ b/apps/worker/src/ops/mailchimp-capture-historical.ts
@@ -1,0 +1,400 @@
+#!/usr/bin/env tsx
+import process from "node:process";
+
+import {
+  mailchimpHistoricalCaptureBatchJobName,
+  mailchimpHistoricalCaptureBatchPayloadSchema,
+  stage1JobVersion,
+  type MailchimpHistoricalCaptureBatchPayload,
+} from "@as-comms/contracts";
+import {
+  createMailchimpCapturePort,
+  type MailchimpRecord,
+} from "@as-comms/integrations";
+
+import { readWorkerConfig } from "../runtime.js";
+import { buildOperationId, parseCliFlags, readOptionalIntegerFlag, readRequiredFlag } from "./helpers.js";
+import { enqueueStage1Job } from "./enqueue.js";
+
+const DEFAULT_MAX_RECORDS = 500;
+
+interface Logger {
+  log(...args: readonly unknown[]): void;
+  error(...args: readonly unknown[]): void;
+}
+
+interface MailchimpHistoricalCaptureCommandOptions {
+  readonly since: string;
+  readonly windowStart: string;
+  readonly windowEnd: string;
+  readonly dryRun: boolean;
+  readonly confirm: boolean;
+  readonly limitCampaigns: number | null;
+}
+
+export interface PlannedMailchimpHistoricalJob {
+  readonly payload: MailchimpHistoricalCaptureBatchPayload;
+  readonly expectedRecordCount: number;
+}
+
+export interface MailchimpHistoricalCapturePlan {
+  readonly options: MailchimpHistoricalCaptureCommandOptions;
+  readonly selectedCampaignIds: readonly string[] | null;
+  readonly jobs: readonly PlannedMailchimpHistoricalJob[];
+  readonly totalExpectedRecords: number;
+}
+
+function parseSinceFlag(rawValue: string): string {
+  const trimmed = rawValue.trim();
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    return `${trimmed}T00:00:00.000Z`;
+  }
+
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error("Flag --since must be a valid ISO date or timestamp.");
+  }
+
+  return parsed.toISOString();
+}
+
+export function parseMailchimpHistoricalCaptureArgs(
+  args: readonly string[],
+  now = new Date()
+): MailchimpHistoricalCaptureCommandOptions {
+  const flags = parseCliFlags(args);
+  const confirm = flags.confirm === true;
+  const dryRun = !confirm;
+  const since = parseSinceFlag(readRequiredFlag(flags, "since"));
+  const windowEnd = now.toISOString();
+
+  if (Date.parse(since) >= Date.parse(windowEnd)) {
+    throw new Error("Flag --since must be earlier than now.");
+  }
+
+  const limitCampaigns = (() => {
+    const parsed = readOptionalIntegerFlag(flags, "limit-campaigns", 0);
+    return parsed === 0 ? null : parsed;
+  })();
+
+  return {
+    since,
+    windowStart: since,
+    windowEnd,
+    dryRun,
+    confirm,
+    limitCampaigns,
+  };
+}
+
+function buildHistoricalPayload(input: {
+  readonly correlationId: string;
+  readonly syncStateId: string;
+  readonly windowStart: string;
+  readonly windowEnd: string;
+  readonly cursor: string | null;
+  readonly checkpoint: string | null;
+  readonly recordIds?: readonly string[];
+}): MailchimpHistoricalCaptureBatchPayload {
+  return mailchimpHistoricalCaptureBatchPayloadSchema.parse({
+    version: stage1JobVersion,
+    jobId: buildOperationId("stage1:mailchimp:historical:job"),
+    correlationId: input.correlationId,
+    traceId: null,
+    batchId: buildOperationId("stage1:mailchimp:historical:batch"),
+    syncStateId: input.syncStateId,
+    attempt: 1,
+    maxAttempts: 1,
+    provider: "mailchimp",
+    mode: "historical",
+    jobType: "historical_backfill",
+    cursor: input.cursor,
+    checkpoint: input.checkpoint,
+    windowStart: input.windowStart,
+    windowEnd: input.windowEnd,
+    recordIds: [...(input.recordIds ?? [])],
+    maxRecords: DEFAULT_MAX_RECORDS,
+  });
+}
+
+function collectCampaignIds(records: readonly MailchimpRecord[]): readonly string[] {
+  const campaignIds = new Set<string>();
+
+  for (const record of records) {
+    if (
+      record.recordType === "campaign_member_activity" &&
+      "campaignId" in record &&
+      typeof record.campaignId === "string" &&
+      record.campaignId.length > 0
+    ) {
+      campaignIds.add(record.campaignId);
+    }
+  }
+
+  return [...campaignIds];
+}
+
+async function discoverCampaignIds(input: {
+  readonly captureHistoricalBatch: (
+    payload: MailchimpHistoricalCaptureBatchPayload
+  ) => Promise<{
+    readonly records: readonly MailchimpRecord[];
+    readonly nextCursor: string | null;
+    readonly checkpoint: string | null;
+  }>;
+  readonly options: MailchimpHistoricalCaptureCommandOptions;
+  readonly correlationId: string;
+  readonly syncStateId: string;
+}): Promise<readonly string[]> {
+  const selected = new Set<string>();
+  let cursor: string | null = null;
+  let checkpoint: string | null = null;
+
+  for (;;) {
+    const payload = buildHistoricalPayload({
+      correlationId: input.correlationId,
+      syncStateId: input.syncStateId,
+      windowStart: input.options.windowStart,
+      windowEnd: input.options.windowEnd,
+      cursor,
+      checkpoint,
+    });
+    const batch = await input.captureHistoricalBatch(payload);
+
+    for (const campaignId of collectCampaignIds(batch.records)) {
+      selected.add(campaignId);
+
+      if (
+        input.options.limitCampaigns !== null &&
+        selected.size >= input.options.limitCampaigns
+      ) {
+        return [...selected];
+      }
+    }
+
+    if (batch.nextCursor === null) {
+      return [...selected];
+    }
+
+    cursor = batch.nextCursor;
+    checkpoint = batch.checkpoint;
+  }
+}
+
+async function simulateHistoricalPlan(input: {
+  readonly captureHistoricalBatch: (
+    payload: MailchimpHistoricalCaptureBatchPayload
+  ) => Promise<{
+    readonly records: readonly MailchimpRecord[];
+    readonly nextCursor: string | null;
+    readonly checkpoint: string | null;
+  }>;
+  readonly options: MailchimpHistoricalCaptureCommandOptions;
+  readonly correlationId: string;
+  readonly syncStateId: string;
+  readonly recordIds?: readonly string[];
+}): Promise<readonly PlannedMailchimpHistoricalJob[]> {
+  const jobs: PlannedMailchimpHistoricalJob[] = [];
+  let cursor: string | null = null;
+  let checkpoint: string | null = null;
+
+  for (;;) {
+    const payload = buildHistoricalPayload({
+      correlationId: input.correlationId,
+      syncStateId: input.syncStateId,
+      windowStart: input.options.windowStart,
+      windowEnd: input.options.windowEnd,
+      cursor,
+      checkpoint,
+      ...(input.recordIds === undefined ? {} : { recordIds: input.recordIds }),
+    });
+    const batch = await input.captureHistoricalBatch(payload);
+
+    if (jobs.length > 0 || batch.records.length > 0 || batch.nextCursor !== null) {
+      jobs.push({
+        payload,
+        expectedRecordCount: batch.records.length,
+      });
+    }
+
+    if (batch.nextCursor === null) {
+      return jobs;
+    }
+
+    cursor = batch.nextCursor;
+    checkpoint = batch.checkpoint;
+  }
+}
+
+export async function planMailchimpHistoricalCapture(input: {
+  readonly options: MailchimpHistoricalCaptureCommandOptions;
+  readonly captureHistoricalBatch: (
+    payload: MailchimpHistoricalCaptureBatchPayload
+  ) => Promise<{
+    readonly records: readonly MailchimpRecord[];
+    readonly nextCursor: string | null;
+    readonly checkpoint: string | null;
+  }>;
+}): Promise<MailchimpHistoricalCapturePlan> {
+  const correlationId = buildOperationId("stage1:mailchimp:historical:correlation");
+  const syncStateId = buildOperationId("stage1:mailchimp:historical:sync-state");
+  const selectedCampaignIds =
+    input.options.limitCampaigns === null
+      ? null
+      : await discoverCampaignIds({
+          captureHistoricalBatch: input.captureHistoricalBatch,
+          options: input.options,
+          correlationId,
+          syncStateId,
+        });
+  const jobs = await simulateHistoricalPlan({
+    captureHistoricalBatch: input.captureHistoricalBatch,
+    options: input.options,
+    correlationId,
+    syncStateId,
+    ...(selectedCampaignIds === null ? {} : { recordIds: selectedCampaignIds }),
+  });
+
+  return {
+    options: input.options,
+    selectedCampaignIds,
+    jobs,
+    totalExpectedRecords: jobs.reduce(
+      (total, job) => total + job.expectedRecordCount,
+      0
+    ),
+  };
+}
+
+function logPlan(logger: Logger, plan: MailchimpHistoricalCapturePlan): void {
+  logger.log("mailchimp-capture-historical");
+  logger.log(`Mode: ${plan.options.dryRun ? "dry-run" : "confirm"}`);
+  logger.log(`- since: ${plan.options.since}`);
+  logger.log(`- window start: ${plan.options.windowStart}`);
+  logger.log(`- window end: ${plan.options.windowEnd}`);
+  logger.log(
+    `- limit campaigns: ${
+      plan.options.limitCampaigns === null
+        ? "none"
+        : String(plan.options.limitCampaigns)
+    }`
+  );
+
+  if (plan.selectedCampaignIds !== null) {
+    logger.log(
+      `- selected campaigns: ${
+        plan.selectedCampaignIds.length === 0
+          ? "none"
+          : plan.selectedCampaignIds.join(", ")
+      }`
+    );
+  }
+
+  logger.log(`- jobs planned: ${String(plan.jobs.length)}`);
+  logger.log(`- expected records: ${String(plan.totalExpectedRecords)}`);
+
+  for (const [index, job] of plan.jobs.entries()) {
+    logger.log(
+      `  ${String(index + 1)}. cursor=${
+        job.payload.cursor ?? "null"
+      } checkpoint=${job.payload.checkpoint ?? "null"} records=${String(
+        job.expectedRecordCount
+      )}`
+    );
+  }
+}
+
+export async function runMailchimpHistoricalCaptureCommand(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+  input?: {
+    readonly now?: Date;
+    readonly logger?: Logger;
+    readonly captureHistoricalBatch?: (
+      payload: MailchimpHistoricalCaptureBatchPayload
+    ) => Promise<{
+      readonly records: readonly MailchimpRecord[];
+      readonly nextCursor: string | null;
+      readonly checkpoint: string | null;
+    }>;
+    readonly enqueueJob?: (payload: MailchimpHistoricalCaptureBatchPayload) => Promise<{
+      readonly enqueuedJobId: string;
+    }>;
+  }
+): Promise<MailchimpHistoricalCapturePlan> {
+  const logger = input?.logger ?? console;
+  const options = parseMailchimpHistoricalCaptureArgs(args, input?.now ?? new Date());
+  const captureHistoricalBatch =
+    input?.captureHistoricalBatch ??
+    (() => {
+      const config = readWorkerConfig({
+        ...env,
+        WORKER_BOOT_MODE: "run",
+      });
+
+      if (config?.capture.mailchimp === undefined) {
+        throw new Error("Mailchimp capture is not configured for this worker runtime.");
+      }
+
+      const port = createMailchimpCapturePort(config.capture.mailchimp);
+      return (payload: MailchimpHistoricalCaptureBatchPayload) =>
+        port.captureHistoricalBatch(payload);
+    })();
+  const enqueueJob =
+    input?.enqueueJob ??
+    (async (payload: MailchimpHistoricalCaptureBatchPayload) => {
+      const connectionString = env.WORKER_DATABASE_URL ?? env.DATABASE_URL;
+
+      if (connectionString === undefined || connectionString.trim().length === 0) {
+        throw new Error(
+          "DATABASE_URL or WORKER_DATABASE_URL is required for this ops command."
+        );
+      }
+
+      return enqueueStage1Job({
+        connectionString,
+        request: {
+          jobName: mailchimpHistoricalCaptureBatchJobName,
+          payload,
+        },
+      });
+    });
+
+  const plan = await planMailchimpHistoricalCapture({
+    options,
+    captureHistoricalBatch,
+  });
+
+  logPlan(logger, plan);
+
+  if (options.dryRun) {
+    logger.log(
+      "Dry run complete. Re-run with --confirm to enqueue Mailchimp historical capture jobs."
+    );
+    return plan;
+  }
+
+  for (const job of plan.jobs) {
+    const enqueued = await enqueueJob(job.payload);
+    logger.log(`- enqueued ${enqueued.enqueuedJobId}`);
+  }
+
+  logger.log(
+    `Enqueued ${String(plan.jobs.length)} Mailchimp historical capture job(s).`
+  );
+  return plan;
+}
+
+async function main(): Promise<void> {
+  await runMailchimpHistoricalCaptureCommand(process.argv.slice(2), process.env);
+}
+
+void main().catch((error: unknown) => {
+  console.error(
+    error instanceof Error
+      ? error.message
+      : "mailchimp-capture-historical failed."
+  );
+  process.exitCode = 1;
+});

--- a/apps/worker/test/stage1-mailchimp-capture-historical.test.ts
+++ b/apps/worker/test/stage1-mailchimp-capture-historical.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { MailchimpRecord } from "@as-comms/integrations";
+
+import {
+  parseMailchimpHistoricalCaptureArgs,
+  runMailchimpHistoricalCaptureCommand,
+} from "../src/ops/mailchimp-capture-historical.js";
+
+function buildMailchimpRecord(input: {
+  readonly recordId: string;
+  readonly campaignId: string;
+  readonly occurredAt: string;
+}): MailchimpRecord {
+  return {
+    recordType: "campaign_member_activity",
+    recordId: input.recordId,
+    activityType: "sent",
+    occurredAt: input.occurredAt,
+    receivedAt: "2026-05-03T12:00:00.000Z",
+    payloadRef: `payloads/mailchimp/${input.recordId}.json`,
+    checksum: `checksum:${input.recordId}`,
+    normalizedEmail: "volunteer@example.org",
+    salesforceContactId: null,
+    volunteerIdPlainValues: [],
+    normalizedPhones: [],
+    campaignId: input.campaignId,
+    audienceId: "aud-1",
+    memberId: `member:${input.recordId}`,
+    campaignName: `Campaign ${input.campaignId}`,
+    snippet: "",
+  };
+}
+
+function createCapturingLogger() {
+  const lines: string[] = [];
+
+  return {
+    logger: {
+      log: (...args: readonly unknown[]) => {
+        lines.push(args.join(" "));
+      },
+      error: (...args: readonly unknown[]) => {
+        lines.push(args.join(" "));
+      },
+    },
+    lines,
+  };
+}
+
+describe("Mailchimp historical capture ops command", () => {
+  it("parses required flags and defaults to dry-run", () => {
+    const parsed = parseMailchimpHistoricalCaptureArgs(
+      ["--since=2026-04-03", "--limit-campaigns=2"],
+      new Date("2026-05-03T12:00:00.000Z")
+    );
+
+    expect(parsed).toEqual({
+      since: "2026-04-03T00:00:00.000Z",
+      windowStart: "2026-04-03T00:00:00.000Z",
+      windowEnd: "2026-05-03T12:00:00.000Z",
+      dryRun: true,
+      confirm: false,
+      limitCampaigns: 2,
+    });
+  });
+
+  it("logs the planned historical job sequence in dry-run mode", async () => {
+    const { logger, lines } = createCapturingLogger();
+    const captureHistoricalBatch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        records: [
+          buildMailchimpRecord({
+            recordId: "record-1",
+            campaignId: "campaign-1",
+            occurredAt: "2026-04-03T10:00:00.000Z",
+          }),
+        ],
+        nextCursor: "cursor-2",
+        checkpoint: "2026-04-03T10:00:00.000Z",
+      })
+      .mockResolvedValueOnce({
+        records: [
+          buildMailchimpRecord({
+            recordId: "record-2",
+            campaignId: "campaign-2",
+            occurredAt: "2026-04-03T11:00:00.000Z",
+          }),
+        ],
+        nextCursor: null,
+        checkpoint: "2026-04-03T11:00:00.000Z",
+      });
+
+    const plan = await runMailchimpHistoricalCaptureCommand(
+      ["--since=2026-04-03"],
+      {},
+      {
+        now: new Date("2026-05-03T12:00:00.000Z"),
+        logger,
+        captureHistoricalBatch,
+      }
+    );
+
+    expect(plan.jobs).toHaveLength(2);
+    expect(lines).toEqual(
+      expect.arrayContaining([
+        "mailchimp-capture-historical",
+        "Mode: dry-run",
+        "- jobs planned: 2",
+        "- expected records: 2",
+        "Dry run complete. Re-run with --confirm to enqueue Mailchimp historical capture jobs.",
+      ])
+    );
+  });
+
+  it("enqueues the planned job sequence when --confirm is provided", async () => {
+    const { logger } = createCapturingLogger();
+    const captureHistoricalBatch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        records: [
+          buildMailchimpRecord({
+            recordId: "record-1",
+            campaignId: "campaign-1",
+            occurredAt: "2026-04-03T10:00:00.000Z",
+          }),
+        ],
+        nextCursor: "cursor-2",
+        checkpoint: "2026-04-03T10:00:00.000Z",
+      })
+      .mockResolvedValueOnce({
+        records: [
+          buildMailchimpRecord({
+            recordId: "record-2",
+            campaignId: "campaign-2",
+            occurredAt: "2026-04-03T11:00:00.000Z",
+          }),
+        ],
+        nextCursor: null,
+        checkpoint: "2026-04-03T11:00:00.000Z",
+      });
+    const enqueuedPayloads: unknown[] = [];
+
+    await runMailchimpHistoricalCaptureCommand(
+      ["--since=2026-04-03", "--confirm"],
+      {},
+      {
+        now: new Date("2026-05-03T12:00:00.000Z"),
+        logger,
+        captureHistoricalBatch,
+        enqueueJob: (payload) => {
+          enqueuedPayloads.push(payload);
+          return Promise.resolve({
+            enqueuedJobId: `job-${String(enqueuedPayloads.length)}`,
+          });
+        },
+      }
+    );
+
+    expect(enqueuedPayloads).toHaveLength(2);
+    expect(enqueuedPayloads[0]).toMatchObject({
+      cursor: null,
+      checkpoint: null,
+      windowStart: "2026-04-03T00:00:00.000Z",
+      windowEnd: "2026-05-03T12:00:00.000Z",
+    });
+    expect(enqueuedPayloads[1]).toMatchObject({
+      cursor: "cursor-2",
+      checkpoint: "2026-04-03T10:00:00.000Z",
+      windowStart: "2026-04-03T00:00:00.000Z",
+      windowEnd: "2026-05-03T12:00:00.000Z",
+    });
+    expect(
+      (enqueuedPayloads[0] as { readonly correlationId: string }).correlationId
+    ).toBe(
+      (enqueuedPayloads[1] as { readonly correlationId: string }).correlationId
+    );
+    expect(
+      (enqueuedPayloads[0] as { readonly syncStateId: string }).syncStateId
+    ).toBe(
+      (enqueuedPayloads[1] as { readonly syncStateId: string }).syncStateId
+    );
+  });
+});

--- a/docs/02-bundles/campaigns-bundle.md
+++ b/docs/02-bundles/campaigns-bundle.md
@@ -29,6 +29,7 @@ Add one-to-many messaging inside the same product foundation, with Email first a
 - campaign content, review state, and frozen audience remain product-owned
 - SendGrid is the Email delivery provider, not the authoring source of truth
 - Mailchimp remains historical and transition-period live ingest scope until native Email Campaigns are trusted
+- transition-period live Mailchimp ingest is now operational for the cutover window; see PRD #283 and the [Mailchimp decommission runbook](../runbooks/mailchimp-decommission.md)
 
 ## Required Interfaces / Concepts
 

--- a/docs/04-implementation-specs/stage-1-provider-ingest-matrix.md
+++ b/docs/04-implementation-specs/stage-1-provider-ingest-matrix.md
@@ -8,7 +8,8 @@
 ## Summary
 
 - narrowed launch-scope completion is Gmail + Salesforce only
-- SimpleTexting and Mailchimp remain valid Stage 1 architecture paths, but they are deferred for initial launch acceptance
+- SimpleTexting remains a valid Stage 1 architecture path, but it is deferred for initial launch acceptance
+- Mailchimp is now an active transition-period live-ingest path until SendGrid cutover; see the [Mailchimp decommission runbook](../runbooks/mailchimp-decommission.md)
 - Historical backfill and live ingest must map into the same normalization path.
 - Keep provider scope narrow and explicit.
 - If a source record cannot be mapped safely in Stage 1, defer it or send it to review; do not widen the matrix by guesswork.
@@ -132,7 +133,8 @@
 
 Launch-scope note:
 
-- deferred for initial Gmail + Salesforce launch completion
+- live transition path active until SendGrid cutover
+- decommission sequence: [mailchimp-decommission.md](../runbooks/mailchimp-decommission.md)
 
 ### Required first pass
 
@@ -225,7 +227,8 @@ Launch-scope note:
 ### Historical backfill vs live ingest
 
 - historical campaign activity is the first-priority Stage 1 scope
-- transition-period live ingest uses the same event taxonomy and normalization path only if Mailchimp is still active during cutover
+- transition-period live ingest is active during the Mailchimp → SendGrid cutover window and uses the same event taxonomy and normalization path
+- once SendGrid is trusted, disable scheduling, drain the 30-day tail, and retire the capture service per the decommission runbook
 
 ### Tie-break and identity-anchor notes
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -41,6 +41,7 @@ edit the markdown here and re-mirror.
 | Runbook | Symptom |
 |---|---|
 | [worker-queue-stuck.md](./worker-queue-stuck.md) | Worker is running but jobs not advancing; no `reconcile.completed` logs |
+| [mailchimp-decommission.md](./mailchimp-decommission.md) | Planned SendGrid cutover is complete and the temporary Mailchimp ingest path must be retired |
 
 ## Investigation guides
 

--- a/docs/runbooks/mailchimp-decommission.md
+++ b/docs/runbooks/mailchimp-decommission.md
@@ -1,0 +1,153 @@
+# Runbook: Decommission Mailchimp transition ingest after SendGrid cutover
+
+**Severity:** S2  
+**Average time to recover:** planned change window + 30-day tail drain  
+**Last verified:** 2026-05-03 against commit af11e396
+
+## Purpose
+
+Retire the temporary Mailchimp live-ingest path once native SendGrid campaign
+sending is fully trusted. This removes scheduler activity and the dedicated
+`mailchimp-capture` service without deleting canonical history.
+
+## Preconditions
+
+1. SendGrid native campaign sending is fully validated in production.
+2. Operators have confirmed no active Mailchimp campaign sends remain scheduled.
+3. The fallback path is understood: re-enable transition ingest only if
+   SendGrid issues require a temporary rollback.
+4. The historical Mailchimp data already needed by Stage 1 has been captured.
+
+## Sequence
+
+### 1. Freeze new transition scheduling
+
+1. In Railway, open the `worker` service environment.
+2. Set `MAILCHIMP_TRANSITION_ENABLED=false`.
+3. Redeploy or restart the `worker` service.
+4. Verify worker logs contain `event="mailchimp.scheduler.disabled"`.
+5. Verify no new `stage1.mailchimp.capture.transition` jobs are being created
+   after the restart.
+
+### 2. Confirm Mailchimp authoring is idle
+
+1. Confirm with operations that no Mailchimp campaign sends remain scheduled.
+2. Confirm with the architect that SendGrid is now the only active campaign
+   send path.
+3. If any Mailchimp campaign is still scheduled, stop here. Do not disable the
+   ingest tail early.
+
+### 3. Drain the activity tail
+
+1. Identify the last Mailchimp campaign send timestamp.
+2. Wait 30 full days from that send timestamp.
+3. During that window, leave the `mailchimp-capture` service running.
+4. The tail period allows open and click activity to settle before shutdown.
+
+### 4. Verify the queue is empty
+
+1. Check the Graphile Worker queue for residual
+   `stage1.mailchimp.capture.transition` jobs.
+2. Expected result: zero runnable, zero pending, zero retrying rows for that
+   job name.
+3. If any jobs remain, investigate before continuing:
+   - stale scheduler deploy
+   - worker restart did not pick up the disabled flag
+   - manually enqueued test jobs still present
+
+### 5. Verify the final sync surface
+
+1. Open Settings → Integrations.
+2. Before shutdown, confirm the Mailchimp tile still shows the latest
+   successful sync information.
+3. After decommission, the tile is expected to auto-hide once both of these are
+   true:
+   - `MAILCHIMP_CAPTURE_BASE_URL` is unset
+   - there has been no Mailchimp activity for 60 days
+
+### 6. Shut down the capture service
+
+1. In Railway, open the `mailchimp-capture` service.
+2. Stop the service.
+3. Delete the service once the stop is confirmed.
+4. Record the delete time in the change log or deployment notes.
+
+### 7. Remove secrets and endpoints
+
+Remove these environment variables after the service is stopped:
+
+- On `worker`:
+  - `MAILCHIMP_CAPTURE_BASE_URL`
+  - `MAILCHIMP_CAPTURE_TOKEN`
+  - `MAILCHIMP_TRANSITION_ENABLED`
+- On `mailchimp-capture`:
+  - `MAILCHIMP_API_KEY`
+  - `MAILCHIMP_CAPTURE_TOKEN`
+
+If the `mailchimp-capture` service is deleted first, still document the removed
+variables in the change notes.
+
+### 8. Database cleanup stance
+
+Do not delete Mailchimp history tables as part of decommission.
+
+Keep:
+
+- `mailchimp_campaign_activity_details`
+- `mailchimp_campaign_tail_state`
+- all Mailchimp canonical events in `canonical_event_ledger`
+- all linked source evidence in `source_evidence_log`
+
+Rationale:
+
+- Stage 1 data-core principles keep canonical history forever.
+- The Mailchimp transition path is cheap to leave available for forensic
+  investigation.
+- Removing historical evidence now would reduce trust and make later audits
+  harder.
+
+### 9. Code cleanup stance
+
+Do not remove the Mailchimp provider mapping, capture port, or ops commands in
+this decommission step.
+
+Leave in place:
+
+- `packages/integrations/src/providers/mailchimp.ts`
+- historical backfill ops commands
+- worker orchestration support
+
+If code cleanup is desired later, open a separate cleanup PR after the cutover
+has been stable for a while.
+
+## Verification checklist
+
+1. `MAILCHIMP_TRANSITION_ENABLED` is absent or false on the `worker` service.
+2. Worker logs confirm the Mailchimp scheduler is disabled.
+3. No pending `stage1.mailchimp.capture.transition` jobs remain.
+4. The `mailchimp-capture` Railway service is stopped and deleted.
+5. `MAILCHIMP_API_KEY` and `MAILCHIMP_CAPTURE_TOKEN` are removed from the
+   relevant services.
+6. Settings → Integrations no longer shows the Mailchimp tile after 60 days of
+   inactivity with `MAILCHIMP_CAPTURE_BASE_URL` removed.
+7. Historical Mailchimp canonical events still appear in volunteer timelines.
+
+## Rollback
+
+If SendGrid issues require a temporary fallback:
+
+1. Restore the `mailchimp-capture` service.
+2. Restore `MAILCHIMP_API_KEY` on `mailchimp-capture`.
+3. Restore `MAILCHIMP_CAPTURE_TOKEN` on both `worker` and
+   `mailchimp-capture`.
+4. Restore `MAILCHIMP_CAPTURE_BASE_URL` on `worker`.
+5. Set `MAILCHIMP_TRANSITION_ENABLED=true` on `worker`.
+6. Restart `worker`.
+7. Confirm new `stage1.mailchimp.capture.transition` jobs resume and the
+   Settings tile returns to a connected or stale state.
+
+## Related
+
+- [stage-1-provider-ingest-matrix.md](../04-implementation-specs/stage-1-provider-ingest-matrix.md)
+- [campaigns-bundle.md](../02-bundles/campaigns-bundle.md)
+- [worker-queue-stuck.md](./worker-queue-stuck.md)


### PR DESCRIPTION
## Summary

Brief 3 of 3 under [PRD #283](https://github.com/nico-kneler-as/as-comms-platform/issues/283). Three disjoint operator-facing surfaces:

- **Settings → Integrations tile** (read-only) — Mailchimp connection status, last sync, last campaign captured, recipient count of last batch. Auto-hides 60d after decommission.
- **Gap-backfill ops command** — `pnpm --filter @as-comms/worker ops:mailchimp-capture-historical -- --since=YYYY-MM-DD [--confirm]`. Dry-run by default. Reuses the existing `stage1.mailchimp.capture.historical` job path shipped in #284.
- **Decommission runbook** — `docs/runbooks/mailchimp-decommission.md` plus canon updates promoting Mailchimp from deferred to live transition status in `stage-1-provider-ingest-matrix.md` and `campaigns-bundle.md`.

## Context

- Brief 1 ([#284](https://github.com/nico-kneler-as/as-comms-platform/pull/284)) shipped the capture service shell + Marketing API client — merged
- Brief 2 (worker scheduler) is in flight in parallel
- This PR surfaces the operator UI and the operational tooling around the runtime stack

No worker scheduler logic here — that's Brief 2's surface. No new schema. No changes to the capture service or provider mapping.

## Validation

- `pnpm typecheck` — 16/16 ✅
- `pnpm lint` — 16/16 ✅
- New unit tests: `apps/worker/test/stage1-mailchimp-capture-historical.test.ts`, additions to `apps/web/tests/unit/settings-selectors.test.ts`. Local `test:unit` skipped per concurrency-and-token-strategy memory; CI authoritative.

## Test plan

- [ ] CI green
- [ ] After Brief 2 merges: end-to-end smoke — start `mailchimp-capture` Railway service, set `MAILCHIMP_TRANSITION_ENABLED=true`, confirm Settings tile populates within ~70 minutes
- [ ] Run gap-backfill with `--since=2026-04-03` against staging first, verify canonical events land for known volunteers
- [ ] Production: gap-backfill same window after staging passes

## Files

- `apps/web/app/settings/_components/integrations-section.tsx` — Mailchimp tile
- `apps/web/src/server/settings/selectors.ts` — health selector
- `apps/web/src/server/stage1-runtime.test-support.ts` — test fixture extensions
- `apps/web/tests/unit/settings-selectors.test.ts` — selector tests
- `apps/worker/package.json` — ops script entry
- `apps/worker/src/ops/cli.ts` — CLI registration
- `apps/worker/src/ops/mailchimp-capture-historical.ts` — gap-backfill command
- `apps/worker/test/stage1-mailchimp-capture-historical.test.ts` — command tests
- `docs/02-bundles/campaigns-bundle.md` — canon update
- `docs/04-implementation-specs/stage-1-provider-ingest-matrix.md` — canon promotion
- `docs/runbooks/README.md` — runbook index
- `docs/runbooks/mailchimp-decommission.md` — new runbook

🤖 Generated with [Claude Code](https://claude.com/claude-code)