### PR TITLE
diag(mailchimp): log raw env var when scheduler short-circuits

### DIFF
--- a/apps/worker/src/orchestration/mailchimp-transition-scheduler.ts
+++ b/apps/worker/src/orchestration/mailchimp-transition-scheduler.ts
@@ -173,7 +173,9 @@ export function createMailchimpTransitionScheduler(
   return {
     async runTick(params) {
       if (!input.config.enabled) {
-        logger.info("[mailchimp.scheduler] disabled");
+        logger.info(
+          `[mailchimp.scheduler] disabled (config.enabled=${String(input.config.enabled)} env.MAILCHIMP_TRANSITION_ENABLED=${JSON.stringify(process.env.MAILCHIMP_TRANSITION_ENABLED ?? null)})`,
+        );
         return;
       }
 

--- a/apps/worker/test/stage1-mailchimp-transition-scheduler.test.ts
+++ b/apps/worker/test/stage1-mailchimp-transition-scheduler.test.ts
@@ -168,7 +168,9 @@ describe("Mailchimp transition scheduler", () => {
 
       expect(addJob).not.toHaveBeenCalled();
       expect(captureTransitionBatch).not.toHaveBeenCalled();
-      expect(logger.info).toHaveBeenCalledWith("[mailchimp.scheduler] disabled");
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringMatching(/^\[mailchimp\.scheduler\] disabled\b/),
+      );
     } finally {
       await context.dispose();
     }


### PR DESCRIPTION
Production worker is reading `config.enabled` as `false` despite `MAILCHIMP_TRANSITION_ENABLED=true` confirmed in Railway dashboard + CLI.

This adds the raw `process.env.MAILCHIMP_TRANSITION_ENABLED` to the existing 'disabled' log line so we can see whether it's the env path (var not reaching the process), or the Zod schema (parsing wrong) that's at fault.

Pure additive log change. Will revert or keep depending on what we learn.