### PR TITLE
fix(inbox-rail): paginate Project activity, absolute dates, scrollable container

### DIFF
--- a/apps/web/app/inbox/_components/inbox-contact-rail.tsx
+++ b/apps/web/app/inbox/_components/inbox-contact-rail.tsx
@@ -1,8 +1,11 @@
+"use client";
+
 import type {
   InboxContactSummaryViewModel,
   InboxProjectMembershipViewModel,
   InboxProjectStatus,
 } from "../_lib/view-models";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { SectionLabel } from "@/components/ui/section-label";
 import { StatusBadge } from "@/components/ui/status-badge";
@@ -27,15 +30,22 @@ interface RailProps {
   readonly onClose?: () => void;
 }
 
+const ACTIVITY_COLLAPSED_LIMIT = 5;
+
 /**
- * Server component: renders contact reference data for the detail workspace.
+ * Renders contact reference data for the detail workspace.
  *
  * Header: name + record ID (mono, dim). Then contact details (with phone
- * fallback), active and past project participations, and
- * milestone activity. Visibility is controlled by the parent detail
- * component via conditional render.
+ * fallback), active and past project participations, and milestone activity.
+ * Visibility is controlled by the parent detail component via conditional
+ * render.
  */
 export function InboxContactRail({ contact, onClose }: RailProps) {
+  const [activityExpanded, setActivityExpanded] = useState(false);
+  const visibleActivity = activityExpanded
+    ? contact.recentActivity
+    : contact.recentActivity.slice(0, ACTIVITY_COLLAPSED_LIMIT);
+
   return (
     <aside
       id="inbox-contact-rail"
@@ -64,8 +74,9 @@ export function InboxContactRail({ contact, onClose }: RailProps) {
         ) : null}
       </header>
 
-      <div className="min-h-0 flex-1 overflow-y-auto">
-      <section className={`border-b border-slate-200 ${SPACING.section}`}>
+      <section
+        className={`shrink-0 border-b border-slate-200 bg-white ${SPACING.section}`}
+      >
         <SectionLabel as="h3">
           Contact
         </SectionLabel>
@@ -93,61 +104,77 @@ export function InboxContactRail({ contact, onClose }: RailProps) {
         </dl>
       </section>
 
-      <ProjectsSection
-        title="Active Projects"
-        projects={contact.activeProjects}
-        emptyLabel="No active projects"
-      />
-      <ProjectsSection
-        title="Past Projects"
-        projects={contact.pastProjects}
-        emptyLabel="No past projects"
-      />
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <ProjectsSection
+          title="Active Projects"
+          projects={contact.activeProjects}
+          emptyLabel="No active projects"
+        />
+        <ProjectsSection
+          title="Past Projects"
+          projects={contact.pastProjects}
+          emptyLabel="No past projects"
+        />
 
-      <section className={SPACING.section}>
-        <SectionLabel as="h3">
-          Project activity
-        </SectionLabel>
-        {contact.recentActivity.length === 0 ? (
-          <p className="mt-2 text-[12px] text-slate-400">
-            No project activity recorded.
-          </p>
-        ) : (
-          <ul className="mt-3 space-y-3">
-            {contact.recentActivity.map((entry, index) => (
-              <li
-                key={entry.id}
-                className="relative flex gap-3 pb-1 last:pb-0"
-              >
-                {/* Vertical connector line — passes through dot center (5px) */}
-                {index < contact.recentActivity.length - 1 ? (
-                  <div className="absolute left-[5px] top-3 h-full w-px bg-slate-200" />
-                ) : null}
-                {/* Dot — h-[10px] w-[10px] centers at 5px to match line */}
-                <div
-                  className={`relative mt-1.5 h-[10px] w-[10px] shrink-0 rounded-full border-2 ${
-                    index === 0
-                      ? `border-sky-500 ${TONE_CLASSES.sky.dot}`
-                      : "border-slate-300 bg-white"
-                  }`}
-                />
-                <div className="min-w-0 flex-1">
-                  <p className="text-[12.5px] leading-snug text-slate-700">
-                    {entry.label}
-                  </p>
-                  <p
-                    className={`text-[11px] ${
-                      index === 0 ? "text-slate-700" : "text-slate-400"
-                    }`}
+        <section className={SPACING.section}>
+          <SectionLabel as="h3">
+            Project activity
+          </SectionLabel>
+          {contact.recentActivity.length === 0 ? (
+            <p className="mt-2 text-[12px] text-slate-400">
+              No project activity recorded.
+            </p>
+          ) : (
+            <>
+              <ul className="mt-3 space-y-3">
+                {visibleActivity.map((entry, index) => (
+                  <li
+                    key={entry.id}
+                    className="relative flex gap-3 pb-1 last:pb-0"
                   >
-                    {entry.occurredAtLabel}
-                  </p>
-                </div>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
+                    {/* Vertical connector line — passes through dot center (5px) */}
+                    {index < visibleActivity.length - 1 ? (
+                      <div className="absolute left-[5px] top-3 h-full w-px bg-slate-200" />
+                    ) : null}
+                    {/* Dot — h-[10px] w-[10px] centers at 5px to match line */}
+                    <div
+                      className={`relative mt-1.5 h-[10px] w-[10px] shrink-0 rounded-full border-2 ${
+                        index === 0
+                          ? `border-sky-500 ${TONE_CLASSES.sky.dot}`
+                          : "border-slate-300 bg-white"
+                      }`}
+                    />
+                    <div className="min-w-0 flex-1">
+                      <p className="text-[12.5px] leading-snug text-slate-700">
+                        {entry.label}
+                      </p>
+                      <p
+                        className={`text-[11px] ${
+                          index === 0 ? "text-slate-700" : "text-slate-400"
+                        }`}
+                      >
+                        {entry.occurredAtLabel}
+                      </p>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+              {contact.recentActivity.length > ACTIVITY_COLLAPSED_LIMIT ? (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setActivityExpanded((value) => !value);
+                  }}
+                  className="mt-2 text-[12px] font-medium text-slate-500 transition-colors duration-150 hover:text-slate-700"
+                >
+                  {activityExpanded
+                    ? "Show less"
+                    : `Show all (${contact.recentActivity.length.toString()})`}
+                </button>
+              ) : null}
+            </>
+          )}
+        </section>
       </div>
     </aside>
   );

--- a/apps/web/app/inbox/_lib/format-date.ts
+++ b/apps/web/app/inbox/_lib/format-date.ts
@@ -1,0 +1,37 @@
+const RAIL_EVENT_TIME_ZONE = "America/Denver";
+
+const RAIL_EVENT_FORMATTER_SAME_YEAR = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  timeZone: RAIL_EVENT_TIME_ZONE,
+});
+
+const RAIL_EVENT_FORMATTER_WITH_YEAR = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  timeZone: RAIL_EVENT_TIME_ZONE,
+});
+
+const RAIL_EVENT_YEAR_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  year: "numeric",
+  timeZone: RAIL_EVENT_TIME_ZONE,
+});
+
+/**
+ * Returns "Apr 23" if `occurredAt` is in the same Mountain Time calendar year
+ * as `referenceNowIso`, otherwise "Apr 23, 2025".
+ */
+export function formatRailEventDate(
+  occurredAt: string,
+  referenceNowIso: string,
+): string {
+  const occurred = new Date(occurredAt);
+  const reference = new Date(referenceNowIso);
+  const occurredYear = RAIL_EVENT_YEAR_FORMATTER.format(occurred);
+  const referenceYear = RAIL_EVENT_YEAR_FORMATTER.format(reference);
+
+  return occurredYear === referenceYear
+    ? RAIL_EVENT_FORMATTER_SAME_YEAR.format(occurred)
+    : RAIL_EVENT_FORMATTER_WITH_YEAR.format(occurred);
+}

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -19,6 +19,7 @@ import {
 } from "@/app/_lib/cutover";
 
 import { INBOX_FILTERS } from "./filters";
+import { formatRailEventDate } from "./format-date";
 import type {
   InboxActiveProjectOption,
   InboxAvatarTone,
@@ -1939,14 +1940,10 @@ function buildRecentActivity(
         item.family === "salesforce_event",
     )
     .sort((left, right) => right.occurredAt.localeCompare(left.occurredAt))
-    .slice(0, 5)
     .map((item) => ({
       id: item.id,
       label: lifecycleRailActivityLabel(item),
-      occurredAtLabel: formatRelativeTimestamp(
-        item.occurredAt,
-        referenceNowIso,
-      ),
+      occurredAtLabel: formatRailEventDate(item.occurredAt, referenceNowIso),
     }));
 }
 

--- a/apps/web/tests/unit/format-rail-event-date.test.ts
+++ b/apps/web/tests/unit/format-rail-event-date.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { formatRailEventDate } from "../../app/inbox/_lib/format-date";
+
+describe("formatRailEventDate", () => {
+  it("renders month and day for events in the same Mountain Time calendar year", () => {
+    expect(
+      formatRailEventDate(
+        "2026-04-23T15:00:00.000Z",
+        "2026-08-01T12:00:00.000Z",
+      ),
+    ).toBe("Apr 23");
+  });
+
+  it("renders month, day, and year for events from an older Mountain Time calendar year", () => {
+    expect(
+      formatRailEventDate(
+        "2025-04-23T15:00:00.000Z",
+        "2026-08-01T12:00:00.000Z",
+      ),
+    ).toBe("Apr 23, 2025");
+  });
+
+  it("respects Mountain Time year boundaries", () => {
+    expect(
+      formatRailEventDate(
+        "2025-12-31T23:30:00.000Z",
+        "2026-01-15T12:00:00.000Z",
+      ),
+    ).toBe("Dec 31, 2025");
+  });
+});

--- a/apps/web/tests/unit/inbox-contact-rail.test.tsx
+++ b/apps/web/tests/unit/inbox-contact-rail.test.tsx
@@ -1,0 +1,234 @@
+import { createRequire } from "node:module";
+import React, { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { InboxContactSummaryViewModel } from "../../app/inbox/_lib/view-models";
+
+Object.assign(globalThis, { React });
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) =>
+    createElement("button", props, children),
+}));
+
+vi.mock("@/components/ui/section-label", () => ({
+  SectionLabel: ({
+    children,
+  }: {
+    readonly children?: React.ReactNode;
+    readonly as?: string;
+  }) => createElement("span", null, children),
+}));
+
+vi.mock("@/components/ui/status-badge", () => ({
+  StatusBadge: ({ label }: { readonly label: string }) =>
+    createElement("span", null, label),
+}));
+
+vi.mock("@/app/_lib/design-tokens", () => ({
+  PROJECT_STATUS_BADGE: {
+    lead: "",
+    applied: "",
+    "in-training": "",
+    "trip-planning": "",
+    "in-field": "",
+    successful: "",
+  },
+}));
+
+vi.mock("@/app/_lib/design-tokens-v2", () => ({
+  LAYOUT: {
+    railWidth: "w-80",
+    headerHeight: "h-[54px]",
+  },
+  SPACING: {
+    section: "px-5 py-4",
+  },
+  TONE_CLASSES: {
+    slate: {
+      subtle: "bg-slate-50",
+    },
+    sky: {
+      dot: "bg-sky-500",
+    },
+  },
+  TYPE: {
+    headingSm: "text-sm font-semibold text-slate-900",
+  },
+}));
+
+vi.mock("../../app/inbox/_components/icons", () => ({
+  CalendarIcon: () => createElement("svg"),
+  MailIcon: () => createElement("svg"),
+  PanelRightCloseIcon: () => createElement("svg"),
+  PhoneIcon: () => createElement("svg"),
+}));
+
+vi.mock("lucide-react", () => ({
+  ExternalLink: () => createElement("svg"),
+}));
+
+import { InboxContactRail } from "../../app/inbox/_components/inbox-contact-rail";
+
+const workerRequire = createRequire(
+  new URL("../../../worker/package.json", import.meta.url),
+);
+const { JSDOM } = workerRequire("jsdom") as {
+  readonly JSDOM: new (
+    html: string,
+    options: { readonly url: string },
+  ) => {
+    readonly window: Window &
+      typeof globalThis & {
+        close: () => void;
+      };
+  };
+};
+
+interface RenderSession {
+  readonly container: HTMLElement;
+  readonly root: Root;
+  readonly cleanup: () => Promise<void>;
+}
+
+let activeSession: RenderSession | null = null;
+
+function setDomGlobals(window: Window & typeof globalThis) {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: window,
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: window.document,
+  });
+  Object.defineProperty(globalThis, "HTMLElement", {
+    configurable: true,
+    value: window.HTMLElement,
+  });
+  Object.defineProperty(globalThis, "Node", {
+    configurable: true,
+    value: window.Node,
+  });
+  Object.defineProperty(globalThis, "Event", {
+    configurable: true,
+    value: window.Event,
+  });
+  Object.defineProperty(globalThis, "MouseEvent", {
+    configurable: true,
+    value: window.MouseEvent,
+  });
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: window.navigator,
+  });
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+}
+
+function buildContact(activityCount: number): InboxContactSummaryViewModel {
+  return {
+    contactId: "contact:sarah-martinez",
+    displayName: "Sarah Martinez",
+    volunteerId: "VOL-001",
+    primaryEmail: "sarah@example.org",
+    primaryPhone: "555-0100",
+    joinedAtLabel: "Joined Apr 2024",
+    hasUnresolved: false,
+    pinnedNote: null,
+    activeProjects: [],
+    pastProjects: [],
+    recentActivity: Array.from({ length: activityCount }, (_, index) => ({
+      id: `activity-${(index + 1).toString()}`,
+      label: `Lifecycle event ${(index + 1).toString()}`,
+      occurredAtLabel: `Apr ${(index + 1).toString()}`,
+    })),
+  };
+}
+
+async function renderRail(
+  contact: InboxContactSummaryViewModel,
+): Promise<RenderSession> {
+  const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+    url: "http://localhost/inbox",
+  });
+  setDomGlobals(dom.window);
+
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(createElement(InboxContactRail, { contact }));
+    await Promise.resolve();
+  });
+
+  return {
+    container,
+    root,
+    cleanup: async () => {
+      await act(async () => {
+        root.unmount();
+        await Promise.resolve();
+      });
+      container.remove();
+      dom.window.close();
+    },
+  };
+}
+
+async function click(element: Element | null) {
+  if (element === null) {
+    throw new Error("Expected clickable element");
+  }
+
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await Promise.resolve();
+  });
+}
+
+afterEach(async () => {
+  await activeSession?.cleanup();
+  activeSession = null;
+});
+
+describe("InboxContactRail", () => {
+  it("shows five activity items by default and toggles the full list open and closed", async () => {
+    activeSession = await renderRail(buildContact(8));
+
+    expect(activeSession.container.textContent).toContain("Show all (8)");
+    expect(
+      activeSession.container.querySelectorAll("section:last-of-type ul li").length,
+    ).toBe(5);
+    expect(activeSession.container.textContent).not.toContain("Lifecycle event 6");
+
+    await click(
+      Array.from(activeSession.container.querySelectorAll("button")).find(
+        (element) => element.textContent === "Show all (8)",
+      ) ?? null,
+    );
+
+    expect(activeSession.container.textContent).toContain("Show less");
+    expect(
+      activeSession.container.querySelectorAll("section:last-of-type ul li").length,
+    ).toBe(8);
+    expect(activeSession.container.textContent).toContain("Lifecycle event 8");
+
+    await click(
+      Array.from(activeSession.container.querySelectorAll("button")).find(
+        (element) => element.textContent === "Show less",
+      ) ?? null,
+    );
+
+    expect(activeSession.container.textContent).toContain("Show all (8)");
+    expect(
+      activeSession.container.querySelectorAll("section:last-of-type ul li").length,
+    ).toBe(5);
+    expect(activeSession.container.textContent).not.toContain("Lifecycle event 6");
+  });
+});

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -3442,10 +3442,8 @@ describe("real inbox selectors", () => {
     expect(detail?.contact.recentActivity[0]).toMatchObject({
       id: "timeline:sarah-lifecycle-1",
       label: "Received training - Amazon Basin Research",
+      occurredAtLabel: "Apr 9",
     });
-    expect(detail?.contact.recentActivity[0]?.occurredAtLabel).toEqual(
-      expect.any(String),
-    );
   });
 
   it("uses short project aliases in lifecycle timeline bodies and project activity labels", async () => {
@@ -3530,6 +3528,71 @@ describe("real inbox selectors", () => {
       "Received training - Amazon Basin Research",
       "Signed up - Amazon Basin Research",
     ]);
+    expect(
+      detail?.contact.recentActivity.map((entry) => entry.occurredAtLabel),
+    ).toEqual(["Apr 11", "Apr 10", "Apr 9", "Apr 8"]);
+  });
+
+  it("returns all lifecycle activity items and does not hard-cap the rail feed at five", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "sarah-activity-1",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-06T09:00:00.000Z",
+      eventType: "lifecycle.signed_up",
+      summary: "Signed up",
+      projectId: "project:amazon-basin",
+    });
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "sarah-activity-2",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-07T09:00:00.000Z",
+      eventType: "lifecycle.received_training",
+      summary: "Received training",
+      projectId: "project:amazon-basin",
+    });
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "sarah-activity-3",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-08T09:00:00.000Z",
+      eventType: "lifecycle.completed_training",
+      summary: "Completed training",
+      projectId: "project:amazon-basin",
+    });
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "sarah-activity-4",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-09T09:00:00.000Z",
+      eventType: "lifecycle.submitted_first_data",
+      summary: "Submitted first data",
+      projectId: "project:amazon-basin",
+    });
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "sarah-activity-5",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-10T09:00:00.000Z",
+      eventType: "lifecycle.received_training",
+      summary: "Received training",
+      projectId: "project:amazon-basin",
+    });
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "sarah-activity-6",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-11T09:00:00.000Z",
+      eventType: "lifecycle.completed_training",
+      summary: "Completed training",
+      projectId: "project:amazon-basin",
+    });
+
+    const detail = await getInboxDetail("contact:sarah-martinez");
+
+    expect(detail?.contact.recentActivity).toHaveLength(6);
+    expect(
+      detail?.contact.recentActivity.map((entry) => entry.occurredAtLabel),
+    ).toEqual(["Apr 11", "Apr 10", "Apr 9", "Apr 8", "Apr 7", "Apr 6"]);
   });
 
   it("shows only the lifecycle milestones that exist for a contact", async () => {
@@ -3658,12 +3721,12 @@ describe("real inbox selectors", () => {
             {
               id: "recent-1",
               label: "Submitted first data - Amazon Basin",
-              occurredAtLabel: "1h ago",
+              occurredAtLabel: "Apr 11",
             },
             {
               id: "recent-2",
               label: "Received training - Amazon Basin",
-              occurredAtLabel: "2d ago",
+              occurredAtLabel: "Apr 9",
             },
           ],
         },


### PR DESCRIPTION
Three small contact-rail UX fixes (Issue 1a / 1b / 1d in the architect tracker).

## Changes

- **Project activity (1a):** show 5 items by default with a `Show all (N)` / `Show less` toggle. Removes the hard cap of 5 in `buildRecentActivity` and lets the rail paginate locally.
- **Date format (1b):** absolute dates (`Apr 23` for current year, `Apr 23, 2025` for older years) in Mountain Time via new `formatRailEventDate` in `apps/web/app/inbox/_lib/format-date.ts`. Replaces the relative-time labels in the rail. Other surfaces (timeline bubbles, list rows) unchanged.
- **Scrollable rail (1d):** rail body scrolls when content exceeds the viewport. Contact header pinned at top.

## Tests

- New `format-rail-event-date.test.ts` — same-year, older-year, year-boundary edge cases.
- New `inbox-contact-rail.test.tsx` — collapsed/expanded toggle behavior.
- Existing `inbox-selectors.test.ts` — updated for absolute labels and removed 5-item cap.

## Out of scope

Past-project `signupYear` (the year next to the project name) is the subject of a separate fix and is unchanged here.

## Validation

- `pnpm typecheck` — green
- `pnpm lint` — green
- `pnpm boundaries` — green
- `pnpm build` — failed in dispatch worktree on `next/font` Google Fonts fetch (no network in sandbox); CI on Linux will validate.
- `pnpm test:unit` — blocked locally by `rollup-darwin-arm64` macOS gotcha; CI authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)