### PR TITLE
fix(worker): bump mailchimp capture-port timeout default to 60s

### DIFF
--- a/apps/worker/src/runtime.ts
+++ b/apps/worker/src/runtime.ts
@@ -182,8 +182,12 @@ function readOptionalCaptureConfig(
   input: {
     readonly baseUrlKey: string;
     readonly tokenKey: string;
+    readonly timeoutMsKey?: string;
+    readonly defaultTimeoutMs?: number;
   },
-): { readonly baseUrl?: string; readonly bearerToken?: string } | undefined {
+):
+  | { readonly baseUrl?: string; readonly bearerToken?: string; readonly timeoutMs?: number }
+  | undefined {
   const baseUrl = env[input.baseUrlKey];
   const bearerToken = env[input.tokenKey];
 
@@ -191,9 +195,19 @@ function readOptionalCaptureConfig(
     return undefined;
   }
 
+  const timeoutFromEnv =
+    input.timeoutMsKey === undefined
+      ? undefined
+      : Number.parseInt(env[input.timeoutMsKey] ?? "", 10);
+  const timeoutMs =
+    timeoutFromEnv !== undefined && Number.isFinite(timeoutFromEnv)
+      ? timeoutFromEnv
+      : input.defaultTimeoutMs;
+
   return {
     ...(baseUrl === undefined ? {} : { baseUrl }),
     ...(bearerToken === undefined ? {} : { bearerToken }),
+    ...(timeoutMs === undefined ? {} : { timeoutMs }),
   };
 }
 
@@ -275,6 +289,11 @@ export function readWorkerConfig(env: NodeJS.ProcessEnv): WorkerConfig | null {
       mailchimp: readOptionalCaptureConfig(env, {
         baseUrlKey: "MAILCHIMP_CAPTURE_BASE_URL",
         tokenKey: "MAILCHIMP_CAPTURE_TOKEN",
+        timeoutMsKey: "MAILCHIMP_CAPTURE_TIMEOUT_MS",
+        // Mailchimp's Marketing API can be slow on /reports/email-activity
+        // for large campaigns. Observed 2026-05-04: P95 17s+ for legitimate
+        // responses. Default 60s; override via MAILCHIMP_CAPTURE_TIMEOUT_MS.
+        defaultTimeoutMs: 60_000,
       }),
     },
     mailchimpTransition: readMailchimpTransitionConfig(env),


### PR DESCRIPTION
Mailchimp's Marketing API `/reports/email-activity` endpoint can take 17+ seconds for legitimate responses on larger campaigns. The worker's capture-port HTTP timeout defaulted to 15s and was aborting in-flight requests despite the capture service returning successfully (status=200, dur=17s observed in production today).

Adds a per-provider `timeoutMsKey`/`defaultTimeoutMs` to `readOptionalCaptureConfig` and wires Mailchimp at 60s default. Optional override via `MAILCHIMP_CAPTURE_TIMEOUT_MS` env var.

Other capture ports (Gmail, Salesforce) keep their 15s default.