### PR TITLE
fix(inbox): skeleton alignment + Follow-Up tooltip + drop disabled state

### DIFF
--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -318,7 +318,6 @@ export function InboxDetail({ detail, timelineSlot }: DetailProps) {
                 <>
                   <FollowUpToggleControl
                     needsFollowUp={isFollowUp}
-                    isPending={followUpToggle.isPending}
                     error={followUpToggle.error}
                     onToggle={followUpToggle.toggle}
                   />
@@ -730,22 +729,16 @@ export function InboxDetailTimelineFallback() {
 
 function FollowUpToggleControl({
   needsFollowUp,
-  isPending,
   error,
   onToggle,
 }: {
   readonly needsFollowUp: boolean;
-  readonly isPending: boolean;
   readonly error: UiError | null;
   readonly onToggle: () => void;
 }) {
   return (
     <div className="relative">
-      <FollowUpToggleButton
-        needsFollowUp={needsFollowUp}
-        pending={isPending}
-        onToggle={onToggle}
-      />
+      <FollowUpToggleButton needsFollowUp={needsFollowUp} onToggle={onToggle} />
 
       {error ? (
         <div
@@ -761,33 +754,38 @@ function FollowUpToggleControl({
 
 function FollowUpToggleButton({
   needsFollowUp,
-  pending,
   onToggle,
 }: {
   readonly needsFollowUp: boolean;
-  readonly pending: boolean;
   readonly onToggle: () => void;
 }) {
+  const tooltipLabel = needsFollowUp
+    ? "Pending — click to clear"
+    : "Needs Follow-Up";
+
   return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon"
-      title="Needs Follow-Up"
-      disabled={pending}
-      aria-pressed={needsFollowUp}
-      aria-label="Needs Follow-Up"
-      aria-keyshortcuts="f"
-      data-inbox-follow-up-toggle="true"
-      onClick={onToggle}
-      className={cn(
-        "size-8 rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-900 focus-visible:z-20",
-        needsFollowUp &&
-          "bg-rose-50 text-rose-800 hover:bg-rose-100 hover:text-rose-900",
-      )}
-    >
-      <FlagIcon className="size-4" />
-    </Button>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-pressed={needsFollowUp}
+          aria-label="Needs Follow-Up"
+          aria-keyshortcuts="f"
+          data-inbox-follow-up-toggle="true"
+          onClick={onToggle}
+          className={cn(
+            "size-8 rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-900 focus-visible:z-20",
+            needsFollowUp &&
+              "bg-rose-50 text-rose-800 hover:bg-rose-100 hover:text-rose-900",
+          )}
+        >
+          <FlagIcon className="size-4" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="top">{tooltipLabel}</TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -802,6 +800,9 @@ function useOptimisticBooleanToggle({
 }) {
   const router = useRouter();
   const serverValueRef = useRef(value);
+  const optimisticValueRef = useRef(value);
+  const desiredValueRef = useRef(value);
+  const inFlightRef = useRef(false);
   const [committedValue, setCommittedValue] = useState(value);
   const [error, setError] = useState<UiError | null>(null);
   const [isPending, startTransition] = useTransition();
@@ -812,32 +813,64 @@ function useOptimisticBooleanToggle({
 
   useEffect(() => {
     serverValueRef.current = value;
+    optimisticValueRef.current = value;
+    desiredValueRef.current = value;
+    inFlightRef.current = false;
     setCommittedValue(value);
     setError(null);
   }, [scopeKey, value]);
 
   const toggle = useCallback(() => {
-    const nextValue = !optimisticValue;
+    const nextValue = !optimisticValueRef.current;
+
+    if (inFlightRef.current) {
+      startTransition(() => {
+        optimisticValueRef.current = nextValue;
+        desiredValueRef.current = nextValue;
+        setError(null);
+        setOptimisticValue(nextValue);
+      });
+      return;
+    }
 
     startTransition(async () => {
+      optimisticValueRef.current = nextValue;
+      desiredValueRef.current = nextValue;
       setError(null);
       setOptimisticValue(nextValue);
-      const result = await perform(nextValue);
+      inFlightRef.current = true;
+      let hasCommittedUpdate = false;
 
-      if (result.ok) {
-        serverValueRef.current = nextValue;
-        setCommittedValue(nextValue);
+      while (serverValueRef.current !== desiredValueRef.current) {
+        const valueToPersist = desiredValueRef.current;
+        const result = await perform(valueToPersist);
+
+        if (!result.ok) {
+          optimisticValueRef.current = serverValueRef.current;
+          desiredValueRef.current = serverValueRef.current;
+          setCommittedValue(serverValueRef.current);
+          setOptimisticValue(serverValueRef.current);
+          setError(result);
+          inFlightRef.current = false;
+          return;
+        }
+
+        hasCommittedUpdate = true;
+        serverValueRef.current = valueToPersist;
+        optimisticValueRef.current = valueToPersist;
+        setCommittedValue(valueToPersist);
+      }
+
+      inFlightRef.current = false;
+
+      if (hasCommittedUpdate) {
         // Re-render the RSC tree so the inbox list row reflects the new
         // value. Layout is `force-dynamic` (D-040), so this is a real
         // refetch, not a cache hit.
         router.refresh();
-        return;
       }
-
-      setCommittedValue(serverValueRef.current);
-      setError(result);
     });
-  }, [optimisticValue, perform, router, setOptimisticValue]);
+  }, [perform, router, setOptimisticValue]);
 
   return {
     value: optimisticValue,

--- a/apps/web/app/inbox/_components/inbox-loading.tsx
+++ b/apps/web/app/inbox/_components/inbox-loading.tsx
@@ -324,13 +324,11 @@ function TimelineBubbleSkeleton({
         <div aria-hidden="true" className="size-9 rounded-full bg-slate-200" />
       </div>
       <div
-        className={`${
-          isInbound
-            ? "col-start-2 justify-self-start"
-            : "col-start-2 justify-self-end"
-        } w-full ${EMAIL_BUBBLE_MAX_W}`}
+        className={`col-start-2 ${
+          isInbound ? "justify-self-start" : "justify-self-end"
+        } ${EMAIL_BUBBLE_MAX_W}`}
       >
-        <div className="rounded-2xl border border-slate-200 bg-white px-4 py-3 shadow-sm">
+        <div className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 shadow-sm">
           <div className="space-y-2">
             {lineWidths.map((width, index) => (
               <Skeleton

--- a/apps/web/tests/unit/inbox-detail-header.test.tsx
+++ b/apps/web/tests/unit/inbox-detail-header.test.tsx
@@ -78,7 +78,8 @@ vi.mock("@/components/ui/tooltip", () => ({
     createElement(React.Fragment, null, children),
   TooltipTrigger: ({ children }: { readonly children: React.ReactNode }) =>
     children,
-  TooltipContent: () => null,
+  TooltipContent: ({ children }: { readonly children?: React.ReactNode }) =>
+    createElement("div", { "data-tooltip-content": true }, children),
 }));
 
 vi.mock("../../app/inbox/_components/inbox-avatar", () => ({
@@ -306,6 +307,10 @@ describe("Inbox detail header", () => {
     activeSession = await renderDetail(buildDetail());
     const session = activeSession;
 
+    const followUpButton = findButtonByLabel(
+      session.container,
+      "Needs Follow-Up",
+    );
     const markUnreadButton = findButtonByLabel(session.container, "Mark unread");
     const archiveButton = findButtonByLabel(
       session.container,
@@ -316,6 +321,9 @@ describe("Inbox detail header", () => {
       "Volunteer details",
     );
 
+    expect(followUpButton.dataset.inboxFollowUpToggle).toBe("true");
+    expect(followUpButton.getAttribute("title")).toBeNull();
+    expect(followUpButton.disabled).toBe(false);
     expect(markUnreadButton.dataset.inboxMarkUnread).toBe("true");
     expect(markUnreadButton.textContent).toBe("");
     expect(archiveButton.textContent).toBe("");
@@ -325,6 +333,7 @@ describe("Inbox detail header", () => {
     ).toBeNull();
     expect(session.container.textContent).not.toContain("Set Reminder");
     expect(session.container.textContent).not.toContain("Volunteer Details");
+    expect(session.container.textContent).toContain("Needs Follow-Up");
   });
 
   it("uses the archived header label and hides the volunteer trigger once the rail opens", async () => {
@@ -350,5 +359,85 @@ describe("Inbox detail header", () => {
     expect(
       session.container.querySelector('button[aria-label="Volunteer details"]'),
     ).toBeNull();
+  });
+
+  it("updates the follow-up tooltip copy from the current optimistic state", async () => {
+    activeSession = await renderDetail(
+      buildDetail({
+        needsFollowUp: true,
+      }),
+    );
+    const session = activeSession;
+
+    expect(session.container.textContent).toContain("Pending — click to clear");
+    expect(
+      session.container.querySelector(
+        '[data-tooltip-content="true"]',
+      )?.textContent,
+    ).toContain("Pending — click to clear");
+  });
+
+  it("keeps the follow-up toggle clickable while a request is in flight and queues the latest intent", async () => {
+    let resolveMark:
+      | ((value: { ok: true; data: null; requestId: string }) => void)
+      | null = null;
+    let resolveClear:
+      | ((value: { ok: true; data: null; requestId: string }) => void)
+      | null = null;
+
+    markInboxNeedsFollowUpActionMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveMark = resolve;
+        }),
+    );
+    clearInboxNeedsFollowUpActionMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveClear = resolve;
+        }),
+    );
+
+    activeSession = await renderDetail(buildDetail());
+    const session = activeSession;
+    const followUpButton = findButtonByLabel(
+      session.container,
+      "Needs Follow-Up",
+    );
+
+    await act(async () => {
+      followUpButton.click();
+      await Promise.resolve();
+    });
+
+    expect(followUpButton.disabled).toBe(false);
+    expect(followUpButton.getAttribute("aria-pressed")).toBe("true");
+    expect(markInboxNeedsFollowUpActionMock).toHaveBeenCalledTimes(1);
+    expect(clearInboxNeedsFollowUpActionMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      followUpButton.click();
+      await Promise.resolve();
+    });
+
+    expect(followUpButton.disabled).toBe(false);
+    expect(followUpButton.getAttribute("aria-pressed")).toBe("false");
+    expect(markInboxNeedsFollowUpActionMock).toHaveBeenCalledTimes(1);
+    expect(clearInboxNeedsFollowUpActionMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveMark?.({ ok: true, data: null, requestId: "req-mark" });
+      await Promise.resolve();
+    });
+
+    expect(clearInboxNeedsFollowUpActionMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveClear?.({ ok: true, data: null, requestId: "req-clear" });
+      await Promise.resolve();
+    });
+
+    expect(routerRefreshMock).toHaveBeenCalledTimes(1);
+    expect(followUpButton.getAttribute("aria-pressed")).toBe("false");
   });
 });

--- a/apps/web/tests/unit/inbox-loading.test.tsx
+++ b/apps/web/tests/unit/inbox-loading.test.tsx
@@ -1,0 +1,50 @@
+import React, { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+Object.assign(globalThis, { React });
+
+vi.mock("@/components/ui/skeleton", () => ({
+  Skeleton: ({ className }: { readonly className?: string }) =>
+    createElement("div", { className, "data-skeleton": true }),
+}));
+
+vi.mock("@/app/_lib/design-tokens", () => ({
+  SPACING: { container: "px-6 py-4" },
+  TONE: {},
+}));
+
+vi.mock("@/app/_lib/design-tokens-v2", () => ({
+  LAYOUT: {
+    iconRailWidth: "w-16",
+    listWidth: "w-80",
+    headerHeight: "h-14",
+    welcomeHeaderHeight: "h-16",
+  },
+}));
+
+import { TimelineSkeleton } from "../../app/inbox/_components/inbox-loading";
+
+describe("TimelineSkeleton", () => {
+  it("keeps skeleton bubbles capped at the shared 560px width without a full-width wrapper", () => {
+    const markup = renderToStaticMarkup(createElement(TimelineSkeleton));
+
+    expect(markup).toContain("col-start-2 justify-self-start max-w-[560px]");
+    expect(markup).toContain("col-start-2 justify-self-end max-w-[560px]");
+    expect(markup).toContain(
+      "w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 shadow-sm",
+    );
+    expect(markup).not.toContain("justify-self-start w-full max-w-[560px]");
+    expect(markup).not.toContain("justify-self-end w-full max-w-[560px]");
+  });
+
+  it("keeps the lifecycle pill skeleton inline-sized", () => {
+    const markup = renderToStaticMarkup(createElement(TimelineSkeleton));
+
+    expect(markup).toContain("col-start-2 flex py-1");
+    expect(markup).toContain(
+      "inline-flex items-center rounded-full border border-slate-200 bg-white px-4 py-2",
+    );
+    expect(markup).not.toContain("col-start-2 flex w-full");
+  });
+});


### PR DESCRIPTION
## Summary

Three architect-flagged bugs after PR #327 shipped:

### 1. Skeleton bubble alignment

Outbound skeleton bubbles briefly stretched toward the right edge of the screen before the \`max-w-[560px]\` cap kicked in (visible flash during streaming reflow). Caused by the \`w-full\` on the bubble wrapper in [inbox-loading.tsx](apps/web/app/inbox/_components/inbox-loading.tsx). Width ownership now lives on the inner shell; the wrapper just places the column + caps.

### 2. Follow-Up button tooltip

Was using native \`title=\"...\"\` instead of the Radix Tooltip primitive that other header buttons got in PR #318. Now wrapped in the same Tooltip pattern, with label flipping to \"Pending — click to clear\" when the flag is active.

### 3. Follow-Up button disabled lock

Button was \`disabled={pending}\` during the server roundtrip, making it feel slow even though \`useOptimisticBooleanToggle\` was flipping the visual instantly. Dropped the disabled lock; the hook now queues the latest desired boolean for rapid re-clicks.

## Files

- \`apps/web/app/inbox/_components/inbox-loading.tsx\`
- \`apps/web/app/inbox/_components/inbox-detail.tsx\`
- \`apps/web/tests/unit/inbox-detail-header.test.tsx\` (updated)
- \`apps/web/tests/unit/inbox-loading.test.tsx\` (new)

Net: 4 files, +216/-46.

## Validation

- [x] \`pnpm typecheck\` — pass
- [x] \`pnpm lint\` — pass
- [x] Targeted unit tests — pass
- [ ] CI \`test:unit\`
- [ ] Visual: skeleton no longer flashes wide; Follow-Up shows real tooltip; rapid Follow-Up clicks don't lock the button

Brief: [.codex-inbox-bugs-2026-05-05.md](https://github.com/nico-kneler-as/as-comms-platform/blob/fix/inbox-quick-bugs-2026-05-05/.codex-inbox-bugs-2026-05-05.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)