### PR TITLE
fix(db): cast Date to timestamptz inside least() in tail-state upsert

### DIFF
--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -613,6 +613,11 @@ export function createMailchimpCampaignTailStateRepository(
         audienceId: record.audienceId,
         firstSeenSendTime: new Date(record.firstSeenSendTime),
       };
+      // Inside a raw sql`` template, Drizzle does not apply the column's
+      // type-mapping. A Date object falls through to Date.prototype.toString()
+      // ("Sun Apr 05 2026 15:00:00 GMT+0000 ..."), which Postgres rejects
+      // as a timestamptz. Pre-stringify to ISO and cast explicitly.
+      const firstSeenIso = values.firstSeenSendTime.toISOString();
       const [row] = await db
         .insert(mailchimpCampaignTailState)
         .values(values)
@@ -620,7 +625,7 @@ export function createMailchimpCampaignTailStateRepository(
           target: mailchimpCampaignTailStateTable.campaignId,
           set: {
             audienceId: values.audienceId,
-            firstSeenSendTime: sql`least(${mailchimpCampaignTailState.firstSeenSendTime}, ${values.firstSeenSendTime})`,
+            firstSeenSendTime: sql`least(${mailchimpCampaignTailState.firstSeenSendTime}, ${firstSeenIso}::timestamptz)`,
             updatedAt: new Date(),
           },
         })


### PR DESCRIPTION
Mailchimp scheduler was failing on every tick after the first one with:

```
Failed query: insert into "mailchimp_campaign_tail_state" ... on conflict ("campaign_id") do update set ... "first_seen_send_time" = least(...., $5) ...
params: ..., Sun Apr 05 2026 15:00:00 GMT+0000 (Coordinated Universal Time), ...
```

When a Date object is interpolated into Drizzle's raw `sql\`\`` template, the column's type-mapping does NOT apply — postgres-js falls back to `Date.prototype.toString()`, which Postgres rejects as a timestamptz.

Pre-stringify to ISO + cast via `::timestamptz`. The INSERT path was already fine because Drizzle does apply column type-mapping for `.values()`.