### PR TITLE
fix(inbox-detail): wrap header tooltip buttons in TooltipProvider (P0 regression)

### DIFF
--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -15,6 +15,7 @@ import { Button } from "@/components/ui/button";
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
@@ -538,6 +539,7 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
             </div>
           </div>
 
+          <TooltipProvider delayDuration={200}>
           <div className="flex shrink-0 items-center gap-2">
             {detail.projectionAvailable ? (
               <>
@@ -621,6 +623,7 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
               </Tooltip>
             ) : null}
           </div>
+          </TooltipProvider>
         </header>
 
         {contact.hasUnresolved ? <UnresolvedBanner /> : null}

--- a/apps/web/tests/unit/inbox-detail-header.test.tsx
+++ b/apps/web/tests/unit/inbox-detail-header.test.tsx
@@ -74,6 +74,8 @@ vi.mock("../../app/inbox/_components/icons", () => ({
 vi.mock("@/components/ui/tooltip", () => ({
   Tooltip: ({ children }: { readonly children: React.ReactNode }) =>
     createElement(React.Fragment, null, children),
+  TooltipProvider: ({ children }: { readonly children: React.ReactNode }) =>
+    createElement(React.Fragment, null, children),
   TooltipTrigger: ({ children }: { readonly children: React.ReactNode }) =>
     children,
   TooltipContent: () => null,


### PR DESCRIPTION
**P0 prod regression** — operators see "Something went wrong / We couldn't load the inbox" when navigating into a conversation.

## Cause

PR #318 (header redesign) replaced the expanding-pill `HeaderActionButton` with radix `<Tooltip>` icon buttons but didn't ensure a `<TooltipProvider>` ancestor. Browser console shows:

```
Error: `Tooltip` must be used within `TooltipProvider`
```

The error trips the inbox route's error boundary at `apps/web/app/inbox/error.tsx`, which renders the friendly "Something went wrong" page.

## Fix

Wrap the header action-buttons div in `<TooltipProvider delayDuration={200}>`, matching the existing pattern in `composer-detail-surfaces.tsx` (lines 339, 798), `inbox-timeline.tsx` (line 92), and `settings/integrations-section.tsx`.

## Validation

- `pnpm typecheck` — green
- `pnpm lint` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)