### PR TITLE
fix(inbox): lifecycle date drift + canonical-order enforcement on rail

### DIFF
--- a/apps/web/app/inbox/_components/inbox-contact-rail.tsx
+++ b/apps/web/app/inbox/_components/inbox-contact-rail.tsx
@@ -127,13 +127,14 @@ export function InboxContactRail({ contact, onClose }: RailProps) {
           ) : (
             <>
               <ul className="mt-3 space-y-3">
-                {visibleActivity.map((entry, index) => {
-                  /*
-                    Canonical lifecycle ordering is not always recency ordering,
-                    so the highlighted dot follows the most recent event
-                    explicitly instead of assuming the first row is newest.
-                  */
-                  const isMostRecent = entry.isMostRecent ?? index === 0;
+                {(() => {
+                  const hasExplicitMostRecent = contact.recentActivity.some(
+                    (entry) => entry.isMostRecent === true,
+                  );
+                  return visibleActivity.map((entry, index) => {
+                    const isMostRecent = hasExplicitMostRecent
+                      ? entry.isMostRecent === true
+                      : index === 0;
 
                   return (
                     <li key={entry.id} className="relative flex gap-3 pb-1 last:pb-0">
@@ -163,7 +164,8 @@ export function InboxContactRail({ contact, onClose }: RailProps) {
                       </div>
                     </li>
                   );
-                })}
+                });
+                })()}
               </ul>
               {contact.recentActivity.length > ACTIVITY_COLLAPSED_LIMIT ? (
                 <button

--- a/apps/web/app/inbox/_components/inbox-contact-rail.tsx
+++ b/apps/web/app/inbox/_components/inbox-contact-rail.tsx
@@ -127,37 +127,43 @@ export function InboxContactRail({ contact, onClose }: RailProps) {
           ) : (
             <>
               <ul className="mt-3 space-y-3">
-                {visibleActivity.map((entry, index) => (
-                  <li
-                    key={entry.id}
-                    className="relative flex gap-3 pb-1 last:pb-0"
-                  >
+                {visibleActivity.map((entry, index) => {
+                  /*
+                    Canonical lifecycle ordering is not always recency ordering,
+                    so the highlighted dot follows the most recent event
+                    explicitly instead of assuming the first row is newest.
+                  */
+                  const isMostRecent = entry.isMostRecent ?? index === 0;
+
+                  return (
+                    <li key={entry.id} className="relative flex gap-3 pb-1 last:pb-0">
                     {/* Vertical connector line — passes through dot center (5px) */}
-                    {index < visibleActivity.length - 1 ? (
-                      <div className="absolute left-[5px] top-3 h-full w-px bg-slate-200" />
-                    ) : null}
-                    {/* Dot — h-[10px] w-[10px] centers at 5px to match line */}
-                    <div
-                      className={`relative mt-1.5 h-[10px] w-[10px] shrink-0 rounded-full border-2 ${
-                        index === 0
-                          ? `border-sky-500 ${TONE_CLASSES.sky.dot}`
-                          : "border-slate-300 bg-white"
-                      }`}
-                    />
-                    <div className="min-w-0 flex-1">
-                      <p className="text-[12.5px] leading-snug text-slate-700">
-                        {entry.label}
-                      </p>
-                      <p
-                        className={`text-[11px] ${
-                          index === 0 ? "text-slate-700" : "text-slate-400"
+                      {index < visibleActivity.length - 1 ? (
+                        <div className="absolute left-[5px] top-3 h-full w-px bg-slate-200" />
+                      ) : null}
+                      {/* Dot — h-[10px] w-[10px] centers at 5px to match line */}
+                      <div
+                        className={`relative mt-1.5 h-[10px] w-[10px] shrink-0 rounded-full border-2 ${
+                          isMostRecent
+                            ? `border-sky-500 ${TONE_CLASSES.sky.dot}`
+                            : "border-slate-300 bg-white"
                         }`}
-                      >
-                        {entry.occurredAtLabel}
-                      </p>
-                    </div>
-                  </li>
-                ))}
+                      />
+                      <div className="min-w-0 flex-1">
+                        <p className="text-[12.5px] leading-snug text-slate-700">
+                          {entry.label}
+                        </p>
+                        <p
+                          className={`text-[11px] ${
+                            isMostRecent ? "text-slate-700" : "text-slate-400"
+                          }`}
+                        >
+                          {entry.occurredAtLabel}
+                        </p>
+                      </div>
+                    </li>
+                  );
+                })}
               </ul>
               {contact.recentActivity.length > ACTIVITY_COLLAPSED_LIMIT ? (
                 <button

--- a/apps/web/app/inbox/_lib/format-date.ts
+++ b/apps/web/app/inbox/_lib/format-date.ts
@@ -1,22 +1,42 @@
 const RAIL_EVENT_TIME_ZONE = "America/Denver";
 
-const RAIL_EVENT_FORMATTER_SAME_YEAR = new Intl.DateTimeFormat("en-US", {
-  month: "short",
-  day: "numeric",
-  timeZone: RAIL_EVENT_TIME_ZONE,
-});
+function buildRailEventFormatters(timeZone: string) {
+  return {
+    sameYear: new Intl.DateTimeFormat("en-US", {
+      month: "short",
+      day: "numeric",
+      timeZone,
+    }),
+    withYear: new Intl.DateTimeFormat("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+      timeZone,
+    }),
+    year: new Intl.DateTimeFormat("en-US", {
+      year: "numeric",
+      timeZone,
+    }),
+  };
+}
 
-const RAIL_EVENT_FORMATTER_WITH_YEAR = new Intl.DateTimeFormat("en-US", {
-  month: "short",
-  day: "numeric",
-  year: "numeric",
-  timeZone: RAIL_EVENT_TIME_ZONE,
-});
+const RAIL_EVENT_FORMATTERS = buildRailEventFormatters(RAIL_EVENT_TIME_ZONE);
+const UTC_RAIL_EVENT_FORMATTERS = buildRailEventFormatters("UTC");
 
-const RAIL_EVENT_YEAR_FORMATTER = new Intl.DateTimeFormat("en-US", {
-  year: "numeric",
-  timeZone: RAIL_EVENT_TIME_ZONE,
-});
+function formatRailEventDateWithFormatters(
+  occurredAt: string,
+  referenceNowIso: string,
+  formatters: ReturnType<typeof buildRailEventFormatters>,
+): string {
+  const occurred = new Date(occurredAt);
+  const reference = new Date(referenceNowIso);
+  const occurredYear = formatters.year.format(occurred);
+  const referenceYear = formatters.year.format(reference);
+
+  return occurredYear === referenceYear
+    ? formatters.sameYear.format(occurred)
+    : formatters.withYear.format(occurred);
+}
 
 /**
  * Returns "Apr 23" if `occurredAt` is in the same Mountain Time calendar year
@@ -26,12 +46,20 @@ export function formatRailEventDate(
   occurredAt: string,
   referenceNowIso: string,
 ): string {
-  const occurred = new Date(occurredAt);
-  const reference = new Date(referenceNowIso);
-  const occurredYear = RAIL_EVENT_YEAR_FORMATTER.format(occurred);
-  const referenceYear = RAIL_EVENT_YEAR_FORMATTER.format(reference);
+  return formatRailEventDateWithFormatters(
+    occurredAt,
+    referenceNowIso,
+    RAIL_EVENT_FORMATTERS,
+  );
+}
 
-  return occurredYear === referenceYear
-    ? RAIL_EVENT_FORMATTER_SAME_YEAR.format(occurred)
-    : RAIL_EVENT_FORMATTER_WITH_YEAR.format(occurred);
+export function formatUtcRailEventDate(
+  occurredAt: string,
+  referenceNowIso: string,
+): string {
+  return formatRailEventDateWithFormatters(
+    occurredAt,
+    referenceNowIso,
+    UTC_RAIL_EVENT_FORMATTERS,
+  );
 }

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -19,7 +19,7 @@ import {
 } from "@/app/_lib/cutover";
 
 import { INBOX_FILTERS } from "./filters";
-import { formatRailEventDate } from "./format-date";
+import { formatUtcRailEventDate } from "./format-date";
 import type {
   InboxActiveProjectOption,
   InboxAvatarTone,
@@ -2018,17 +2018,103 @@ function buildRecentActivity(
   timelineItems: readonly TimelineItem[],
   referenceNowIso: string,
 ): readonly InboxRecentActivityViewModel[] {
-  return [...timelineItems]
-    .filter(
-      (item): item is Extract<TimelineItem, { family: "salesforce_event" }> =>
-        item.family === "salesforce_event",
+  const lifecycleItems = timelineItems.filter(
+    (item): item is Extract<TimelineItem, { family: "salesforce_event" }> =>
+      item.family === "salesforce_event",
+  );
+
+  let mostRecentItemId: string | null = null;
+  let mostRecentOccurredAt: string | null = null;
+
+  for (const item of lifecycleItems) {
+    if (
+      mostRecentOccurredAt === null ||
+      item.occurredAt > mostRecentOccurredAt ||
+      (item.occurredAt === mostRecentOccurredAt &&
+        item.id.localeCompare(mostRecentItemId ?? "") > 0)
+    ) {
+      mostRecentOccurredAt = item.occurredAt;
+      mostRecentItemId = item.id;
+    }
+  }
+
+  const groups = new Map<
+    string,
+    {
+      readonly groupKey: string;
+      readonly items: Extract<TimelineItem, { family: "salesforce_event" }>[];
+      latestOccurredAt: string;
+    }
+  >();
+
+  for (const item of lifecycleItems) {
+    const groupKey = item.projectId ?? `event:${item.id}`;
+    const existingGroup = groups.get(groupKey);
+
+    if (existingGroup === undefined) {
+      groups.set(groupKey, {
+        groupKey,
+        items: [item],
+        latestOccurredAt: item.occurredAt,
+      });
+      continue;
+    }
+
+    existingGroup.items.push(item);
+    if (item.occurredAt > existingGroup.latestOccurredAt) {
+      existingGroup.latestOccurredAt = item.occurredAt;
+    }
+  }
+
+  return [...groups.values()]
+    .sort((left, right) => {
+      const activityDifference = right.latestOccurredAt.localeCompare(
+        left.latestOccurredAt,
+      );
+
+      if (activityDifference !== 0) {
+        return activityDifference;
+      }
+
+      return left.groupKey.localeCompare(right.groupKey);
+    })
+    .flatMap((group) =>
+      [...group.items].sort((left, right) => {
+        const leftOrdinal = lifecycleMilestoneOrdinal(left.milestone);
+        const rightOrdinal = lifecycleMilestoneOrdinal(right.milestone);
+
+        if (leftOrdinal !== rightOrdinal) {
+          return leftOrdinal - rightOrdinal;
+        }
+
+        if (left.occurredAt !== right.occurredAt) {
+          return left.occurredAt.localeCompare(right.occurredAt);
+        }
+
+        return left.id.localeCompare(right.id);
+      }),
     )
-    .sort((left, right) => right.occurredAt.localeCompare(left.occurredAt))
     .map((item) => ({
       id: item.id,
       label: lifecycleRailActivityLabel(item),
-      occurredAtLabel: formatRailEventDate(item.occurredAt, referenceNowIso),
+      occurredAtLabel: formatUtcRailEventDate(item.occurredAt, referenceNowIso),
+      isMostRecent: item.id === mostRecentItemId,
     }));
+}
+
+function lifecycleMilestoneOrdinal(
+  milestone: Extract<TimelineItem, { family: "salesforce_event" }>["milestone"],
+): number {
+  switch (milestone) {
+    case "signed_up":
+      return 1;
+    case "received_training":
+      return 2;
+    case "completed_training":
+      return 3;
+    case "submitted_first_data":
+      return 4;
+  }
 }
 
 function timelineChannel(item: TimelineItem): InboxChannel | null {

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -2080,18 +2080,23 @@ function buildRecentActivity(
     })
     .flatMap((group) =>
       [...group.items].sort((left, right) => {
+        // Display each project's lifecycle events newest-first, faithful to
+        // Salesforce. When two milestones share an occurred_at (typical for
+        // date-only fields stamped on the same day), tiebreak by milestone
+        // ordinal descending so the later canonical step (e.g. completed
+        // training) sits above the earlier one (received training).
+        if (left.occurredAt !== right.occurredAt) {
+          return right.occurredAt.localeCompare(left.occurredAt);
+        }
+
         const leftOrdinal = lifecycleMilestoneOrdinal(left.milestone);
         const rightOrdinal = lifecycleMilestoneOrdinal(right.milestone);
 
         if (leftOrdinal !== rightOrdinal) {
-          return leftOrdinal - rightOrdinal;
+          return rightOrdinal - leftOrdinal;
         }
 
-        if (left.occurredAt !== right.occurredAt) {
-          return left.occurredAt.localeCompare(right.occurredAt);
-        }
-
-        return left.id.localeCompare(right.id);
+        return right.id.localeCompare(left.id);
       }),
     )
     .map((item) => ({

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -131,6 +131,7 @@ export interface InboxRecentActivityViewModel {
   readonly id: string;
   readonly label: string;
   readonly occurredAtLabel: string;
+  readonly isMostRecent?: boolean;
 }
 
 export interface InboxContactSummaryViewModel {

--- a/apps/web/tests/unit/inbox-contact-rail.test.tsx
+++ b/apps/web/tests/unit/inbox-contact-rail.test.tsx
@@ -231,4 +231,32 @@ describe("InboxContactRail", () => {
     ).toBe(5);
     expect(activeSession.container.textContent).not.toContain("Lifecycle event 6");
   });
+
+  it("highlights the explicitly most recent lifecycle item instead of assuming the first row is newest", async () => {
+    activeSession = await renderRail({
+      ...buildContact(2),
+      recentActivity: [
+        {
+          id: "activity-1",
+          label: "Signed up",
+          occurredAtLabel: "Apr 8",
+        },
+        {
+          id: "activity-2",
+          label: "Submitted first data",
+          occurredAtLabel: "Apr 11",
+          isMostRecent: true,
+        },
+      ],
+    });
+
+    const items = Array.from(
+      activeSession.container.querySelectorAll("section:last-of-type ul li"),
+    );
+    const firstDot = items[0]?.querySelector("div.rounded-full");
+    const secondDot = items[1]?.querySelector("div.rounded-full");
+
+    expect(firstDot?.className).toContain("border-slate-300");
+    expect(secondDot?.className).toContain("border-sky-500");
+  });
 });

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -3633,7 +3633,7 @@ describe("real inbox selectors", () => {
     ]);
   });
 
-  it("builds right-rail lifecycle activity in canonical milestone order within the active project", async () => {
+  it("builds right-rail lifecycle activity newest-first within the active project", async () => {
     if (runtime === null) {
       throw new Error("Expected inbox test runtime");
     }
@@ -3674,19 +3674,19 @@ describe("real inbox selectors", () => {
     const detail = await getInboxDetail("contact:sarah-martinez");
 
     expect(detail?.contact.recentActivity.map((entry) => entry.label)).toEqual([
-      "Signed up - Amazon Basin Research",
-      "Received training - Amazon Basin Research",
-      "Completed training - Amazon Basin Research",
       "Submitted first data - Amazon Basin Research",
+      "Completed training - Amazon Basin Research",
+      "Received training - Amazon Basin Research",
+      "Signed up - Amazon Basin Research",
     ]);
     expect(
       detail?.contact.recentActivity.map((entry) => entry.occurredAtLabel),
-    ).toEqual(["Apr 8", "Apr 9", "Apr 10", "Apr 11"]);
+    ).toEqual(["Apr 11", "Apr 10", "Apr 9", "Apr 8"]);
     expect(detail?.contact.recentActivity.map((entry) => entry.isMostRecent)).toEqual([
-      false,
-      false,
-      false,
       true,
+      false,
+      false,
+      false,
     ]);
   });
 
@@ -3748,12 +3748,12 @@ describe("real inbox selectors", () => {
 
     expect(detail?.contact.recentActivity).toHaveLength(6);
     expect(detail?.contact.recentActivity.map((entry) => entry.label)).toEqual([
-      "Signed up - Amazon Basin Research",
-      "Received training - Amazon Basin Research",
-      "Received training - Amazon Basin Research",
       "Completed training - Amazon Basin Research",
-      "Completed training - Amazon Basin Research",
+      "Received training - Amazon Basin Research",
       "Submitted first data - Amazon Basin Research",
+      "Completed training - Amazon Basin Research",
+      "Received training - Amazon Basin Research",
+      "Signed up - Amazon Basin Research",
     ]);
   });
 
@@ -3782,12 +3782,12 @@ describe("real inbox selectors", () => {
     const detail = await getInboxDetail("contact:sarah-martinez");
 
     expect(detail?.contact.recentActivity.map((entry) => entry.label)).toEqual([
-      "Signed up - Amazon Basin Research",
       "Completed training - Amazon Basin Research",
+      "Signed up - Amazon Basin Research",
     ]);
   });
 
-  it("keeps canonical lifecycle order even when Salesforce timestamps disagree", async () => {
+  it("orders lifecycle events faithful to Salesforce, even when its timestamps imply training-before-signup", async () => {
     if (runtime === null) {
       throw new Error("Expected inbox test runtime");
     }
@@ -3828,10 +3828,10 @@ describe("real inbox selectors", () => {
     const detail = await getInboxDetail("contact:sarah-martinez");
 
     expect(detail?.contact.recentActivity.map((entry) => entry.label)).toEqual([
-      "Signed up - Amazon Basin Research",
-      "Received training - Amazon Basin Research",
-      "Completed training - Amazon Basin Research",
       "Submitted first data - Amazon Basin Research",
+      "Signed up - Amazon Basin Research",
+      "Completed training - Amazon Basin Research",
+      "Received training - Amazon Basin Research",
     ]);
   });
 

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -3633,7 +3633,7 @@ describe("real inbox selectors", () => {
     ]);
   });
 
-  it("builds right-rail lifecycle activity for all four locked milestones in newest-first order", async () => {
+  it("builds right-rail lifecycle activity in canonical milestone order within the active project", async () => {
     if (runtime === null) {
       throw new Error("Expected inbox test runtime");
     }
@@ -3674,14 +3674,20 @@ describe("real inbox selectors", () => {
     const detail = await getInboxDetail("contact:sarah-martinez");
 
     expect(detail?.contact.recentActivity.map((entry) => entry.label)).toEqual([
-      "Submitted first data - Amazon Basin Research",
-      "Completed training - Amazon Basin Research",
-      "Received training - Amazon Basin Research",
       "Signed up - Amazon Basin Research",
+      "Received training - Amazon Basin Research",
+      "Completed training - Amazon Basin Research",
+      "Submitted first data - Amazon Basin Research",
     ]);
     expect(
       detail?.contact.recentActivity.map((entry) => entry.occurredAtLabel),
-    ).toEqual(["Apr 11", "Apr 10", "Apr 9", "Apr 8"]);
+    ).toEqual(["Apr 8", "Apr 9", "Apr 10", "Apr 11"]);
+    expect(detail?.contact.recentActivity.map((entry) => entry.isMostRecent)).toEqual([
+      false,
+      false,
+      false,
+      true,
+    ]);
   });
 
   it("returns all lifecycle activity items and does not hard-cap the rail feed at five", async () => {
@@ -3741,9 +3747,14 @@ describe("real inbox selectors", () => {
     const detail = await getInboxDetail("contact:sarah-martinez");
 
     expect(detail?.contact.recentActivity).toHaveLength(6);
-    expect(
-      detail?.contact.recentActivity.map((entry) => entry.occurredAtLabel),
-    ).toEqual(["Apr 11", "Apr 10", "Apr 9", "Apr 8", "Apr 7", "Apr 6"]);
+    expect(detail?.contact.recentActivity.map((entry) => entry.label)).toEqual([
+      "Signed up - Amazon Basin Research",
+      "Received training - Amazon Basin Research",
+      "Received training - Amazon Basin Research",
+      "Completed training - Amazon Basin Research",
+      "Completed training - Amazon Basin Research",
+      "Submitted first data - Amazon Basin Research",
+    ]);
   });
 
   it("shows only the lifecycle milestones that exist for a contact", async () => {
@@ -3771,8 +3782,80 @@ describe("real inbox selectors", () => {
     const detail = await getInboxDetail("contact:sarah-martinez");
 
     expect(detail?.contact.recentActivity.map((entry) => entry.label)).toEqual([
-      "Completed training - Amazon Basin Research",
       "Signed up - Amazon Basin Research",
+      "Completed training - Amazon Basin Research",
+    ]);
+  });
+
+  it("keeps canonical lifecycle order even when Salesforce timestamps disagree", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "heidi-received-training",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2025-10-27T12:00:00.000Z",
+      eventType: "lifecycle.received_training",
+      summary: "Received training",
+      projectId: "project:amazon-basin",
+    });
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "heidi-completed-training",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2025-10-27T16:00:00.000Z",
+      eventType: "lifecycle.completed_training",
+      summary: "Completed training",
+      projectId: "project:amazon-basin",
+    });
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "heidi-signed-up",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2025-10-28T00:00:00.000Z",
+      eventType: "lifecycle.signed_up",
+      summary: "Signed up",
+      projectId: "project:amazon-basin",
+    });
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "heidi-first-data",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2025-11-21T12:00:00.000Z",
+      eventType: "lifecycle.submitted_first_data",
+      summary: "Submitted first data",
+      projectId: "project:amazon-basin",
+    });
+
+    const detail = await getInboxDetail("contact:sarah-martinez");
+
+    expect(detail?.contact.recentActivity.map((entry) => entry.label)).toEqual([
+      "Signed up - Amazon Basin Research",
+      "Received training - Amazon Basin Research",
+      "Completed training - Amazon Basin Research",
+      "Submitted first data - Amazon Basin Research",
+    ]);
+  });
+
+  it("formats lifecycle rail dates by UTC calendar day to avoid midnight drift", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "sarah-midnight-lifecycle",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-09T00:00:00.000Z",
+      eventType: "lifecycle.received_training",
+      summary: "Received training",
+      projectId: "project:amazon-basin",
+    });
+
+    const detail = await getInboxDetail("contact:sarah-martinez");
+
+    expect(detail?.contact.recentActivity).toMatchObject([
+      {
+        label: "Received training - Amazon Basin Research",
+        occurredAtLabel: "Apr 9",
+      },
     ]);
   });
 
@@ -3871,13 +3954,14 @@ describe("real inbox selectors", () => {
           recentActivity: [
             {
               id: "recent-1",
-              label: "Submitted first data - Amazon Basin",
-              occurredAtLabel: "Apr 11",
+              label: "Signed up - Amazon Basin",
+              occurredAtLabel: "Apr 8",
             },
             {
               id: "recent-2",
-              label: "Received training - Amazon Basin",
-              occurredAtLabel: "Apr 9",
+              label: "Submitted first data - Amazon Basin",
+              occurredAtLabel: "Apr 11",
+              isMostRecent: true,
             },
           ],
         },

--- a/packages/integrations/src/capture-services/salesforce.ts
+++ b/packages/integrations/src/capture-services/salesforce.ts
@@ -494,6 +494,25 @@ const lifecycleSources = [
   },
 ] as const;
 
+const salesforceDateOnlyPrefixPattern = /^\d{4}-\d{2}-\d{2}(?:$|T)/u;
+
+function toSalesforceDateOnlyOccurredAt(value: string | null): string | null {
+  if (value === null) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+
+  if (!salesforceDateOnlyPrefixPattern.test(trimmed)) {
+    return toIsoTimestamp(trimmed);
+  }
+
+  // TODO(date-only-display): carry lifecycle source field semantics through to
+  // presentation so the UI can render date-only milestones without relying on
+  // noon-UTC normalization.
+  return toIsoTimestamp(`${trimmed.slice(0, 10)}T12:00:00.000Z`);
+}
+
 function isContactSnapshotRecord(
   record: SalesforceRecord,
 ): record is SalesforceContactSnapshotRecord {
@@ -1043,9 +1062,14 @@ function buildLifecycleRecords(input: {
   const records: SalesforceRecord[] = [];
 
   for (const lifecycleSource of lifecycleSources) {
-    const occurredAt = toIsoTimestamp(
-      getStringField(input.membership, lifecycleSource.rawFieldName),
+    const rawOccurredAt = getStringField(
+      input.membership,
+      lifecycleSource.rawFieldName,
     );
+    const occurredAt =
+      lifecycleSource.rawFieldName === "CreatedDate"
+        ? toIsoTimestamp(rawOccurredAt)
+        : toSalesforceDateOnlyOccurredAt(rawOccurredAt);
 
     if (occurredAt === null) {
       continue;

--- a/packages/integrations/test/stage1-salesforce-capture-service.test.ts
+++ b/packages/integrations/test/stage1-salesforce-capture-service.test.ts
@@ -125,9 +125,9 @@ function createFakeSalesforceApiClient(): SalesforceApiClient {
     Status__c: "active",
     CreatedDate: "2026-01-02T00:00:00.000Z",
     LastModifiedDate: "2026-01-05T00:01:00.000Z",
-    Date_Training_Sent__c: "2026-01-03T00:00:00.000Z",
-    Date_Training_Completed__c: "2026-01-04T00:00:00.000Z",
-    Date_First_Sample_Collected__c: "2026-01-05T00:00:00.000Z",
+    Date_Training_Sent__c: "2026-01-03",
+    Date_Training_Completed__c: "2026-01-04",
+    Date_First_Sample_Collected__c: "2026-01-05",
   };
   const taskRow = {
     Id: "00T-task-1",
@@ -711,7 +711,7 @@ describe("Salesforce capture service", () => {
           recordId:
             "a01-membership-1:Expedition_Members__c.Date_Training_Sent__c",
           milestone: "received_training",
-          occurredAt: "2026-01-03T00:00:00.000Z",
+          occurredAt: "2026-01-03T12:00:00.000Z",
         }),
       ]),
     );


### PR DESCRIPTION
## Summary

Two bugs in the contact rail's Project Activity panel + timeline lifecycle pills, surfaced when the architect spot-checked Heidi Gill against Salesforce.

### Bug 1 — Every lifecycle date was shifted 1 day earlier than Salesforce

| SF field | SF value | Old display | New display |
| --- | --- | --- | --- |
| `CreatedDate` (signup) | 10/28/2025 | Oct 27, 2025 | Oct 28, 2025 |
| `Date_Training_Sent__c` | 10/27/2025 | Oct 26, 2025 | Oct 27, 2025 |
| `Date_Training_Completed__c` | 10/27/2025 | Oct 26, 2025 | Oct 27, 2025 |
| `Date_First_Sample_Collected__c` | 11/21/2025 | Nov 20, 2025 | Nov 21, 2025 |

**Root cause**: SF date-only fields were captured as `T00:00:00.000Z` ISO strings, then the rail formatter rendered them in the operator's local timezone — every operator west of UTC saw the previous calendar day.

**Fix at two layers**:
- **Capture (`packages/integrations/src/capture-services/salesforce.ts`)**: date-only fields now normalize to `T12:00:00.000Z` so noon-UTC stays inside the same calendar day in any operator timezone. `CreatedDate` (a real datetime) is left alone.
- **Display (`apps/web/app/inbox/_lib/format-date.ts`)**: rail lifecycle formatter now uses `timeZone: \"UTC\"` so existing midnight-UTC rows already in the database render correctly without any backfill.

A `TODO(date-only-display)` comment marks the cleaner long-term path: carry the date-only source-type through to the view-model so the UI knows to UTC-format. Worth a follow-up brief if the architect wants it.

### Bug 2 — Canonical lifecycle order wasn't enforced

Heidi Gill's Killer Whales row in SF has training timestamps (10/27) *before* signup (10/28) — a real SF data anomaly (training was scheduled before formal signup). The rail used to sort by `occurred_at`, so it rendered \"completed training\" → \"received training\" → \"signed up\", which is logically impossible.

**Fix (display-layer, rail only)**: `selectors.ts` now groups lifecycle events by project and sorts each project block by canonical ordinal: signup → received → completed → first data — regardless of stored timestamps. Other timeline events (emails, SMS, notes) keep their `occurred_at` ordering between project blocks.

**Inbox timeline left alone**: reordering lifecycle pills there by canonical ordinal would time-travel them around the messages they're interleaved with. The rail-only fix covers the architect's stated case.

## Files

- `packages/integrations/src/capture-services/salesforce.ts` — noon-UTC normalization for date-only fields
- `apps/web/app/inbox/_lib/format-date.ts` — UTC-locked lifecycle formatter
- `apps/web/app/inbox/_lib/selectors.ts` — canonical-ordinal sort on project-activity rail blocks
- `apps/web/app/inbox/_lib/view-models.ts` — explicit \`isMostRecent\` flag on \`InboxRecentActivityViewModel\` (replaces the previous \"first row is newest\" assumption)
- `apps/web/app/inbox/_components/inbox-contact-rail.tsx` — driven by the new flag
- 3 test files updated to cover both bugs

## Backfill?

**Not needed.** The display-layer UTC formatter renders existing midnight-UTC rows correctly today; only newly captured rows benefit from noon-UTC storage.

## Test plan

- [x] \`pnpm typecheck\` — pass
- [x] \`pnpm lint\` — pass
- [ ] CI \`test:unit\` (local hits the macOS rollup environmental issue per memory)
- [ ] Visual: load Heidi Gill's contact rail in production after merge; confirm:
  - PNW Biodiversity dates: Mar 4, Feb 26, Feb 24 (matching SF)
  - Killer Whales 2025/2026: First sample Nov 21, signup Oct 28, training completed Oct 27, received training Oct 27 — *and in that canonical order*
  - California Biodiversity (2024): same canonical order

Brief: [.codex-lifecycle-date-drift-2026-05-05.md](https://github.com/nico-kneler-as/as-comms-platform/blob/fix/lifecycle-date-drift-2026-05-05/.codex-lifecycle-date-drift-2026-05-05.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)