### PR TITLE
fix(worker): parseBooleanEnv must pass booleans through unchanged

### DIFF
--- a/apps/worker/src/runtime.ts
+++ b/apps/worker/src/runtime.ts
@@ -54,6 +54,16 @@ const defaultSyncStateLeaseThresholdMs = 5 * 60 * 1000;
 const mailchimpTransitionDiscoverySeedLookbackDays = 35;
 
 function parseBooleanEnv(value: unknown): boolean {
+  // Pass booleans through unchanged. The schema this preprocess feeds is
+  // composed inside an outer schema (workerConfigSchema), so when the outer
+  // schema re-parses an already-parsed inner value, the preprocess fires a
+  // second time on a boolean — which would otherwise fall through to the
+  // non-string branch and incorrectly return false. Observed 2026-05-04 in
+  // production after MAILCHIMP_TRANSITION_ENABLED=true was set.
+  if (typeof value === "boolean") {
+    return value;
+  }
+
   if (typeof value !== "string") {
     return false;
   }


### PR DESCRIPTION
## Root cause

\`workerMailchimpTransitionConfigSchema\` uses \`z.preprocess(parseBooleanEnv, z.boolean()).default(false)\`. This schema is parsed twice:
1. Explicitly in \`readMailchimpTransitionConfig\` to convert the env-string \`"true"\` → boolean \`true\`
2. Implicitly when the outer \`workerConfigSchema\` parses its composed \`mailchimpTransition\` field

The second parse re-runs \`parseBooleanEnv\` on the already-converted boolean. The function returned \`false\` for non-string inputs, so it flipped the boolean \`true\` to \`false\`.

## Production observation

Today (2026-05-04), \`MAILCHIMP_TRANSITION_ENABLED=true\` was set on the Railway worker. Diagnostic logs confirmed:
- \`env.MAILCHIMP_TRANSITION_ENABLED="true"\` reaching the worker process ✅
- \`readMailchimpTransitionConfig\` returns \`parsed.enabled=true\` at first parse ✅
- But the scheduler reads \`config.enabled=false\` at runtime ❌

The double-parse was the culprit.

## Fix

\`parseBooleanEnv\` short-circuits booleans through unchanged before the type-string check. Comment explains the trap.

## Validation

- \`pnpm --filter @as-comms/worker typecheck\` ✅
- \`pnpm --filter @as-comms/worker lint\` ✅
- Existing scheduler tests still pass (PR #297's relaxed log-match still matches the log line whether or not enabled was true)

## Test plan

- [ ] CI green
- [ ] After merge: worker auto-deploys; manually enqueue \`poll-mailchimp-transition-scheduler\` job; logs show \`event="mailchimp.scheduler.tick.started"\` then discovery → refresh → completed events instead of \`disabled\`
- [ ] Confirm canonical events for recent Mailchimp campaigns land in volunteer timelines

## Diagnostic logs

PR #297 (\`[mailchimp.scheduler] disabled (config.enabled=... env.MAILCHIMP_TRANSITION_ENABLED=...)\`) and PR #299 (\`[mailchimp.config.diag] rawEnabled=... parseBooleanEnv=... parsed.enabled=...\`) added focused diagnostics that pinpointed this. Both stay in for now; we can clean them up in a follow-up if they're noisy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)