### PR TITLE
fix(inbox): broaden search and stabilize filters

### DIFF
--- a/apps/web/app/inbox/_components/inbox-filter-list.tsx
+++ b/apps/web/app/inbox/_components/inbox-filter-list.tsx
@@ -62,6 +62,10 @@ export function InboxFilterList({
     selectedProjectId === null
       ? null
       : (projects.find((project) => project.id === selectedProjectId) ?? null);
+  const selectedProjectLabel =
+    selectedProject === null
+      ? "All projects"
+      : (selectedProject.alias ?? selectedProject.name);
 
   return (
     <div
@@ -135,7 +139,7 @@ export function InboxFilterList({
                         : "",
                     )}
                   >
-                    {selectedProject?.name ?? "All projects"}
+                    {selectedProjectLabel}
                   </span>
                   <ChevronDownIcon
                     aria-hidden="true"
@@ -166,7 +170,7 @@ export function InboxFilterList({
                       value={project.id}
                       className="rounded-lg text-[12.5px]"
                     >
-                      {project.name}
+                      {project.alias ?? project.name}
                     </DropdownMenuRadioItem>
                   ))}
                 </DropdownMenuRadioGroup>

--- a/apps/web/app/inbox/_components/inbox-list.tsx
+++ b/apps/web/app/inbox/_components/inbox-list.tsx
@@ -3,7 +3,6 @@
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
   useCallback,
-  useDeferredValue,
   useEffect,
   useMemo,
   useRef,
@@ -103,8 +102,6 @@ function resolveInboxHeaderTitle(input: {
     );
 
     if (selectedProject !== undefined) {
-      // TODO(feat/inbox-header-dynamic-label): Once the alias bug-fix branch is
-      // merged everywhere, remove the name fallback and rely on alias only.
       projectLabel = selectedProject.alias ?? selectedProject.name;
     }
   }
@@ -137,11 +134,8 @@ export function InboxList({
   const urlProjectId = searchParams.get("projectId");
   const urlProjectIds = searchParams.getAll("projectId");
   const rawSearchQuery = search.query.trim();
-  const deferredQuery = useDeferredValue(search.query);
-  const normalizedQuery = deferredQuery.trim();
+  const normalizedQuery = rawSearchQuery;
   const isSearchThresholdMet = rawSearchQuery.length >= 3;
-  const isDeferredSearchPending =
-    isSearchThresholdMet && rawSearchQuery !== normalizedQuery;
   const isServerSearchActive =
     isSearchThresholdMet && normalizedQuery.length >= 3;
   const serverQuery = isServerSearchActive ? normalizedQuery : null;
@@ -191,6 +185,7 @@ export function InboxList({
       !shouldApplyUrlSearchQuery({
         urlQuery,
         previousUrlQuery: previousUrlQueryRef.current,
+        currentQuery: search.query,
       })
     ) {
       return;
@@ -243,6 +238,10 @@ export function InboxList({
   }, [pathname, router, searchParams, urlFilter]);
 
   useEffect(() => {
+    if (normalizedQuery.length > 0 && normalizedQuery.length < 3) {
+      return;
+    }
+
     const currentUrlQuery = urlQuery.trim();
 
     if (normalizedQuery === currentUrlQuery) {
@@ -265,13 +264,13 @@ export function InboxList({
           : `${pathname}?${nextQueryString}`;
 
       previousUrlQueryRef.current = normalizedQuery;
-      router.replace(nextHref, { scroll: false });
+      window.history.replaceState(window.history.state, "", nextHref);
     }, 400);
 
     return () => {
       window.clearTimeout(handle);
     };
-  }, [normalizedQuery, pathname, router, searchParams, urlQuery]);
+  }, [normalizedQuery, pathname, searchParams, urlQuery]);
 
   const loadFilterPage = useCallback(
     async (input: {
@@ -422,8 +421,7 @@ export function InboxList({
     isServerSearchActive &&
     isQueueLoading &&
     pendingAppendCursorRef.current === null;
-  const shouldShowSearchSkeleton =
-    isSearchThresholdMet && (isDeferredSearchPending || isSearchInFlight);
+  const shouldShowSearchSkeleton = isSearchThresholdMet && isSearchInFlight;
   const shouldShowInitialSkeleton =
     isQueueLoading && currentList.items.length === 0 && !shouldShowSearchSkeleton;
   const canLoadMore =
@@ -462,6 +460,14 @@ export function InboxList({
       });
 
       const nextParams = new URLSearchParams(searchParams.toString());
+      const currentSearchQuery = search.query.trim();
+
+      if (currentSearchQuery.length < 3) {
+        nextParams.delete("q");
+      } else {
+        nextParams.set("q", currentSearchQuery);
+      }
+
       if (id === null) {
         nextParams.delete("projectId");
       } else {
@@ -473,9 +479,10 @@ export function InboxList({
         nextQueryString.length === 0 ? pathname : `${pathname}?${nextQueryString}`;
 
       previousUrlProjectIdRef.current = id;
+      previousUrlQueryRef.current = currentSearchQuery;
       router.replace(nextHref, { scroll: false });
     },
-    [pathname, router, searchParams, startFilterTransition],
+    [pathname, router, search.query, searchParams, startFilterTransition],
   );
 
   const toggleFilterPane = useCallback(() => {

--- a/apps/web/app/inbox/_lib/search-sync.ts
+++ b/apps/web/app/inbox/_lib/search-sync.ts
@@ -1,6 +1,10 @@
 export function shouldApplyUrlSearchQuery(input: {
   readonly urlQuery: string;
   readonly previousUrlQuery: string;
+  readonly currentQuery: string;
 }): boolean {
-  return input.urlQuery !== input.previousUrlQuery;
+  return (
+    input.urlQuery !== input.previousUrlQuery &&
+    input.currentQuery === input.previousUrlQuery
+  );
 }

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -2978,7 +2978,8 @@ async function readInboxListCacheData(input: {
   const runtime = await getStage1WebRuntime();
   const decodedCursor = decodeInboxListCursor(input.cursor);
   const normalizedQuery = normalizeInlineText(input.query) ?? null;
-  const order = orderForInboxFilter(input.filterId);
+  const isSearchActive = normalizedQuery !== null;
+  const order = orderForInboxFilter(isSearchActive ? "inbox" : input.filterId);
   const projectionScanLimit = Math.min(INBOX_LIST_SCAN_LIMIT, input.limit + 1);
   type RepoFilter =
     | "visible"
@@ -2987,34 +2988,39 @@ async function readInboxListCacheData(input: {
     | "follow-up"
     | "sent"
     | "archived";
-  const loadProjectionRows = (filter: RepoFilter) =>
-    normalizedQuery === null
+  const loadProjectionRows = (filter: RepoFilter) => {
+    const effectiveProjectId = isSearchActive ? null : input.projectId;
+
+    return normalizedQuery === null
       ? runtime.repositories.inboxProjection.listPageOrderedByRecency({
           filter,
           order,
           limit: projectionScanLimit,
           cursor: null,
-          projectId: input.projectId,
+          projectId: effectiveProjectId,
         })
       : runtime.repositories.inboxProjection
           .searchPageOrderedByRecency({
-            // Search-bypass: when the operator types a query, the Inbox
-            // filter widens to "visible" so non-1:1 contacts (the ~4000
-            // hidden by lastInboundAt IS NOT NULL) become findable by name.
-            // Other filters keep their semantics.
-            filter: filter === "inbox" ? "visible" : filter,
+            // Search-bypass: a typed query searches the full visible inbox,
+            // ignoring the currently selected state/project facets.
+            filter: "visible",
             order,
             limit: projectionScanLimit,
             cursor: null,
             query: normalizedQuery,
-            projectId: input.projectId,
+            projectId: effectiveProjectId,
           })
           .then((result) => result.rows);
+  };
   // The primary loader pulls only the active filter slice. Counts come from
   // the aggregate repo method below, so opening a conversation does not hydrate
   // unrelated inbox or archived rows.
   const primaryFilterForLoader: RepoFilter =
-    input.filterId === "unread" ? "inbox" : input.filterId;
+    isSearchActive
+      ? "visible"
+      : input.filterId === "unread"
+        ? "inbox"
+        : input.filterId;
   const [
     visibleProjections,
     projectionCounts,
@@ -3034,7 +3040,11 @@ async function readInboxListCacheData(input: {
   const activeProjects: readonly InboxActiveProjectOption[] =
     activeProjectRecords.map((record) => ({
       id: record.projectId,
-      name: record.projectName,
+      name:
+        record.projectAlias?.trim().length &&
+        record.projectAlias.trim().length > 0
+          ? record.projectAlias.trim()
+          : record.projectName,
       alias:
         record.projectAlias?.trim().length &&
         record.projectAlias.trim().length > 0
@@ -3175,7 +3185,7 @@ async function readInboxListCacheData(input: {
     )
     .filter((item) =>
       matchesServerFilter(item, input.filterId, {
-        bypassInboxScope: normalizedQuery !== null,
+        bypassAllFilters: isSearchActive,
       }),
     )
     .sort(
@@ -4120,9 +4130,14 @@ function matchesServerFilter(
   item: InboxListItemViewModel,
   filterId: InboxFilterId,
   input?: {
+    readonly bypassAllFilters?: boolean;
     readonly bypassInboxScope?: boolean;
   },
 ): boolean {
+  if (input?.bypassAllFilters === true) {
+    return !item.isArchived;
+  }
+
   if (item.isArchived) {
     return filterId === "archived";
   }
@@ -4186,7 +4201,7 @@ export async function getInboxList(
   return {
     items: items.filter((item) =>
       matchesServerFilter(item, filterId, {
-        bypassInboxScope: (input.query?.trim().length ?? 0) > 0,
+        bypassAllFilters: (input.query?.trim().length ?? 0) > 0,
       }),
     ),
     filters,

--- a/apps/web/tests/unit/inbox-list-shell.test.tsx
+++ b/apps/web/tests/unit/inbox-list-shell.test.tsx
@@ -582,7 +582,7 @@ describe("Inbox list shell", () => {
     });
 
     await act(async () => {
-      findButtonByText(document.body, "Pacific Northwest Biodiversity Survey").click();
+      findButtonByText(document.body, "PNW Biodiversity").click();
       await Promise.resolve();
     });
     await flushReact();
@@ -590,6 +590,40 @@ describe("Inbox list shell", () => {
     expect(findButtonByLabel(session.container, "Filters").getAttribute("aria-expanded")).toBe(
       "true",
     );
+  });
+
+  it("keeps the current typed search query when project changes update the URL", async () => {
+    fetchInboxListPageMock.mockResolvedValue(buildPnwProjectList());
+    activeSession = await mountInboxList(buildPnwProjectList(), {
+      query: "darrel",
+      isQueueLoading: false,
+    });
+    const session = activeSession;
+
+    await act(async () => {
+      findButtonByLabel(session.container, "Filters").click();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      findButtonByText(session.container, "All projects").click();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      findButtonByText(document.body, "PNW Biodiversity").click();
+      await Promise.resolve();
+    });
+
+    expect(routerReplaceMock).toHaveBeenLastCalledWith(
+      "/inbox?q=darrel&projectId=project-pnw",
+      { scroll: false },
+    );
+    expect(
+      session.container.querySelector<HTMLInputElement>(
+        "[data-inbox-search-input='true']",
+      )?.value,
+    ).toBe("darrel");
   });
 
   it("replaces the clear-search control with a spinner while search is loading", async () => {
@@ -665,6 +699,22 @@ describe("Inbox list shell", () => {
       ),
     ).toBeNull();
     expect(activeSession.container.textContent).toContain("Riley Carter");
+  });
+
+  it("does not write below-threshold search text into the URL", async () => {
+    fetchInboxListPageMock.mockResolvedValue(buildList());
+    activeSession = await mountInboxList(buildList(), {
+      query: "da",
+      isQueueLoading: false,
+    });
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 450));
+    });
+
+    expect(routerReplaceMock).not.toHaveBeenCalledWith(
+      "/inbox?q=da",
+      expect.anything(),
+    );
   });
 
   it("renders the primary project chip without the overflow count badge", async () => {

--- a/apps/web/tests/unit/inbox-search-sync.test.ts
+++ b/apps/web/tests/unit/inbox-search-sync.test.ts
@@ -8,6 +8,7 @@ describe("inbox search sync", () => {
       shouldApplyUrlSearchQuery({
         urlQuery: "",
         previousUrlQuery: "",
+        currentQuery: "",
       }),
     ).toBe(false);
   });
@@ -17,7 +18,18 @@ describe("inbox search sync", () => {
       shouldApplyUrlSearchQuery({
         urlQuery: "alex",
         previousUrlQuery: "",
+        currentQuery: "",
       }),
     ).toBe(true);
+  });
+
+  it("does not apply stale delayed URL writes over newer local input", () => {
+    expect(
+      shouldApplyUrlSearchQuery({
+        urlQuery: "d",
+        previousUrlQuery: "",
+        currentQuery: "darrel",
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -770,6 +770,31 @@ describe("real inbox selectors", () => {
     });
   });
 
+  it("uses project aliases in inbox project filter options", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await runtime.context.repositories.projectDimensions.upsert({
+      projectId: "project:killer-whales",
+      projectName: "Searching For Killer Whales 2025/2026",
+      projectAlias: "Killer Whales",
+      source: "salesforce",
+      isActive: true,
+    });
+
+    const list = await getInboxList();
+    const project = list.activeProjects.find(
+      (option) => option.id === "project:killer-whales",
+    );
+
+    expect(project).toMatchObject({
+      id: "project:killer-whales",
+      name: "Killer Whales",
+      alias: "Killer Whales",
+    });
+  });
+
   it("keeps one-to-one SMS visible in the timeline regardless of SMS compose availability", async () => {
     const originalSmsEnabled = process.env.SMS_ENABLED;
     process.env.SMS_ENABLED = "false";
@@ -6046,18 +6071,26 @@ describe("real inbox selectors", () => {
     ]);
   });
 
-  it("composes search with unread and follow-up filters", async () => {
+  it("ignores state and project facets while searching", async () => {
     const unread = await getInboxList("unread", {
-      query: "sarah@example.org",
+      query: "Alex Thompson",
     });
     const followUp = await getInboxList("follow-up", {
-      query: "Sarah",
+      query: "Alex Thompson",
     });
+    const projectFiltered = await getInboxList("inbox", {
+      query: "Alex Thompson",
+      projectId: "project:amazon-basin",
+    });
+
     expect(unread.items.map((item) => item.contactId)).toEqual([
-      "contact:sarah-martinez",
+      "contact:alex-thompson",
     ]);
     expect(followUp.items.map((item) => item.contactId)).toEqual([
-      "contact:sarah-martinez",
+      "contact:alex-thompson",
+    ]);
+    expect(projectFiltered.items.map((item) => item.contactId)).toEqual([
+      "contact:alex-thompson",
     ]);
   });
 


### PR DESCRIPTION
## Summary
- Search now ignores active inbox state/project facets and reads the full visible inbox when a query is present.
- Project filter labels prefer project aliases in selector output and filter controls.
- Search input URL syncing no longer overwrites newer local typing or triggers route refreshes while typing.

## Checks
- pnpm --filter @as-comms/web typecheck
- pnpm --filter @as-comms/web lint
- pnpm --filter @as-comms/db typecheck
- pnpm --filter @as-comms/web test:unit tests/unit/inbox-selectors.test.ts
- pnpm --filter @as-comms/web test:unit tests/unit/inbox-list-shell.test.tsx tests/unit/inbox-search-sync.test.ts

## Browser QA
- Started @as-comms/web on 127.0.0.1:3101 with Homebrew Node 24.
- Used dev auth for nico@adventurescientists.org.
- Verified project labels show aliases: PNW Biodiversity, Killer Whales, Whitebark Pine.
- Verified search input preserves "darrel" during slow and fast typing.
- Verified Darrel Robertson appears for search while a Killer Whales project URL is active.
- No current-tab console errors after final reload; earlier local DB ECONNRESET errors occurred during hot reload/slow DB attempts and recovered on retry.