### PR TITLE
feat(home): metric detail dialog + people-list action (PRD #293, brief 3)

### DIFF
--- a/apps/web/app/inbox/_components/inbox-welcome-workload.tsx
+++ b/apps/web/app/inbox/_components/inbox-welcome-workload.tsx
@@ -28,6 +28,7 @@ import {
   QuoteIcon,
   RefreshCwIcon,
 } from "./icons";
+import { ProjectMetricDetailDialog } from "./project-metric-detail-dialog";
 import { ProjectLifecycleTile } from "./project-lifecycle-tile";
 
 interface InboxWelcomeWorkloadProps {
@@ -35,6 +36,12 @@ interface InboxWelcomeWorkloadProps {
   readonly salesforceLifecycle: InboxWelcomeSalesforceLifecycleData;
   readonly firstName: string;
 }
+
+const METRIC_DIALOG_LABELS: Readonly<Record<MetricKey, string>> = {
+  signups: "New Signups",
+  trainingCompletions: "Training Completions",
+  dataSubmissions: "Data Submissions",
+};
 
 function formatDay(date: Date): string {
   return date.toLocaleDateString("en-US", {
@@ -53,9 +60,12 @@ export function InboxWelcomeWorkload({
   const today = new Date();
   const initialQuoteIdx = today.getDate() % FIELD_QUOTES.length;
   const [quoteIdx, setQuoteIdx] = useState(initialQuoteIdx);
-  const [, setPendingMetric] = useState<{
+  const [metricDialog, setMetricDialog] = useState<{
     readonly projectId: string;
+    readonly projectName: string;
     readonly metricKey: MetricKey;
+    readonly metricLabel: string;
+    readonly totalForDescription: number;
   } | null>(null);
   const quote = FIELD_QUOTES[quoteIdx] ?? FIELD_QUOTES[0];
 
@@ -100,7 +110,21 @@ export function InboxWelcomeWorkload({
           salesforceLifecycle={salesforceLifecycle}
           onOpenProject={openProject}
           onOpenMetric={(projectId, metricKey) => {
-            setPendingMetric({ projectId, metricKey });
+            const tile = salesforceLifecycle.tiles.find(
+              (candidate) => candidate.projectId === projectId,
+            );
+
+            if (tile === undefined) {
+              return;
+            }
+
+            setMetricDialog({
+              projectId,
+              projectName: tile.projectName,
+              metricKey,
+              metricLabel: METRIC_DIALOG_LABELS[metricKey],
+              totalForDescription: tile.totals[metricKey],
+            });
           }}
         />
 
@@ -116,6 +140,24 @@ export function InboxWelcomeWorkload({
           />
         ) : null}
       </div>
+
+      <ProjectMetricDetailDialog
+        open={metricDialog !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setMetricDialog(null);
+          }
+        }}
+        onOpenContact={(contactId) => {
+          router.push(`/inbox/${encodeURIComponent(contactId)}`);
+          setMetricDialog(null);
+        }}
+        projectId={metricDialog?.projectId ?? null}
+        projectName={metricDialog?.projectName ?? null}
+        metricKey={metricDialog?.metricKey ?? null}
+        metricLabel={metricDialog?.metricLabel ?? null}
+        totalForDescription={metricDialog?.totalForDescription ?? 0}
+      />
     </section>
   );
 }

--- a/apps/web/app/inbox/_components/project-metric-detail-dialog.tsx
+++ b/apps/web/app/inbox/_components/project-metric-detail-dialog.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+import {
+  loadProjectMetricContacts,
+  type ProjectMetricContactRow,
+  type ProjectMetricKey,
+} from "../actions";
+import { InboxAvatar } from "./inbox-avatar";
+import { XIcon } from "./icons";
+
+interface ProjectMetricDetailDialogProps {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly onOpenContact: (contactId: string) => void;
+  readonly projectId: string | null;
+  readonly projectName: string | null;
+  readonly metricKey: ProjectMetricKey | null;
+  readonly metricLabel: string | null;
+  readonly totalForDescription: number;
+}
+
+type LoadState =
+  | {
+      readonly status: "idle" | "loading";
+      readonly rows: readonly ProjectMetricContactRow[];
+    }
+  | {
+      readonly status: "loaded";
+      readonly rows: readonly ProjectMetricContactRow[];
+    }
+  | {
+      readonly status: "error";
+      readonly rows: readonly ProjectMetricContactRow[];
+    };
+
+function startOfUtcDay(date: Date): number {
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+}
+
+function readDescription(total: number, metricKey: ProjectMetricKey | null): string {
+  const personLabel = total === 1 ? "person" : "people";
+
+  switch (metricKey) {
+    case "signups":
+      return `${total.toString()} ${personLabel} signed up`;
+    case "trainingCompletions":
+      return `${total.toString()} ${personLabel} completed training`;
+    case "dataSubmissions":
+      return `${total.toString()} ${personLabel} started submitting data`;
+    default:
+      return `${total.toString()} ${personLabel}`;
+  }
+}
+
+function toInitials(label: string): string {
+  const parts = label
+    .trim()
+    .split(/\s+/)
+    .filter((part) => part.length > 0)
+    .slice(0, 2);
+
+  if (parts.length === 0) {
+    return "??";
+  }
+
+  return parts.map((part) => part.charAt(0).toUpperCase()).join("");
+}
+
+function readRowTitle(row: ProjectMetricContactRow): string {
+  const name = row.name?.trim() ?? "";
+  if (name.length > 0) {
+    return name;
+  }
+
+  const email = row.email?.trim() ?? "";
+  if (email.length > 0) {
+    return email;
+  }
+
+  return "Unknown contact";
+}
+
+function readRelativeDayLabel(occurredAtIso: string, now: Date): string {
+  const occurredAt = new Date(occurredAtIso);
+  if (Number.isNaN(occurredAt.getTime())) {
+    return "";
+  }
+
+  const diffDays = Math.max(
+    0,
+    Math.floor((startOfUtcDay(now) - startOfUtcDay(occurredAt)) / 86_400_000),
+  );
+  return `${diffDays.toString()}d ago`;
+}
+
+function MetricContactRowSkeleton() {
+  return (
+    <div className="flex items-center gap-3 px-5 py-3">
+      <Skeleton className="size-10 shrink-0 rounded-full" />
+      <div className="min-w-0 flex-1 space-y-2">
+        <Skeleton className="h-4 w-36" />
+        <Skeleton className="h-3 w-48" />
+      </div>
+      <Skeleton className="h-3 w-14 shrink-0" />
+    </div>
+  );
+}
+
+export function ProjectMetricDetailDialog({
+  open,
+  onOpenChange,
+  onOpenContact,
+  projectId,
+  projectName,
+  metricKey,
+  metricLabel,
+  totalForDescription,
+}: ProjectMetricDetailDialogProps) {
+  const [state, setState] = useState<LoadState>({
+    status: "idle",
+    rows: [],
+  });
+  const requestVersionRef = useRef(0);
+
+  useEffect(() => {
+    if (!open || projectId === null || metricKey === null) {
+      requestVersionRef.current += 1;
+      setState({
+        status: "idle",
+        rows: [],
+      });
+      return;
+    }
+
+    const requestVersion = requestVersionRef.current + 1;
+    requestVersionRef.current = requestVersion;
+    setState({
+      status: "loading",
+      rows: [],
+    });
+
+    void loadProjectMetricContacts({
+      projectId,
+      metricKey,
+    })
+      .then((result) => {
+        if (requestVersionRef.current !== requestVersion) {
+          return;
+        }
+
+        setState({
+          status: "loaded",
+          rows: result.rows,
+        });
+      })
+      .catch(() => {
+        if (requestVersionRef.current !== requestVersion) {
+          return;
+        }
+
+        setState({
+          status: "error",
+          rows: [],
+        });
+      });
+  }, [metricKey, open, projectId]);
+
+  const title =
+    projectName !== null && metricLabel !== null
+      ? `${projectName} · ${metricLabel} · last 7 days`
+      : "Last 7 days";
+  const description = readDescription(totalForDescription, metricKey);
+  const now = new Date();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        showCloseButton={false}
+        className="max-w-2xl gap-0 overflow-hidden p-0"
+      >
+        <header className="border-b border-slate-200 px-5 py-4">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <DialogTitle className="truncate text-lg leading-tight">
+                {title}
+              </DialogTitle>
+              <DialogDescription className="mt-1">
+                {description}
+              </DialogDescription>
+            </div>
+            <DialogClose
+              type="button"
+              aria-label="Close metric detail dialog"
+              className="inline-flex size-8 shrink-0 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2"
+            >
+              <XIcon className="size-4" />
+            </DialogClose>
+          </div>
+        </header>
+
+        <div className="max-h-[60vh] overflow-y-auto">
+          {state.status === "loading"
+            ? Array.from({ length: 8 }, (_, index) => (
+                <MetricContactRowSkeleton key={`metric-skeleton-${index.toString()}`} />
+              ))
+            : null}
+
+          {state.status === "error" ? (
+            <p className="px-5 py-4 text-sm text-slate-500">
+              Couldn&apos;t load this list. Try again.
+            </p>
+          ) : null}
+
+          {state.status === "loaded" && state.rows.length === 0 ? (
+            <p className="px-5 py-4 text-sm text-slate-500">
+              No people matched this metric in the last 7 days.
+            </p>
+          ) : null}
+
+          {state.status === "loaded"
+            ? state.rows.map((row) => {
+                const titleText = readRowTitle(row);
+                const showEmailSubtitle =
+                  row.name !== null &&
+                  row.name.trim().length > 0 &&
+                  row.email !== null &&
+                  row.email.trim().length > 0;
+
+                return (
+                  <button
+                    key={row.contactId}
+                    type="button"
+                    onClick={() => {
+                      onOpenContact(row.contactId);
+                      onOpenChange(false);
+                    }}
+                    className="flex w-full items-center gap-3 border-b border-slate-100 px-5 py-3 text-left transition-colors hover:bg-slate-50"
+                  >
+                    <InboxAvatar
+                      initials={toInitials(titleText)}
+                      tone="slate"
+                      size="md"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-semibold text-slate-900">
+                        {titleText}
+                      </p>
+                      {showEmailSubtitle ? (
+                        <p className="truncate text-sm text-slate-500">
+                          {row.email}
+                        </p>
+                      ) : null}
+                    </div>
+                    <span className="shrink-0 text-xs text-slate-400">
+                      {readRelativeDayLabel(row.occurredAt, now)}
+                    </span>
+                  </button>
+                );
+              })
+            : null}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/app/inbox/actions.ts
+++ b/apps/web/app/inbox/actions.ts
@@ -2,6 +2,7 @@
 
 import { createHash, randomUUID } from "node:crypto";
 
+import { sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { composerSendInputSchema } from "@as-comms/contracts";
@@ -41,6 +42,7 @@ import { getStage1WebRuntime } from "@/src/server/stage1-runtime";
 import { appendSecurityAudit } from "@/src/server/security/audit";
 import { enforceRateLimit } from "@/src/server/security/rate-limit";
 
+import type { MetricKey } from "./_lib/project-lifecycle-metrics";
 import type { UiResult } from "../../src/server/ui-result";
 
 const SMS_AI_MAX_TOKENS = 120;
@@ -162,6 +164,16 @@ export type ContactSearchActionResult = UiResult<
 export type AiDraftResponseVm = AiDraftResponse;
 export type DraftWithAiActionResult = UiResult<AiDraftResponseVm>;
 
+export type ProjectMetricKey = MetricKey;
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type ProjectMetricContactRow = {
+  readonly contactId: string;
+  readonly name: string | null;
+  readonly email: string | null;
+  readonly occurredAt: string;
+};
+
 type AiDraftFailureClassification =
   | { readonly kind: "misconfigured" }
   | { readonly kind: "unexpected" };
@@ -170,9 +182,23 @@ interface AiDraftConcurrencyState {
   readonly counts: Map<string, number>;
 }
 
+interface ProjectMetricContactSqlRow {
+  readonly contactId: string;
+  readonly name: string | null;
+  readonly email: string | null;
+  readonly occurredAt: Date | string;
+}
+
 declare global {
   var __AS_COMMS_AI_DRAFT_CONCURRENCY__: AiDraftConcurrencyState | undefined;
 }
+
+const PROJECT_METRIC_EVENT_TYPE: Readonly<Record<ProjectMetricKey, string>> = {
+  signups: "lifecycle.signed_up",
+  trainingCompletions: "lifecycle.completed_training",
+  dataSubmissions: "lifecycle.submitted_first_data",
+};
+const MS_PER_DAY = 24 * 60 * 60 * 1_000;
 
 function describeComposerSendError(error: GmailSendError): string {
   if ("detail" in error) {
@@ -196,6 +222,58 @@ function getAiDraftConcurrencyState(): AiDraftConcurrencyState {
   };
 
   return globalThis.__AS_COMMS_AI_DRAFT_CONCURRENCY__;
+}
+
+function normalizeSqlResultRows(result: unknown): readonly unknown[] {
+  if (
+    typeof result === "object" &&
+    result !== null &&
+    "rows" in result &&
+    Array.isArray(result.rows)
+  ) {
+    return result.rows;
+  }
+
+  return [];
+}
+
+function toValidDate(value: Date | string | null | undefined): Date | null {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function startOfUtcDay(date: Date): Date {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  );
+}
+
+function mapProjectMetricContactRow(
+  row: ProjectMetricContactSqlRow,
+): ProjectMetricContactRow | null {
+  const occurredAt = toValidDate(row.occurredAt);
+
+  if (occurredAt === null) {
+    return null;
+  }
+
+  const name = row.name?.trim() ?? "";
+  const email = row.email?.trim() ?? "";
+
+  return {
+    contactId: row.contactId,
+    name: name.length > 0 ? name : null,
+    email: email.length > 0 ? email : null,
+    occurredAt: occurredAt.toISOString(),
+  };
 }
 
 function maskKnowledgeExample(value: string): string {
@@ -722,6 +800,60 @@ function buildAttachmentMetadata(
     size: Buffer.from(attachment.contentBase64, "base64").length,
     contentType: attachment.contentType,
   }));
+}
+
+export async function loadProjectMetricContacts(input: {
+  readonly projectId: string;
+  readonly metricKey: ProjectMetricKey;
+}): Promise<{ readonly rows: readonly ProjectMetricContactRow[] }> {
+  await requireSession();
+
+  const runtime = await getStage1WebRuntime();
+  const [project] = await runtime.repositories.projectDimensions.listByIds([
+    input.projectId,
+  ]);
+
+  if (project?.isActive !== true || runtime.connection === null) {
+    return { rows: [] };
+  }
+
+  const now = new Date();
+  const todayStart = startOfUtcDay(now);
+  const windowStart = new Date(todayStart.getTime() - 6 * MS_PER_DAY);
+  const windowEndExclusive = new Date(todayStart.getTime() + MS_PER_DAY);
+  const eventType = PROJECT_METRIC_EVENT_TYPE[input.metricKey];
+  const result = await runtime.connection.db.execute(
+    sql<ProjectMetricContactSqlRow>`
+      with deduped_contacts as (
+        select
+          cel.contact_id as "contactId",
+          min(cel.occurred_at) as "occurredAt"
+        from canonical_event_ledger cel
+        inner join contact_memberships cm
+          on cm.contact_id = cel.contact_id
+         and cm.project_id = ${input.projectId}
+        where cel.event_type = ${eventType}
+          and cel.occurred_at >= ${windowStart.toISOString()}
+          and cel.occurred_at < ${windowEndExclusive.toISOString()}
+        group by cel.contact_id
+      )
+      select
+        dc."contactId" as "contactId",
+        c.display_name as "name",
+        c.primary_email as "email",
+        dc."occurredAt" as "occurredAt"
+      from deduped_contacts dc
+      inner join contacts c
+        on c.id = dc."contactId"
+      order by dc."occurredAt" desc, dc."contactId" asc
+    `,
+  );
+
+  return {
+    rows: normalizeSqlResultRows(result)
+      .map((row) => mapProjectMetricContactRow(row as ProjectMetricContactSqlRow))
+      .filter((row): row is ProjectMetricContactRow => row !== null),
+  };
 }
 
 export async function searchContactsAction(

--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -54,10 +54,11 @@ type DialogContentProps = React.HTMLAttributes<HTMLDivElement> & {
   onEscapeKeyDown?: (event: KeyboardEvent) => void
   onPointerDownOutside?: (event: Event) => void
   onInteractOutside?: (event: Event) => void
+  showCloseButton?: boolean
 }
 
 const DialogContent = React.forwardRef<HTMLElement, DialogContentProps>(
-  ({ className, children, ...props }, ref) => (
+  ({ className, children, showCloseButton = true, ...props }, ref) => (
     <DialogPortalPrimitive>
       <DialogOverlay />
       <DialogContentPrimitive
@@ -69,14 +70,16 @@ const DialogContent = React.forwardRef<HTMLElement, DialogContentProps>(
         {...props}
       >
         {children}
-        <DialogClosePrimitive
-          className={cn(
-            "absolute right-4 top-4 rounded-sm opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 disabled:pointer-events-none"
-          )}
-        >
-          <X className="size-4" />
-          <span className="sr-only">Close</span>
-        </DialogClosePrimitive>
+        {showCloseButton ? (
+          <DialogClosePrimitive
+            className={cn(
+              "absolute right-4 top-4 rounded-sm opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 disabled:pointer-events-none"
+            )}
+          >
+            <X className="size-4" />
+            <span className="sr-only">Close</span>
+          </DialogClosePrimitive>
+        ) : null}
       </DialogContentPrimitive>
     </DialogPortalPrimitive>
   )

--- a/apps/web/tests/unit/inbox-welcome-workload-component.test.tsx
+++ b/apps/web/tests/unit/inbox-welcome-workload-component.test.tsx
@@ -30,6 +30,10 @@ vi.mock("../../app/inbox/_components/icons", () => ({
   RefreshCwIcon: iconMock("RefreshCwIcon"),
 }));
 
+vi.mock("../../app/inbox/_components/project-metric-detail-dialog", () => ({
+  ProjectMetricDetailDialog: () => null,
+}));
+
 vi.mock("../../app/inbox/_components/inbox-avatar", () => ({
   InboxAvatar: ({
     initials,

--- a/apps/web/tests/unit/inbox-welcome-workload-metric-dialog.test.tsx
+++ b/apps/web/tests/unit/inbox-welcome-workload-metric-dialog.test.tsx
@@ -1,0 +1,337 @@
+import { createRequire } from "node:module";
+import React, { act } from "react";
+
+Object.assign(globalThis, { React });
+
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { InboxWelcomeSalesforceLifecycleData } from "../../app/inbox/_lib/home-dashboard";
+import type { InboxWelcomeWorkloadViewModel } from "../../app/inbox/_lib/view-models";
+
+const routerPushMock = vi.hoisted(() => vi.fn());
+const projectMetricDetailDialogMock = vi.hoisted(() => vi.fn());
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: routerPushMock,
+  }),
+}));
+
+function iconMock(name: string) {
+  return (props: Record<string, unknown>) => {
+    return React.createElement("svg", { "data-icon": name, ...props });
+  };
+}
+
+vi.mock("../../app/inbox/_components/icons", () => ({
+  AlertTriangleIcon: iconMock("AlertTriangleIcon"),
+  ArrowUpRightIcon: iconMock("ArrowUpRightIcon"),
+  DatabaseIcon: iconMock("DatabaseIcon"),
+  QuoteIcon: iconMock("QuoteIcon"),
+  RefreshCwIcon: iconMock("RefreshCwIcon"),
+}));
+
+vi.mock("../../app/inbox/_components/inbox-avatar", () => ({
+  InboxAvatar: ({
+    initials,
+  }: {
+    readonly initials: string;
+  }) => {
+    return <span>{initials}</span>;
+  },
+}));
+
+vi.mock("../../app/inbox/_components/project-metric-detail-dialog", () => ({
+  ProjectMetricDetailDialog: (
+    props: {
+      readonly open: boolean;
+      readonly onOpenChange: (open: boolean) => void;
+      readonly onOpenContact: (contactId: string) => void;
+      readonly projectName: string | null;
+      readonly metricLabel: string | null;
+    },
+  ) => {
+    projectMetricDetailDialogMock(props);
+
+    if (!props.open) {
+      return null;
+    }
+
+    return (
+      <div data-metric-dialog="true">
+        <p>{props.projectName}</p>
+        <p>{props.metricLabel}</p>
+        <button
+          type="button"
+          onClick={() => {
+            props.onOpenChange(false);
+          }}
+        >
+          Close dialog
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            props.onOpenContact("contact:alpha");
+          }}
+        >
+          Open Alpha contact
+        </button>
+      </div>
+    );
+  },
+}));
+
+import { InboxWelcomeWorkload } from "../../app/inbox/_components/inbox-welcome-workload";
+
+const workerRequire = createRequire(
+  new URL("../../../worker/package.json", import.meta.url),
+);
+const { JSDOM } = workerRequire("jsdom") as {
+  readonly JSDOM: new (
+    html: string,
+    options: { readonly url: string },
+  ) => {
+    readonly window: Window &
+      typeof globalThis & {
+        close: () => void;
+      };
+  };
+};
+
+interface RenderSession {
+  readonly container: HTMLElement;
+  readonly root: Root;
+  readonly cleanup: () => void;
+}
+
+let activeSession: RenderSession | null = null;
+
+function setDomGlobals(window: Window & typeof globalThis) {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: window,
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: window.document,
+  });
+  Object.defineProperty(globalThis, "HTMLElement", {
+    configurable: true,
+    value: window.HTMLElement,
+  });
+  Object.defineProperty(globalThis, "Node", {
+    configurable: true,
+    value: window.Node,
+  });
+  Object.defineProperty(globalThis, "Event", {
+    configurable: true,
+    value: window.Event,
+  });
+  Object.defineProperty(globalThis, "MouseEvent", {
+    configurable: true,
+    value: window.MouseEvent,
+  });
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: window.navigator,
+  });
+  Object.defineProperty(globalThis, "requestAnimationFrame", {
+    configurable: true,
+    value: (callback: FrameRequestCallback) => {
+      return window.setTimeout(callback, 16);
+    },
+  });
+  Object.defineProperty(globalThis, "cancelAnimationFrame", {
+    configurable: true,
+    value: (id: number) => {
+      window.clearTimeout(id);
+    },
+  });
+}
+
+function buildWorkload(): InboxWelcomeWorkloadViewModel {
+  return {
+    projects: [],
+    totals: {
+      activeProjects: 0,
+      unread: 0,
+      needsFollowUp: 0,
+    },
+    followUpRail: {
+      totalCount: 0,
+      entries: [],
+    },
+  };
+}
+
+function buildSalesforceLifecycle(): InboxWelcomeSalesforceLifecycleData {
+  return {
+    freshness: "fresh",
+    lastSuccessAt: new Date("2026-05-07T11:55:00.000Z"),
+    tiles: [
+      {
+        projectId: "project:alpha",
+        projectName: "Alpha Research",
+        projectTone: "sky",
+        unreadCount: 3,
+        totals: {
+          signups: 4,
+          trainingCompletions: 2,
+          dataSubmissions: 1,
+        },
+        today: {
+          signups: 1,
+          trainingCompletions: 1,
+          dataSubmissions: 0,
+        },
+        sparkline: {
+          signups: [0, 0, 1, 0, 1, 1, 1],
+          trainingCompletions: [0, 0, 0, 0, 0, 1, 1],
+          dataSubmissions: [0, 0, 0, 0, 0, 1, 0],
+        },
+      },
+    ],
+  };
+}
+
+function renderComponent(): RenderSession {
+  const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+    url: "http://localhost/inbox",
+  });
+  setDomGlobals(dom.window);
+
+  const container = dom.window.document.createElement("div");
+  dom.window.document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <InboxWelcomeWorkload
+        workload={buildWorkload()}
+        salesforceLifecycle={buildSalesforceLifecycle()}
+        firstName="Nicolas"
+      />,
+    );
+  });
+
+  return {
+    container,
+    root,
+    cleanup: () => {
+      act(() => {
+        root.unmount();
+      });
+      dom.window.close();
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-05-07T12:00:00.000Z"));
+  routerPushMock.mockReset();
+  projectMetricDetailDialogMock.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+
+  if (activeSession !== null) {
+    activeSession.cleanup();
+    activeSession = null;
+  }
+});
+
+describe("InboxWelcomeWorkload metric dialog wiring", () => {
+  it("opens the dialog with the right project name and metric label from a tile click", () => {
+    activeSession = renderComponent();
+
+    const signupsButton = Array.from(
+      activeSession.container.querySelectorAll("button"),
+    ).find((element) => element.textContent.includes("Signups"));
+
+    if (signupsButton === undefined) {
+      throw new Error("Expected signups metric button");
+    }
+
+    act(() => {
+      signupsButton.dispatchEvent(
+        new window.MouseEvent("click", { bubbles: true }),
+      );
+    });
+
+    expect(activeSession.container.textContent).toContain("Alpha Research");
+    expect(activeSession.container.textContent).toContain("New Signups");
+  });
+
+  it("clears metricDialog state when the dialog closes", () => {
+    activeSession = renderComponent();
+
+    const trainingButton = Array.from(
+      activeSession.container.querySelectorAll("button"),
+    ).find((element) => element.textContent.includes("Training"));
+
+    if (trainingButton === undefined) {
+      throw new Error("Expected training metric button");
+    }
+
+    act(() => {
+      trainingButton.dispatchEvent(
+        new window.MouseEvent("click", { bubbles: true }),
+      );
+    });
+
+    const closeButton = Array.from(
+      activeSession.container.querySelectorAll("button"),
+    ).find((element) => element.textContent === "Close dialog");
+
+    if (closeButton === undefined) {
+      throw new Error("Expected dialog close button");
+    }
+
+    act(() => {
+      closeButton.dispatchEvent(
+        new window.MouseEvent("click", { bubbles: true }),
+      );
+    });
+
+    expect(activeSession.container.querySelector("[data-metric-dialog]")).toBeNull();
+  });
+
+  it("navigates to the inbox detail route when the dialog opens a contact", () => {
+    activeSession = renderComponent();
+
+    const submissionsButton = Array.from(
+      activeSession.container.querySelectorAll("button"),
+    ).find((element) => element.textContent.includes("Submissions"));
+
+    if (submissionsButton === undefined) {
+      throw new Error("Expected submissions metric button");
+    }
+
+    act(() => {
+      submissionsButton.dispatchEvent(
+        new window.MouseEvent("click", { bubbles: true }),
+      );
+    });
+
+    const openContactButton = Array.from(
+      activeSession.container.querySelectorAll("button"),
+    ).find((element) => element.textContent === "Open Alpha contact");
+
+    if (openContactButton === undefined) {
+      throw new Error("Expected dialog contact button");
+    }
+
+    act(() => {
+      openContactButton.dispatchEvent(
+        new window.MouseEvent("click", { bubbles: true }),
+      );
+    });
+
+    expect(routerPushMock).toHaveBeenCalledWith("/inbox/contact%3Aalpha");
+    expect(activeSession.container.querySelector("[data-metric-dialog]")).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/project-metric-contacts-action.test.ts
+++ b/apps/web/tests/unit/project-metric-contacts-action.test.ts
@@ -1,0 +1,279 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireSession = vi.hoisted(() => vi.fn());
+const getCurrentUser = vi.hoisted(() => vi.fn().mockResolvedValue(null));
+
+vi.mock("next/cache", () => ({
+  unstable_cache: (loader: () => unknown) => loader,
+}));
+
+vi.mock("@/src/server/auth/session", () => ({
+  requireSession,
+  getCurrentUser,
+}));
+
+import { loadProjectMetricContacts } from "../../app/inbox/actions";
+import {
+  createInboxTestRuntime,
+  seedInboxContact,
+  seedInboxLifecycleEvent,
+  type InboxTestRuntime,
+} from "./inbox-stage1-helpers";
+
+function buildCurrentUser() {
+  const now = new Date("2026-05-07T12:00:00.000Z");
+  return {
+    id: "user:nico",
+    name: "Nico",
+    email: "nico@adventurescientists.org",
+    emailVerified: now,
+    image: null,
+    role: "operator" as const,
+    deactivatedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+describe("loadProjectMetricContacts", () => {
+  let runtime: InboxTestRuntime | null = null;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-07T12:00:00.000Z"));
+    requireSession.mockReset();
+    requireSession.mockResolvedValue(buildCurrentUser());
+    runtime = await createInboxTestRuntime();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await runtime?.dispose();
+    runtime = null;
+  });
+
+  it("returns deduped rows newest-first within the last 7 UTC calendar days", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:alpha",
+      salesforceContactId: "003-alpha",
+      displayName: "Alpha Person",
+      primaryEmail: "alpha@example.org",
+      primaryPhone: null,
+      projectId: "project:alpha",
+      projectName: "Alpha Research",
+      projectAlias: "Alpha",
+      membershipId: "membership:alpha",
+      membershipStatus: "active",
+    });
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:bravo",
+      salesforceContactId: "003-bravo",
+      displayName: "Bravo Person",
+      primaryEmail: "bravo@example.org",
+      primaryPhone: null,
+      projectId: "project:alpha",
+      projectName: "Alpha Research",
+      projectAlias: "Alpha",
+      membershipId: "membership:bravo",
+      membershipStatus: "active",
+    });
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:charlie",
+      salesforceContactId: "003-charlie",
+      displayName: "Charlie Person",
+      primaryEmail: "charlie@example.org",
+      primaryPhone: null,
+      projectId: "project:beta",
+      projectName: "Beta Research",
+      projectAlias: "Beta",
+      membershipId: "membership:charlie",
+      membershipStatus: "active",
+    });
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:delta",
+      salesforceContactId: "003-delta",
+      displayName: "Delta Person",
+      primaryEmail: "delta@example.org",
+      primaryPhone: null,
+      projectId: "project:alpha",
+      projectName: "Alpha Research",
+      projectAlias: "Alpha",
+      membershipId: "membership:delta",
+      membershipStatus: "active",
+    });
+
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "alpha-signup-earliest",
+      contactId: "contact:alpha",
+      occurredAt: "2026-05-03T08:00:00.000Z",
+      eventType: "lifecycle.signed_up",
+      summary: "Signed up",
+      projectId: "project:alpha",
+    });
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "alpha-signup-reemit",
+      contactId: "contact:alpha",
+      occurredAt: "2026-05-06T09:00:00.000Z",
+      eventType: "lifecycle.signed_up",
+      summary: "Signed up again",
+      projectId: "project:alpha",
+    });
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "bravo-signup",
+      contactId: "contact:bravo",
+      occurredAt: "2026-05-05T11:00:00.000Z",
+      eventType: "lifecycle.signed_up",
+      summary: "Signed up",
+      projectId: "project:alpha",
+    });
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "charlie-signup",
+      contactId: "contact:charlie",
+      occurredAt: "2026-05-07T09:30:00.000Z",
+      eventType: "lifecycle.signed_up",
+      summary: "Signed up",
+      projectId: "project:beta",
+    });
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "delta-outside-window",
+      contactId: "contact:delta",
+      occurredAt: "2026-04-30T23:59:59.000Z",
+      eventType: "lifecycle.signed_up",
+      summary: "Signed up",
+      projectId: "project:alpha",
+    });
+
+    const result = await loadProjectMetricContacts({
+      projectId: "project:alpha",
+      metricKey: "signups",
+    });
+
+    expect(result).toEqual({
+      rows: [
+        {
+          contactId: "contact:bravo",
+          name: "Bravo Person",
+          email: "bravo@example.org",
+          occurredAt: "2026-05-05T11:00:00.000Z",
+        },
+        {
+          contactId: "contact:alpha",
+          name: "Alpha Person",
+          email: "alpha@example.org",
+          occurredAt: "2026-05-03T08:00:00.000Z",
+        },
+      ],
+    });
+  });
+
+  it.each([
+    {
+      metricKey: "signups" as const,
+      includedEventType: "lifecycle.signed_up" as const,
+      excludedEventType: "lifecycle.completed_training" as const,
+    },
+    {
+      metricKey: "trainingCompletions" as const,
+      includedEventType: "lifecycle.completed_training" as const,
+      excludedEventType: "lifecycle.submitted_first_data" as const,
+    },
+    {
+      metricKey: "dataSubmissions" as const,
+      includedEventType: "lifecycle.submitted_first_data" as const,
+      excludedEventType: "lifecycle.signed_up" as const,
+    },
+  ])("maps $metricKey to the correct canonical event type", async ({
+    metricKey,
+    includedEventType,
+    excludedEventType,
+  }) => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: `contact:${metricKey}`,
+      salesforceContactId: `003:${metricKey}`,
+      displayName: `Contact ${metricKey}`,
+      primaryEmail: `${metricKey}@example.org`,
+      primaryPhone: null,
+      projectId: "project:alpha",
+      projectName: "Alpha Research",
+      projectAlias: "Alpha",
+      membershipId: `membership:${metricKey}`,
+      membershipStatus: "active",
+    });
+
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: `${metricKey}:included`,
+      contactId: `contact:${metricKey}`,
+      occurredAt: "2026-05-07T10:00:00.000Z",
+      eventType: includedEventType,
+      summary: "Included event",
+      projectId: "project:alpha",
+    });
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: `${metricKey}:excluded`,
+      contactId: `contact:${metricKey}`,
+      occurredAt: "2026-05-07T11:00:00.000Z",
+      eventType: excludedEventType,
+      summary: "Excluded event",
+      projectId: "project:alpha",
+    });
+
+    const result = await loadProjectMetricContacts({
+      projectId: "project:alpha",
+      metricKey,
+    });
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]?.contactId).toBe(`contact:${metricKey}`);
+    expect(result.rows[0]?.occurredAt).toBe("2026-05-07T10:00:00.000Z");
+  });
+
+  it("returns an empty list for missing, inactive, or membershipless projects", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await runtime.context.repositories.projectDimensions.upsert({
+      projectId: "project:inactive",
+      projectName: "Inactive Project",
+      projectAlias: "Inactive",
+      source: "salesforce",
+      isActive: false,
+    });
+    await runtime.context.repositories.projectDimensions.upsert({
+      projectId: "project:empty",
+      projectName: "Empty Project",
+      projectAlias: "Empty",
+      source: "salesforce",
+      isActive: true,
+    });
+
+    expect(
+      await loadProjectMetricContacts({
+        projectId: "project:missing",
+        metricKey: "signups",
+      }),
+    ).toEqual({ rows: [] });
+
+    expect(
+      await loadProjectMetricContacts({
+        projectId: "project:inactive",
+        metricKey: "signups",
+      }),
+    ).toEqual({ rows: [] });
+
+    expect(
+      await loadProjectMetricContacts({
+        projectId: "project:empty",
+        metricKey: "signups",
+      }),
+    ).toEqual({ rows: [] });
+  });
+});

--- a/apps/web/tests/unit/project-metric-detail-dialog.test.tsx
+++ b/apps/web/tests/unit/project-metric-detail-dialog.test.tsx
@@ -174,7 +174,9 @@ function renderDialog(
     });
   };
 
-  void renderCurrent();
+  act(() => {
+    root.render(<ProjectMetricDetailDialog {...props} />);
+  });
 
   return {
     container,

--- a/apps/web/tests/unit/project-metric-detail-dialog.test.tsx
+++ b/apps/web/tests/unit/project-metric-detail-dialog.test.tsx
@@ -1,0 +1,405 @@
+import { createRequire } from "node:module";
+import React, { act } from "react";
+
+Object.assign(globalThis, { React });
+
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadProjectMetricContacts = vi.hoisted(() => vi.fn());
+
+vi.mock("../../app/inbox/actions", () => ({
+  loadProjectMetricContacts,
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({
+    children,
+    open,
+  }: {
+    readonly children: React.ReactNode;
+    readonly open: boolean;
+  }) => (open ? <div data-dialog-root="true">{children}</div> : null),
+  DialogContent: ({
+    children,
+    className,
+  }: {
+    readonly children: React.ReactNode;
+    readonly className?: string;
+  }) => (
+    <div className={className} role="dialog">
+      {children}
+    </div>
+  ),
+  DialogTitle: ({
+    children,
+    className,
+  }: {
+    readonly children: React.ReactNode;
+    readonly className?: string;
+  }) => <h2 className={className}>{children}</h2>,
+  DialogDescription: ({
+    children,
+    className,
+  }: {
+    readonly children: React.ReactNode;
+    readonly className?: string;
+  }) => <p className={className}>{children}</p>,
+  DialogClose: ({
+    children,
+    className,
+    onClick,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button className={className} onClick={onClick} type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("../../app/inbox/_components/inbox-avatar", () => ({
+  InboxAvatar: ({
+    initials,
+  }: {
+    readonly initials: string;
+  }) => <span data-avatar-initials={initials}>{initials}</span>,
+}));
+
+vi.mock("../../app/inbox/_components/icons", () => ({
+  XIcon: (props: Record<string, unknown>) => <svg data-icon="x" {...props} />,
+}));
+
+import { ProjectMetricDetailDialog } from "../../app/inbox/_components/project-metric-detail-dialog";
+
+const workerRequire = createRequire(
+  new URL("../../../worker/package.json", import.meta.url),
+);
+const { JSDOM } = workerRequire("jsdom") as {
+  readonly JSDOM: new (
+    html: string,
+    options: { readonly url: string },
+  ) => {
+    readonly window: Window &
+      typeof globalThis & {
+        close: () => void;
+      };
+  };
+};
+
+interface RenderSession {
+  readonly container: HTMLElement;
+  readonly root: Root;
+  readonly cleanup: () => void;
+  readonly rerender: (
+    overrides?: Partial<React.ComponentProps<typeof ProjectMetricDetailDialog>>,
+  ) => Promise<void>;
+}
+
+let activeSession: RenderSession | null = null;
+
+function setDomGlobals(window: Window & typeof globalThis) {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: window,
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: window.document,
+  });
+  Object.defineProperty(globalThis, "HTMLElement", {
+    configurable: true,
+    value: window.HTMLElement,
+  });
+  Object.defineProperty(globalThis, "Node", {
+    configurable: true,
+    value: window.Node,
+  });
+  Object.defineProperty(globalThis, "Event", {
+    configurable: true,
+    value: window.Event,
+  });
+  Object.defineProperty(globalThis, "MouseEvent", {
+    configurable: true,
+    value: window.MouseEvent,
+  });
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: window.navigator,
+  });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+function buildProps(
+  overrides: Partial<React.ComponentProps<typeof ProjectMetricDetailDialog>> = {},
+): React.ComponentProps<typeof ProjectMetricDetailDialog> {
+  return {
+    open: overrides.open ?? true,
+    onOpenChange: overrides.onOpenChange ?? vi.fn(),
+    onOpenContact: overrides.onOpenContact ?? vi.fn(),
+    projectId: overrides.projectId ?? "project:alpha",
+    projectName: overrides.projectName ?? "Alpha Research",
+    metricKey: overrides.metricKey ?? "signups",
+    metricLabel: overrides.metricLabel ?? "New Signups",
+    totalForDescription: overrides.totalForDescription ?? 23,
+  };
+}
+
+function renderDialog(
+  overrides: Partial<React.ComponentProps<typeof ProjectMetricDetailDialog>> = {},
+): RenderSession {
+  const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+    url: "http://localhost/inbox",
+  });
+  setDomGlobals(dom.window);
+
+  const container = dom.window.document.createElement("div");
+  dom.window.document.body.appendChild(container);
+  const root = createRoot(container);
+  let props = buildProps(overrides);
+
+  const renderCurrent = async () => {
+    await act(async () => {
+      root.render(<ProjectMetricDetailDialog {...props} />);
+      await Promise.resolve();
+    });
+  };
+
+  void renderCurrent();
+
+  return {
+    container,
+    root,
+    cleanup: () => {
+      act(() => {
+        root.unmount();
+      });
+      dom.window.close();
+    },
+    rerender: async (nextOverrides = {}) => {
+      props = buildProps({
+        ...props,
+        ...nextOverrides,
+      });
+      await renderCurrent();
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-05-07T12:00:00.000Z"));
+  loadProjectMetricContacts.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+
+  if (activeSession !== null) {
+    activeSession.cleanup();
+    activeSession = null;
+  }
+});
+
+describe("ProjectMetricDetailDialog", () => {
+  it("does not render dialog content when closed", async () => {
+    activeSession = renderDialog({ open: false, projectId: null, metricKey: null });
+    await activeSession.rerender();
+
+    expect(activeSession.container.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it("renders the dialog header title when opened", async () => {
+    loadProjectMetricContacts.mockResolvedValue({ rows: [] });
+    activeSession = renderDialog();
+    await activeSession.rerender();
+
+    expect(activeSession.container.textContent).toContain(
+      "Alpha Research · New Signups · last 7 days",
+    );
+    expect(activeSession.container.textContent).toContain("23 people signed up");
+  });
+
+  it("shows loading skeletons before rows replace them", async () => {
+    const pending = deferred<{
+      readonly rows: readonly [
+        {
+          readonly contactId: string;
+          readonly name: string | null;
+          readonly email: string | null;
+          readonly occurredAt: string;
+        },
+      ];
+    }>();
+    loadProjectMetricContacts.mockReturnValue(pending.promise);
+    activeSession = renderDialog();
+    await activeSession.rerender();
+
+    expect(activeSession.container.querySelectorAll(".animate-pulse")).toHaveLength(24);
+
+    pending.resolve({
+      rows: [
+        {
+          contactId: "contact:alpha",
+          name: "Alpha Person",
+          email: "alpha@example.org",
+          occurredAt: "2026-05-07T09:00:00.000Z",
+        },
+      ],
+    });
+
+    await act(async () => {
+      await pending.promise;
+      await Promise.resolve();
+    });
+
+    expect(activeSession.container.querySelectorAll(".animate-pulse")).toHaveLength(0);
+    expect(activeSession.container.textContent).toContain("Alpha Person");
+  });
+
+  it("falls back from name to email to unknown contact", async () => {
+    loadProjectMetricContacts.mockResolvedValue({
+      rows: [
+        {
+          contactId: "contact:email-only",
+          name: null,
+          email: "x@y.org",
+          occurredAt: "2026-05-06T08:00:00.000Z",
+        },
+        {
+          contactId: "contact:unknown",
+          name: null,
+          email: null,
+          occurredAt: "2026-05-05T08:00:00.000Z",
+        },
+      ],
+    });
+    activeSession = renderDialog();
+    await activeSession.rerender();
+
+    expect(activeSession.container.textContent).toContain("x@y.org");
+    expect(activeSession.container.textContent).toContain("Unknown contact");
+  });
+
+  it("calls onOpenContact and closes when a row is clicked", async () => {
+    const onOpenContact = vi.fn();
+    const onOpenChange = vi.fn();
+    loadProjectMetricContacts.mockResolvedValue({
+      rows: [
+        {
+          contactId: "contact:alpha",
+          name: "Alpha Person",
+          email: "alpha@example.org",
+          occurredAt: "2026-05-07T09:00:00.000Z",
+        },
+      ],
+    });
+    activeSession = renderDialog({
+      onOpenContact,
+      onOpenChange,
+    });
+    await activeSession.rerender();
+
+    const rowButton = Array.from(
+      activeSession.container.querySelectorAll("button"),
+    ).find((element) => element.textContent.includes("Alpha Person"));
+
+    if (rowButton === undefined) {
+      throw new Error("Expected metric contact row button");
+    }
+
+    act(() => {
+      rowButton.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onOpenContact).toHaveBeenCalledWith("contact:alpha");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("ignores stale responses when a newer open request replaces them", async () => {
+    const first = deferred<{
+      readonly rows: readonly [
+        {
+          readonly contactId: string;
+          readonly name: string | null;
+          readonly email: string | null;
+          readonly occurredAt: string;
+        },
+      ];
+    }>();
+    const second = deferred<{
+      readonly rows: readonly [
+        {
+          readonly contactId: string;
+          readonly name: string | null;
+          readonly email: string | null;
+          readonly occurredAt: string;
+        },
+      ];
+    }>();
+
+    loadProjectMetricContacts
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+
+    activeSession = renderDialog({
+      projectId: "project:alpha",
+      metricKey: "signups",
+      metricLabel: "New Signups",
+    });
+    await activeSession.rerender();
+
+    await activeSession.rerender({
+      projectId: "project:beta",
+      projectName: "Beta Research",
+      metricKey: "trainingCompletions",
+      metricLabel: "Training Completions",
+    });
+
+    first.resolve({
+      rows: [
+        {
+          contactId: "contact:stale",
+          name: "Stale Person",
+          email: "stale@example.org",
+          occurredAt: "2026-05-06T09:00:00.000Z",
+        },
+      ],
+    });
+
+    await act(async () => {
+      await first.promise;
+      await Promise.resolve();
+    });
+
+    expect(activeSession.container.textContent).not.toContain("Stale Person");
+
+    second.resolve({
+      rows: [
+        {
+          contactId: "contact:fresh",
+          name: "Fresh Person",
+          email: "fresh@example.org",
+          occurredAt: "2026-05-07T09:30:00.000Z",
+        },
+      ],
+    });
+
+    await act(async () => {
+      await second.promise;
+      await Promise.resolve();
+    });
+
+    expect(activeSession.container.textContent).not.toContain("Stale Person");
+    expect(activeSession.container.textContent).toContain("Fresh Person");
+  });
+});

--- a/apps/web/tests/unit/project-metric-detail-dialog.test.tsx
+++ b/apps/web/tests/unit/project-metric-detail-dialog.test.tsx
@@ -246,7 +246,7 @@ describe("ProjectMetricDetailDialog", () => {
     activeSession = renderDialog();
     await activeSession.rerender();
 
-    expect(activeSession.container.querySelectorAll(".animate-pulse")).toHaveLength(24);
+    expect(activeSession.container.querySelectorAll(".animate-pulse")).toHaveLength(32);
 
     pending.resolve({
       rows: [


### PR DESCRIPTION
## Summary
- Final piece of the home dashboard (PRD #293, brief 3 of 3): clicking a metric on a project tile opens a centered Dialog listing the people behind that number
- New \`loadProjectMetricContacts\` server action in \`apps/web/app/inbox/actions.ts\` — newest-first, distinct contact, last 7 UTC calendar days, scoped to project membership
- New \`ProjectMetricDetailDialog\` component using the existing Radix Dialog primitive at \`max-w-2xl\`, ComposerPaneChrome-style header
- Welcome workload wires \`pendingMetric\` state → dialog → \`/inbox/<contactId>\` navigation
- Skeleton loading rows, name → email → "Unknown contact" fallback, stale-response guard
- Small opt-in tweak to the Dialog primitive so this dialog can render its own header close button without duplicating the default one

## Test plan
- [x] \`pnpm typecheck\` passes (run by Codex)
- [x] \`pnpm lint\` passes (run by Codex)
- [ ] CI \`pnpm test:unit\` green (vitest blocked locally by macOS rollup gotcha)
- [ ] Visual check: open dashboard → click each metric → dialog opens with right title, list, fallbacks; click row → navigates and closes; rapidly open two different metrics → no stale-response leak

🤖 Generated with [Claude Code](https://claude.com/claude-code)