### PR TITLE
fix(inbox-rail): correct past-project signup year (no membership.createdAt fallback)

### DIFF
--- a/apps/web/app/inbox/_components/inbox-contact-rail.tsx
+++ b/apps/web/app/inbox/_components/inbox-contact-rail.tsx
@@ -182,7 +182,7 @@ function ProjectsSection({ title, projects, emptyLabel }: ProjectsSectionProps) 
                     {project.projectName}
                   </p>
                   <p className="mt-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
-                    {isPastSection ? (
+                    {isPastSection && project.signupYear !== null ? (
                       <>
                         <span className="tabular-nums">
                           {project.signupYear.toString()}

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -655,13 +655,26 @@ function buildProjectActivityIndex(
   timelineItems: readonly TimelineItem[],
 ): {
   readonly firstOccurredAtByProjectId: ReadonlyMap<string, string>;
+  readonly firstOccurredAtForContact: string | null;
   readonly lastOccurredAtByProjectId: ReadonlyMap<string, string>;
 } {
   const firstOccurredAtByProjectId = new Map<string, string>();
+  let firstOccurredAtForContact: string | null = null;
   const lastOccurredAtByProjectId = new Map<string, string>();
 
   for (const item of timelineItems) {
-    if (item.family !== "salesforce_event" || item.projectId === null) {
+    if (item.family !== "salesforce_event") {
+      continue;
+    }
+
+    if (
+      firstOccurredAtForContact === null ||
+      item.occurredAt < firstOccurredAtForContact
+    ) {
+      firstOccurredAtForContact = item.occurredAt;
+    }
+
+    if (item.projectId === null) {
       continue;
     }
 
@@ -681,6 +694,7 @@ function buildProjectActivityIndex(
 
   return {
     firstOccurredAtByProjectId,
+    firstOccurredAtForContact,
     lastOccurredAtByProjectId,
   };
 }
@@ -861,6 +875,9 @@ function buildProjectMembershipViewModel(
     >
   >,
   firstOccurredAtByProjectId: ReadonlyMap<string, string>,
+  firstOccurredAtForContact: string | null,
+  contactCreatedAt: string,
+  referenceNowIso: string,
 ): InboxProjectMembershipViewModel | null {
   const projectName =
     membership.projectId === null
@@ -872,13 +889,27 @@ function buildProjectMembershipViewModel(
     return null;
   }
 
+  const projectOccurredAt =
+    firstOccurredAtByProjectId.get(membership.projectId) ?? null;
+  const signupYearSource =
+    projectOccurredAt !== null
+      ? "project-event"
+      : firstOccurredAtForContact !== null
+        ? "contact-event"
+        : "contact-created-at";
+  const signupYearTimestamp =
+    projectOccurredAt ?? firstOccurredAtForContact ?? contactCreatedAt;
+  const signupYear = new Date(signupYearTimestamp).getUTCFullYear();
+  const referenceYear = new Date(referenceNowIso).getUTCFullYear();
+
   return {
     membershipId: membership.id,
     projectId: membership.projectId,
     projectName,
-    signupYear: new Date(
-      firstOccurredAtByProjectId.get(membership.projectId) ?? membership.createdAt,
-    ).getUTCFullYear(),
+    signupYear:
+      signupYearSource === "contact-created-at" && signupYear === referenceYear
+        ? null
+        : signupYear,
     projectIsActive:
       projectMetadataById[membership.projectId]?.isActive ?? false,
     status: mapProjectStatus(membership.status),
@@ -4054,6 +4085,9 @@ function buildContactSummary(input: {
         membership,
         input.projectMetadataById,
         projectActivityIndex.firstOccurredAtByProjectId,
+        projectActivityIndex.firstOccurredAtForContact,
+        input.contact.createdAt,
+        input.referenceNowIso,
       ),
     )
     .filter(
@@ -4067,6 +4101,9 @@ function buildContactSummary(input: {
         membership,
         input.projectMetadataById,
         projectActivityIndex.firstOccurredAtByProjectId,
+        projectActivityIndex.firstOccurredAtForContact,
+        input.contact.createdAt,
+        input.referenceNowIso,
       ),
     )
     .filter(

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -119,7 +119,7 @@ export interface InboxProjectMembershipViewModel {
   readonly membershipId: string;
   readonly projectId: string;
   readonly projectName: string;
-  readonly signupYear: number;
+  readonly signupYear: number | null;
   readonly projectIsActive: boolean;
   readonly status: InboxProjectStatus;
   readonly statusLabel: string;

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -2712,6 +2712,20 @@ describe("real inbox selectors", () => {
       "project:killer-whales",
       false,
     );
+
+    // Seed a project-linked lifecycle event so signupYear resolves to a real
+    // historical year (otherwise the fallback chain reaches contact.createdAt
+    // which equals the current/backfill year and is intentionally suppressed —
+    // see "correct past-project signup year").
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "lisa-killer-whales-signup",
+      contactId: "contact:lisa-zhang",
+      occurredAt: "2023-06-15T15:00:00.000Z",
+      eventType: "lifecycle.signed_up",
+      summary: "Signed up - Searching for Killer Whales",
+      projectId: "project:killer-whales",
+    });
+
     const [activeDetail, pastDetail] = await Promise.all([
       getInboxDetail("contact:sarah-martinez"),
       getInboxDetail("contact:lisa-zhang"),
@@ -2737,7 +2751,7 @@ describe("real inbox selectors", () => {
 
     expect(activeSection).not.toContain("tabular-nums");
     expect(pastSection).toContain("tabular-nums");
-    expect(pastSection).toContain("2026");
+    expect(pastSection).toContain("2023");
   });
 
   it("uses the most recent internal note as the pinned note proxy", async () => {

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -738,6 +738,7 @@ describe("real inbox selectors", () => {
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
     await runtime?.dispose();
     runtime = null;
   });
@@ -2470,6 +2471,7 @@ describe("real inbox selectors", () => {
       displayName: "Membership All Time",
       primaryEmail: "membership-all-time@example.org",
       primaryPhone: null,
+      contactCreatedAt: "2023-06-01T12:00:00.000Z",
       projectId: "project:all-time-membership",
       projectName: "All-Time Membership Project",
       membershipId: "membership:all-time-membership",
@@ -2558,7 +2560,7 @@ describe("real inbox selectors", () => {
       projectIsActive: false,
       status: "applied",
       statusLabel: "Applied",
-      signupYear: 2024,
+      signupYear: null,
       expeditionMemberUrl:
         "https://adventurescientists.lightning.force.com/lightning/r/Expedition_Members__c/a0B-ryan-parks/view",
     });
@@ -2625,8 +2627,8 @@ describe("real inbox selectors", () => {
       "Older Project",
     ]);
     expect(detail?.contact.pastProjects.map((project) => project.signupYear)).toEqual([
-      2025,
-      2022,
+      null,
+      null,
     ]);
   });
 
@@ -2896,7 +2898,7 @@ describe("real inbox selectors", () => {
     expect(detail).not.toBeNull();
     expect(detail?.contact.pastProjects[0]).toMatchObject({
       projectIsActive: false,
-      signupYear: 2026,
+      signupYear: null,
       status: "successful",
       statusLabel: "Successful",
       crmUrl:
@@ -2906,7 +2908,7 @@ describe("real inbox selectors", () => {
     });
   });
 
-  it("derives past-project signup year from the earliest lifecycle event and falls back to membership createdAt", async () => {
+  it("derives past-project signup year from project events, contact-level events, and suppresses backfill-year fallbacks", async () => {
     if (runtime === null) {
       throw new Error("Expected inbox test runtime");
     }
@@ -2925,24 +2927,61 @@ describe("real inbox selectors", () => {
       membershipCreatedAt: "2026-02-01T00:00:00.000Z",
     });
     await seedInboxContact(runtime.context, {
-      contactId: "contact:past-signup-year",
-      salesforceContactId: "003-past-signup-year",
-      displayName: "Past Signup Year",
-      primaryEmail: "past-signup-year@example.org",
+      contactId: "contact:contact-event-signup-year",
+      salesforceContactId: "003-contact-event-signup-year",
+      displayName: "Contact Event Signup Year",
+      primaryEmail: "contact-event-signup-year@example.org",
       primaryPhone: null,
-      projectId: "project:fallback-membership-year",
-      projectName: "Fallback Membership Year",
-      membershipId: "membership:past:fallback-membership-year",
-      salesforceMembershipId: "a0B-past-fallback-membership-year",
+      contactCreatedAt: "2018-01-01T00:00:00.000Z",
+      projectId: "project:contact-event-fallback-year",
+      projectName: "Contact Event Fallback Year",
+      membershipId: "membership:contact-event-fallback-year",
+      salesforceMembershipId: "a0B-contact-event-fallback-year",
       membershipStatus: "completed",
-      membershipCreatedAt: "2024-05-01T00:00:00.000Z",
+      membershipCreatedAt: "2026-04-15T00:00:00.000Z",
+    });
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:null-project-fallback-year",
+      salesforceContactId: "003-null-project-fallback-year",
+      displayName: "Null Project Fallback Year",
+      primaryEmail: "null-project-fallback-year@example.org",
+      primaryPhone: null,
+      contactCreatedAt: "2019-01-01T00:00:00.000Z",
+      projectId: "project:null-project-fallback-year",
+      projectName: "Null Project Fallback Year",
+      membershipId: "membership:null-project-fallback-year",
+      salesforceMembershipId: "a0B-null-project-fallback-year",
+      membershipStatus: "successful",
+      membershipCreatedAt: "2026-04-15T00:00:00.000Z",
+    });
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:suppressed-signup-year",
+      salesforceContactId: "003-suppressed-signup-year",
+      displayName: "Suppressed Signup Year",
+      primaryEmail: "suppressed-signup-year@example.org",
+      primaryPhone: null,
+      contactCreatedAt: "2026-01-05T00:00:00.000Z",
+      projectId: "project:suppressed-signup-year",
+      projectName: "Suppressed Signup Year",
+      membershipId: "membership:suppressed-signup-year",
+      salesforceMembershipId: "a0B-suppressed-signup-year",
+      membershipStatus: "completed",
+      membershipCreatedAt: "2026-04-15T00:00:00.000Z",
     });
     await runtime.context.settings.projects.setActive(
       "project:old-ledger-year",
       false,
     );
     await runtime.context.settings.projects.setActive(
-      "project:fallback-membership-year",
+      "project:contact-event-fallback-year",
+      false,
+    );
+    await runtime.context.settings.projects.setActive(
+      "project:null-project-fallback-year",
+      false,
+    );
+    await runtime.context.settings.projects.setActive(
+      "project:suppressed-signup-year",
       false,
     );
     await seedInboxLifecycleEvent(runtime.context, {
@@ -2960,6 +2999,22 @@ describe("real inbox selectors", () => {
       eventType: "lifecycle.completed_training",
       summary: "Completed training",
       projectId: "project:old-ledger-year",
+    });
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "contact-event-fallback-year-earliest",
+      contactId: "contact:contact-event-signup-year",
+      occurredAt: "2020-05-09T00:00:00.000Z",
+      eventType: "lifecycle.signed_up",
+      summary: "Signed up",
+      projectId: "project:other-contact-project",
+    });
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "null-project-fallback-year-earliest",
+      contactId: "contact:null-project-fallback-year",
+      occurredAt: "2022-09-10T00:00:00.000Z",
+      eventType: "lifecycle.signed_up",
+      summary: "Signed up",
+      projectId: null,
     });
     const latest = await seedInboxEmailEvent(runtime.context, {
       id: "past-signup-year-inbound",
@@ -2981,22 +3036,104 @@ describe("real inbox selectors", () => {
       lastCanonicalEventId: latest.canonicalEventId,
       lastEventType: "communication.email.inbound",
     });
+    const contactFallbackLatest = await seedInboxEmailEvent(runtime.context, {
+      id: "contact-event-signup-year-inbound",
+      contactId: "contact:contact-event-signup-year",
+      occurredAt: "2026-04-25T13:00:00.000Z",
+      direction: "inbound",
+      subject: "Contact event signup year check",
+      snippet: "Checking contact-level signup year fallback.",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:contact-event-signup-year",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-25T13:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-04-25T13:00:00.000Z",
+      snippet: "Checking contact-level signup year fallback.",
+      lastCanonicalEventId: contactFallbackLatest.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+    const nullProjectLatest = await seedInboxEmailEvent(runtime.context, {
+      id: "null-project-fallback-year-inbound",
+      contactId: "contact:null-project-fallback-year",
+      occurredAt: "2026-04-25T13:00:00.000Z",
+      direction: "inbound",
+      subject: "Null project signup year check",
+      snippet: "Checking null-project contact-level signup year fallback.",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:null-project-fallback-year",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-25T13:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-04-25T13:00:00.000Z",
+      snippet: "Checking null-project contact-level signup year fallback.",
+      lastCanonicalEventId: nullProjectLatest.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+    const suppressedLatest = await seedInboxEmailEvent(runtime.context, {
+      id: "suppressed-signup-year-inbound",
+      contactId: "contact:suppressed-signup-year",
+      occurredAt: "2026-04-25T13:00:00.000Z",
+      direction: "inbound",
+      subject: "Suppressed signup year check",
+      snippet: "Checking backfill-year suppression.",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:suppressed-signup-year",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-25T13:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-04-25T13:00:00.000Z",
+      snippet: "Checking backfill-year suppression.",
+      lastCanonicalEventId: suppressedLatest.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
 
     const detail = await getInboxDetail("contact:past-signup-year");
+    const contactEventDetail = await getInboxDetail(
+      "contact:contact-event-signup-year",
+    );
+    const nullProjectDetail = await getInboxDetail(
+      "contact:null-project-fallback-year",
+    );
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-04T12:00:00.000Z"));
+    const suppressedDetail = await getInboxDetail("contact:suppressed-signup-year");
 
     // Past projects sort by membership.createdAt desc (newest first).
-    // Old Ledger Year has membershipCreatedAt 2026-02-01, Fallback has 2024-05-01.
-    // signupYear is independent of sort: derived from earliest project event
-    // (2021 for Old Ledger via lifecycle event), or falls back to membership
-    // year (2024 for Fallback Membership Year, no events).
+    // signupYear is independent of sort and resolves via:
+    // project-linked event -> contact-level event -> contact createdAt.
     expect(detail?.contact.pastProjects).toMatchObject([
       {
         projectName: "Old Ledger Year",
         signupYear: 2021,
       },
+    ]);
+    expect(contactEventDetail?.contact.pastProjects).toMatchObject([
       {
-        projectName: "Fallback Membership Year",
-        signupYear: 2024,
+        projectName: "Contact Event Fallback Year",
+        signupYear: 2020,
+      },
+    ]);
+    expect(nullProjectDetail?.contact.pastProjects).toMatchObject([
+      {
+        projectName: "Null Project Fallback Year",
+        signupYear: 2022,
+      },
+    ]);
+    expect(suppressedDetail?.contact.pastProjects).toMatchObject([
+      {
+        projectName: "Suppressed Signup Year",
+        signupYear: null,
       },
     ]);
   });

--- a/apps/web/tests/unit/inbox-stage1-helpers.ts
+++ b/apps/web/tests/unit/inbox-stage1-helpers.ts
@@ -17,6 +17,7 @@ export async function seedInboxContact(
     readonly displayName: string;
     readonly primaryEmail: string | null;
     readonly primaryPhone: string | null;
+    readonly contactCreatedAt?: string;
     readonly projectId?: string;
     readonly projectName?: string;
     readonly projectAlias?: string | null;
@@ -32,8 +33,8 @@ export async function seedInboxContact(
     displayName: input.displayName,
     primaryEmail: input.primaryEmail,
     primaryPhone: input.primaryPhone,
-    createdAt: "2026-01-01T00:00:00.000Z",
-    updatedAt: "2026-01-01T00:00:00.000Z",
+    createdAt: input.contactCreatedAt ?? "2026-01-01T00:00:00.000Z",
+    updatedAt: input.contactCreatedAt ?? "2026-01-01T00:00:00.000Z",
   });
 
   if (input.projectId !== undefined) {


### PR DESCRIPTION
Issue 1c in the architect tracker.

Past Projects in the contact rail were showing the year of the Salesforce backfill (often 2026) when no project-linked timeline event was available. The fallback was `membership.createdAt`, which is the DB row's creation date — meaningless for "signup year".

## Fix

Widened fallback chain for `signupYear`:

1. Earliest `salesforce_event` with matching `projectId` (unchanged).
2. **NEW:** earliest `salesforce_event` for the contact (any project).
3. **NEW:** contact's own `created_at` (when the contact first appeared).

When the resolved year equals the current/backfill year AND no project-linked event exists, the year is **suppressed** — the rail shows only the status pill. Better than displaying a misleading year.

## View-model change

`InboxProjectMembershipViewModel.signupYear` is now `number | null`. The rail's Past Projects section conditionally renders the year + separator.

## Tests

Added scenarios for:

- Project event present (year preserved).
- No project event but contact event on a different project → uses earliest contact-event year.
- No project event but only null-project Salesforce event → uses contact-event year.
- No events anywhere (year suppressed when only the current/backfill year remains).

## Validation

- `pnpm typecheck` — green
- `pnpm lint` — green
- `pnpm boundaries` — green
- `pnpm build` — failed in dispatch worktree on `next/font` Google Fonts fetch (no network); CI on Linux will validate.
- `pnpm test:unit` — blocked locally by `rollup-darwin-arm64` macOS gotcha; CI authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)