### PR TITLE
fix(inbox): remove campaign accent-icon overlay; rely on state pill

### DIFF
--- a/apps/web/app/inbox/_components/inbox-timeline-automated-row.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-automated-row.tsx
@@ -132,34 +132,6 @@ function describeCampaignVisualState(
   return "sent";
 }
 
-function CampaignStateIcon({
-  state,
-}: {
-  readonly state: ReturnType<typeof describeCampaignVisualState>;
-}) {
-  const AccentIcon =
-    state === "clicked"
-      ? MousePointerClickIcon
-      : state === "opened"
-        ? EyeIcon
-        : state === "unsubscribed"
-          ? XIcon
-          : null;
-
-  return (
-    <span className="relative inline-flex">
-      <MegaphoneIcon className="size-4" />
-      {AccentIcon ? (
-        <span className="absolute -right-1 -top-1 inline-flex size-3.5 items-center justify-center rounded-full border border-violet-200 bg-white text-violet-700 shadow-sm">
-          <AccentIcon className="size-2" />
-        </span>
-      ) : (
-        <span className="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-violet-500 ring-2 ring-white" />
-      )}
-    </span>
-  );
-}
-
 function CampaignStateBadge({
   state,
 }: {
@@ -276,11 +248,7 @@ export function TimelineAutomatedRow({
                     descriptor.iconClassName,
                   )}
                 >
-                  {role === "campaign" ? (
-                    <CampaignStateIcon state={campaignState ?? "sent"} />
-                  ) : (
-                    <descriptor.Icon className="size-4" />
-                  )}
+                  <descriptor.Icon className="size-4" />
                 </div>
                 <div className="min-w-0">
                   <div className="flex items-center gap-1.5">


### PR DESCRIPTION
The campaign timeline row stacked a megaphone icon with an accent overlay (eye / click / x / violet dot) plus a separate state pill on the right. The pill alone communicates state — the overlay added visual noise without semantic value.

## Changes

- Remove `CampaignStateIcon` (28 LOC).
- Simplify the campaign icon-shell to render `descriptor.Icon` directly. For `role === "campaign"`, that's already `MegaphoneIcon`.
- Lucide imports retained — still used by `CampaignStateBadge` (the right-side pill).
- No test edits required (no overlay-specific assertions in `apps/web/tests/unit/`).

## Behavior preservation

- `CampaignStateBadge` pill unchanged — still derived from `describeCampaignVisualState(campaignActivity)`.
- `data-campaign-state` attribute unchanged.
- Row expand/collapse interaction unchanged.

## Validation

- `pnpm typecheck` — green
- `pnpm lint` — green
- `pnpm boundaries` — green
- `pnpm build` — failed in dispatch worktree on `next/font` Google Fonts fetch (no network in sandbox); CI on Linux will validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)