### PR TITLE
Fix inbox project filter alias matching

### DIFF
--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -1009,12 +1009,31 @@ function buildInboxProjectPredicate(
   }
 
   return sql`exists (
-    select 1 from ${contactMemberships}
-    inner join ${projectDimensions}
-      on ${contactMemberships.projectId} = ${projectDimensions.projectId}
-    where ${contactMemberships.contactId} = ${contactInboxProjection.contactId}
-      and ${contactMemberships.projectId} = ${projectId}
-      and ${projectDimensions.isActive} = true
+    select 1
+    from (
+      select 1
+      from ${contactMemberships}
+      inner join ${projectDimensions}
+        on ${contactMemberships.projectId} = ${projectDimensions.projectId}
+      where ${contactMemberships.contactId} = ${contactInboxProjection.contactId}
+        and ${contactMemberships.projectId} = ${projectId}
+        and ${projectDimensions.isActive} = true
+
+      union all
+
+      select 1
+      from ${canonicalEventLedger}
+      inner join ${gmailMessageDetails}
+        on ${gmailMessageDetails.sourceEvidenceId} = ${canonicalEventLedger.sourceEvidenceId}
+      inner join ${projectAliases}
+        on ${gmailMessageDetails.projectInboxAlias} = ${projectAliases.alias}
+      inner join ${projectDimensions}
+        on ${projectAliases.projectId} = ${projectDimensions.projectId}
+      where ${canonicalEventLedger.contactId} = ${contactInboxProjection.contactId}
+        and ${gmailMessageDetails.direction} = 'inbound'
+        and ${projectAliases.projectId} = ${projectId}
+        and ${projectDimensions.isActive} = true
+    ) inbox_project_match
   )`;
 }
 

--- a/packages/db/test/stage1-repositories.test.ts
+++ b/packages/db/test/stage1-repositories.test.ts
@@ -1325,6 +1325,7 @@ describe("Stage 1 DB repositories", () => {
 
   it("matches project filters against any active membership and excludes inactive project memberships", async () => {
     const { repositories, settings } = await createTestStage1Context();
+    const now = new Date("2026-04-20T00:00:00.000Z");
 
     // Alias required for active rows per migration 0045 CHECK constraint.
     await repositories.projectDimensions.upsert({
@@ -1342,6 +1343,20 @@ describe("Stage 1 DB repositories", () => {
       isActive: true,
     });
     await repositories.projectDimensions.upsert({
+      projectId: "project:forests-a",
+      projectName: "Forests A",
+      projectAlias: "Forests A",
+      source: "salesforce",
+      isActive: true,
+    });
+    await repositories.projectDimensions.upsert({
+      projectId: "project:forests-b",
+      projectName: "Forests B",
+      projectAlias: "Forests B",
+      source: "salesforce",
+      isActive: true,
+    });
+    await repositories.projectDimensions.upsert({
       projectId: "project:inactive-c",
       projectName: "Inactive Project",
       projectAlias: "Inactive",
@@ -1349,6 +1364,115 @@ describe("Stage 1 DB repositories", () => {
       isActive: true,
     });
     await settings.projects.setActive("project:inactive-c", false);
+    await settings.aliases.create({
+      id: "alias:forests-a",
+      alias: "forests-a@example.org",
+      signature: "",
+      projectId: "project:forests-a",
+      createdAt: now,
+      updatedAt: now,
+      createdBy: null,
+      updatedBy: null,
+    });
+    await settings.aliases.create({
+      id: "alias:forests-b",
+      alias: "forests-b@example.org",
+      signature: "",
+      projectId: "project:forests-b",
+      createdAt: now,
+      updatedAt: now,
+      createdBy: null,
+      updatedBy: null,
+    });
+
+    const seedInboxContact = async (input: {
+      readonly contactId: string;
+      readonly displayName: string;
+      readonly occurredAt: string;
+      readonly sourceEvidenceId: string;
+      readonly canonicalEventId: string;
+      readonly provider: "gmail" | "salesforce";
+      readonly projectInboxAlias?: string;
+      readonly snippet: string;
+    }) => {
+      await repositories.contacts.upsert({
+        id: input.contactId,
+        salesforceContactId: `003-${input.contactId}`,
+        displayName: input.displayName,
+        primaryEmail: `${input.contactId}@example.org`,
+        primaryPhone: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      });
+      await repositories.sourceEvidence.append({
+        id: input.sourceEvidenceId,
+        provider: input.provider,
+        providerRecordType: input.provider === "gmail" ? "message" : "task",
+        providerRecordId: input.canonicalEventId,
+        receivedAt: input.occurredAt,
+        occurredAt: input.occurredAt,
+        payloadRef: `payloads/${input.provider}/${input.canonicalEventId}.json`,
+        idempotencyKey: `${input.provider}:${input.canonicalEventId}`,
+        checksum: `checksum:${input.canonicalEventId}`,
+      });
+      await repositories.canonicalEvents.upsert({
+        id: input.canonicalEventId,
+        contactId: input.contactId,
+        eventType: "communication.email.inbound",
+        channel: "email",
+        occurredAt: input.occurredAt,
+        contentFingerprint: null,
+        sourceEvidenceId: input.sourceEvidenceId,
+        idempotencyKey: `canonical:${input.canonicalEventId}`,
+        provenance: {
+          primaryProvider: input.provider,
+          primarySourceEvidenceId: input.sourceEvidenceId,
+          supportingSourceEvidenceIds: [],
+          winnerReason: "single_source",
+          sourceRecordType: input.provider === "gmail" ? "message" : "task",
+          sourceRecordId: input.canonicalEventId,
+          messageKind: "one_to_one",
+          campaignRef: null,
+          threadRef: null,
+          direction: "inbound",
+          notes: null,
+        },
+        reviewState: "clear",
+      });
+
+      if (input.projectInboxAlias !== undefined) {
+        await repositories.gmailMessageDetails.upsert({
+          sourceEvidenceId: input.sourceEvidenceId,
+          providerRecordId: input.canonicalEventId,
+          gmailThreadId: `thread:${input.canonicalEventId}`,
+          rfc822MessageId: `<${input.canonicalEventId}@example.org>`,
+          direction: "inbound",
+          subject: "Project alias inbound",
+          fromHeader: `${input.displayName} <${input.contactId}@example.org>`,
+          toHeader: input.projectInboxAlias,
+          ccHeader: null,
+          labelIds: ["INBOX"],
+          snippetClean: input.snippet,
+          bodyTextPreview: input.snippet,
+          capturedMailbox: "forests@example.org",
+          projectInboxAlias: input.projectInboxAlias,
+        });
+      }
+
+      await repositories.inboxProjection.upsert({
+        contactId: input.contactId,
+        bucket: "New",
+        needsFollowUp: false,
+        hasUnresolved: false,
+        lastInboundAt: input.occurredAt,
+        lastOutboundAt: null,
+        lastActivityAt: input.occurredAt,
+        snippet: input.snippet,
+        archivedAt: null,
+        lastCanonicalEventId: input.canonicalEventId,
+        lastEventType: "communication.email.inbound",
+      });
+    };
 
     await repositories.contacts.upsert({
       id: "contact:multi-project",
@@ -1440,6 +1564,57 @@ describe("Stage 1 DB repositories", () => {
       lastCanonicalEventId: "event:multi-project-inbound",
       lastEventType: "communication.email.inbound",
     });
+    await seedInboxContact({
+      contactId: "contact:alias-only",
+      displayName: "Alia Sawyer",
+      occurredAt: "2026-04-20T13:00:00.000Z",
+      sourceEvidenceId: "source:alias-only-inbound",
+      canonicalEventId: "event:alias-only-inbound",
+      provider: "gmail",
+      projectInboxAlias: "forests-a@example.org",
+      snippet: "Alias-only project signal.",
+    });
+    await seedInboxContact({
+      contactId: "contact:cross-project",
+      displayName: "Casey Cross",
+      occurredAt: "2026-04-20T14:00:00.000Z",
+      sourceEvidenceId: "source:cross-project-inbound",
+      canonicalEventId: "event:cross-project-inbound",
+      provider: "gmail",
+      projectInboxAlias: "forests-b@example.org",
+      snippet: "Membership and alias point at different projects.",
+    });
+    await repositories.contactMemberships.upsert({
+      id: "membership:cross:forests-a",
+      contactId: "contact:cross-project",
+      projectId: "project:forests-a",
+      expeditionId: null,
+      salesforceMembershipId: "sf-membership:cross:forests-a",
+      role: "volunteer",
+      status: "lead",
+      source: "salesforce",
+      createdAt: "2026-04-04T10:00:00.000Z",
+    });
+    await seedInboxContact({
+      contactId: "contact:pure-membership",
+      displayName: "Morgan Member",
+      occurredAt: "2026-04-20T15:00:00.000Z",
+      sourceEvidenceId: "source:pure-membership-inbound",
+      canonicalEventId: "event:pure-membership-inbound",
+      provider: "salesforce",
+      snippet: "Membership-only project signal.",
+    });
+    await repositories.contactMemberships.upsert({
+      id: "membership:pure:forests-a",
+      contactId: "contact:pure-membership",
+      projectId: "project:forests-a",
+      expeditionId: null,
+      salesforceMembershipId: "sf-membership:pure:forests-a",
+      role: "volunteer",
+      status: "lead",
+      source: "salesforce",
+      createdAt: "2026-04-05T10:00:00.000Z",
+    });
 
     const pnwRows = await repositories.inboxProjection.listPageOrderedByRecency({
       filter: "visible",
@@ -1470,6 +1645,28 @@ describe("Stage 1 DB repositories", () => {
     const inactiveCounts = await repositories.inboxProjection.countByFilters({
       projectId: "project:inactive-c",
     });
+    const forestsARows =
+      await repositories.inboxProjection.listPageOrderedByRecency({
+        filter: "visible",
+        order: "last-inbound",
+        limit: 10,
+        cursor: null,
+        projectId: "project:forests-a",
+      });
+    const forestsBRows =
+      await repositories.inboxProjection.listPageOrderedByRecency({
+        filter: "visible",
+        order: "last-inbound",
+        limit: 10,
+        cursor: null,
+        projectId: "project:forests-b",
+      });
+    const forestsACounts = await repositories.inboxProjection.countByFilters({
+      projectId: "project:forests-a",
+    });
+    const forestsBCounts = await repositories.inboxProjection.countByFilters({
+      projectId: "project:forests-b",
+    });
 
     expect(pnwRows.map((row) => row.contactId)).toEqual([
       "contact:multi-project",
@@ -1480,5 +1677,15 @@ describe("Stage 1 DB repositories", () => {
     expect(inactiveRows).toEqual([]);
     expect(pnwCounts.all).toBe(1);
     expect(inactiveCounts.all).toBe(0);
+    expect(forestsARows.map((row) => row.contactId)).toEqual([
+      "contact:pure-membership",
+      "contact:cross-project",
+      "contact:alias-only",
+    ]);
+    expect(forestsBRows.map((row) => row.contactId)).toEqual([
+      "contact:cross-project",
+    ]);
+    expect(forestsACounts.all).toBe(3);
+    expect(forestsBCounts.all).toBe(1);
   });
 });


### PR DESCRIPTION
## Context
Beech and Butternut are about to be activated as Salesforce projects that both route volunteer mail through the shared Gmail inbox `forests@adventurescientists.org`. Only one of those project rows will be activated in `project_dimensions` and own the alias; the other remains an inactive Salesforce-synced row without claiming an alias. Volunteers in either Salesforce project can still email `forests@`, so the inbox project filter needs to treat the captured alias as project context instead of depending only on `contact_memberships`.

## What changed
- Widened `buildInboxProjectPredicate` so a contact matches a project filter through either an active membership or an inbound Gmail event whose `project_inbox_alias` maps to the active project via `project_aliases`.
- Added repository coverage for alias-only matching, cross-project membership/alias matching, and pure membership matching, while keeping the inactive-project membership negative case.

## Semantic side effect
After merge, any volunteer who emails a project alias will appear in that project's inbox filter even without a `contact_memberships` row for that active project. This is intentional: it brings the inbox list filter in line with the alias-first project resolution already used by timeline rendering and AI Draft / knowledge lookup.

## Existing alias-first paths
This aligns the inbox predicate with the existing alias-first behavior in `packages/domain/src/timeline.ts:1152` and the alias-to-project map in `apps/web/app/inbox/_lib/selectors.ts`.

## Validation
- `pnpm install --force`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- Focused check: `pnpm --filter @as-comms/db exec vitest run test/stage1-repositories.test.ts -t "matches project filters" --config ../../vitest.config.ts`

Skipped full `pnpm test:unit` locally per request; CI remains authoritative for the full unit suite.