### PR TITLE
fix(inbox): degraded detail view when projection missing

### DIFF
--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -342,7 +342,11 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
   // unread state came from an inbound volunteer message or a non-alias
   // teammate reply. The ref prevents re-firing if the effect re-runs.
   useEffect(() => {
-    if (markOpenedRef.current || !detail.isUnread) {
+    if (
+      markOpenedRef.current ||
+      !detail.projectionAvailable ||
+      !detail.isUnread
+    ) {
       return;
     }
     markOpenedRef.current = true;
@@ -353,7 +357,7 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
         router.refresh();
       }
     });
-  }, [contact.contactId, detail.isUnread, router]);
+  }, [contact.contactId, detail.isUnread, detail.projectionAvailable, router]);
 
   const handleMarkUnread = useCallback(() => {
     startMarkUnreadTransition(async () => {
@@ -564,23 +568,27 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
           </div>
 
           <div className="flex shrink-0 items-center gap-2">
-            <FollowUpToggleControl
-              needsFollowUp={isFollowUp}
-              isPending={followUpToggle.isPending}
-              error={followUpToggle.error}
-              onToggle={followUpToggle.toggle}
-            />
+            {detail.projectionAvailable ? (
+              <>
+                <FollowUpToggleControl
+                  needsFollowUp={isFollowUp}
+                  isPending={followUpToggle.isPending}
+                  error={followUpToggle.error}
+                  onToggle={followUpToggle.toggle}
+                />
 
-            <HeaderActionButton
-              label="Mark Unread"
-              aria-label="Mark unread"
-              disabled={isMarkUnreadPending}
-              onClick={handleMarkUnread}
-              data-inbox-mark-unread="true"
-              widthClassName="w-32"
-            >
-              <MailOpenIcon className="size-4" />
-            </HeaderActionButton>
+                <HeaderActionButton
+                  label="Mark Unread"
+                  aria-label="Mark unread"
+                  disabled={isMarkUnreadPending}
+                  onClick={handleMarkUnread}
+                  data-inbox-mark-unread="true"
+                  widthClassName="w-32"
+                >
+                  <MailOpenIcon className="size-4" />
+                </HeaderActionButton>
+              </>
+            ) : null}
 
             <Popover open={reminderOpen} onOpenChange={setReminderOpen}>
               <PopoverTrigger asChild>
@@ -623,23 +631,25 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
               </PopoverContent>
             </Popover>
 
-            <HeaderActionButton
-              label={detail.isArchived ? "Unarchive" : "Archive"}
-              aria-label={
-                detail.isArchived
-                  ? "Move back to inbox"
-                  : "Archive conversation"
-              }
-              disabled={isArchivePending}
-              onClick={detail.isArchived ? handleUnarchive : handleArchive}
-              widthClassName={detail.isArchived ? "w-28" : "w-24"}
-            >
-              {detail.isArchived ? (
-                <ArchiveRestoreIcon className="size-4" />
-              ) : (
-                <ArchiveBoxIcon className="size-4" />
-              )}
-            </HeaderActionButton>
+            {detail.projectionAvailable ? (
+              <HeaderActionButton
+                label={detail.isArchived ? "Unarchive" : "Archive"}
+                aria-label={
+                  detail.isArchived
+                    ? "Move back to inbox"
+                    : "Archive conversation"
+                }
+                disabled={isArchivePending}
+                onClick={detail.isArchived ? handleUnarchive : handleArchive}
+                widthClassName={detail.isArchived ? "w-28" : "w-24"}
+              >
+                {detail.isArchived ? (
+                  <ArchiveRestoreIcon className="size-4" />
+                ) : (
+                  <ArchiveBoxIcon className="size-4" />
+                )}
+              </HeaderActionButton>
+            ) : null}
 
             {!railOpen ? (
               <HeaderActionButton

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -42,6 +42,14 @@ import type {
 } from "./view-models";
 export { groupInboxTimelineSystemMessages } from "./view-models";
 
+type InboxDetailProjection = Omit<
+  InboxProjectionRow,
+  "lastCanonicalEventId" | "lastEventType"
+> & {
+  readonly lastCanonicalEventId: string | null;
+  readonly lastEventType: CanonicalEventRecord["eventType"] | null;
+};
+
 function filterSmsTimelineItems(
   items: readonly TimelineItem[],
   smsEnabled: boolean,
@@ -51,6 +59,24 @@ function filterSmsTimelineItems(
   }
 
   return items.filter((item) => item.family !== "one_to_one_sms");
+}
+
+function findNewestCanonicalEvent(
+  events: readonly CanonicalEventRecord[],
+): CanonicalEventRecord | null {
+  let newestEvent: CanonicalEventRecord | null = null;
+
+  for (const event of events) {
+    if (
+      newestEvent === null ||
+      event.occurredAt > newestEvent.occurredAt ||
+      (event.occurredAt === newestEvent.occurredAt && event.id > newestEvent.id)
+    ) {
+      newestEvent = event;
+    }
+  }
+
+  return newestEvent;
 }
 
 interface InboxListCacheRow {
@@ -101,7 +127,8 @@ interface InboxListCacheData {
 
 interface InboxDetailCacheData {
   readonly contact: ContactRecord;
-  readonly inboxProjection: InboxProjectionRow;
+  readonly inboxProjection: InboxDetailProjection;
+  readonly projectionAvailable: boolean;
   readonly isUnread: boolean;
   readonly memberships: readonly ContactMembershipRecord[];
   readonly latestNote: {
@@ -2355,7 +2382,7 @@ function buildTimelineEntry(input: {
   readonly contactPrimaryEmail: string | null;
   readonly contactDisplayNameByEmail: ReadonlyMap<string, string>;
   readonly operatorDisplayName: string;
-  readonly inboxProjection: InboxProjectionRow;
+  readonly inboxProjection: InboxDetailProjection;
   readonly item: TimelineItem;
   readonly campaignActivitySummaryByCampaignId: Readonly<
     Record<string, CampaignActivitySummary>
@@ -3516,9 +3543,26 @@ async function readInboxDetailCacheData(
     }),
   ]);
 
-  if (contact === null || inboxProjection === null) {
+  if (contact === null) {
     return null;
   }
+
+  const newestCanonicalEvent = findNewestCanonicalEvent(canonicalEvents);
+  const projectionAvailable = inboxProjection !== null;
+  const detailProjection: InboxDetailProjection =
+    inboxProjection ?? {
+      contactId,
+      bucket: "Opened",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      archivedAt: null,
+      lastInboundAt: null,
+      lastOutboundAt: null,
+      lastActivityAt: newestCanonicalEvent?.occurredAt ?? contact.updatedAt,
+      snippet: "",
+      lastCanonicalEventId: newestCanonicalEvent?.id ?? null,
+      lastEventType: newestCanonicalEvent?.eventType ?? null,
+    };
 
   const aliasesByProjectId = new Map<string, string[]>();
 
@@ -3658,13 +3702,14 @@ async function readInboxDetailCacheData(
   }
 
   const isUnread =
-    inboxProjection.bucket === "New" ||
+    detailProjection.bucket === "New" ||
     (lastNonAliasOutboundAt !== null &&
       (latestReadAt === null || lastNonAliasOutboundAt > latestReadAt));
 
   return {
     contact,
-    inboxProjection,
+    inboxProjection: detailProjection,
+    projectionAvailable,
     isUnread,
     memberships,
     latestNote,
@@ -3930,7 +3975,7 @@ function toListItemViewModel(
 
 function buildContactSummary(input: {
   readonly contact: ContactRecord;
-  readonly inboxProjection: InboxProjectionRow;
+  readonly inboxProjection: InboxDetailProjection;
   readonly memberships: readonly ContactMembershipRecord[];
   readonly latestNote: {
     readonly body: string;
@@ -4300,6 +4345,7 @@ export async function getInboxDetail(
 
   return {
     contact: contactSummary,
+    projectionAvailable: cachedData.projectionAvailable,
     conversationProject: buildConversationProject({
       contact: contactSummary,
       timelineItems: cachedData.activityTimelineItems,

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -382,6 +382,7 @@ export interface InboxComposerReplyContext {
 
 export interface InboxDetailViewModel {
   readonly contact: InboxContactSummaryViewModel;
+  readonly projectionAvailable: boolean;
   readonly conversationProject: {
     readonly projectId: string;
     readonly projectName: string;

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -1917,6 +1917,7 @@ describe("real inbox selectors", () => {
 
     expect(detail).not.toBeNull();
     expect(detail).toMatchObject({
+      projectionAvailable: true,
       bucket: "new",
       needsFollowUp: true,
       smsEligible: true,
@@ -1951,6 +1952,86 @@ describe("real inbox selectors", () => {
       nextCursor: null,
       total: 2,
     });
+  });
+
+  it("synthesizes a degraded detail view when the projection row is missing but canonical events exist", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await runtime.context.repositories.inboxProjection.deleteByContactId(
+      "contact:sarah-martinez",
+    );
+
+    const detail = await getInboxDetail("contact:sarah-martinez");
+
+    expect(detail).not.toBeNull();
+    expect(detail).toMatchObject({
+      projectionAvailable: false,
+      bucket: "opened",
+      needsFollowUp: false,
+      isArchived: false,
+    });
+    expect(detail?.freshness.inboxUpdatedAt).toBeNull();
+    expect(detail?.timelinePage).toEqual({
+      hasMore: false,
+      hasHiddenEarlierHistory: false,
+      nextCursor: null,
+      total: 2,
+    });
+    expect(detail?.timeline.at(-1)).toMatchObject({
+      occurredAt: "2026-04-14T13:00:00.000Z",
+      isUnread: false,
+    });
+  });
+
+  it("falls back to contact.updatedAt when the projection row and canonical events are both missing", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:no-projection-no-events",
+      salesforceContactId: "003-no-projection-no-events",
+      displayName: "No Projection No Events",
+      primaryEmail: "no-projection-no-events@example.org",
+      primaryPhone: null,
+    });
+    await runtime.context.repositories.contacts.upsert({
+      id: "contact:no-projection-no-events",
+      salesforceContactId: "003-no-projection-no-events",
+      displayName: "No Projection No Events",
+      primaryEmail: "no-projection-no-events@example.org",
+      primaryPhone: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-04-22T09:45:00.000Z",
+    });
+
+    const detail = await getInboxDetail("contact:no-projection-no-events");
+
+    expect(detail).not.toBeNull();
+    expect(detail).toMatchObject({
+      projectionAvailable: false,
+      bucket: "opened",
+      needsFollowUp: false,
+      isArchived: false,
+    });
+    expect(detail?.timeline).toEqual([]);
+    expect(detail?.timelinePage).toEqual({
+      hasMore: false,
+      hasHiddenEarlierHistory: false,
+      nextCursor: null,
+      total: 0,
+    });
+    expect(detail?.freshness).toEqual({
+      inboxUpdatedAt: null,
+      timelineUpdatedAt: null,
+      timelineCount: 0,
+    });
+  });
+
+  it("still returns null when the contact does not exist", async () => {
+    await expect(getInboxDetail("contact:missing")).resolves.toBeNull();
   });
 
   it("sets conversationProject from membership when the contact has an active project membership", async () => {


### PR DESCRIPTION
## Summary
- synthesize an in-memory inbox detail projection when the real `contact_inbox_projection` row is missing
- expose `projectionAvailable` on inbox detail and hide projection write affordances in degraded mode
- add selector coverage for real projection, missing projection with canonical history, missing projection without history, and missing contact 404 behavior

## Context
Defense-in-depth follow-up for the projection rule-widening initiative: valid contact deep-links should keep rendering even when the projection row is temporarily or unexpectedly absent.