### PR TITLE
fix(inbox): restore sms and third-party message truth

### DIFF
--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -10,7 +10,6 @@ import type {
 } from "@as-comms/contracts";
 
 import { getCurrentUser } from "@/src/server/auth/session";
-import { readWebEnv } from "@/src/server/env";
 import { recordSensitiveReadForCurrentUserDetached } from "@/src/server/security/audit";
 import { getStage1WebRuntime } from "../../../src/server/stage1-runtime";
 import {
@@ -68,17 +67,6 @@ type InboxDetailProjection = Omit<
   readonly lastCanonicalEventId: string | null;
   readonly lastEventType: CanonicalEventRecord["eventType"] | null;
 };
-
-function filterSmsTimelineItems(
-  items: readonly TimelineItem[],
-  smsEnabled: boolean,
-): readonly TimelineItem[] {
-  if (smsEnabled) {
-    return items;
-  }
-
-  return items.filter((item) => item.family !== "one_to_one_sms");
-}
 
 function findNewestCanonicalEvent(
   events: readonly CanonicalEventRecord[],
@@ -1267,11 +1255,10 @@ function fallbackOneToOneEmailBody(
 ): string {
   const normalizedSummary = normalizeInlineText(item.summary) ?? "";
 
-  if (
-    item.primaryProvider === "salesforce" &&
-    /^(outbound|inbound) email (sent|received)$/i.test(normalizedSummary)
-  ) {
-    return "Email body not cached - open in Salesforce";
+  if (/^(outbound|inbound) email (sent|received)$/i.test(normalizedSummary)) {
+    return item.primaryProvider === "gmail"
+      ? "Email body not cached - open in Gmail"
+      : "Email body not cached - open in Salesforce";
   }
 
   return normalizedSummary;
@@ -1668,6 +1655,19 @@ function timelineActorLabel(
     return normalizeDisplayName(contactDisplayName) || contactDisplayName;
   }
 
+  if (kind === "outbound-email" && item.family === "one_to_one_email") {
+    const senderLabel = participantHeaderLabel(item.fromHeader ?? null);
+    const normalizedSenderLabel =
+      senderLabel === null ? "" : normalizeDisplayName(senderLabel);
+
+    if (
+      normalizedSenderLabel.length > 0 &&
+      !isEmailLikeName(normalizedSenderLabel)
+    ) {
+      return normalizedSenderLabel;
+    }
+  }
+
   if (kind === "outbound-email" || kind === "outbound-sms") {
     return normalizeDisplayName(operatorDisplayName) || "Adventure Scientists";
   }
@@ -1891,7 +1891,7 @@ function timelineBody(item: TimelineItem): string {
           fallbackOneToOneEmailBody(item),
       );
     case "one_to_one_sms":
-      return item.messageTextPreview;
+      return item.messageTextPreview || item.summary;
     case "auto_email":
       return stripSignature(
         parseCommunicationPreview(item.snippet).body || item.summary,
@@ -2984,7 +2984,8 @@ async function readInboxListCacheData(input: {
   // The primary loader pulls only the active filter slice. Counts come from
   // the aggregate repo method below, so opening a conversation does not hydrate
   // unrelated inbox or archived rows.
-  const primaryFilterForLoader: RepoFilter = input.filterId;
+  const primaryFilterForLoader: RepoFilter =
+    input.filterId === "unread" ? "inbox" : input.filterId;
   const [
     visibleProjections,
     projectionCounts,
@@ -3220,7 +3221,6 @@ async function readInboxDetailCacheData(
   },
 ): Promise<InboxDetailCacheData | null> {
   const runtime = await getStage1WebRuntime();
-  const env = readWebEnv();
   const [
     contact,
     inboxProjection,
@@ -3298,16 +3298,12 @@ async function readInboxDetailCacheData(
     aliasesByProjectId.set(aliasRecord.projectId, aliases);
   }
 
-  const smsFilteredTimelineItems = filterSmsTimelineItems(
-    activityTimelineItems,
-    env.SMS_ENABLED,
-  );
   const hasPostCutoverActivity = canonicalEvents.some((event) =>
     occurredAtIsOnOrAfterPlatformFullCaptureCutover(event.occurredAt),
   );
   const visibleTimelineItems = hasPostCutoverActivity
-    ? filterItemsAtOrAfterPlatformFullCaptureCutover(smsFilteredTimelineItems)
-    : smsFilteredTimelineItems;
+    ? filterItemsAtOrAfterPlatformFullCaptureCutover(activityTimelineItems)
+    : activityTimelineItems;
   const orderedTimelineItems =
     reorderSameDayLifecycleTimelineItems(visibleTimelineItems);
   const timelinePage = paginateTimelineItems({

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -769,6 +769,87 @@ describe("real inbox selectors", () => {
     });
   });
 
+  it("keeps one-to-one SMS visible in the timeline regardless of SMS compose availability", async () => {
+    const originalSmsEnabled = process.env.SMS_ENABLED;
+    process.env.SMS_ENABLED = "false";
+
+    try {
+      const detail = await getInboxDetail("contact:alex-thompson");
+
+      expect(detail?.timeline).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: "outbound-sms",
+            actorLabel: "Adventure Scientists",
+            body: "We can shift the mountain research dates if weather stays rough.",
+            channel: "sms",
+          }),
+          expect.objectContaining({
+            kind: "inbound-sms",
+            actorLabel: "Alex Thompson",
+            body: "Had to postpone due to weather. Proposing new dates.",
+            channel: "sms",
+          }),
+        ]),
+      );
+    } finally {
+      if (originalSmsEnabled === undefined) {
+        delete process.env.SMS_ENABLED;
+      } else {
+        process.env.SMS_ENABLED = originalSmsEnabled;
+      }
+    }
+  });
+
+  it("renders third-party Gmail outbound body and sender identity instead of a generic event label", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:darrel-robertson",
+      salesforceContactId: null,
+      displayName: "Darrel Robertson",
+      primaryEmail: "darrel@example.org",
+      primaryPhone: null,
+    });
+    const latest = await seedInboxEmailEvent(runtime.context, {
+      id: "darrel-scotty-gmail-1",
+      contactId: "contact:darrel-robertson",
+      occurredAt: "2026-04-16T16:00:00.000Z",
+      direction: "outbound",
+      subject: "Adventure Scientists follow-up",
+      snippet: "Hi Darrel, looping back with the details we discussed.",
+      bodyTextPreview: "Hi Darrel, looping back with the details we discussed.",
+      fromHeader: "Scotty Stalp <scotty@adventurescientists.org>",
+      toHeader: "Darrel Robertson <darrel@example.org>",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:darrel-robertson",
+      bucket: "Opened",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: null,
+      lastOutboundAt: "2026-04-16T16:00:00.000Z",
+      lastActivityAt: "2026-04-16T16:00:00.000Z",
+      snippet: "Outbound email sent",
+      lastCanonicalEventId: latest.canonicalEventId,
+      lastEventType: "communication.email.outbound",
+    });
+
+    const detail = await getInboxDetail("contact:darrel-robertson");
+    const entry = detail?.timeline.at(-1);
+
+    expect(entry).toMatchObject({
+      kind: "outbound-email",
+      actorLabel: "Scotty Stalp",
+      subject: "Adventure Scientists follow-up",
+      body: "Hi Darrel, looping back with the details we discussed.",
+      fromHeader: "Scotty Stalp <scotty@adventurescientists.org>",
+      toHeader: "Darrel Robertson <darrel@example.org>",
+    });
+  });
+
   it("batches list-side canonical event and audit reads per page load", async () => {
     if (runtime === null) {
       throw new Error("Expected inbox test runtime");

--- a/packages/domain/src/timeline.ts
+++ b/packages/domain/src/timeline.ts
@@ -1176,7 +1176,7 @@ function buildTimelineItemsFromRows(input: {
           messageTextPreview:
             simpleTextingDetail?.messageTextPreview ??
             salesforceCommunicationDetail?.snippet ??
-            "",
+            row.summary,
           phone: simpleTextingDetail?.normalizedPhone ?? null,
           threadKey:
             simpleTextingDetail?.threadKey ??


### PR DESCRIPTION
## Summary
- restore one-to-one SMS timeline visibility independently of SMS compose availability
- preserve SMS body truth by falling back to timeline summaries when provider detail text is absent
- render Gmail outbound sender/body truth for third-party conversations instead of generic event labels
- align unread filter loading with computed attention/unread semantics for non-alias teammate replies

## Root cause
- `SMS_ENABLED` was being used as a read-time timeline filter, hiding historical SMS messages when the composer/send feature was disabled.
- The unread filter preloaded only projection `New` rows, so computed attention rows from non-alias teammate replies were dropped before selector filtering.
- Outbound email actor/body rendering preferred generic fallbacks even when Gmail headers/body were available.

## Validation
- `pnpm --filter @as-comms/web typecheck`
- `pnpm --filter @as-comms/web lint`
- `pnpm --filter @as-comms/domain typecheck`
- `pnpm --filter @as-comms/domain lint`
- `pnpm --filter @as-comms/web test:unit tests/unit/inbox-selectors.test.ts`

## QA note
- No emails or SMS were sent. Local visual QA was limited because localhost browser/dev-server QA was unreliable in the in-app browser, but server-side selector routes and unit coverage passed locally.
