### PR TITLE
fix(worker): rename mailchimp scheduler cron task to use hyphens

### DIFF
--- a/apps/worker/src/orchestration/mailchimp-transition-scheduler.ts
+++ b/apps/worker/src/orchestration/mailchimp-transition-scheduler.ts
@@ -20,8 +20,12 @@ const rotationWindowMs = 30 * 24 * 60 * 60 * 1000;
 const matureCampaignRefreshIntervalMs = 6 * 60 * 60 * 1000;
 const defaultDiscoveryBatchMaxRecords = 1000;
 
+// Graphile Worker's crontab parser rejects dots in task identifiers
+// (the job-name pattern used elsewhere in this codebase), so this
+// scheduler uses the hyphenated `poll-*` convention from sibling
+// cron tasks like `poll-gmail-live`.
 export const mailchimpTransitionSchedulerJobName =
-  "stage1.mailchimp.transition.scheduler" as const;
+  "poll-mailchimp-transition-scheduler" as const;
 export const mailchimpTransitionDiscoverySyncStateId =
   "sync:mailchimp:transition:discovery" as const;
 

--- a/apps/worker/test/stage1-runtime.test.ts
+++ b/apps/worker/test/stage1-runtime.test.ts
@@ -147,7 +147,7 @@ describe("Stage 1 worker runtime task registration", () => {
       [
         `*/1 * * * * ${pollGmailLiveJobName} ?id=gmail-live-poll&max=1`,
         `*/5 * * * * ${pollSalesforceLiveJobName} ?id=salesforce-live-poll&max=1`,
-        `0 * * * * stage1.mailchimp.transition.scheduler ?id=mailchimp-transition-scheduler&max=1`,
+        `0 * * * * poll-mailchimp-transition-scheduler ?id=mailchimp-transition-scheduler&max=1`,
         `*/5 * * * * ${pollIntegrationHealthJobName} ?id=integration-health-poll&max=1`,
         `*/5 * * * * ${sweepPendingOutboundsJobName} ?id=composer-orphan-sweep&max=1`,
         `* * * * * ${reconcileStaleRunningJobName} ?id=stale-running-sweep&max=1`,


### PR DESCRIPTION
## Summary

Hotfix for the worker bootstrap failure introduced by [#289](https://github.com/nico-kneler-as/as-comms-platform/pull/289). Graphile Worker's crontab parser rejects dots in task identifiers — Railway worker has been crash-looping with:

```
Stage 1 worker bootstrap failed.
Invalid command specification in line 3 of crontab.
```

Line 3 was the new `stage1.mailchimp.transition.scheduler` cron entry. Sibling cron tasks (`poll-gmail-live`, `poll-salesforce-live`, etc.) all use hyphenated identifiers for this reason — the dot convention works fine for ad-hoc job dispatch but not for crontab.

## Change

Rename `mailchimpTransitionSchedulerJobName` from `"stage1.mailchimp.transition.scheduler"` to `"poll-mailchimp-transition-scheduler"`. All call sites use the constant by import, so this is a one-place rename plus the runtime test fixture.

## Validation

- `pnpm typecheck` — 16/16 ✅
- `pnpm lint` — 16/16 ✅
- Local test:unit hits the macOS rollup gotcha (env, not code); CI authoritative

## Impact

Worker has been rolled back to pre-#278 image since #289's deploy failure (no SMS task names registered, scheduler not running, but otherwise stable). After this PR merges and the auto-deploy lands cleanly, worker will:

1. Run preDeployCommand → migrator (now post-#287)
2. Apply migration 0053_mailchimp_campaign_tail_state (also the live test for issue #286)
3. Start with the new task list including poll-mailchimp-transition-scheduler
4. Scheduler ticks hourly but short-circuits because MAILCHIMP_TRANSITION_ENABLED defaults false

🤖 Generated with [Claude Code](https://claude.com/claude-code)