### PR TITLE
fix(ops): surface postgres error fields in backfill error logs

### DIFF
--- a/apps/worker/src/ops/backfill-inbox-projection-coverage.ts
+++ b/apps/worker/src/ops/backfill-inbox-projection-coverage.ts
@@ -336,6 +336,52 @@ export async function backfillInboxProjectionCoverage(input: {
           error instanceof Error ? error.message : String(error)
         }`
       );
+      if (error instanceof Error) {
+        logger.error(`  stack: ${error.stack ?? "(no stack)"}`);
+        const anyError = error as unknown as Record<string, unknown>;
+        for (const key of [
+          "cause",
+          "code",
+          "detail",
+          "constraint",
+          "column",
+          "table",
+          "schema",
+          "severity",
+          "position",
+          "where",
+          "hint",
+          "errno",
+          "syscall",
+        ]) {
+          if (anyError[key] !== undefined) {
+            logger.error(`  ${key}: ${JSON.stringify(anyError[key])}`);
+          }
+        }
+        if (anyError.cause instanceof Error) {
+          const causeError = anyError.cause as Error & Record<string, unknown>;
+          logger.error(`  cause.message: ${causeError.message}`);
+          logger.error(`  cause.stack: ${causeError.stack ?? "(no stack)"}`);
+          for (const key of [
+            "code",
+            "detail",
+            "constraint",
+            "column",
+            "table",
+            "schema",
+            "severity",
+            "position",
+            "where",
+            "hint",
+          ]) {
+            if (causeError[key] !== undefined) {
+              logger.error(
+                `  cause.${key}: ${JSON.stringify(causeError[key])}`
+              );
+            }
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Expand the catch-block error logging in `backfill-inbox-projection-coverage.ts` to dump the underlying postgres error metadata (code, constraint, detail, etc.), the stack trace, and `error.cause` recursively.
- No runtime behavior change. Pure observability.

## Why
During the live backfill against prod, drizzle/postgres-js wraps the real postgres error inside an `Error` whose `message` is just `"Failed query: <SQL>\nparams: ..."`. The actual error code / constraint / detail lives on `.cause` and on top-level postgres-js fields. Without logging those, you can't tell whether a batch failed because of a connection drop, a constraint violation, a timeout, or something else — every error looks the same. The next backfill run (and any future ops script that reuses this pattern) deserves better.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- CI runs unit tests; behavior is logging-only inside an existing catch path.