### PR TITLE
fix(timeline): canonical lifecycle ordinal in sort key tiebreak

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -24,6 +24,7 @@
     "ops:cleanup-salesforce-owner-scope": "tsx src/ops/cleanup-salesforce-owner-scope.ts",
     "ops:recover-orphan-gmail-details": "tsx src/ops/recover-orphan-gmail-details.ts",
     "ops:recover-orphan-task-details": "tsx src/ops/recover-orphan-task-details.ts",
+    "ops:rewrite-timeline-sort-keys": "tsx src/ops/rewrite-timeline-sort-keys.ts",
     "ops:dedup-historical-ledger": "tsx src/ops/dedup-historical-ledger.ts",
     "ops:migrate-notion-child-dbs-to-project-knowledge": "tsx src/ops/migrate-notion-child-dbs-to-project-knowledge.ts",
     "ops:dump-notion-page": "tsx src/ops/dump-notion-page.ts",

--- a/apps/worker/src/ops/rewrite-timeline-sort-keys.ts
+++ b/apps/worker/src/ops/rewrite-timeline-sort-keys.ts
@@ -1,0 +1,254 @@
+#!/usr/bin/env tsx
+/**
+ * rewrite-timeline-sort-keys
+ *
+ * Usage:
+ *   pnpm --filter @as-comms/worker ops:rewrite-timeline-sort-keys
+ *   pnpm --filter @as-comms/worker ops:rewrite-timeline-sort-keys --limit 100
+ *   pnpm --filter @as-comms/worker ops:rewrite-timeline-sort-keys --execute
+ *
+ * Dry-run by default. Recomputes lifecycle timeline sort keys using the current
+ * canonical lifecycle ordinal tiebreak and updates only rows whose sort key
+ * changed.
+ */
+import process from "node:process";
+
+import { asc, eq, inArray } from "drizzle-orm";
+
+import {
+  canonicalEventTypeValues,
+  type CanonicalEventRecord
+} from "@as-comms/contracts";
+import {
+  closeDatabaseConnection,
+  contactTimelineProjection,
+  createDatabaseConnection,
+  type Stage1Database
+} from "@as-comms/db";
+import { buildTimelineSortKey } from "@as-comms/domain";
+import { toIsoTimestamp } from "@as-comms/integrations";
+
+import {
+  parseCliFlags,
+  readOptionalBooleanFlag,
+  readOptionalIntegerFlag
+} from "./helpers.js";
+
+const sampleLimit = 10;
+const updateBatchSize = 500;
+
+const lifecycleEventTypes = canonicalEventTypeValues.filter((eventType) =>
+  eventType.startsWith("lifecycle.")
+) as readonly CanonicalEventRecord["eventType"][];
+
+interface Logger {
+  error(...args: readonly unknown[]): void;
+}
+
+interface RewriteTimelineSortKeyCandidate {
+  readonly id: string;
+  readonly canonicalEventId: string;
+  readonly occurredAt: string;
+  readonly eventType: CanonicalEventRecord["eventType"];
+  readonly oldSortKey: string;
+  readonly newSortKey: string;
+}
+
+export interface RewriteTimelineSortKeysResult {
+  readonly dryRun: boolean;
+  readonly scannedCount: number;
+  readonly updatedCount: number;
+  readonly sample: readonly {
+    readonly id: string;
+    readonly canonicalEventId: string;
+    readonly eventType: CanonicalEventRecord["eventType"];
+    readonly oldSortKey: string;
+    readonly newSortKey: string;
+  }[];
+}
+
+function readConnectionString(env: NodeJS.ProcessEnv): string {
+  const connectionString = env.WORKER_DATABASE_URL ?? env.DATABASE_URL;
+
+  if (connectionString === undefined || connectionString.trim().length === 0) {
+    throw new Error(
+      "DATABASE_URL or WORKER_DATABASE_URL is required for this ops command."
+    );
+  }
+
+  return connectionString;
+}
+
+function chunkValues<TValue>(
+  values: readonly TValue[],
+  chunkSize: number
+): TValue[][] {
+  const chunks: TValue[][] = [];
+
+  for (let index = 0; index < values.length; index += chunkSize) {
+    chunks.push(values.slice(index, index + chunkSize));
+  }
+
+  return chunks;
+}
+
+function normalizeOccurredAt(value: Date): string {
+  const normalized = toIsoTimestamp(value);
+
+  if (normalized === null) {
+    throw new Error(
+      "Expected contact_timeline_projection.occurred_at to be a valid timestamp."
+    );
+  }
+
+  return normalized;
+}
+
+async function loadCandidates(input: {
+  readonly db: Stage1Database;
+  readonly limit: number | null;
+}): Promise<{
+  readonly scannedCount: number;
+  readonly candidates: readonly RewriteTimelineSortKeyCandidate[];
+}> {
+  const rows = await input.db
+    .select({
+      id: contactTimelineProjection.id,
+      canonicalEventId: contactTimelineProjection.canonicalEventId,
+      occurredAt: contactTimelineProjection.occurredAt,
+      eventType: contactTimelineProjection.eventType,
+      sortKey: contactTimelineProjection.sortKey
+    })
+    .from(contactTimelineProjection)
+    .where(inArray(contactTimelineProjection.eventType, [...lifecycleEventTypes]))
+    .orderBy(
+      asc(contactTimelineProjection.occurredAt),
+      asc(contactTimelineProjection.canonicalEventId)
+    );
+
+  const limitedRows = input.limit === null ? rows : rows.slice(0, input.limit);
+
+  const candidates = limitedRows
+    .map((row) => {
+      const occurredAt = normalizeOccurredAt(row.occurredAt);
+
+      return {
+        id: row.id,
+        canonicalEventId: row.canonicalEventId,
+        occurredAt,
+        eventType: row.eventType,
+        oldSortKey: row.sortKey,
+        newSortKey: buildTimelineSortKey(
+          row.canonicalEventId,
+          occurredAt,
+          row.eventType
+        )
+      };
+    })
+    .filter((row) => row.oldSortKey !== row.newSortKey);
+
+  return {
+    scannedCount: limitedRows.length,
+    candidates
+  };
+}
+
+async function applyUpdates(input: {
+  readonly db: Stage1Database;
+  readonly candidates: readonly RewriteTimelineSortKeyCandidate[];
+}): Promise<number> {
+  let updatedCount = 0;
+
+  for (const batch of chunkValues(input.candidates, updateBatchSize)) {
+    await input.db.transaction(async (tx) => {
+      for (const candidate of batch) {
+        await tx
+          .update(contactTimelineProjection)
+          .set({
+            sortKey: candidate.newSortKey,
+            updatedAt: new Date()
+          })
+          .where(eq(contactTimelineProjection.id, candidate.id));
+      }
+    });
+
+    updatedCount += batch.length;
+  }
+
+  return updatedCount;
+}
+
+export async function rewriteTimelineSortKeys(input: {
+  readonly db: Stage1Database;
+  readonly dryRun?: boolean;
+  readonly limit?: number | null;
+  readonly logger?: Logger;
+}): Promise<RewriteTimelineSortKeysResult> {
+  const dryRun = input.dryRun ?? true;
+  const logger = input.logger ?? console;
+  const { scannedCount, candidates } = await loadCandidates({
+    db: input.db,
+    limit: input.limit ?? null
+  });
+  const updatedCount = dryRun
+    ? 0
+    : await applyUpdates({
+        db: input.db,
+        candidates
+      });
+  const sample = candidates.slice(0, sampleLimit).map((candidate) => ({
+    id: candidate.id,
+    canonicalEventId: candidate.canonicalEventId,
+    eventType: candidate.eventType,
+    oldSortKey: candidate.oldSortKey,
+    newSortKey: candidate.newSortKey
+  }));
+
+  logger.error("rewrite-timeline-sort-keys");
+  logger.error(`Mode: ${dryRun ? "dry-run" : "execute"}`);
+  logger.error(`- rows scanned: ${String(scannedCount)}`);
+  logger.error(`- rows needing update: ${String(candidates.length)}`);
+  logger.error(`- rows updated: ${String(updatedCount)}`);
+  logger.error(`- sample: ${JSON.stringify(sample, null, 2)}`);
+
+  return {
+    dryRun,
+    scannedCount,
+    updatedCount,
+    sample
+  };
+}
+
+export async function runRewriteTimelineSortKeysCommand(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv = process.env
+): Promise<RewriteTimelineSortKeysResult> {
+  const flags = parseCliFlags(args);
+  const connection = createDatabaseConnection({
+    connectionString: readConnectionString(env)
+  });
+
+  try {
+    return await rewriteTimelineSortKeys({
+      db: connection.db,
+      dryRun: !readOptionalBooleanFlag(flags, "execute", false),
+      limit: readOptionalIntegerFlag(flags, "limit", 0) || null
+    });
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1] ?? ""}`) {
+  void runRewriteTimelineSortKeysCommand(process.argv.slice(2)).catch(
+    (error: unknown) => {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "rewrite-timeline-sort-keys failed.";
+
+      console.error(message);
+      process.exitCode = 1;
+    }
+  );
+}

--- a/packages/db/test/stage1-normalization.test.ts
+++ b/packages/db/test/stage1-normalization.test.ts
@@ -913,7 +913,7 @@ describe("Stage 1 normalization service", () => {
       );
       expect(outboundResult.inboxProjection?.bucket).toBe("Opened");
       expect(outboundResult.timelineProjection.sortKey).toBe(
-        "2026-01-01T00:04:00.000Z::evt_1"
+        "2026-01-01T00:04:00.000Z::00::evt_1"
       );
     }
 

--- a/packages/domain/src/normalization.ts
+++ b/packages/domain/src/normalization.ts
@@ -1,4 +1,5 @@
 import {
+  canonicalEventTypeValues,
   canonicalEventSchema,
   contactIdentitySchema,
   contactMembershipSchema,
@@ -76,6 +77,28 @@ import {
 import type { Stage1PersistenceService } from "./persistence.js";
 
 type ContactLookupMap = ReadonlyMap<string, ContactRecord>;
+
+const [
+  ,
+  ,
+  ,
+  ,
+  ,
+  ,
+  lifecycleSignedUpEventType,
+  lifecycleReceivedTrainingEventType,
+  lifecycleCompletedTrainingEventType,
+  lifecycleSubmittedFirstDataEventType
+] = canonicalEventTypeValues;
+
+const lifecycleTimelineOrdinalByEventType: Partial<
+  Record<CanonicalEventRecord["eventType"], string>
+> = {
+  [lifecycleSignedUpEventType]: "01",
+  [lifecycleReceivedTrainingEventType]: "02",
+  [lifecycleCompletedTrainingEventType]: "03",
+  [lifecycleSubmittedFirstDataEventType]: "04"
+};
 
 interface IdentityResolutionContext {
   loadContactsForIdentityKind(
@@ -330,8 +353,18 @@ function buildTimelineProjectionId(canonicalEventId: string): string {
   return `timeline:${canonicalEventId}`;
 }
 
-function buildTimelineSortKey(canonicalEventId: string, occurredAt: string): string {
-  return `${occurredAt}::${canonicalEventId}`;
+function resolveTimelineSortOrdinal(
+  eventType: CanonicalEventRecord["eventType"]
+): string {
+  return lifecycleTimelineOrdinalByEventType[eventType] ?? "00";
+}
+
+export function buildTimelineSortKey(
+  canonicalEventId: string,
+  occurredAt: string,
+  eventType: CanonicalEventRecord["eventType"]
+): string {
+  return `${occurredAt}::${resolveTimelineSortOrdinal(eventType)}::${canonicalEventId}`;
 }
 
 function buildIdentityCaseId(
@@ -2083,7 +2116,8 @@ export function createStage1NormalizationService(
         occurredAt: parsed.canonicalEvent.occurredAt,
         sortKey: buildTimelineSortKey(
           parsed.canonicalEvent.id,
-          parsed.canonicalEvent.occurredAt
+          parsed.canonicalEvent.occurredAt,
+          parsed.canonicalEvent.eventType
         ),
         eventType: parsed.canonicalEvent.eventType,
         summary: parsed.summary,

--- a/packages/domain/test/timeline-sort-key.test.ts
+++ b/packages/domain/test/timeline-sort-key.test.ts
@@ -1,0 +1,121 @@
+import { canonicalEventTypeValues } from "@as-comms/contracts";
+
+import { describe, expect, it } from "vitest";
+
+import { buildTimelineSortKey } from "../src/normalization.js";
+
+const [
+  communicationEmailInboundEventType,
+  ,
+  ,
+  ,
+  ,
+  ,
+  lifecycleSignedUpEventType,
+  lifecycleReceivedTrainingEventType,
+  lifecycleCompletedTrainingEventType
+] = canonicalEventTypeValues;
+
+describe("buildTimelineSortKey", () => {
+  it("orders same-day lifecycle events by canonical lifecycle order", () => {
+    const occurredAt = "2025-11-17T00:00:00.000Z";
+    const rows = [
+      {
+        canonicalEventId: "evt:received-training",
+        sortKey: buildTimelineSortKey(
+          "evt:received-training",
+          occurredAt,
+          lifecycleReceivedTrainingEventType
+        )
+      },
+      {
+        canonicalEventId: "evt:signed-up",
+        sortKey: buildTimelineSortKey(
+          "evt:signed-up",
+          occurredAt,
+          lifecycleSignedUpEventType
+        )
+      }
+    ];
+
+    const orderedIds = rows
+      .sort((left, right) => left.sortKey.localeCompare(right.sortKey))
+      .map((row) => row.canonicalEventId);
+
+    expect(orderedIds).toEqual(["evt:signed-up", "evt:received-training"]);
+  });
+
+  it("orders multiple same-day lifecycle events by the locked lifecycle sequence", () => {
+    const occurredAt = "2025-11-17T00:00:00.000Z";
+    const rows = [
+      {
+        canonicalEventId: "evt:completed-training",
+        sortKey: buildTimelineSortKey(
+          "evt:completed-training",
+          occurredAt,
+          lifecycleCompletedTrainingEventType
+        )
+      },
+      {
+        canonicalEventId: "evt:signed-up",
+        sortKey: buildTimelineSortKey(
+          "evt:signed-up",
+          occurredAt,
+          lifecycleSignedUpEventType
+        )
+      },
+      {
+        canonicalEventId: "evt:received-training",
+        sortKey: buildTimelineSortKey(
+          "evt:received-training",
+          occurredAt,
+          lifecycleReceivedTrainingEventType
+        )
+      }
+    ];
+
+    const orderedIds = rows
+      .sort((left, right) => left.sortKey.localeCompare(right.sortKey))
+      .map((row) => row.canonicalEventId);
+
+    expect(orderedIds).toEqual([
+      "evt:signed-up",
+      "evt:received-training",
+      "evt:completed-training"
+    ]);
+  });
+
+  it("preserves non-lifecycle ordering by occurredAt then canonicalEventId", () => {
+    const occurredAt = "2025-11-17T00:00:00.000Z";
+    const rows = [
+      buildTimelineSortKey("evt:b", occurredAt, communicationEmailInboundEventType),
+      buildTimelineSortKey("evt:a", occurredAt, communicationEmailInboundEventType)
+    ].sort((left, right) => left.localeCompare(right));
+
+    expect(rows).toEqual([
+      `${occurredAt}::00::evt:a`,
+      `${occurredAt}::00::evt:b`
+    ]);
+  });
+
+  it("sorts non-lifecycle events before lifecycle events at the same timestamp", () => {
+    const occurredAt = "2025-11-17T00:00:00.000Z";
+    const rows = [
+      buildTimelineSortKey(
+        "evt:lifecycle",
+        occurredAt,
+        lifecycleSignedUpEventType
+      ),
+      buildTimelineSortKey(
+        "evt:email",
+        occurredAt,
+        communicationEmailInboundEventType
+      )
+    ].sort((left, right) => left.localeCompare(right));
+
+    expect(rows).toEqual([
+      `${occurredAt}::00::evt:email`,
+      `${occurredAt}::01::evt:lifecycle`
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- fix timeline projection sort keys so same-day lifecycle events use the locked canonical lifecycle ordinal before falling back to canonical event id
- add `ops:rewrite-timeline-sort-keys` to rewrite stale lifecycle projection rows in dry-run or execute mode with before/after samples
- add direct unit coverage for same-day lifecycle ordering, non-lifecycle stability, and lifecycle vs non-lifecycle ties

## Repro
- Drew Fuentes (`contact:salesforce:003VK00000cptKmYAI`) had `lifecycle.received_training` rendering before `lifecycle.signed_up` on 2025-11-17 because both events shared the same day-precision timestamp and the old tiebreak fell through to `canonicalEventId`

## Validation
- `pnpm typecheck`
- `pnpm lint`