### PR TITLE
feat(inbox): bubble layout — avatars outside column, readability widths, group consistency (rebase of #323)

### DIFF
--- a/apps/web/app/inbox/_components/icons.tsx
+++ b/apps/web/app/inbox/_components/icons.tsx
@@ -75,6 +75,4 @@ export {
   Database as DatabaseIcon,
   Archive as ArchiveBoxIcon,
   ArchiveRestore as ArchiveRestoreIcon,
-  Hand as HandIcon,
-  Star as StarIcon,
 } from "lucide-react";

--- a/apps/web/app/inbox/_components/icons.tsx
+++ b/apps/web/app/inbox/_components/icons.tsx
@@ -75,4 +75,6 @@ export {
   Database as DatabaseIcon,
   Archive as ArchiveBoxIcon,
   ArchiveRestore as ArchiveRestoreIcon,
+  Hand as HandIcon,
+  Star as StarIcon,
 } from "lucide-react";

--- a/apps/web/app/inbox/_components/inbox-timeline-automated-row.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-automated-row.tsx
@@ -16,6 +16,10 @@ import type {
 } from "../_lib/view-models";
 import { autolinkText } from "./_autolink";
 import {
+  EMAIL_BUBBLE_MAX_W,
+  TIMELINE_GRID_COLUMNS,
+} from "./inbox-timeline-bubble";
+import {
   CheckCircleIcon,
   ChevronRightIcon,
   EyeIcon,
@@ -192,11 +196,13 @@ export function TimelineAutomatedRow({
   role,
   isExpanded,
   onToggle,
+  nested = false,
 }: {
   readonly entry: InboxTimelineEntryViewModel;
   readonly role: "automated" | "campaign" | "activity";
   readonly isExpanded: boolean;
   readonly onToggle: () => void;
+  readonly nested?: boolean;
 }) {
   const isEmail = entry.channel === "email";
   const campaignActivity =
@@ -218,106 +224,118 @@ export function TimelineAutomatedRow({
   });
 
   return (
-    <li className="flex w-full flex-col items-end pl-16">
+    <li
+      className={cn(
+        nested ? "w-full" : cn("col-span-3 grid", TIMELINE_GRID_COLUMNS),
+      )}
+    >
       <Tooltip>
         <TooltipTrigger asChild>
           <div
             className={cn(
-              "w-full max-w-[560px] overflow-hidden rounded-xl border",
-              descriptor.shellClassName,
+              nested ? "flex w-full justify-end" : "col-start-2 flex justify-end",
             )}
           >
-            <button
-              type="button"
-              aria-expanded={isExpanded}
-              title={formatExactTimestamp(entry.occurredAt)}
-              onClick={onToggle}
-              data-event-role={role}
-              data-campaign-state={campaignState}
+            <div
               className={cn(
-                "group flex w-full items-center justify-between gap-3 px-4 py-2.5 text-left",
-                "transition-[background-color,transform] duration-150 ease-out active:scale-[0.99]",
-                descriptor.hoverClassName,
-                TRANSITION.reduceMotion,
+                nested
+                  ? "w-full overflow-hidden rounded-xl border"
+                  : cn("w-full overflow-hidden rounded-xl border", EMAIL_BUBBLE_MAX_W),
+                descriptor.shellClassName,
               )}
             >
-              <div className="flex min-w-0 items-center gap-2.5">
-                <div
-                  className={cn(
-                    "inline-flex size-6 shrink-0 items-center justify-center rounded-md",
-                    descriptor.iconClassName,
-                  )}
-                >
-                  <descriptor.Icon className="size-4" />
-                </div>
-                <div className="min-w-0">
-                  <div className="flex items-center gap-1.5">
-                    <span
-                      className={cn(
-                        "text-[9.5px] font-semibold uppercase tracking-wider",
-                        descriptor.labelClassName,
-                      )}
-                    >
-                      {descriptor.label}
-                    </span>
-                    <span
-                      aria-hidden="true"
-                      className="text-[11px] text-slate-400 tabular-nums"
-                    >
-                      ·
-                    </span>
-                    <RelativeTimestamp
-                      timestamp={entry.occurredAt}
-                      label={entry.occurredAtLabel}
-                      className="text-[11px] text-slate-400 tabular-nums"
-                    />
+              <button
+                type="button"
+                aria-expanded={isExpanded}
+                title={formatExactTimestamp(entry.occurredAt)}
+                onClick={onToggle}
+                data-event-role={role}
+                data-campaign-state={campaignState}
+                className={cn(
+                  "group flex w-full items-center justify-between gap-3 px-4 py-2.5 text-left",
+                  "transition-[background-color,transform] duration-150 ease-out active:scale-[0.99]",
+                  descriptor.hoverClassName,
+                  TRANSITION.reduceMotion,
+                )}
+              >
+                <div className="flex min-w-0 items-center gap-2.5">
+                  <div
+                    className={cn(
+                      "inline-flex size-6 shrink-0 items-center justify-center rounded-md",
+                      descriptor.iconClassName,
+                    )}
+                  >
+                    <descriptor.Icon className="size-4" />
                   </div>
-                  {headline ? (
-                    <p
-                      className={cn(
-                        "mt-0.5 truncate text-[12.5px] font-medium text-slate-800",
-                        WRAP_ANYWHERE,
-                      )}
-                    >
-                      {headline}
-                    </p>
-                  ) : null}
-                  {!hideCollapsedBody && body.length > 0 ? (
-                    <p
-                      className={cn(
-                        "mt-0.5 line-clamp-1 text-[13.5px] leading-relaxed text-slate-700",
-                        WRAP_ANYWHERE,
-                      )}
-                    >
-                      {body}
-                    </p>
-                  ) : null}
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-1.5">
+                      <span
+                        className={cn(
+                          "text-[9.5px] font-semibold uppercase tracking-wider",
+                          descriptor.labelClassName,
+                        )}
+                      >
+                        {descriptor.label}
+                      </span>
+                      <span
+                        aria-hidden="true"
+                        className="text-[11px] text-slate-400 tabular-nums"
+                      >
+                        ·
+                      </span>
+                      <RelativeTimestamp
+                        timestamp={entry.occurredAt}
+                        label={entry.occurredAtLabel}
+                        className="text-[11px] text-slate-400 tabular-nums"
+                      />
+                    </div>
+                    {headline ? (
+                      <p
+                        className={cn(
+                          "mt-0.5 truncate text-[12.5px] font-medium text-slate-800",
+                          WRAP_ANYWHERE,
+                        )}
+                      >
+                        {headline}
+                      </p>
+                    ) : null}
+                    {!hideCollapsedBody && body.length > 0 ? (
+                      <p
+                        className={cn(
+                          "mt-0.5 line-clamp-1 text-[13.5px] leading-relaxed text-slate-700",
+                          WRAP_ANYWHERE,
+                        )}
+                      >
+                        {body}
+                      </p>
+                    ) : null}
+                  </div>
                 </div>
-              </div>
-              <div className="flex shrink-0 items-center gap-2">
-                {role === "campaign" && campaignState !== undefined ? (
-                  <CampaignStateBadge state={campaignState} />
-                ) : null}
-                <ChevronRightIcon
-                  className={cn(
-                    "size-3.5 text-slate-500 transition-transform duration-150",
-                    isExpanded && "rotate-90",
-                  )}
-                />
-              </div>
-            </button>
-            {isExpanded && body.length > 0 ? (
-              <div className="border-t border-slate-200 bg-white px-4 py-3">
-                <p
-                  className={cn(
-                    "whitespace-pre-wrap text-pretty text-[13.5px] leading-relaxed text-slate-700",
-                    WRAP_ANYWHERE,
-                  )}
-                >
-                  {autolinkText(body, "text-sky-600")}
-                </p>
-              </div>
-            ) : null}
+                <div className="flex shrink-0 items-center gap-2">
+                  {role === "campaign" && campaignState !== undefined ? (
+                    <CampaignStateBadge state={campaignState} />
+                  ) : null}
+                  <ChevronRightIcon
+                    className={cn(
+                      "size-3.5 text-slate-500 transition-transform duration-150",
+                      isExpanded && "rotate-90",
+                    )}
+                  />
+                </div>
+              </button>
+              {isExpanded && body.length > 0 ? (
+                <div className="border-t border-slate-200 bg-white px-4 py-3">
+                  <p
+                    className={cn(
+                      "whitespace-pre-wrap text-pretty text-[13.5px] leading-relaxed text-slate-700",
+                      WRAP_ANYWHERE,
+                    )}
+                  >
+                    {autolinkText(body, "text-sky-600")}
+                  </p>
+                </div>
+              ) : null}
+            </div>
           </div>
         </TooltipTrigger>
         <TooltipContent side="top">

--- a/apps/web/app/inbox/_components/inbox-timeline-bubble.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-bubble.tsx
@@ -37,6 +37,11 @@ import {
 const WRAP_ANYWHERE = "break-words [overflow-wrap:anywhere]";
 const HTML_TAG_PATTERN = /<\/?[a-zA-Z][^>]*>/u;
 const BODY_CLAMP_TEXT_LENGTH = 800;
+export const TIMELINE_OUTER_MAX_W = "max-w-[1024px]";
+export const TIMELINE_GRID_COLUMNS =
+  "grid-cols-[2.75rem_minmax(0,1fr)_2.75rem]";
+export const EMAIL_BUBBLE_MAX_W = "max-w-[560px]";
+export const SMS_BUBBLE_MAX_W = "max-w-[480px]";
 const EMAIL_HTML_BODY_CLASS =
   "text-pretty text-[13px] leading-relaxed text-slate-700 [&_a]:text-sky-700 [&_a]:underline [&_blockquote]:border-l-2 [&_blockquote]:border-slate-200 [&_blockquote]:pl-3 [&_blockquote]:text-slate-600 [&_code]:rounded-sm [&_code]:bg-slate-100 [&_code]:px-1 [&_code]:py-0.5 [&_h1]:text-lg [&_h1]:font-semibold [&_h2]:text-base [&_h2]:font-semibold [&_h3]:text-sm [&_h3]:font-semibold [&_ol]:ml-5 [&_ol]:list-decimal [&_pre]:overflow-x-auto [&_pre]:rounded-md [&_pre]:bg-slate-100 [&_pre]:p-3 [&_table]:my-2 [&_table]:border-collapse [&_td]:border [&_td]:border-slate-200 [&_td]:px-2 [&_td]:py-1 [&_th]:border [&_th]:border-slate-200 [&_th]:px-2 [&_th]:py-1 [&_ul]:ml-5 [&_ul]:list-disc";
 
@@ -379,12 +384,14 @@ export function MessageBubble({
   onReply,
   isRetrying = false,
   onRetryPending,
+  nested = false,
 }: {
   readonly entry: InboxTimelineEntryViewModel;
   readonly direction: "inbound" | "outbound";
   readonly onReply?: (entryId: string) => void;
   readonly isRetrying?: boolean;
   readonly onRetryPending?: (entryId: string) => void;
+  readonly nested?: boolean;
 }) {
   const isEmail = entry.channel === "email";
   // Pre-PR-#170 we rendered every email body as plaintext via
@@ -415,99 +422,115 @@ export function MessageBubble({
     : isOutbound
       ? "border border-sky-600 bg-sky-600 text-white"
       : "border border-slate-200 bg-white";
+  const bubbleWidthClassName = nested
+    ? "w-full"
+    : isEmail
+      ? cn("w-fit", EMAIL_BUBBLE_MAX_W)
+      : cn("w-fit", SMS_BUBBLE_MAX_W);
+  const bubble = (
+    <div
+      className={cn(
+        "min-w-0 overflow-hidden rounded-xl",
+        bubbleWidthClassName,
+        SHADOW.sm,
+        bubbleClassName,
+      )}
+    >
+      {isEmail ? (
+        <EmailParticipantHeader
+          entry={entry}
+          tone={isOutbound ? "sky" : "slate"}
+        />
+      ) : null}
+
+      <div className={cn("px-4", isEmail ? "py-3" : "py-2.5")}>
+        {isOutbound ? (
+          <OutboundStatusBanner
+            entry={entry}
+            isRetrying={isRetrying}
+            {...(onRetryPending === undefined ? {} : { onRetryPending })}
+          />
+        ) : null}
+
+        {isEmail && entry.subject ? (
+          <p
+            className={cn(
+              "mb-1.5 text-balance text-[14px] font-semibold text-slate-900",
+              WRAP_ANYWHERE,
+            )}
+          >
+            {entry.subject}
+          </p>
+        ) : null}
+
+        {sanitizedHtmlBody !== null && sanitizedHtmlBody.length > 0 ? (
+          <CollapsibleBody shouldClamp={shouldClamp}>
+            <div
+              className={cn(EMAIL_HTML_BODY_CLASS, WRAP_ANYWHERE)}
+              dangerouslySetInnerHTML={{ __html: sanitizedHtmlBody }}
+            />
+          </CollapsibleBody>
+        ) : body.length > 0 ? (
+          <CollapsibleBody shouldClamp={shouldClamp}>
+            <p
+              className={cn(
+                "whitespace-pre-wrap text-pretty text-[13px] leading-relaxed",
+                isOutbound && !isEmail ? "text-white" : "text-slate-700",
+                WRAP_ANYWHERE,
+              )}
+            >
+              {autolinkText(body)}
+            </p>
+          </CollapsibleBody>
+        ) : null}
+
+        <MessageAttachments attachments={entry.attachments} />
+      </div>
+
+      <ReplyFooter
+        entryId={entry.id}
+        {...(onReply === undefined ? {} : { onReply })}
+      />
+    </div>
+  );
 
   return (
     <li
       className={cn(
-        "flex w-full flex-col",
-        isOutbound ? "items-end pl-16" : "items-start pr-16",
+        nested ? "w-full" : cn("col-span-3 grid", TIMELINE_GRID_COLUMNS),
       )}
     >
-      {isOutbound && !isEmail ? <OutboundSmsMetaRow entry={entry} /> : null}
+      {!nested ? (
+        !isOutbound ? (
+          <div className="flex justify-start pt-2">{inboundAvatar}</div>
+        ) : (
+          <div aria-hidden="true" />
+        )
+      ) : null}
 
       <div
         className={cn(
-          "flex w-full items-start gap-2.5",
+          nested ? "min-w-0 flex" : "col-start-2 min-w-0 flex",
           isOutbound ? "justify-end" : "justify-start",
         )}
       >
-        {!isOutbound ? (
-          <div className="mt-2 shrink-0">{inboundAvatar}</div>
-        ) : null}
-
-        <div
-          className={cn(
-            "min-w-0 w-full max-w-[640px] overflow-hidden rounded-xl",
-            SHADOW.sm,
-            bubbleClassName,
-          )}
-        >
-          {isEmail ? (
-            <EmailParticipantHeader
-              entry={entry}
-              tone={isOutbound ? "sky" : "slate"}
-            />
+        <div className="min-w-0">
+          {isOutbound && !isEmail ? <OutboundSmsMetaRow entry={entry} /> : null}
+          {bubble}
+          {!isOutbound && entry.channel !== "email" ? (
+            <InboundMetadataRow entry={entry} />
           ) : null}
-
-          <div className={cn("px-4", isEmail ? "py-3" : "py-2.5")}>
-            {isOutbound ? (
-              <OutboundStatusBanner
-                entry={entry}
-                isRetrying={isRetrying}
-                {...(onRetryPending === undefined ? {} : { onRetryPending })}
-              />
-            ) : null}
-
-            {isEmail && entry.subject ? (
-              <p
-                className={cn(
-                  "mb-1.5 text-balance text-[14px] font-semibold text-slate-900",
-                  WRAP_ANYWHERE,
-                )}
-              >
-                {entry.subject}
-              </p>
-            ) : null}
-
-            {sanitizedHtmlBody !== null && sanitizedHtmlBody.length > 0 ? (
-              <CollapsibleBody shouldClamp={shouldClamp}>
-                <div
-                  className={cn(EMAIL_HTML_BODY_CLASS, WRAP_ANYWHERE)}
-                  dangerouslySetInnerHTML={{ __html: sanitizedHtmlBody }}
-                />
-              </CollapsibleBody>
-            ) : body.length > 0 ? (
-              <CollapsibleBody shouldClamp={shouldClamp}>
-                <p
-                  className={cn(
-                    "whitespace-pre-wrap text-pretty text-[13px] leading-relaxed",
-                    isOutbound && !isEmail ? "text-white" : "text-slate-700",
-                    WRAP_ANYWHERE,
-                  )}
-                >
-                  {autolinkText(body)}
-                </p>
-              </CollapsibleBody>
-            ) : null}
-
-            <MessageAttachments attachments={entry.attachments} />
-          </div>
-
-          <ReplyFooter
-            entryId={entry.id}
-            {...(onReply === undefined ? {} : { onReply })}
-          />
         </div>
-
-        {isOutbound ? (
-          <div className="mt-2 shrink-0">
-            <OutboundBrandAvatar />
-          </div>
-        ) : null}
       </div>
 
-      {!isOutbound && entry.channel !== "email" ? (
-        <InboundMetadataRow entry={entry} />
+      {!nested ? (
+        isOutbound ? (
+          <div className="flex justify-end pt-2">
+            <OutboundBrandAvatar />
+          </div>
+        ) : (
+          <div aria-hidden="true" />
+        )
       ) : null}
     </li>
   );

--- a/apps/web/app/inbox/_components/inbox-timeline-note-entry.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-note-entry.tsx
@@ -14,6 +14,10 @@ import { cn } from "@/lib/utils";
 import { deleteNoteAction, updateNoteAction } from "../actions";
 import type { InboxTimelineEntryViewModel } from "../_lib/view-models";
 import { getInternalNoteValidationError } from "@/src/lib/internal-note-validation";
+import {
+  EMAIL_BUBBLE_MAX_W,
+  TIMELINE_GRID_COLUMNS,
+} from "./inbox-timeline-bubble";
 import { LoaderIcon, NoteIcon } from "./icons";
 
 const WRAP_ANYWHERE = "break-words [overflow-wrap:anywhere]";
@@ -35,9 +39,11 @@ function formatExactTimestamp(timestamp: string): string {
 export function TimelineNoteEntry({
   entry,
   currentOperatorUserId,
+  nested = false,
 }: {
   readonly entry: InboxTimelineEntryViewModel;
   readonly currentOperatorUserId: string;
+  readonly nested?: boolean;
 }) {
   const router = useRouter();
   const [isEditing, setIsEditing] = useState(false);
@@ -112,145 +118,160 @@ export function TimelineNoteEntry({
   };
 
   return (
-    <li className="flex w-full flex-col items-end pl-16">
-      <div className="w-full max-w-[640px] rounded-xl border border-amber-200 bg-amber-50/60 px-4 py-2.5 shadow-sm">
-        <div className="mb-1 flex items-center justify-between gap-3 text-[11px] text-amber-700">
-          <div className="flex items-center gap-1.5">
-            <NoteIcon className="size-3" />
-            <span className="font-medium">Note</span>
-            <span className="text-amber-300">·</span>
-            <span>{entry.actorLabel}</span>
-            <span className="text-amber-300">·</span>
-            <time dateTime={entry.occurredAt} title={formatExactTimestamp(entry.occurredAt)}>
-              {entry.occurredAtLabel}
-            </time>
-          </div>
-          {canManageNote ? (
-            <div className="flex items-center gap-2">
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="h-auto px-2 py-1 text-[11px] text-amber-800 hover:bg-amber-100"
-                onClick={() => {
-                  setDraftBody(entry.body);
-                  setInlineError(null);
-                  setIsEditing(true);
-                }}
-              >
-                Edit
-              </Button>
-              <Popover open={deleteOpen} onOpenChange={setDeleteOpen}>
-                <PopoverTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="h-auto px-2 py-1 text-[11px] text-amber-800 hover:bg-amber-100"
-                  >
-                    Delete
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent className="w-64 space-y-3" align="end">
-                  <p className="text-sm font-medium text-slate-900">
-                    Delete this note?
-                  </p>
-                  <p className="text-xs text-slate-500">
-                    This removes the note from the shared timeline.
-                  </p>
-                  <div className="flex justify-end gap-2">
+    <li
+      className={cn(
+        nested ? "w-full" : cn("col-span-3 grid", TIMELINE_GRID_COLUMNS),
+      )}
+    >
+      <div
+        className={cn(
+          nested ? "flex w-full justify-end" : "col-start-2 flex justify-end",
+        )}
+      >
+        <div
+          className={cn(
+            nested ? "w-full" : cn("w-fit", EMAIL_BUBBLE_MAX_W),
+            "rounded-xl border border-amber-200 bg-amber-50/60 px-4 py-2.5 shadow-sm",
+          )}
+        >
+          <div className="mb-1 flex items-center justify-between gap-3 text-[11px] text-amber-700">
+            <div className="flex items-center gap-1.5">
+              <NoteIcon className="size-3" />
+              <span className="font-medium">Note</span>
+              <span className="text-amber-300">·</span>
+              <span>{entry.actorLabel}</span>
+              <span className="text-amber-300">·</span>
+              <time dateTime={entry.occurredAt} title={formatExactTimestamp(entry.occurredAt)}>
+                {entry.occurredAtLabel}
+              </time>
+            </div>
+            {canManageNote ? (
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-auto px-2 py-1 text-[11px] text-amber-800 hover:bg-amber-100"
+                  onClick={() => {
+                    setDraftBody(entry.body);
+                    setInlineError(null);
+                    setIsEditing(true);
+                  }}
+                >
+                  Edit
+                </Button>
+                <Popover open={deleteOpen} onOpenChange={setDeleteOpen}>
+                  <PopoverTrigger asChild>
                     <Button
                       type="button"
                       variant="ghost"
                       size="sm"
-                      onClick={() => {
-                        setDeleteOpen(false);
-                      }}
+                      className="h-auto px-2 py-1 text-[11px] text-amber-800 hover:bg-amber-100"
                     >
-                      Cancel
+                      Delete
                     </Button>
-                    <Button
-                      type="button"
-                      size="sm"
-                      disabled={isDeleting}
-                      onClick={deleteNote}
-                    >
-                      {isDeleting ? (
-                        <>
-                          <LoaderIcon className="size-3 animate-spin" />
-                          Deleting...
-                        </>
-                      ) : (
-                        "Delete"
-                      )}
-                    </Button>
-                  </div>
-                </PopoverContent>
-              </Popover>
-            </div>
-          ) : null}
-        </div>
-        {isEditing ? (
-          <div className="space-y-3">
-            <textarea
-              rows={4}
-              value={draftBody}
-              onChange={(event) => {
-                setDraftBody(event.currentTarget.value);
-                if (inlineError !== null) {
-                  setInlineError(null);
-                }
-              }}
-              className="w-full resize-y rounded-md border border-amber-200 bg-white px-3 py-2 text-[13px] leading-relaxed text-slate-900 shadow-sm focus:outline-none focus:ring-1 focus:ring-amber-300"
-            />
-            {inlineError ? (
-              <p className="text-xs text-rose-700">{inlineError}</p>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-64 space-y-3" align="end">
+                    <p className="text-sm font-medium text-slate-900">
+                      Delete this note?
+                    </p>
+                    <p className="text-xs text-slate-500">
+                      This removes the note from the shared timeline.
+                    </p>
+                    <div className="flex justify-end gap-2">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => {
+                          setDeleteOpen(false);
+                        }}
+                      >
+                        Cancel
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        disabled={isDeleting}
+                        onClick={deleteNote}
+                      >
+                        {isDeleting ? (
+                          <>
+                            <LoaderIcon className="size-3 animate-spin" />
+                            Deleting...
+                          </>
+                        ) : (
+                          "Delete"
+                        )}
+                      </Button>
+                    </div>
+                  </PopoverContent>
+                </Popover>
+              </div>
             ) : null}
-            <div className="flex justify-end gap-2">
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => {
-                  setDraftBody(entry.body);
-                  setInlineError(null);
-                  setIsEditing(false);
-                }}
-              >
-                Cancel
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                disabled={isSaving}
-                onClick={saveEdit}
-              >
-                {isSaving ? (
-                  <>
-                    <LoaderIcon className="size-3 animate-spin" />
-                    Saving...
-                  </>
-                ) : (
-                  "Save"
-                )}
-              </Button>
-            </div>
           </div>
-        ) : (
-          <>
-            <p
-              className={cn(
-                "font-message-body whitespace-pre-wrap text-pretty text-[13.5px] leading-relaxed text-amber-900",
-                WRAP_ANYWHERE,
-              )}
-            >
-              {entry.body}
-            </p>
-            {inlineError ? (
-              <p className="mt-2 text-xs text-rose-700">{inlineError}</p>
-            ) : null}
-          </>
-        )}
+          {isEditing ? (
+            <div className="space-y-3">
+              <textarea
+                rows={4}
+                value={draftBody}
+                onChange={(event) => {
+                  setDraftBody(event.currentTarget.value);
+                  if (inlineError !== null) {
+                    setInlineError(null);
+                  }
+                }}
+                className="w-full resize-y rounded-md border border-amber-200 bg-white px-3 py-2 text-[13px] leading-relaxed text-slate-900 shadow-sm focus:outline-none focus:ring-1 focus:ring-amber-300"
+              />
+              {inlineError ? (
+                <p className="text-xs text-rose-700">{inlineError}</p>
+              ) : null}
+              <div className="flex justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setDraftBody(entry.body);
+                    setInlineError(null);
+                    setIsEditing(false);
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  disabled={isSaving}
+                  onClick={saveEdit}
+                >
+                  {isSaving ? (
+                    <>
+                      <LoaderIcon className="size-3 animate-spin" />
+                      Saving...
+                    </>
+                  ) : (
+                    "Save"
+                  )}
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <>
+              <p
+                className={cn(
+                  "font-message-body whitespace-pre-wrap text-pretty text-[13.5px] leading-relaxed text-amber-900",
+                  WRAP_ANYWHERE,
+                )}
+              >
+                {entry.body}
+              </p>
+              {inlineError ? (
+                <p className="mt-2 text-xs text-rose-700">{inlineError}</p>
+              ) : null}
+            </>
+          )}
+        </div>
       </div>
     </li>
   );

--- a/apps/web/app/inbox/_components/inbox-timeline-system-divider.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-system-divider.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 import { SHADOW, TONE_CLASSES, type ToneNameV2 } from "@/app/_lib/design-tokens-v2";
 
 import type { InboxTimelineEntryViewModel } from "../_lib/view-models";
+import { TIMELINE_GRID_COLUMNS } from "./inbox-timeline-bubble";
 import {
   BookOpenIcon,
   CalendarIcon,
@@ -128,32 +129,34 @@ export function SystemDivider({
   const tone = TONE_CLASSES[category.tone];
 
   return (
-    <li className="flex w-full items-start pr-16">
-      <div
-        className={cn(
-          "inline-flex max-w-[560px] items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1.5",
-          SHADOW.sm,
-        )}
-      >
-        <span
+    <li className={cn("col-span-3 grid", TIMELINE_GRID_COLUMNS)}>
+      <div className="col-start-2 flex items-start">
+        <div
           className={cn(
-            "inline-flex size-5 shrink-0 items-center justify-center rounded-full",
-            tone.subtle,
+            "inline-flex max-w-[560px] items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1.5",
+            SHADOW.sm,
           )}
         >
-          <category.Icon className={cn("size-3", tone.text)} />
-        </span>
-        <span className="text-[12.5px] text-slate-700">{body}</span>
-        <span className="text-[11px] text-slate-400 tabular-nums" aria-hidden="true">
-          ·
-        </span>
-        <time
-          dateTime={entry.occurredAt}
-          title={formatExactTimestamp(entry.occurredAt)}
-          className="cursor-help text-[11px] text-slate-400 tabular-nums"
-        >
-          {entry.occurredAtLabel}
-        </time>
+          <span
+            className={cn(
+              "inline-flex size-5 shrink-0 items-center justify-center rounded-full",
+              tone.subtle,
+            )}
+          >
+            <category.Icon className={cn("size-3", tone.text)} />
+          </span>
+          <span className="text-[12.5px] text-slate-700">{body}</span>
+          <span className="text-[11px] text-slate-400 tabular-nums" aria-hidden="true">
+            ·
+          </span>
+          <time
+            dateTime={entry.occurredAt}
+            title={formatExactTimestamp(entry.occurredAt)}
+            className="cursor-help text-[11px] text-slate-400 tabular-nums"
+          >
+            {entry.occurredAtLabel}
+          </time>
+        </div>
       </div>
     </li>
   );

--- a/apps/web/app/inbox/_components/inbox-timeline.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline.tsx
@@ -22,7 +22,12 @@ import {
 import { cn } from "@/lib/utils";
 import { TRANSITION } from "@/app/_lib/design-tokens-v2";
 import { TimelineAutomatedRow } from "./inbox-timeline-automated-row";
-import { MessageBubble } from "./inbox-timeline-bubble";
+import {
+  EMAIL_BUBBLE_MAX_W,
+  MessageBubble,
+  TIMELINE_GRID_COLUMNS,
+  TIMELINE_OUTER_MAX_W,
+} from "./inbox-timeline-bubble";
 import { TimelineNoteEntry } from "./inbox-timeline-note-entry";
 import { SmsMessage } from "./sms-message";
 import { SystemDivider } from "./inbox-timeline-system-divider";
@@ -112,10 +117,19 @@ export function InboxTimeline({
           </div>
         ) : null}
 
-        <ol className="mx-auto flex w-full max-w-[920px] flex-col gap-3">
+        <ol
+          className={cn(
+            "mx-auto grid w-full gap-x-2.5 gap-y-3",
+            TIMELINE_OUTER_MAX_W,
+            TIMELINE_GRID_COLUMNS,
+          )}
+        >
           {showEarlierHistoryDivider ? (
-            <li aria-label="Earlier history not shown" className="list-none">
-              <div className="flex items-center gap-3 py-1 text-xs text-muted-foreground">
+            <li
+              aria-label="Earlier history not shown"
+              className={cn("col-span-3 list-none grid", TIMELINE_GRID_COLUMNS)}
+            >
+              <div className="col-start-2 flex items-center gap-3 py-1 text-xs text-muted-foreground">
                 <div className="h-px flex-1 bg-border" />
                 <span className="whitespace-nowrap">
                   Earlier history not shown - full capture began Jan 1, 2025
@@ -264,6 +278,7 @@ interface EntryProps {
   readonly onRetryPending: ((entryId: string) => void) | undefined;
   readonly onReply?: (entryId: string) => void;
   readonly onToggle: () => void;
+  readonly nested?: boolean;
 }
 
 function TimelineEntry({
@@ -275,6 +290,7 @@ function TimelineEntry({
   onRetryPending,
   onReply,
   onToggle,
+  nested = false,
 }: EntryProps) {
   const role = roleForKind(entry.kind);
 
@@ -285,6 +301,7 @@ function TimelineEntry({
           <SmsMessage
             entry={entry}
             direction="inbound"
+            nested={nested}
             {...(onReply === undefined ? {} : { onReply })}
           />
         );
@@ -294,6 +311,7 @@ function TimelineEntry({
         <MessageBubble
           entry={entry}
           direction="inbound"
+          nested={nested}
           {...(onReply === undefined ? {} : { onReply })}
         />
       );
@@ -304,6 +322,7 @@ function TimelineEntry({
             entry={entry}
             direction="outbound"
             isRetrying={retryingEntryId === entry.id}
+            nested={nested}
             {...(onReply === undefined ? {} : { onReply })}
             {...(onRetryPending === undefined ? {} : { onRetryPending })}
           />
@@ -315,6 +334,7 @@ function TimelineEntry({
           entry={entry}
           direction="outbound"
           isRetrying={retryingEntryId === entry.id}
+          nested={nested}
           {...(onReply === undefined ? {} : { onReply })}
           {...(onRetryPending === undefined ? {} : { onRetryPending })}
         />
@@ -328,6 +348,7 @@ function TimelineEntry({
           role={role}
           isExpanded={isExpanded}
           onToggle={onToggle}
+          nested={nested}
         />
       );
     case "note":
@@ -335,6 +356,7 @@ function TimelineEntry({
         <TimelineNoteEntry
           entry={entry}
           currentOperatorUserId={currentOperatorUserId}
+          nested={nested}
         />
       );
     case "system":
@@ -366,77 +388,85 @@ function SystemMessageGroup({
   const summary = formatSystemGroupSummary(group);
 
   return (
-    <li className="flex w-full justify-end pl-16">
-      <div className="w-full max-w-[560px] overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
-        <button
-          type="button"
-          aria-expanded={isExpanded}
-          onClick={onToggle}
+    <li className={cn("col-span-3 grid", TIMELINE_GRID_COLUMNS)}>
+      <div className="col-start-2 flex justify-end">
+        <div
           className={cn(
-            "flex w-full items-center justify-between gap-3 px-4 py-2.5 text-left hover:bg-slate-50/60",
-            "transition-[background-color,transform] duration-150 ease-out active:scale-[0.99]",
-            TRANSITION.reduceMotion,
+            "w-full overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm",
+            EMAIL_BUBBLE_MAX_W,
           )}
         >
-          <div className="flex min-w-0 items-center gap-2.5">
-            <div className="-space-x-1 flex shrink-0 items-center">
-              {group.entries.slice(0, 3).map((entry) => (
-                <span
-                  key={entry.id}
-                  className={cn(
-                    "inline-flex size-5 items-center justify-center rounded-full ring-2 ring-white",
-                    roleForKind(entry.kind) === "campaign"
-                      ? "bg-violet-100 text-violet-700"
-                      : "bg-slate-100 text-slate-600",
-                  )}
-                >
-                  {roleForKind(entry.kind) === "campaign" ? (
-                    <MegaphoneIcon className="size-2.5" />
-                  ) : (
-                    <ZapIcon className="size-2.5" />
-                  )}
-                </span>
-              ))}
-            </div>
-            <div className="min-w-0">
-              <div className="text-[12.5px] font-medium text-slate-800">
-                {summary}
-              </div>
-              <RelativeTimestamp
-                timestamp={group.occurredAt}
-                label={group.occurredAtLabel}
-                asSpan
-                focusable={false}
-                className="text-[11px] text-slate-400"
-              />
-            </div>
-          </div>
-          <ChevronRightIcon
+          <button
+            type="button"
+            aria-expanded={isExpanded}
+            onClick={onToggle}
             className={cn(
-              "size-3.5 shrink-0 text-slate-400 transition-transform duration-150",
-              isExpanded && "rotate-90",
+              "flex w-full items-center justify-between gap-3 px-4 py-2.5 text-left hover:bg-slate-50/60",
+              "transition-[background-color,transform] duration-150 ease-out active:scale-[0.99]",
               TRANSITION.reduceMotion,
             )}
-          />
-        </button>
-        {isExpanded ? (
-          <ol className="space-y-2 border-t border-slate-100 bg-slate-50/30 p-3">
-            {group.entries.map((entry) => (
-              <TimelineEntry
-                key={entry.id}
-                entry={entry}
-                volunteerFirstName=""
-                currentOperatorUserId={currentOperatorUserId}
-                isExpanded={isChildExpanded(entry.id)}
-                retryingEntryId={retryingEntryId}
-                onRetryPending={onRetryPending}
-                onToggle={() => {
-                  onToggleChild(entry.id);
-                }}
-              />
-            ))}
-          </ol>
-        ) : null}
+          >
+            <div className="flex min-w-0 items-center gap-2.5">
+              <div className="-space-x-1 flex shrink-0 items-center">
+                {group.entries.slice(0, 3).map((entry) => (
+                  <span
+                    key={entry.id}
+                    className={cn(
+                      "inline-flex size-5 items-center justify-center rounded-full ring-2 ring-white",
+                      roleForKind(entry.kind) === "campaign"
+                        ? "bg-violet-100 text-violet-700"
+                        : "bg-slate-100 text-slate-600",
+                    )}
+                  >
+                    {roleForKind(entry.kind) === "campaign" ? (
+                      <MegaphoneIcon className="size-2.5" />
+                    ) : (
+                      <ZapIcon className="size-2.5" />
+                    )}
+                  </span>
+                ))}
+              </div>
+              <div className="min-w-0">
+                <div className="text-[12.5px] font-medium text-slate-800">
+                  {summary}
+                </div>
+                <RelativeTimestamp
+                  timestamp={group.occurredAt}
+                  label={group.occurredAtLabel}
+                  asSpan
+                  focusable={false}
+                  className="text-[11px] text-slate-400"
+                />
+              </div>
+            </div>
+            <ChevronRightIcon
+              className={cn(
+                "size-3.5 shrink-0 text-slate-400 transition-transform duration-150",
+                isExpanded && "rotate-90",
+                TRANSITION.reduceMotion,
+              )}
+            />
+          </button>
+          {isExpanded ? (
+            <ol className="space-y-2 border-t border-slate-100 bg-slate-50/30 p-2">
+              {group.entries.map((entry) => (
+                <TimelineEntry
+                  key={entry.id}
+                  entry={entry}
+                  volunteerFirstName=""
+                  currentOperatorUserId={currentOperatorUserId}
+                  isExpanded={isChildExpanded(entry.id)}
+                  retryingEntryId={retryingEntryId}
+                  onRetryPending={onRetryPending}
+                  nested
+                  onToggle={() => {
+                    onToggleChild(entry.id);
+                  }}
+                />
+              ))}
+            </ol>
+          ) : null}
+        </div>
       </div>
     </li>
   );

--- a/apps/web/app/inbox/_components/sms-message.tsx
+++ b/apps/web/app/inbox/_components/sms-message.tsx
@@ -5,6 +5,10 @@ import { cn } from "@/lib/utils";
 import type { InboxTimelineEntryViewModel } from "../_lib/view-models";
 import { autolinkText } from "./_autolink";
 import {
+  SMS_BUBBLE_MAX_W,
+  TIMELINE_GRID_COLUMNS,
+} from "./inbox-timeline-bubble";
+import {
   CornerUpLeftIcon,
   LoaderIcon,
   RefreshCwIcon,
@@ -64,88 +68,99 @@ export function SmsMessage({
   onReply,
   isRetrying = false,
   onRetryPending,
+  nested = false,
 }: {
   readonly entry: InboxTimelineEntryViewModel;
   readonly direction: "inbound" | "outbound";
   readonly onReply?: (entryId: string) => void;
   readonly isRetrying?: boolean;
   readonly onRetryPending?: (entryId: string) => void;
+  readonly nested?: boolean;
 }) {
   const isOutbound = direction === "outbound";
 
   return (
     <li
       className={cn(
-        "flex w-full flex-col",
-        isOutbound ? "items-end pl-16" : "items-start pr-16",
+        nested ? "w-full" : cn("col-span-3 grid", TIMELINE_GRID_COLUMNS),
       )}
     >
-      <div className="mb-1 px-1">
-        <span
-          className={cn(
-            "text-[10px] font-semibold uppercase tracking-wider",
-            isOutbound ? "text-sky-600" : "text-emerald-700",
-          )}
-        >
-          SMS
-        </span>
-      </div>
-
       <div
         className={cn(
-          "w-full max-w-[440px] rounded-2xl border px-4 py-3 shadow-sm",
-          isOutbound
-            ? "rounded-br-md border-sky-600 bg-sky-600 text-white"
-            : "rounded-bl-md border-slate-200 bg-white text-slate-900",
+          nested ? "min-w-0 flex" : "col-start-2 min-w-0 flex",
+          isOutbound ? "justify-end" : "justify-start",
         )}
       >
-        {isOutbound ? (
-          <StatusBanner
-            entry={entry}
-            isRetrying={isRetrying}
-            {...(onRetryPending === undefined ? {} : { onRetryPending })}
-          />
-        ) : null}
+        <div className="min-w-0">
+          <div className="mb-1 px-1">
+            <span
+              className={cn(
+                "text-[10px] font-semibold uppercase tracking-wider",
+                isOutbound ? "text-sky-600" : "text-emerald-700",
+              )}
+            >
+              SMS
+            </span>
+          </div>
 
-        {entry.body.trim().length > 0 ? (
-          <p
+          <div
             className={cn(
-              "whitespace-pre-wrap text-[13px] leading-relaxed [overflow-wrap:anywhere]",
-              isOutbound ? "text-white" : "text-slate-700",
+              nested ? "w-full" : cn("w-fit", SMS_BUBBLE_MAX_W),
+              "rounded-2xl border px-4 py-3 shadow-sm",
+              isOutbound
+                ? "rounded-br-md border-sky-600 bg-sky-600 text-white"
+                : "rounded-bl-md border-slate-200 bg-white text-slate-900",
             )}
           >
-            {autolinkText(entry.body)}
-          </p>
-        ) : null}
+            {isOutbound ? (
+              <StatusBanner
+                entry={entry}
+                isRetrying={isRetrying}
+                {...(onRetryPending === undefined ? {} : { onRetryPending })}
+              />
+            ) : null}
 
-        <div
-          className={cn(
-            "mt-2 text-[11px]",
-            isOutbound ? "text-white/75" : "text-slate-500",
+            {entry.body.trim().length > 0 ? (
+              <p
+                className={cn(
+                  "whitespace-pre-wrap text-[13px] leading-relaxed [overflow-wrap:anywhere]",
+                  isOutbound ? "text-white" : "text-slate-700",
+                )}
+              >
+                {autolinkText(entry.body)}
+              </p>
+            ) : null}
+
+            <div
+              className={cn(
+                "mt-2 text-[11px]",
+                isOutbound ? "text-white/75" : "text-slate-500",
+              )}
+            >
+              {entry.occurredAtLabel}
+            </div>
+          </div>
+
+          {isOutbound ? (
+            <div className="mt-1 px-1 text-[11px] text-slate-500">
+              {entry.actorLabel}
+            </div>
+          ) : null}
+
+          {onReply === undefined ? null : (
+            <button
+              type="button"
+              onClick={() => {
+                onReply(entry.id);
+              }}
+              className="mt-2 inline-flex items-center gap-1 px-1 text-[11px] text-slate-500 hover:text-slate-800"
+            >
+              <CornerUpLeftIcon className="size-3" />
+              Reply
+            </button>
           )}
-        >
-          {entry.occurredAtLabel}
         </div>
       </div>
-
-      {isOutbound ? (
-        <div className="mt-1 px-1 text-[11px] text-slate-500">
-          {entry.actorLabel}
-        </div>
-      ) : null}
-
-      {onReply === undefined ? null : (
-        <button
-          type="button"
-          onClick={() => {
-            onReply(entry.id);
-          }}
-          className="mt-2 inline-flex items-center gap-1 px-1 text-[11px] text-slate-500 hover:text-slate-800"
-        >
-          <CornerUpLeftIcon className="size-3" />
-          Reply
-        </button>
-      )}
     </li>
   );
 }

--- a/apps/web/tests/unit/inbox-timeline-bubble.test.tsx
+++ b/apps/web/tests/unit/inbox-timeline-bubble.test.tsx
@@ -272,6 +272,45 @@ describe("MessageBubble attachments", () => {
 });
 
 describe("MessageBubble metadata and polish", () => {
+  it("uses the shared gutter grid and 560px email cap instead of padded rows", () => {
+    const markup = renderToStaticMarkup(
+      createElement(MessageBubble, {
+        entry: buildEntry({
+          kind: "outbound-email",
+          actorLabel: "You",
+        }),
+        direction: "outbound",
+      }),
+    );
+
+    expect(markup).toContain("col-span-3 grid");
+    expect(markup).toContain("grid-cols-[2.75rem_minmax(0,1fr)_2.75rem]");
+    expect(markup).toContain("col-start-2 min-w-0 flex justify-end");
+    expect(markup).toContain("w-fit max-w-[560px]");
+    expect(markup).not.toContain("max-w-[640px]");
+    expect(markup).not.toContain("pl-16");
+    expect(markup).not.toContain("pr-16");
+  });
+
+  it("caps compact sms bubbles at 480px", () => {
+    const markup = renderToStaticMarkup(
+      createElement(MessageBubble, {
+        entry: buildEntry({
+          channel: "sms",
+          kind: "inbound-sms",
+          subject: null,
+          fromHeader: null,
+          toHeader: null,
+          body: "SMS body",
+        }),
+        direction: "inbound",
+      }),
+    );
+
+    expect(markup).toContain("w-fit max-w-[480px]");
+    expect(markup).not.toContain("max-w-[640px]");
+  });
+
   it("hides the inbound metadata row for email bubbles", () => {
     const markup = renderToStaticMarkup(
       createElement(MessageBubble, {

--- a/apps/web/tests/unit/inbox-timeline.test.ts
+++ b/apps/web/tests/unit/inbox-timeline.test.ts
@@ -781,6 +781,7 @@ describe("InboxTimeline", () => {
     expect(markup).not.toContain(">YO<");
   });
 
+<<<<<<< HEAD
   it("classifies signup system dividers into the violet hand achievement category", () => {
     expect(
       classifySystemDivider("Signed up for the Pacific Northwest expedition."),
@@ -809,6 +810,9 @@ describe("InboxTimeline", () => {
   });
 
   it("classifies first-data system dividers into the emerald star achievement category", () => {
+=======
+  it("classifies first-data system dividers into the emerald star category", () => {
+>>>>>>> 5ecc91a4 (chore(inbox): harmonize system-divider with PR #322 lifecycle pills)
     expect(
       classifySystemDivider("Submitted first batch from the field."),
     ).toMatchObject({

--- a/apps/web/tests/unit/inbox-timeline.test.ts
+++ b/apps/web/tests/unit/inbox-timeline.test.ts
@@ -1,12 +1,25 @@
+import { createRequire } from "node:module";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import React, { createElement } from "react";
+import React, { act, createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { createRoot, type Root } from "react-dom/client";
 
 Object.assign(globalThis, { React });
 
 vi.mock("../../app/inbox/actions", () => ({
   updateNoteAction: vi.fn(),
   deleteNoteAction: vi.fn(),
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { readonly children?: React.ReactNode }) =>
+    createElement("div", null, children),
+  Tooltip: ({ children }: { readonly children?: React.ReactNode }) =>
+    createElement("div", null, children),
+  TooltipTrigger: ({ children }: { readonly children?: React.ReactNode }) =>
+    createElement("div", null, children),
+  TooltipContent: ({ children }: { readonly children?: React.ReactNode }) =>
+    createElement("div", null, children),
 }));
 
 vi.mock("@/components/ui/divider-label", () => ({
@@ -66,6 +79,7 @@ import {
   InboxTimeline,
   shouldHideAutomatedRowBody,
 } from "../../app/inbox/_components/inbox-timeline";
+import type { InboxTimelineEntryViewModel } from "../../app/inbox/_lib/view-models";
 import { classifySystemDivider } from "../../app/inbox/_components/inbox-timeline-system-divider";
 import {
   BookOpenIcon,
@@ -73,6 +87,21 @@ import {
   HandIcon,
   StarIcon,
 } from "../../app/inbox/_components/icons";
+
+const workerRequire = createRequire(
+  new URL("../../../worker/package.json", import.meta.url),
+);
+const { JSDOM } = workerRequire("jsdom") as {
+  readonly JSDOM: new (
+    html: string,
+    options: { readonly url: string },
+  ) => {
+    readonly window: Window &
+      typeof globalThis & {
+        close: () => void;
+      };
+  };
+};
 
 const baseEntry = {
   id: "timeline:auto-email-1",
@@ -100,9 +129,191 @@ const baseEntry = {
   campaignActivity: [],
 };
 
+interface RenderSession {
+  readonly container: HTMLElement;
+  readonly root: Root;
+  readonly cleanup: () => Promise<void>;
+}
+
+type DomGlobalKey =
+  | "window"
+  | "document"
+  | "HTMLElement"
+  | "Node"
+  | "Event"
+  | "MouseEvent"
+  | "navigator"
+  | "IS_REACT_ACT_ENVIRONMENT";
+
+interface DomGlobalSnapshotEntry {
+  readonly exists: boolean;
+  readonly value: unknown;
+}
+
+type DomGlobalSnapshot = Record<DomGlobalKey, DomGlobalSnapshotEntry>;
+
+let activeSession: RenderSession | null = null;
+
+function captureDomGlobals(): DomGlobalSnapshot {
+  const globalKeys = [
+    "window",
+    "document",
+    "HTMLElement",
+    "Node",
+    "Event",
+    "MouseEvent",
+    "navigator",
+    "IS_REACT_ACT_ENVIRONMENT",
+  ] as const satisfies readonly DomGlobalKey[];
+
+  return Object.fromEntries(
+    globalKeys.map((key) => [
+      key,
+      {
+        exists: key in globalThis,
+        value: (globalThis as Record<string, unknown>)[key],
+      },
+    ]),
+  ) as DomGlobalSnapshot;
+}
+
+function clearDomGlobal(key: DomGlobalKey) {
+  switch (key) {
+    case "window":
+      delete (globalThis as { window?: Window }).window;
+      return;
+    case "document":
+      delete (globalThis as { document?: Document }).document;
+      return;
+    case "HTMLElement":
+      delete (globalThis as { HTMLElement?: typeof HTMLElement }).HTMLElement;
+      return;
+    case "Node":
+      delete (globalThis as { Node?: typeof Node }).Node;
+      return;
+    case "Event":
+      delete (globalThis as { Event?: typeof Event }).Event;
+      return;
+    case "MouseEvent":
+      delete (globalThis as { MouseEvent?: typeof MouseEvent }).MouseEvent;
+      return;
+    case "navigator":
+      delete (globalThis as { navigator?: Navigator }).navigator;
+      return;
+    case "IS_REACT_ACT_ENVIRONMENT":
+      delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean })
+        .IS_REACT_ACT_ENVIRONMENT;
+  }
+}
+
+function restoreDomGlobals(snapshot: DomGlobalSnapshot) {
+  for (const [key, entry] of Object.entries(snapshot) as [
+    DomGlobalKey,
+    DomGlobalSnapshotEntry,
+  ][]) {
+    if (!entry.exists) {
+      clearDomGlobal(key);
+      continue;
+    }
+
+    Object.defineProperty(globalThis, key, {
+      configurable: true,
+      value: entry.value,
+    });
+  }
+}
+
+function setDomGlobals(window: Window & typeof globalThis) {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: window,
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: window.document,
+  });
+  Object.defineProperty(globalThis, "HTMLElement", {
+    configurable: true,
+    value: window.HTMLElement,
+  });
+  Object.defineProperty(globalThis, "Node", {
+    configurable: true,
+    value: window.Node,
+  });
+  Object.defineProperty(globalThis, "Event", {
+    configurable: true,
+    value: window.Event,
+  });
+  Object.defineProperty(globalThis, "MouseEvent", {
+    configurable: true,
+    value: window.MouseEvent,
+  });
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: window.navigator,
+  });
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+}
+
+async function mountTimeline(
+  entries: readonly InboxTimelineEntryViewModel[],
+): Promise<RenderSession> {
+  const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+    url: "http://localhost/inbox",
+  });
+  const globalSnapshot = captureDomGlobals();
+  setDomGlobals(dom.window);
+
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(
+      createElement(InboxTimeline, {
+        entries,
+        volunteerFirstName: "Alice",
+        currentOperatorUserId: "user:operator",
+      }),
+    );
+    await Promise.resolve();
+  });
+
+  const cleanup = async () => {
+    await act(async () => {
+      root.unmount();
+      await Promise.resolve();
+    });
+    container.remove();
+    dom.window.close();
+    restoreDomGlobals(globalSnapshot);
+  };
+
+  activeSession = { container, root, cleanup };
+  return activeSession;
+}
+
 describe("InboxTimeline", () => {
-  afterEach(() => {
+  afterEach(async () => {
+    await activeSession?.cleanup();
+    activeSession = null;
     vi.restoreAllMocks();
+  });
+
+  it("uses a shared three-column grid instead of padded timeline rows", () => {
+    const markup = renderToStaticMarkup(
+      createElement(InboxTimeline, {
+        entries: [baseEntry],
+        volunteerFirstName: "Alice",
+        currentOperatorUserId: "user:operator",
+      }),
+    );
+
+    expect(markup).toContain("max-w-[1024px]");
+    expect(markup).toContain("grid-cols-[2.75rem_minmax(0,1fr)_2.75rem]");
+    expect(markup).not.toContain("pl-16");
+    expect(markup).not.toContain("pr-16");
   });
 
   it("keeps auto-email rows collapsed to the subject line by default", () => {
@@ -186,6 +397,32 @@ describe("InboxTimeline", () => {
     expect(markup).not.toContain("1 automated");
   });
 
+  it("renders sms rows with a fit-content bubble capped at 480px", () => {
+    const markup = renderToStaticMarkup(
+      createElement(InboxTimeline, {
+        entries: [
+          {
+            ...baseEntry,
+            id: "timeline:outbound-sms-1",
+            kind: "outbound-sms" as const,
+            channel: "sms" as const,
+            actorLabel: "You",
+            subject: null,
+            fromHeader: null,
+            toHeader: null,
+            mailbox: null,
+            body: "See you at 9.",
+          },
+        ],
+        volunteerFirstName: "Alice",
+        currentOperatorUserId: "user:operator",
+      }),
+    );
+
+    expect(markup).toContain("w-fit max-w-[480px]");
+    expect(markup).not.toContain("max-w-[440px]");
+  });
+
   it("renders the earlier-history divider when pre-cutover events exist", () => {
     const markup = renderToStaticMarkup(
       createElement(InboxTimeline, {
@@ -254,6 +491,38 @@ describe("InboxTimeline", () => {
     expect(markup).toContain(">Clicked<");
   });
 
+  it("keeps expanded system-group children flush with the parent card interior", async () => {
+    const session = await mountTimeline([
+      baseEntry,
+      {
+        ...baseEntry,
+        id: "timeline:auto-email-2",
+        occurredAtLabel: "90m ago",
+        subject: "Reminder details",
+      },
+      {
+        ...baseEntry,
+        id: "timeline:campaign-email-1",
+        kind: "outbound-campaign-email" as const,
+        occurredAtLabel: "1h ago",
+        subject: "April field update",
+      },
+    ]);
+
+    const button = session.container.querySelector("button");
+    expect(button?.textContent).toContain("2 automated · 1 campaign");
+
+    await act(async () => {
+      button?.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(session.container.innerHTML).toContain("space-y-2 border-t border-slate-100 bg-slate-50/30 p-2");
+    expect(session.container.innerHTML).not.toContain("bg-slate-50/30 p-3");
+    expect(session.container.innerHTML.match(/max-w-\[560px\]/g)?.length ?? 0).toBe(1);
+    expect(session.container.innerHTML).not.toContain("pl-16");
+  });
+
   it("renders lifecycle events as left-aligned achievement markers without category text", () => {
     const markup = renderToStaticMarkup(
       createElement(InboxTimeline, {
@@ -273,7 +542,7 @@ describe("InboxTimeline", () => {
       }),
     );
 
-    expect(markup).toContain('class="flex w-full items-start pr-16"');
+    expect(markup).toContain("col-span-3 grid");
     expect(markup).toContain("Alice applied to the Pacific Northwest expedition.");
     expect(markup).not.toContain(">APPLIED<");
   });

--- a/apps/web/tests/unit/inbox-timeline.test.ts
+++ b/apps/web/tests/unit/inbox-timeline.test.ts
@@ -781,7 +781,6 @@ describe("InboxTimeline", () => {
     expect(markup).not.toContain(">YO<");
   });
 
-<<<<<<< HEAD
   it("classifies signup system dividers into the violet hand achievement category", () => {
     expect(
       classifySystemDivider("Signed up for the Pacific Northwest expedition."),
@@ -810,9 +809,6 @@ describe("InboxTimeline", () => {
   });
 
   it("classifies first-data system dividers into the emerald star achievement category", () => {
-=======
-  it("classifies first-data system dividers into the emerald star category", () => {
->>>>>>> 5ecc91a4 (chore(inbox): harmonize system-divider with PR #322 lifecycle pills)
     expect(
       classifySystemDivider("Submitted first batch from the field."),
     ).toMatchObject({


### PR DESCRIPTION
**Replaces #323** — rebased onto current main after #322 merged. Same intent, divider file harmonized with #322's lifecycle-pill content.

## Summary

Pure visual fix to the inbox conversation timeline. Three architect-review issues from 2026-05-05:

1. **Avatars sat *inside* the 920px content column** → bubbles' inner edges didn't align across the thread. Now the timeline uses a CSS-grid column model with avatars in dedicated 44px gutter columns *outside* the bubble area.
2. **Bubbles 640px but content filled ~60–70%** → wasteful gutters. Locked widths per readability research (~65 CPL):
   - email bubbles (in/outbound): \`max-w-[560px]\`, no \`w-full\`
   - SMS bubbles: \`w-fit max-w-[480px]\` (chat-style)
   - notes: \`max-w-[560px]\`
3. **Expanded automated/campaign group**: child rows were narrower than the wrapping pill due to a double cap + \`p-3\` inner padding. Children now render \`nested\` and fill the parent's interior with \`p-2\` padding.

## Files

- \`inbox-timeline.tsx\` — outer grid wrapper, group nesting wiring
- \`inbox-timeline-bubble.tsx\` — \`MessageBubble\` width tuning, exports \`TIMELINE_GRID_COLUMNS\` / \`EMAIL_BUBBLE_MAX_W\` / \`SMS_BUBBLE_MAX_W\`, \`nested\` prop
- \`inbox-timeline-automated-row.tsx\` — grid wrap, nested mode
- \`inbox-timeline-note-entry.tsx\` — grid wrap, narrower max-w
- \`inbox-timeline-system-divider.tsx\` — grid wrap (kept #322's content)
- \`sms-message.tsx\` — grid wrap (legitimate caller)
- 2 test files updated

## Validation

- [x] \`pnpm typecheck\` — pass
- [x] \`pnpm lint\` — pass
- [ ] CI \`test:unit\` (local hits the macOS rollup environmental issue)
- [ ] Visual smoke after merge in production: bubble inner edges align; widths feel readable; expanded automated groups have flush inner rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)