### PR TITLE
fix(db): run migrator in-process from worker startup (resolves #286)

### DIFF
--- a/apps/worker/railway.json
+++ b/apps/worker/railway.json
@@ -6,7 +6,6 @@
   },
   "deploy": {
     "startCommand": "pnpm --filter @as-comms/worker start",
-    "preDeployCommand": "pnpm --filter @as-comms/db migrate",
     "healthcheckPath": null
   }
 }

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,6 +1,34 @@
+import { runMigrations } from "@as-comms/db";
+
 import { startWorker } from "./runtime.js";
 
+function readDatabaseUrl(): string | null {
+  const url =
+    process.env.DATABASE_URL?.trim() ?? process.env.DATABASE_PUBLIC_URL?.trim();
+  return url && url.length > 0 ? url : null;
+}
+
+async function applyMigrationsOrFail(): Promise<void> {
+  if (process.env.WORKER_AUTO_MIGRATE_ENABLED === "false") {
+    console.info(
+      "[migrate] WORKER_AUTO_MIGRATE_ENABLED=false — skipping in-process migration run",
+    );
+    return;
+  }
+
+  const databaseUrl = readDatabaseUrl();
+  if (databaseUrl === null) {
+    throw new Error(
+      "[migrate] Neither DATABASE_URL nor DATABASE_PUBLIC_URL is set; cannot run migrations.",
+    );
+  }
+
+  await runMigrations({ databaseUrl });
+}
+
 async function main() {
+  await applyMigrationsOrFail();
+
   const runner = await startWorker();
   if (!runner) {
     return;

--- a/packages/db/scripts/migrate.mjs
+++ b/packages/db/scripts/migrate.mjs
@@ -1,261 +1,43 @@
 #!/usr/bin/env node
 // @ts-check
 /**
- * Custom auto-apply migrator for the AS Comms Platform.
+ * Thin CLI wrapper around the in-process migrator.
  *
- * Replaces the broken `drizzle-kit migrate` invocation that PR #237 tried to
- * wire into the worker's Railway preDeployCommand. drizzle-kit migrate
- * silently failed because the repo never carried a `meta/_journal.json`
- * (schema state has historically been managed by drizzle-kit push).
+ * The substantive logic lives in `packages/db/src/migrator.ts` and is
+ * exported via the package's public API so the worker can call it at
+ * startup. This script remains for local-dev / ad-hoc invocation:
  *
- * Behavior:
- *   1. Connect via DATABASE_URL (Railway-provided in the worker), with a
- *      fallback to DATABASE_PUBLIC_URL.
- *   2. CREATE TABLE IF NOT EXISTS applied_migrations.
- *   3. Discover SQL files under packages/db/drizzle/<NNNN>_*.sql, sorted.
- *   4. If applied_migrations is empty AND `message_attachments.is_inline`
- *      exists (proxy: 0049 was already applied manually after the
- *      2026-05-02 outage), seed every migration as already-applied. This
- *      is the one-time bootstrap path — it runs at most once on prod.
- *   5. Otherwise, run any pending migrations in order, each in its own
- *      transaction. Track success in applied_migrations.
- *   6. Exit non-zero on any error so Railway fails the deploy.
+ *   pnpm --filter @as-comms/db migrate
  *
- * The bootstrap detection is intentionally narrow. If no sentinel column
- * is found AND there are unrelated tables in `public`, the migrator
- * refuses to guess and exits 1 with a clear instruction. Better to fail
- * loud than silently double-apply migrations against a partially-set-up
- * database.
+ * Production now invokes the migrator in-process from the worker
+ * bootstrap (see apps/worker/src/runtime.ts) rather than relying on
+ * Railway preDeployCommand, which was observed to silently no-op
+ * (issue #286).
  */
 
-import { createHash } from "node:crypto";
-import { readFileSync, readdirSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-
-import postgres from "postgres";
-
-const TRACKING_TABLE = "applied_migrations";
-// Column added by 0049_inline_attachments. Used as the bootstrap sentinel:
-// its presence means migrations 0000-0049 have been applied to the DB
-// (whether by drizzle-kit push, manual SQL, or any future mix).
-const SENTINEL_TABLE = "message_attachments";
-const SENTINEL_COLUMN = "is_inline";
-
-function log(message) {
-  console.log(`[migrate] ${message}`);
-}
-
-function logError(message) {
-  console.error(`[migrate] ERROR: ${message}`);
-}
+import { runMigrations, MigratorError } from "../dist/migrator.js";
 
 function readDatabaseUrl() {
   const url =
     process.env.DATABASE_URL?.trim() ?? process.env.DATABASE_PUBLIC_URL?.trim();
   if (!url || url.length === 0) {
-    logError(
-      "Neither DATABASE_URL nor DATABASE_PUBLIC_URL is set. Cannot connect.",
+    console.error(
+      "[migrate] ERROR: Neither DATABASE_URL nor DATABASE_PUBLIC_URL is set.",
     );
     process.exit(1);
   }
   return url;
 }
 
-function discoverMigrations() {
-  const here = dirname(fileURLToPath(import.meta.url));
-  const drizzleDir = resolve(here, "..", "drizzle");
-  const entries = readdirSync(drizzleDir, { withFileTypes: true });
-  const files = entries
-    .filter((entry) => entry.isFile() && /^\d{4}_.+\.sql$/u.test(entry.name))
-    .map((entry) => entry.name)
-    .sort((a, b) => a.localeCompare(b));
-
-  return files.map((filename) => {
-    const fullPath = join(drizzleDir, filename);
-    const raw = readFileSync(fullPath, "utf8");
-    // Normalize line endings + trim trailing whitespace so the hash is
-    // stable across platforms. The hash is informational only — the
-    // filename is the unique key we re-check against applied_migrations.
-    const normalized = raw.replace(/\r\n/g, "\n").trimEnd();
-    const hash = createHash("sha256").update(normalized).digest("hex");
-    const id = filename.replace(/\.sql$/u, "");
-    return { id, filename, fullPath, sql: raw, hash };
-  });
-}
-
-async function ensureTrackingTable(sql) {
-  await sql.unsafe(`
-    CREATE TABLE IF NOT EXISTS ${TRACKING_TABLE} (
-      id           text PRIMARY KEY,
-      hash         text NOT NULL,
-      applied_at   timestamptz NOT NULL DEFAULT now()
-    )
-  `);
-}
-
-async function listAppliedIds(sql) {
-  const rows = await sql`SELECT id FROM ${sql(TRACKING_TABLE)}`;
-  return new Set(rows.map((row) => row.id));
-}
-
-async function sentinelColumnExists(sql) {
-  const rows = await sql`
-    SELECT column_name
-    FROM information_schema.columns
-    WHERE table_schema = 'public'
-      AND table_name = ${SENTINEL_TABLE}
-      AND column_name = ${SENTINEL_COLUMN}
-    LIMIT 1
-  `;
-  return rows.length > 0;
-}
-
-async function publicHasUnrelatedTables(sql) {
-  const rows = await sql`
-    SELECT table_name
-    FROM information_schema.tables
-    WHERE table_schema = 'public'
-      AND table_type = 'BASE TABLE'
-      AND table_name <> ${TRACKING_TABLE}
-    LIMIT 1
-  `;
-  return rows.length > 0;
-}
-
-async function bootstrap(sql, migrations) {
-  log(
-    `bootstrap mode: seeding ${String(migrations.length)} migrations as already applied`,
-  );
-  const rows = migrations.map((migration) => ({
-    id: migration.id,
-    hash: migration.hash,
-  }));
-  await sql`
-    INSERT INTO ${sql(TRACKING_TABLE)} ${sql(rows, "id", "hash")}
-    ON CONFLICT (id) DO NOTHING
-  `;
-}
-
-// Migrations may opt out of the per-migration transaction by including the
-// directive `-- migrate:no-transaction` anywhere in the file. Required for
-// statements Postgres forbids inside transaction blocks — most commonly
-// `ALTER TYPE ... ADD VALUE` and `CREATE INDEX CONCURRENTLY`.
-//
-// The trade-off: a partial-failure mid-migration leaves the DB in an
-// intermediate state. Keep no-transaction migrations narrow (ideally a
-// single statement) so partial failure is recoverable.
-const NO_TRANSACTION_DIRECTIVE = /^[ \t]*--[ \t]*migrate:no-transaction\b/mu;
-
-function migrationOptsOutOfTransaction(migration) {
-  return NO_TRANSACTION_DIRECTIVE.test(migration.sql);
-}
-
-async function applyMigration(sql, migration) {
-  const noTransaction = migrationOptsOutOfTransaction(migration);
-  log(`applying ${migration.id}${noTransaction ? " (no-transaction)" : ""}`);
-
-  if (noTransaction) {
-    await sql.unsafe(migration.sql);
-    await sql`
-      INSERT INTO ${sql(TRACKING_TABLE)} (id, hash)
-      VALUES (${migration.id}, ${migration.hash})
-    `;
-  } else {
-    await sql.begin(async (tx) => {
-      await tx.unsafe(migration.sql);
-      await tx`
-        INSERT INTO ${tx(TRACKING_TABLE)} (id, hash)
-        VALUES (${migration.id}, ${migration.hash})
-      `;
-    });
-  }
-
-  log(`applied ${migration.id}`);
-}
-
-function summarizeError(error, migration) {
-  const code = error?.code ? `[${error.code}] ` : "";
-  const message = error?.message ?? String(error);
-  const position = error?.position ? ` at position ${error.position}` : "";
-  const snippet = migration.sql.replace(/\s+/g, " ").slice(0, 200);
-  logError(`failed ${migration.filename}${position}: ${code}${message}`);
-  logError(`SQL preview: ${snippet}${migration.sql.length > 200 ? "..." : ""}`);
-}
-
 async function main() {
-  const databaseUrl = readDatabaseUrl();
-  const sql = postgres(databaseUrl, {
-    max: 1,
-    idle_timeout: 5,
-    connect_timeout: 15,
-    onnotice: () => {},
-  });
-
-  try {
-    const migrations = discoverMigrations();
-    log(`discovered ${String(migrations.length)} migration files`);
-
-    await ensureTrackingTable(sql);
-    const applied = await listAppliedIds(sql);
-
-    if (applied.size === 0) {
-      const hasSentinel = await sentinelColumnExists(sql);
-      if (hasSentinel) {
-        await bootstrap(sql, migrations);
-        log(`OK — bootstrap complete (${String(migrations.length)} total)`);
-        return;
-      }
-
-      const hasOtherTables = await publicHasUnrelatedTables(sql);
-      if (hasOtherTables) {
-        logError(
-          "Schema appears partially applied (tables exist in public) but " +
-            "the sentinel column " +
-            SENTINEL_TABLE +
-            "." +
-            SENTINEL_COLUMN +
-            " is missing and applied_migrations is empty. Refusing to " +
-            "guess. Operator must seed applied_migrations manually before " +
-            "the next deploy.",
-        );
-        process.exit(1);
-      }
-
-      log("fresh database detected — applying all migrations from scratch");
-    }
-
-    const pending = migrations.filter((migration) => !applied.has(migration.id));
-
-    if (pending.length === 0) {
-      log(
-        `OK — 0 applied this run, ${String(migrations.length)} total`,
-      );
-      return;
-    }
-
-    log(`pending: ${String(pending.length)}`);
-    let appliedThisRun = 0;
-    for (const migration of pending) {
-      try {
-        await applyMigration(sql, migration);
-        appliedThisRun += 1;
-      } catch (error) {
-        summarizeError(error, migration);
-        process.exit(1);
-      }
-    }
-
-    log(
-      `OK — ${String(appliedThisRun)} applied this run, ${String(migrations.length)} total`,
-    );
-  } finally {
-    await sql.end({ timeout: 5 });
-  }
+  await runMigrations({ databaseUrl: readDatabaseUrl() });
 }
 
 main().catch((error) => {
-  logError(error?.message ?? String(error));
+  if (error instanceof MigratorError) {
+    process.exit(1);
+  }
+  console.error("[migrate] ERROR:", error?.message ?? String(error));
   if (error?.stack) {
     console.error(error.stack);
   }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./client.js";
 export * from "./mappers.js";
+export * from "./migrator.js";
 export * from "./repositories.js";
 export * from "./schema/index.js";

--- a/packages/db/src/migrator.ts
+++ b/packages/db/src/migrator.ts
@@ -1,0 +1,261 @@
+import { createHash } from "node:crypto";
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import postgres from "postgres";
+
+const TRACKING_TABLE = "applied_migrations";
+// Column added by 0049_inline_attachments. Used as the bootstrap sentinel:
+// its presence means migrations 0000-0049 have been applied to the DB
+// (whether by drizzle-kit push, manual SQL, or any future mix).
+const SENTINEL_TABLE = "message_attachments";
+const SENTINEL_COLUMN = "is_inline";
+
+// Stable Postgres advisory-lock key. Picked from a SHA-256 prefix of
+// "as-comms:migrator"; well within JS safe-integer range so we can keep it
+// as a plain number for postgres.js parameter binding.
+const ADVISORY_LOCK_KEY = 73_314_011;
+
+const NO_TRANSACTION_DIRECTIVE = /^[ \t]*--[ \t]*migrate:no-transaction\b/mu;
+
+interface MigrationFile {
+  readonly id: string;
+  readonly filename: string;
+  readonly fullPath: string;
+  readonly sql: string;
+  readonly hash: string;
+}
+
+export interface RunMigrationsInput {
+  readonly databaseUrl: string;
+  /** Override directory containing the `<NNNN>_*.sql` files. Defaults to
+   *  `packages/db/drizzle/` resolved relative to the compiled module. */
+  readonly drizzleDir?: string;
+  /** Replace the structured log emitter. Default writes `[migrate] ...` to
+   *  stdout. */
+  readonly log?: (message: string) => void;
+  /** Replace the structured error emitter. Default writes `[migrate] ERROR:
+   *  ...` to stderr. */
+  readonly logError?: (message: string) => void;
+}
+
+export interface RunMigrationsResult {
+  readonly mode: "bootstrap" | "fresh" | "incremental" | "noop";
+  readonly totalMigrations: number;
+  readonly appliedThisRun: number;
+}
+
+export class MigratorError extends Error {
+  readonly migration: MigrationFile | undefined;
+  constructor(message: string, options?: { cause?: unknown; migration?: MigrationFile }) {
+    super(message, options?.cause === undefined ? undefined : { cause: options.cause });
+    this.name = "MigratorError";
+    this.migration = options?.migration;
+  }
+}
+
+function defaultLog(message: string): void {
+  console.log(`[migrate] ${message}`);
+}
+
+function defaultLogError(message: string): void {
+  console.error(`[migrate] ERROR: ${message}`);
+}
+
+function defaultDrizzleDir(): string {
+  // After tsc build this module lives in `packages/db/dist/migrator.js`.
+  // Source SQL files live in `packages/db/drizzle/`.
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, "..", "drizzle");
+}
+
+function discoverMigrations(drizzleDir: string): MigrationFile[] {
+  const entries = readdirSync(drizzleDir, { withFileTypes: true });
+  const files = entries
+    .filter((entry) => entry.isFile() && /^\d{4}_.+\.sql$/u.test(entry.name))
+    .map((entry) => entry.name)
+    .sort((a, b) => a.localeCompare(b));
+
+  return files.map((filename) => {
+    const fullPath = join(drizzleDir, filename);
+    const raw = readFileSync(fullPath, "utf8");
+    const normalized = raw.replace(/\r\n/g, "\n").trimEnd();
+    const hash = createHash("sha256").update(normalized).digest("hex");
+    const id = filename.replace(/\.sql$/u, "");
+    return { id, filename, fullPath, sql: raw, hash };
+  });
+}
+
+function migrationOptsOutOfTransaction(migration: MigrationFile): boolean {
+  return NO_TRANSACTION_DIRECTIVE.test(migration.sql);
+}
+
+function summarizeError(error: unknown, migration: MigrationFile): string {
+  const errAny = error as { code?: string; message?: string; position?: string } | null;
+  const code = errAny?.code ? `[${errAny.code}] ` : "";
+  const message = errAny?.message ?? String(error);
+  const position = errAny?.position ? ` at position ${errAny.position}` : "";
+  const snippet = migration.sql.replace(/\s+/g, " ").slice(0, 200);
+  return `failed ${migration.filename}${position}: ${code}${message} | SQL preview: ${snippet}${
+    migration.sql.length > 200 ? "..." : ""
+  }`;
+}
+
+export async function runMigrations(
+  input: RunMigrationsInput,
+): Promise<RunMigrationsResult> {
+  const log = input.log ?? defaultLog;
+  const logError = input.logError ?? defaultLogError;
+  const drizzleDir = input.drizzleDir ?? defaultDrizzleDir();
+
+  const sql = postgres(input.databaseUrl, {
+    max: 1,
+    idle_timeout: 5,
+    connect_timeout: 15,
+    onnotice: () => {
+      // Suppress NOTICE-level Postgres messages (e.g., "table already exists").
+    },
+  });
+
+  let lockAcquired = false;
+  try {
+    // Concurrency: hold an advisory lock for the duration of the migrator run.
+    // If two replicas come up simultaneously, the second blocks on the first
+    // and then sees applied_migrations already populated.
+    const lockProbeRows = await sql<{ acquired: boolean }[]>`
+      SELECT pg_try_advisory_lock(${ADVISORY_LOCK_KEY}) AS acquired
+    `;
+    const acquired = lockProbeRows[0]?.acquired ?? false;
+    if (!acquired) {
+      log("another migrator run is in progress; waiting for advisory lock");
+      await sql`SELECT pg_advisory_lock(${ADVISORY_LOCK_KEY})`;
+    }
+    lockAcquired = true;
+
+    const migrations = discoverMigrations(drizzleDir);
+    log(`discovered ${String(migrations.length)} migration files`);
+
+    await sql.unsafe(`
+      CREATE TABLE IF NOT EXISTS ${TRACKING_TABLE} (
+        id           text PRIMARY KEY,
+        hash         text NOT NULL,
+        applied_at   timestamptz NOT NULL DEFAULT now()
+      )
+    `);
+
+    const appliedRows = await sql.unsafe<{ id: string }[]>(
+      `SELECT id FROM ${TRACKING_TABLE}`,
+    );
+    const applied = new Set(appliedRows.map((row) => row.id));
+
+    if (applied.size === 0) {
+      const sentinelRows = await sql<{ column_name: string }[]>`
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = ${SENTINEL_TABLE}
+          AND column_name = ${SENTINEL_COLUMN}
+        LIMIT 1
+      `;
+      const hasSentinel = sentinelRows.length > 0;
+
+      if (hasSentinel) {
+        log(
+          `bootstrap mode: seeding ${String(migrations.length)} migrations as already applied`,
+        );
+        await sql.begin(async (tx) => {
+          for (const migration of migrations) {
+            await tx.unsafe(
+              `INSERT INTO ${TRACKING_TABLE} (id, hash) VALUES ($1, $2) ON CONFLICT (id) DO NOTHING`,
+              [migration.id, migration.hash],
+            );
+          }
+        });
+        log(`OK — bootstrap complete (${String(migrations.length)} total)`);
+        return { mode: "bootstrap", totalMigrations: migrations.length, appliedThisRun: 0 };
+      }
+
+      const otherTablesRows = await sql<{ table_name: string }[]>`
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND table_type = 'BASE TABLE'
+          AND table_name <> ${TRACKING_TABLE}
+        LIMIT 1
+      `;
+      if (otherTablesRows.length > 0) {
+        const message =
+          `schema appears partially applied (tables exist in public) but ` +
+          `the sentinel column ${SENTINEL_TABLE}.${SENTINEL_COLUMN} is missing ` +
+          `and ${TRACKING_TABLE} is empty. Refusing to guess. Operator must seed ` +
+          `${TRACKING_TABLE} manually before the next deploy.`;
+        logError(message);
+        throw new MigratorError(message);
+      }
+
+      log("fresh database detected — applying all migrations from scratch");
+    }
+
+    const pending = migrations.filter((migration) => !applied.has(migration.id));
+
+    if (pending.length === 0) {
+      log(`OK — 0 applied this run, ${String(migrations.length)} total`);
+      return {
+        mode: applied.size === 0 ? "fresh" : "noop",
+        totalMigrations: migrations.length,
+        appliedThisRun: 0,
+      };
+    }
+
+    log(`pending: ${String(pending.length)}`);
+    let appliedThisRun = 0;
+    for (const migration of pending) {
+      const noTransaction = migrationOptsOutOfTransaction(migration);
+      log(`applying ${migration.id}${noTransaction ? " (no-transaction)" : ""}`);
+
+      try {
+        if (noTransaction) {
+          await sql.unsafe(migration.sql);
+          await sql.unsafe(
+            `INSERT INTO ${TRACKING_TABLE} (id, hash) VALUES ($1, $2)`,
+            [migration.id, migration.hash],
+          );
+        } else {
+          await sql.begin(async (tx) => {
+            await tx.unsafe(migration.sql);
+            await tx.unsafe(
+              `INSERT INTO ${TRACKING_TABLE} (id, hash) VALUES ($1, $2)`,
+              [migration.id, migration.hash],
+            );
+          });
+        }
+      } catch (error) {
+        const summary = summarizeError(error, migration);
+        logError(summary);
+        throw new MigratorError(summary, { cause: error, migration });
+      }
+
+      log(`applied ${migration.id}`);
+      appliedThisRun += 1;
+    }
+
+    log(
+      `OK — ${String(appliedThisRun)} applied this run, ${String(migrations.length)} total`,
+    );
+    return {
+      mode: applied.size === 0 ? "fresh" : "incremental",
+      totalMigrations: migrations.length,
+      appliedThisRun,
+    };
+  } finally {
+    if (lockAcquired) {
+      try {
+        await sql`SELECT pg_advisory_unlock(${ADVISORY_LOCK_KEY})`;
+      } catch {
+        // ignore unlock errors during shutdown
+      }
+    }
+    await sql.end({ timeout: 5 });
+  }
+}


### PR DESCRIPTION
## Summary

Resolves [#286](https://github.com/nico-kneler-as/as-comms-platform/issues/286). Today's incident traced to: Railway preDeployCommand `pnpm --filter @as-comms/db migrate` **silently no-ops in production**. Across every deploy since #263 merged, no `[migrate]` log entries ever appeared — five migrations (bootstrap + 0050 + 0051 + 0052 + 0053) were applied by hand.

This PR moves migration execution into the worker's own startup, so:
- Migrations run inside the worker container with full visibility in worker logs
- Failure causes the worker process to exit non-zero → Railway rolls back to previous image (matching the original intent of preDeployCommand)
- No reliance on Railway's preDeployCommand semantics under RAILPACK builder
- Concurrent replica startups serialize via Postgres advisory lock

## Changes

### `packages/db/src/migrator.ts` (new)

Exports `runMigrations({databaseUrl, drizzleDir?, log?, logError?})` returning a `RunMigrationsResult`. Same algorithm as the prior CLI:

- Bootstrap detection via `message_attachments.is_inline` sentinel
- `-- migrate:no-transaction` directive support (from #287)
- Per-migration transactions (or out-of-transaction for opt-in DDL)

New: wraps the run in a Postgres advisory lock (`pg_advisory_lock(73_314_011)`) so concurrent worker replicas serialize cleanly. The second replica blocks on the first, then sees `applied_migrations` populated and exits the noop path.

### `packages/db/scripts/migrate.mjs` (rewritten)

Now a thin CLI wrapper that imports `runMigrations` from the compiled `@as-comms/db` package. Local dev invocation `pnpm --filter @as-comms/db migrate` still works for ad-hoc use.

### `apps/worker/src/index.ts`

Worker bootstrap calls `runMigrations()` before `startWorker()`. New env flag `WORKER_AUTO_MIGRATE_ENABLED=false` skips it for local-dev or recovery scenarios.

### `apps/worker/railway.json`

Removes `deploy.preDeployCommand`. Migrations are now part of the worker's own startup, so the separate phase is redundant.

## Validation

- `pnpm typecheck` — 16/16 ✅
- `pnpm lint` — 16/16 ✅
- `pnpm --filter @as-comms/db build` — clean output, `dist/migrator.js` produced
- Local test:unit hits the macOS rollup gotcha (env, not code); CI authoritative

## Test plan

- [ ] CI green
- [ ] After merge: confirm worker startup logs include `[migrate] discovered N migration files` followed by `[migrate] OK — 0 applied this run, 43 total` (43 because 0000–0053 are already in `applied_migrations` from prior manual remediation)
- [ ] Next migration that lands on main should auto-apply on the next worker deploy without manual intervention — closing #286

## What this DOESN'T solve

- The historical reason preDeployCommand was silent (RAILPACK builder behavior, file pruning, etc.) — we sidestep it rather than diagnose it. Fine to leave open under #286 if you want that root cause documented; closing #286 here is also fine since the symptom is resolved.
- Concurrent migrator runs across services — only the worker invokes the migrator now. If web ever needs to run migrations independently, it can import the same function. Currently it doesn't need to.

## Risk

- **Worker startup latency:** an additional `runMigrations` call on every worker boot. In the steady state (no pending migrations), this is one round-trip to Postgres for the advisory lock + a SELECT on `applied_migrations`. Trivial.
- **Failure mode change:** if migrations fail, the worker fails to start. Previously a migrator failure left the worker on the old image but possibly running on a new schema. New behavior is strictly safer (worker won't start against an out-of-sync schema).
- **Schema-vs-code drift during partial outages:** worker can come up clean while `mailchimp-capture` or other services are mid-deploy. Acceptable — migrations are additive and other services don't see new tables until they redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)