### PR TITLE
fix(inbox): polish trust formatting and settings qa

### DIFF
--- a/apps/web/app/inbox/_lib/message-formatting.ts
+++ b/apps/web/app/inbox/_lib/message-formatting.ts
@@ -16,6 +16,10 @@ const PREVIEW_NOISE_THRESHOLD = 0.3;
 const PREVIEW_NOISE_MIN_LENGTH = 32;
 const SHORT_PREVIEW_NOISE_MIN_SUSPICIOUS = 3;
 const REPLACEMENT_CHARACTER = "�";
+const WORD_JOINED_CONTROL_PATTERN = /([\p{L}\p{N}])[\u0018\u0019]([\p{L}\p{N}])/gu;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g;
+const GLUED_SIGN_OFF_PATTERN =
+  /([\p{Ll}\p{N}])((?:Best|Thanks|Warmly|Cheers|Sincerely|Regards|Saludos)\b,?)/gu;
 
 const STRUCTURED_EMAIL_TRANSLATION_MARKER_PATTERN =
   /\b(?:en|es|fr|de|pt):(?=[A-ZÀ-Ý])/g;
@@ -41,7 +45,9 @@ const STRUCTURED_EMAIL_PARAGRAPH_STARTERS = [
 const SIGNATURE_SEPARATOR_PATTERN = /^(?:---|--\s)$/;
 const SENT_WITH_SIGNATURE_PATTERN = /^Sent with\b/i;
 const SIGN_OFF_PREFIX_PATTERN =
-  /^(?:Best|Thanks|Warmly|Cheers|Sincerely|Saludos),/i;
+  /^(?:Best|Thanks|Warmly|Cheers|Sincerely|Regards|Saludos),?/i;
+const HTML_TAG_PATTERN = /<\/?[a-z][\w:-]*(?:\s[^>]*)?>/i;
+const HTML_TAG_GLOBAL_PATTERN = /<\/?[a-z][\w:-]*(?:\s[^>]*)?>/gi;
 
 const MIME_HEADER_LINE_PATTERN =
   /^(Content-Type|Content-Transfer-Encoding|Content-Disposition|MIME-Version|charset|boundary|name|filename):/i;
@@ -74,8 +80,18 @@ export function normalizeInlineText(
     return null;
   }
 
-  const normalized = value.replace(/\s+/g, " ").trim();
+  const normalized = normalizeDisplayTextArtifacts(value)
+    .replace(/\s+/g, " ")
+    .trim();
   return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeDisplayTextArtifacts(value: string): string {
+  return value
+    .replace(WORD_JOINED_CONTROL_PATTERN, "$1'$2")
+    .replace(CONTROL_CHARACTER_PATTERN, " ")
+    .replace(new RegExp(REPLACEMENT_CHARACTER, "g"), "\n")
+    .replace(GLUED_SIGN_OFF_PATTERN, "$1\n$2");
 }
 
 function decodeHtmlEntities(value: string): string {
@@ -154,7 +170,7 @@ export function stripMimeScaffolding(value: string): string {
 
 export function sanitizePreviewText(value: string): string {
   const mimeAware = stripMimeScaffolding(decodeQuotedPrintable(value));
-  const htmlAware = /<[^>]+>/.test(mimeAware)
+  const htmlAware = HTML_TAG_PATTERN.test(mimeAware)
     ? mimeAware
         .replace(/<\s*br\s*\/?>/gi, "\n")
         .replace(
@@ -163,10 +179,10 @@ export function sanitizePreviewText(value: string): string {
         )
         .replace(/<li[^>]*>/gi, "- ")
         .replace(/<\/li\s*>/gi, "\n")
-        .replace(/<[^>]+>/g, " ")
+        .replace(HTML_TAG_GLOBAL_PATTERN, " ")
     : mimeAware;
 
-  return decodeHtmlEntities(htmlAware)
+  return normalizeDisplayTextArtifacts(decodeHtmlEntities(htmlAware))
     .replace(/\r\n?/g, "\n")
     .replace(/[ \t]+\n/g, "\n")
     .replace(/\n[ \t]+/g, "\n")
@@ -205,6 +221,18 @@ function isLikelyPreviewNoise(value: string): boolean {
   }
 
   const ratio = suspicious / total;
+  const shortFragments = normalized
+    .split(/\s+/)
+    .filter((fragment) => fragment.length > 0 && fragment.length <= 2);
+  const asciiLetterCount = normalized.match(/[A-Za-z]/g)?.length ?? 0;
+
+  if (
+    total < PREVIEW_NOISE_MIN_LENGTH &&
+    shortFragments.length >= 4 &&
+    asciiLetterCount <= 5
+  ) {
+    return true;
+  }
 
   if (total < PREVIEW_NOISE_MIN_LENGTH) {
     return (
@@ -468,7 +496,7 @@ export function stripSignature(body: string): string {
   }
 
   const inlineClosingMatch =
-    /([.!?])\s*(?:Best|Thanks|Warmly|Cheers|Sincerely|Saludos),\s*(?:[A-ZÀ-Ý][A-Za-zÀ-ÿ'’.&-]*(?:\s+[A-ZÀ-Ý][A-Za-zÀ-ÿ'’.&-]*){0,4})?\s*$/iu.exec(
+    /([.!?])\s*(?:Best|Thanks|Warmly|Cheers|Sincerely|Regards|Saludos),?\s*(?:[A-ZÀ-Ý][A-Za-zÀ-ÿ'’.&-]*(?:\s+[A-ZÀ-Ý][A-Za-zÀ-ÿ'’.&-]*){0,4})?\s*$/iu.exec(
       normalized,
     );
 
@@ -480,7 +508,7 @@ export function stripSignature(body: string): string {
   }
 
   const trailingSignatureMatch =
-    /\n+\s*(?:Best|Thanks|Warmly|Cheers|Sincerely|Saludos),\s*(?:[A-ZÀ-Ý][A-Za-zÀ-ÿ'’.&-]*(?:\s+[A-ZÀ-Ý][A-Za-zÀ-ÿ'’.&-]*){0,4})?\s*$/iu.exec(
+    /\n+\s*(?:Best|Thanks|Warmly|Cheers|Sincerely|Regards|Saludos),?\s*(?:[A-ZÀ-Ý][A-Za-zÀ-ÿ'’.&-]*(?:\s+[A-ZÀ-Ý][A-Za-zÀ-ÿ'’.&-]*){0,4})?\s*$/iu.exec(
       normalized,
     );
 
@@ -508,11 +536,21 @@ export function parseCommunicationPreview(raw: string): ParsedPreview {
   }
 
   const structuredEmail = STRUCTURED_EMAIL_HEADER_PATTERN.test(sanitized);
-  const fromMatch = FROM_HEADER_PATTERN.exec(sanitized);
-  const recipientsMatch = RECIPIENTS_HEADER_PATTERN.exec(sanitized);
-  const ccMatch = CC_HEADER_PATTERN.exec(sanitized);
-  const bccMatch = BCC_HEADER_PATTERN.exec(sanitized);
-  const replyToMatch = REPLY_TO_HEADER_PATTERN.exec(sanitized);
+  const forwardedHeaderBlockStart = findForwardedHeaderBlockStart(sanitized);
+  const headerMetadataAllowed = forwardedHeaderBlockStart <= 0;
+  const fromMatch = headerMetadataAllowed
+    ? FROM_HEADER_PATTERN.exec(sanitized)
+    : null;
+  const recipientsMatch = headerMetadataAllowed
+    ? RECIPIENTS_HEADER_PATTERN.exec(sanitized)
+    : null;
+  const ccMatch = headerMetadataAllowed ? CC_HEADER_PATTERN.exec(sanitized) : null;
+  const bccMatch = headerMetadataAllowed
+    ? BCC_HEADER_PATTERN.exec(sanitized)
+    : null;
+  const replyToMatch = headerMetadataAllowed
+    ? REPLY_TO_HEADER_PATTERN.exec(sanitized)
+    : null;
   const subjectMatch = SUBJECT_HEADER_PATTERN.exec(sanitized);
   const subject = normalizeInlineText(subjectMatch?.[1] ?? null);
   const fromAddresses = extractEmailAddresses(fromMatch?.[1]);

--- a/apps/web/app/settings/_components/integrations-section.tsx
+++ b/apps/web/app/settings/_components/integrations-section.tsx
@@ -102,18 +102,18 @@ function formatMailchimpStatus(
   switch (integration.mailchimp?.status) {
     case "connected":
       return {
-        label: "✓ Connected",
+        label: "Connected",
         colorClasses: "bg-emerald-50 text-emerald-700 ring-emerald-200"
       };
     case "stale":
       return {
-        label: "✗ Stale",
+        label: "Sync stale",
         colorClasses: "bg-rose-50 text-rose-700 ring-rose-200"
       };
     case "unconfigured":
     default:
       return {
-        label: "⚠ Unconfigured",
+        label: "Not configured",
         colorClasses: "bg-amber-50 text-amber-800 ring-amber-200"
       };
   }

--- a/apps/web/app/settings/_components/projects-section.tsx
+++ b/apps/web/app/settings/_components/projects-section.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { FolderOpen, Pencil, Plus } from "lucide-react";
+import { FolderOpen, Plus } from "lucide-react";
 
 import {
   FOCUS_RING,
@@ -87,21 +87,6 @@ export function ProjectsSection({
                   colorClasses="bg-emerald-50 text-emerald-700 ring-emerald-200"
                   variant="soft"
                 />
-              )}
-              renderAction={(project) => (
-                <Link
-                  href={`/settings/projects/${encodeURIComponent(project.projectId)}`}
-                  aria-label={`Open ${project.projectName}`}
-                  className={cn(
-                    "flex size-8 shrink-0 items-center justify-center",
-                    RADIUS.sm,
-                    "text-slate-400 hover:bg-slate-100 hover:text-slate-700",
-                    TRANSITION.fast,
-                    FOCUS_RING
-                  )}
-                >
-                  <Pencil className="size-4" aria-hidden="true" />
-                </Link>
               )}
             />
           </div>

--- a/apps/web/src/server/settings/selectors.ts
+++ b/apps/web/src/server/settings/selectors.ts
@@ -199,8 +199,8 @@ const LOGS_PAGE_SIZE = 25;
 const LOG_STREAMS: readonly LogStreamDescriptorViewModel[] = [
   {
     id: DEFAULT_LOG_STREAM_ID,
-    label: "Source-evidence quarantines",
-    description: "Checksum collisions for provider idempotency keys."
+    label: "Source-evidence duplicates",
+    description: "Provider replay collisions kept out of canonical history."
   }
 ];
 const PROVIDER_LABEL: Record<Provider, string> = {
@@ -402,7 +402,7 @@ function buildSourceEvidenceCollisionSummary(
   detail: SourceEvidenceCollisionDetailViewModel
 ): string {
   const checksumCount = detail.losing.length + 1;
-  return `${PROVIDER_LABEL[detail.provider]} • ${String(checksumCount)} different checksums for idempotency key ${detail.idempotencyKey}`;
+  return `${PROVIDER_LABEL[detail.provider]} • ${String(checksumCount)} payload versions for one idempotency key; canonical winner preserved`;
 }
 
 function hasActivationRequirements(input: {

--- a/apps/web/tests/unit/inbox-message-formatting.test.ts
+++ b/apps/web/tests/unit/inbox-message-formatting.test.ts
@@ -125,4 +125,21 @@ describe("inbox message formatting", () => {
       "Ready =ZZ still visible",
     );
   });
+
+  it("normalizes control characters and glued sign-offs in previews", () => {
+    expect(sanitizePreviewText("I don\u0019t see raw controls.")).toBe(
+      "I don't see raw controls.",
+    );
+
+    const resolved = resolvePreferredMessagePreview({
+      rawCandidates: [
+        "Please can you send me a link to log inRegards�Tony Hoult�",
+      ],
+    });
+
+    expect(resolved.body).toBe(
+      "Please can you send me a link to log in",
+    );
+    expect(resolved.body).not.toContain("�");
+  });
 });

--- a/apps/web/tests/unit/settings-projects-section.test.tsx
+++ b/apps/web/tests/unit/settings-projects-section.test.tsx
@@ -1,0 +1,89 @@
+import * as React from "react";
+import { createElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+Object.assign(globalThis, { React });
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    readonly children: ReactNode;
+    readonly href: string;
+  }) => createElement("a", { href, ...props }, children),
+}));
+
+vi.mock("lucide-react", () => ({
+  FolderOpen: () => null,
+  Plus: () => null,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: {
+    readonly children: ReactNode;
+  }) => createElement("button", props, children),
+}));
+
+vi.mock("@/components/ui/status-badge", () => ({
+  StatusBadge: ({ label }: { readonly label: string }) =>
+    createElement("span", null, label),
+}));
+
+vi.mock("../../app/settings/_components/activation-wizard", () => ({
+  ActivationWizard: () => null,
+}));
+
+import { ProjectsSection } from "../../app/settings/_components/projects-section";
+import type { ProjectsSettingsViewModel } from "../../src/server/settings/selectors";
+
+describe("ProjectsSection accessibility", () => {
+  it("renders one project-detail link per active project", () => {
+    const viewModel: ProjectsSettingsViewModel = {
+      isAdmin: true,
+      active: [
+        {
+          projectId: "project:one",
+          projectName: "Orca Soundwatch",
+          suggestedAlias: "Orca Soundwatch",
+          projectAlias: "orca",
+          isActive: true,
+          primaryEmail: "orca@example.org",
+          emailAliases: ["orca@example.org"],
+          additionalEmailCount: 0,
+          aiKnowledgeUrl: null,
+          aiKnowledgeSyncedAt: null,
+          hasCachedAiKnowledge: false,
+          memberCount: 3,
+          activationRequirementsMet: true,
+        },
+      ],
+      inactive: [],
+      counts: {
+        active: 1,
+        inactive: 0,
+        total: 1,
+      },
+    };
+
+    const html = renderToStaticMarkup(
+      createElement(ProjectsSection, { viewModel }),
+    );
+
+    expect(
+      html.match(/href="\/settings\/projects\/project%3Aone"/g),
+    ).toHaveLength(1);
+    expect(html.match(/aria-label="Open Orca Soundwatch"/g)).toHaveLength(1);
+  });
+});

--- a/apps/web/tests/unit/settings-selectors.test.ts
+++ b/apps/web/tests/unit/settings-selectors.test.ts
@@ -794,8 +794,8 @@ describe("settings selectors", () => {
     expect(viewModel.streams).toEqual([
       {
         id: "source-evidence-quarantine",
-        label: "Source-evidence quarantines",
-        description: "Checksum collisions for provider idempotency keys."
+        label: "Source-evidence duplicates",
+        description: "Provider replay collisions kept out of canonical history."
       }
     ]);
     expect(viewModel.activeStreamId).toBe("source-evidence-quarantine");
@@ -804,7 +804,7 @@ describe("settings selectors", () => {
       streamId: "source-evidence-quarantine",
       timestamp: "2026-04-20T14:05:00.000Z",
       summary:
-        "Gmail • 2 different checksums for idempotency key gmail:collision:newer",
+        "Gmail • 2 payload versions for one idempotency key; canonical winner preserved",
       detail: {
         provider: "gmail",
         idempotencyKey: "gmail:collision:newer",


### PR DESCRIPTION
## Summary
- normalize inbox preview display artifacts and glued sign-offs
- remove duplicate active-project detail link in Settings
- soften source-evidence/integration status wording
- add focused regression tests

## Checks
- pnpm --filter @as-comms/web typecheck
- pnpm --filter @as-comms/web lint
- pnpm --filter @as-comms/db typecheck
- pnpm --filter @as-comms/web test:unit tests/unit/inbox-message-formatting.test.ts tests/unit/settings-projects-section.test.tsx tests/unit/settings-selectors.test.ts
- pnpm --filter @as-comms/web test:unit tests/unit/inbox-selectors.test.ts

## QA
- Browser QA was blocked for Agent 3 by local listen EPERM, so this PR relies on focused unit coverage plus typecheck/lint.