### PR TITLE
feat(home): lifecycle metrics aggregator + sync freshness (PRD #293, brief 1)

### DIFF
--- a/apps/web/app/inbox/_lib/home-dashboard.ts
+++ b/apps/web/app/inbox/_lib/home-dashboard.ts
@@ -1,0 +1,219 @@
+import { sql } from "drizzle-orm";
+
+import { getStage1WebRuntime } from "@/src/server/stage1-runtime";
+
+import {
+  buildProjectLifecycleMetrics,
+  type LifecycleEventRow,
+  type MembershipRow,
+  type ProjectLifecycleTile,
+  type ProjectRow,
+} from "./project-lifecycle-metrics";
+import { projectToneFromName } from "./project-tone";
+import {
+  classifySyncFreshness,
+  type SyncFreshnessState,
+} from "./sync-freshness";
+
+interface LifecycleEventSqlRow {
+  readonly contactId: string;
+  readonly eventType: LifecycleEventRow["eventType"];
+  readonly occurredAt: Date | string;
+}
+
+export interface InboxWelcomeSalesforceLifecycleData {
+  readonly tiles: readonly ProjectLifecycleTile[];
+  readonly freshness: SyncFreshnessState;
+}
+
+const LIFECYCLE_EVENT_TYPES = [
+  "lifecycle.signed_up",
+  "lifecycle.completed_training",
+  "lifecycle.submitted_first_data",
+] as const satisfies readonly LifecycleEventRow["eventType"][];
+const MS_PER_DAY = 24 * 60 * 60 * 1_000;
+
+function normalizeSqlResultRows(result: unknown): readonly unknown[] {
+  if (
+    typeof result === "object" &&
+    result !== null &&
+    "rows" in result &&
+    Array.isArray(result.rows)
+  ) {
+    return result.rows;
+  }
+
+  return [];
+}
+
+function toValidDate(value: Date | string | null | undefined): Date | null {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function startOfUtcDay(date: Date): Date {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  );
+}
+
+function readProjectDisplayName(project: {
+  readonly projectAlias?: string | null | undefined;
+  readonly projectName: string;
+}): string {
+  const trimmedAlias = project.projectAlias?.trim() ?? "";
+  return trimmedAlias.length > 0 ? trimmedAlias : project.projectName;
+}
+
+async function readLifecycleEvents(
+  now: Date,
+): Promise<readonly LifecycleEventRow[]> {
+  const runtime = await getStage1WebRuntime();
+  if (runtime.connection === null) {
+    return [];
+  }
+
+  const todayStart = startOfUtcDay(now);
+  const windowStart = new Date(todayStart.getTime() - 6 * MS_PER_DAY);
+  const result = await runtime.connection.db.execute(
+    sql<LifecycleEventSqlRow>`
+      select
+        contact_id as "contactId",
+        event_type as "eventType",
+        occurred_at as "occurredAt"
+      from canonical_event_ledger
+      where event_type in (
+        ${LIFECYCLE_EVENT_TYPES[0]},
+        ${LIFECYCLE_EVENT_TYPES[1]},
+        ${LIFECYCLE_EVENT_TYPES[2]}
+      )
+        and occurred_at >= ${windowStart.toISOString()}
+        and occurred_at <= ${now.toISOString()}
+      order by occurred_at asc, id asc
+    `,
+  );
+
+  return normalizeSqlResultRows(result)
+    .map((row) => row as LifecycleEventSqlRow)
+    .map((row) => ({
+      contactId: row.contactId,
+      eventType: row.eventType,
+      occurredAt: toValidDate(row.occurredAt),
+    }))
+    .filter(
+      (
+        row,
+      ): row is {
+        readonly contactId: string;
+        readonly eventType: LifecycleEventRow["eventType"];
+        readonly occurredAt: Date;
+      } => row.occurredAt !== null,
+    );
+}
+
+async function readLifecycleProjects(): Promise<readonly ProjectRow[]> {
+  const runtime = await getStage1WebRuntime();
+  const activeProjects = await runtime.repositories.projectDimensions.listActive();
+  const projectCounts = await Promise.all(
+    activeProjects.map((project) =>
+      runtime.repositories.inboxProjection.countByFilters({
+        projectId: project.projectId,
+      }),
+    ),
+  );
+
+  return activeProjects.map((project, index) => {
+    const projectName = readProjectDisplayName(project);
+    return {
+      projectId: project.projectId,
+      projectName,
+      projectTone: projectToneFromName(projectName),
+      isActive: project.isActive ?? true,
+      unreadCount: projectCounts[index]?.unread ?? 0,
+    };
+  });
+}
+
+async function readLifecycleMemberships(
+  contactIds: readonly string[],
+): Promise<readonly MembershipRow[]> {
+  const runtime = await getStage1WebRuntime();
+  const memberships =
+    contactIds.length === 0
+      ? []
+      : await runtime.repositories.contactMemberships.listByContactIds(contactIds);
+
+  return memberships
+    .filter(
+      (membership): membership is typeof membership & { readonly projectId: string } =>
+        membership.projectId !== null,
+    )
+    .map((membership) => ({
+      contactId: membership.contactId,
+      projectId: membership.projectId,
+    }));
+}
+
+async function readSalesforceCaptureLastSuccessAt(
+): Promise<Date | null> {
+  const runtime = await getStage1WebRuntime();
+
+  await runtime.settings.integrationHealth.seedDefaults();
+  const [integrationHealth, latestLiveSync] = await Promise.all([
+    runtime.settings.integrationHealth.findById("salesforce"),
+    runtime.repositories.syncState.findLatest({
+      scope: "provider",
+      provider: "salesforce",
+      jobType: "live_ingest",
+    }),
+  ]);
+
+  if (integrationHealth?.status === "not_configured") {
+    return null;
+  }
+
+  const lastSuccessfulAt = toValidDate(latestLiveSync?.lastSuccessfulAt ?? null);
+
+  if (lastSuccessfulAt === null) {
+    return null;
+  }
+
+  return lastSuccessfulAt;
+}
+
+export async function getInboxWelcomeSalesforceLifecycle(
+  input?: {
+    readonly now?: Date;
+  },
+): Promise<InboxWelcomeSalesforceLifecycleData> {
+  const now = input?.now ?? new Date();
+  const [events, projects, lastSuccessAt] = await Promise.all([
+    readLifecycleEvents(now),
+    readLifecycleProjects(),
+    readSalesforceCaptureLastSuccessAt(),
+  ]);
+  const memberships = await readLifecycleMemberships(
+    Array.from(new Set(events.map((event) => event.contactId))),
+  );
+
+  return {
+    tiles: buildProjectLifecycleMetrics({
+      events,
+      memberships,
+      projects,
+      now,
+    }),
+    freshness: classifySyncFreshness({
+      lastSuccessAt,
+      now,
+    }),
+  };
+}

--- a/apps/web/app/inbox/_lib/project-lifecycle-metrics.ts
+++ b/apps/web/app/inbox/_lib/project-lifecycle-metrics.ts
@@ -1,0 +1,287 @@
+export type LifecycleEventType =
+  | "lifecycle.signed_up"
+  | "lifecycle.completed_training"
+  | "lifecycle.submitted_first_data";
+
+export interface LifecycleEventRow {
+  readonly contactId: string;
+  readonly eventType: LifecycleEventType;
+  readonly occurredAt: Date;
+}
+
+export interface MembershipRow {
+  readonly contactId: string;
+  readonly projectId: string;
+}
+
+export interface ProjectRow {
+  readonly projectId: string;
+  readonly projectName: string;
+  readonly projectTone: string;
+  readonly isActive: boolean;
+  readonly unreadCount: number;
+}
+
+export type MetricKey =
+  | "signups"
+  | "trainingCompletions"
+  | "dataSubmissions";
+
+export interface MetricCounts {
+  readonly signups: number;
+  readonly trainingCompletions: number;
+  readonly dataSubmissions: number;
+}
+
+export interface ProjectLifecycleTile {
+  readonly projectId: string;
+  readonly projectName: string;
+  readonly projectTone: string;
+  readonly unreadCount: number;
+  readonly totals: MetricCounts;
+  readonly today: MetricCounts;
+  readonly sparkline: {
+    readonly signups: readonly number[];
+    readonly trainingCompletions: readonly number[];
+    readonly dataSubmissions: readonly number[];
+  };
+}
+
+interface MutableMetricCounts {
+  signups: number;
+  trainingCompletions: number;
+  dataSubmissions: number;
+}
+
+const DEFAULT_DAYS = 7;
+const METRIC_KEYS = [
+  "signups",
+  "trainingCompletions",
+  "dataSubmissions",
+] as const satisfies readonly MetricKey[];
+const MS_PER_DAY = 24 * 60 * 60 * 1_000;
+
+function startOfUtcDay(date: Date): number {
+  return Date.UTC(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate(),
+    0,
+    0,
+    0,
+    0,
+  );
+}
+
+function buildZeroCounts(): MetricCounts {
+  return {
+    signups: 0,
+    trainingCompletions: 0,
+    dataSubmissions: 0,
+  };
+}
+
+function metricKeyFromEventType(eventType: LifecycleEventType): MetricKey {
+  switch (eventType) {
+    case "lifecycle.signed_up":
+      return "signups";
+    case "lifecycle.completed_training":
+      return "trainingCompletions";
+    case "lifecycle.submitted_first_data":
+      return "dataSubmissions";
+  }
+}
+
+function getUtcDayIndex(input: {
+  readonly occurredAt: Date;
+  readonly now: Date;
+  readonly days: number;
+}): number | null {
+  const occurredAtMs = input.occurredAt.getTime();
+  const nowMs = input.now.getTime();
+
+  if (Number.isNaN(occurredAtMs) || Number.isNaN(nowMs) || occurredAtMs > nowMs) {
+    return null;
+  }
+
+  const todayStartMs = startOfUtcDay(input.now);
+  const windowStartMs = todayStartMs - (input.days - 1) * MS_PER_DAY;
+  const occurredDayStartMs = startOfUtcDay(input.occurredAt);
+
+  if (occurredDayStartMs < windowStartMs || occurredDayStartMs > todayStartMs) {
+    return null;
+  }
+
+  return Math.floor((occurredDayStartMs - windowStartMs) / MS_PER_DAY);
+}
+
+export function bucketEventsByUtcDay(input: {
+  readonly occurredAts: readonly Date[];
+  readonly now: Date;
+  readonly days?: number;
+}): readonly number[] {
+  const days = Math.max(0, input.days ?? DEFAULT_DAYS);
+  const buckets = Array.from({ length: days }, () => 0);
+
+  for (const occurredAt of input.occurredAts) {
+    const index = getUtcDayIndex({
+      occurredAt,
+      now: input.now,
+      days,
+    });
+
+    if (index !== null && index >= 0 && index < buckets.length) {
+      const current = buckets[index] ?? 0;
+      buckets[index] = current + 1;
+    }
+  }
+
+  return buckets;
+}
+
+export function buildProjectLifecycleMetrics(input: {
+  readonly events: readonly LifecycleEventRow[];
+  readonly memberships: readonly MembershipRow[];
+  readonly projects: readonly ProjectRow[];
+  readonly now: Date;
+}): readonly ProjectLifecycleTile[] {
+  const activeProjects = input.projects.filter((project) => project.isActive);
+  if (activeProjects.length === 0) {
+    return [];
+  }
+
+  const activeProjectIds = new Set(
+    activeProjects.map((project) => project.projectId),
+  );
+  const projectIdsByContactId = new Map<string, Set<string>>();
+
+  for (const membership of input.memberships) {
+    if (!activeProjectIds.has(membership.projectId)) {
+      continue;
+    }
+
+    let projectIds = projectIdsByContactId.get(membership.contactId);
+    if (projectIds === undefined) {
+      projectIds = new Set<string>();
+      projectIdsByContactId.set(membership.contactId, projectIds);
+    }
+
+    projectIds.add(membership.projectId);
+  }
+
+  const earliestEventByContactProjectMetric = new Map<string, Date>();
+
+  for (const event of input.events) {
+    const dayIndex = getUtcDayIndex({
+      occurredAt: event.occurredAt,
+      now: input.now,
+      days: DEFAULT_DAYS,
+    });
+    if (dayIndex === null) {
+      continue;
+    }
+
+    const projectIds = projectIdsByContactId.get(event.contactId);
+    if (projectIds === undefined || projectIds.size === 0) {
+      continue;
+    }
+
+    const metricKey = metricKeyFromEventType(event.eventType);
+    for (const projectId of projectIds) {
+      const dedupeKey = `${event.contactId}::${projectId}::${metricKey}`;
+      const existing = earliestEventByContactProjectMetric.get(dedupeKey);
+
+      if (existing === undefined || event.occurredAt.getTime() < existing.getTime()) {
+        earliestEventByContactProjectMetric.set(dedupeKey, event.occurredAt);
+      }
+    }
+  }
+
+  const occurredAtsByProjectMetric = new Map<
+    string,
+    Record<MetricKey, Date[]>
+  >();
+
+  for (const project of activeProjects) {
+    occurredAtsByProjectMetric.set(project.projectId, {
+      signups: [],
+      trainingCompletions: [],
+      dataSubmissions: [],
+    });
+  }
+
+  for (const [dedupeKey, occurredAt] of earliestEventByContactProjectMetric) {
+    const [, projectId, metricKeyRaw] = dedupeKey.split("::");
+    if (projectId === undefined || metricKeyRaw === undefined) {
+      continue;
+    }
+
+    const metricKey = metricKeyRaw as MetricKey;
+    const projectMetrics = occurredAtsByProjectMetric.get(projectId);
+
+    if (projectMetrics !== undefined) {
+      projectMetrics[metricKey].push(occurredAt);
+    }
+  }
+
+  return [...activeProjects]
+    .map((project) => {
+      const projectMetrics = occurredAtsByProjectMetric.get(project.projectId) ?? {
+        signups: [],
+        trainingCompletions: [],
+        dataSubmissions: [],
+      };
+
+      const sparkline = {
+        signups: bucketEventsByUtcDay({
+          occurredAts: projectMetrics.signups,
+          now: input.now,
+        }),
+        trainingCompletions: bucketEventsByUtcDay({
+          occurredAts: projectMetrics.trainingCompletions,
+          now: input.now,
+        }),
+        dataSubmissions: bucketEventsByUtcDay({
+          occurredAts: projectMetrics.dataSubmissions,
+          now: input.now,
+        }),
+      };
+
+      const totals: MutableMetricCounts = buildZeroCounts();
+      const today: MutableMetricCounts = buildZeroCounts();
+
+      for (const metricKey of METRIC_KEYS) {
+        const buckets = sparkline[metricKey];
+        const total = buckets.reduce((sum, count) => sum + count, 0);
+
+        totals[metricKey] = total;
+        today[metricKey] = buckets[DEFAULT_DAYS - 1] ?? 0;
+      }
+
+      return {
+        projectId: project.projectId,
+        projectName: project.projectName,
+        projectTone: project.projectTone,
+        unreadCount: project.unreadCount,
+        totals,
+        today,
+        sparkline,
+      };
+    })
+    .sort((left, right) => {
+      const leftTotal =
+        left.totals.signups +
+        left.totals.trainingCompletions +
+        left.totals.dataSubmissions;
+      const rightTotal =
+        right.totals.signups +
+        right.totals.trainingCompletions +
+        right.totals.dataSubmissions;
+
+      if (leftTotal !== rightTotal) {
+        return rightTotal - leftTotal;
+      }
+
+      return left.projectName.localeCompare(right.projectName);
+    });
+}

--- a/apps/web/app/inbox/_lib/sync-freshness.ts
+++ b/apps/web/app/inbox/_lib/sync-freshness.ts
@@ -1,0 +1,29 @@
+export type SyncFreshnessState =
+  | "fresh"
+  | "stale-30m"
+  | "stale-2h"
+  | "unknown";
+
+const THIRTY_MINUTES_MS = 30 * 60 * 1_000;
+const TWO_HOURS_MS = 2 * 60 * 60 * 1_000;
+
+export function classifySyncFreshness(input: {
+  readonly lastSuccessAt: Date | null;
+  readonly now: Date;
+}): SyncFreshnessState {
+  if (input.lastSuccessAt === null) {
+    return "unknown";
+  }
+
+  const ageMs = input.now.getTime() - input.lastSuccessAt.getTime();
+
+  if (ageMs <= THIRTY_MINUTES_MS) {
+    return "fresh";
+  }
+
+  if (ageMs <= TWO_HOURS_MS) {
+    return "stale-30m";
+  }
+
+  return "stale-2h";
+}

--- a/apps/web/app/inbox/page.tsx
+++ b/apps/web/app/inbox/page.tsx
@@ -1,6 +1,7 @@
 import { requireSession } from "@/src/server/auth/session";
 
 import { InboxWelcomeWorkload } from "./_components/inbox-welcome-workload";
+import { getInboxWelcomeSalesforceLifecycle } from "./_lib/home-dashboard";
 import { getInboxWelcomeWorkload } from "./_lib/selectors";
 
 function deriveFirstName(name: string | null, email: string): string {
@@ -31,12 +32,22 @@ function deriveFirstName(name: string | null, email: string): string {
 }
 
 export default async function InboxListPage() {
-  const [workload, currentUser] = await Promise.all([
+  const [workload, salesforceLifecycle, currentUser] = await Promise.all([
     getInboxWelcomeWorkload(),
+    getInboxWelcomeSalesforceLifecycle(),
     requireSession(),
   ]);
+  const dashboardData = {
+    workload,
+    salesforceLifecycle,
+  };
 
   const firstName = deriveFirstName(currentUser.name, currentUser.email);
 
-  return <InboxWelcomeWorkload workload={workload} firstName={firstName} />;
+  return (
+    <InboxWelcomeWorkload
+      workload={dashboardData.workload}
+      firstName={firstName}
+    />
+  );
 }

--- a/apps/web/tests/unit/inbox-home-dashboard.test.ts
+++ b/apps/web/tests/unit/inbox-home-dashboard.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { getInboxWelcomeSalesforceLifecycle } from "../../app/inbox/_lib/home-dashboard";
+import { projectToneFromName } from "../../app/inbox/_lib/project-tone";
+import {
+  createInboxTestRuntime,
+  seedInboxContact,
+  seedInboxLifecycleEvent,
+  seedInboxProjection,
+  type InboxTestRuntime,
+} from "./inbox-stage1-helpers";
+
+describe("getInboxWelcomeSalesforceLifecycle", () => {
+  let runtime: InboxTestRuntime | null = null;
+
+  beforeEach(async () => {
+    runtime = await createInboxTestRuntime();
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    runtime = null;
+  });
+
+  it("returns lifecycle tiles and freshness from runtime-backed fixtures", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:active",
+      salesforceContactId: "003-active",
+      displayName: "Active Contact",
+      primaryEmail: "active@example.org",
+      primaryPhone: null,
+      projectId: "project:alpha",
+      projectName: "Alpha Research",
+      projectAlias: "Alpha",
+      membershipId: "membership:alpha",
+      membershipStatus: "active",
+      membershipCreatedAt: "2026-04-20T12:00:00.000Z",
+    });
+    await runtime.context.repositories.projectDimensions.upsert({
+      projectId: "project:beta",
+      projectName: "Beta Research",
+      projectAlias: "Beta",
+      source: "salesforce",
+      isActive: true,
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:active",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-05-07T11:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-05-07T11:00:00.000Z",
+      snippet: "Unread inbound",
+      lastCanonicalEventId: "event:lifecycle-alpha-signup",
+      lastEventType: "communication.email.inbound",
+    });
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "lifecycle-alpha-signup",
+      contactId: "contact:active",
+      occurredAt: "2026-05-07T10:00:00.000Z",
+      eventType: "lifecycle.signed_up",
+      summary: "Signed up",
+      projectId: "project:alpha",
+    });
+    await runtime.context.settings.integrationHealth.seedDefaults();
+    const salesforceHealth =
+      await runtime.context.settings.integrationHealth.findById("salesforce");
+
+    if (salesforceHealth === null) {
+      throw new Error("Expected seeded Salesforce integration health row");
+    }
+
+    await runtime.context.settings.integrationHealth.upsert({
+      ...salesforceHealth,
+      status: "healthy",
+      lastCheckedAt: "2026-05-07T11:55:00.000Z",
+      updatedAt: "2026-05-07T11:55:00.000Z",
+    });
+    await runtime.context.repositories.syncState.upsert({
+      id: "sync:salesforce:live:latest",
+      scope: "provider",
+      provider: "salesforce",
+      jobType: "live_ingest",
+      cursor: "cursor:salesforce",
+      windowStart: "2026-05-07T11:45:00.000Z",
+      windowEnd: "2026-05-07T11:50:00.000Z",
+      status: "succeeded",
+      parityPercent: null,
+      freshnessP95Seconds: null,
+      freshnessP99Seconds: null,
+      lastSuccessfulAt: "2026-05-07T11:50:00.000Z",
+      consecutiveFailureCount: 0,
+      leaseOwner: null,
+      heartbeatAt: null,
+      deadLetterCount: 0,
+    });
+
+    const result = await getInboxWelcomeSalesforceLifecycle({
+      now: new Date("2026-05-07T12:00:00.000Z"),
+    });
+
+    expect(result.freshness).toBe("fresh");
+    expect(result.tiles).toEqual([
+      {
+        projectId: "project:alpha",
+        projectName: "Alpha",
+        projectTone: projectToneFromName("Alpha"),
+        unreadCount: 1,
+        totals: {
+          signups: 1,
+          trainingCompletions: 0,
+          dataSubmissions: 0,
+        },
+        today: {
+          signups: 1,
+          trainingCompletions: 0,
+          dataSubmissions: 0,
+        },
+        sparkline: {
+          signups: [0, 0, 0, 0, 0, 0, 1],
+          trainingCompletions: [0, 0, 0, 0, 0, 0, 0],
+          dataSubmissions: [0, 0, 0, 0, 0, 0, 0],
+        },
+      },
+      {
+        projectId: "project:beta",
+        projectName: "Beta",
+        projectTone: projectToneFromName("Beta"),
+        unreadCount: 0,
+        totals: {
+          signups: 0,
+          trainingCompletions: 0,
+          dataSubmissions: 0,
+        },
+        today: {
+          signups: 0,
+          trainingCompletions: 0,
+          dataSubmissions: 0,
+        },
+        sparkline: {
+          signups: [0, 0, 0, 0, 0, 0, 0],
+          trainingCompletions: [0, 0, 0, 0, 0, 0, 0],
+          dataSubmissions: [0, 0, 0, 0, 0, 0, 0],
+        },
+      },
+    ]);
+  });
+});

--- a/apps/web/tests/unit/inbox-home-dashboard.test.ts
+++ b/apps/web/tests/unit/inbox-home-dashboard.test.ts
@@ -47,6 +47,14 @@ describe("getInboxWelcomeSalesforceLifecycle", () => {
       source: "salesforce",
       isActive: true,
     });
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "lifecycle-alpha-signup",
+      contactId: "contact:active",
+      occurredAt: "2026-05-07T10:00:00.000Z",
+      eventType: "lifecycle.signed_up",
+      summary: "Signed up",
+      projectId: "project:alpha",
+    });
     await seedInboxProjection(runtime.context, {
       contactId: "contact:active",
       bucket: "New",
@@ -58,14 +66,6 @@ describe("getInboxWelcomeSalesforceLifecycle", () => {
       snippet: "Unread inbound",
       lastCanonicalEventId: "event:lifecycle-alpha-signup",
       lastEventType: "communication.email.inbound",
-    });
-    await seedInboxLifecycleEvent(runtime.context, {
-      id: "lifecycle-alpha-signup",
-      contactId: "contact:active",
-      occurredAt: "2026-05-07T10:00:00.000Z",
-      eventType: "lifecycle.signed_up",
-      summary: "Signed up",
-      projectId: "project:alpha",
     });
     await runtime.context.settings.integrationHealth.seedDefaults();
     const salesforceHealth =

--- a/apps/web/tests/unit/project-lifecycle-metrics.test.ts
+++ b/apps/web/tests/unit/project-lifecycle-metrics.test.ts
@@ -1,0 +1,404 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  bucketEventsByUtcDay,
+  buildProjectLifecycleMetrics,
+  type LifecycleEventRow,
+  type MembershipRow,
+  type ProjectRow,
+} from "../../app/inbox/_lib/project-lifecycle-metrics";
+
+function date(value: string): Date {
+  return new Date(value);
+}
+
+function buildEvent(
+  overrides: Partial<LifecycleEventRow> = {},
+): LifecycleEventRow {
+  return {
+    contactId: overrides.contactId ?? "contact-1",
+    eventType: overrides.eventType ?? "lifecycle.signed_up",
+    occurredAt: overrides.occurredAt ?? date("2026-05-07T10:00:00.000Z"),
+  };
+}
+
+function buildMembership(
+  overrides: Partial<MembershipRow> = {},
+): MembershipRow {
+  return {
+    contactId: overrides.contactId ?? "contact-1",
+    projectId: overrides.projectId ?? "project-a",
+  };
+}
+
+function buildProject(
+  overrides: Partial<ProjectRow> = {},
+): ProjectRow {
+  return {
+    projectId: overrides.projectId ?? "project-a",
+    projectName: overrides.projectName ?? "Alpha Project",
+    projectTone: overrides.projectTone ?? "sky",
+    isActive: overrides.isActive ?? true,
+    unreadCount: overrides.unreadCount ?? 0,
+  };
+}
+
+describe("bucketEventsByUtcDay", () => {
+  it("separates adjacent UTC-midnight boundary events into different buckets", () => {
+    const now = date("2026-05-07T12:00:00.000Z");
+
+    expect(
+      bucketEventsByUtcDay({
+        occurredAts: [
+          date("2026-05-05T23:59:59.999Z"),
+          date("2026-05-06T00:00:00.000Z"),
+        ],
+        now,
+      }),
+    ).toEqual([0, 0, 0, 0, 1, 1, 0]);
+  });
+
+  it("ignores out-of-window events", () => {
+    const now = date("2026-05-07T12:00:00.000Z");
+
+    expect(
+      bucketEventsByUtcDay({
+        occurredAts: [
+          date("2026-04-29T23:59:59.999Z"),
+          date("2026-05-08T00:00:00.000Z"),
+        ],
+        now,
+      }),
+    ).toEqual([0, 0, 0, 0, 0, 0, 0]);
+  });
+
+  it("returns zero-filled arrays for empty input", () => {
+    expect(
+      bucketEventsByUtcDay({
+        occurredAts: [],
+        now: date("2026-05-07T12:00:00.000Z"),
+      }),
+    ).toEqual([0, 0, 0, 0, 0, 0, 0]);
+  });
+
+  it("respects a custom day count", () => {
+    expect(
+      bucketEventsByUtcDay({
+        occurredAts: [date("2026-05-07T12:00:00.000Z")],
+        now: date("2026-05-07T12:00:00.000Z"),
+        days: 3,
+      }),
+    ).toEqual([0, 0, 1]);
+  });
+});
+
+describe("buildProjectLifecycleMetrics", () => {
+  it("returns an empty result for empty input", () => {
+    expect(
+      buildProjectLifecycleMetrics({
+        events: [],
+        memberships: [],
+        projects: [],
+        now: date("2026-05-07T12:00:00.000Z"),
+      }),
+    ).toEqual([]);
+  });
+
+  it("preserves active zero-event projects with zero totals and seven-day sparklines", () => {
+    expect(
+      buildProjectLifecycleMetrics({
+        events: [],
+        memberships: [],
+        projects: [
+          buildProject({
+            projectId: "project-a",
+            projectName: "Alpha",
+            unreadCount: 3,
+          }),
+        ],
+        now: date("2026-05-07T12:00:00.000Z"),
+      }),
+    ).toEqual([
+      {
+        projectId: "project-a",
+        projectName: "Alpha",
+        projectTone: "sky",
+        unreadCount: 3,
+        totals: {
+          signups: 0,
+          trainingCompletions: 0,
+          dataSubmissions: 0,
+        },
+        today: {
+          signups: 0,
+          trainingCompletions: 0,
+          dataSubmissions: 0,
+        },
+        sparkline: {
+          signups: [0, 0, 0, 0, 0, 0, 0],
+          trainingCompletions: [0, 0, 0, 0, 0, 0, 0],
+          dataSubmissions: [0, 0, 0, 0, 0, 0, 0],
+        },
+      },
+    ]);
+  });
+
+  it("excludes inactive projects even when lifecycle events exist", () => {
+    expect(
+      buildProjectLifecycleMetrics({
+        events: [
+          buildEvent({
+            contactId: "contact-1",
+            occurredAt: date("2026-05-07T10:00:00.000Z"),
+          }),
+        ],
+        memberships: [buildMembership()],
+        projects: [
+          buildProject({
+            projectId: "project-a",
+            projectName: "Alpha",
+            isActive: false,
+          }),
+        ],
+        now: date("2026-05-07T12:00:00.000Z"),
+      }),
+    ).toEqual([]);
+  });
+
+  it("orders projects by seven-day total activity descending", () => {
+    const now = date("2026-05-07T12:00:00.000Z");
+
+    const result = buildProjectLifecycleMetrics({
+      events: [
+        buildEvent({
+          contactId: "contact-a1",
+          occurredAt: date("2026-05-07T08:00:00.000Z"),
+        }),
+        buildEvent({
+          contactId: "contact-a2",
+          occurredAt: date("2026-05-06T08:00:00.000Z"),
+        }),
+        buildEvent({
+          contactId: "contact-b1",
+          eventType: "lifecycle.completed_training",
+          occurredAt: date("2026-05-05T08:00:00.000Z"),
+        }),
+      ],
+      memberships: [
+        buildMembership({ contactId: "contact-a1", projectId: "project-a" }),
+        buildMembership({ contactId: "contact-a2", projectId: "project-a" }),
+        buildMembership({ contactId: "contact-b1", projectId: "project-b" }),
+      ],
+      projects: [
+        buildProject({ projectId: "project-b", projectName: "Beta" }),
+        buildProject({ projectId: "project-a", projectName: "Alpha" }),
+        buildProject({ projectId: "project-c", projectName: "Gamma" }),
+      ],
+      now,
+    });
+
+    expect(result.map((project) => project.projectId)).toEqual([
+      "project-a",
+      "project-b",
+      "project-c",
+    ]);
+  });
+
+  it("breaks activity ties alphabetically by project name", () => {
+    const result = buildProjectLifecycleMetrics({
+      events: [
+        buildEvent({
+          contactId: "contact-1",
+          occurredAt: date("2026-05-07T08:00:00.000Z"),
+        }),
+        buildEvent({
+          contactId: "contact-2",
+          occurredAt: date("2026-05-07T08:00:00.000Z"),
+        }),
+      ],
+      memberships: [
+        buildMembership({ contactId: "contact-1", projectId: "project-b" }),
+        buildMembership({ contactId: "contact-2", projectId: "project-a" }),
+      ],
+      projects: [
+        buildProject({ projectId: "project-b", projectName: "Zulu" }),
+        buildProject({ projectId: "project-a", projectName: "Alpha" }),
+      ],
+      now: date("2026-05-07T12:00:00.000Z"),
+    });
+
+    expect(result.map((project) => project.projectName)).toEqual([
+      "Alpha",
+      "Zulu",
+    ]);
+  });
+
+  it("deduplicates repeated ledger rows for the same contact, project, and milestone", () => {
+    const result = buildProjectLifecycleMetrics({
+      events: [
+        buildEvent({
+          contactId: "contact-1",
+          occurredAt: date("2026-05-06T10:00:00.000Z"),
+        }),
+        buildEvent({
+          contactId: "contact-1",
+          occurredAt: date("2026-05-07T10:00:00.000Z"),
+        }),
+      ],
+      memberships: [buildMembership()],
+      projects: [buildProject()],
+      now: date("2026-05-07T12:00:00.000Z"),
+    });
+
+    expect(result[0]?.totals.signups).toBe(1);
+    expect(result[0]?.today.signups).toBe(0);
+    expect(result[0]?.sparkline.signups).toEqual([0, 0, 0, 0, 0, 1, 0]);
+  });
+
+  it("counts the same milestone for the same contact across different projects", () => {
+    const result = buildProjectLifecycleMetrics({
+      events: [buildEvent()],
+      memberships: [
+        buildMembership({ projectId: "project-a" }),
+        buildMembership({ projectId: "project-b" }),
+      ],
+      projects: [
+        buildProject({ projectId: "project-a", projectName: "Alpha" }),
+        buildProject({ projectId: "project-b", projectName: "Beta" }),
+      ],
+      now: date("2026-05-07T12:00:00.000Z"),
+    });
+
+    expect(result.map((project) => project.totals.signups)).toEqual([1, 1]);
+  });
+
+  it("includes events just after the window start and excludes events just before it", () => {
+    const now = date("2026-05-07T00:00:00.000Z");
+
+    const result = buildProjectLifecycleMetrics({
+      events: [
+        buildEvent({
+          contactId: "contact-inside",
+          occurredAt: date("2026-05-01T00:00:00.001Z"),
+        }),
+        buildEvent({
+          contactId: "contact-outside",
+          occurredAt: date("2026-04-30T23:59:59.999Z"),
+        }),
+      ],
+      memberships: [
+        buildMembership({
+          contactId: "contact-inside",
+          projectId: "project-a",
+        }),
+        buildMembership({
+          contactId: "contact-outside",
+          projectId: "project-a",
+        }),
+      ],
+      projects: [buildProject()],
+      now,
+    });
+
+    expect(result[0]?.totals.signups).toBe(1);
+    expect(result[0]?.sparkline.signups).toEqual([1, 0, 0, 0, 0, 0, 0]);
+  });
+
+  it("excludes future events", () => {
+    const result = buildProjectLifecycleMetrics({
+      events: [
+        buildEvent({
+          occurredAt: date("2026-05-08T00:00:00.000Z"),
+        }),
+      ],
+      memberships: [buildMembership()],
+      projects: [buildProject()],
+      now: date("2026-05-07T12:00:00.000Z"),
+    });
+
+    expect(result[0]?.totals.signups).toBe(0);
+  });
+
+  it("counts only the current UTC day in the today metric", () => {
+    const result = buildProjectLifecycleMetrics({
+      events: [
+        buildEvent({
+          contactId: "today-contact",
+          occurredAt: date("2026-05-07T10:00:00.000Z"),
+        }),
+        buildEvent({
+          contactId: "yesterday-contact",
+          occurredAt: date("2026-05-06T23:59:59.999Z"),
+        }),
+      ],
+      memberships: [
+        buildMembership({ contactId: "today-contact" }),
+        buildMembership({ contactId: "yesterday-contact" }),
+      ],
+      projects: [buildProject()],
+      now: date("2026-05-07T12:00:00.000Z"),
+    });
+
+    expect(result[0]?.today.signups).toBe(1);
+    expect(result[0]?.totals.signups).toBe(2);
+  });
+
+  it("places today at index 6 and yesterday at index 5", () => {
+    const result = buildProjectLifecycleMetrics({
+      events: [
+        buildEvent({
+          contactId: "today-contact",
+          eventType: "lifecycle.completed_training",
+          occurredAt: date("2026-05-07T10:00:00.000Z"),
+        }),
+        buildEvent({
+          contactId: "yesterday-contact",
+          eventType: "lifecycle.completed_training",
+          occurredAt: date("2026-05-06T10:00:00.000Z"),
+        }),
+      ],
+      memberships: [
+        buildMembership({ contactId: "today-contact" }),
+        buildMembership({ contactId: "yesterday-contact" }),
+      ],
+      projects: [buildProject()],
+      now: date("2026-05-07T12:00:00.000Z"),
+    });
+
+    expect(result[0]?.sparkline.trainingCompletions).toEqual([
+      0, 0, 0, 0, 0, 1, 1,
+    ]);
+  });
+
+  it("rolls many same-day events into a single sparkline bucket", () => {
+    const result = buildProjectLifecycleMetrics({
+      events: [
+        buildEvent({
+          contactId: "contact-1",
+          eventType: "lifecycle.submitted_first_data",
+          occurredAt: date("2026-05-04T01:00:00.000Z"),
+        }),
+        buildEvent({
+          contactId: "contact-2",
+          eventType: "lifecycle.submitted_first_data",
+          occurredAt: date("2026-05-04T12:00:00.000Z"),
+        }),
+        buildEvent({
+          contactId: "contact-3",
+          eventType: "lifecycle.submitted_first_data",
+          occurredAt: date("2026-05-04T23:00:00.000Z"),
+        }),
+      ],
+      memberships: [
+        buildMembership({ contactId: "contact-1" }),
+        buildMembership({ contactId: "contact-2" }),
+        buildMembership({ contactId: "contact-3" }),
+      ],
+      projects: [buildProject()],
+      now: date("2026-05-07T12:00:00.000Z"),
+    });
+
+    expect(result[0]?.sparkline.dataSubmissions).toEqual([0, 0, 0, 3, 0, 0, 0]);
+    expect(result[0]?.totals.dataSubmissions).toBe(3);
+  });
+});

--- a/apps/web/tests/unit/sync-freshness.test.ts
+++ b/apps/web/tests/unit/sync-freshness.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { classifySyncFreshness } from "../../app/inbox/_lib/sync-freshness";
+
+function date(value: string): Date {
+  return new Date(value);
+}
+
+describe("classifySyncFreshness", () => {
+  const now = date("2026-05-07T12:00:00.000Z");
+
+  it.each([
+    {
+      label: "null becomes unknown",
+      lastSuccessAt: null,
+      expected: "unknown",
+    },
+    {
+      label: "current success is fresh",
+      lastSuccessAt: date("2026-05-07T12:00:00.000Z"),
+      expected: "fresh",
+    },
+    {
+      label: "exactly thirty minutes stays fresh",
+      lastSuccessAt: date("2026-05-07T11:30:00.000Z"),
+      expected: "fresh",
+    },
+    {
+      label: "thirty minutes and one millisecond becomes stale-30m",
+      lastSuccessAt: date("2026-05-07T11:29:59.999Z"),
+      expected: "stale-30m",
+    },
+    {
+      label: "exactly two hours stays stale-30m",
+      lastSuccessAt: date("2026-05-07T10:00:00.000Z"),
+      expected: "stale-30m",
+    },
+    {
+      label: "two hours and one millisecond becomes stale-2h",
+      lastSuccessAt: date("2026-05-07T09:59:59.999Z"),
+      expected: "stale-2h",
+    },
+    {
+      label: "future timestamps stay defensive-fresh",
+      lastSuccessAt: date("2026-05-07T12:00:00.001Z"),
+      expected: "fresh",
+    },
+  ])("$label", ({ lastSuccessAt, expected }) => {
+    expect(
+      classifySyncFreshness({
+        lastSuccessAt,
+        now,
+      }),
+    ).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- Pure-logic layer for the new home Salesforce dashboard (PRD #293, brief 1 of 3)
- `buildProjectLifecycleMetrics` (7d totals, today, sparkline, distinct contact × project × metric, UTC day boundaries, total-activity desc + alpha tie-break)
- `bucketEventsByUtcDay` (7-bucket helper)
- `classifySyncFreshness` (fresh / stale-30m / stale-2h / unknown thresholds against salesforce-capture lastSuccessAt)
- Thin server assembler `home-dashboard.ts` that wires real DB reads → aggregator → freshness classifier
- `ProjectMiniDashboard` is untouched — brief 2 swaps it.

No new runtime dependencies. No UI changes in this PR.

## Test plan
- [x] \`pnpm typecheck\` passes (run by Codex)
- [x] \`pnpm lint\` passes (run by Codex)
- [ ] CI \`pnpm test:unit\` green (vitest blocked locally by macOS rollup gotcha; CI authoritative per concurrency memo)
- [ ] Visual verification deferred to brief 2 (this brief ships no UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)