### PR TITLE
fix(inbox): dedupe archived list + add unarchive flow regression test

### DIFF
--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -3511,7 +3511,17 @@ async function readInboxListCacheData(input: {
     runtime.repositories.projectDimensions.listActive(),
     runtime.settings.aliases.listAll(),
   ]);
-  const matchedProjections = [...visibleProjections, ...archivedProjections];
+  const seenContactIds = new Set<string>();
+  const matchedProjections = [
+    ...visibleProjections,
+    ...archivedProjections,
+  ].filter((projection) => {
+    if (seenContactIds.has(projection.contactId)) {
+      return false;
+    }
+    seenContactIds.add(projection.contactId);
+    return true;
+  });
   const activeProjects: readonly InboxActiveProjectOption[] =
     activeProjectRecords.map((record) => ({
       id: record.projectId,

--- a/apps/web/tests/unit/inbox-actions.test.ts
+++ b/apps/web/tests/unit/inbox-actions.test.ts
@@ -27,6 +27,7 @@ import {
   draftWithAiAction,
   markInboxOpenedAction,
   markInboxNeedsFollowUpAction,
+  unarchiveInboxContactAction,
 } from "../../app/inbox/actions";
 import { resetSecurityRateLimiterForTests } from "../../src/server/security/rate-limit";
 import { getInboxDetail, getInboxList } from "../../app/inbox/_lib/selectors";
@@ -292,6 +293,79 @@ describe("server-backed follow-up actions", () => {
     expect(after.items.map((item) => item.contactId)).not.toContain(
       "contact:cross-dept",
     );
+  });
+
+  it("moves a contact cleanly from archived back into the inbox", async () => {
+    if (runtime === null) {
+      throw new Error("runtime not initialized");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:archived-restore",
+      salesforceContactId: "003-archived-restore",
+      displayName: "Archived Restore",
+      primaryEmail: "archived-restore@example.org",
+      primaryPhone: null,
+      projectId: "project:amazon-basin",
+      projectName: "Amazon Basin Research",
+      membershipId: "membership:archived-restore",
+      membershipStatus: "active",
+    });
+    const archivedLatest = await seedInboxEmailEvent(runtime.context, {
+      id: "archived-restore-inbound-1",
+      contactId: "contact:archived-restore",
+      occurredAt: "2026-04-15T11:00:00.000Z",
+      direction: "inbound",
+      subject: "Archived restore check",
+      snippet: "This contact should return to the inbox once unarchived.",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:archived-restore",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-15T11:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-04-15T11:00:00.000Z",
+      snippet: "This contact should return to the inbox once unarchived.",
+      archivedAt: "2026-04-15T12:00:00.000Z",
+      lastCanonicalEventId: archivedLatest.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+
+    const formData = new FormData();
+    formData.set("contactId", "contact:archived-restore");
+
+    const archivedBefore = await getInboxList("archived");
+    expect(
+      archivedBefore.items.filter(
+        (item) => item.contactId === "contact:archived-restore",
+      ),
+    ).toHaveLength(1);
+
+    const unarchiveResult = await unarchiveInboxContactAction(formData);
+    const projection =
+      await runtime.context.repositories.inboxProjection.findByContactId(
+        "contact:archived-restore",
+      );
+    const inboxAfter = await getInboxList("inbox");
+    const archivedAfter = await getInboxList("archived");
+
+    expect(unarchiveResult).toMatchObject({
+      ok: true,
+      data: {
+        contactId: "contact:archived-restore",
+      },
+    });
+    expect(projection?.archivedAt).toBeNull();
+    expect(
+      inboxAfter.items.filter(
+        (item) => item.contactId === "contact:archived-restore",
+      ),
+    ).toHaveLength(1);
+    expect(
+      archivedAfter.items.map((item) => item.contactId),
+    ).not.toContain("contact:archived-restore");
   });
 
   it("does not clobber fresher projection state when follow-up is toggled", async () => {

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -841,6 +841,47 @@ describe("real inbox selectors", () => {
     );
   });
 
+  it("dedupes archived rows by contactId when loading the archived filter", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:archived-dedupe",
+      salesforceContactId: "003-archived-dedupe",
+      displayName: "Archived Dedupe",
+      primaryEmail: "archived-dedupe@example.org",
+      primaryPhone: null,
+    });
+    const archivedLatest = await seedInboxEmailEvent(runtime.context, {
+      id: "archived-dedupe-email-1",
+      contactId: "contact:archived-dedupe",
+      occurredAt: "2026-04-24T10:00:00.000Z",
+      direction: "inbound",
+      subject: "Archived dedupe check",
+      snippet: "This archived row should only render once.",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:archived-dedupe",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-24T10:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-04-24T10:00:00.000Z",
+      snippet: "This archived row should only render once.",
+      archivedAt: "2026-04-24T11:00:00.000Z",
+      lastCanonicalEventId: archivedLatest.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+
+    const list = await getInboxList("archived");
+
+    expect(
+      list.items.filter((item) => item.contactId === "contact:archived-dedupe"),
+    ).toHaveLength(1);
+  });
+
   it("emits count chips only for unread and pending", async () => {
     const list = await getInboxList("inbox");
     const filtersById = new Map(list.filters.map((filter) => [filter.id, filter]));


### PR DESCRIPTION
## Summary

Fixes the duplicate archived conversations bug architects flagged after PR #329. Root cause:

[selectors.ts:3493-3514](apps/web/app/inbox/_lib/selectors.ts) — when the user filter is \`archived\`, both loaders return the same archived rows and the merge \`[...visibleProjections, ...archivedProjections]\` doubles them.

Fix: dedupe the merged array by \`contactId\`. The two-loader structure is preserved (still useful for per-filter count computation across both visible + archived sets).

## Unarchive→inbox leak symptom

Investigated the unarchive flow as a separate hypothesis:
- [actions.ts:2225](apps/web/app/inbox/actions.ts) calls \`setInboxArchived\`
- [inbox-detail.tsx:238](apps/web/app/inbox/_components/inbox-detail.tsx) uses \`router.refresh()\` on unarchive
- [revalidate.ts:1](apps/web/src/server/inbox/revalidate.ts) is a deliberate no-op under D-040

No cache-invalidation bug. The architect's \"strange state\" most likely came from the same duplicate-merge bug above seen mid-transition between filters. Added a regression test proving an unarchived contact moves back to Inbox cleanly.

## Files

- \`apps/web/app/inbox/_lib/selectors.ts\` — dedupe merged projections
- \`apps/web/tests/unit/inbox-selectors.test.ts\` — archived-dedupe assertion
- \`apps/web/tests/unit/inbox-actions.test.ts\` — unarchive flow regression test

Net: 3 files, +126/-1.

## Validation

- [x] \`pnpm typecheck\` — pass
- [x] \`pnpm lint\` — pass
- [ ] CI \`test:unit\`
- [ ] Visual after merge:
  - Open Archived filter → no duplicate conversations
  - Click unarchive on one → that contact moves to Inbox; other archived contacts stay in Archived (no longer leak)

Brief: [.codex-archived-dup-2026-05-05.md](https://github.com/nico-kneler-as/as-comms-platform/blob/fix/inbox-archived-duplicates-2026-05-05/.codex-archived-dup-2026-05-05.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)