### PR TITLE
feat(ops): backfill contact_inbox_projection coverage

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -22,6 +22,7 @@
     "ops:backfill-salesforce-communication-details": "tsx src/ops/backfill-salesforce-communication-details.ts",
     "ops:audit-salesforce-task-ingest": "tsx src/ops/audit-salesforce-task-ingest.ts",
     "ops:cleanup-salesforce-owner-scope": "tsx src/ops/cleanup-salesforce-owner-scope.ts",
+    "ops:backfill-inbox-projection-coverage": "tsx src/ops/backfill-inbox-projection-coverage.ts",
     "ops:recover-orphan-gmail-details": "tsx src/ops/recover-orphan-gmail-details.ts",
     "ops:recover-orphan-task-details": "tsx src/ops/recover-orphan-task-details.ts",
     "ops:rewrite-timeline-sort-keys": "tsx src/ops/rewrite-timeline-sort-keys.ts",

--- a/apps/worker/src/ops/backfill-inbox-projection-coverage.ts
+++ b/apps/worker/src/ops/backfill-inbox-projection-coverage.ts
@@ -1,0 +1,401 @@
+#!/usr/bin/env tsx
+/**
+ * backfill-inbox-projection-coverage
+ *
+ * Usage:
+ *   pnpm --filter @as-comms/worker ops:backfill-inbox-projection-coverage
+ *   pnpm --filter @as-comms/worker ops:backfill-inbox-projection-coverage --execute
+ *   pnpm --filter @as-comms/worker ops:backfill-inbox-projection-coverage --execute --batch-size 250 --limit 1000
+ *
+ * Dry-run by default. Finds contacts with canonical events but no inbox
+ * projection row, then rebuilds inbox projections in batches through the
+ * existing projection_rebuild orchestration path.
+ */
+import process from "node:process";
+
+import { asc, eq, isNull } from "drizzle-orm";
+
+import {
+  projectionRebuildBatchPayloadSchema,
+  stage1JobVersion
+} from "@as-comms/contracts";
+import {
+  canonicalEventLedger,
+  closeDatabaseConnection,
+  contactInboxProjection,
+  createDatabaseConnection,
+  createStage1RepositoryBundleFromConnection,
+  type DatabaseConnection,
+  type Stage1Database
+} from "@as-comms/db";
+import {
+  createStage1NormalizationService,
+  createStage1PersistenceService,
+  qualifiesForInboxProjection,
+  type Stage1PersistenceService
+} from "@as-comms/domain";
+
+import { createStage1IngestService } from "../ingest/index.js";
+import {
+  createStage1WorkerOrchestrationService,
+  type Stage1WorkerOrchestrationService
+} from "../orchestration/index.js";
+import {
+  buildOperationId,
+  parseCliFlags,
+  readOptionalBooleanFlag,
+  readOptionalIntegerFlag
+} from "./helpers.js";
+
+const defaultBatchSize = 100;
+
+interface Logger {
+  log(...args: readonly unknown[]): void;
+  error(...args: readonly unknown[]): void;
+}
+
+interface CandidateContactRow {
+  readonly contact_id: string;
+}
+
+interface BackfillServices {
+  readonly persistence: Stage1PersistenceService;
+  readonly orchestration: Pick<
+    Stage1WorkerOrchestrationService,
+    "runProjectionRebuildBatch"
+  >;
+}
+
+export interface BackfillInboxProjectionCoverageResult {
+  readonly dryRun: boolean;
+  readonly candidateCount: number;
+  readonly scannedCount: number;
+  readonly insertedCount: number;
+  readonly skippedCount: number;
+  readonly errorCount: number;
+}
+
+function readConnectionString(env: NodeJS.ProcessEnv): string {
+  const connectionString = env.WORKER_DATABASE_URL ?? env.DATABASE_URL;
+
+  if (connectionString === undefined || connectionString.trim().length === 0) {
+    throw new Error(
+      "DATABASE_URL or WORKER_DATABASE_URL is required for this ops command."
+    );
+  }
+
+  return connectionString;
+}
+
+function chunkValues<TValue>(
+  values: readonly TValue[],
+  chunkSize: number
+): TValue[][] {
+  const chunks: TValue[][] = [];
+
+  for (let index = 0; index < values.length; index += chunkSize) {
+    chunks.push(values.slice(index, index + chunkSize));
+  }
+
+  return chunks;
+}
+
+function buildUnexpectedCapturePorts() {
+  const unexpectedUse = () =>
+    Promise.reject(
+      new Error(
+        "This ops command should not call provider capture ports while rebuilding inbox projections."
+      )
+    );
+
+  return {
+    gmail: {
+      captureHistoricalBatch: unexpectedUse,
+      captureLiveBatch: unexpectedUse
+    },
+    salesforce: {
+      captureHistoricalBatch: unexpectedUse,
+      captureLiveBatch: unexpectedUse
+    },
+    simpleTexting: {
+      captureHistoricalBatch: unexpectedUse,
+      captureLiveBatch: unexpectedUse
+    },
+    mailchimp: {
+      captureHistoricalBatch: unexpectedUse,
+      captureTransitionBatch: unexpectedUse
+    }
+  };
+}
+
+function createProjectionRebuildOrchestration(
+  connection: DatabaseConnection
+): BackfillServices {
+  const repositories = createStage1RepositoryBundleFromConnection(connection);
+  const persistence = createStage1PersistenceService(repositories);
+  const normalization = createStage1NormalizationService(persistence);
+  const ingest = createStage1IngestService(normalization);
+
+  return {
+    persistence,
+    orchestration: createStage1WorkerOrchestrationService({
+      capture: buildUnexpectedCapturePorts(),
+      ingest,
+      normalization,
+      persistence,
+      gmailHistoricalReplay: {
+        liveAccount: "unused@example.org",
+        projectInboxAliases: []
+      }
+    })
+  };
+}
+
+export async function loadBackfillInboxProjectionCoverageCandidateContactIds(
+  connection: Pick<DatabaseConnection, "sql">,
+  input?: {
+    readonly limit?: number | null;
+  }
+): Promise<readonly string[]> {
+  const limitClause =
+    input?.limit === null || input?.limit === undefined
+      ? connection.sql``
+      : connection.sql`limit ${input.limit}`;
+
+  const rows = await connection.sql<readonly CandidateContactRow[]>`
+    select distinct canonical_event_ledger.contact_id
+    from canonical_event_ledger
+    left join contact_inbox_projection
+      on contact_inbox_projection.contact_id = canonical_event_ledger.contact_id
+    where contact_inbox_projection.contact_id is null
+    order by canonical_event_ledger.contact_id asc
+    ${limitClause}
+  `;
+
+  return rows.map((row) => row.contact_id);
+}
+
+export async function loadBackfillInboxProjectionCoverageCandidateContactIdsFromDb(
+  db: Stage1Database,
+  input?: {
+    readonly limit?: number | null;
+  }
+): Promise<readonly string[]> {
+  const baseQuery = db
+    .select({
+      contactId: canonicalEventLedger.contactId
+    })
+    .from(canonicalEventLedger)
+    .leftJoin(
+      contactInboxProjection,
+      eq(contactInboxProjection.contactId, canonicalEventLedger.contactId)
+    )
+    .where(isNull(contactInboxProjection.contactId))
+    .groupBy(canonicalEventLedger.contactId)
+    .orderBy(asc(canonicalEventLedger.contactId));
+
+  const rows =
+    input?.limit === null || input?.limit === undefined
+      ? await baseQuery
+      : await baseQuery.limit(input.limit);
+
+  return rows.map((row) => row.contactId);
+}
+
+async function classifyDryRunContact(
+  persistence: Stage1PersistenceService,
+  contactId: string
+): Promise<"inserted" | "skipped"> {
+  const events = await persistence.repositories.canonicalEvents.listByContactId(
+    contactId
+  );
+
+  return events.some((event) => qualifiesForInboxProjection(event))
+    ? "inserted"
+    : "skipped";
+}
+
+function printSummary(
+  result: BackfillInboxProjectionCoverageResult,
+  logger: Logger
+): void {
+  const actionLabel = result.dryRun
+    ? "projections that would be inserted"
+    : "projections inserted";
+  const rows: readonly [string, string][] = [
+    ["candidate contacts", String(result.candidateCount)],
+    ["contacts scanned", String(result.scannedCount)],
+    [actionLabel, String(result.insertedCount)],
+    ["contacts skipped", String(result.skippedCount)],
+    ["errors", String(result.errorCount)]
+  ];
+  const labelWidth = rows.reduce(
+    (max, [label]) => Math.max(max, label.length),
+    0
+  );
+
+  logger.log("Summary:");
+  for (const [label, value] of rows) {
+    logger.log(`- ${label.padEnd(labelWidth, " ")}  ${value}`);
+  }
+}
+
+export async function backfillInboxProjectionCoverage(input: {
+  readonly candidateContactIds: readonly string[];
+  readonly services: BackfillServices;
+  readonly dryRun: boolean;
+  readonly batchSize?: number;
+  readonly logger?: Logger;
+}): Promise<BackfillInboxProjectionCoverageResult> {
+  const logger = input.logger ?? console;
+  const batchSize = input.batchSize ?? defaultBatchSize;
+  const batches = chunkValues(input.candidateContactIds, batchSize);
+  let scannedCount = 0;
+  let insertedCount = 0;
+  let skippedCount = 0;
+  let errorCount = 0;
+
+  logger.log("backfill-inbox-projection-coverage");
+  logger.log(`Mode: ${input.dryRun ? "dry-run" : "execute"}`);
+  logger.log(`- candidate contacts: ${String(input.candidateContactIds.length)}`);
+  logger.log(`- batch size: ${String(batchSize)}`);
+
+  for (const [index, chunk] of batches.entries()) {
+    if (input.dryRun) {
+      const classifications = await Promise.all(
+        chunk.map((contactId) =>
+          classifyDryRunContact(input.services.persistence, contactId)
+        )
+      );
+      const batchInsertedCount = classifications.filter(
+        (outcome) => outcome === "inserted"
+      ).length;
+      const batchSkippedCount = chunk.length - batchInsertedCount;
+
+      scannedCount += chunk.length;
+      insertedCount += batchInsertedCount;
+      skippedCount += batchSkippedCount;
+
+      logger.log(
+        `- batch ${String(index + 1)} / ${String(batches.length)}: scanned ${String(scannedCount)} / ${String(input.candidateContactIds.length)} contacts; would insert ${String(insertedCount)} projections, skip ${String(skippedCount)}`
+      );
+      continue;
+    }
+
+    try {
+      const result = await input.services.orchestration.runProjectionRebuildBatch(
+        projectionRebuildBatchPayloadSchema.parse({
+          version: stage1JobVersion,
+          jobId: buildOperationId("ops:backfill-inbox-projection-coverage:job"),
+          correlationId: buildOperationId(
+            "ops:backfill-inbox-projection-coverage:correlation"
+          ),
+          traceId: null,
+          batchId: buildOperationId(
+            "ops:backfill-inbox-projection-coverage:batch"
+          ),
+          syncStateId: buildOperationId(
+            "ops:backfill-inbox-projection-coverage:sync-state"
+          ),
+          attempt: 1,
+          maxAttempts: 1,
+          jobType: "projection_rebuild",
+          projection: "inbox",
+          contactIds: chunk,
+          includeReviewOverlayRefresh: true
+        })
+      );
+
+      if (result.outcome !== "succeeded") {
+        const failureMessage = result.failure?.message ?? "unknown failure";
+        throw new Error(failureMessage);
+      }
+
+      const projections = await Promise.all(
+        chunk.map((contactId) =>
+          input.services.persistence.repositories.inboxProjection.findByContactId(
+            contactId
+          )
+        )
+      );
+      const batchInsertedCount = projections.filter((row) => row !== null).length;
+      const batchSkippedCount = chunk.length - batchInsertedCount;
+
+      scannedCount += chunk.length;
+      insertedCount += batchInsertedCount;
+      skippedCount += batchSkippedCount;
+
+      logger.log(
+        `- batch ${String(index + 1)} / ${String(batches.length)}: scanned ${String(scannedCount)} / ${String(input.candidateContactIds.length)} contacts; inserted ${String(insertedCount)} projections, skipped ${String(skippedCount)}`
+      );
+    } catch (error) {
+      scannedCount += chunk.length;
+      errorCount += chunk.length;
+      logger.error(
+        `- batch ${String(index + 1)} / ${String(batches.length)} failed for ${String(chunk.length)} contacts: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
+
+  const summary = {
+    dryRun: input.dryRun,
+    candidateCount: input.candidateContactIds.length,
+    scannedCount,
+    insertedCount,
+    skippedCount,
+    errorCount
+  } as const satisfies BackfillInboxProjectionCoverageResult;
+
+  printSummary(summary, logger);
+  return summary;
+}
+
+export async function runBackfillInboxProjectionCoverageCommand(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv = process.env
+): Promise<BackfillInboxProjectionCoverageResult> {
+  const flags = parseCliFlags(args);
+  const dryRun = !readOptionalBooleanFlag(flags, "execute", false);
+  const batchSize = readOptionalIntegerFlag(
+    flags,
+    "batch-size",
+    defaultBatchSize
+  );
+  const limit = readOptionalIntegerFlag(flags, "limit", 0) || null;
+  const connection = createDatabaseConnection({
+    connectionString: readConnectionString(env)
+  });
+
+  try {
+    const candidateContactIds =
+      await loadBackfillInboxProjectionCoverageCandidateContactIds(connection, {
+        limit
+      });
+    const services = createProjectionRebuildOrchestration(connection);
+
+    return await backfillInboxProjectionCoverage({
+      candidateContactIds,
+      services,
+      dryRun,
+      batchSize
+    });
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1] ?? ""}`) {
+  void runBackfillInboxProjectionCoverageCommand(process.argv.slice(2)).catch(
+    (error: unknown) => {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "backfill-inbox-projection-coverage failed.";
+
+      console.error(message);
+      process.exitCode = 1;
+    }
+  );
+}

--- a/apps/worker/test/stage1-backfill-inbox-projection-coverage.test.ts
+++ b/apps/worker/test/stage1-backfill-inbox-projection-coverage.test.ts
@@ -1,0 +1,454 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canonicalEventSchema,
+  resolveCanonicalChannel,
+  type CanonicalEventRecord,
+  type SourceEvidenceRecord
+} from "@as-comms/contracts";
+
+import {
+  backfillInboxProjectionCoverage,
+  loadBackfillInboxProjectionCoverageCandidateContactIdsFromDb
+} from "../src/ops/backfill-inbox-projection-coverage.js";
+import { createTestWorkerContext, type TestWorkerContext } from "./helpers.js";
+
+async function seedContact(input: {
+  readonly context: TestWorkerContext;
+  readonly contactId: string;
+  readonly salesforceContactId: string | null;
+  readonly email: string;
+  readonly displayName: string;
+}): Promise<void> {
+  await input.context.normalization.upsertNormalizedContactGraph({
+    contact: {
+      id: input.contactId,
+      salesforceContactId: input.salesforceContactId,
+      displayName: input.displayName,
+      primaryEmail: input.email,
+      primaryPhone: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z"
+    },
+    identities: [
+      {
+        id: `identity:${input.contactId}:email`,
+        contactId: input.contactId,
+        kind: "email",
+        normalizedValue: input.email,
+        isPrimary: true,
+        source: "salesforce",
+        verifiedAt: "2026-01-01T00:00:00.000Z"
+      }
+    ],
+    memberships:
+      input.salesforceContactId === null
+        ? []
+        : [
+            {
+              id: `membership:${input.contactId}:default`,
+              contactId: input.contactId,
+              salesforceMembershipId: `membership:${input.contactId}:default:sf`,
+              projectId: "project_default",
+              expeditionId: "expedition_default",
+              role: "volunteer",
+              status: "active",
+              source: "salesforce",
+              createdAt: "2026-01-01T00:00:00.000Z"
+            }
+          ]
+  });
+}
+
+function buildSourceEvidence(input: {
+  readonly key: string;
+  readonly provider: SourceEvidenceRecord["provider"];
+  readonly providerRecordType: string;
+  readonly occurredAt: string;
+}): SourceEvidenceRecord {
+  return {
+    id: `sev_${input.key}`,
+    provider: input.provider,
+    providerRecordType: input.providerRecordType,
+    providerRecordId: `${input.provider}:${input.key}`,
+    receivedAt: input.occurredAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `payloads/${input.provider}/${input.key}.json`,
+    idempotencyKey: `${input.provider}:${input.providerRecordType}:${input.key}`,
+    checksum: `checksum:${input.key}`
+  };
+}
+
+function buildCanonicalEvent(input: {
+  readonly key: string;
+  readonly contactId: string;
+  readonly eventType: CanonicalEventRecord["eventType"];
+  readonly occurredAt: string;
+  readonly primaryProvider: CanonicalEventRecord["provenance"]["primaryProvider"];
+  readonly sourceRecordType: string;
+  readonly direction: CanonicalEventRecord["provenance"]["direction"];
+  readonly messageKind: CanonicalEventRecord["provenance"]["messageKind"];
+  readonly inboxProjectionExclusionReason?: "forwarded_chain" | null;
+}): CanonicalEventRecord {
+  return canonicalEventSchema.parse({
+    id: `evt_${input.key}`,
+    contactId: input.contactId,
+    eventType: input.eventType,
+    channel: resolveCanonicalChannel(input.eventType),
+    occurredAt: input.occurredAt,
+    contentFingerprint: null,
+    sourceEvidenceId: `sev_${input.key}`,
+    idempotencyKey: `canonical:${input.key}`,
+    provenance: {
+      primaryProvider: input.primaryProvider,
+      primarySourceEvidenceId: `sev_${input.key}`,
+      supportingSourceEvidenceIds: [],
+      winnerReason:
+        input.primaryProvider === "salesforce"
+          ? "salesforce_only_best_evidence"
+          : "single_source",
+      sourceRecordType: input.sourceRecordType,
+      sourceRecordId: `${input.primaryProvider}:${input.key}`,
+      messageKind: input.messageKind,
+      campaignRef: null,
+      threadRef: null,
+      direction: input.direction,
+      inboxProjectionExclusionReason:
+        input.inboxProjectionExclusionReason ?? null,
+      notes: null
+    },
+    reviewState: "clear"
+  });
+}
+
+async function seedCanonicalEventOnly(input: {
+  readonly context: TestWorkerContext;
+  readonly event: CanonicalEventRecord;
+}): Promise<void> {
+  await input.context.repositories.sourceEvidence.append(
+    buildSourceEvidence({
+      key: input.event.id.replace("evt_", ""),
+      provider: input.event.provenance.primaryProvider,
+      providerRecordType: input.event.provenance.sourceRecordType ?? "message",
+      occurredAt: input.event.occurredAt
+    })
+  );
+  await input.context.repositories.canonicalEvents.upsert(input.event);
+}
+
+async function runForCurrentCandidates(input: {
+  readonly context: TestWorkerContext;
+  readonly dryRun: boolean;
+}): Promise<Awaited<ReturnType<typeof backfillInboxProjectionCoverage>>> {
+  const candidateContactIds =
+    await loadBackfillInboxProjectionCoverageCandidateContactIdsFromDb(
+      input.context.db
+    );
+
+  return backfillInboxProjectionCoverage({
+    candidateContactIds,
+    services: {
+      persistence: input.context.persistence,
+      orchestration: input.context.orchestration
+    },
+    dryRun: input.dryRun,
+    batchSize: 2,
+    logger: {
+      log(..._args) {
+        void _args;
+      },
+      error(..._args) {
+        void _args;
+      }
+    }
+  });
+}
+
+describe("Stage 1 inbox projection coverage backfill ops", () => {
+  it("creates projections for auto-only, campaign-only, and lifecycle-only contacts while skipping excluded-only contacts", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact({
+        context,
+        contactId: "contact_auto",
+        salesforceContactId: "003-auto",
+        email: "auto@example.org",
+        displayName: "Auto Only"
+      });
+      await seedContact({
+        context,
+        contactId: "contact_campaign",
+        salesforceContactId: "003-campaign",
+        email: "campaign@example.org",
+        displayName: "Campaign Only"
+      });
+      await seedContact({
+        context,
+        contactId: "contact_lifecycle",
+        salesforceContactId: "003-lifecycle",
+        email: "lifecycle@example.org",
+        displayName: "Lifecycle Only"
+      });
+      await seedContact({
+        context,
+        contactId: "contact_excluded",
+        salesforceContactId: "003-excluded",
+        email: "excluded@example.org",
+        displayName: "Excluded Only"
+      });
+
+      await seedCanonicalEventOnly({
+        context,
+        event: buildCanonicalEvent({
+          key: "auto_older",
+          contactId: "contact_auto",
+          eventType: "communication.email.outbound",
+          occurredAt: "2026-04-24T14:45:00.000Z",
+          primaryProvider: "salesforce",
+          sourceRecordType: "task_communication",
+          direction: "outbound",
+          messageKind: "auto"
+        })
+      });
+      await seedCanonicalEventOnly({
+        context,
+        event: buildCanonicalEvent({
+          key: "auto_newer",
+          contactId: "contact_auto",
+          eventType: "communication.email.outbound",
+          occurredAt: "2026-04-24T14:50:00.000Z",
+          primaryProvider: "salesforce",
+          sourceRecordType: "task_communication",
+          direction: "outbound",
+          messageKind: "auto"
+        })
+      });
+      await seedCanonicalEventOnly({
+        context,
+        event: buildCanonicalEvent({
+          key: "campaign_older",
+          contactId: "contact_campaign",
+          eventType: "campaign.email.sent",
+          occurredAt: "2026-04-24T15:00:00.000Z",
+          primaryProvider: "mailchimp",
+          sourceRecordType: "campaign_activity",
+          direction: null,
+          messageKind: "campaign"
+        })
+      });
+      await seedCanonicalEventOnly({
+        context,
+        event: buildCanonicalEvent({
+          key: "campaign_newer",
+          contactId: "contact_campaign",
+          eventType: "campaign.email.sent",
+          occurredAt: "2026-04-24T15:05:00.000Z",
+          primaryProvider: "mailchimp",
+          sourceRecordType: "campaign_activity",
+          direction: null,
+          messageKind: "campaign"
+        })
+      });
+      await seedCanonicalEventOnly({
+        context,
+        event: buildCanonicalEvent({
+          key: "campaign_opened",
+          contactId: "contact_campaign",
+          eventType: "campaign.email.opened",
+          occurredAt: "2026-04-24T15:08:00.000Z",
+          primaryProvider: "mailchimp",
+          sourceRecordType: "campaign_activity",
+          direction: null,
+          messageKind: "campaign"
+        })
+      });
+      await seedCanonicalEventOnly({
+        context,
+        event: buildCanonicalEvent({
+          key: "lifecycle_received_training",
+          contactId: "contact_lifecycle",
+          eventType: "lifecycle.received_training",
+          occurredAt: "2026-04-24T15:10:00.000Z",
+          primaryProvider: "salesforce",
+          sourceRecordType: "contact_membership",
+          direction: null,
+          messageKind: null
+        })
+      });
+      await seedCanonicalEventOnly({
+        context,
+        event: buildCanonicalEvent({
+          key: "excluded_forwarded_chain",
+          contactId: "contact_excluded",
+          eventType: "communication.email.outbound",
+          occurredAt: "2026-04-24T15:12:00.000Z",
+          primaryProvider: "gmail",
+          sourceRecordType: "message",
+          direction: "outbound",
+          messageKind: "one_to_one",
+          inboxProjectionExclusionReason: "forwarded_chain"
+        })
+      });
+      await seedCanonicalEventOnly({
+        context,
+        event: buildCanonicalEvent({
+          key: "excluded_internal_only",
+          contactId: "contact_excluded",
+          eventType: "communication.email.outbound",
+          occurredAt: "2026-04-24T15:15:00.000Z",
+          primaryProvider: "gmail",
+          sourceRecordType: "internal_only_message",
+          direction: "outbound",
+          messageKind: "one_to_one"
+        })
+      });
+
+      const result = await runForCurrentCandidates({
+        context,
+        dryRun: false
+      });
+
+      expect(result).toMatchObject({
+        dryRun: false,
+        candidateCount: 4,
+        scannedCount: 4,
+        insertedCount: 3,
+        skippedCount: 1,
+        errorCount: 0
+      });
+
+      await expect(
+        context.repositories.inboxProjection.findByContactId("contact_auto")
+      ).resolves.toMatchObject({
+        bucket: "Opened",
+        lastInboundAt: null,
+        lastOutboundAt: "2026-04-24T14:50:00.000Z",
+        lastActivityAt: "2026-04-24T14:50:00.000Z",
+        lastEventType: "communication.email.outbound"
+      });
+      await expect(
+        context.repositories.inboxProjection.findByContactId("contact_campaign")
+      ).resolves.toMatchObject({
+        bucket: "Opened",
+        lastInboundAt: null,
+        lastOutboundAt: "2026-04-24T15:05:00.000Z",
+        lastActivityAt: "2026-04-24T15:08:00.000Z",
+        lastEventType: "campaign.email.opened"
+      });
+      await expect(
+        context.repositories.inboxProjection.findByContactId("contact_lifecycle")
+      ).resolves.toMatchObject({
+        bucket: "Opened",
+        lastInboundAt: null,
+        lastOutboundAt: null,
+        lastActivityAt: "2026-04-24T15:10:00.000Z",
+        lastEventType: "lifecycle.received_training"
+      });
+      await expect(
+        context.repositories.inboxProjection.findByContactId("contact_excluded")
+      ).resolves.toBeNull();
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("is idempotent because the candidate query excludes contacts once projections exist", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact({
+        context,
+        contactId: "contact_idempotent",
+        salesforceContactId: "003-idempotent",
+        email: "idempotent@example.org",
+        displayName: "Idempotent Contact"
+      });
+      await seedCanonicalEventOnly({
+        context,
+        event: buildCanonicalEvent({
+          key: "idempotent_campaign",
+          contactId: "contact_idempotent",
+          eventType: "campaign.email.sent",
+          occurredAt: "2026-04-24T15:20:00.000Z",
+          primaryProvider: "mailchimp",
+          sourceRecordType: "campaign_activity",
+          direction: null,
+          messageKind: "campaign"
+        })
+      });
+
+      const first = await runForCurrentCandidates({
+        context,
+        dryRun: false
+      });
+      const second = await runForCurrentCandidates({
+        context,
+        dryRun: false
+      });
+
+      expect(first).toMatchObject({
+        candidateCount: 1,
+        scannedCount: 1,
+        insertedCount: 1,
+        skippedCount: 0,
+        errorCount: 0
+      });
+      expect(second).toMatchObject({
+        candidateCount: 0,
+        scannedCount: 0,
+        insertedCount: 0,
+        skippedCount: 0,
+        errorCount: 0
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("does not write projections in dry-run mode", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact({
+        context,
+        contactId: "contact_dry_run",
+        salesforceContactId: "003-dry-run",
+        email: "dryrun@example.org",
+        displayName: "Dry Run Contact"
+      });
+      await seedCanonicalEventOnly({
+        context,
+        event: buildCanonicalEvent({
+          key: "dry_run_auto",
+          contactId: "contact_dry_run",
+          eventType: "communication.email.outbound",
+          occurredAt: "2026-04-24T15:25:00.000Z",
+          primaryProvider: "salesforce",
+          sourceRecordType: "task_communication",
+          direction: "outbound",
+          messageKind: "auto"
+        })
+      });
+
+      const result = await runForCurrentCandidates({
+        context,
+        dryRun: true
+      });
+
+      expect(result).toMatchObject({
+        dryRun: true,
+        candidateCount: 1,
+        scannedCount: 1,
+        insertedCount: 1,
+        skippedCount: 0,
+        errorCount: 0
+      });
+      await expect(
+        context.repositories.inboxProjection.findByContactId("contact_dry_run")
+      ).resolves.toBeNull();
+    } finally {
+      await context.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## What changed
- adds a one-shot worker ops script, `ops:backfill-inbox-projection-coverage`, to find contacts with canonical events but no `contact_inbox_projection` row and rebuild inbox projections in batches
- reuses the existing `projection_rebuild` orchestration path in `projection: "inbox"` mode so the backfill follows the same production rebuild semantics already used elsewhere
- adds worker test coverage for auto-only, campaign-only, lifecycle-only, excluded-only, idempotent, and dry-run cases

## Why
PR #310 widened `qualifiesForInboxProjection` prospectively, but existing rows were never backfilled. Production still has contacts with qualifying canonical history and no inbox projection row, which breaks inbox discoverability and detail recovery for those contacts.

## Impact
- dry-run mode reports candidate volume without writing
- execute mode creates the missing inbox projection rows for qualifying contacts and leaves excluded-only contacts without a projection
- rerunning the script is idempotent because the candidate query excludes contacts once a projection exists

## Validation
- `pnpm install --force`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @as-comms/worker exec vitest run test/stage1-backfill-inbox-projection-coverage.test.ts --config ../../vitest.config.ts`

Production deployment plan:

1. Merge this PR; Railway auto-deploys to worker.
2. Dry-run first:
   `railway run --service worker pnpm --filter @as-comms/worker ops:backfill-inbox-projection-coverage`
   Confirm count is in the ~5,400-5,500 range.
3. Execute:
   `railway run --service worker pnpm --filter @as-comms/worker ops:backfill-inbox-projection-coverage --execute`
4. Spot-check Drew Fuentes (`contact:salesforce:003VK00000cptKmYAI`) and
   Kent Laudon (`contact:salesforce:003VK00000lGPt5YAG`) — both should
   now have projection rows (Drew's was previously created by SMS
   activity; Kent's is the canary for the rule widening).
5. Re-run the inbox dashboard 404 on a metric drilldown — should now
   resolve to a real detail view.
