### PR TITLE
fix(inbox): bubble width wrapper + same-day lifecycle canonical order

### DIFF
--- a/apps/web/app/inbox/_components/inbox-timeline-bubble.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-bubble.tsx
@@ -505,7 +505,12 @@ export function MessageBubble({
           isOutbound ? "justify-end" : "justify-start",
         )}
       >
-        <div className="min-w-0">
+        <div
+          className={cn(
+            "min-w-0 w-full",
+            isEmail ? EMAIL_BUBBLE_MAX_W : SMS_BUBBLE_MAX_W,
+          )}
+        >
           {isOutbound && !isEmail ? <OutboundSmsMetaRow entry={entry} /> : null}
           {bubble}
           {!isOutbound && entry.channel !== "email" ? (

--- a/apps/web/app/inbox/_components/sms-message.tsx
+++ b/apps/web/app/inbox/_components/sms-message.tsx
@@ -85,7 +85,7 @@ export function SmsMessage({
           isOutbound ? "justify-end" : "justify-start",
         )}
       >
-        <div className="min-w-0">
+        <div className={cn("min-w-0 w-full", SMS_BUBBLE_MAX_W)}>
           <div className="mb-1 px-1">
             <span
               className={cn(

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -2108,23 +2108,21 @@ function buildRecentActivity(
     })
     .flatMap((group) =>
       [...group.items].sort((left, right) => {
-        // Display each project's lifecycle events newest-first, faithful to
-        // Salesforce. When two milestones share an occurred_at (typical for
-        // date-only fields stamped on the same day), tiebreak by milestone
-        // ordinal descending so the later canonical step (e.g. completed
-        // training) sits above the earlier one (received training).
-        if (left.occurredAt !== right.occurredAt) {
-          return right.occurredAt.localeCompare(left.occurredAt);
+        const leftDate = utcCalendarDate(left.occurredAt);
+        const rightDate = utcCalendarDate(right.occurredAt);
+
+        if (leftDate !== rightDate) {
+          return rightDate.localeCompare(leftDate);
         }
 
         const leftOrdinal = lifecycleMilestoneOrdinal(left.milestone);
         const rightOrdinal = lifecycleMilestoneOrdinal(right.milestone);
 
         if (leftOrdinal !== rightOrdinal) {
-          return rightOrdinal - leftOrdinal;
+          return leftOrdinal - rightOrdinal;
         }
 
-        return right.id.localeCompare(left.id);
+        return left.id.localeCompare(right.id);
       }),
     )
     .map((item) => ({
@@ -2148,6 +2146,61 @@ function lifecycleMilestoneOrdinal(
     case "submitted_first_data":
       return 4;
   }
+}
+
+function utcCalendarDate(occurredAt: string): string {
+  return occurredAt.slice(0, 10);
+}
+
+function reorderSameDayLifecycleTimelineItems(
+  timelineItems: readonly TimelineItem[],
+): readonly TimelineItem[] {
+  const reordered: TimelineItem[] = [];
+
+  for (let index = 0; index < timelineItems.length; ) {
+    const item = timelineItems[index];
+
+    if (item?.family !== "salesforce_event") {
+      if (item !== undefined) {
+        reordered.push(item);
+      }
+      index += 1;
+      continue;
+    }
+
+    const groupDate = utcCalendarDate(item.occurredAt);
+    const lifecycleGroup: Extract<TimelineItem, { family: "salesforce_event" }>[] =
+      [];
+
+    while (index < timelineItems.length) {
+      const candidate = timelineItems[index];
+
+      if (
+        candidate?.family !== "salesforce_event" ||
+        utcCalendarDate(candidate.occurredAt) !== groupDate
+      ) {
+        break;
+      }
+
+      lifecycleGroup.push(candidate);
+      index += 1;
+    }
+
+    reordered.push(
+      ...lifecycleGroup.sort((left, right) => {
+        const leftOrdinal = lifecycleMilestoneOrdinal(left.milestone);
+        const rightOrdinal = lifecycleMilestoneOrdinal(right.milestone);
+
+        if (leftOrdinal !== rightOrdinal) {
+          return leftOrdinal - rightOrdinal;
+        }
+
+        return left.id.localeCompare(right.id);
+      }),
+    );
+  }
+
+  return reordered;
 }
 
 function timelineChannel(item: TimelineItem): InboxChannel | null {
@@ -3853,8 +3906,10 @@ async function readInboxDetailCacheData(
   const visibleTimelineItems = hasPostCutoverActivity
     ? filterItemsAtOrAfterPlatformFullCaptureCutover(smsFilteredTimelineItems)
     : smsFilteredTimelineItems;
+  const orderedTimelineItems =
+    reorderSameDayLifecycleTimelineItems(visibleTimelineItems);
   const timelinePage = paginateTimelineItems({
-    timelineItems: visibleTimelineItems,
+    timelineItems: orderedTimelineItems,
     limit: input.timelineLimit,
     beforeSortKey: input.timelineCursor,
   });

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -4037,6 +4037,50 @@ describe("real inbox selectors", () => {
     ]);
   });
 
+  it("uses canonical lifecycle order for milestones that share the same UTC day in both rail and timeline", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "same-day-received-training",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-08T09:00:00.000Z",
+      eventType: "lifecycle.received_training",
+      summary: "Received training",
+      projectId: "project:amazon-basin",
+    });
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "same-day-signed-up",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-08T17:00:00.000Z",
+      eventType: "lifecycle.signed_up",
+      summary: "Signed up",
+      projectId: "project:amazon-basin",
+    });
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "same-day-completed-training",
+      contactId: "contact:sarah-martinez",
+      occurredAt: "2026-04-09T08:00:00.000Z",
+      eventType: "lifecycle.completed_training",
+      summary: "Completed training",
+      projectId: "project:amazon-basin",
+    });
+
+    const detail = await getInboxDetail("contact:sarah-martinez");
+
+    expect(detail?.contact.recentActivity.map((entry) => entry.label)).toEqual([
+      "Completed training - Amazon Basin Research",
+      "Signed up - Amazon Basin Research",
+      "Received training - Amazon Basin Research",
+    ]);
+    expect(detail?.timeline.map((entry) => entry.id)).toEqual([
+      "timeline:same-day-signed-up",
+      "timeline:same-day-received-training",
+      "timeline:same-day-completed-training",
+    ]);
+  });
+
   it("formats lifecycle rail dates by UTC calendar day to avoid midnight drift", async () => {
     if (runtime === null) {
       throw new Error("Expected inbox test runtime");

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -3989,7 +3989,7 @@ describe("real inbox selectors", () => {
     ]);
   });
 
-  it("orders lifecycle events faithful to Salesforce, even when its timestamps imply training-before-signup", async () => {
+  it("orders lifecycle events by UTC day desc + canonical ordinal asc within day, faithful to SF cross-day timestamps", async () => {
     if (runtime === null) {
       throw new Error("Expected inbox test runtime");
     }
@@ -4029,11 +4029,14 @@ describe("real inbox selectors", () => {
 
     const detail = await getInboxDetail("contact:sarah-martinez");
 
+    // Cross-day order is faithful to SF timestamps (SF anomaly: training stamped
+    // before signup). Within the Oct 27 group, both training events share a
+    // UTC day so they sort by canonical ordinal asc (received before completed).
     expect(detail?.contact.recentActivity.map((entry) => entry.label)).toEqual([
       "Submitted first data - Amazon Basin Research",
       "Signed up - Amazon Basin Research",
-      "Completed training - Amazon Basin Research",
       "Received training - Amazon Basin Research",
+      "Completed training - Amazon Basin Research",
     ]);
   });
 
@@ -4074,7 +4077,13 @@ describe("real inbox selectors", () => {
       "Signed up - Amazon Basin Research",
       "Received training - Amazon Basin Research",
     ]);
-    expect(detail?.timeline.map((entry) => entry.id)).toEqual([
+    // Filter to lifecycle pills only — the shared runtime seeds non-lifecycle
+    // sarah events that are unrelated to this same-day-canonical-order check.
+    expect(
+      detail?.timeline
+        .filter((entry) => entry.kind === "system-event")
+        .map((entry) => entry.id),
+    ).toEqual([
       "timeline:same-day-signed-up",
       "timeline:same-day-received-training",
       "timeline:same-day-completed-training",

--- a/apps/web/tests/unit/inbox-timeline-bubble.test.tsx
+++ b/apps/web/tests/unit/inbox-timeline-bubble.test.tsx
@@ -286,7 +286,7 @@ describe("MessageBubble metadata and polish", () => {
     expect(markup).toContain("col-span-3 grid");
     expect(markup).toContain("grid-cols-[2.75rem_minmax(0,1fr)_2.75rem]");
     expect(markup).toContain("col-start-2 min-w-0 flex justify-end");
-    expect(markup).toContain("w-full max-w-[560px]");
+    expect(markup.match(/w-full max-w-\[560px\]/g)).toHaveLength(2);
     expect(markup).not.toContain("w-fit");
     expect(markup).not.toContain("max-w-[640px]");
     expect(markup).not.toContain("pl-16");
@@ -308,7 +308,7 @@ describe("MessageBubble metadata and polish", () => {
       }),
     );
 
-    expect(markup).toContain("w-full max-w-[560px]");
+    expect(markup.match(/w-full max-w-\[560px\]/g)).toHaveLength(2);
     expect(markup).not.toContain("w-fit");
     expect(markup).not.toContain("max-w-[640px]");
   });


### PR DESCRIPTION
## Summary

Two architect-flagged issues after PR #329:

### 1. Bubble width — inbound shorter than outbound

Root cause was the col-2 inner wrapper at [inbox-timeline-bubble.tsx:502](apps/web/app/inbox/_components/inbox-timeline-bubble.tsx:502) being just \`min-w-0\` with no \`w-full\` + max-w cap. Flexbox collapsed it to content width; the bubble inside had \`w-full\` which then resolved against the shrunk wrapper. Long content filled 560 naturally; short content didn't.

Fix: wrapper now carries \`w-full max-w-[560px]\` matching the bubble. Same fix applied to \`sms-message.tsx\`. \`inbox-timeline-automated-row.tsx\` and \`inbox-timeline-note-entry.tsx\` already used a direct \`w-full max-w-[560px]\` child and don't have this bug.

### 2. Same-day lifecycle canonical order

Architect: \"if 2 events happened in the same day, they should respect the given order both in the right column and the message history: signup > received > completed > submitted.\" Cross-day events keep their stored timestamp order (Heidi/Killer Whales SF-faithful behavior preserved).

- **Rail's Project Activity panel** ([selectors.ts:2110](apps/web/app/inbox/_lib/selectors.ts:2110)) — sort by UTC calendar day first, then canonical milestone ordinal within a day.
- **Inbox timeline** ([selectors.ts:2155](apps/web/app/inbox/_lib/selectors.ts:2155)) — read-time \`reorderSameDayLifecycleTimelineItems\` hook reorders adjacent same-day lifecycle pills into canonical order without touching persisted sort keys.

## Files

- \`apps/web/app/inbox/_components/inbox-timeline-bubble.tsx\`
- \`apps/web/app/inbox/_components/sms-message.tsx\`
- \`apps/web/app/inbox/_lib/selectors.ts\`
- 2 test files updated

Net: 5 files, +118/-14.

## Validation

- [x] \`pnpm typecheck\` — pass
- [x] \`pnpm lint\` — pass
- [ ] CI \`test:unit\`
- [ ] Visual: short inbound replies render at the same 560px width as outbound + the violet automated/campaign pill; same-day lifecycle pills appear in canonical order in both rail and timeline; Heidi/Killer Whales cross-day order unchanged

Brief: [.codex-inbox-bubbles-and-order-2026-05-05.md](https://github.com/nico-kneler-as/as-comms-platform/blob/fix/inbox-bubble-width-and-same-day-order-2026-05-05/.codex-inbox-bubbles-and-order-2026-05-05.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)