### PR TITLE
perf(inbox): stream timeline + smaller initial page + refreshed skeleton

### DIFF
--- a/apps/web/app/inbox/[contactId]/page.tsx
+++ b/apps/web/app/inbox/[contactId]/page.tsx
@@ -1,19 +1,77 @@
+import { Suspense } from "react";
 import { notFound } from "next/navigation";
 
 import { requireSession } from "@/src/server/auth/session";
-import { InboxDetail } from "../_components/inbox-detail";
-import { getInboxDetail } from "../_lib/selectors";
+import {
+  InboxDetail,
+  InboxDetailTimelineFallback,
+  InboxDetailTimelinePanel,
+} from "../_components/inbox-detail";
+import type { InboxDetailSummaryViewModel } from "../_lib/view-models";
+import {
+  getInboxDetailSummary,
+  getInboxDetailTimeline,
+} from "../_lib/selectors";
 
 interface PageProps {
   readonly params: Promise<{ readonly contactId: string }>;
 }
 
+interface TimelineSectionProps {
+  readonly contactId: string;
+  readonly contact: InboxDetailSummaryViewModel["contact"];
+  readonly composerReplyContext: InboxDetailSummaryViewModel["composerReplyContext"];
+  readonly currentOperatorUserId: string;
+}
+
+async function InboxContactTimelineSection({
+  contactId,
+  contact,
+  composerReplyContext,
+  currentOperatorUserId,
+}: TimelineSectionProps) {
+  const timeline = await getInboxDetailTimeline(contactId, {
+    recordReadAudit: true,
+  });
+
+  if (timeline === null) {
+    notFound();
+  }
+
+  return (
+    <InboxDetailTimelinePanel
+      contact={contact}
+      composerReplyContext={composerReplyContext}
+      initialTimeline={timeline}
+      currentOperatorUserId={currentOperatorUserId}
+    />
+  );
+}
+
 export default async function InboxContactPage({ params }: PageProps) {
   const { contactId } = await params;
   const currentUser = await requireSession();
-  const detail = await getInboxDetail(decodeURIComponent(contactId));
+  const decodedContactId = decodeURIComponent(contactId);
+  const detail = await getInboxDetailSummary(decodedContactId);
+
   if (!detail) {
     notFound();
   }
-  return <InboxDetail detail={detail} currentOperatorUserId={currentUser.id} />;
+
+  return (
+    <InboxDetail
+      detail={detail}
+      currentOperatorUserId={currentUser.id}
+      timelineSlot={
+        <Suspense fallback={<InboxDetailTimelineFallback />}>
+          <InboxContactTimelineSection
+            contactId={decodedContactId}
+            contact={detail.contact}
+            composerReplyContext={detail.composerReplyContext}
+            currentOperatorUserId={currentUser.id}
+          />
+        </Suspense>
+      }
+    />
+  );
 }

--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -9,6 +9,7 @@ import {
   useRef,
   useState,
   useTransition,
+  type ReactNode,
 } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -33,7 +34,8 @@ import { plaintextToComposerHtml } from "@/src/lib/html-sanitizer";
 import { fetchInboxTimelinePage } from "../_lib/client-api";
 import type {
   InboxComposerReplyContext,
-  InboxDetailViewModel,
+  InboxDetailSummaryViewModel,
+  InboxDetailTimelineViewModel,
   InboxTimelineEntryViewModel,
   OptimisticOutbound,
 } from "../_lib/view-models";
@@ -63,7 +65,15 @@ import {
 } from "./icons";
 
 interface DetailProps {
-  readonly detail: InboxDetailViewModel;
+  readonly detail: InboxDetailSummaryViewModel;
+  readonly timelineSlot?: ReactNode;
+  readonly currentOperatorUserId: string;
+}
+
+interface InboxDetailTimelinePanelProps {
+  readonly contact: InboxDetailSummaryViewModel["contact"];
+  readonly composerReplyContext: InboxComposerReplyContext | null;
+  readonly initialTimeline: InboxDetailTimelineViewModel;
   readonly currentOperatorUserId: string;
 }
 
@@ -113,8 +123,7 @@ function buildTimelineReplyContext(input: {
     contactDisplayName: input.contactDisplayName,
     contactPrimaryPhone: input.contactPrimaryPhone,
     subject: buildReplySubject(input.entry.subject),
-    threadCursor:
-      input.entry.kind === "inbound-email" ? input.entry.id : null,
+    threadCursor: input.entry.kind === "inbound-email" ? input.entry.id : null,
     threadId: input.entry.threadId,
     inReplyToRfc822:
       input.entry.kind === "inbound-email"
@@ -156,152 +165,11 @@ function realEntryMatchesOptimistic(
   return realEntry.occurredAt >= optimisticEntry.occurredAt;
 }
 
-export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
+export function InboxDetail({ detail, timelineSlot }: DetailProps) {
   const { contact } = detail;
-  const timelineScrollRef = useRef<HTMLDivElement>(null);
-  const activeTimelineRequestIdRef = useRef(0);
-  const shouldScrollToLatestRef = useRef(true);
-  const previousContactIdRef = useRef(detail.contact.contactId);
-  const {
-    isTimelineLoading,
-    setTimelineLoading,
-    optimisticOutbounds,
-    clearOptimisticForContact,
-    removeOptimisticOutbound,
-    openReplyDraft,
-    showToast,
-  } = useInboxClient();
+  const { openReplyDraft } = useInboxClient();
 
   const [railOpen, setRailOpen] = useState(false);
-  const [timelineEntries, setTimelineEntries] = useState(detail.timeline);
-  const [timelinePage, setTimelinePage] = useState(detail.timelinePage);
-  const [retryingEntryId, setRetryingEntryId] = useState<string | null>(null);
-  const [isRetryPending, startRetryTransition] = useTransition();
-
-  useEffect(() => {
-    activeTimelineRequestIdRef.current += 1;
-    setTimelineLoading(false);
-    setTimelineEntries(detail.timeline);
-    setTimelinePage(detail.timelinePage);
-
-    if (previousContactIdRef.current !== detail.contact.contactId) {
-      clearOptimisticForContact(previousContactIdRef.current);
-      shouldScrollToLatestRef.current = true;
-      previousContactIdRef.current = detail.contact.contactId;
-    }
-  }, [
-    clearOptimisticForContact,
-    detail.contact.contactId,
-    detail.freshness.inboxUpdatedAt,
-    detail.freshness.timelineCount,
-    detail.freshness.timelineUpdatedAt,
-    detail.timeline,
-    detail.timelinePage,
-    setTimelineLoading,
-  ]);
-
-  const activeOptimisticOutbounds = useMemo(
-    () =>
-      optimisticOutbounds.filter(
-        (entry) => entry.contactId === detail.contact.contactId,
-      ),
-    [detail.contact.contactId, optimisticOutbounds],
-  );
-
-  const mergedTimelineEntries = useMemo(
-    () => sortTimelineEntries([...timelineEntries, ...activeOptimisticOutbounds]),
-    [activeOptimisticOutbounds, timelineEntries],
-  );
-
-  useEffect(() => {
-    const matchedSettledIds = activeOptimisticOutbounds
-      .filter(
-        (entry) =>
-          entry.settledAt !== null &&
-          timelineEntries.some((realEntry) =>
-            realEntryMatchesOptimistic(realEntry, entry),
-          ),
-      )
-      .map((entry) => entry.clientGeneratedId);
-
-    if (matchedSettledIds.length === 0) {
-      return;
-    }
-
-    for (const clientGeneratedId of matchedSettledIds) {
-      removeOptimisticOutbound(clientGeneratedId);
-    }
-  }, [activeOptimisticOutbounds, removeOptimisticOutbound, timelineEntries]);
-
-  useEffect(() => {
-    if (!shouldScrollToLatestRef.current) {
-      return;
-    }
-
-    const frame = window.requestAnimationFrame(() => {
-      const container = timelineScrollRef.current;
-
-      if (!container) {
-        return;
-      }
-
-      container.scrollTop = container.scrollHeight;
-      shouldScrollToLatestRef.current = false;
-    });
-
-    return () => {
-      window.cancelAnimationFrame(frame);
-    };
-  }, [detail.contact.contactId, mergedTimelineEntries]);
-
-  const loadOlderTimeline = useCallback(async () => {
-    if (!timelinePage.hasMore || timelinePage.nextCursor === null) {
-      return;
-    }
-
-    const requestId = activeTimelineRequestIdRef.current + 1;
-    activeTimelineRequestIdRef.current = requestId;
-    const container = timelineScrollRef.current;
-    const previousScrollHeight = container?.scrollHeight ?? 0;
-    const previousScrollTop = container?.scrollTop ?? 0;
-    setTimelineLoading(true);
-
-    try {
-      const nextPage = await fetchInboxTimelinePage({
-        contactId: contact.contactId,
-        cursor: timelinePage.nextCursor,
-      });
-
-      if (activeTimelineRequestIdRef.current !== requestId) {
-        return;
-      }
-
-      setTimelineEntries((previousEntries) => [
-        ...nextPage.entries,
-        ...previousEntries,
-      ]);
-      setTimelinePage(nextPage.page);
-
-      window.requestAnimationFrame(() => {
-        const nextContainer = timelineScrollRef.current;
-
-        if (!nextContainer) {
-          return;
-        }
-
-        const nextScrollHeight = nextContainer.scrollHeight;
-        nextContainer.scrollTop =
-          previousScrollTop + (nextScrollHeight - previousScrollHeight);
-      });
-    } catch {
-      // Keep the current timeline page visible; polling or the next click can retry.
-    } finally {
-      if (activeTimelineRequestIdRef.current === requestId) {
-        setTimelineLoading(false);
-      }
-    }
-  }, [contact.contactId, setTimelineLoading, timelinePage]);
-
   const followUpToggle = useOptimisticBooleanToggle({
     scopeKey: contact.contactId,
     value: detail.needsFollowUp,
@@ -382,103 +250,8 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
   }, [contact.contactId, router]);
 
   const headerProject = contact.activeProjects[0] ?? detail.conversationProject;
-  const firstName = contact.displayName.split(" ")[0] ?? contact.displayName;
   const isFollowUp = followUpToggle.value;
   const composerReplyContext = detail.composerReplyContext;
-  const handleReply = useCallback(
-    (entryId: string) => {
-      const entry = mergedTimelineEntries.find((item) => item.id === entryId);
-
-      if (entry === undefined) {
-        if (composerReplyContext !== null) {
-          openReplyDraft(composerReplyContext);
-        }
-        return;
-      }
-
-      const replyContext =
-        buildTimelineReplyContext({
-          contactId: contact.contactId,
-          contactDisplayName: contact.displayName,
-          contactPrimaryPhone: contact.primaryPhone,
-          entry,
-          defaultAlias: composerReplyContext?.defaultAlias ?? null,
-        }) ?? composerReplyContext;
-
-      if (replyContext !== null) {
-        openReplyDraft(replyContext);
-      }
-    },
-    [
-      composerReplyContext,
-      contact.contactId,
-      contact.displayName,
-      mergedTimelineEntries,
-      openReplyDraft,
-    ],
-  );
-
-  const handleRetryPending = useCallback(
-    (entryId: string) => {
-      const entry = mergedTimelineEntries.find((item) => item.id === entryId);
-
-      if (
-        entry?.sendStatus === undefined ||
-        entry.sendStatus === null ||
-        entry.sendStatus === "pending" ||
-        entry.attachmentCount > 0 ||
-        entry.mailbox === null
-      ) {
-        return;
-      }
-
-      const pendingId = entry.id.startsWith("pending-outbound:")
-        ? entry.id.slice("pending-outbound:".length)
-        : entry.id.startsWith("optimistic:")
-          ? null
-          : null;
-
-      if (!entry.id.startsWith("pending-outbound:") && !entry.id.startsWith("optimistic:")) {
-        return;
-      }
-
-      const mailbox = entry.mailbox;
-
-      setRetryingEntryId(entry.id);
-      startRetryTransition(async () => {
-        try {
-          const result = await sendComposerAction({
-            recipient: {
-              kind: "contact",
-              contactId: contact.contactId,
-            },
-            alias: mailbox,
-            subject: entry.subject ?? "",
-            bodyPlaintext: entry.body,
-            bodyHtml: plaintextToComposerHtml(entry.body),
-            attachments: [],
-            ...(entry.threadId === null ? {} : { threadId: entry.threadId }),
-            ...(entry.inReplyToRfc822 === null
-              ? {}
-              : { inReplyToRfc822: entry.inReplyToRfc822 }),
-            ...(pendingId === null
-              ? {}
-              : { supersedesPendingId: pendingId }),
-          });
-
-          if (result.ok) {
-            showToast(`Sent to ${contact.displayName}`, "success");
-          } else {
-            showToast(result.message, "error");
-          }
-        } catch {
-          showToast("We could not retry that email right now.", "error");
-        }
-        setRetryingEntryId(null);
-      });
-    },
-    [contact.contactId, contact.displayName, mergedTimelineEntries, showToast],
-  );
 
   return (
     <div className="flex min-h-0 flex-1">
@@ -540,119 +313,97 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
           </div>
 
           <TooltipProvider delayDuration={200}>
-          <div className="flex shrink-0 items-center gap-2">
-            {detail.projectionAvailable ? (
-              <>
-                <FollowUpToggleControl
-                  needsFollowUp={isFollowUp}
-                  isPending={followUpToggle.isPending}
-                  error={followUpToggle.error}
-                  onToggle={followUpToggle.toggle}
-                />
+            <div className="flex shrink-0 items-center gap-2">
+              {detail.projectionAvailable ? (
+                <>
+                  <FollowUpToggleControl
+                    needsFollowUp={isFollowUp}
+                    isPending={followUpToggle.isPending}
+                    error={followUpToggle.error}
+                    onToggle={followUpToggle.toggle}
+                  />
 
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        aria-label="Mark unread"
+                        data-inbox-mark-unread="true"
+                        disabled={isMarkUnreadPending}
+                        onClick={handleMarkUnread}
+                        className="size-8 rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-900 focus-visible:z-20"
+                      >
+                        <MailOpenIcon className="size-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="top">Mark unread</TooltipContent>
+                  </Tooltip>
+                </>
+              ) : null}
+
+              {detail.projectionAvailable ? (
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button
                       type="button"
                       variant="ghost"
                       size="icon"
-                      aria-label="Mark unread"
-                      data-inbox-mark-unread="true"
-                      disabled={isMarkUnreadPending}
-                      onClick={handleMarkUnread}
+                      aria-label={
+                        detail.isArchived
+                          ? "Move back to inbox"
+                          : "Archive conversation"
+                      }
+                      disabled={isArchivePending}
+                      onClick={
+                        detail.isArchived ? handleUnarchive : handleArchive
+                      }
                       className="size-8 rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-900 focus-visible:z-20"
                     >
-                      <MailOpenIcon className="size-4" />
+                      {detail.isArchived ? (
+                        <ArchiveRestoreIcon className="size-4" />
+                      ) : (
+                        <ArchiveBoxIcon className="size-4" />
+                      )}
                     </Button>
                   </TooltipTrigger>
-                  <TooltipContent side="top">Mark unread</TooltipContent>
+                  <TooltipContent side="top">
+                    {detail.isArchived
+                      ? "Move back to inbox"
+                      : "Archive conversation"}
+                  </TooltipContent>
                 </Tooltip>
-              </>
-            ) : null}
+              ) : null}
 
-            {detail.projectionAvailable ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    aria-label={
-                      detail.isArchived
-                        ? "Move back to inbox"
-                        : "Archive conversation"
-                    }
-                    disabled={isArchivePending}
-                    onClick={detail.isArchived ? handleUnarchive : handleArchive}
-                    className="size-8 rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-900 focus-visible:z-20"
-                  >
-                    {detail.isArchived ? (
-                      <ArchiveRestoreIcon className="size-4" />
-                    ) : (
-                      <ArchiveBoxIcon className="size-4" />
-                    )}
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="top">
-                  {detail.isArchived
-                    ? "Move back to inbox"
-                    : "Archive conversation"}
-                </TooltipContent>
-              </Tooltip>
-            ) : null}
-
-            {!railOpen ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    aria-label="Volunteer details"
-                    aria-expanded={false}
-                    aria-controls="inbox-contact-rail"
-                    onClick={() => {
-                      setRailOpen(true);
-                    }}
-                    className="size-8 rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-900 focus-visible:z-20"
-                  >
-                    <UserRoundIcon className="size-4" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="top">Volunteer details</TooltipContent>
-              </Tooltip>
-            ) : null}
-          </div>
+              {!railOpen ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      aria-label="Volunteer details"
+                      aria-expanded={false}
+                      aria-controls="inbox-contact-rail"
+                      onClick={() => {
+                        setRailOpen(true);
+                      }}
+                      className="size-8 rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-900 focus-visible:z-20"
+                    >
+                      <UserRoundIcon className="size-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">Volunteer details</TooltipContent>
+                </Tooltip>
+              ) : null}
+            </div>
           </TooltipProvider>
         </header>
 
         {contact.hasUnresolved ? <UnresolvedBanner /> : null}
 
-        <div
-          ref={timelineScrollRef}
-          className={`min-h-0 flex-1 overflow-y-auto ${TONE_CLASSES.slate.subtle} ${SPACING.container}`}
-        >
-          {isTimelineLoading && mergedTimelineEntries.length === 0 ? (
-            <TimelineSkeleton />
-          ) : (
-            <InboxTimeline
-              entries={mergedTimelineEntries}
-              volunteerFirstName={firstName}
-              currentOperatorUserId={currentOperatorUserId}
-              showEarlierHistoryDivider={
-                timelinePage.hasHiddenEarlierHistory
-              }
-              hasMore={timelinePage.hasMore}
-              isLoadingOlder={isTimelineLoading}
-              retryingEntryId={isRetryPending ? retryingEntryId : null}
-              onRetryPending={handleRetryPending}
-              onReply={handleReply}
-              onLoadOlder={() => {
-                void loadOlderTimeline();
-              }}
-            />
-          )}
-        </div>
+        {timelineSlot ?? <InboxDetailTimelineFallback />}
 
         <div className="shrink-0">
           {composerReplyContext ? (
@@ -686,6 +437,293 @@ export function InboxDetail({ detail, currentOperatorUserId }: DetailProps) {
           />
         </div>
       </div>
+    </div>
+  );
+}
+
+export function InboxDetailTimelinePanel({
+  contact,
+  composerReplyContext,
+  initialTimeline,
+  currentOperatorUserId,
+}: InboxDetailTimelinePanelProps) {
+  const timelineScrollRef = useRef<HTMLDivElement>(null);
+  const activeTimelineRequestIdRef = useRef(0);
+  const shouldScrollToLatestRef = useRef(true);
+  const previousContactIdRef = useRef(contact.contactId);
+  const {
+    isTimelineLoading,
+    setTimelineLoading,
+    optimisticOutbounds,
+    clearOptimisticForContact,
+    removeOptimisticOutbound,
+    openReplyDraft,
+    showToast,
+  } = useInboxClient();
+  const [timelineEntries, setTimelineEntries] = useState(
+    initialTimeline.timeline,
+  );
+  const [timelinePage, setTimelinePage] = useState(
+    initialTimeline.timelinePage,
+  );
+  const [retryingEntryId, setRetryingEntryId] = useState<string | null>(null);
+  const [isRetryPending, startRetryTransition] = useTransition();
+
+  useEffect(() => {
+    activeTimelineRequestIdRef.current += 1;
+    setTimelineLoading(false);
+    setTimelineEntries(initialTimeline.timeline);
+    setTimelinePage(initialTimeline.timelinePage);
+
+    if (previousContactIdRef.current !== contact.contactId) {
+      clearOptimisticForContact(previousContactIdRef.current);
+      shouldScrollToLatestRef.current = true;
+      previousContactIdRef.current = contact.contactId;
+    }
+  }, [
+    clearOptimisticForContact,
+    contact.contactId,
+    initialTimeline.timeline,
+    initialTimeline.timelinePage,
+    setTimelineLoading,
+  ]);
+
+  const activeOptimisticOutbounds = useMemo(
+    () =>
+      optimisticOutbounds.filter(
+        (entry) => entry.contactId === contact.contactId,
+      ),
+    [contact.contactId, optimisticOutbounds],
+  );
+
+  const mergedTimelineEntries = useMemo(
+    () =>
+      sortTimelineEntries([...timelineEntries, ...activeOptimisticOutbounds]),
+    [activeOptimisticOutbounds, timelineEntries],
+  );
+
+  useEffect(() => {
+    const matchedSettledIds = activeOptimisticOutbounds
+      .filter(
+        (entry) =>
+          entry.settledAt !== null &&
+          timelineEntries.some((realEntry) =>
+            realEntryMatchesOptimistic(realEntry, entry),
+          ),
+      )
+      .map((entry) => entry.clientGeneratedId);
+
+    if (matchedSettledIds.length === 0) {
+      return;
+    }
+
+    for (const clientGeneratedId of matchedSettledIds) {
+      removeOptimisticOutbound(clientGeneratedId);
+    }
+  }, [activeOptimisticOutbounds, removeOptimisticOutbound, timelineEntries]);
+
+  useEffect(() => {
+    if (!shouldScrollToLatestRef.current) {
+      return;
+    }
+
+    const frame = window.requestAnimationFrame(() => {
+      const container = timelineScrollRef.current;
+
+      if (!container) {
+        return;
+      }
+
+      container.scrollTop = container.scrollHeight;
+      shouldScrollToLatestRef.current = false;
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
+  }, [contact.contactId, mergedTimelineEntries]);
+
+  const loadOlderTimeline = useCallback(async () => {
+    if (!timelinePage.hasMore || timelinePage.nextCursor === null) {
+      return;
+    }
+
+    const requestId = activeTimelineRequestIdRef.current + 1;
+    activeTimelineRequestIdRef.current = requestId;
+    const container = timelineScrollRef.current;
+    const previousScrollHeight = container?.scrollHeight ?? 0;
+    const previousScrollTop = container?.scrollTop ?? 0;
+    setTimelineLoading(true);
+
+    try {
+      const nextPage = await fetchInboxTimelinePage({
+        contactId: contact.contactId,
+        cursor: timelinePage.nextCursor,
+      });
+
+      if (activeTimelineRequestIdRef.current !== requestId) {
+        return;
+      }
+
+      setTimelineEntries((previousEntries) => [
+        ...nextPage.entries,
+        ...previousEntries,
+      ]);
+      setTimelinePage(nextPage.page);
+
+      window.requestAnimationFrame(() => {
+        const nextContainer = timelineScrollRef.current;
+
+        if (!nextContainer) {
+          return;
+        }
+
+        const nextScrollHeight = nextContainer.scrollHeight;
+        nextContainer.scrollTop =
+          previousScrollTop + (nextScrollHeight - previousScrollHeight);
+      });
+    } catch {
+      // Keep the current timeline page visible; polling or the next click can retry.
+    } finally {
+      if (activeTimelineRequestIdRef.current === requestId) {
+        setTimelineLoading(false);
+      }
+    }
+  }, [contact.contactId, setTimelineLoading, timelinePage]);
+
+  const handleReply = useCallback(
+    (entryId: string) => {
+      const entry = mergedTimelineEntries.find((item) => item.id === entryId);
+
+      if (entry === undefined) {
+        if (composerReplyContext !== null) {
+          openReplyDraft(composerReplyContext);
+        }
+        return;
+      }
+
+      const replyContext =
+        buildTimelineReplyContext({
+          contactId: contact.contactId,
+          contactDisplayName: contact.displayName,
+          contactPrimaryPhone: contact.primaryPhone,
+          entry,
+          defaultAlias: composerReplyContext?.defaultAlias ?? null,
+        }) ?? composerReplyContext;
+
+      if (replyContext !== null) {
+        openReplyDraft(replyContext);
+      }
+    },
+    [
+      composerReplyContext,
+      contact.contactId,
+      contact.displayName,
+      contact.primaryPhone,
+      mergedTimelineEntries,
+      openReplyDraft,
+    ],
+  );
+
+  const handleRetryPending = useCallback(
+    (entryId: string) => {
+      const entry = mergedTimelineEntries.find((item) => item.id === entryId);
+
+      if (
+        entry?.sendStatus === undefined ||
+        entry.sendStatus === null ||
+        entry.sendStatus === "pending" ||
+        entry.attachmentCount > 0 ||
+        entry.mailbox === null
+      ) {
+        return;
+      }
+
+      const pendingId = entry.id.startsWith("pending-outbound:")
+        ? entry.id.slice("pending-outbound:".length)
+        : entry.id.startsWith("optimistic:")
+          ? null
+          : null;
+
+      if (
+        !entry.id.startsWith("pending-outbound:") &&
+        !entry.id.startsWith("optimistic:")
+      ) {
+        return;
+      }
+
+      const mailbox = entry.mailbox;
+
+      setRetryingEntryId(entry.id);
+      startRetryTransition(async () => {
+        try {
+          const result = await sendComposerAction({
+            recipient: {
+              kind: "contact",
+              contactId: contact.contactId,
+            },
+            alias: mailbox,
+            subject: entry.subject ?? "",
+            bodyPlaintext: entry.body,
+            bodyHtml: plaintextToComposerHtml(entry.body),
+            attachments: [],
+            ...(entry.threadId === null ? {} : { threadId: entry.threadId }),
+            ...(entry.inReplyToRfc822 === null
+              ? {}
+              : { inReplyToRfc822: entry.inReplyToRfc822 }),
+            ...(pendingId === null ? {} : { supersedesPendingId: pendingId }),
+          });
+
+          if (result.ok) {
+            showToast(`Sent to ${contact.displayName}`, "success");
+          } else {
+            showToast(result.message, "error");
+          }
+        } catch {
+          showToast("We could not retry that email right now.", "error");
+        }
+        setRetryingEntryId(null);
+      });
+    },
+    [contact.contactId, contact.displayName, mergedTimelineEntries, showToast],
+  );
+
+  const volunteerFirstName =
+    contact.displayName.split(" ")[0] ?? contact.displayName;
+
+  return (
+    <div
+      ref={timelineScrollRef}
+      className={`min-h-0 flex-1 overflow-y-auto ${TONE_CLASSES.slate.subtle} ${SPACING.container}`}
+    >
+      {isTimelineLoading && mergedTimelineEntries.length === 0 ? (
+        <TimelineSkeleton />
+      ) : (
+        <InboxTimeline
+          entries={mergedTimelineEntries}
+          volunteerFirstName={volunteerFirstName}
+          currentOperatorUserId={currentOperatorUserId}
+          showEarlierHistoryDivider={timelinePage.hasHiddenEarlierHistory}
+          hasMore={timelinePage.hasMore}
+          isLoadingOlder={isTimelineLoading}
+          retryingEntryId={isRetryPending ? retryingEntryId : null}
+          onRetryPending={handleRetryPending}
+          onReply={handleReply}
+          onLoadOlder={() => {
+            void loadOlderTimeline();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+export function InboxDetailTimelineFallback() {
+  return (
+    <div
+      className={`min-h-0 flex-1 overflow-y-auto ${TONE_CLASSES.slate.subtle} ${SPACING.container}`}
+    >
+      <TimelineSkeleton />
     </div>
   );
 }

--- a/apps/web/app/inbox/_components/inbox-loading.tsx
+++ b/apps/web/app/inbox/_components/inbox-loading.tsx
@@ -1,6 +1,11 @@
 import { Skeleton } from "@/components/ui/skeleton";
 import { SPACING, TONE } from "@/app/_lib/design-tokens";
 import { LAYOUT } from "@/app/_lib/design-tokens-v2";
+import {
+  EMAIL_BUBBLE_MAX_W,
+  TIMELINE_GRID_COLUMNS,
+  TIMELINE_OUTER_MAX_W,
+} from "./inbox-timeline-bubble";
 
 /**
  * Full-screen app loading skeleton for the inbox home (`/inbox`).
@@ -12,7 +17,9 @@ export function InboxAppLoading() {
   return (
     <div className="flex h-dvh w-screen overflow-hidden bg-slate-100 antialiased">
       {/* Icon rail skeleton */}
-      <div className={`flex ${LAYOUT.iconRailWidth} shrink-0 flex-col items-center border-r border-slate-200 bg-white py-4`}>
+      <div
+        className={`flex ${LAYOUT.iconRailWidth} shrink-0 flex-col items-center border-r border-slate-200 bg-white py-4`}
+      >
         <Skeleton className="size-9 rounded-xl" />
         <div className="mt-4 flex flex-1 flex-col items-center gap-1">
           <Skeleton className="size-10 rounded-xl" />
@@ -23,7 +30,9 @@ export function InboxAppLoading() {
       </div>
 
       {/* List column skeleton */}
-      <div className={`flex ${LAYOUT.listWidth} shrink-0 flex-col border-r border-slate-200 bg-white`}>
+      <div
+        className={`flex ${LAYOUT.listWidth} shrink-0 flex-col border-r border-slate-200 bg-white`}
+      >
         <div className="border-b border-slate-200 px-4">
           <div className={`flex ${LAYOUT.headerHeight} items-center gap-2`}>
             <Skeleton className="h-5 w-24" />
@@ -180,27 +189,16 @@ function FollowUpRailRowSkeleton() {
  */
 export function InboxDetailLoading() {
   return (
-    <div className="flex min-h-0 flex-1" role="status" aria-label="Loading conversation history">
+    <div
+      className="flex min-h-0 flex-1"
+      role="status"
+      aria-label="Loading conversation history"
+    >
       <section className="flex min-w-0 flex-1 flex-col border-r border-slate-200 bg-white">
-        <header className={`flex ${LAYOUT.headerHeight} items-center gap-4 border-b border-slate-200 px-6`}>
-          <div className="flex min-w-0 flex-1 items-center gap-3.5">
-            <Skeleton className="size-7 shrink-0 rounded-full" />
-            <div className="min-w-0">
-              <Skeleton className="h-5 w-40" />
-              <Skeleton className="mt-1 h-3 w-56" />
-            </div>
-          </div>
-          <div className="flex shrink-0 items-center gap-2">
-            {Array.from({ length: 4 }).map((_, i) => (
-              <Skeleton key={i} className="size-8 rounded-md" />
-            ))}
-          </div>
-        </header>
-        <div className={`min-h-0 flex-1 overflow-y-auto ${TONE.slate.subtle} ${SPACING.container}`}>
+        <div
+          className={`min-h-0 flex-1 overflow-y-auto ${TONE.slate.subtle} ${SPACING.container}`}
+        >
           <TimelineSkeleton />
-        </div>
-        <div className="border-t border-slate-200 px-5 py-4">
-          <Skeleton className="h-16 w-full rounded-lg" />
         </div>
       </section>
     </div>
@@ -239,7 +237,11 @@ export function QueueLoadingSkeleton({
   readonly label?: string;
 }) {
   return (
-    <div className="min-h-0 flex-1 overflow-hidden" role="status" aria-label={label}>
+    <div
+      className="min-h-0 flex-1 overflow-hidden"
+      role="status"
+      aria-label={label}
+    >
       {Array.from({ length: rowCount }).map((_, i) => (
         <QueueRowSkeleton key={i} />
       ))}
@@ -270,64 +272,75 @@ export function QueueLoadMoreSkeleton({
   );
 }
 
-/**
- * Timeline loading skeleton. Mirrors the alternating left/right bubble
- * pattern of the real timeline.
- */
 export function TimelineSkeleton() {
   return (
-    <div className="flex flex-col gap-3" role="status" aria-label="Loading timeline">
-      {/* Inbound email bubble (left) */}
-      <div className="flex w-full flex-col items-start">
-        <Skeleton className="mb-1 h-3 w-24" />
-        <Skeleton className="h-20 w-[70%] rounded-2xl rounded-bl-md" />
-        <Skeleton className="mt-1 h-3 w-16" />
-      </div>
-
-      {/* Outbound email bubble (right) */}
-      <div className="flex w-full flex-col items-end">
-        <Skeleton className="mb-1 h-3 w-20" />
-        <Skeleton className="h-16 w-[65%] rounded-2xl rounded-br-md" />
-        <Skeleton className="mt-1 h-3 w-14" />
-      </div>
-
-      {/* Automated/campaign row */}
-      <div className="flex w-full flex-col items-end pl-16">
-        <div className="w-full max-w-[560px] overflow-hidden rounded-xl border border-slate-200 bg-slate-50/40 px-4 py-2.5">
-          <div className="flex items-center gap-2.5">
-            <Skeleton className="size-6 shrink-0 rounded-md" />
-            <div className="min-w-0 flex-1 space-y-1.5">
-              <Skeleton className="h-3 w-24" />
-              <Skeleton className="h-3.5 w-3/4" />
+    <div role="status" aria-label="Loading timeline">
+      <div
+        className={`mx-auto grid w-full gap-x-2.5 gap-y-3 ${TIMELINE_OUTER_MAX_W} ${TIMELINE_GRID_COLUMNS}`}
+      >
+        <TimelineBubbleSkeleton
+          direction="inbound"
+          lineWidths={["w-full", "w-5/6", "w-3/4"]}
+        />
+        <TimelineBubbleSkeleton
+          direction="outbound"
+          lineWidths={["w-full", "w-5/6", "w-2/3"]}
+        />
+        <li className={`col-span-3 grid ${TIMELINE_GRID_COLUMNS}`}>
+          <div className="col-start-2 flex py-1">
+            <div className="inline-flex items-center rounded-full border border-slate-200 bg-white px-4 py-2">
+              <Skeleton className="h-3 w-40 rounded-full" />
             </div>
           </div>
-        </div>
+        </li>
+        <TimelineBubbleSkeleton
+          direction="inbound"
+          lineWidths={["w-full", "w-4/5", "w-3/5"]}
+        />
       </div>
+      <span className="sr-only">Loading conversation...</span>
+    </div>
+  );
+}
 
-      {/* System divider */}
-      <div className="flex w-full items-center justify-center">
-        <Skeleton className="h-6 w-56 rounded-full" />
+function TimelineBubbleSkeleton({
+  direction,
+  lineWidths,
+}: {
+  readonly direction: "inbound" | "outbound";
+  readonly lineWidths: readonly string[];
+}) {
+  const isInbound = direction === "inbound";
+
+  return (
+    <li className={`col-span-3 grid ${TIMELINE_GRID_COLUMNS}`}>
+      <div
+        className={`row-span-1 self-end ${
+          isInbound
+            ? "col-start-1 flex justify-center"
+            : "col-start-3 flex justify-center"
+        }`}
+      >
+        <div aria-hidden="true" className="size-9 rounded-full bg-slate-200" />
       </div>
-
-      {/* Internal note */}
-      <div className="flex w-full flex-col items-start">
-        <div className="w-full max-w-[560px] overflow-hidden rounded-xl border border-amber-200 bg-amber-50/40 px-4 py-3">
+      <div
+        className={`${
+          isInbound
+            ? "col-start-2 justify-self-start"
+            : "col-start-2 justify-self-end"
+        } w-full ${EMAIL_BUBBLE_MAX_W}`}
+      >
+        <div className="rounded-2xl border border-slate-200 bg-white px-4 py-3 shadow-sm">
           <div className="space-y-2">
-            <Skeleton className="h-3 w-32" />
-            <Skeleton className="h-3 w-full" />
-            <Skeleton className="h-3 w-3/4" />
+            {lineWidths.map((width, index) => (
+              <Skeleton
+                key={`${direction}-${index.toString()}`}
+                className={`h-3 ${width}`}
+              />
+            ))}
           </div>
         </div>
       </div>
-
-      {/* Inbound email bubble (left) */}
-      <div className="flex w-full flex-col items-start">
-        <Skeleton className="mb-1 h-3 w-20" />
-        <Skeleton className="h-14 w-[60%] rounded-2xl rounded-bl-md" />
-        <Skeleton className="mt-1 h-3 w-12" />
-      </div>
-
-      <span className="sr-only">Loading conversation...</span>
-    </div>
+    </li>
   );
 }

--- a/apps/web/app/inbox/_lib/client-api.ts
+++ b/apps/web/app/inbox/_lib/client-api.ts
@@ -1,31 +1,32 @@
 "use client";
 
 import type {
-  InboxDetailViewModel,
+  InboxDetailFreshnessViewModel,
+  InboxDetailTimelinePageViewModel,
   InboxFilterId,
   InboxListViewModel,
-  InboxTimelineEntryViewModel
+  InboxTimelineEntryViewModel,
 } from "./view-models";
 
 export interface InboxTimelinePageResponse {
   readonly entries: readonly InboxTimelineEntryViewModel[];
-  readonly page: InboxDetailViewModel["timelinePage"];
+  readonly page: InboxDetailTimelinePageViewModel;
 }
 
 export interface InboxFreshnessResponse {
   readonly list: InboxListViewModel["freshness"];
-  readonly detail:
-    | InboxDetailViewModel["freshness"]
-    | null;
+  readonly detail: InboxDetailFreshnessViewModel | null;
 }
 
 async function readJson<T>(input: RequestInfo | URL): Promise<T> {
   const response = await fetch(input, {
-    cache: "no-store"
+    cache: "no-store",
   });
 
   if (!response.ok) {
-    throw new Error(`Request failed with status ${response.status.toString()}.`);
+    throw new Error(
+      `Request failed with status ${response.status.toString()}.`,
+    );
   }
 
   return (await response.json()) as T;
@@ -39,7 +40,7 @@ export function fetchInboxListPage(input: {
   readonly projectId?: string | null;
 }): Promise<InboxListViewModel> {
   const params = new URLSearchParams({
-    filter: input.filterId
+    filter: input.filterId,
   });
 
   if (input.cursor) {
@@ -56,7 +57,11 @@ export function fetchInboxListPage(input: {
     params.set("q", trimmedQuery);
   }
 
-  if (input.projectId !== undefined && input.projectId !== null && input.projectId.length > 0) {
+  if (
+    input.projectId !== undefined &&
+    input.projectId !== null &&
+    input.projectId.length > 0
+  ) {
     params.set("projectId", input.projectId);
   }
 
@@ -79,12 +84,12 @@ export function fetchInboxTimelinePage(input: {
   }
 
   return readJson<InboxTimelinePageResponse>(
-    `/api/inbox/contact/${encodeURIComponent(input.contactId)}/timeline?${params.toString()}`
+    `/api/inbox/contact/${encodeURIComponent(input.contactId)}/timeline?${params.toString()}`,
   );
 }
 
 export function fetchInboxFreshness(
-  contactId?: string
+  contactId?: string,
 ): Promise<InboxFreshnessResponse> {
   const params = new URLSearchParams();
 
@@ -94,6 +99,8 @@ export function fetchInboxFreshness(
 
   const query = params.toString();
   return readJson<InboxFreshnessResponse>(
-    query.length === 0 ? "/api/inbox/freshness" : `/api/inbox/freshness?${query}`
+    query.length === 0
+      ? "/api/inbox/freshness"
+      : `/api/inbox/freshness?${query}`,
   );
 }

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -27,6 +27,10 @@ import type {
   InboxChannel,
   InboxComposerReplyContext,
   InboxContactSummaryViewModel,
+  InboxDetailFreshnessViewModel,
+  InboxDetailSummaryViewModel,
+  InboxDetailTimelinePageViewModel,
+  InboxDetailTimelineViewModel,
   InboxDetailViewModel,
   InboxFilterId,
   InboxFilterViewModel,
@@ -166,17 +170,40 @@ interface InboxDetailCacheData {
     string,
     readonly MessageAttachmentRecord[]
   >;
-  readonly timelinePage: {
-    readonly hasMore: boolean;
-    readonly hasHiddenEarlierHistory: boolean;
-    readonly nextCursor: string | null;
-    readonly total: number;
-  };
-  readonly freshness: {
-    readonly inboxUpdatedAt: string | null;
-    readonly timelineUpdatedAt: string | null;
-    readonly timelineCount: number;
-  };
+  readonly timelinePage: InboxDetailTimelinePageViewModel;
+  readonly freshness: InboxDetailFreshnessViewModel;
+}
+
+interface InboxDetailSummaryCacheData {
+  readonly contact: ContactRecord;
+  readonly inboxProjection: InboxDetailProjection;
+  readonly projectionAvailable: boolean;
+  readonly isUnread: boolean;
+  readonly memberships: readonly ContactMembershipRecord[];
+  readonly latestNote: {
+    readonly body: string;
+    readonly authorDisplayName: string | null;
+    readonly authorId: string | null;
+    readonly createdAt: string;
+  } | null;
+  readonly activityTimelineItems: readonly TimelineItem[];
+  readonly canonicalEventById: ReadonlyMap<string, CanonicalEventRecord>;
+  readonly projectMetadataById: Readonly<
+    Record<
+      string,
+      {
+        readonly projectName: string;
+        readonly isActive: boolean;
+      }
+    >
+  >;
+  readonly salesforceEventContextBySourceEvidenceId: ReadonlyMap<
+    string,
+    {
+      readonly projectId: string | null;
+    }
+  >;
+  readonly freshness: InboxDetailFreshnessViewModel;
 }
 
 interface InboxWelcomeWorkloadCacheData {
@@ -186,7 +213,7 @@ interface InboxWelcomeWorkloadCacheData {
 }
 
 const DEFAULT_INBOX_LIST_PAGE_SIZE = 50;
-const DEFAULT_INBOX_TIMELINE_PAGE_SIZE = 40;
+const DEFAULT_INBOX_TIMELINE_PAGE_SIZE = 20;
 const INBOX_LIST_SCAN_LIMIT = 5_000;
 const WELCOME_FOLLOW_UP_INLINE_LIMIT = 3;
 
@@ -293,7 +320,8 @@ function buildAliasSetForMemberships(input: {
       continue;
     }
 
-    for (const alias of input.aliasesByProjectId.get(membership.projectId) ?? []) {
+    for (const alias of input.aliasesByProjectId.get(membership.projectId) ??
+      []) {
       aliases.add(alias);
     }
   }
@@ -332,7 +360,8 @@ function findLastNonAliasMessageAt(input: {
     }
 
     const fromAddresses = extractEmailAddresses(
-      input.gmailDetailBySourceEvidenceId.get(event.sourceEvidenceId)?.fromHeader,
+      input.gmailDetailBySourceEvidenceId.get(event.sourceEvidenceId)
+        ?.fromHeader,
     );
 
     if (fromAddresses.length === 0) {
@@ -376,7 +405,8 @@ function findLastNonAliasOutboundAt(input: {
     }
 
     const fromAddresses = extractEmailAddresses(
-      input.gmailDetailBySourceEvidenceId.get(event.sourceEvidenceId)?.fromHeader,
+      input.gmailDetailBySourceEvidenceId.get(event.sourceEvidenceId)
+        ?.fromHeader,
     );
 
     if (fromAddresses.length === 0) {
@@ -494,7 +524,8 @@ async function loadCampaignActivitySummaryByCampaignId(input: {
 
     const key = campaignId.trim();
     const summary =
-      summaryByCampaignId[key] ?? (summaryByCampaignId[key] = emptyCampaignActivitySummary());
+      summaryByCampaignId[key] ??
+      (summaryByCampaignId[key] = emptyCampaignActivitySummary());
     const summaryKey = campaignActivitySummaryKey(detail.activityType);
 
     summary[summaryKey] = keepMostRecentTimestamp(
@@ -535,10 +566,8 @@ function decodeInboxListCursor(cursor: string | null): {
     const lastActivityAt = parsed.lastActivityAt;
     const contactId = parsed.contactId;
 
-    return (
-      lastNonAliasMessageAt === null ||
-      typeof lastNonAliasMessageAt === "string"
-    ) &&
+    return (lastNonAliasMessageAt === null ||
+      typeof lastNonAliasMessageAt === "string") &&
       (lastOutboundAt === null || typeof lastOutboundAt === "string") &&
       typeof lastActivityAt === "string" &&
       typeof contactId === "string"
@@ -652,9 +681,7 @@ function sortMemberships(
   });
 }
 
-function buildProjectActivityIndex(
-  timelineItems: readonly TimelineItem[],
-): {
+function buildProjectActivityIndex(timelineItems: readonly TimelineItem[]): {
   readonly firstOccurredAtByProjectId: ReadonlyMap<string, string>;
   readonly firstOccurredAtForContact: string | null;
   readonly lastOccurredAtByProjectId: ReadonlyMap<string, string>;
@@ -686,7 +713,8 @@ function buildProjectActivityIndex(
       firstOccurredAtByProjectId.set(item.projectId, item.occurredAt);
     }
 
-    const lastOccurredAt = lastOccurredAtByProjectId.get(item.projectId) ?? null;
+    const lastOccurredAt =
+      lastOccurredAtByProjectId.get(item.projectId) ?? null;
 
     if (lastOccurredAt === null || item.occurredAt > lastOccurredAt) {
       lastOccurredAtByProjectId.set(item.projectId, item.occurredAt);
@@ -706,13 +734,15 @@ function sortMembershipsByLastActivity(
 ): readonly ContactMembershipRecord[] {
   return [...memberships].sort((left, right) => {
     const leftLastActivityAt =
-      (left.projectId === null ? null : lastOccurredAtByProjectId.get(left.projectId)) ??
-      left.createdAt;
+      (left.projectId === null
+        ? null
+        : lastOccurredAtByProjectId.get(left.projectId)) ?? left.createdAt;
     const rightLastActivityAt =
       (right.projectId === null
         ? null
         : lastOccurredAtByProjectId.get(right.projectId)) ?? right.createdAt;
-    const activityDifference = rightLastActivityAt.localeCompare(leftLastActivityAt);
+    const activityDifference =
+      rightLastActivityAt.localeCompare(leftLastActivityAt);
 
     if (activityDifference !== 0) {
       return activityDifference;
@@ -1063,11 +1093,15 @@ export function formatBubbleTimestamp(
   const yesterdayReference = new Date(referenceDate);
   yesterdayReference.setDate(referenceDate.getDate() - 1);
 
-  if (targetDayKey === bubbleDayKey(yesterdayReference.toISOString(), timeZone)) {
+  if (
+    targetDayKey === bubbleDayKey(yesterdayReference.toISOString(), timeZone)
+  ) {
     return BUBBLE_MONTH_DAY_FORMATTER.format(new Date(timestamp));
   }
 
-  if (bubbleYear(timestamp, timeZone) === bubbleYear(referenceNowIso, timeZone)) {
+  if (
+    bubbleYear(timestamp, timeZone) === bubbleYear(referenceNowIso, timeZone)
+  ) {
     return BUBBLE_MONTH_DAY_FORMATTER.format(new Date(timestamp));
   }
 
@@ -1205,12 +1239,7 @@ function isLikelyPreviewNoise(value: string): boolean {
 
     const code = character.codePointAt(0) ?? 0;
 
-    if (
-      code < 0x20 &&
-      code !== 0x09 &&
-      code !== 0x0a &&
-      code !== 0x0d
-    ) {
+    if (code < 0x20 && code !== 0x09 && code !== 0x0a && code !== 0x0d) {
       suspicious += 1;
     }
   }
@@ -2195,7 +2224,9 @@ function timelineActorLabel(
   switch (item.family) {
     case "one_to_one_email":
     case "one_to_one_sms":
-      return normalizeDisplayName(operatorDisplayName) || "Adventure Scientists";
+      return (
+        normalizeDisplayName(operatorDisplayName) || "Adventure Scientists"
+      );
     case "auto_email":
     case "auto_sms":
       return item.sourceLabel;
@@ -2283,10 +2314,7 @@ function normalizeDisplayName(raw: string): string {
       .join(" ");
   }
 
-  return trimmed
-    .split(/\s+/u)
-    .map(titleCaseSimpleToken)
-    .join(" ");
+  return trimmed.split(/\s+/u).map(titleCaseSimpleToken).join(" ");
 }
 
 function participantHeaderLabel(headerValue: string | null): string | null {
@@ -2307,7 +2335,8 @@ function participantHeaderLabel(headerValue: string | null): string | null {
     return name;
   }
 
-  const emailMatch = PARTICIPANT_HEADER_EMAIL_PATTERN.exec(trimmed)?.[0]?.trim();
+  const emailMatch =
+    PARTICIPANT_HEADER_EMAIL_PATTERN.exec(trimmed)?.[0]?.trim();
 
   if (emailMatch !== undefined && emailMatch.length > 0) {
     return emailMatch;
@@ -2697,9 +2726,9 @@ function buildTimelineEntry(input: {
       : null;
   const canonicalSenderDisplayName =
     input.item.family === "one_to_one_email"
-      ? input.contactDisplayNameByEmail.get(
+      ? (input.contactDisplayNameByEmail.get(
           participantHeaderEmail(input.item.fromHeader ?? null) ?? "",
-        ) ?? null
+        ) ?? null)
       : null;
 
   return {
@@ -2856,11 +2885,7 @@ function resolveVolunteerParticipantName(input: {
 }): string | null {
   if (input.emailAddress !== null) {
     const lookup = input.contactDisplayNameByEmail.get(input.emailAddress);
-    if (
-      lookup !== undefined &&
-      lookup.length > 0 &&
-      !isEmailLikeName(lookup)
-    ) {
+    if (lookup !== undefined && lookup.length > 0 && !isEmailLikeName(lookup)) {
       const normalized = normalizeDisplayName(lookup);
       if (normalized.length > 0) {
         return normalized;
@@ -2934,8 +2959,7 @@ function buildParticipantRows(input: {
     // name appears on the wire (handles legacy / non-aliased sends
     // like "PNW Project <pnwbio@…>") → operator name → fallback.
     const fromHeaderName =
-      fromHeaderDisplayName !== null &&
-      !isEmailLikeName(fromHeaderDisplayName)
+      fromHeaderDisplayName !== null && !isEmailLikeName(fromHeaderDisplayName)
         ? normalizeDisplayName(fromHeaderDisplayName) || fromHeaderDisplayName
         : null;
     rows.push({
@@ -2983,10 +3007,7 @@ function buildParticipantRows(input: {
     });
   }
 
-  if (
-    input.item.ccHeader !== null &&
-    input.item.ccHeader.trim().length > 0
-  ) {
+  if (input.item.ccHeader !== null && input.item.ccHeader.trim().length > 0) {
     rows.push({
       label: "Cc",
       name: input.item.ccHeader.trim(),
@@ -3024,9 +3045,7 @@ function resolveHeaderProjectLabel(input: {
   }
 
   const toMatch =
-    toEmail !== null
-      ? (input.projectLabelByAlias.get(toEmail) ?? null)
-      : null;
+    toEmail !== null ? (input.projectLabelByAlias.get(toEmail) ?? null) : null;
   if (toMatch !== null) {
     return toMatch;
   }
@@ -3128,7 +3147,7 @@ function paginateTimelineItems(input: {
   return {
     items,
     hasMore,
-    nextCursor: hasMore ? items[0]?.sortKey ?? null : null,
+    nextCursor: hasMore ? (items[0]?.sortKey ?? null) : null,
     total,
   };
 }
@@ -3167,7 +3186,7 @@ function pickPrimaryActiveProjectName(input: {
 
   return membership?.projectId == null
     ? null
-    : input.projectLabelById.get(membership.projectId) ?? null;
+    : (input.projectLabelById.get(membership.projectId) ?? null);
 }
 
 async function loadProjectMetadataById(
@@ -3208,10 +3227,9 @@ async function loadProjectMetadataById(
     dimensions.map((dimension) => [
       dimension.projectId,
       {
-        projectName:
-          dimension.projectAlias?.trim().length
-            ? dimension.projectAlias
-            : dimension.projectName,
+        projectName: dimension.projectAlias?.trim().length
+          ? dimension.projectAlias
+          : dimension.projectName,
         isActive: dimension.isActive ?? false,
       },
     ]),
@@ -3477,7 +3495,8 @@ async function readInboxListCacheData(input: {
       id: record.projectId,
       name: record.projectName,
       alias:
-        record.projectAlias?.trim().length && record.projectAlias.trim().length > 0
+        record.projectAlias?.trim().length &&
+        record.projectAlias.trim().length > 0
           ? record.projectAlias.trim()
           : null,
     }));
@@ -3501,19 +3520,27 @@ async function readInboxListCacheData(input: {
       candidateContactIds,
     ),
     Promise.all(
-      candidateContactIds.map(async (contactId) => [
-        contactId,
-        await runtime.repositories.canonicalEvents.listByContactId(contactId),
-      ] as const),
+      candidateContactIds.map(
+        async (contactId) =>
+          [
+            contactId,
+            await runtime.repositories.canonicalEvents.listByContactId(
+              contactId,
+            ),
+          ] as const,
+      ),
     ),
     Promise.all(
-      candidateContactIds.map(async (contactId) => [
-        contactId,
-        await runtime.repositories.auditEvidence.listByEntity({
-          entityType: "contact",
-          entityId: contactId,
-        }),
-      ] as const),
+      candidateContactIds.map(
+        async (contactId) =>
+          [
+            contactId,
+            await runtime.repositories.auditEvidence.listByEntity({
+              entityType: "contact",
+              entityId: contactId,
+            }),
+          ] as const,
+      ),
     ),
   ]);
   const contactById = new Map(contacts.map((contact) => [contact.id, contact]));
@@ -3636,7 +3663,8 @@ async function readInboxListCacheData(input: {
       : allItems.findIndex(
           (item) =>
             item.contactId === decodedCursor.contactId &&
-            item.lastNonAliasMessageAt === decodedCursor.lastNonAliasMessageAt &&
+            item.lastNonAliasMessageAt ===
+              decodedCursor.lastNonAliasMessageAt &&
             item.lastOutboundAt === decodedCursor.lastOutboundAt &&
             item.lastActivityAt === decodedCursor.lastActivityAt,
         );
@@ -3652,7 +3680,8 @@ async function readInboxListCacheData(input: {
     return row === undefined ? [] : [row];
   });
   const counts = {
-    all: allRows.filter((row) => row.inboxProjection.archivedAt === null).length,
+    all: allRows.filter((row) => row.inboxProjection.archivedAt === null)
+      .length,
     unread: allRows.filter(
       (row) => row.inboxProjection.archivedAt === null && row.isUnread,
     ).length,
@@ -3691,8 +3720,8 @@ async function readInboxListCacheData(input: {
               lastNonAliasMessageAt:
                 pageRows[pageRows.length - 1]?.lastNonAliasMessageAt ?? null,
               lastOutboundAt:
-                pageRows[pageRows.length - 1]?.inboxProjection
-                  .lastOutboundAt ?? null,
+                pageRows[pageRows.length - 1]?.inboxProjection.lastOutboundAt ??
+                null,
               lastActivityAt:
                 pageRows[pageRows.length - 1]?.inboxProjection.lastActivityAt ??
                 "",
@@ -3758,20 +3787,19 @@ async function readInboxDetailCacheData(
 
   const newestCanonicalEvent = findNewestCanonicalEvent(canonicalEvents);
   const projectionAvailable = inboxProjection !== null;
-  const detailProjection: InboxDetailProjection =
-    inboxProjection ?? {
-      contactId,
-      bucket: "Opened",
-      needsFollowUp: false,
-      hasUnresolved: false,
-      archivedAt: null,
-      lastInboundAt: null,
-      lastOutboundAt: null,
-      lastActivityAt: newestCanonicalEvent?.occurredAt ?? contact.updatedAt,
-      snippet: "",
-      lastCanonicalEventId: newestCanonicalEvent?.id ?? null,
-      lastEventType: newestCanonicalEvent?.eventType ?? null,
-    };
+  const detailProjection: InboxDetailProjection = inboxProjection ?? {
+    contactId,
+    bucket: "Opened",
+    needsFollowUp: false,
+    hasUnresolved: false,
+    archivedAt: null,
+    lastInboundAt: null,
+    lastOutboundAt: null,
+    lastActivityAt: newestCanonicalEvent?.occurredAt ?? contact.updatedAt,
+    snippet: "",
+    lastCanonicalEventId: newestCanonicalEvent?.id ?? null,
+    lastEventType: newestCanonicalEvent?.eventType ?? null,
+  };
 
   const aliasesByProjectId = new Map<string, string[]>();
 
@@ -3848,7 +3876,9 @@ async function readInboxDetailCacheData(
   );
   const timelineSourceEvidenceIds = uniqueStrings(
     timelinePage.items
-      .map((item) => sourceEvidenceIdByCanonicalEventId.get(item.canonicalEventId))
+      .map((item) =>
+        sourceEvidenceIdByCanonicalEventId.get(item.canonicalEventId),
+      )
       .filter((value): value is string => typeof value === "string"),
   );
   const senderEmails = uniqueStrings(
@@ -3938,7 +3968,9 @@ async function readInboxDetailCacheData(
         runtime,
         canonicalEvents,
       }),
-    canonicalEventById: new Map(canonicalEvents.map((event) => [event.id, event])),
+    canonicalEventById: new Map(
+      canonicalEvents.map((event) => [event.id, event]),
+    ),
     projectMetadataById: await loadProjectMetadataById(
       memberships,
       salesforceEventContexts.map((context) => context.projectId),
@@ -3978,6 +4010,156 @@ async function readInboxDetailCacheData(
   };
 }
 
+async function readInboxDetailSummaryCacheData(
+  contactId: string,
+): Promise<InboxDetailSummaryCacheData | null> {
+  const runtime = await getStage1WebRuntime();
+  const [
+    contact,
+    inboxProjection,
+    memberships,
+    latestNote,
+    activityTimelineItems,
+    inboxFreshness,
+    timelineFreshness,
+    canonicalEvents,
+    projectAliasRecords,
+    attentionReadAudits,
+  ] = await Promise.all([
+    runtime.repositories.contacts.findById(contactId),
+    runtime.repositories.inboxProjection.findByContactId(contactId),
+    runtime.repositories.contactMemberships.listByContactId(contactId),
+    runtime.repositories.internalNotes
+      .findByContactId(contactId, 1)
+      .then((rows) => {
+        const newestNote = rows[0];
+        return newestNote === undefined
+          ? null
+          : {
+              body: newestNote.body,
+              authorDisplayName: newestNote.authorDisplayName,
+              authorId: newestNote.authorId,
+              createdAt: newestNote.createdAt.toISOString(),
+            };
+      }),
+    runtime.timelinePresentation.listTimelineItemsByContactId(contactId),
+    runtime.repositories.inboxProjection.getFreshnessByContactId(contactId),
+    runtime.repositories.timelineProjection.getFreshnessByContactId(contactId),
+    runtime.repositories.canonicalEvents.listByContactId(contactId),
+    runtime.settings.aliases.listAssigned(),
+    runtime.repositories.auditEvidence.listByEntity({
+      entityType: "contact",
+      entityId: contactId,
+    }),
+  ]);
+
+  if (contact === null) {
+    return null;
+  }
+
+  const newestCanonicalEvent = findNewestCanonicalEvent(canonicalEvents);
+  const projectionAvailable = inboxProjection !== null;
+  const detailProjection: InboxDetailProjection = inboxProjection ?? {
+    contactId,
+    bucket: "Opened",
+    needsFollowUp: false,
+    hasUnresolved: false,
+    archivedAt: null,
+    lastInboundAt: null,
+    lastOutboundAt: null,
+    lastActivityAt: newestCanonicalEvent?.occurredAt ?? contact.updatedAt,
+    snippet: "",
+    lastCanonicalEventId: newestCanonicalEvent?.id ?? null,
+    lastEventType: newestCanonicalEvent?.eventType ?? null,
+  };
+
+  const aliasesByProjectId = new Map<string, string[]>();
+
+  for (const aliasRecord of projectAliasRecords) {
+    if (aliasRecord.projectId === null) {
+      continue;
+    }
+
+    const normalizedAlias = normalizeEmailAddress(aliasRecord.alias);
+
+    if (normalizedAlias === null) {
+      continue;
+    }
+
+    const aliases = aliasesByProjectId.get(aliasRecord.projectId) ?? [];
+    aliases.push(normalizedAlias);
+    aliasesByProjectId.set(aliasRecord.projectId, aliases);
+  }
+
+  const gmailSourceEvidenceIds = uniqueStrings(
+    canonicalEvents
+      .filter((event) => event.eventType === "communication.email.outbound")
+      .map((event) => event.sourceEvidenceId),
+  );
+  const canonicalSourceEvidenceIds = uniqueStrings(
+    canonicalEvents.map((event) => event.sourceEvidenceId),
+  );
+  const [gmailDetails, salesforceEventContexts] = await Promise.all([
+    gmailSourceEvidenceIds.length === 0
+      ? Promise.resolve([])
+      : runtime.repositories.gmailMessageDetails.listBySourceEvidenceIds(
+          gmailSourceEvidenceIds,
+        ),
+    canonicalSourceEvidenceIds.length === 0
+      ? Promise.resolve([])
+      : runtime.repositories.salesforceEventContext.listBySourceEvidenceIds(
+          canonicalSourceEvidenceIds,
+        ),
+  ]);
+  const gmailDetailBySourceEvidenceId = new Map(
+    gmailDetails.map((detail) => [detail.sourceEvidenceId, detail]),
+  );
+  const lastNonAliasOutboundAt = findLastNonAliasOutboundAt({
+    events: canonicalEvents,
+    aliasSet: buildAliasSetForMemberships({
+      memberships,
+      aliasesByProjectId,
+    }),
+    gmailDetailBySourceEvidenceId,
+  });
+  const latestReadAt = latestAttentionReadAt(attentionReadAudits);
+  const isUnread =
+    detailProjection.bucket === "New" ||
+    (lastNonAliasOutboundAt !== null &&
+      (latestReadAt === null || lastNonAliasOutboundAt > latestReadAt));
+  const projectMetadataById = await loadProjectMetadataById(
+    memberships,
+    salesforceEventContexts.map((context) => context.projectId),
+  );
+
+  return {
+    contact,
+    inboxProjection: detailProjection,
+    projectionAvailable,
+    isUnread,
+    memberships,
+    latestNote,
+    activityTimelineItems,
+    canonicalEventById: new Map(
+      canonicalEvents.map((event) => [event.id, event]),
+    ),
+    projectMetadataById,
+    salesforceEventContextBySourceEvidenceId: new Map(
+      salesforceEventContexts.map((context) => [
+        context.sourceEvidenceId,
+        {
+          projectId: context.projectId,
+        },
+      ]),
+    ),
+    freshness: {
+      inboxUpdatedAt: inboxFreshness?.updatedAt ?? null,
+      timelineUpdatedAt: timelineFreshness.latestUpdatedAt ?? null,
+      timelineCount: timelineFreshness.total,
+    },
+  };
+}
+
 function loadInboxListCacheData(input: {
   readonly filterId: InboxFilterId;
   readonly cursor: string | null;
@@ -3998,9 +4180,14 @@ function loadInboxDetailCacheData(
   return readInboxDetailCacheData(contactId, input);
 }
 
+function loadInboxDetailSummaryCacheData(contactId: string) {
+  return readInboxDetailSummaryCacheData(contactId);
+}
+
 async function readInboxWelcomeWorkloadCacheData(): Promise<InboxWelcomeWorkloadCacheData> {
   const runtime = await getStage1WebRuntime();
-  const activeProjects = await runtime.repositories.projectDimensions.listActive();
+  const activeProjects =
+    await runtime.repositories.projectDimensions.listActive();
   const activeProjectIds = new Set(
     activeProjects.map((project) => project.projectId),
   );
@@ -4048,7 +4235,9 @@ async function readInboxWelcomeWorkloadCacheData(): Promise<InboxWelcomeWorkload
     inlineContactIds.length === 0
       ? []
       : await runtime.repositories.contacts.listByIds(inlineContactIds);
-  const contactById = new Map(inlineContacts.map((contact) => [contact.id, contact]));
+  const contactById = new Map(
+    inlineContacts.map((contact) => [contact.id, contact]),
+  );
   // Operator-facing label: prefer the alias (e.g. "PNW Biodiversity")
   // over the verbose Salesforce projectName. Falls back to projectName
   // when alias is null/empty so we never show a blank label.
@@ -4060,7 +4249,10 @@ async function readInboxWelcomeWorkloadCacheData(): Promise<InboxWelcomeWorkload
     return trimmedAlias.length > 0 ? trimmedAlias : project.projectName;
   };
   const projectLabelById = new Map(
-    activeProjects.map((project) => [project.projectId, projectDisplayName(project)]),
+    activeProjects.map((project) => [
+      project.projectId,
+      projectDisplayName(project),
+    ]),
   );
   const referenceNowIso = new Date().toISOString();
 
@@ -4177,8 +4369,7 @@ function toListItemViewModel(
     isUnanswered:
       row.inboxProjection.lastInboundAt !== null &&
       (row.inboxProjection.lastOutboundAt === null ||
-        row.inboxProjection.lastInboundAt >
-          row.inboxProjection.lastOutboundAt),
+        row.inboxProjection.lastInboundAt > row.inboxProjection.lastOutboundAt),
     lastInboundAt: row.inboxProjection.lastInboundAt,
     lastNonAliasMessageAt: row.lastNonAliasMessageAt,
     lastOutboundAt: row.inboxProjection.lastOutboundAt,
@@ -4220,7 +4411,9 @@ function buildContactSummary(input: {
     input.memberships,
     projectActivityIndex.lastOccurredAtByProjectId,
   )
-    .filter((membership) => !isPastProject(membership, input.projectMetadataById))
+    .filter(
+      (membership) => !isPastProject(membership, input.projectMetadataById),
+    )
     .map((membership) =>
       buildProjectMembershipViewModel(
         membership,
@@ -4236,7 +4429,9 @@ function buildContactSummary(input: {
         membership !== null,
     );
   const pastProjects = sortMembershipsByCreatedAt(input.memberships)
-    .filter((membership) => isPastProject(membership, input.projectMetadataById))
+    .filter((membership) =>
+      isPastProject(membership, input.projectMetadataById),
+    )
     .map((membership) =>
       buildProjectMembershipViewModel(
         membership,
@@ -4313,8 +4508,9 @@ function buildConversationProject(input: {
   for (const item of [...input.timelineItems].sort((left, right) =>
     right.occurredAt.localeCompare(left.occurredAt),
   )) {
-    const sourceEvidenceId =
-      input.canonicalEventById.get(item.canonicalEventId)?.sourceEvidenceId;
+    const sourceEvidenceId = input.canonicalEventById.get(
+      item.canonicalEventId,
+    )?.sourceEvidenceId;
 
     if (sourceEvidenceId === undefined) {
       continue;
@@ -4342,6 +4538,76 @@ function buildConversationProject(input: {
   }
 
   return null;
+}
+
+function buildInboxDetailSummaryViewModel(input: {
+  readonly cachedData: InboxDetailSummaryCacheData | InboxDetailCacheData;
+  readonly defaultAlias: string | null;
+  readonly referenceNowIso: string;
+}): InboxDetailSummaryViewModel {
+  const contactSummary = buildContactSummary({
+    contact: input.cachedData.contact,
+    inboxProjection: input.cachedData.inboxProjection,
+    memberships: input.cachedData.memberships,
+    latestNote: input.cachedData.latestNote,
+    activityTimelineItems: input.cachedData.activityTimelineItems,
+    projectMetadataById: input.cachedData.projectMetadataById,
+    referenceNowIso: input.referenceNowIso,
+  });
+
+  return {
+    contact: contactSummary,
+    projectionAvailable: input.cachedData.projectionAvailable,
+    conversationProject: buildConversationProject({
+      contact: contactSummary,
+      timelineItems: input.cachedData.activityTimelineItems,
+      canonicalEventById: input.cachedData.canonicalEventById,
+      salesforceEventContextBySourceEvidenceId:
+        input.cachedData.salesforceEventContextBySourceEvidenceId,
+      projectMetadataById: input.cachedData.projectMetadataById,
+    }),
+    initials: toInitials(input.cachedData.contact.displayName),
+    avatarTone: avatarToneForContact(input.cachedData.contact.id),
+    bucket: mapBucket(input.cachedData.inboxProjection.bucket),
+    needsFollowUp: input.cachedData.inboxProjection.needsFollowUp,
+    isArchived: input.cachedData.inboxProjection.archivedAt !== null,
+    isUnread: input.cachedData.isUnread,
+    smsEligible: input.cachedData.contact.primaryPhone !== null,
+    composerReplyContext: buildComposerReplyContext({
+      contact: input.cachedData.contact,
+      timelineItems: input.cachedData.activityTimelineItems,
+      defaultAlias: input.defaultAlias,
+    }),
+    freshness: input.cachedData.freshness,
+  };
+}
+
+function buildInboxDetailTimelineViewModel(input: {
+  readonly cachedData: InboxDetailCacheData;
+  readonly operatorDisplayName: string;
+  readonly referenceNowIso: string;
+}): InboxDetailTimelineViewModel {
+  return {
+    timeline: input.cachedData.timelineItems.map((item) =>
+      buildTimelineEntry({
+        contactDisplayName: input.cachedData.contact.displayName,
+        contactPrimaryEmail: input.cachedData.contact.primaryEmail,
+        contactDisplayNameByEmail: input.cachedData.contactDisplayNameByEmail,
+        operatorDisplayName: input.operatorDisplayName,
+        inboxProjection: input.cachedData.inboxProjection,
+        item,
+        campaignActivitySummaryByCampaignId:
+          input.cachedData.campaignActivitySummaryByCampaignId,
+        memberships: input.cachedData.memberships,
+        projectMetadataById: input.cachedData.projectMetadataById,
+        projectLabelByAlias: input.cachedData.projectLabelByAlias,
+        referenceNowIso: input.referenceNowIso,
+        attachmentsByCanonicalEventId:
+          input.cachedData.attachmentsByCanonicalEventId,
+      }),
+    ),
+    timelinePage: input.cachedData.timelinePage,
+  };
 }
 
 function matchesServerFilter(
@@ -4411,7 +4677,7 @@ export async function getInboxList(
             ? totals.sent
             : filter.id === "archived"
               ? totals.archived
-            : totals[filter.id],
+              : totals[filter.id],
   }));
 
   return {
@@ -4433,6 +4699,67 @@ export async function getInboxWelcomeWorkload(): Promise<InboxWelcomeWorkloadVie
     totals: cachedData.totals,
     followUpRail: cachedData.followUpRail,
   };
+}
+
+export async function getInboxDetailSummary(
+  contactId: string,
+): Promise<InboxDetailSummaryViewModel | null> {
+  const [cachedData, runtime] = await Promise.all([
+    loadInboxDetailSummaryCacheData(contactId),
+    getStage1WebRuntime(),
+  ]);
+
+  if (cachedData === null) {
+    return null;
+  }
+
+  const [referenceNowIso, defaultAlias] = await Promise.all([
+    Promise.resolve(new Date().toISOString()),
+    runtime.timelinePresentation.findLastInboundAliasForContact(contactId),
+  ]);
+
+  return buildInboxDetailSummaryViewModel({
+    cachedData,
+    defaultAlias,
+    referenceNowIso,
+  });
+}
+
+export async function getInboxDetailTimeline(
+  contactId: string,
+  input: {
+    readonly limit?: number;
+    readonly recordReadAudit?: boolean;
+  } = {},
+): Promise<InboxDetailTimelineViewModel | null> {
+  const cachedData = await loadInboxDetailCacheData(contactId, {
+    timelineLimit: input.limit ?? DEFAULT_INBOX_TIMELINE_PAGE_SIZE,
+    timelineCursor: null,
+  });
+
+  if (cachedData === null) {
+    return null;
+  }
+
+  if (input.recordReadAudit === true) {
+    recordSensitiveReadForCurrentUserDetached({
+      action: "contact.timeline.read",
+      entityType: "contact",
+      entityId: contactId,
+      metadataJson: {
+        timelineCount: cachedData.timelinePage.total,
+      },
+    });
+  }
+
+  const currentUser = await getCurrentUser();
+
+  return buildInboxDetailTimelineViewModel({
+    cachedData,
+    operatorDisplayName:
+      normalizeDisplayName(currentUser?.name ?? "") || "Adventure Scientists",
+    referenceNowIso: new Date().toISOString(),
+  });
 }
 
 export async function getInboxTimelinePage(
@@ -4462,23 +4789,11 @@ export async function getInboxTimelinePage(
   const operatorDisplayName = "Adventure Scientists";
 
   return {
-    entries: cachedData.timelineItems.map((item) =>
-      buildTimelineEntry({
-        contactDisplayName: cachedData.contact.displayName,
-        contactPrimaryEmail: cachedData.contact.primaryEmail,
-        contactDisplayNameByEmail: cachedData.contactDisplayNameByEmail,
-        operatorDisplayName,
-        inboxProjection: cachedData.inboxProjection,
-        item,
-        campaignActivitySummaryByCampaignId:
-          cachedData.campaignActivitySummaryByCampaignId,
-        memberships: cachedData.memberships,
-        projectMetadataById: cachedData.projectMetadataById,
-        projectLabelByAlias: cachedData.projectLabelByAlias,
-        referenceNowIso,
-        attachmentsByCanonicalEventId: cachedData.attachmentsByCanonicalEventId,
-      }),
-    ),
+    entries: buildInboxDetailTimelineViewModel({
+      cachedData,
+      operatorDisplayName,
+      referenceNowIso,
+    }).timeline,
     page: cachedData.timelinePage,
   };
 }
@@ -4546,64 +4861,22 @@ export async function getInboxDetail(
 
   const runtime = await getStage1WebRuntime();
   const referenceNowIso = new Date().toISOString();
-  const currentUser = await getCurrentUser();
-  const operatorDisplayName =
-    normalizeDisplayName(currentUser?.name ?? "") || "Adventure Scientists";
-  const contactSummary = buildContactSummary({
-    contact: cachedData.contact,
-    inboxProjection: cachedData.inboxProjection,
-    memberships: cachedData.memberships,
-    latestNote: cachedData.latestNote,
-    activityTimelineItems: cachedData.activityTimelineItems,
-    projectMetadataById: cachedData.projectMetadataById,
-    referenceNowIso,
-  });
-  const composerReplyContext = buildComposerReplyContext({
-    contact: cachedData.contact,
-    timelineItems: cachedData.timelineItems,
-    defaultAlias:
-      await runtime.timelinePresentation.findLastInboundAliasForContact(
-        contactId,
-      ),
-  });
+  const [currentUser, defaultAlias] = await Promise.all([
+    getCurrentUser(),
+    runtime.timelinePresentation.findLastInboundAliasForContact(contactId),
+  ]);
 
   return {
-    contact: contactSummary,
-    projectionAvailable: cachedData.projectionAvailable,
-    conversationProject: buildConversationProject({
-      contact: contactSummary,
-      timelineItems: cachedData.activityTimelineItems,
-      canonicalEventById: cachedData.canonicalEventById,
-      salesforceEventContextBySourceEvidenceId:
-        cachedData.salesforceEventContextBySourceEvidenceId,
-      projectMetadataById: cachedData.projectMetadataById,
+    ...buildInboxDetailSummaryViewModel({
+      cachedData,
+      defaultAlias,
+      referenceNowIso,
     }),
-    initials: toInitials(cachedData.contact.displayName),
-    avatarTone: avatarToneForContact(cachedData.contact.id),
-    timeline: cachedData.timelineItems.map((item) =>
-      buildTimelineEntry({
-        contactDisplayName: cachedData.contact.displayName,
-        contactPrimaryEmail: cachedData.contact.primaryEmail,
-        contactDisplayNameByEmail: cachedData.contactDisplayNameByEmail,
-        operatorDisplayName,
-        inboxProjection: cachedData.inboxProjection,
-        item,
-        campaignActivitySummaryByCampaignId:
-          cachedData.campaignActivitySummaryByCampaignId,
-        memberships: cachedData.memberships,
-        projectMetadataById: cachedData.projectMetadataById,
-        projectLabelByAlias: cachedData.projectLabelByAlias,
-        referenceNowIso,
-        attachmentsByCanonicalEventId: cachedData.attachmentsByCanonicalEventId,
-      }),
-    ),
-    bucket: mapBucket(cachedData.inboxProjection.bucket),
-    needsFollowUp: cachedData.inboxProjection.needsFollowUp,
-    isArchived: cachedData.inboxProjection.archivedAt !== null,
-    isUnread: cachedData.isUnread,
-    smsEligible: cachedData.contact.primaryPhone !== null,
-    composerReplyContext,
-    timelinePage: cachedData.timelinePage,
-    freshness: cachedData.freshness,
+    ...buildInboxDetailTimelineViewModel({
+      cachedData,
+      operatorDisplayName:
+        normalizeDisplayName(currentUser?.name ?? "") || "Adventure Scientists",
+      referenceNowIso,
+    }),
   };
 }

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -382,7 +382,20 @@ export interface InboxComposerReplyContext {
   readonly cc?: readonly string[];
 }
 
-export interface InboxDetailViewModel {
+export interface InboxDetailTimelinePageViewModel {
+  readonly hasMore: boolean;
+  readonly hasHiddenEarlierHistory: boolean;
+  readonly nextCursor: string | null;
+  readonly total: number;
+}
+
+export interface InboxDetailFreshnessViewModel {
+  readonly inboxUpdatedAt: string | null;
+  readonly timelineUpdatedAt: string | null;
+  readonly timelineCount: number;
+}
+
+export interface InboxDetailSummaryViewModel {
   readonly contact: InboxContactSummaryViewModel;
   readonly projectionAvailable: boolean;
   readonly conversationProject: {
@@ -392,25 +405,22 @@ export interface InboxDetailViewModel {
   } | null;
   readonly initials: string;
   readonly avatarTone: InboxAvatarTone;
-  readonly timeline: readonly InboxTimelineEntryViewModel[];
   readonly bucket: InboxBucket;
   readonly needsFollowUp: boolean;
   readonly isArchived: boolean;
   readonly isUnread: boolean;
   readonly smsEligible: boolean;
   readonly composerReplyContext: InboxComposerReplyContext | null;
-  readonly timelinePage: {
-    readonly hasMore: boolean;
-    readonly hasHiddenEarlierHistory: boolean;
-    readonly nextCursor: string | null;
-    readonly total: number;
-  };
-  readonly freshness: {
-    readonly inboxUpdatedAt: string | null;
-    readonly timelineUpdatedAt: string | null;
-    readonly timelineCount: number;
-  };
+  readonly freshness: InboxDetailFreshnessViewModel;
 }
+
+export interface InboxDetailTimelineViewModel {
+  readonly timeline: readonly InboxTimelineEntryViewModel[];
+  readonly timelinePage: InboxDetailTimelinePageViewModel;
+}
+
+export interface InboxDetailViewModel
+  extends InboxDetailSummaryViewModel, InboxDetailTimelineViewModel {}
 
 export interface InboxFilterViewModel {
   readonly id: InboxFilterId;

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -64,6 +64,8 @@ import {
   compareInboxRecency,
   formatBubbleTimestamp,
   getInboxDetail,
+  getInboxDetailSummary,
+  getInboxDetailTimeline,
   getInboxList,
   getInboxTimelinePage,
   getInboxWelcomeWorkload,
@@ -112,8 +114,7 @@ function buildItem(
     snippet: overrides.snippet ?? "Snippet",
     latestChannel: overrides.latestChannel ?? "email",
     projectLabel: overrides.projectLabel ?? null,
-    additionalActiveProjectsCount:
-      overrides.additionalActiveProjectsCount ?? 0,
+    additionalActiveProjectsCount: overrides.additionalActiveProjectsCount ?? 0,
     volunteerStage: overrides.volunteerStage ?? "active",
     bucket: overrides.bucket ?? "opened",
     needsFollowUp: overrides.needsFollowUp ?? false,
@@ -658,11 +659,11 @@ describe("sortMembershipsByCreatedAt", () => {
       }),
     ];
 
-    expect(sortMembershipsByCreatedAt(memberships).map((membership) => membership.id)).toEqual([
-      "membership:2",
-      "membership:3",
-      "membership:1",
-    ]);
+    expect(
+      sortMembershipsByCreatedAt(memberships).map(
+        (membership) => membership.id,
+      ),
+    ).toEqual(["membership:2", "membership:3", "membership:1"]);
   });
 });
 
@@ -1022,7 +1023,9 @@ describe("real inbox selectors", () => {
     const inactiveProjectFilter = await getInboxList("all", {
       projectId: "project:whitebark-pine",
     });
-    const ryan = list.items.find((item) => item.contactId === "contact:ryan-davis");
+    const ryan = list.items.find(
+      (item) => item.contactId === "contact:ryan-davis",
+    );
 
     expect(ryan).toMatchObject({
       projectLabel: "PNW Biodiversity",
@@ -1689,7 +1692,9 @@ describe("real inbox selectors", () => {
 
     expect(workload.followUpRail.totalCount).toBe(5);
     expect(workload.followUpRail.entries).toHaveLength(3);
-    expect(workload.followUpRail.entries.map((entry) => entry.contactId)).toEqual([
+    expect(
+      workload.followUpRail.entries.map((entry) => entry.contactId),
+    ).toEqual([
       "contact:follow-up-a",
       "contact:follow-up-b",
       "contact:follow-up-c",
@@ -1770,11 +1775,9 @@ describe("real inbox selectors", () => {
 
     const workload = await getInboxWelcomeWorkload();
 
-    expect(workload.followUpRail.entries.map((entry) => entry.contactId)).toEqual([
-      "contact:alpha",
-      "contact:zeta",
-      "contact:middle",
-    ]);
+    expect(
+      workload.followUpRail.entries.map((entry) => entry.contactId),
+    ).toEqual(["contact:alpha", "contact:zeta", "contact:middle"]);
   });
 
   it("uses one active project label per row based on the newest active membership", async () => {
@@ -1956,6 +1959,103 @@ describe("real inbox selectors", () => {
     expect(detail?.composerReplyContext).toMatchObject({
       subject: "Re: Amazon Basin equipment list",
     });
+  });
+
+  it("splits the summary and streamed timeline selectors into disjoint payloads", async () => {
+    const summary = await getInboxDetailSummary("contact:sarah-martinez");
+    const timeline = await getInboxDetailTimeline("contact:sarah-martinez", {
+      limit: 1,
+    });
+
+    expect(summary).not.toBeNull();
+    expect(summary).toMatchObject({
+      projectionAvailable: true,
+      bucket: "new",
+      needsFollowUp: true,
+      contact: {
+        contactId: "contact:sarah-martinez",
+        displayName: "Sarah Martinez",
+      },
+      composerReplyContext: {
+        subject: "Re: Amazon Basin equipment list",
+      },
+    });
+    expect("timeline" in (summary ?? {})).toBe(false);
+    expect("timelinePage" in (summary ?? {})).toBe(false);
+
+    expect(timeline).not.toBeNull();
+    expect(timeline?.timeline).toHaveLength(1);
+    expect(timeline?.timeline[0]).toMatchObject({
+      kind: "inbound-email",
+      subject: "Re: Amazon Basin equipment list",
+    });
+    expect(timeline?.timelinePage.hasMore).toBe(true);
+    expect(timeline?.timelinePage.hasHiddenEarlierHistory).toBe(false);
+    expect(typeof timeline?.timelinePage.nextCursor).toBe("string");
+    expect(timeline?.timelinePage.total).toBe(2);
+  });
+
+  it("defaults the initial streamed timeline page size to twenty entries", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:timeline-page-size",
+      salesforceContactId: "003-timeline-page-size",
+      displayName: "Timeline Page Size",
+      primaryEmail: "timeline-page-size@example.org",
+      primaryPhone: null,
+    });
+
+    let newestEventId: string | null = null;
+
+    for (let index = 0; index < 21; index += 1) {
+      const occurredAt = new Date(
+        Date.UTC(2026, 3, 1, 12, index, 0, 0),
+      ).toISOString();
+      const seeded = await seedInboxEmailEvent(runtime.context, {
+        id: `timeline-page-size-${index.toString().padStart(2, "0")}`,
+        contactId: "contact:timeline-page-size",
+        occurredAt,
+        direction: index % 2 === 0 ? "inbound" : "outbound",
+        subject: `Timeline page size ${index.toString()}`,
+        snippet: `Timeline page size ${index.toString()}`,
+      });
+
+      newestEventId = seeded.canonicalEventId;
+    }
+
+    if (newestEventId === null) {
+      throw new Error("Expected newest timeline event id");
+    }
+
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:timeline-page-size",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-01T12:20:00.000Z",
+      lastOutboundAt: "2026-04-01T12:19:00.000Z",
+      lastActivityAt: "2026-04-01T12:20:00.000Z",
+      snippet: "Timeline page size 20",
+      lastCanonicalEventId: newestEventId,
+      lastEventType: "communication.email.inbound",
+    });
+
+    const detail = await getInboxDetail("contact:timeline-page-size");
+    const timeline = await getInboxDetailTimeline("contact:timeline-page-size");
+
+    expect(detail?.timeline).toHaveLength(20);
+    expect(detail?.timelinePage.hasMore).toBe(true);
+    expect(detail?.timelinePage.hasHiddenEarlierHistory).toBe(false);
+    expect(typeof detail?.timelinePage.nextCursor).toBe("string");
+    expect(detail?.timelinePage.total).toBe(21);
+    expect(timeline?.timeline).toHaveLength(20);
+    expect(timeline?.timelinePage.hasMore).toBe(true);
+    expect(timeline?.timelinePage.hasHiddenEarlierHistory).toBe(false);
+    expect(typeof timeline?.timelinePage.nextCursor).toBe("string");
+    expect(timeline?.timelinePage.total).toBe(21);
   });
 
   it("synthesizes a degraded detail view when the projection row is missing but canonical events exist", async () => {
@@ -2622,14 +2722,12 @@ describe("real inbox selectors", () => {
 
     const detail = await getInboxDetail("contact:past-order");
 
-    expect(detail?.contact.pastProjects.map((project) => project.projectName)).toEqual([
-      "Newer Project",
-      "Older Project",
-    ]);
-    expect(detail?.contact.pastProjects.map((project) => project.signupYear)).toEqual([
-      null,
-      null,
-    ]);
+    expect(
+      detail?.contact.pastProjects.map((project) => project.projectName),
+    ).toEqual(["Newer Project", "Older Project"]);
+    expect(
+      detail?.contact.pastProjects.map((project) => project.signupYear),
+    ).toEqual([null, null]);
   });
 
   it("normalizes the full Salesforce membership-status label surface for rail badges", async () => {
@@ -2699,7 +2797,9 @@ describe("real inbox selectors", () => {
 
     expect(detail).not.toBeNull();
     expect(
-      new Set(detail?.contact.pastProjects.map((project) => project.statusLabel)),
+      new Set(
+        detail?.contact.pastProjects.map((project) => project.statusLabel),
+      ),
     ).toEqual(new Set(statuses.map(([, label]) => label)));
   });
 
@@ -2746,7 +2846,8 @@ describe("real inbox selectors", () => {
       }),
     );
 
-    const activeSection = activeMarkup.split("Past Projects")[0] ?? activeMarkup;
+    const activeSection =
+      activeMarkup.split("Past Projects")[0] ?? activeMarkup;
     const pastSection = pastMarkup.split("Past Projects")[1] ?? pastMarkup;
 
     expect(activeSection).not.toContain("tabular-nums");
@@ -2884,11 +2985,9 @@ describe("real inbox selectors", () => {
       throw new Error("Expected inbox detail for Steve Herman");
     }
 
-    expect(detail.contact.activeProjects.map((project) => project.projectName)).toEqual([
-      "Passive Acoustic",
-      "Whitebark Pine",
-      "Illegal Timber",
-    ]);
+    expect(
+      detail.contact.activeProjects.map((project) => project.projectName),
+    ).toEqual(["Passive Acoustic", "Whitebark Pine", "Illegal Timber"]);
     expect(
       renderToStaticMarkup(
         createElement(InboxContactRail, {
@@ -3121,7 +3220,9 @@ describe("real inbox selectors", () => {
 
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-04T12:00:00.000Z"));
-    const suppressedDetail = await getInboxDetail("contact:suppressed-signup-year");
+    const suppressedDetail = await getInboxDetail(
+      "contact:suppressed-signup-year",
+    );
 
     // Past projects sort by membership.createdAt desc (newest first).
     // signupYear is independent of sort and resolves via:
@@ -3422,7 +3523,10 @@ describe("real inbox selectors", () => {
       });
     }
 
-    const detailByContactId = new Map<string, Awaited<ReturnType<typeof getInboxDetail>>>(
+    const detailByContactId = new Map<
+      string,
+      Awaited<ReturnType<typeof getInboxDetail>>
+    >(
       await Promise.all(
         cases.map(async (entry) => {
           const detail = await getInboxDetail(entry.contactId);
@@ -3431,14 +3535,18 @@ describe("real inbox selectors", () => {
       ),
     );
 
-    expect(detailByContactId.get("contact:normalized-last-first")?.timeline.at(-1))
-      .toMatchObject({ actorLabel: "Joe Rutledge" });
-    expect(detailByContactId.get("contact:normalized-all-caps")?.timeline.at(-1))
-      .toMatchObject({ actorLabel: "Joe Rutledge" });
-    expect(detailByContactId.get("contact:normalized-lowercase")?.timeline.at(-1))
-      .toMatchObject({ actorLabel: "Joe Rutledge" });
-    expect(detailByContactId.get("contact:normalized-username")?.timeline.at(-1))
-      .toMatchObject({ actorLabel: "jrutle" });
+    expect(
+      detailByContactId.get("contact:normalized-last-first")?.timeline.at(-1),
+    ).toMatchObject({ actorLabel: "Joe Rutledge" });
+    expect(
+      detailByContactId.get("contact:normalized-all-caps")?.timeline.at(-1),
+    ).toMatchObject({ actorLabel: "Joe Rutledge" });
+    expect(
+      detailByContactId.get("contact:normalized-lowercase")?.timeline.at(-1),
+    ).toMatchObject({ actorLabel: "Joe Rutledge" });
+    expect(
+      detailByContactId.get("contact:normalized-username")?.timeline.at(-1),
+    ).toMatchObject({ actorLabel: "jrutle" });
   });
 
   it("uses a known sender contact record for inbound actor labels when the sender already exists", async () => {
@@ -3682,12 +3790,9 @@ describe("real inbox selectors", () => {
     expect(
       detail?.contact.recentActivity.map((entry) => entry.occurredAtLabel),
     ).toEqual(["Apr 11", "Apr 10", "Apr 9", "Apr 8"]);
-    expect(detail?.contact.recentActivity.map((entry) => entry.isMostRecent)).toEqual([
-      true,
-      false,
-      false,
-      false,
-    ]);
+    expect(
+      detail?.contact.recentActivity.map((entry) => entry.isMostRecent),
+    ).toEqual([true, false, false, false]);
   });
 
   it("returns all lifecycle activity items and does not hard-cap the rail feed at five", async () => {
@@ -5801,7 +5906,9 @@ describe("real inbox selectors", () => {
       attemptedAt: "2026-04-20T12:59:00.000Z",
     });
 
-    const detail = await getInboxDetail("contact:canonical-attachment-preferred");
+    const detail = await getInboxDetail(
+      "contact:canonical-attachment-preferred",
+    );
 
     const canonicalEntry = detail?.timeline.find((entry) =>
       entry.attachments.some((attachment) => attachment.proxyUrl !== null),


### PR DESCRIPTION
## Why

Architect QA on 2026-05-05 against production:

- Every RSC fetch for \`/inbox/[contactId]\` consistently takes **3.9–4.5 seconds** server-side.
- Payload size: **116–171 KB** per contact's initial detail render.
- ~20% of navigations 503 (Railway proxy timeout), causing hard-fallback navigation up to **9 seconds** click-to-render.
- Zero \`<Suspense>\` boundaries inside the \`/inbox/[contactId]\` segment — the page blocked on \`getInboxDetail()\` returning everything before any header / rail / composer rendered.
- The skeleton itself was written before PRs #324 / #326 and used percentage widths + \`pl-16\` instead of the grid column model.

## Three coupled changes

### 1. Stream the timeline behind \`<Suspense>\`

\`getInboxDetail\` was split into two selectors in [selectors.ts](apps/web/app/inbox/_lib/selectors.ts):
- \`getInboxDetailSummary(contactId)\` — fast: contact, project metadata, contact-rail data, composer aliases, status pills. **No timeline.**
- \`getInboxDetailTimeline(contactId, { limit })\` — the work that took 3+ seconds today.

[page.tsx](apps/web/app/inbox/[contactId]/page.tsx) now awaits the summary and renders the timeline as a Suspense-wrapped async child with \`<TimelineSkeleton />\` fallback. [inbox-detail.tsx](apps/web/app/inbox/_components/inbox-detail.tsx) was split into a shell (header, rail, composer) plus a streamed timeline component.

Expected effect: header / rail / composer render in <500ms; timeline streams in below them.

### 2. Initial page size 40 → 20

\`DEFAULT_INBOX_TIMELINE_PAGE_SIZE\` now defaults to 20. \"Load older activity\" still loads in 40-row chunks and works as before.

Expected effect: ~50% reduction in initial payload size (60–85 KB instead of 116–171 KB).

### 3. Skeleton refresh

[inbox-loading.tsx](apps/web/app/inbox/_components/inbox-loading.tsx) — \`TimelineSkeleton\` now uses the live grid (\`TIMELINE_GRID_COLUMNS\`, \`max-w-[1024px]\`) and \`w-full max-w-[560px]\` bubble shells. \`InboxDetailLoading\` no longer renders a fake conversation header (Suspense + summary load <500ms means the real header is visible during navigation).

## Files

- \`apps/web/app/inbox/[contactId]/page.tsx\` — split into summary + Suspense-wrapped timeline child
- \`apps/web/app/inbox/_components/inbox-detail.tsx\` — shell + streamed timeline component
- \`apps/web/app/inbox/_components/inbox-loading.tsx\` — TimelineSkeleton rewrite, drop fake header
- \`apps/web/app/inbox/_lib/selectors.ts\` — selector split, default page size = 20
- \`apps/web/app/inbox/_lib/view-models.ts\` — view-model split
- \`apps/web/app/inbox/_lib/client-api.ts\` — minor wiring
- \`apps/web/tests/unit/inbox-selectors.test.ts\` — coverage for split + new default

Net: 7 files, +1145/-639.

## Validation

- [x] \`pnpm typecheck\` — pass
- [x] \`pnpm lint\` — pass
- [ ] CI \`test:unit\` (local hits the macOS rollup environmental issue)
- [ ] Visual smoke after merge:
  - Click a contact → name/project/header/composer appear in <1s
  - Timeline area shows the new skeleton briefly, then the real timeline replaces it without layout shift
  - 503 rate should drop to ~zero (proxy timeouts only fire above ~3s)
  - Skeleton's bubbles are 560px wide, not percentage-of-screen

Brief: [.codex-inbox-perf-2026-05-05.md](https://github.com/nico-kneler-as/as-comms-platform/blob/perf/inbox-conversation-switch-2026-05-05/.codex-inbox-perf-2026-05-05.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)