### PR TITLE
fix(db): cast Date to timestamptz in tail-state updateLastActivitySeenAt

### DIFF
--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -653,11 +653,16 @@ export function createMailchimpCampaignTailStateRepository(
     },
 
     async updateLastActivitySeenAt(input) {
-      const lastActivitySeenAt = new Date(input.lastActivitySeenAt);
+      // Same trap as the upsert path: Date interpolated in raw sql`` doesn't
+      // get column type-mapped → Postgres rejects Date.toString() as
+      // timestamptz. Pre-stringify + cast.
+      const lastActivitySeenIso = new Date(
+        input.lastActivitySeenAt,
+      ).toISOString();
       const [row] = await db
         .update(mailchimpCampaignTailState)
         .set({
-          lastActivitySeenAt: sql`greatest(coalesce(${mailchimpCampaignTailState.lastActivitySeenAt}, ${lastActivitySeenAt}), ${lastActivitySeenAt})`,
+          lastActivitySeenAt: sql`greatest(coalesce(${mailchimpCampaignTailState.lastActivitySeenAt}, ${lastActivitySeenIso}::timestamptz), ${lastActivitySeenIso}::timestamptz)`,
           updatedAt: new Date(),
         })
         .where(eq(mailchimpCampaignTailState.campaignId, input.campaignId))


### PR DESCRIPTION
Sibling fix to #305. Same Drizzle gotcha in the `updateLastActivitySeenAt` repo method's `greatest()` raw sql.

Production effect: scheduler discovered 23 campaigns and scheduled 23 transition jobs that all reached Mailchimp and got 200 responses ("capture" succeeded), but the post-batch hook in `apps/worker/src/orchestration/service.ts` calls `tailState.updateLastActivitySeenAt()` and that's where the timestamptz cast bug fires. Each transition job fails after the capture path is already done.

Pre-stringify the Date to ISO and cast via `::timestamptz` inside the sql template.