### PR TITLE
fix(mailchimp): bump sent-snippet cap from 280 to 8000 chars

### DIFF
--- a/packages/integrations/src/capture-services/mailchimp.ts
+++ b/packages/integrations/src/capture-services/mailchimp.ts
@@ -39,7 +39,12 @@ import {
 const DEFAULT_MAX_RECORDS = 500
 const MAX_MAILCHIMP_CONCURRENCY = 5
 const MAILCHIMP_PAGE_SIZE = 1_000
-const MAILCHIMP_SENT_SNIPPET_MAX = 280
+// Stored in mailchimp_campaign_activity_details.snippet (DB column type: text,
+// unbounded). 280 was Brief 1's arbitrary default and ended up cropping
+// campaign bodies mid-sentence in the operator timeline. 8000 covers a typical
+// volunteer-facing campaign email body comfortably; the timeline UI applies
+// its own visual clamp on top.
+const MAILCHIMP_SENT_SNIPPET_MAX = 8_000
 const mailchimpCaptureServiceResponseSchema =
   createCapturedBatchResponseSchema(mailchimpRecordSchema)
 const jsonObjectSchema = z.record(z.string(), z.unknown())


### PR DESCRIPTION
Brief 1 chose 280 char cap on the captured sent snippet which ends up cropping campaign bodies mid-sentence in the operator timeline. DB column is unbounded text. Bumps to 8000. Existing rows can be re-filled via ops:backfill-mailchimp-campaign-body.