### PR TITLE
fix(inbox): prefer known sender identity for aliases

### DIFF
--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -1656,6 +1656,18 @@ function timelineActorLabel(
   }
 
   if (kind === "outbound-email" && item.family === "one_to_one_email") {
+    const normalizedCanonicalContactName =
+      canonicalContactDisplayName === null
+        ? ""
+        : normalizeDisplayName(canonicalContactDisplayName);
+
+    if (
+      normalizedCanonicalContactName.length > 0 &&
+      !isEmailLikeName(normalizedCanonicalContactName)
+    ) {
+      return normalizedCanonicalContactName;
+    }
+
     const senderLabel = participantHeaderLabel(item.fromHeader ?? null);
     const normalizedSenderLabel =
       senderLabel === null ? "" : normalizeDisplayName(senderLabel);
@@ -2375,9 +2387,10 @@ function resolveVolunteerParticipantName(input: {
  * compact bubble header and the expanded debug view. Direction is
  * baked in so the component can render
  * `participantRows[0].name → participantRows[1].name` without
- * branching: the From slot for outbound is the project alias, for
- * inbound it is the volunteer's resolved name (and vice versa for
- * To). When toHeader is missing on an inbound capture the To row
+ * branching: the From slot for outbound is the known sender behind
+ * an alias when we have one, then the project alias; for inbound it
+ * is the volunteer's resolved name (and vice versa for To). When
+ * toHeader is missing on an inbound capture the To row
  * falls back to `item.mailbox` so we never render an empty right
  * side.
  */
@@ -2410,16 +2423,32 @@ function buildParticipantRows(input: {
 
   if (input.item.direction === "outbound") {
     // For outbound the From slot holds whatever the operator was
-    // sending AS. Order: resolved project alias → whatever display
-    // name appears on the wire (handles legacy / non-aliased sends
-    // like "PNW Project <pnwbio@…>") → operator name → fallback.
+    // sending AS. Order: known sender identity behind the alias →
+    // resolved project alias → whatever display name appears on the
+    // wire (handles legacy / non-aliased sends like
+    // "PNW Project <pnwbio@…>") → operator name → fallback.
+    const fromContactName =
+      fromEmail === null
+        ? null
+        : (input.contactDisplayNameByEmail.get(fromEmail) ?? null);
+    const normalizedFromContactName =
+      fromContactName === null ? "" : normalizeDisplayName(fromContactName);
+    const senderContactName =
+      normalizedFromContactName.length > 0 &&
+      !isEmailLikeName(normalizedFromContactName)
+        ? normalizedFromContactName
+        : null;
     const fromHeaderName =
       fromHeaderDisplayName !== null && !isEmailLikeName(fromHeaderDisplayName)
         ? normalizeDisplayName(fromHeaderDisplayName) || fromHeaderDisplayName
         : null;
     rows.push({
       label: "From",
-      name: input.headerProjectLabel ?? fromHeaderName ?? operatorLabel,
+      name:
+        senderContactName ??
+        input.headerProjectLabel ??
+        fromHeaderName ??
+        operatorLabel,
       email: fromEmail,
     });
     rows.push({

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -214,7 +214,7 @@ export interface InboxTimelineEntryViewModel {
    * non-email entries or when the alias email can't be matched.
    *
    * Used by `EmailParticipantHeader` to render headers as
-   *   outbound: <projectAlias> → <volunteer>
+   *   outbound: <sender or projectAlias> → <volunteer>
    *   inbound:  <volunteer>     → <projectAlias>
    * without the bubble component needing access to the alias map.
    */

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -1150,6 +1150,104 @@ describe("real inbox selectors", () => {
     });
   });
 
+  it("prefers a known teammate identity over a project alias in outbound email headers", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:darrel-robertson",
+      salesforceContactId: null,
+      displayName: "Darrel Robertson",
+      primaryEmail: "darrel@example.org",
+      primaryPhone: null,
+      projectId: "project:pnw-bio",
+      projectName: "PNW Biodiversity",
+      projectAlias: "PNW Biodiversity",
+      membershipId: "membership:darrel:pnw-bio",
+      membershipStatus: "active",
+      membershipCreatedAt: "2026-04-01T10:00:00.000Z",
+    });
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:scotty-stalp",
+      salesforceContactId: null,
+      displayName: "Scotty Stalp",
+      primaryEmail: "or-rural-coordinator@adventurescientists.org",
+      primaryPhone: null,
+    });
+    await runtime.context.repositories.contactIdentities.upsert({
+      id: "identity:scotty-or-rural",
+      contactId: "contact:scotty-stalp",
+      kind: "email",
+      normalizedValue: "or-rural-coordinator@adventurescientists.org",
+      isPrimary: true,
+      source: "gmail",
+      verifiedAt: null,
+    });
+    await runtime.context.settings.aliases.create({
+      id: "alias:or-rural-coordinator",
+      alias: "or-rural-coordinator@adventurescientists.org",
+      signature: "",
+      projectId: "project:pnw-bio",
+      createdAt: new Date("2026-05-03T12:00:00.000Z"),
+      updatedAt: new Date("2026-05-03T12:00:00.000Z"),
+      createdBy: null,
+      updatedBy: null,
+    });
+    const latest = await seedInboxEmailEvent(runtime.context, {
+      id: "darrel-scotty-alias-gmail-1",
+      contactId: "contact:darrel-robertson",
+      occurredAt: "2026-05-03T16:00:00.000Z",
+      direction: "outbound",
+      subject: "Re: Shipping ARUs",
+      snippet: "Hey Darrel, I shipped 8 ARUs via FedEx today.",
+      bodyTextPreview: "Hey Darrel, I shipped 8 ARUs via FedEx today.",
+      fromHeader:
+        "PNW Biodiversity <or-rural-coordinator@adventurescientists.org>",
+      toHeader: "Darrel Robertson <darrel@example.org>",
+      ccHeader: "Adventure Scientists <pnwbio@adventurescientists.org>",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:darrel-robertson",
+      bucket: "Opened",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: null,
+      lastOutboundAt: "2026-05-03T16:00:00.000Z",
+      lastActivityAt: "2026-05-03T16:00:00.000Z",
+      snippet: "Hey Darrel, I shipped 8 ARUs via FedEx today.",
+      lastCanonicalEventId: latest.canonicalEventId,
+      lastEventType: "communication.email.outbound",
+    });
+
+    const detail = await getInboxDetail("contact:darrel-robertson");
+    const entry = detail?.timeline.at(-1);
+
+    expect(entry).toMatchObject({
+      kind: "outbound-email",
+      actorLabel: "Scotty Stalp",
+      headerProjectLabel: "PNW Biodiversity",
+      body: "Hey Darrel, I shipped 8 ARUs via FedEx today.",
+      participantRows: [
+        {
+          label: "From",
+          name: "Scotty Stalp",
+          email: "or-rural-coordinator@adventurescientists.org",
+        },
+        {
+          label: "To",
+          name: "Darrel Robertson",
+          email: "darrel@example.org",
+        },
+        {
+          label: "Cc",
+          name: "Adventure Scientists <pnwbio@adventurescientists.org>",
+          email: null,
+        },
+      ],
+    });
+  });
+
   it("batches list-side canonical event and audit reads per page load", async () => {
     if (runtime === null) {
       throw new Error("Expected inbox test runtime");


### PR DESCRIPTION
## Summary
- prefer known contact identity over generic project alias labels for outbound one-to-one email sender display
- preserve project alias truth as header metadata/fallback
- add Darrel/Scotty-style regression coverage alongside SMS visibility focused checks

## Checks
- PATH="/Users/nicolas/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/nicolas/.codex/tmp/arg0/codex-arg0xmePEy:/Users/nicolas/.local/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/opt/homebrew/bin" pnpm --filter @as-comms/web typecheck
- PATH="/Users/nicolas/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/nicolas/.codex/tmp/arg0/codex-arg0xmePEy:/Users/nicolas/.local/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/opt/homebrew/bin" pnpm --filter @as-comms/web lint
- PATH="/Users/nicolas/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/nicolas/.codex/tmp/arg0/codex-arg0xmePEy:/Users/nicolas/.local/bin:/Applications/Codex.app/Contents/Resources:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/opt/homebrew/bin" pnpm --filter @as-comms/web test:unit tests/unit/inbox-selectors.test.ts -t "prefers a known teammate identity|keeps one-to-one SMS visible|renders historical SimpleTexting SMS|renders future Twilio SMS"

## QA
- Read-only Playwright QA on localhost:3001 confirmed visible SMS bubbles for Keyla Chavarria (contact:salesforce:003VK00000a4Mi1YAE).