### PR TITLE
feat(inbox): bubble width consistency + expanded-group restructure + collapsed pill redesign

### DIFF
--- a/apps/web/app/inbox/_components/inbox-timeline-automated-row.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-automated-row.tsx
@@ -196,13 +196,11 @@ export function TimelineAutomatedRow({
   role,
   isExpanded,
   onToggle,
-  nested = false,
 }: {
   readonly entry: InboxTimelineEntryViewModel;
   readonly role: "automated" | "campaign" | "activity";
   readonly isExpanded: boolean;
   readonly onToggle: () => void;
-  readonly nested?: boolean;
 }) {
   const isEmail = entry.channel === "email";
   const campaignActivity =
@@ -224,23 +222,14 @@ export function TimelineAutomatedRow({
   });
 
   return (
-    <li
-      className={cn(
-        nested ? "w-full" : cn("col-span-3 grid", TIMELINE_GRID_COLUMNS),
-      )}
-    >
+    <li className={cn("col-span-3 grid", TIMELINE_GRID_COLUMNS)}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <div
-            className={cn(
-              nested ? "flex w-full justify-end" : "col-start-2 flex justify-end",
-            )}
-          >
+          <div className="col-start-2 flex justify-end">
             <div
               className={cn(
-                nested
-                  ? "w-full overflow-hidden rounded-xl border"
-                  : cn("w-full overflow-hidden rounded-xl border", EMAIL_BUBBLE_MAX_W),
+                "w-full overflow-hidden rounded-xl border",
+                EMAIL_BUBBLE_MAX_W,
                 descriptor.shellClassName,
               )}
             >

--- a/apps/web/app/inbox/_components/inbox-timeline-bubble.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-bubble.tsx
@@ -41,7 +41,7 @@ export const TIMELINE_OUTER_MAX_W = "max-w-[1024px]";
 export const TIMELINE_GRID_COLUMNS =
   "grid-cols-[2.75rem_minmax(0,1fr)_2.75rem]";
 export const EMAIL_BUBBLE_MAX_W = "max-w-[560px]";
-export const SMS_BUBBLE_MAX_W = "max-w-[480px]";
+export const SMS_BUBBLE_MAX_W = "max-w-[560px]";
 const EMAIL_HTML_BODY_CLASS =
   "text-pretty text-[13px] leading-relaxed text-slate-700 [&_a]:text-sky-700 [&_a]:underline [&_blockquote]:border-l-2 [&_blockquote]:border-slate-200 [&_blockquote]:pl-3 [&_blockquote]:text-slate-600 [&_code]:rounded-sm [&_code]:bg-slate-100 [&_code]:px-1 [&_code]:py-0.5 [&_h1]:text-lg [&_h1]:font-semibold [&_h2]:text-base [&_h2]:font-semibold [&_h3]:text-sm [&_h3]:font-semibold [&_ol]:ml-5 [&_ol]:list-decimal [&_pre]:overflow-x-auto [&_pre]:rounded-md [&_pre]:bg-slate-100 [&_pre]:p-3 [&_table]:my-2 [&_table]:border-collapse [&_td]:border [&_td]:border-slate-200 [&_td]:px-2 [&_td]:py-1 [&_th]:border [&_th]:border-slate-200 [&_th]:px-2 [&_th]:py-1 [&_ul]:ml-5 [&_ul]:list-disc";
 
@@ -384,14 +384,12 @@ export function MessageBubble({
   onReply,
   isRetrying = false,
   onRetryPending,
-  nested = false,
 }: {
   readonly entry: InboxTimelineEntryViewModel;
   readonly direction: "inbound" | "outbound";
   readonly onReply?: (entryId: string) => void;
   readonly isRetrying?: boolean;
   readonly onRetryPending?: (entryId: string) => void;
-  readonly nested?: boolean;
 }) {
   const isEmail = entry.channel === "email";
   // Pre-PR-#170 we rendered every email body as plaintext via
@@ -422,11 +420,10 @@ export function MessageBubble({
     : isOutbound
       ? "border border-sky-600 bg-sky-600 text-white"
       : "border border-slate-200 bg-white";
-  const bubbleWidthClassName = nested
-    ? "w-full"
-    : isEmail
-      ? cn("w-fit", EMAIL_BUBBLE_MAX_W)
-      : cn("w-fit", SMS_BUBBLE_MAX_W);
+  const bubbleWidthClassName = cn(
+    "w-full",
+    isEmail ? EMAIL_BUBBLE_MAX_W : SMS_BUBBLE_MAX_W,
+  );
   const bubble = (
     <div
       className={cn(
@@ -495,22 +492,16 @@ export function MessageBubble({
   );
 
   return (
-    <li
-      className={cn(
-        nested ? "w-full" : cn("col-span-3 grid", TIMELINE_GRID_COLUMNS),
+    <li className={cn("col-span-3 grid", TIMELINE_GRID_COLUMNS)}>
+      {!isOutbound ? (
+        <div className="flex justify-start pt-2">{inboundAvatar}</div>
+      ) : (
+        <div aria-hidden="true" />
       )}
-    >
-      {!nested ? (
-        !isOutbound ? (
-          <div className="flex justify-start pt-2">{inboundAvatar}</div>
-        ) : (
-          <div aria-hidden="true" />
-        )
-      ) : null}
 
       <div
         className={cn(
-          nested ? "min-w-0 flex" : "col-start-2 min-w-0 flex",
+          "col-start-2 min-w-0 flex",
           isOutbound ? "justify-end" : "justify-start",
         )}
       >
@@ -523,15 +514,13 @@ export function MessageBubble({
         </div>
       </div>
 
-      {!nested ? (
-        isOutbound ? (
-          <div className="flex justify-end pt-2">
-            <OutboundBrandAvatar />
-          </div>
-        ) : (
-          <div aria-hidden="true" />
-        )
-      ) : null}
+      {isOutbound ? (
+        <div className="flex justify-end pt-2">
+          <OutboundBrandAvatar />
+        </div>
+      ) : (
+        <div aria-hidden="true" />
+      )}
     </li>
   );
 }

--- a/apps/web/app/inbox/_components/inbox-timeline-note-entry.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-note-entry.tsx
@@ -39,11 +39,9 @@ function formatExactTimestamp(timestamp: string): string {
 export function TimelineNoteEntry({
   entry,
   currentOperatorUserId,
-  nested = false,
 }: {
   readonly entry: InboxTimelineEntryViewModel;
   readonly currentOperatorUserId: string;
-  readonly nested?: boolean;
 }) {
   const router = useRouter();
   const [isEditing, setIsEditing] = useState(false);
@@ -118,19 +116,12 @@ export function TimelineNoteEntry({
   };
 
   return (
-    <li
-      className={cn(
-        nested ? "w-full" : cn("col-span-3 grid", TIMELINE_GRID_COLUMNS),
-      )}
-    >
-      <div
-        className={cn(
-          nested ? "flex w-full justify-end" : "col-start-2 flex justify-end",
-        )}
-      >
+    <li className={cn("col-span-3 grid", TIMELINE_GRID_COLUMNS)}>
+      <div className="col-start-2 flex justify-end">
         <div
           className={cn(
-            nested ? "w-full" : cn("w-fit", EMAIL_BUBBLE_MAX_W),
+            "w-full",
+            EMAIL_BUBBLE_MAX_W,
             "rounded-xl border border-amber-200 bg-amber-50/60 px-4 py-2.5 shadow-sm",
           )}
         >

--- a/apps/web/app/inbox/_components/inbox-timeline.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 import type {
   InboxTimelineEntryKind,
-  InboxTimelinePresentationItem,
   InboxTimelineSystemGroupViewModel,
   InboxTimelineEntryViewModel,
 } from "../_lib/view-models";
@@ -20,7 +19,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import { TRANSITION } from "@/app/_lib/design-tokens-v2";
+import { TONE_CLASSES, TRANSITION } from "@/app/_lib/design-tokens-v2";
 import { TimelineAutomatedRow } from "./inbox-timeline-automated-row";
 import {
   EMAIL_BUBBLE_MAX_W,
@@ -138,80 +137,61 @@ export function InboxTimeline({
               </div>
             </li>
           ) : null}
-          {presentationItems.map((item) => (
-            <TimelinePresentationItem
-              key={item.id}
-              item={item}
-              volunteerFirstName={volunteerFirstName}
-              currentOperatorUserId={currentOperatorUserId}
-              isExpanded={expanded.has(item.id)}
-              retryingEntryId={retryingEntryId}
-              onRetryPending={onRetryPending}
-              {...(onReply === undefined ? {} : { onReply })}
-              onToggle={() => {
-                toggle(item.id);
-              }}
-              isChildExpanded={(entryId) => expanded.has(entryId)}
-              onToggleChild={toggle}
-            />
-          ))}
+          {presentationItems.flatMap((item) => {
+            if (item.kind !== "system-message-group") {
+              return [
+                <TimelineEntry
+                  key={item.id}
+                  entry={item}
+                  volunteerFirstName={volunteerFirstName}
+                  currentOperatorUserId={currentOperatorUserId}
+                  isExpanded={expanded.has(item.id)}
+                  retryingEntryId={retryingEntryId}
+                  onRetryPending={onRetryPending}
+                  {...(onReply === undefined ? {} : { onReply })}
+                  onToggle={() => {
+                    toggle(item.id);
+                  }}
+                />,
+              ];
+            }
+
+            const rows = [
+              <SystemMessageGroup
+                key={item.id}
+                group={item}
+                isExpanded={expanded.has(item.id)}
+                onToggle={() => {
+                  toggle(item.id);
+                }}
+              />,
+            ];
+
+            if (!expanded.has(item.id)) {
+              return rows;
+            }
+
+            return rows.concat(
+              item.entries.map((entry) => (
+                <TimelineEntry
+                  key={entry.id}
+                  entry={entry}
+                  volunteerFirstName={volunteerFirstName}
+                  currentOperatorUserId={currentOperatorUserId}
+                  isExpanded={expanded.has(entry.id)}
+                  retryingEntryId={retryingEntryId}
+                  onRetryPending={onRetryPending}
+                  {...(onReply === undefined ? {} : { onReply })}
+                  onToggle={() => {
+                    toggle(entry.id);
+                  }}
+                />
+              )),
+            );
+          })}
         </ol>
       </div>
     </TooltipProvider>
-  );
-}
-
-interface PresentationItemProps {
-  readonly item: InboxTimelinePresentationItem;
-  readonly volunteerFirstName: string;
-  readonly currentOperatorUserId: string;
-  readonly isExpanded: boolean;
-  readonly retryingEntryId: string | null;
-  readonly onRetryPending: ((entryId: string) => void) | undefined;
-  readonly onReply?: (entryId: string) => void;
-  readonly onToggle: () => void;
-  readonly isChildExpanded: (entryId: string) => boolean;
-  readonly onToggleChild: (entryId: string) => void;
-}
-
-function TimelinePresentationItem({
-  item,
-  volunteerFirstName,
-  currentOperatorUserId,
-  isExpanded,
-  retryingEntryId,
-  onRetryPending,
-  onReply,
-  onToggle,
-  isChildExpanded,
-  onToggleChild,
-}: PresentationItemProps) {
-  if (item.kind === "system-message-group") {
-    return (
-      <SystemMessageGroup
-        group={item}
-        isExpanded={isExpanded}
-        currentOperatorUserId={currentOperatorUserId}
-        retryingEntryId={retryingEntryId}
-        onRetryPending={onRetryPending}
-        onToggle={onToggle}
-        isChildExpanded={isChildExpanded}
-        onToggleChild={onToggleChild}
-      />
-    );
-  }
-
-  return (
-    <TimelineEntry
-      entry={item}
-      volunteerFirstName={volunteerFirstName}
-      currentOperatorUserId={currentOperatorUserId}
-      isExpanded={isExpanded}
-      retryingEntryId={retryingEntryId}
-      onRetryPending={onRetryPending}
-      {...(onReply === undefined ? {} : { onReply })}
-      onToggle={onToggle}
-    />
   );
 }
 
@@ -278,7 +258,6 @@ interface EntryProps {
   readonly onRetryPending: ((entryId: string) => void) | undefined;
   readonly onReply?: (entryId: string) => void;
   readonly onToggle: () => void;
-  readonly nested?: boolean;
 }
 
 function TimelineEntry({
@@ -290,7 +269,6 @@ function TimelineEntry({
   onRetryPending,
   onReply,
   onToggle,
-  nested = false,
 }: EntryProps) {
   const role = roleForKind(entry.kind);
 
@@ -301,7 +279,6 @@ function TimelineEntry({
           <SmsMessage
             entry={entry}
             direction="inbound"
-            nested={nested}
             {...(onReply === undefined ? {} : { onReply })}
           />
         );
@@ -311,7 +288,6 @@ function TimelineEntry({
         <MessageBubble
           entry={entry}
           direction="inbound"
-          nested={nested}
           {...(onReply === undefined ? {} : { onReply })}
         />
       );
@@ -322,7 +298,6 @@ function TimelineEntry({
             entry={entry}
             direction="outbound"
             isRetrying={retryingEntryId === entry.id}
-            nested={nested}
             {...(onReply === undefined ? {} : { onReply })}
             {...(onRetryPending === undefined ? {} : { onRetryPending })}
           />
@@ -334,7 +309,6 @@ function TimelineEntry({
           entry={entry}
           direction="outbound"
           isRetrying={retryingEntryId === entry.id}
-          nested={nested}
           {...(onReply === undefined ? {} : { onReply })}
           {...(onRetryPending === undefined ? {} : { onRetryPending })}
         />
@@ -348,7 +322,6 @@ function TimelineEntry({
           role={role}
           isExpanded={isExpanded}
           onToggle={onToggle}
-          nested={nested}
         />
       );
     case "note":
@@ -356,7 +329,6 @@ function TimelineEntry({
         <TimelineNoteEntry
           entry={entry}
           currentOperatorUserId={currentOperatorUserId}
-          nested={nested}
         />
       );
     case "system":
@@ -368,105 +340,71 @@ function TimelineEntry({
 
 function SystemMessageGroup({
   group,
-  currentOperatorUserId,
   isExpanded,
-  retryingEntryId,
-  onRetryPending,
   onToggle,
-  isChildExpanded,
-  onToggleChild,
 }: {
   readonly group: InboxTimelineSystemGroupViewModel;
-  readonly currentOperatorUserId: string;
   readonly isExpanded: boolean;
-  readonly retryingEntryId: string | null;
-  readonly onRetryPending: ((entryId: string) => void) | undefined;
   readonly onToggle: () => void;
-  readonly isChildExpanded: (entryId: string) => boolean;
-  readonly onToggleChild: (entryId: string) => void;
 }) {
   const summary = formatSystemGroupSummary(group);
+  const primaryKind = group.campaignCount > 0 ? "campaign" : "automated";
+  const GroupIcon = primaryKind === "campaign" ? MegaphoneIcon : ZapIcon;
 
   return (
     <li className={cn("col-span-3 grid", TIMELINE_GRID_COLUMNS)}>
       <div className="col-start-2 flex justify-end">
-        <div
+        <button
+          type="button"
+          aria-expanded={isExpanded}
+          onClick={onToggle}
+          data-group-icon={primaryKind}
           className={cn(
-            "w-full overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm",
+            "group w-full overflow-hidden rounded-xl border px-4 py-3 text-left shadow-sm",
+            "border-violet-200/70 bg-violet-50/40 hover:bg-violet-50/70",
+            "transition-[background-color,border-color,transform] duration-150 ease-out active:scale-[0.99]",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-300 focus-visible:ring-offset-2",
             EMAIL_BUBBLE_MAX_W,
+            TRANSITION.reduceMotion,
           )}
         >
-          <button
-            type="button"
-            aria-expanded={isExpanded}
-            onClick={onToggle}
-            className={cn(
-              "flex w-full items-center justify-between gap-3 px-4 py-2.5 text-left hover:bg-slate-50/60",
-              "transition-[background-color,transform] duration-150 ease-out active:scale-[0.99]",
-              TRANSITION.reduceMotion,
-            )}
-          >
-            <div className="flex min-w-0 items-center gap-2.5">
-              <div className="-space-x-1 flex shrink-0 items-center">
-                {group.entries.slice(0, 3).map((entry) => (
-                  <span
-                    key={entry.id}
-                    className={cn(
-                      "inline-flex size-5 items-center justify-center rounded-full ring-2 ring-white",
-                      roleForKind(entry.kind) === "campaign"
-                        ? "bg-violet-100 text-violet-700"
-                        : "bg-slate-100 text-slate-600",
-                    )}
-                  >
-                    {roleForKind(entry.kind) === "campaign" ? (
-                      <MegaphoneIcon className="size-2.5" />
-                    ) : (
-                      <ZapIcon className="size-2.5" />
-                    )}
-                  </span>
-                ))}
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex min-w-0 items-center gap-3">
+              <div
+                className={cn(
+                  "inline-flex size-9 shrink-0 items-center justify-center rounded-full",
+                  TONE_CLASSES.violet.avatar,
+                )}
+              >
+                <GroupIcon className="size-4" />
               </div>
               <div className="min-w-0">
-                <div className="text-[12.5px] font-medium text-slate-800">
+                <div className="text-[13px] font-semibold text-slate-900">
                   {summary}
                 </div>
-                <RelativeTimestamp
-                  timestamp={group.occurredAt}
-                  label={group.occurredAtLabel}
-                  asSpan
-                  focusable={false}
-                  className="text-[11px] text-slate-400"
-                />
+                <div className="mt-0.5 flex items-center gap-1.5 text-[11px] text-violet-700/80 tabular-nums">
+                  <RelativeTimestamp
+                    timestamp={group.occurredAt}
+                    label={group.occurredAtLabel}
+                    asSpan
+                    focusable={false}
+                  />
+                  <span aria-hidden="true" className="text-violet-300">
+                    ·
+                  </span>
+                  <span>{isExpanded ? "Click to collapse" : "Click to expand"}</span>
+                </div>
               </div>
             </div>
             <ChevronRightIcon
               className={cn(
-                "size-3.5 shrink-0 text-slate-400 transition-transform duration-150",
+                "size-3.5 shrink-0 text-violet-500 transition-transform duration-150",
                 isExpanded && "rotate-90",
                 TRANSITION.reduceMotion,
               )}
             />
-          </button>
-          {isExpanded ? (
-            <ol className="space-y-2 border-t border-slate-100 bg-slate-50/30 p-2">
-              {group.entries.map((entry) => (
-                <TimelineEntry
-                  key={entry.id}
-                  entry={entry}
-                  volunteerFirstName=""
-                  currentOperatorUserId={currentOperatorUserId}
-                  isExpanded={isChildExpanded(entry.id)}
-                  retryingEntryId={retryingEntryId}
-                  onRetryPending={onRetryPending}
-                  nested
-                  onToggle={() => {
-                    onToggleChild(entry.id);
-                  }}
-                />
-              ))}
-            </ol>
-          ) : null}
-        </div>
+          </div>
+        </button>
       </div>
     </li>
   );
@@ -475,6 +413,14 @@ function SystemMessageGroup({
 function formatSystemGroupSummary(
   group: InboxTimelineSystemGroupViewModel,
 ): string {
+  if (group.campaignCount > 0 && group.automatedCount === 0) {
+    return `${String(group.campaignCount)} campaign${group.campaignCount === 1 ? "" : "s"}`;
+  }
+
+  if (group.automatedCount > 0 && group.campaignCount === 0) {
+    return `${String(group.automatedCount)} automated send${group.automatedCount === 1 ? "" : "s"}`;
+  }
+
   const parts: string[] = [];
 
   if (group.automatedCount > 0) {

--- a/apps/web/app/inbox/_components/sms-message.tsx
+++ b/apps/web/app/inbox/_components/sms-message.tsx
@@ -68,26 +68,20 @@ export function SmsMessage({
   onReply,
   isRetrying = false,
   onRetryPending,
-  nested = false,
 }: {
   readonly entry: InboxTimelineEntryViewModel;
   readonly direction: "inbound" | "outbound";
   readonly onReply?: (entryId: string) => void;
   readonly isRetrying?: boolean;
   readonly onRetryPending?: (entryId: string) => void;
-  readonly nested?: boolean;
 }) {
   const isOutbound = direction === "outbound";
 
   return (
-    <li
-      className={cn(
-        nested ? "w-full" : cn("col-span-3 grid", TIMELINE_GRID_COLUMNS),
-      )}
-    >
+    <li className={cn("col-span-3 grid", TIMELINE_GRID_COLUMNS)}>
       <div
         className={cn(
-          nested ? "min-w-0 flex" : "col-start-2 min-w-0 flex",
+          "col-start-2 min-w-0 flex",
           isOutbound ? "justify-end" : "justify-start",
         )}
       >
@@ -105,7 +99,8 @@ export function SmsMessage({
 
           <div
             className={cn(
-              nested ? "w-full" : cn("w-fit", SMS_BUBBLE_MAX_W),
+              "w-full",
+              SMS_BUBBLE_MAX_W,
               "rounded-2xl border px-4 py-3 shadow-sm",
               isOutbound
                 ? "rounded-br-md border-sky-600 bg-sky-600 text-white"

--- a/apps/web/tests/unit/inbox-timeline-bubble.test.tsx
+++ b/apps/web/tests/unit/inbox-timeline-bubble.test.tsx
@@ -272,7 +272,7 @@ describe("MessageBubble attachments", () => {
 });
 
 describe("MessageBubble metadata and polish", () => {
-  it("uses the shared gutter grid and 560px email cap instead of padded rows", () => {
+  it("uses the shared gutter grid and full-width 560px email cap instead of padded rows", () => {
     const markup = renderToStaticMarkup(
       createElement(MessageBubble, {
         entry: buildEntry({
@@ -286,13 +286,14 @@ describe("MessageBubble metadata and polish", () => {
     expect(markup).toContain("col-span-3 grid");
     expect(markup).toContain("grid-cols-[2.75rem_minmax(0,1fr)_2.75rem]");
     expect(markup).toContain("col-start-2 min-w-0 flex justify-end");
-    expect(markup).toContain("w-fit max-w-[560px]");
+    expect(markup).toContain("w-full max-w-[560px]");
+    expect(markup).not.toContain("w-fit");
     expect(markup).not.toContain("max-w-[640px]");
     expect(markup).not.toContain("pl-16");
     expect(markup).not.toContain("pr-16");
   });
 
-  it("caps compact sms bubbles at 480px", () => {
+  it("uses the shared 560px width for sms bubbles too", () => {
     const markup = renderToStaticMarkup(
       createElement(MessageBubble, {
         entry: buildEntry({
@@ -307,7 +308,8 @@ describe("MessageBubble metadata and polish", () => {
       }),
     );
 
-    expect(markup).toContain("w-fit max-w-[480px]");
+    expect(markup).toContain("w-full max-w-[560px]");
+    expect(markup).not.toContain("w-fit");
     expect(markup).not.toContain("max-w-[640px]");
   });
 

--- a/apps/web/tests/unit/inbox-timeline.test.ts
+++ b/apps/web/tests/unit/inbox-timeline.test.ts
@@ -11,6 +11,17 @@ vi.mock("../../app/inbox/actions", () => ({
   deleteNoteAction: vi.fn(),
 }));
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: vi.fn(),
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+}));
+
 vi.mock("@/components/ui/tooltip", () => ({
   TooltipProvider: ({ children }: { readonly children?: React.ReactNode }) =>
     createElement("div", null, children),

--- a/apps/web/tests/unit/inbox-timeline.test.ts
+++ b/apps/web/tests/unit/inbox-timeline.test.ts
@@ -384,6 +384,58 @@ describe("InboxTimeline", () => {
     expect(markup).not.toContain("April field update");
   });
 
+  it("renders the collapsed group pill as a violet card with one campaign icon", () => {
+    const markup = renderToStaticMarkup(
+      createElement(InboxTimeline, {
+        entries: [
+          baseEntry,
+          {
+            ...baseEntry,
+            id: "timeline:auto-email-2",
+            occurredAtLabel: "90m ago",
+            subject: "Reminder details",
+          },
+          {
+            ...baseEntry,
+            id: "timeline:campaign-email-1",
+            kind: "outbound-campaign-email" as const,
+            occurredAtLabel: "1h ago",
+            subject: "April field update",
+          },
+        ],
+        volunteerFirstName: "Alice",
+        currentOperatorUserId: "user:operator",
+      }),
+    );
+
+    expect(markup).toContain('data-group-icon="campaign"');
+    expect(markup).toContain("border-violet-200/70 bg-violet-50/40");
+    expect(markup).toContain("Click to expand");
+    expect(markup).not.toContain("-space-x-1");
+    expect(markup).not.toContain("ring-2 ring-white");
+  });
+
+  it("uses the automated icon for automated-only group pills", () => {
+    const markup = renderToStaticMarkup(
+      createElement(InboxTimeline, {
+        entries: [
+          baseEntry,
+          {
+            ...baseEntry,
+            id: "timeline:auto-email-2",
+            occurredAtLabel: "90m ago",
+            subject: "Reminder details",
+          },
+        ],
+        volunteerFirstName: "Alice",
+        currentOperatorUserId: "user:operator",
+      }),
+    );
+
+    expect(markup).toContain('data-group-icon="automated"');
+    expect(markup).toContain("2 automated sends");
+  });
+
   it("does not collapse a single automated row", () => {
     const markup = renderToStaticMarkup(
       createElement(InboxTimeline, {
@@ -397,7 +449,7 @@ describe("InboxTimeline", () => {
     expect(markup).not.toContain("1 automated");
   });
 
-  it("renders sms rows with a fit-content bubble capped at 480px", () => {
+  it("renders sms rows with the shared 560px bubble width", () => {
     const markup = renderToStaticMarkup(
       createElement(InboxTimeline, {
         entries: [
@@ -419,8 +471,33 @@ describe("InboxTimeline", () => {
       }),
     );
 
-    expect(markup).toContain("w-fit max-w-[480px]");
-    expect(markup).not.toContain("max-w-[440px]");
+    expect(markup).toContain("w-full max-w-[560px]");
+    expect(markup).not.toContain("w-fit max-w-[480px]");
+  });
+
+  it("renders note rows at the shared 560px width instead of fit-content", () => {
+    const markup = renderToStaticMarkup(
+      createElement(InboxTimeline, {
+        entries: [
+          {
+            ...baseEntry,
+            id: "timeline:note-1",
+            kind: "internal-note" as const,
+            actorLabel: "Alex Operator",
+            subject: null,
+            body: "Check prior field history before replying.",
+            channel: null,
+            noteId: "note-1",
+            authorId: "user:operator",
+          },
+        ],
+        volunteerFirstName: "Alice",
+        currentOperatorUserId: "user:operator",
+      }),
+    );
+
+    expect(markup).toContain("w-full max-w-[560px]");
+    expect(markup).not.toContain("w-fit max-w-[560px]");
   });
 
   it("renders the earlier-history divider when pre-cutover events exist", () => {
@@ -491,7 +568,7 @@ describe("InboxTimeline", () => {
     expect(markup).toContain(">Clicked<");
   });
 
-  it("keeps expanded system-group children flush with the parent card interior", async () => {
+  it("renders expanded system-group children as sibling timeline rows instead of nested cards", async () => {
     const session = await mountTimeline([
       baseEntry,
       {
@@ -517,9 +594,13 @@ describe("InboxTimeline", () => {
       await Promise.resolve();
     });
 
-    expect(session.container.innerHTML).toContain("space-y-2 border-t border-slate-100 bg-slate-50/30 p-2");
-    expect(session.container.innerHTML).not.toContain("bg-slate-50/30 p-3");
-    expect(session.container.innerHTML.match(/max-w-\[560px\]/g)?.length ?? 0).toBe(1);
+    expect(button?.getAttribute("aria-expanded")).toBe("true");
+    expect(session.container.textContent).toContain("Reminder details");
+    expect(session.container.textContent).toContain("April field update");
+    expect(session.container.querySelectorAll("ol > li")).toHaveLength(4);
+    expect(session.container.querySelectorAll("ol ol")).toHaveLength(0);
+    expect(session.container.innerHTML).not.toContain("space-y-2 border-t border-slate-100 bg-slate-50/30 p-2");
+    expect(session.container.innerHTML.match(/max-w-\[560px\]/g)?.length ?? 0).toBeGreaterThanOrEqual(4);
     expect(session.container.innerHTML).not.toContain("pl-16");
   });
 


### PR DESCRIPTION
## Summary

Three coupled visual fixes from architect review on 2026-05-05:

1. **Bubble width consistency** — bubbles now always render at the same width as the campaign-group pill instead of shrinking to content. Email + note + SMS all use \`w-full max-w-[560px]\`. SMS aligned to 560px (matching the architect's \"same width as the campaign bubbles\") rather than the prior chat-style 480px.
2. **Expanded automated/campaign groups: children render below, not inside** — the collapsed pill stays one \`<li>\`; on expand, children render as normal sibling timeline rows in the flat list. The old nested \`<ol>\` inside a parent card is gone, along with the \`nested\` prop chain that supported it.
3. **Collapsed pill redesign (Option A)** — violet-tinted card (\`TONE_CLASSES.violet\`), single categorical icon (Megaphone if any campaigns, else Zap) replacing the 3-icon avatar pile, stronger summary typography, chevron expand/collapse motion preserved.

Brief: [.codex-bubble-visuals-2026-05-05.md](https://github.com/nico-kneler-as/as-comms-platform/blob/feat/inbox-bubble-visuals-2026-05-05/.codex-bubble-visuals-2026-05-05.md).

## Files

- \`inbox-timeline.tsx\` — flat-list expansion, collapsed pill redesign
- \`inbox-timeline-bubble.tsx\` — width fix, drop \`nested\` prop
- \`inbox-timeline-automated-row.tsx\` — drop \`nested\` mode
- \`inbox-timeline-note-entry.tsx\` — width fix
- \`sms-message.tsx\` — width fix, drop \`nested\` mode
- 2 test files updated for new structure / widths

## Net change

7 files, +222/-229 — refactor reduces complexity rather than adding it (flat sibling rendering is simpler than nested-card mode).

## Test plan

- [x] \`pnpm typecheck\` — pass
- [x] \`pnpm lint\` — pass
- [ ] CI \`test:unit\` (local hits the macOS rollup environmental issue)
- [ ] Visual smoke after merge:
  - Bubble inner edges align consistently across email, SMS, notes
  - Automated/campaign group: collapsed = single violet pill; expanded = pill + N sibling rows below at the same width
  - Long emails wrap at ~65 CPL; short content sits left-aligned within a 560px bubble (no shrink)

🤖 Generated with [Claude Code](https://claude.com/claude-code)