### PR TITLE
chore(mailchimp-capture): add Railway service config

### DIFF
--- a/apps/mailchimp-capture/railway.json
+++ b/apps/mailchimp-capture/railway.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "RAILPACK",
+    "buildCommand": "pnpm install --frozen-lockfile && pnpm --filter @as-comms/mailchimp-capture... build"
+  },
+  "deploy": {
+    "startCommand": "pnpm --filter @as-comms/mailchimp-capture start",
+    "healthcheckPath": "/health"
+  }
+}


### PR DESCRIPTION
Brief 1 (#284) shipped the app shell but omitted \`railway.json\`. Without it, Railway can't infer which workspace package to build for the new \`mailchimp-capture\` service.

Mirrors \`apps/gmail-capture/railway.json\` and the worker pattern:
- RAILPACK builder
- \`pnpm install --frozen-lockfile\` + \`pnpm --filter @as-comms/mailchimp-capture... build\`
- Start with the workspace start script
- Healthcheck at \`/health\` (the unauthenticated endpoint exposed by the service shell)

Required before the user provisions the Railway service in the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)