### PR TITLE
feat(home): lifecycle tiles + sparkline + freshness label (PRD #293, brief 2)

### DIFF
--- a/apps/web/app/inbox/_components/inbox-welcome-workload.tsx
+++ b/apps/web/app/inbox/_components/inbox-welcome-workload.tsx
@@ -4,25 +4,35 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 import { SectionLabel } from "@/components/ui/section-label";
+import { EmptyState } from "@/components/ui/empty-state";
 import {
-  LAYOUT,
   TONE_CLASSES,
+  LAYOUT,
   TYPE,
 } from "@/app/_lib/design-tokens-v2";
 import { cn } from "@/lib/utils";
 
 import type {
   InboxWelcomeFollowUpEntryViewModel,
-  InboxWelcomeProjectWorkloadViewModel,
   InboxWelcomeWorkloadViewModel,
 } from "../_lib/view-models";
 import { FIELD_QUOTES } from "../_lib/field-quotes";
+import type { InboxWelcomeSalesforceLifecycleData } from "../_lib/home-dashboard";
+import type { MetricKey } from "../_lib/project-lifecycle-metrics";
 import { projectToneFromName } from "../_lib/project-tone";
 import { InboxAvatar } from "./inbox-avatar";
-import { ArrowUpRightIcon, QuoteIcon, RefreshCwIcon } from "./icons";
+import {
+  AlertTriangleIcon,
+  ArrowUpRightIcon,
+  DatabaseIcon,
+  QuoteIcon,
+  RefreshCwIcon,
+} from "./icons";
+import { ProjectLifecycleTile } from "./project-lifecycle-tile";
 
 interface InboxWelcomeWorkloadProps {
   readonly workload: InboxWelcomeWorkloadViewModel;
+  readonly salesforceLifecycle: InboxWelcomeSalesforceLifecycleData;
   readonly firstName: string;
 }
 
@@ -36,12 +46,17 @@ function formatDay(date: Date): string {
 
 export function InboxWelcomeWorkload({
   workload,
+  salesforceLifecycle,
   firstName,
 }: InboxWelcomeWorkloadProps) {
   const router = useRouter();
   const today = new Date();
   const initialQuoteIdx = today.getDate() % FIELD_QUOTES.length;
   const [quoteIdx, setQuoteIdx] = useState(initialQuoteIdx);
+  const [, setPendingMetric] = useState<{
+    readonly projectId: string;
+    readonly metricKey: MetricKey;
+  } | null>(null);
   const quote = FIELD_QUOTES[quoteIdx] ?? FIELD_QUOTES[0];
 
   const cycleQuote = () => {
@@ -51,6 +66,8 @@ export function InboxWelcomeWorkload({
   const openProject = (projectId: string) => {
     router.push(`/inbox?projectId=${encodeURIComponent(projectId)}`);
   };
+
+  const freshnessBadge = readFreshnessBadge(salesforceLifecycle, today);
 
   return (
     <section className="flex min-h-0 flex-1 flex-col overflow-y-auto bg-slate-50/40">
@@ -64,7 +81,11 @@ export function InboxWelcomeWorkload({
             </h1>
             <p className={`mt-1 ${TYPE.caption}`}>Today is {formatDay(today)}</p>
           </div>
-          <p className={`shrink-0 ${TYPE.caption}`}>Last synced just now</p>
+          <p
+            className={`shrink-0 rounded-full border px-3 py-1 text-xs font-medium ${freshnessBadge.className}`}
+          >
+            {freshnessBadge.label}
+          </p>
         </div>
       </header>
 
@@ -75,9 +96,12 @@ export function InboxWelcomeWorkload({
           onCycle={cycleQuote}
         />
 
-        <ProjectMiniDashboard
-          projects={workload.projects}
+        <ProjectLifecycleDashboard
+          salesforceLifecycle={salesforceLifecycle}
           onOpenProject={openProject}
+          onOpenMetric={(projectId, metricKey) => {
+            setPendingMetric({ projectId, metricKey });
+          }}
         />
 
         {workload.followUpRail.totalCount > 0 ? (
@@ -94,6 +118,54 @@ export function InboxWelcomeWorkload({
       </div>
     </section>
   );
+}
+
+function readFreshnessBadge(
+  salesforceLifecycle: InboxWelcomeSalesforceLifecycleData,
+  now: Date,
+): {
+  readonly label: string;
+  readonly className: string;
+} {
+  switch (salesforceLifecycle.freshness) {
+    case "fresh": {
+      if (salesforceLifecycle.lastSuccessAt === null) {
+        return {
+          label: "Up to date",
+          className: "border-emerald-200 bg-emerald-50 text-emerald-800",
+        };
+      }
+
+      const ageMs = Math.max(
+        0,
+        now.getTime() - salesforceLifecycle.lastSuccessAt.getTime(),
+      );
+      const ageMinutes = Math.floor(ageMs / 60_000);
+
+      return {
+        label:
+          ageMinutes <= 0
+            ? "Last synced just now"
+            : `Last synced ${ageMinutes.toString()} min ago`,
+        className: "border-emerald-200 bg-emerald-50 text-emerald-800",
+      };
+    }
+    case "stale-30m":
+      return {
+        label: "Last synced over 30 min ago",
+        className: "border-amber-200 bg-amber-50 text-amber-700",
+      };
+    case "stale-2h":
+      return {
+        label: "Last synced over 2 hr ago",
+        className: "border-slate-200 bg-slate-50 text-slate-600",
+      };
+    case "unknown":
+      return {
+        label: "Salesforce sync status unavailable",
+        className: "border-slate-200 bg-slate-50 text-slate-600",
+      };
+  }
 }
 
 interface QuoteCardProps {
@@ -139,82 +211,56 @@ function QuoteCard({ quoteText, author, onCycle }: QuoteCardProps) {
   );
 }
 
-interface ProjectMiniDashboardProps {
-  readonly projects: readonly InboxWelcomeProjectWorkloadViewModel[];
+interface ProjectLifecycleDashboardProps {
+  readonly salesforceLifecycle: InboxWelcomeSalesforceLifecycleData;
   readonly onOpenProject: (projectId: string) => void;
+  readonly onOpenMetric: (projectId: string, metricKey: MetricKey) => void;
 }
 
-function ProjectMiniDashboard({
-  projects,
+function ProjectLifecycleDashboard({
+  salesforceLifecycle,
   onOpenProject,
-}: ProjectMiniDashboardProps) {
-  if (projects.length === 0) {
-    return (
-      <div className="rounded-xl border border-slate-200 bg-white px-7 py-10 text-center">
-        <SectionLabel as="h2" className="text-slate-500">
-          Active project workload
-        </SectionLabel>
-        <p className={`mt-2 ${TYPE.caption}`}>
-          No active projects are currently enabled. Activate projects in
-          Settings to surface unread and follow-up counts here.
-        </p>
-      </div>
-    );
-  }
+  onOpenMetric,
+}: ProjectLifecycleDashboardProps) {
+  const { tiles, freshness } = salesforceLifecycle;
 
   return (
     <div>
-      <SectionLabel as="h2">Active project workload</SectionLabel>
-      <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
-        {projects.map((project) => {
-          const tone = projectToneFromName(project.projectName);
-          const t = TONE_CLASSES[tone];
-          return (
-            <button
-              key={project.projectId}
-              type="button"
-              onClick={() => {
-                onOpenProject(project.projectId);
-              }}
-              className="group relative overflow-hidden rounded-xl border border-slate-200 bg-white p-4 text-left transition-all duration-200 hover:border-slate-300 hover:shadow-sm"
-            >
-              <span
-                aria-hidden="true"
-                className={`absolute left-0 top-0 h-full w-1 ${t.bg}`}
-              />
-              <div className="flex items-start justify-between gap-2 pl-2">
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
-                    <span
-                      aria-hidden="true"
-                      className={`size-1.5 shrink-0 rounded-full ${t.dot}`}
-                    />
-                    <span className={`${TYPE.headingSm} truncate`}>
-                      {project.projectName}
-                    </span>
-                  </div>
-                </div>
-                <ArrowUpRightIcon className="size-3.5 shrink-0 text-slate-300 transition-colors group-hover:text-slate-600" />
-              </div>
+      {freshness === "stale-2h" ? (
+        <div
+          role="alert"
+          className="mb-3 flex min-h-10 items-center gap-2 rounded-xl border border-amber-200 bg-amber-50 px-4 py-2 text-amber-900"
+        >
+          <AlertTriangleIcon className="size-4 shrink-0 text-amber-600" />
+          <p className="min-w-0 flex-1 text-sm font-medium">
+            Salesforce sync delayed — numbers may be stale.
+          </p>
+        </div>
+      ) : null}
 
-              <div className="mt-4 grid grid-cols-2 gap-2 pl-2">
-                <Stat
-                  label="Unread"
-                  value={project.unreadCount}
-                  emphasis={project.unreadCount > 0}
-                  tone="slate"
-                />
-                <Stat
-                  label="Follow-up"
-                  value={project.needsFollowUpCount}
-                  emphasis={project.needsFollowUpCount > 0}
-                  tone="amber"
-                />
-              </div>
-            </button>
-          );
-        })}
-      </div>
+      <SectionLabel as="h2">Active Projects · Last 7 Days</SectionLabel>
+      {tiles.length === 0 ? (
+        <div className="mt-3 rounded-xl border border-slate-200 bg-white px-7 py-10 text-center">
+          <EmptyState
+            size="sm"
+            icon={<DatabaseIcon className="size-6 text-slate-400" />}
+            title="No active projects yet — activate one in Settings"
+            description={<span aria-hidden="true">&nbsp;</span>}
+            className="px-0 py-10"
+          />
+        </div>
+      ) : (
+        <div className="mt-3 space-y-3">
+          {tiles.map((tile) => (
+            <ProjectLifecycleTile
+              key={tile.projectId}
+              tile={tile}
+              onOpenProject={onOpenProject}
+              onOpenMetric={onOpenMetric}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }
@@ -313,29 +359,5 @@ function FollowUpRailRow({ entry, onOpenContact }: FollowUpRailRowProps) {
       </span>
       <ArrowUpRightIcon className="size-3.5 shrink-0 text-slate-300 transition-colors group-hover:text-slate-600" />
     </button>
-  );
-}
-
-interface StatProps {
-  readonly label: string;
-  readonly value: number;
-  readonly emphasis: boolean;
-  readonly tone: "slate" | "amber";
-}
-
-function Stat({ label, value, emphasis, tone }: StatProps) {
-  const valueClass = emphasis
-    ? tone === "amber"
-      ? "text-amber-700"
-      : "text-slate-900"
-    : "text-slate-300";
-
-  return (
-    <div className="flex items-baseline gap-1.5">
-      <span className={cn("text-xl font-semibold tabular-nums", valueClass)}>
-        {value.toLocaleString("en-US")}
-      </span>
-      <span className={TYPE.micro}>{label}</span>
-    </div>
   );
 }

--- a/apps/web/app/inbox/_components/project-lifecycle-tile.tsx
+++ b/apps/web/app/inbox/_components/project-lifecycle-tile.tsx
@@ -1,0 +1,120 @@
+import {
+  FOCUS_RING,
+  TONE_CLASSES,
+  TYPE,
+  type ToneNameV2,
+} from "@/app/_lib/design-tokens-v2";
+import { cn } from "@/lib/utils";
+
+import type {
+  MetricKey,
+  ProjectLifecycleTile as ProjectLifecycleTileData,
+} from "../_lib/project-lifecycle-metrics";
+import { Sparkline7 } from "./sparkline-7";
+
+export interface ProjectLifecycleTileProps {
+  readonly tile: ProjectLifecycleTileData;
+  readonly onOpenProject: (projectId: string) => void;
+  readonly onOpenMetric: (projectId: string, metricKey: MetricKey) => void;
+}
+
+const METRIC_CONFIG: readonly {
+  readonly key: MetricKey;
+  readonly label: string;
+  readonly valueClassName: string;
+}[] = [
+  { key: "signups", label: "Signups", valueClassName: "text-sky-700" },
+  {
+    key: "trainingCompletions",
+    label: "Training",
+    valueClassName: "text-emerald-700",
+  },
+  {
+    key: "dataSubmissions",
+    label: "Submissions",
+    valueClassName: "text-amber-700",
+  },
+];
+
+function readUnreadLabel(unreadCount: number): string {
+  if (unreadCount === 0) {
+    return "No unread";
+  }
+
+  return `${unreadCount.toString()} unread`;
+}
+
+function readToneClasses(tone: string) {
+  if (tone in TONE_CLASSES) {
+    return TONE_CLASSES[tone as ToneNameV2];
+  }
+
+  return TONE_CLASSES.slate;
+}
+
+export function ProjectLifecycleTile({
+  tile,
+  onOpenProject,
+  onOpenMetric,
+}: ProjectLifecycleTileProps) {
+  const toneClasses = readToneClasses(tile.projectTone);
+
+  return (
+    <article className="relative overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <span
+        aria-hidden="true"
+        className={cn("absolute inset-y-0 left-0 w-1.5", toneClasses.bg)}
+      />
+      <div className="grid gap-4 pl-6 pr-5 py-5 lg:grid-cols-[minmax(0,220px)_1fr]">
+        <button
+          type="button"
+          onClick={() => {
+            onOpenProject(tile.projectId);
+          }}
+          className={cn(
+            "flex min-w-0 flex-col items-start rounded-xl px-2 py-1 text-left transition-colors hover:bg-slate-50",
+            FOCUS_RING,
+          )}
+        >
+          <span className={cn(TYPE.headingMd, "truncate")}>{tile.projectName}</span>
+          <span className={cn(TYPE.caption, "mt-1")}>
+            {readUnreadLabel(tile.unreadCount)}
+          </span>
+        </button>
+
+        <div className="grid gap-3 sm:grid-cols-3">
+          {METRIC_CONFIG.map((metric) => (
+            <button
+              key={metric.key}
+              type="button"
+              onClick={() => {
+                onOpenMetric(tile.projectId, metric.key);
+              }}
+              className={cn(
+                "rounded-xl border border-slate-200 px-3 py-3 text-left transition-colors hover:border-slate-300 hover:bg-slate-50",
+                FOCUS_RING,
+              )}
+            >
+              <p className={TYPE.label}>{metric.label}</p>
+              <div className="mt-2 flex items-baseline gap-2">
+                <span className={cn("text-[28px] font-semibold tracking-tight", metric.valueClassName)}>
+                  {tile.totals[metric.key].toString()}
+                </span>
+                <span className={TYPE.caption}>
+                  +{tile.today[metric.key].toString()} today
+                </span>
+              </div>
+              <div className="mt-3">
+                <Sparkline7
+                  values={tile.sparkline[metric.key]}
+                  tone={tile.projectTone}
+                  metricKey={metric.key}
+                />
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/apps/web/app/inbox/_components/sparkline-7.tsx
+++ b/apps/web/app/inbox/_components/sparkline-7.tsx
@@ -1,0 +1,72 @@
+import { TONE_CLASSES, type ToneNameV2 } from "@/app/_lib/design-tokens-v2";
+
+type MetricKey = "signups" | "trainingCompletions" | "dataSubmissions";
+
+export interface Sparkline7Props {
+  readonly values: readonly number[];
+  readonly tone: string;
+  readonly metricKey: MetricKey;
+}
+
+const METRIC_BAR_CLASS: Record<MetricKey, string> = {
+  signups: "fill-sky-500",
+  trainingCompletions: "fill-emerald-500",
+  dataSubmissions: "fill-amber-500",
+};
+
+function readToneClasses(tone: string) {
+  if (tone in TONE_CLASSES) {
+    return TONE_CLASSES[tone as ToneNameV2];
+  }
+
+  return TONE_CLASSES.slate;
+}
+
+export function Sparkline7({
+  values,
+  tone,
+  metricKey,
+}: Sparkline7Props) {
+  const toneClasses = readToneClasses(tone);
+  const points = values.slice(0, 7);
+  const max = Math.max(0, ...points);
+
+  return (
+    <svg
+      viewBox="0 0 70 20"
+      aria-hidden="true"
+      className="h-5 w-full"
+      preserveAspectRatio="none"
+    >
+      <line
+        x1="0"
+        y1="19"
+        x2="70"
+        y2="19"
+        className={toneClasses.dot}
+        stroke="currentColor"
+        strokeOpacity="0.18"
+        strokeWidth="1"
+      />
+      {points.map((value, index) => {
+        const normalizedHeight = max === 0 ? 1.5 : Math.max(1.5, (value / max) * 15);
+        const x = index * 10 + 1;
+        const y = 19 - normalizedHeight;
+        const isToday = index === 6;
+
+        return (
+          <rect
+            key={`${metricKey}-${index.toString()}`}
+            x={x}
+            y={y}
+            width="6"
+            height={normalizedHeight}
+            rx="1.5"
+            className={METRIC_BAR_CLASS[metricKey]}
+            fillOpacity={isToday ? 0.95 : 0.38}
+          />
+        );
+      })}
+    </svg>
+  );
+}

--- a/apps/web/app/inbox/_lib/home-dashboard.ts
+++ b/apps/web/app/inbox/_lib/home-dashboard.ts
@@ -24,6 +24,7 @@ interface LifecycleEventSqlRow {
 export interface InboxWelcomeSalesforceLifecycleData {
   readonly tiles: readonly ProjectLifecycleTile[];
   readonly freshness: SyncFreshnessState;
+  readonly lastSuccessAt: Date | null;
 }
 
 const LIFECYCLE_EVENT_TYPES = [
@@ -215,5 +216,6 @@ export async function getInboxWelcomeSalesforceLifecycle(
       lastSuccessAt,
       now,
     }),
+    lastSuccessAt,
   };
 }

--- a/apps/web/app/inbox/page.tsx
+++ b/apps/web/app/inbox/page.tsx
@@ -47,6 +47,7 @@ export default async function InboxListPage() {
   return (
     <InboxWelcomeWorkload
       workload={dashboardData.workload}
+      salesforceLifecycle={dashboardData.salesforceLifecycle}
       firstName={firstName}
     />
   );

--- a/apps/web/tests/unit/inbox-home-dashboard.test.ts
+++ b/apps/web/tests/unit/inbox-home-dashboard.test.ts
@@ -105,6 +105,7 @@ describe("getInboxWelcomeSalesforceLifecycle", () => {
     });
 
     expect(result.freshness).toBe("fresh");
+    expect(result.lastSuccessAt?.toISOString()).toBe("2026-05-07T11:50:00.000Z");
     expect(result.tiles).toEqual([
       {
         projectId: "project:alpha",

--- a/apps/web/tests/unit/inbox-welcome-workload-component.test.tsx
+++ b/apps/web/tests/unit/inbox-welcome-workload-component.test.tsx
@@ -24,6 +24,7 @@ function iconMock(name: string) {
 
 vi.mock("../../app/inbox/_components/icons", () => ({
   AlertTriangleIcon: iconMock("AlertTriangleIcon"),
+  ArrowUpRightIcon: iconMock("ArrowUpRightIcon"),
   DatabaseIcon: iconMock("DatabaseIcon"),
   QuoteIcon: iconMock("QuoteIcon"),
   RefreshCwIcon: iconMock("RefreshCwIcon"),

--- a/apps/web/tests/unit/inbox-welcome-workload-component.test.tsx
+++ b/apps/web/tests/unit/inbox-welcome-workload-component.test.tsx
@@ -4,8 +4,9 @@ import React, { act, createElement } from "react";
 Object.assign(globalThis, { React });
 
 import { createRoot, type Root } from "react-dom/client";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { InboxWelcomeSalesforceLifecycleData } from "../../app/inbox/_lib/home-dashboard";
 import type { InboxWelcomeWorkloadViewModel } from "../../app/inbox/_lib/view-models";
 
 const routerPushMock = vi.hoisted(() => vi.fn());
@@ -22,7 +23,8 @@ function iconMock(name: string) {
 }
 
 vi.mock("../../app/inbox/_components/icons", () => ({
-  ArrowUpRightIcon: iconMock("ArrowUpRightIcon"),
+  AlertTriangleIcon: iconMock("AlertTriangleIcon"),
+  DatabaseIcon: iconMock("DatabaseIcon"),
   QuoteIcon: iconMock("QuoteIcon"),
   RefreshCwIcon: iconMock("RefreshCwIcon"),
 }));
@@ -103,7 +105,10 @@ function setDomGlobals(window: Window & typeof globalThis) {
   });
 }
 
-function renderComponent(workload: InboxWelcomeWorkloadViewModel): RenderSession {
+function renderComponent(
+  workload: InboxWelcomeWorkloadViewModel,
+  salesforceLifecycle: InboxWelcomeSalesforceLifecycleData,
+): RenderSession {
   const dom = new JSDOM("<!doctype html><html><body></body></html>", {
     url: "http://localhost/inbox",
   });
@@ -115,7 +120,11 @@ function renderComponent(workload: InboxWelcomeWorkloadViewModel): RenderSession
 
   act(() => {
     root.render(
-      <InboxWelcomeWorkload workload={workload} firstName="Nicolas" />,
+      <InboxWelcomeWorkload
+        workload={workload}
+        salesforceLifecycle={salesforceLifecycle}
+        firstName="Nicolas"
+      />,
     );
   });
 
@@ -181,6 +190,60 @@ function buildWorkload(
   };
 }
 
+function buildSalesforceLifecycle(
+  overrides: Partial<InboxWelcomeSalesforceLifecycleData> = {},
+): InboxWelcomeSalesforceLifecycleData {
+  return {
+    freshness: overrides.freshness ?? "fresh",
+    lastSuccessAt:
+      overrides.lastSuccessAt ?? new Date("2026-05-07T11:55:00.000Z"),
+    tiles: overrides.tiles ?? [
+      {
+        projectId: "project:beta",
+        projectName: "Beta Research",
+        projectTone: "emerald",
+        unreadCount: 0,
+        totals: {
+          signups: 2,
+          trainingCompletions: 1,
+          dataSubmissions: 0,
+        },
+        today: {
+          signups: 1,
+          trainingCompletions: 0,
+          dataSubmissions: 0,
+        },
+        sparkline: {
+          signups: [0, 0, 0, 0, 1, 0, 1],
+          trainingCompletions: [0, 0, 0, 0, 0, 1, 0],
+          dataSubmissions: [0, 0, 0, 0, 0, 0, 0],
+        },
+      },
+      {
+        projectId: "project:alpha",
+        projectName: "Alpha Research",
+        projectTone: "sky",
+        unreadCount: 3,
+        totals: {
+          signups: 4,
+          trainingCompletions: 2,
+          dataSubmissions: 1,
+        },
+        today: {
+          signups: 1,
+          trainingCompletions: 1,
+          dataSubmissions: 0,
+        },
+        sparkline: {
+          signups: [0, 0, 1, 0, 1, 1, 1],
+          trainingCompletions: [0, 0, 0, 0, 0, 1, 1],
+          dataSubmissions: [0, 0, 0, 0, 0, 1, 0],
+        },
+      },
+    ],
+  };
+}
+
 afterEach(() => {
   routerPushMock.mockReset();
 
@@ -190,9 +253,18 @@ afterEach(() => {
   }
 });
 
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-05-07T12:00:00.000Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe("InboxWelcomeWorkload follow-up rail", () => {
   it("renders follow-up rows with conversation aria labels", () => {
-    activeSession = renderComponent(buildWorkload(3));
+    activeSession = renderComponent(buildWorkload(3), buildSalesforceLifecycle());
 
     const buttons = Array.from(
       activeSession.container.querySelectorAll(
@@ -213,7 +285,7 @@ describe("InboxWelcomeWorkload follow-up rail", () => {
   });
 
   it("hides the follow-up rail entirely when the total count is zero", () => {
-    activeSession = renderComponent(buildWorkload(0));
+    activeSession = renderComponent(buildWorkload(0), buildSalesforceLifecycle());
 
     expect(activeSession.container.textContent).not.toContain(
       "These need follow-up",
@@ -222,7 +294,7 @@ describe("InboxWelcomeWorkload follow-up rail", () => {
   });
 
   it("routes View all clicks to the follow-up inbox filter", () => {
-    activeSession = renderComponent(buildWorkload(3));
+    activeSession = renderComponent(buildWorkload(3), buildSalesforceLifecycle());
 
     const viewAllButton = Array.from(
       activeSession.container.querySelectorAll("button"),
@@ -241,5 +313,88 @@ describe("InboxWelcomeWorkload follow-up rail", () => {
     });
 
     expect(routerPushMock).toHaveBeenCalledWith("/inbox?filter=follow-up");
+  });
+});
+
+describe("InboxWelcomeWorkload lifecycle dashboard", () => {
+  it("renders tiles in the order provided by the server assembler", () => {
+    activeSession = renderComponent(buildWorkload(0), buildSalesforceLifecycle());
+
+    const projectButtons = Array.from(
+      activeSession.container.querySelectorAll("button"),
+    ).filter((element) =>
+      ["Beta Research", "Alpha Research"].some((name) =>
+        element.textContent.includes(name),
+      ),
+    );
+
+    expect(projectButtons.map((element) => element.textContent)).toEqual([
+      expect.stringContaining("Beta Research"),
+      expect.stringContaining("Alpha Research"),
+    ]);
+  });
+
+  it("renders the empty state when no active lifecycle tiles are returned", () => {
+    activeSession = renderComponent(
+      buildWorkload(0),
+      buildSalesforceLifecycle({ tiles: [] }),
+    );
+
+    expect(activeSession.container.textContent).toContain(
+      "No active projects yet — activate one in Settings",
+    );
+  });
+
+  it("renders the stale banner only for stale-2h freshness", () => {
+    activeSession = renderComponent(
+      buildWorkload(0),
+      buildSalesforceLifecycle({ freshness: "stale-2h" }),
+    );
+
+    expect(activeSession.container.textContent).toContain(
+      "Salesforce sync delayed — numbers may be stale.",
+    );
+
+    activeSession.cleanup();
+    activeSession = renderComponent(
+      buildWorkload(0),
+      buildSalesforceLifecycle({ freshness: "stale-30m" }),
+    );
+
+    expect(activeSession.container.textContent).not.toContain(
+      "Salesforce sync delayed — numbers may be stale.",
+    );
+  });
+
+  it.each([
+    {
+      freshness: "fresh" as const,
+      lastSuccessAt: new Date("2026-05-07T11:55:00.000Z"),
+      expectedLabel: "Last synced 5 min ago",
+    },
+    {
+      freshness: "stale-30m" as const,
+      lastSuccessAt: new Date("2026-05-07T11:00:00.000Z"),
+      expectedLabel: "Last synced over 30 min ago",
+    },
+    {
+      freshness: "stale-2h" as const,
+      lastSuccessAt: new Date("2026-05-07T09:30:00.000Z"),
+      expectedLabel: "Last synced over 2 hr ago",
+    },
+  ])("updates the freshness label for $freshness", ({
+    freshness,
+    lastSuccessAt,
+    expectedLabel,
+  }) => {
+    activeSession = renderComponent(
+      buildWorkload(0),
+      buildSalesforceLifecycle({
+        freshness,
+        lastSuccessAt,
+      }),
+    );
+
+    expect(activeSession.container.textContent).toContain(expectedLabel);
   });
 });

--- a/apps/web/tests/unit/project-lifecycle-tile.test.tsx
+++ b/apps/web/tests/unit/project-lifecycle-tile.test.tsx
@@ -6,6 +6,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { ProjectLifecycleTile } from "../../app/inbox/_components/project-lifecycle-tile";
 import type { ProjectLifecycleTile as ProjectLifecycleTileData } from "../../app/inbox/_lib/project-lifecycle-metrics";
 
+Object.assign(globalThis, { React });
+
 const workerRequire = createRequire(
   new URL("../../../worker/package.json", import.meta.url),
 );

--- a/apps/web/tests/unit/project-lifecycle-tile.test.tsx
+++ b/apps/web/tests/unit/project-lifecycle-tile.test.tsx
@@ -1,0 +1,216 @@
+import { createRequire } from "node:module";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ProjectLifecycleTile } from "../../app/inbox/_components/project-lifecycle-tile";
+import type { ProjectLifecycleTile as ProjectLifecycleTileData } from "../../app/inbox/_lib/project-lifecycle-metrics";
+
+const workerRequire = createRequire(
+  new URL("../../../worker/package.json", import.meta.url),
+);
+const { JSDOM } = workerRequire("jsdom") as {
+  readonly JSDOM: new (
+    html: string,
+    options: { readonly url: string },
+  ) => {
+    readonly window: Window &
+      typeof globalThis & {
+        close: () => void;
+      };
+  };
+};
+
+interface RenderSession {
+  readonly container: HTMLElement;
+  readonly root: Root;
+  readonly cleanup: () => void;
+}
+
+let activeSession: RenderSession | null = null;
+
+function setDomGlobals(window: Window & typeof globalThis) {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: window,
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: window.document,
+  });
+  Object.defineProperty(globalThis, "HTMLElement", {
+    configurable: true,
+    value: window.HTMLElement,
+  });
+  Object.defineProperty(globalThis, "Node", {
+    configurable: true,
+    value: window.Node,
+  });
+  Object.defineProperty(globalThis, "Event", {
+    configurable: true,
+    value: window.Event,
+  });
+  Object.defineProperty(globalThis, "MouseEvent", {
+    configurable: true,
+    value: window.MouseEvent,
+  });
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: window.navigator,
+  });
+}
+
+function renderComponent(
+  tile: ProjectLifecycleTileData,
+  handlers: {
+    readonly onOpenProject?: (projectId: string) => void;
+    readonly onOpenMetric?: (
+      projectId: string,
+      metricKey: "signups" | "trainingCompletions" | "dataSubmissions",
+    ) => void;
+  } = {},
+): RenderSession {
+  const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+    url: "http://localhost/inbox",
+  });
+  setDomGlobals(dom.window);
+
+  const container = dom.window.document.createElement("div");
+  dom.window.document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <ProjectLifecycleTile
+        tile={tile}
+        onOpenProject={handlers.onOpenProject ?? (() => undefined)}
+        onOpenMetric={handlers.onOpenMetric ?? (() => undefined)}
+      />,
+    );
+  });
+
+  return {
+    container,
+    root,
+    cleanup: () => {
+      act(() => {
+        root.unmount();
+      });
+      dom.window.close();
+    },
+  };
+}
+
+function buildTile(overrides: Partial<ProjectLifecycleTileData> = {}): ProjectLifecycleTileData {
+  return {
+    projectId: overrides.projectId ?? "project:alpha",
+    projectName: overrides.projectName ?? "Alpha Research",
+    projectTone: overrides.projectTone ?? "sky",
+    unreadCount: overrides.unreadCount ?? 4,
+    totals: overrides.totals ?? {
+      signups: 10,
+      trainingCompletions: 6,
+      dataSubmissions: 3,
+    },
+    today: overrides.today ?? {
+      signups: 2,
+      trainingCompletions: 1,
+      dataSubmissions: 0,
+    },
+    sparkline: overrides.sparkline ?? {
+      signups: [0, 1, 2, 1, 2, 2, 2],
+      trainingCompletions: [0, 0, 1, 1, 1, 2, 1],
+      dataSubmissions: [0, 0, 0, 0, 1, 1, 0],
+    },
+  };
+}
+
+afterEach(() => {
+  if (activeSession !== null) {
+    activeSession.cleanup();
+    activeSession = null;
+  }
+});
+
+describe("ProjectLifecycleTile", () => {
+  it("renders project content, metrics, today counters, and three sparklines", () => {
+    activeSession = renderComponent(buildTile());
+
+    expect(activeSession.container.textContent).toContain("Alpha Research");
+    expect(activeSession.container.textContent).toContain("4 unread");
+    expect(activeSession.container.textContent).toContain("10");
+    expect(activeSession.container.textContent).toContain("6");
+    expect(activeSession.container.textContent).toContain("3");
+    expect(activeSession.container.textContent).toContain("+2 today");
+    expect(activeSession.container.textContent).toContain("+1 today");
+    expect(activeSession.container.textContent).toContain("+0 today");
+    expect(activeSession.container.querySelectorAll("svg").length).toBe(3);
+    expect(activeSession.container.textContent).not.toContain("↗");
+  });
+
+  it("opens the project when the header region is clicked", () => {
+    const onOpenProject = vi.fn();
+    activeSession = renderComponent(buildTile(), { onOpenProject });
+
+    const projectButton = Array.from(
+      activeSession.container.querySelectorAll("button"),
+    ).find((element) => element.textContent.includes("Alpha Research"));
+
+    if (projectButton === undefined) {
+      throw new Error("Expected project button");
+    }
+
+    act(() => {
+      projectButton.dispatchEvent(
+        new window.MouseEvent("click", { bubbles: true }),
+      );
+    });
+
+    expect(onOpenProject).toHaveBeenCalledWith("project:alpha");
+  });
+
+  it("opens the correct metric when each metric block is clicked", () => {
+    const onOpenMetric = vi.fn();
+    activeSession = renderComponent(buildTile(), { onOpenMetric });
+
+    const buttons = Array.from(activeSession.container.querySelectorAll("button"));
+    const signupsButton = buttons.find((element) =>
+      element.textContent.includes("Signups"),
+    );
+    const trainingButton = buttons.find((element) =>
+      element.textContent.includes("Training"),
+    );
+    const submissionsButton = buttons.find((element) =>
+      element.textContent.includes("Submissions"),
+    );
+
+    for (const button of [signupsButton, trainingButton, submissionsButton]) {
+      if (button === undefined) {
+        throw new Error("Expected metric button");
+      }
+
+      act(() => {
+        button.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+      });
+    }
+
+    expect(onOpenMetric).toHaveBeenNthCalledWith(1, "project:alpha", "signups");
+    expect(onOpenMetric).toHaveBeenNthCalledWith(
+      2,
+      "project:alpha",
+      "trainingCompletions",
+    );
+    expect(onOpenMetric).toHaveBeenNthCalledWith(
+      3,
+      "project:alpha",
+      "dataSubmissions",
+    );
+  });
+
+  it("renders the zero unread phrase instead of 0 unread", () => {
+    activeSession = renderComponent(buildTile({ unreadCount: 0 }));
+
+    expect(activeSession.container.textContent).toContain("No unread");
+    expect(activeSession.container.textContent).not.toContain("0 unread");
+  });
+});

--- a/apps/web/tests/unit/sparkline-7.test.tsx
+++ b/apps/web/tests/unit/sparkline-7.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { Sparkline7 } from "../../app/inbox/_components/sparkline-7";
+
+describe("Sparkline7", () => {
+  it("renders an svg with 7 bars", () => {
+    const html = renderToStaticMarkup(
+      <Sparkline7
+        values={[1, 3, 2, 4, 3, 5, 6]}
+        tone="sky"
+        metricKey="signups"
+      />,
+    );
+
+    expect(html).toContain("<svg");
+    expect((html.match(/<rect/g) ?? []).length).toBe(7);
+  });
+
+  it("renders 7 baseline bars for an all-zero sparkline", () => {
+    const html = renderToStaticMarkup(
+      <Sparkline7
+        values={[0, 0, 0, 0, 0, 0, 0]}
+        tone="emerald"
+        metricKey="trainingCompletions"
+      />,
+    );
+
+    expect((html.match(/<rect/g) ?? []).length).toBe(7);
+  });
+});

--- a/apps/web/tests/unit/sparkline-7.test.tsx
+++ b/apps/web/tests/unit/sparkline-7.test.tsx
@@ -4,6 +4,8 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import { Sparkline7 } from "../../app/inbox/_components/sparkline-7";
 
+Object.assign(globalThis, { React });
+
 describe("Sparkline7", () => {
   it("renders an svg with 7 bars", () => {
     const html = renderToStaticMarkup(


### PR DESCRIPTION
## Summary
- Replaces \`ProjectMiniDashboard\` in the inbox welcome surface with new lifecycle tiles fed by Brief 1's selector (PRD #293, brief 2 of 3)
- New \`ProjectLifecycleTile\` component (project header → \`/inbox?projectId\`, metric region → \`onOpenMetric\` stub for Brief 3, no top-right arrow)
- New \`Sparkline7\` inline SVG (7 bars, today emphasized, all-zero baseline)
- "Last synced…" label restyled per \`SyncFreshnessState\`; stale-2h adds an amber banner above the dashboard
- Empty state when no active projects
- \`getInboxWelcomeSalesforceLifecycle\` now also returns \`lastSuccessAt\` for prose
- Detail dialog itself ships in Brief 3

## Test plan
- [x] \`pnpm typecheck\` passes (run by Codex)
- [x] \`pnpm lint\` passes (run by Codex)
- [ ] CI \`pnpm test:unit\` green (vitest blocked locally by macOS rollup gotcha)
- [ ] Visual check on welcome surface in dev: tiles render, freshness label states, banner triggers, empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)