### PR TITLE
fix(home): accept postgres-js array result shape (zeros bug)

### DIFF
--- a/apps/web/app/inbox/_lib/home-dashboard.ts
+++ b/apps/web/app/inbox/_lib/home-dashboard.ts
@@ -35,6 +35,12 @@ const LIFECYCLE_EVENT_TYPES = [
 const MS_PER_DAY = 24 * 60 * 60 * 1_000;
 
 function normalizeSqlResultRows(result: unknown): readonly unknown[] {
+  // postgres-js (drizzle-orm/postgres-js, used in production) returns a
+  // plain array; node-pg / pglite return { rows: [...] }.
+  if (Array.isArray(result)) {
+    return result;
+  }
+
   if (
     typeof result === "object" &&
     result !== null &&

--- a/apps/web/app/inbox/actions.ts
+++ b/apps/web/app/inbox/actions.ts
@@ -225,6 +225,12 @@ function getAiDraftConcurrencyState(): AiDraftConcurrencyState {
 }
 
 function normalizeSqlResultRows(result: unknown): readonly unknown[] {
+  // postgres-js (drizzle-orm/postgres-js, used in production) returns a
+  // plain array; node-pg / pglite return { rows: [...] }.
+  if (Array.isArray(result)) {
+    return result;
+  }
+
   if (
     typeof result === "object" &&
     result !== null &&


### PR DESCRIPTION
## Summary
- Dashboard was still rendering all-zero metrics in production after #301 even though the SQL ran fine (169 lifecycle events in the last 7 days, 119 distributed across the 3 active projects).
- Root cause: production uses \`drizzle-orm/postgres-js\` (the \`postgres\` driver). \`db.execute(sql\`...\`)\` on that driver returns a plain array. The local \`normalizeSqlResultRows\` helper in \`home-dashboard.ts\` and \`actions.ts\` only handled the \`{ rows: [...] }\` shape returned by node-pg / pglite (used by tests). So the helper returned \`[]\` and the aggregator/dialog had no events to attribute.
- Tests passed because pglite returns \`{ rows }\`; prod silently returned no data.

## Fix
- Both helpers now accept arrays as well as \`{ rows }\`. Mirrors the canonical \`normalizeSqlResultRows\` in \`packages/db/src/repositories.ts\` which already handles both shapes.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm boundaries\` clean
- [ ] CI \`pnpm test:unit\` green
- [ ] After deploy: home dashboard shows non-zero metrics for the 3 active projects (PNW Biodiversity ~101 signups, Whitebark Pine ~13, Killer Whales ~5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)