### PR TITLE
fix(mailchimp-capture): accept MAILCHIMP_CAPTURE_TOKEN as bearer name

### DIFF
--- a/apps/mailchimp-capture/src/index.ts
+++ b/apps/mailchimp-capture/src/index.ts
@@ -91,9 +91,13 @@ export function readMailchimpCaptureRuntimeConfig(
     port: parseOptionalPositiveIntEnv(env.PORT, 3003, "PORT"),
     logLevel: parseOptionalStringEnv(env.LOG_LEVEL, "info"),
     service: {
+      // Accept either env name. The worker reads the bearer token under
+      // `MAILCHIMP_CAPTURE_TOKEN` (matching the GMAIL_/SALESFORCE_ pattern).
+      // `MAILCHIMP_CAPTURE_BEARER_TOKEN` is retained for backward compat
+      // with the original Brief 1 shape.
       bearerToken: parseRequiredStringEnv(
-        env.MAILCHIMP_CAPTURE_BEARER_TOKEN,
-        "MAILCHIMP_CAPTURE_BEARER_TOKEN",
+        env.MAILCHIMP_CAPTURE_TOKEN ?? env.MAILCHIMP_CAPTURE_BEARER_TOKEN,
+        "MAILCHIMP_CAPTURE_TOKEN",
       ),
       apiKey: parseRequiredStringEnv(env.MAILCHIMP_API_KEY, "MAILCHIMP_API_KEY"),
       salesforceContactIdMergeField: "SFCONTACTID",


### PR DESCRIPTION
Brief 1 (#284) named the bearer-token env var \`MAILCHIMP_CAPTURE_BEARER_TOKEN\` on the capture service, while the worker reads the same value under \`MAILCHIMP_CAPTURE_TOKEN\` (matching the GMAIL_/SALESFORCE_ pattern in \`apps/worker/src/runtime.ts\`).

This made operators set the same secret under two different names across services. This change makes the capture service prefer \`MAILCHIMP_CAPTURE_TOKEN\` with fallback to \`MAILCHIMP_CAPTURE_BEARER_TOKEN\`, so a single naming convention works on both services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)