### PR TITLE
fix(welcome): sticky header so content scrolls behind the welcome bar

### DIFF
--- a/apps/web/app/inbox/_components/inbox-welcome-workload.tsx
+++ b/apps/web/app/inbox/_components/inbox-welcome-workload.tsx
@@ -82,7 +82,7 @@ export function InboxWelcomeWorkload({
   return (
     <section className="flex min-h-0 flex-1 flex-col overflow-y-auto bg-slate-50/40">
       <header
-        className={`flex ${LAYOUT.welcomeHeaderHeight} shrink-0 items-center border-b border-slate-200 bg-white px-10`}
+        className={`sticky top-0 z-10 flex ${LAYOUT.welcomeHeaderHeight} shrink-0 items-center border-b border-slate-200 bg-white px-10`}
       >
         <div className="flex w-full items-baseline justify-between gap-4">
           <div className="min-w-0">


### PR DESCRIPTION
The welcome screen's header (`Welcome back, {firstName}` + `Today is …` + sync-freshness badge) now stays pinned at the top while the body (quote card, project lifecycle tiles, follow-up rail) scrolls behind it.

## Change

One line on `inbox-welcome-workload.tsx`'s header — added `sticky top-0 z-10`. The parent `<section>` already uses `overflow-y-auto`, so the header pins within that scroll container. Header is opaque (`bg-white`), so content scrolls behind cleanly.

## Validation

- `pnpm typecheck` — green
- `pnpm lint` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)