### PR TITLE
[codex] Stabilize inbox lifecycle and settings trust

### DIFF
--- a/apps/web/app/inbox/_components/_autolink.tsx
+++ b/apps/web/app/inbox/_components/_autolink.tsx
@@ -46,10 +46,7 @@ function splitTrailingPunctuation(segment: string): {
   };
 }
 
-export function autolinkText(
-  body: string,
-  linkClassName?: string,
-): ReactNode {
+export function autolinkText(body: string, linkClassName?: string): ReactNode {
   return renderLinks(body, linkClassName);
 }
 
@@ -179,10 +176,7 @@ function findParentheticalLabel(
   openParenthesisIndex: number,
 ): { start: number; text: string } | null {
   const labelEnd = openParenthesisIndex - 1;
-  const searchStart = Math.max(
-    0,
-    labelEnd - MAX_PARENTHETICAL_LABEL_LOOKBACK,
-  );
+  const searchStart = Math.max(0, labelEnd - MAX_PARENTHETICAL_LABEL_LOOKBACK);
 
   for (let index = labelEnd - 1; index >= searchStart; index -= 1) {
     const boundaryStart = getBoundaryStart(segment, index, labelEnd);
@@ -309,7 +303,7 @@ function renderLink(
         href={href}
         target="_blank"
         rel="noopener noreferrer"
-        className={cn(linkClassName, LINK_CLASS_NAME)}
+        className={cn(LINK_CLASS_NAME, linkClassName)}
       >
         {label}
       </a>

--- a/apps/web/app/inbox/_components/inbox-loading.tsx
+++ b/apps/web/app/inbox/_components/inbox-loading.tsx
@@ -1,8 +1,9 @@
 import { Skeleton } from "@/components/ui/skeleton";
-import { SPACING, TONE } from "@/app/_lib/design-tokens";
+import { SPACING } from "@/app/_lib/design-tokens";
 import { LAYOUT } from "@/app/_lib/design-tokens-v2";
 import {
   EMAIL_BUBBLE_MAX_W,
+  SMS_BUBBLE_MAX_W,
   TIMELINE_GRID_COLUMNS,
   TIMELINE_OUTER_MAX_W,
 } from "./inbox-timeline-bubble";
@@ -195,10 +196,38 @@ export function InboxDetailLoading() {
       aria-label="Loading conversation history"
     >
       <section className="flex min-w-0 flex-1 flex-col border-r border-slate-200 bg-white">
+        <header
+          className={`flex ${LAYOUT.headerHeight} shrink-0 items-center justify-between gap-4 border-b border-slate-200 px-5`}
+        >
+          <div className="flex min-w-0 items-center gap-3.5">
+            <Skeleton className="size-7 shrink-0 rounded-full bg-slate-200/80" />
+            <div className="min-w-0 space-y-1.5">
+              <Skeleton className="h-4 w-40 max-w-[42vw] bg-slate-200/80" />
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-3 w-32 bg-slate-200/70" />
+                <Skeleton className="h-5 w-16 rounded-full bg-slate-200/70" />
+              </div>
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <Skeleton className="size-8 rounded-md bg-slate-200/70" />
+            <Skeleton className="size-8 rounded-md bg-slate-200/70" />
+            <Skeleton className="size-8 rounded-md bg-slate-200/70" />
+          </div>
+        </header>
         <div
-          className={`min-h-0 flex-1 overflow-y-auto ${TONE.slate.subtle} ${SPACING.container}`}
+          className={`min-h-0 flex-1 overflow-y-auto bg-slate-50/40 ${SPACING.container}`}
         >
           <TimelineSkeleton />
+        </div>
+        <div className="shrink-0 border-t border-slate-200 bg-white px-5 py-3">
+          <div className="flex items-center justify-between gap-3 rounded-lg bg-slate-50 px-3 py-2">
+            <div className="min-w-0 space-y-1.5">
+              <Skeleton className="h-3.5 w-48 max-w-full bg-slate-200/70" />
+              <Skeleton className="h-3 w-32 max-w-full bg-slate-200/60" />
+            </div>
+            <Skeleton className="h-8 w-24 shrink-0 rounded-md bg-slate-200/70" />
+          </div>
         </div>
       </section>
     </div>
@@ -211,15 +240,24 @@ export function InboxDetailLoading() {
  */
 export function QueueRowSkeleton() {
   return (
-    <div className={`flex gap-3 border-b border-slate-100 ${SPACING.listItem}`}>
-      <Skeleton className="size-10 shrink-0 rounded-full" />
-      <div className="min-w-0 flex-1 space-y-2">
+    <div
+      className={`flex min-h-[88px] gap-3 border-b border-slate-100 ${SPACING.listItem}`}
+    >
+      <Skeleton className="size-9 shrink-0 rounded-full bg-slate-200/80" />
+      <div className="min-w-0 flex-1">
         <div className="flex items-center justify-between gap-2">
-          <Skeleton className="h-3.5 w-28" />
-          <Skeleton className="h-3 w-12" />
+          <Skeleton className="h-3.5 w-36 bg-slate-200/80" />
+          <Skeleton className="h-3 w-11 shrink-0 bg-slate-200/70" />
         </div>
-        <Skeleton className="h-3 w-full" />
-        <Skeleton className="h-2.5 w-3/4" />
+        <div className="mt-2 flex items-center gap-1.5">
+          <Skeleton className="size-3 shrink-0 rounded-sm bg-slate-200/70" />
+          <Skeleton className="h-3 w-40 max-w-[72%] bg-slate-200/70" />
+        </div>
+        <Skeleton className="mt-2 h-2.5 w-52 max-w-[86%] bg-slate-200/60" />
+        <div className="mt-2 flex items-center gap-1.5">
+          <Skeleton className="h-5 w-20 rounded bg-slate-200/60" />
+          <Skeleton className="h-5 w-16 rounded bg-slate-200/50" />
+        </div>
       </div>
     </div>
   );
@@ -258,14 +296,7 @@ export function QueueLoadMoreSkeleton({
     <div className="pt-3" role="status" aria-label="Loading more conversations">
       <div className="space-y-0">
         {Array.from({ length: rowCount }).map((_, i) => (
-          <div key={i} className="flex gap-3 px-4 py-3">
-            <Skeleton className="size-9 shrink-0 rounded-full" />
-            <div className="min-w-0 flex-1 space-y-1.5">
-              <Skeleton className="h-3 w-32" />
-              <Skeleton className="h-3 w-48 max-w-full" />
-              <Skeleton className="h-3 w-40 max-w-full" />
-            </div>
-          </div>
+          <QueueRowSkeleton key={i} />
         ))}
       </div>
     </div>
@@ -278,24 +309,24 @@ export function TimelineSkeleton() {
       <div
         className={`mx-auto grid w-full gap-x-2.5 gap-y-3 ${TIMELINE_OUTER_MAX_W} ${TIMELINE_GRID_COLUMNS}`}
       >
-        <TimelineBubbleSkeleton
+        <TimelineEmailBubbleSkeleton
           direction="inbound"
           lineWidths={["w-full", "w-5/6", "w-3/4"]}
         />
-        <TimelineBubbleSkeleton
+        <TimelineSmsBubbleSkeleton
           direction="outbound"
-          lineWidths={["w-full", "w-5/6", "w-2/3"]}
+          lineWidths={["w-11/12", "w-3/4"]}
         />
         <li className={`col-span-3 grid ${TIMELINE_GRID_COLUMNS}`}>
           <div className="col-start-2 flex py-1">
-            <div className="inline-flex items-center rounded-full border border-slate-200 bg-white px-4 py-2">
-              <Skeleton className="h-3 w-40 rounded-full" />
+            <div className="inline-flex items-center rounded-full border border-slate-200 bg-white px-4 py-2 shadow-sm">
+              <Skeleton className="h-3 w-40 rounded-full bg-slate-200/70" />
             </div>
           </div>
         </li>
-        <TimelineBubbleSkeleton
+        <TimelineSmsBubbleSkeleton
           direction="inbound"
-          lineWidths={["w-full", "w-4/5", "w-3/5"]}
+          lineWidths={["w-4/5", "w-3/5"]}
         />
       </div>
       <span className="sr-only">Loading conversation...</span>
@@ -303,7 +334,7 @@ export function TimelineSkeleton() {
   );
 }
 
-function TimelineBubbleSkeleton({
+function TimelineEmailBubbleSkeleton({
   direction,
   lineWidths,
 }: {
@@ -321,24 +352,79 @@ function TimelineBubbleSkeleton({
             : "col-start-3 flex justify-center"
         }`}
       >
-        <div aria-hidden="true" className="size-9 rounded-full bg-slate-200" />
+        <Skeleton
+          aria-hidden="true"
+          className="size-8 rounded-full bg-slate-200/80"
+        />
       </div>
       <div
         className={`col-start-2 ${
           isInbound ? "justify-self-start" : "justify-self-end"
-        } ${EMAIL_BUBBLE_MAX_W}`}
+        } w-full ${EMAIL_BUBBLE_MAX_W}`}
       >
-        <div className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 shadow-sm">
-          <div className="space-y-2">
+        <div className="w-full overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+          <div className="border-b border-slate-100 px-4 py-2.5">
+            <Skeleton className="h-3 w-44 max-w-full bg-slate-200/70" />
+          </div>
+          <div className="space-y-2 px-4 py-3">
             {lineWidths.map((width, index) => (
               <Skeleton
                 key={`${direction}-${index.toString()}`}
-                className={`h-3 ${width}`}
+                className={`h-3 ${width} bg-slate-200/70`}
               />
             ))}
           </div>
         </div>
       </div>
+    </li>
+  );
+}
+
+function TimelineSmsBubbleSkeleton({
+  direction,
+  lineWidths,
+}: {
+  readonly direction: "inbound" | "outbound";
+  readonly lineWidths: readonly string[];
+}) {
+  const isInbound = direction === "inbound";
+
+  return (
+    <li className={`col-span-3 grid ${TIMELINE_GRID_COLUMNS}`}>
+      <div aria-hidden="true" />
+      <div
+        className={`col-start-2 min-w-0 ${
+          isInbound ? "justify-self-start" : "justify-self-end"
+        } w-full ${SMS_BUBBLE_MAX_W}`}
+      >
+        <div className="mb-1 px-1">
+          <Skeleton className="h-3 w-10 bg-slate-200/70" />
+        </div>
+        <div
+          className={`w-full rounded-2xl border px-4 py-3 shadow-sm ${
+            isInbound
+              ? "rounded-bl-md border-slate-200 bg-white"
+              : "rounded-br-md border-sky-200 bg-sky-50"
+          }`}
+        >
+          <div className="space-y-2">
+            {lineWidths.map((width, index) => (
+              <Skeleton
+                key={`${direction}-sms-${index.toString()}`}
+                className={`h-3 ${width} ${
+                  isInbound ? "bg-slate-200/70" : "bg-sky-200/70"
+                }`}
+              />
+            ))}
+          </div>
+          <Skeleton
+            className={`mt-3 h-3 w-16 ${
+              isInbound ? "bg-slate-200/60" : "bg-sky-200/60"
+            }`}
+          />
+        </div>
+      </div>
+      <div aria-hidden="true" />
     </li>
   );
 }

--- a/apps/web/app/inbox/_components/sms-message.tsx
+++ b/apps/web/app/inbox/_components/sms-message.tsx
@@ -14,6 +14,9 @@ import {
   RefreshCwIcon,
 } from "./icons";
 
+const SMS_OUTBOUND_LINK_CLASS_NAME =
+  "font-medium text-sky-800 underline decoration-sky-300 underline-offset-2 hover:text-sky-950 focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 [overflow-wrap:anywhere]";
+
 function StatusBanner({
   entry,
   isRetrying,
@@ -25,7 +28,7 @@ function StatusBanner({
 }) {
   if (entry.sendStatus === "pending") {
     return (
-      <div className="mb-2 inline-flex items-center gap-1 rounded-full bg-white/20 px-2 py-1 text-[11px] font-medium text-white/90">
+      <div className="mb-2 inline-flex items-center gap-1 rounded-full border border-sky-200 bg-white/70 px-2 py-1 text-[11px] font-medium text-sky-700">
         <LoaderIcon className="size-3 animate-spin" />
         Sending...
       </div>
@@ -37,7 +40,7 @@ function StatusBanner({
   }
 
   return (
-    <div className="mb-2 flex items-center justify-between gap-2 rounded-lg bg-white/12 px-2.5 py-2 text-[11px] text-white/90">
+    <div className="mb-2 flex items-center justify-between gap-2 rounded-lg border border-rose-200 bg-rose-50 px-2.5 py-2 text-[11px] text-rose-800">
       <span>
         {entry.sendStatus === "failed" ? "Send failed." : "Send stalled."}
       </span>
@@ -48,7 +51,7 @@ function StatusBanner({
             onRetryPending(entry.id);
           }}
           disabled={isRetrying}
-          className="inline-flex items-center gap-1 rounded-full bg-white/90 px-2 py-1 font-medium text-sky-700 disabled:opacity-60"
+          className="inline-flex items-center gap-1 rounded-full bg-white px-2 py-1 font-medium text-rose-800 shadow-sm hover:bg-rose-100 disabled:opacity-60"
         >
           {isRetrying ? (
             <LoaderIcon className="size-3 animate-spin" />
@@ -103,7 +106,7 @@ export function SmsMessage({
               SMS_BUBBLE_MAX_W,
               "rounded-2xl border px-4 py-3 shadow-sm",
               isOutbound
-                ? "rounded-br-md border-sky-600 bg-sky-600 text-white"
+                ? "rounded-br-md border-sky-200 bg-sky-50 text-slate-800"
                 : "rounded-bl-md border-slate-200 bg-white text-slate-900",
             )}
           >
@@ -118,20 +121,18 @@ export function SmsMessage({
             {entry.body.trim().length > 0 ? (
               <p
                 className={cn(
-                  "whitespace-pre-wrap text-[13px] leading-relaxed [overflow-wrap:anywhere]",
-                  isOutbound ? "text-white" : "text-slate-700",
+                  "whitespace-pre-wrap text-pretty text-[13px] leading-relaxed [overflow-wrap:anywhere]",
+                  isOutbound ? "text-slate-800" : "text-slate-700",
                 )}
               >
-                {autolinkText(entry.body)}
+                {autolinkText(
+                  entry.body,
+                  isOutbound ? SMS_OUTBOUND_LINK_CLASS_NAME : undefined,
+                )}
               </p>
             ) : null}
 
-            <div
-              className={cn(
-                "mt-2 text-[11px]",
-                isOutbound ? "text-white/75" : "text-slate-500",
-              )}
-            >
+            <div className="mt-2 text-[11px] text-slate-500">
               {entry.occurredAtLabel}
             </div>
           </div>

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -300,6 +300,24 @@ function uniqueStrings(
   );
 }
 
+function uniqueInboxProjectionsByContactId(
+  rows: readonly InboxProjectionRow[],
+): InboxProjectionRow[] {
+  const seen = new Set<string>();
+  const uniqueRows: InboxProjectionRow[] = [];
+
+  for (const row of rows) {
+    if (seen.has(row.contactId)) {
+      continue;
+    }
+
+    seen.add(row.contactId);
+    uniqueRows.push(row);
+  }
+
+  return uniqueRows;
+}
+
 function isInboundInboxEvent(
   eventType: CanonicalEventRecord["eventType"],
 ): boolean {
@@ -468,6 +486,8 @@ function campaignActivitySummaryKey(
       return "clickedAt";
     case "unsubscribed":
       return "unsubscribedAt";
+    default:
+      return "sentAt";
   }
 }
 
@@ -538,6 +558,7 @@ async function loadCampaignActivitySummaryByCampaignId(input: {
 }
 
 function encodeInboxListCursor(input: {
+  readonly lastInboundAt: string | null;
   readonly lastNonAliasMessageAt: string | null;
   readonly lastOutboundAt: string | null;
   readonly lastActivityAt: string;
@@ -547,6 +568,7 @@ function encodeInboxListCursor(input: {
 }
 
 function decodeInboxListCursor(cursor: string | null): {
+  readonly lastInboundAt: string | null;
   readonly lastNonAliasMessageAt: string | null;
   readonly lastOutboundAt: string | null;
   readonly lastActivityAt: string;
@@ -560,18 +582,21 @@ function decodeInboxListCursor(cursor: string | null): {
     const parsed = JSON.parse(
       Buffer.from(cursor, "base64url").toString("utf8"),
     ) as Record<string, unknown>;
+    const lastInboundAt = parsed.lastInboundAt ?? null;
     const lastNonAliasMessageAt =
       parsed.lastNonAliasMessageAt ?? parsed.lastInboundAt;
     const lastOutboundAt = parsed.lastOutboundAt ?? null;
     const lastActivityAt = parsed.lastActivityAt;
     const contactId = parsed.contactId;
 
-    return (lastNonAliasMessageAt === null ||
-      typeof lastNonAliasMessageAt === "string") &&
+    return (lastInboundAt === null || typeof lastInboundAt === "string") &&
+      (lastNonAliasMessageAt === null ||
+        typeof lastNonAliasMessageAt === "string") &&
       (lastOutboundAt === null || typeof lastOutboundAt === "string") &&
       typeof lastActivityAt === "string" &&
       typeof contactId === "string"
       ? {
+          lastInboundAt,
           lastNonAliasMessageAt: lastNonAliasMessageAt ?? null,
           lastOutboundAt,
           lastActivityAt,
@@ -581,6 +606,26 @@ function decodeInboxListCursor(cursor: string | null): {
   } catch {
     return null;
   }
+}
+
+function toInboxRepositoryCursor(
+  cursor: ReturnType<typeof decodeInboxListCursor>,
+): {
+  readonly lastInboundAt: string | null;
+  readonly lastOutboundAt: string | null;
+  readonly lastActivityAt: string;
+  readonly contactId: string;
+} | null {
+  if (cursor === null) {
+    return null;
+  }
+
+  return {
+    lastInboundAt: cursor.lastInboundAt,
+    lastOutboundAt: cursor.lastOutboundAt,
+    lastActivityAt: cursor.lastActivityAt,
+    contactId: cursor.contactId,
+  };
 }
 
 function toInitials(displayName: string): string {
@@ -1286,6 +1331,10 @@ function timelineLifecycleBodyLabel(
       return context === null
         ? "Submitted first data"
         : `Submitted first data for ${context}`;
+    default:
+      return context === null
+        ? "Project activity"
+        : `Project activity for ${context}`;
   }
 }
 
@@ -1313,6 +1362,10 @@ function lifecycleRailActivityLabel(
       return projectContext === null
         ? "Submitted first data"
         : `Submitted first data - ${projectContext}`;
+    default:
+      return projectContext === null
+        ? "Project activity"
+        : `Project activity - ${projectContext}`;
   }
 }
 
@@ -1348,6 +1401,8 @@ function fallbackLatestSubject(eventType: CanonicalEventType): string {
       return "Campaign email unsubscribed";
     case "note.internal.created":
       return "Internal note created";
+    default:
+      return "Activity recorded";
   }
 }
 
@@ -1387,6 +1442,8 @@ function mapTimelineKind(item: TimelineItem): InboxTimelineEntryKind {
       return "internal-note";
     case "salesforce_event":
       return "system-event";
+    default:
+      return "system-event";
   }
 }
 
@@ -1406,6 +1463,49 @@ function inferPreviewDirection(
 
   const fromContact = preview.fromAddresses.includes(contactEmail);
   const recipientContact = preview.recipientAddresses.includes(contactEmail);
+
+  if (fromContact && !recipientContact) {
+    return "inbound";
+  }
+
+  if (recipientContact && !fromContact) {
+    return "outbound";
+  }
+
+  return null;
+}
+
+function participantHeaderEmails(
+  headerValue: string | null,
+): readonly string[] {
+  if (headerValue === null) {
+    return [];
+  }
+
+  return uniqueStrings(
+    Array.from(headerValue.matchAll(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/giu))
+      .map((match) => normalizeEmailAddress(match[0]))
+      .filter((value): value is string => value !== null),
+  );
+}
+
+function inferHeaderDirection(input: {
+  readonly item: Extract<TimelineItem, { family: "one_to_one_email" }>;
+  readonly contactPrimaryEmail: string | null;
+}): "inbound" | "outbound" | null {
+  const contactEmail = normalizeEmailAddress(input.contactPrimaryEmail);
+
+  if (contactEmail === null) {
+    return null;
+  }
+
+  const fromEmails = participantHeaderEmails(input.item.fromHeader ?? null);
+  const recipientEmails = uniqueStrings([
+    ...participantHeaderEmails(input.item.toHeader ?? null),
+    ...participantHeaderEmails(input.item.ccHeader ?? null),
+  ]);
+  const fromContact = fromEmails.includes(contactEmail);
+  const recipientContact = recipientEmails.includes(contactEmail);
 
   if (fromContact && !recipientContact) {
     return "inbound";
@@ -1439,86 +1539,19 @@ function buildRecentActivity(
       item.family === "salesforce_event",
   );
 
-  let mostRecentItemId: string | null = null;
-  let mostRecentOccurredAt: string | null = null;
+  const orderedLifecycleItems = [...lifecycleItems].sort((left, right) =>
+    compareLifecycleActivityForRail(left, right),
+  );
+  const mostRecentItemId =
+    [...lifecycleItems].sort(compareLifecycleActivityAscending).at(-1)?.id ??
+    null;
 
-  for (const item of lifecycleItems) {
-    if (
-      mostRecentOccurredAt === null ||
-      item.occurredAt > mostRecentOccurredAt ||
-      (item.occurredAt === mostRecentOccurredAt &&
-        item.id.localeCompare(mostRecentItemId ?? "") > 0)
-    ) {
-      mostRecentOccurredAt = item.occurredAt;
-      mostRecentItemId = item.id;
-    }
-  }
-
-  const groups = new Map<
-    string,
-    {
-      readonly groupKey: string;
-      readonly items: Extract<TimelineItem, { family: "salesforce_event" }>[];
-      latestOccurredAt: string;
-    }
-  >();
-
-  for (const item of lifecycleItems) {
-    const groupKey = item.projectId ?? `event:${item.id}`;
-    const existingGroup = groups.get(groupKey);
-
-    if (existingGroup === undefined) {
-      groups.set(groupKey, {
-        groupKey,
-        items: [item],
-        latestOccurredAt: item.occurredAt,
-      });
-      continue;
-    }
-
-    existingGroup.items.push(item);
-    if (item.occurredAt > existingGroup.latestOccurredAt) {
-      existingGroup.latestOccurredAt = item.occurredAt;
-    }
-  }
-
-  return [...groups.values()]
-    .sort((left, right) => {
-      const activityDifference = right.latestOccurredAt.localeCompare(
-        left.latestOccurredAt,
-      );
-
-      if (activityDifference !== 0) {
-        return activityDifference;
-      }
-
-      return left.groupKey.localeCompare(right.groupKey);
-    })
-    .flatMap((group) =>
-      [...group.items].sort((left, right) => {
-        const leftDate = utcCalendarDate(left.occurredAt);
-        const rightDate = utcCalendarDate(right.occurredAt);
-
-        if (leftDate !== rightDate) {
-          return rightDate.localeCompare(leftDate);
-        }
-
-        const leftOrdinal = lifecycleMilestoneOrdinal(left.milestone);
-        const rightOrdinal = lifecycleMilestoneOrdinal(right.milestone);
-
-        if (leftOrdinal !== rightOrdinal) {
-          return leftOrdinal - rightOrdinal;
-        }
-
-        return left.id.localeCompare(right.id);
-      }),
-    )
-    .map((item) => ({
-      id: item.id,
-      label: lifecycleRailActivityLabel(item),
-      occurredAtLabel: formatUtcRailEventDate(item.occurredAt, referenceNowIso),
-      isMostRecent: item.id === mostRecentItemId,
-    }));
+  return orderedLifecycleItems.map((item) => ({
+    id: item.id,
+    label: lifecycleRailActivityLabel(item),
+    occurredAtLabel: formatUtcRailEventDate(item.occurredAt, referenceNowIso),
+    isMostRecent: item.id === mostRecentItemId,
+  }));
 }
 
 function lifecycleMilestoneOrdinal(
@@ -1540,57 +1573,81 @@ function utcCalendarDate(occurredAt: string): string {
   return occurredAt.slice(0, 10);
 }
 
+function compareLifecycleActivityAscending(
+  left: Extract<TimelineItem, { family: "salesforce_event" }>,
+  right: Extract<TimelineItem, { family: "salesforce_event" }>,
+): number {
+  const leftDate = utcCalendarDate(left.occurredAt);
+  const rightDate = utcCalendarDate(right.occurredAt);
+
+  if (leftDate !== rightDate) {
+    return leftDate.localeCompare(rightDate);
+  }
+
+  const leftOrdinal = lifecycleMilestoneOrdinal(left.milestone);
+  const rightOrdinal = lifecycleMilestoneOrdinal(right.milestone);
+
+  if (leftOrdinal !== rightOrdinal) {
+    return leftOrdinal - rightOrdinal;
+  }
+
+  return left.id.localeCompare(right.id);
+}
+
+function compareLifecycleActivityForRail(
+  left: Extract<TimelineItem, { family: "salesforce_event" }>,
+  right: Extract<TimelineItem, { family: "salesforce_event" }>,
+): number {
+  const leftDate = utcCalendarDate(left.occurredAt);
+  const rightDate = utcCalendarDate(right.occurredAt);
+
+  if (leftDate !== rightDate) {
+    return rightDate.localeCompare(leftDate);
+  }
+
+  return compareLifecycleActivityAscending(left, right);
+}
+
 function reorderSameDayLifecycleTimelineItems(
   timelineItems: readonly TimelineItem[],
 ): readonly TimelineItem[] {
-  const reordered: TimelineItem[] = [];
+  const lifecycleByDate = new Map<
+    string,
+    Extract<TimelineItem, { family: "salesforce_event" }>[]
+  >();
 
-  for (let index = 0; index < timelineItems.length; ) {
-    const item = timelineItems[index];
-
-    if (item?.family !== "salesforce_event") {
-      if (item !== undefined) {
-        reordered.push(item);
-      }
-      index += 1;
+  for (const item of timelineItems) {
+    if (item.family !== "salesforce_event") {
       continue;
     }
 
-    const groupDate = utcCalendarDate(item.occurredAt);
-    const lifecycleGroup: Extract<
-      TimelineItem,
-      { family: "salesforce_event" }
-    >[] = [];
+    const date = utcCalendarDate(item.occurredAt);
+    const existing = lifecycleByDate.get(date) ?? [];
+    existing.push(item);
+    lifecycleByDate.set(date, existing);
+  }
 
-    while (index < timelineItems.length) {
-      const candidate = timelineItems[index];
+  const orderedLifecycleByDate = new Map<
+    string,
+    Extract<TimelineItem, { family: "salesforce_event" }>[]
+  >();
 
-      if (
-        candidate?.family !== "salesforce_event" ||
-        utcCalendarDate(candidate.occurredAt) !== groupDate
-      ) {
-        break;
-      }
-
-      lifecycleGroup.push(candidate);
-      index += 1;
-    }
-
-    reordered.push(
-      ...lifecycleGroup.sort((left, right) => {
-        const leftOrdinal = lifecycleMilestoneOrdinal(left.milestone);
-        const rightOrdinal = lifecycleMilestoneOrdinal(right.milestone);
-
-        if (leftOrdinal !== rightOrdinal) {
-          return leftOrdinal - rightOrdinal;
-        }
-
-        return left.id.localeCompare(right.id);
-      }),
+  for (const [date, items] of lifecycleByDate) {
+    orderedLifecycleByDate.set(
+      date,
+      [...items].sort(compareLifecycleActivityAscending),
     );
   }
 
-  return reordered;
+  return timelineItems.map((item) => {
+    if (item.family !== "salesforce_event") {
+      return item;
+    }
+
+    const date = utcCalendarDate(item.occurredAt);
+    const next = orderedLifecycleByDate.get(date)?.shift();
+    return next ?? item;
+  });
 }
 
 function timelineChannel(item: TimelineItem): InboxChannel | null {
@@ -1605,6 +1662,8 @@ function timelineChannel(item: TimelineItem): InboxChannel | null {
       return "sms";
     case "internal_note":
     case "salesforce_event":
+      return null;
+    default:
       return null;
   }
 }
@@ -1875,6 +1934,8 @@ function timelineSubject(item: TimelineItem): string | null {
     case "internal_note":
     case "salesforce_event":
       return null;
+    default:
+      return null;
   }
 }
 
@@ -1918,6 +1979,8 @@ function timelineBody(item: TimelineItem): string {
       return item.body;
     case "salesforce_event":
       return timelineLifecycleBodyLabel(item);
+    default:
+      return "";
   }
 }
 
@@ -1948,6 +2011,7 @@ function resolveRecipientLabel(input: {
   readonly contactDisplayName: string;
   readonly contactDisplayNameByEmail: ReadonlyMap<string, string>;
   readonly projectLabelByAlias: ReadonlyMap<string, string>;
+  readonly visualDirection: "inbound" | "outbound" | null;
 }): string | null {
   if (input.item.family !== "one_to_one_email") {
     return null;
@@ -1962,7 +2026,7 @@ function resolveRecipientLabel(input: {
   // when the recipient email isn't a known contact, then the bare
   // email. Notably, we don't fall back to the conversation's canonical
   // contact name — that contact may not match the actual To address.
-  if (input.item.direction === "outbound") {
+  if (input.visualDirection === "outbound") {
     const contactName =
       toEmail !== null ? input.contactDisplayNameByEmail.get(toEmail) : null;
     if (contactName !== null && contactName !== undefined) {
@@ -2005,6 +2069,8 @@ function formatCampaignActivityLabel(
       return `Clicked ${occurredAtLabel}`;
     case "unsubscribed":
       return `Unsubscribed ${occurredAtLabel}`;
+    default:
+      return `Activity ${occurredAtLabel}`;
   }
 }
 
@@ -2073,6 +2139,8 @@ function isPreviewTimelineItem(item: TimelineItem): boolean {
     case "one_to_one_email":
     case "one_to_one_sms":
       return true;
+    default:
+      return false;
   }
 }
 
@@ -2123,16 +2191,28 @@ function buildTimelineEntry(input: {
           input.contactPrimaryEmail,
         )
       : null;
+  const headerDirection =
+    input.item.family === "one_to_one_email"
+      ? inferHeaderDirection({
+          item: input.item,
+          contactPrimaryEmail: input.contactPrimaryEmail,
+        })
+      : null;
+  const visualEmailDirection =
+    input.item.family === "one_to_one_email"
+      ? (inferredDirection ?? headerDirection ?? input.item.direction)
+      : null;
   const isLegacySalesforceEmail = isLegacySalesforceEmailWithoutMessageDetail(
     input.item,
   );
   const kind =
     input.item.family === "one_to_one_email" &&
     isLegacySalesforceEmail &&
-    inferredDirection === null
+    visualEmailDirection === null
       ? "email-activity"
-      : input.item.family === "one_to_one_email" && inferredDirection !== null
-        ? inferredDirection === "inbound"
+      : input.item.family === "one_to_one_email" &&
+          visualEmailDirection !== null
+        ? visualEmailDirection === "inbound"
           ? "inbound-email"
           : "outbound-email"
         : mapTimelineKind(input.item);
@@ -2168,10 +2248,13 @@ function buildTimelineEntry(input: {
       ? input.inboxProjection.bucket === "New" &&
         input.inboxProjection.lastEventType === "communication.sms.inbound" &&
         input.inboxProjection.lastInboundAt === input.item.occurredAt
-      : input.inboxProjection.bucket === "New" &&
-        input.item.canonicalEventId ===
-          input.inboxProjection.lastCanonicalEventId &&
-        finalKind === "inbound-email";
+      : input.item.family === "one_to_one_email" &&
+          (finalKind === "inbound-email" || finalKind === "outbound-email")
+        ? input.inboxProjection.bucket === "New" &&
+          input.item.direction === "inbound" &&
+          input.item.canonicalEventId ===
+            input.inboxProjection.lastCanonicalEventId
+        : false;
   const attachments =
     input.item.family === "one_to_one_email"
       ? buildEmailAttachmentsForEntry({
@@ -2233,6 +2316,7 @@ function buildTimelineEntry(input: {
       contactDisplayName: input.contactDisplayName,
       contactDisplayNameByEmail: input.contactDisplayNameByEmail,
       projectLabelByAlias: input.projectLabelByAlias,
+      visualDirection: visualEmailDirection,
     }),
     ccHeader:
       input.item.family === "one_to_one_email"
@@ -2292,6 +2376,7 @@ function buildTimelineEntry(input: {
             projectLabelByAlias: input.projectLabelByAlias,
             operatorDisplayName: input.operatorDisplayName,
             headerProjectLabel,
+            visualDirection: visualEmailDirection ?? input.item.direction,
           }),
         }
       : {}),
@@ -2402,10 +2487,11 @@ function buildParticipantRows(input: {
   readonly projectLabelByAlias: ReadonlyMap<string, string>;
   readonly operatorDisplayName: string;
   readonly headerProjectLabel: string | null;
+  readonly visualDirection: "inbound" | "outbound";
 }): readonly InboxTimelineEntryParticipantRowViewModel[] {
   const fromEmail =
     participantHeaderEmail(input.item.fromHeader ?? null) ??
-    (input.item.direction === "inbound"
+    (input.visualDirection === "inbound"
       ? normalizeEmailAddress(input.contactPrimaryEmail)
       : null);
   const toEmail = participantHeaderEmail(input.item.toHeader ?? null);
@@ -2421,7 +2507,7 @@ function buildParticipantRows(input: {
 
   const rows: InboxTimelineEntryParticipantRowViewModel[] = [];
 
-  if (input.item.direction === "outbound") {
+  if (input.visualDirection === "outbound") {
     // For outbound the From slot holds whatever the operator was
     // sending AS. Order: known sender identity behind the alias →
     // resolved project alias → whatever display name appears on the
@@ -2442,12 +2528,17 @@ function buildParticipantRows(input: {
       fromHeaderDisplayName !== null && !isEmailLikeName(fromHeaderDisplayName)
         ? normalizeDisplayName(fromHeaderDisplayName) || fromHeaderDisplayName
         : null;
+    const fromProjectAliasLabel =
+      fromEmail === null
+        ? null
+        : (input.projectLabelByAlias.get(fromEmail) ?? null);
     rows.push({
       label: "From",
       name:
         senderContactName ??
-        input.headerProjectLabel ??
+        fromProjectAliasLabel ??
         fromHeaderName ??
+        input.headerProjectLabel ??
         operatorLabel,
       email: fromEmail,
     });
@@ -2977,6 +3068,7 @@ async function readInboxListCacheData(input: {
 }): Promise<InboxListCacheData> {
   const runtime = await getStage1WebRuntime();
   const decodedCursor = decodeInboxListCursor(input.cursor);
+  const repositoryCursor = toInboxRepositoryCursor(decodedCursor);
   const normalizedQuery = normalizeInlineText(input.query) ?? null;
   const isSearchActive = normalizedQuery !== null;
   const order = orderForInboxFilter(isSearchActive ? "inbox" : input.filterId);
@@ -2996,7 +3088,7 @@ async function readInboxListCacheData(input: {
           filter,
           order,
           limit: projectionScanLimit,
-          cursor: null,
+          cursor: repositoryCursor,
           projectId: effectiveProjectId,
         })
       : runtime.repositories.inboxProjection
@@ -3006,7 +3098,7 @@ async function readInboxListCacheData(input: {
             filter: "visible",
             order,
             limit: projectionScanLimit,
-            cursor: null,
+            cursor: repositoryCursor,
             query: normalizedQuery,
             projectId: effectiveProjectId,
           })
@@ -3015,20 +3107,21 @@ async function readInboxListCacheData(input: {
   // The primary loader pulls only the active filter slice. Counts come from
   // the aggregate repo method below, so opening a conversation does not hydrate
   // unrelated inbox or archived rows.
-  const primaryFilterForLoader: RepoFilter =
-    isSearchActive
-      ? "visible"
-      : input.filterId === "unread"
-        ? "inbox"
-        : input.filterId;
+  const primaryFilterForLoader: RepoFilter = isSearchActive
+    ? "visible"
+    : input.filterId;
   const [
-    visibleProjections,
+    primaryProjections,
+    attentionScanProjections,
     projectionCounts,
     freshness,
     activeProjectRecords,
     projectAliasRecords,
   ] = await Promise.all([
     loadProjectionRows(primaryFilterForLoader),
+    !isSearchActive && input.filterId === "unread"
+      ? loadProjectionRows("inbox")
+      : Promise.resolve([]),
     runtime.repositories.inboxProjection.countByFilters({
       projectId: input.projectId,
     }),
@@ -3036,7 +3129,10 @@ async function readInboxListCacheData(input: {
     runtime.repositories.projectDimensions.listActive(),
     runtime.settings.aliases.listAll(),
   ]);
-  const matchedProjections = visibleProjections;
+  const matchedProjections = uniqueInboxProjectionsByContactId([
+    ...primaryProjections,
+    ...attentionScanProjections,
+  ]);
   const activeProjects: readonly InboxActiveProjectOption[] =
     activeProjectRecords.map((record) => ({
       id: record.projectId,
@@ -3193,23 +3289,8 @@ async function readInboxListCacheData(input: {
         ? compareInboxOutboundRecency
         : compareInboxRecency,
     );
-  const cursorIndex =
-    decodedCursor === null
-      ? -1
-      : allItems.findIndex(
-          (item) =>
-            item.contactId === decodedCursor.contactId &&
-            item.lastNonAliasMessageAt ===
-              decodedCursor.lastNonAliasMessageAt &&
-            item.lastOutboundAt === decodedCursor.lastOutboundAt &&
-            item.lastActivityAt === decodedCursor.lastActivityAt,
-        );
-  const itemsAfterCursor =
-    cursorIndex < 0 ? allItems : allItems.slice(cursorIndex + 1);
-  const hasMore = itemsAfterCursor.length > input.limit;
-  const pageItems = hasMore
-    ? itemsAfterCursor.slice(0, input.limit)
-    : itemsAfterCursor;
+  const hasMore = allItems.length > input.limit;
+  const pageItems = hasMore ? allItems.slice(0, input.limit) : allItems;
   const rowByContactId = new Map(allRows.map((row) => [row.contact.id, row]));
   const pageRows = pageItems.flatMap((item) => {
     const row = rowByContactId.get(item.contactId);
@@ -3236,6 +3317,9 @@ async function readInboxListCacheData(input: {
         !hasMore || pageRows.length === 0
           ? null
           : encodeInboxListCursor({
+              lastInboundAt:
+                pageRows[pageRows.length - 1]?.inboxProjection.lastInboundAt ??
+                null,
               lastNonAliasMessageAt:
                 pageRows[pageRows.length - 1]?.lastNonAliasMessageAt ?? null,
               lastOutboundAt:

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -2208,7 +2208,7 @@ function buildTimelineEntry(input: {
   const kind =
     input.item.family === "one_to_one_email" &&
     isLegacySalesforceEmail &&
-    visualEmailDirection === null
+    visualEmailDirection !== "inbound"
       ? "email-activity"
       : input.item.family === "one_to_one_email" &&
           visualEmailDirection !== null
@@ -3080,29 +3080,46 @@ async function readInboxListCacheData(input: {
     | "follow-up"
     | "sent"
     | "archived";
-  const loadProjectionRows = (filter: RepoFilter) => {
+  const loadProjectionPage = async (
+    filter: RepoFilter,
+  ): Promise<{
+    readonly rows: readonly InboxProjectionRow[];
+    readonly total: number | null;
+  }> => {
     const effectiveProjectId = isSearchActive ? null : input.projectId;
 
-    return normalizedQuery === null
-      ? runtime.repositories.inboxProjection.listPageOrderedByRecency({
+    if (normalizedQuery === null) {
+      const rows =
+        await runtime.repositories.inboxProjection.listPageOrderedByRecency({
           filter,
           order,
           limit: projectionScanLimit,
           cursor: repositoryCursor,
           projectId: effectiveProjectId,
-        })
-      : runtime.repositories.inboxProjection
-          .searchPageOrderedByRecency({
-            // Search-bypass: a typed query searches the full visible inbox,
-            // ignoring the currently selected state/project facets.
-            filter: "visible",
-            order,
-            limit: projectionScanLimit,
-            cursor: repositoryCursor,
-            query: normalizedQuery,
-            projectId: effectiveProjectId,
-          })
-          .then((result) => result.rows);
+        });
+
+      return {
+        rows,
+        total: null,
+      };
+    }
+
+    const result =
+      await runtime.repositories.inboxProjection.searchPageOrderedByRecency({
+        // Search-bypass: a typed query searches the full visible inbox,
+        // ignoring the currently selected state/project facets.
+        filter: "visible",
+        order,
+        limit: projectionScanLimit,
+        cursor: repositoryCursor,
+        query: normalizedQuery,
+        projectId: effectiveProjectId,
+      });
+
+    return {
+      rows: result.rows,
+      total: result.total,
+    };
   };
   // The primary loader pulls only the active filter slice. Counts come from
   // the aggregate repo method below, so opening a conversation does not hydrate
@@ -3111,17 +3128,17 @@ async function readInboxListCacheData(input: {
     ? "visible"
     : input.filterId;
   const [
-    primaryProjections,
-    attentionScanProjections,
+    primaryProjectionPage,
+    attentionScanProjectionPage,
     projectionCounts,
     freshness,
     activeProjectRecords,
     projectAliasRecords,
   ] = await Promise.all([
-    loadProjectionRows(primaryFilterForLoader),
+    loadProjectionPage(primaryFilterForLoader),
     !isSearchActive && input.filterId === "unread"
-      ? loadProjectionRows("inbox")
-      : Promise.resolve([]),
+      ? loadProjectionPage("inbox")
+      : Promise.resolve({ rows: [], total: null }),
     runtime.repositories.inboxProjection.countByFilters({
       projectId: input.projectId,
     }),
@@ -3130,8 +3147,8 @@ async function readInboxListCacheData(input: {
     runtime.settings.aliases.listAll(),
   ]);
   const matchedProjections = uniqueInboxProjectionsByContactId([
-    ...primaryProjections,
-    ...attentionScanProjections,
+    ...primaryProjectionPage.rows,
+    ...attentionScanProjectionPage.rows,
   ]);
   const activeProjects: readonly InboxActiveProjectOption[] =
     activeProjectRecords.map((record) => ({
@@ -3330,7 +3347,7 @@ async function readInboxListCacheData(input: {
                 "",
               contactId: pageRows[pageRows.length - 1]?.contact.id ?? "",
             }),
-      total: allItems.length,
+      total: primaryProjectionPage.total ?? allItems.length,
     },
     freshness,
   };

--- a/apps/web/app/settings/_components/integrations-section.tsx
+++ b/apps/web/app/settings/_components/integrations-section.tsx
@@ -4,26 +4,23 @@ import { useState, useTransition } from "react";
 import Image from "next/image";
 import { RefreshCw } from "lucide-react";
 
-import {
-  RADIUS,
-  SHADOW
-} from "@/app/_lib/design-tokens-v2";
+import { RADIUS, SHADOW } from "@/app/_lib/design-tokens-v2";
 import { Button } from "@/components/ui/button";
 import { StatusBadge } from "@/components/ui/status-badge";
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
-  TooltipTrigger
+  TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import {
   formatSmsEstimatedCostUsd,
-  formatUsdAmount
+  formatUsdAmount,
 } from "@/src/lib/sms-pricing";
 import type {
   IntegrationHealthViewModel,
-  IntegrationsSettingsViewModel
+  IntegrationsSettingsViewModel,
 } from "@/src/server/settings/selectors";
 
 import { refreshIntegrationHealthAction } from "../actions";
@@ -42,7 +39,7 @@ const CATEGORY_LABEL: Record<IntegrationHealthViewModel["category"], string> = {
   crm: "CRM",
   messaging: "Messaging",
   knowledge: "Knowledge",
-  ai: "AI"
+  ai: "AI",
 };
 
 const STATUS_META: Record<
@@ -51,24 +48,24 @@ const STATUS_META: Record<
 > = {
   healthy: {
     label: "Healthy",
-    colorClasses: "bg-emerald-50 text-emerald-700 ring-emerald-200"
+    colorClasses: "bg-emerald-50 text-emerald-700 ring-emerald-200",
   },
   needs_attention: {
     label: "Needs attention",
-    colorClasses: "bg-amber-50 text-amber-800 ring-amber-200"
+    colorClasses: "bg-amber-50 text-amber-800 ring-amber-200",
   },
   disconnected: {
     label: "Disconnected",
-    colorClasses: "bg-rose-50 text-rose-700 ring-rose-200"
+    colorClasses: "bg-rose-50 text-rose-700 ring-rose-200",
   },
   not_configured: {
     label: "Not configured",
-    colorClasses: "bg-slate-100 text-slate-600 ring-slate-200"
+    colorClasses: "bg-slate-100 text-slate-600 ring-slate-200",
   },
   not_checked: {
     label: "Not checked",
-    colorClasses: "bg-slate-100 text-slate-700 ring-slate-200"
-  }
+    colorClasses: "bg-slate-100 text-slate-700 ring-slate-200",
+  },
 };
 
 function formatRelative(iso: string | null): string {
@@ -97,24 +94,24 @@ function formatMailchimpCount(value: number | null): string {
 }
 
 function formatMailchimpStatus(
-  integration: Extract<IntegrationHealthViewModel, { mailchimp: unknown }>
+  integration: Extract<IntegrationHealthViewModel, { mailchimp: unknown }>,
 ): { readonly label: string; readonly colorClasses: string } {
   switch (integration.mailchimp?.status) {
     case "connected":
       return {
         label: "Connected",
-        colorClasses: "bg-emerald-50 text-emerald-700 ring-emerald-200"
+        colorClasses: "bg-emerald-50 text-emerald-700 ring-emerald-200",
       };
     case "stale":
       return {
         label: "Sync stale",
-        colorClasses: "bg-rose-50 text-rose-700 ring-rose-200"
+        colorClasses: "bg-rose-50 text-rose-700 ring-rose-200",
       };
     case "unconfigured":
     default:
       return {
         label: "Not configured",
-        colorClasses: "bg-amber-50 text-amber-800 ring-amber-200"
+        colorClasses: "bg-amber-50 text-amber-800 ring-amber-200",
       };
   }
 }
@@ -133,14 +130,14 @@ function buildTwilioUsageState(input: {
   if (input.spendUsd >= input.capUsd) {
     return {
       label: "Cap exceeded — sends still allowed in v1, no hard enforcement",
-      className: "bg-rose-50 text-rose-700 ring-rose-200"
+      className: "bg-rose-50 text-rose-700 ring-rose-200",
     };
   }
 
   if (input.spendUsd >= input.capUsd * 0.8) {
     return {
       label: "Approaching cap",
-      className: "bg-amber-50 text-amber-800 ring-amber-200"
+      className: "bg-amber-50 text-amber-800 ring-amber-200",
     };
   }
 
@@ -163,7 +160,9 @@ export function IntegrationsSection({ viewModel }: IntegrationsSectionProps) {
   function handleRefresh(integration: IntegrationHealthViewModel) {
     setPendingId(integration.serviceName);
     startTransition(async () => {
-      const result = await refreshIntegrationHealthAction(integration.serviceName);
+      const result = await refreshIntegrationHealthAction(
+        integration.serviceName,
+      );
       setPendingId(null);
 
       if (result.ok) {
@@ -174,10 +173,10 @@ export function IntegrationsSection({ viewModel }: IntegrationsSectionProps) {
                   ...item,
                   status: result.data.status,
                   detail: result.data.detail,
-                  lastCheckedAt: result.data.lastCheckedAt
+                  lastCheckedAt: result.data.lastCheckedAt,
                 }
-              : item
-          )
+              : item,
+          ),
         );
         announce(`Refreshed ${integration.displayName}.`);
         return;
@@ -197,13 +196,13 @@ export function IntegrationsSection({ viewModel }: IntegrationsSectionProps) {
         <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           {items.map((integration) => {
             const statusMeta =
-              integration.serviceName === "mailchimp" && integration.mailchimp !== null
+              integration.serviceName === "mailchimp" &&
+              integration.mailchimp !== null
                 ? formatMailchimpStatus(integration)
                 : STATUS_META[integration.status];
             const isRowPending =
               pending && pendingId === integration.serviceName;
-            const isSyncDisabled =
-              !integration.supportsRefresh || isRowPending;
+            const isSyncDisabled = !integration.supportsRefresh || isRowPending;
             const descriptionTerminator = /[.!?]$/.test(integration.description)
               ? ""
               : ".";
@@ -218,7 +217,7 @@ export function IntegrationsSection({ viewModel }: IntegrationsSectionProps) {
                   "flex min-h-full flex-col gap-3 border border-slate-200 bg-white p-4",
                   RADIUS.lg,
                   SHADOW.sm,
-                  isRowPending && "opacity-60"
+                  isRowPending && "opacity-60",
                 )}
               >
                 <div className="flex items-start gap-3">
@@ -302,14 +301,17 @@ function MailchimpTileDetails({
             {integration.mailchimp.lastCampaignName === null
               ? "—"
               : `${integration.mailchimp.lastCampaignName} · ${formatRelative(
-                  integration.mailchimp.lastCampaignSentAt
+                  integration.mailchimp.lastCampaignSentAt,
                 )}`}
           </dd>
         </div>
         <div className="flex items-start justify-between gap-3">
           <dt className="font-medium text-slate-900">Last batch</dt>
           <dd className="text-right tabular-nums">
-            {formatMailchimpCount(integration.mailchimp.lastBatchRecipientCount)} recipients
+            {formatMailchimpCount(
+              integration.mailchimp.lastBatchRecipientCount,
+            )}{" "}
+            recipients
           </dd>
         </div>
       </dl>
@@ -338,7 +340,7 @@ function TwilioConnectorCard({
   }[viewModel.status];
   const usageState = buildTwilioUsageState({
     spendUsd: viewModel.monthToDateSpendUsd,
-    capUsd: viewModel.monthlyCapUsd
+    capUsd: viewModel.monthlyCapUsd,
   });
   const showUsageRows =
     viewModel.smsEnabled &&
@@ -407,9 +409,8 @@ function TwilioConnectorCard({
               </dd>
             </div>
             <div className="-mt-1 text-right text-[11.5px] text-slate-500 tabular-nums">
-              (${formatSmsEstimatedCostUsd(viewModel.outboundRateUsdPerSegment)} /
-              {" "}
-              segment, {String(viewModel.monthToDateSegments)} segments)
+              (${formatSmsEstimatedCostUsd(viewModel.outboundRateUsdPerSegment)}{" "}
+              / segment, {String(viewModel.monthToDateSegments)} segments)
             </div>
             <div className="flex items-start justify-between gap-3">
               <dt className="font-medium text-slate-900">Monthly cap</dt>
@@ -441,14 +442,13 @@ const BRAND_LOGO: Partial<
 > = {
   salesforce: "/integrations/salesforce.png",
   gmail: "/integrations/gmail.png",
-  simpletexting: "/integrations/simpletexting.png",
   mailchimp: "/integrations/mailchimp.png",
   notion: "/integrations/notion.png",
-  openai: "/integrations/anthropic.png"
+  openai: "/integrations/anthropic.png",
 };
 
 function IntegrationLogoMark({
-  integration
+  integration,
 }: {
   readonly integration: IntegrationHealthViewModel;
 }) {
@@ -491,7 +491,7 @@ function SyncButton({
   supportsRefresh,
   pending,
   integrationName,
-  onSync
+  onSync,
 }: SyncButtonProps) {
   const button = (
     <Button

--- a/apps/web/src/server/settings/selectors.ts
+++ b/apps/web/src/server/settings/selectors.ts
@@ -148,7 +148,6 @@ export interface LogsSettingsViewModel {
 const INTEGRATION_ORDER = [
   "salesforce",
   "gmail",
-  "simpletexting",
   "mailchimp",
   "notion",
   "openai"
@@ -164,11 +163,6 @@ const INTEGRATION_META = {
     displayName: "Gmail",
     description: "Inbound and outbound email",
     supportsRefresh: true
-  },
-  simpletexting: {
-    displayName: "SimpleTexting",
-    description: "Volunteer SMS delivery",
-    supportsRefresh: false
   },
   mailchimp: {
     displayName: "Mailchimp",
@@ -570,9 +564,9 @@ function toUserViewModel(user: {
   const status =
     user.deactivatedAt !== null
       ? "deactivated"
-      : user.emailVerified === null
-        ? "pending"
-        : "active";
+      : user.role === "admin" || user.emailVerified !== null
+        ? "active"
+        : "pending";
 
   return {
     userId: user.id,
@@ -650,14 +644,25 @@ async function readIntegrationHealth(): Promise<
   const latestMailchimpSync = getLatestSuccessfulMailchimpTransitionSync(syncStates);
   const latestMailchimpSyncAt = latestMailchimpSync?.lastSuccessfulAt ?? null;
   const mailchimpBaseUrl = readMailchimpCaptureBaseUrl();
+  const latestMailchimpSyncAgeMs =
+    latestMailchimpSyncAt === null
+      ? null
+      : Date.now() - Date.parse(latestMailchimpSyncAt);
   const mailchimpActivityAgeMs =
     mailchimpSnapshot.latestActivityAt === null
       ? null
       : Date.now() - Date.parse(mailchimpSnapshot.latestActivityAt);
+  const hasFreshMailchimpSync =
+    latestMailchimpSyncAgeMs !== null &&
+    Number.isFinite(latestMailchimpSyncAgeMs) &&
+    latestMailchimpSyncAgeMs <= MAILCHIMP_HEALTHY_WINDOW_MS;
+  const hasMailchimpEvidence =
+    latestMailchimpSyncAt !== null || mailchimpSnapshot.latestActivityAt !== null;
   const shouldHideMailchimp =
     mailchimpBaseUrl === null &&
     mailchimpSnapshot.latestActivityAt !== null &&
     mailchimpActivityAgeMs !== null &&
+    Number.isFinite(mailchimpActivityAgeMs) &&
     mailchimpActivityAgeMs > MAILCHIMP_AUTO_HIDE_WINDOW_MS;
   const mailchimpBatchRecipientCount = await readMailchimpLastBatchRecipientCount(
     runtime,
@@ -677,13 +682,11 @@ async function readIntegrationHealth(): Promise<
     const meta = INTEGRATION_META[serviceName];
     if (serviceName === "mailchimp") {
       const mailchimpStatus: MailchimpTileStatus =
-        mailchimpBaseUrl === null
-          ? "unconfigured"
-          : latestMailchimpSyncAt !== null &&
-              Date.now() - Date.parse(latestMailchimpSyncAt) <=
-                MAILCHIMP_HEALTHY_WINDOW_MS
-            ? "connected"
-            : "stale";
+        hasFreshMailchimpSync
+          ? "connected"
+          : mailchimpBaseUrl !== null || hasMailchimpEvidence
+            ? "stale"
+            : "unconfigured";
 
       integrations.push({
         serviceName: record.serviceName,

--- a/apps/web/tests/unit/inbox-freshness.test.ts
+++ b/apps/web/tests/unit/inbox-freshness.test.ts
@@ -9,9 +9,11 @@ const fetchInboxFreshnessMock = vi.hoisted(() => vi.fn());
 const routerRefreshMock = vi.hoisted(() => vi.fn());
 
 vi.mock("next/navigation", () => ({
+  usePathname: () => "/inbox",
   useRouter: () => ({
     refresh: routerRefreshMock,
   }),
+  useSearchParams: () => new URLSearchParams(),
 }));
 
 vi.mock("../../app/inbox/_lib/client-api", () => ({

--- a/apps/web/tests/unit/inbox-loading.test.tsx
+++ b/apps/web/tests/unit/inbox-loading.test.tsx
@@ -23,19 +23,29 @@ vi.mock("@/app/_lib/design-tokens-v2", () => ({
   },
 }));
 
-import { TimelineSkeleton } from "../../app/inbox/_components/inbox-loading";
+import {
+  InboxDetailLoading,
+  QueueRowSkeleton,
+  TimelineSkeleton,
+} from "../../app/inbox/_components/inbox-loading";
 
 describe("TimelineSkeleton", () => {
-  it("keeps skeleton bubbles capped at the shared 560px width without a full-width wrapper", () => {
+  it("keeps skeleton bubbles capped at the shared 560px width using stable full-width geometry", () => {
     const markup = renderToStaticMarkup(createElement(TimelineSkeleton));
 
-    expect(markup).toContain("col-start-2 justify-self-start max-w-[560px]");
-    expect(markup).toContain("col-start-2 justify-self-end max-w-[560px]");
     expect(markup).toContain(
-      "w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 shadow-sm",
+      "col-start-2 justify-self-start w-full max-w-[560px]",
     );
-    expect(markup).not.toContain("justify-self-start w-full max-w-[560px]");
-    expect(markup).not.toContain("justify-self-end w-full max-w-[560px]");
+    expect(markup).toContain(
+      "col-start-2 min-w-0 justify-self-end w-full max-w-[560px]",
+    );
+    expect(markup).toContain(
+      "w-full overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm",
+    );
+    expect(markup).toContain(
+      "w-full rounded-2xl border px-4 py-3 shadow-sm rounded-br-md border-sky-200 bg-sky-50",
+    );
+    expect(markup).not.toContain("border-sky-600 bg-sky-600");
   });
 
   it("keeps the lifecycle pill skeleton inline-sized", () => {
@@ -43,8 +53,26 @@ describe("TimelineSkeleton", () => {
 
     expect(markup).toContain("col-start-2 flex py-1");
     expect(markup).toContain(
-      "inline-flex items-center rounded-full border border-slate-200 bg-white px-4 py-2",
+      "inline-flex items-center rounded-full border border-slate-200 bg-white px-4 py-2 shadow-sm",
     );
     expect(markup).not.toContain("col-start-2 flex w-full");
+  });
+
+  it("renders queue rows with avatar, channel, snippet, and badge-shaped placeholders", () => {
+    const markup = renderToStaticMarkup(createElement(QueueRowSkeleton));
+
+    expect(markup).toContain("flex min-h-[88px] gap-3 border-b");
+    expect(markup).toContain("size-9 shrink-0 rounded-full");
+    expect(markup).toContain("size-3 shrink-0 rounded-sm");
+    expect(markup).toContain("h-5 w-20 rounded");
+  });
+
+  it("keeps detail loading shaped like the real header, timeline, and composer bar", () => {
+    const markup = renderToStaticMarkup(createElement(InboxDetailLoading));
+
+    expect(markup).toContain('aria-label="Loading conversation history"');
+    expect(markup).toContain("items-center justify-between gap-4 border-b");
+    expect(markup).toContain("min-h-0 flex-1 overflow-y-auto bg-slate-50/40");
+    expect(markup).toContain("shrink-0 border-t border-slate-200 bg-white");
   });
 });

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -6408,6 +6408,81 @@ describe("real inbox selectors", () => {
     expect(secondPage.page.nextCursor).toBeNull();
   });
 
+  it("loads unread rows from the unread slice instead of filtering the first inbox page", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await runtime.dispose();
+    runtime = await createInboxTestRuntime();
+
+    for (let index = 0; index < 6; index += 1) {
+      const contactId = `contact:opened-recent-${index.toString()}`;
+      const occurredAt = `2026-04-20T1${index.toString()}:00:00.000Z`;
+
+      await seedInboxContact(runtime.context, {
+        contactId,
+        salesforceContactId: `003-opened-recent-${index.toString()}`,
+        displayName: `Opened Recent ${index.toString()}`,
+        primaryEmail: `${contactId}@example.org`,
+        primaryPhone: null,
+      });
+      const latest = await seedInboxEmailEvent(runtime.context, {
+        id: `${contactId}-email-1`,
+        contactId,
+        occurredAt,
+        direction: "inbound",
+        subject: "Already opened",
+        snippet: "This row should stay out of unread.",
+      });
+      await seedInboxProjection(runtime.context, {
+        contactId,
+        bucket: "Opened",
+        needsFollowUp: false,
+        hasUnresolved: false,
+        lastInboundAt: occurredAt,
+        lastOutboundAt: null,
+        lastActivityAt: occurredAt,
+        snippet: "This row should stay out of unread.",
+        lastCanonicalEventId: latest.canonicalEventId,
+        lastEventType: "communication.email.inbound",
+      });
+    }
+
+    for (let index = 0; index < 4; index += 1) {
+      await seedInboxEmailOnlyContact(runtime, {
+        contactId: `contact:unread-older-${index.toString()}`,
+        displayName: `Unread Older ${index.toString()}`,
+        salesforceContactId: `003-unread-older-${index.toString()}`,
+        subject: "Unread older",
+        snippet: "This row should appear in unread.",
+        occurredAt: `2026-04-19T1${index.toString()}:00:00.000Z`,
+      });
+    }
+
+    const firstPage = await getInboxList("unread", {
+      limit: 3,
+    });
+
+    expect(firstPage.items.map((item) => item.contactId)).toEqual([
+      "contact:unread-older-3",
+      "contact:unread-older-2",
+      "contact:unread-older-1",
+    ]);
+    expect(firstPage.page.hasMore).toBe(true);
+    expect(firstPage.page.nextCursor).not.toBeNull();
+
+    const secondPage = await getInboxList("unread", {
+      limit: 3,
+      cursor: firstPage.page.nextCursor,
+    });
+
+    expect(secondPage.items.map((item) => item.contactId)).toEqual([
+      "contact:unread-older-0",
+    ]);
+    expect(secondPage.page.hasMore).toBe(false);
+  });
+
   it("orders and paginates sent mode by last outbound 1:1 message", async () => {
     if (runtime === null) {
       throw new Error("Expected inbox test runtime");
@@ -6497,6 +6572,174 @@ describe("real inbox selectors", () => {
     expect(sentList.items.map((item) => item.contactId)).not.toContain(
       "contact:campaign-only-outbound",
     );
+  });
+
+  it("orders same-day lifecycle milestones by product lifecycle order in timeline and rail", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:lifecycle-order",
+      salesforceContactId: "003-lifecycle-order",
+      displayName: "Lifecycle Order",
+      primaryEmail: "lifecycle.order@example.org",
+      primaryPhone: null,
+      projectId: "project:pnw-biodiversity",
+      projectName: "PNW Biodiversity",
+      projectAlias: "PNW Biodiversity",
+      membershipId: "membership:lifecycle-order",
+      membershipStatus: "in_training",
+    });
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "lifecycle-order-completed",
+      contactId: "contact:lifecycle-order",
+      occurredAt: "2026-04-18T08:30:00.000Z",
+      eventType: "lifecycle.completed_training",
+      summary: "Volunteer completed training",
+      projectId: "project:pnw-biodiversity",
+    });
+    await seedInboxEmailEvent(runtime.context, {
+      id: "lifecycle-order-email",
+      contactId: "contact:lifecycle-order",
+      occurredAt: "2026-04-18T12:00:00.000Z",
+      direction: "inbound",
+      subject: "Training question",
+      snippet: "Can you confirm the training status?",
+    });
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "lifecycle-order-signed",
+      contactId: "contact:lifecycle-order",
+      occurredAt: "2026-04-18T18:45:00.000Z",
+      eventType: "lifecycle.signed_up",
+      summary: "Volunteer signed up",
+      projectId: "project:pnw-biodiversity",
+    });
+    const latest = await seedInboxLifecycleEvent(runtime.context, {
+      id: "lifecycle-order-received",
+      contactId: "contact:lifecycle-order",
+      occurredAt: "2026-04-18T23:00:00.000Z",
+      eventType: "lifecycle.received_training",
+      summary: "Volunteer received training",
+      projectId: "project:pnw-biodiversity",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:lifecycle-order",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-18T12:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-04-18T23:00:00.000Z",
+      snippet: "Volunteer received training",
+      lastCanonicalEventId: latest.canonicalEventId,
+      lastEventType: "lifecycle.received_training",
+    });
+
+    const detail = await getInboxDetail("contact:lifecycle-order");
+    const lifecycleTimelineLabels =
+      detail?.timeline
+        .filter((entry) => entry.kind === "system-event")
+        .map((entry) => entry.body) ?? [];
+
+    expect(lifecycleTimelineLabels).toEqual([
+      "Signed up for PNW Biodiversity",
+      "Received training for PNW Biodiversity",
+      "Completed training for PNW Biodiversity",
+    ]);
+    expect(detail?.contact.recentActivity.map((entry) => entry.label)).toEqual([
+      "Signed up - PNW Biodiversity",
+      "Received training - PNW Biodiversity",
+      "Completed training - PNW Biodiversity",
+    ]);
+  });
+
+  it("renders project-inbox team copies as outbound-style unread attention", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:team-copy",
+      salesforceContactId: "003-team-copy",
+      displayName: "Shaina Dotson",
+      primaryEmail: "shaina.dotson@gmail.com",
+      primaryPhone: null,
+      projectId: "project:pnw-biodiversity",
+      projectName: "Passive Acoustic Monitoring of Pacific Northwest Forests",
+      projectAlias: "PNW Biodiversity",
+      membershipId: "membership:team-copy",
+      membershipStatus: "active",
+    });
+    await runtime.context.settings.aliases.create({
+      id: "alias:pnw-biodiversity",
+      alias: "pnwbio@adventurescientists.org",
+      signature: "",
+      projectId: "project:pnw-biodiversity",
+      createdAt: new Date("2026-04-18T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-18T00:00:00.000Z"),
+      createdBy: null,
+      updatedBy: null,
+    });
+    const copiedMessage = await seedInboxEmailEvent(runtime.context, {
+      id: "team-copy-latest",
+      contactId: "contact:team-copy",
+      occurredAt: "2026-04-18T15:00:00.000Z",
+      direction: "inbound",
+      subject: "Re: Update on Hex 43191",
+      snippet: "Scotty copied the project inbox on this volunteer thread.",
+      bodyTextPreview:
+        "Scotty copied the project inbox on this volunteer thread.",
+      fromHeader: "Scotty <scotty@adventurescientists.org>",
+      toHeader: "Shaina Dotson <shaina.dotson@gmail.com>",
+      ccHeader: "PNW Biodiversity <pnwbio@adventurescientists.org>",
+      projectInboxAlias: "pnwbio@adventurescientists.org",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:team-copy",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-04-18T15:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-04-18T15:00:00.000Z",
+      snippet: "Scotty copied the project inbox on this volunteer thread.",
+      lastCanonicalEventId: copiedMessage.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+
+    const list = await getInboxList();
+    const detail = await getInboxDetail("contact:team-copy");
+    const entry = detail?.timeline.at(-1);
+
+    expect(list.items[0]).toMatchObject({
+      contactId: "contact:team-copy",
+      bucket: "new",
+      isUnread: true,
+    });
+    expect(entry).toMatchObject({
+      kind: "outbound-email",
+      actorLabel: "Scotty",
+      isUnread: true,
+      headerProjectLabel: "PNW Biodiversity",
+      participantRows: [
+        {
+          label: "From",
+          name: "Scotty",
+          email: "scotty@adventurescientists.org",
+        },
+        {
+          label: "To",
+          name: "Shaina Dotson",
+          email: "shaina.dotson@gmail.com",
+        },
+        {
+          label: "Cc",
+          name: "PNW Biodiversity <pnwbio@adventurescientists.org>",
+          email: null,
+        },
+      ],
+    });
   });
 
   it("batch-loads timeline attachments once and groups them by source evidence id", async () => {

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import React, { createElement, type ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { ContactMembershipRecord } from "@as-comms/contracts";
-import { smsSenders } from "@as-comms/db";
 
 vi.mock("next/cache", () => ({
   unstable_cache: (loader: () => unknown) => loader,
@@ -960,15 +959,25 @@ describe("real inbox selectors", () => {
         primaryEmail: null,
         primaryPhone: "+15550000008",
       });
-      await runtime.context.db.insert(smsSenders).values({
-        id: "sender:twilio-ui",
-        phoneE164: "+15550000001",
-        displayName: "Adventure Scientists SMS",
-        monthlyCap: null,
-        isActive: true,
-        createdAt: new Date("2026-05-03T12:00:00.000Z"),
-        updatedAt: new Date("2026-05-03T12:00:00.000Z"),
-      });
+      await runtime.context.client.exec(`
+        insert into sms_senders (
+          id,
+          phone_e164,
+          display_name,
+          monthly_cap,
+          is_active,
+          created_at,
+          updated_at
+        ) values (
+          'sender:twilio-ui',
+          '+15550000001',
+          'Adventure Scientists SMS',
+          null,
+          true,
+          '2026-05-03T12:00:00.000Z',
+          '2026-05-03T12:00:00.000Z'
+        );
+      `);
       await runtime.context.repositories.sourceEvidence.append({
         id: "source:twilio-inbound-visible",
         provider: "twilio",

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -4102,7 +4102,7 @@ describe("real inbox selectors", () => {
     );
   });
 
-  it("uses the Gmail From header as the inbound actor label when present", async () => {
+  it("uses the Gmail From header as the actor label for copied team email", async () => {
     if (runtime === null) {
       throw new Error("Expected inbox test runtime");
     }
@@ -4143,7 +4143,7 @@ describe("real inbox selectors", () => {
     const latestEntry = detail?.timeline.at(-1);
 
     expect(latestEntry).toMatchObject({
-      kind: "inbound-email",
+      kind: "outbound-email",
       actorLabel: "Ricky Jones",
       fromHeader: "Ricky Jones <ricky@adventurescientists.org>",
       toHeader: "Shaina Dotson <shaina.dotson@gmail.com>",

--- a/apps/web/tests/unit/inbox-timeline.test.ts
+++ b/apps/web/tests/unit/inbox-timeline.test.ts
@@ -460,7 +460,7 @@ describe("InboxTimeline", () => {
     expect(markup).not.toContain("1 automated");
   });
 
-  it("renders sms rows with the shared 560px bubble width", () => {
+  it("renders sms rows with the shared 560px bubble width and quieter outbound styling", () => {
     const markup = renderToStaticMarkup(
       createElement(InboxTimeline, {
         entries: [
@@ -474,7 +474,7 @@ describe("InboxTimeline", () => {
             fromHeader: null,
             toHeader: null,
             mailbox: null,
-            body: "See you at 9.",
+            body: "See you at 9: https://example.org/field-brief",
           },
         ],
         volunteerFirstName: "Alice",
@@ -483,7 +483,11 @@ describe("InboxTimeline", () => {
     );
 
     expect(markup).toContain("w-full max-w-[560px]");
+    expect(markup).toContain("rounded-br-md border-sky-200 bg-sky-50 text-slate-800");
+    expect(markup).toContain("font-medium text-sky-800 underline decoration-sky-300");
+    expect(markup).toContain('href="https://example.org/field-brief"');
     expect(markup).not.toContain("w-fit max-w-[480px]");
+    expect(markup).not.toContain("border-sky-600 bg-sky-600 text-white");
   });
 
   it("renders note rows at the shared 560px width instead of fit-content", () => {

--- a/apps/web/tests/unit/inbox-timeline.test.ts
+++ b/apps/web/tests/unit/inbox-timeline.test.ts
@@ -12,6 +12,7 @@ vi.mock("../../app/inbox/actions", () => ({
 }));
 
 vi.mock("next/navigation", () => ({
+  usePathname: () => "/inbox",
   useRouter: () => ({
     refresh: vi.fn(),
     push: vi.fn(),
@@ -20,6 +21,7 @@ vi.mock("next/navigation", () => ({
     forward: vi.fn(),
     prefetch: vi.fn(),
   }),
+  useSearchParams: () => new URLSearchParams(),
 }));
 
 vi.mock("@/components/ui/tooltip", () => ({
@@ -263,8 +265,9 @@ function setDomGlobals(window: Window & typeof globalThis) {
     configurable: true,
     value: window.navigator,
   });
-  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
-    true;
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
 }
 
 async function mountTimeline(
@@ -483,8 +486,12 @@ describe("InboxTimeline", () => {
     );
 
     expect(markup).toContain("w-full max-w-[560px]");
-    expect(markup).toContain("rounded-br-md border-sky-200 bg-sky-50 text-slate-800");
-    expect(markup).toContain("font-medium text-sky-800 underline decoration-sky-300");
+    expect(markup).toContain(
+      "rounded-br-md border-sky-200 bg-sky-50 text-slate-800",
+    );
+    expect(markup).toContain(
+      "font-medium text-sky-800 underline decoration-sky-300",
+    );
     expect(markup).toContain('href="https://example.org/field-brief"');
     expect(markup).not.toContain("w-fit max-w-[480px]");
     expect(markup).not.toContain("border-sky-600 bg-sky-600 text-white");
@@ -614,8 +621,12 @@ describe("InboxTimeline", () => {
     expect(session.container.textContent).toContain("April field update");
     expect(session.container.querySelectorAll("ol > li")).toHaveLength(4);
     expect(session.container.querySelectorAll("ol ol")).toHaveLength(0);
-    expect(session.container.innerHTML).not.toContain("space-y-2 border-t border-slate-100 bg-slate-50/30 p-2");
-    expect(session.container.innerHTML.match(/max-w-\[560px\]/g)?.length ?? 0).toBeGreaterThanOrEqual(4);
+    expect(session.container.innerHTML).not.toContain(
+      "space-y-2 border-t border-slate-100 bg-slate-50/30 p-2",
+    );
+    expect(
+      session.container.innerHTML.match(/max-w-\[560px\]/g)?.length ?? 0,
+    ).toBeGreaterThanOrEqual(4);
     expect(session.container.innerHTML).not.toContain("pl-16");
   });
 
@@ -639,7 +650,9 @@ describe("InboxTimeline", () => {
     );
 
     expect(markup).toContain("col-span-3 grid");
-    expect(markup).toContain("Alice applied to the Pacific Northwest expedition.");
+    expect(markup).toContain(
+      "Alice applied to the Pacific Northwest expedition.",
+    );
     expect(markup).not.toContain(">APPLIED<");
   });
 
@@ -888,7 +901,9 @@ describe("InboxTimeline", () => {
 
   it("classifies training system dividers into the sky book achievement category", () => {
     expect(
-      classifySystemDivider("Received training for Pacific Northwest expedition."),
+      classifySystemDivider(
+        "Received training for Pacific Northwest expedition.",
+      ),
     ).toMatchObject({
       tone: "sky",
       Icon: BookOpenIcon,
@@ -897,7 +912,9 @@ describe("InboxTimeline", () => {
 
   it("classifies completed training before the generic training branch", () => {
     expect(
-      classifySystemDivider("Completed training for Pacific Northwest expedition."),
+      classifySystemDivider(
+        "Completed training for Pacific Northwest expedition.",
+      ),
     ).toMatchObject({
       tone: "emerald",
       Icon: CheckCircleIcon,

--- a/apps/web/tests/unit/settings-selectors.test.ts
+++ b/apps/web/tests/unit/settings-selectors.test.ts
@@ -1,13 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("next/cache", () => ({
-  unstable_cache: (loader: () => unknown) => loader
+  unstable_cache: (loader: () => unknown) => loader,
 }));
 
 const getCurrentUser = vi.hoisted(() => vi.fn());
 
 vi.mock("@/src/server/auth/session", () => ({
-  getCurrentUser
+  getCurrentUser,
 }));
 
 import {
@@ -15,12 +15,12 @@ import {
   loadIntegrationHealth,
   loadLogsSettings,
   loadProjectSettingsDetail,
-  loadProjectsSettings
+  loadProjectsSettings,
 } from "../../src/server/settings/selectors";
 import { waitForPendingSecurityAuditTasksForTests } from "../../src/server/security/audit";
 import {
   createStage1WebTestRuntime,
-  type Stage1WebTestRuntime
+  type Stage1WebTestRuntime,
 } from "../../src/server/stage1-runtime.test-support";
 
 function buildUser(input: {
@@ -45,12 +45,13 @@ function buildUser(input: {
     id: input.id,
     name: input.email.split("@")[0] ?? input.email,
     email: input.email,
-    emailVerified: input.emailVerified ?? now,
+    emailVerified:
+      input.emailVerified === undefined ? now : input.emailVerified,
     image: null,
     role: input.role,
     deactivatedAt: input.deactivatedAt ?? null,
     createdAt: now,
-    updatedAt: now
+    updatedAt: now,
   };
 }
 
@@ -65,7 +66,7 @@ async function seedProject(
     readonly aiKnowledgeSyncedAt?: string | null;
     readonly emails: readonly string[];
     readonly memberCount: number;
-  }
+  },
 ): Promise<void> {
   await runtime.context.repositories.projectDimensions.upsert({
     projectId: input.projectId,
@@ -75,7 +76,7 @@ async function seedProject(
     source: "salesforce",
     isActive: input.isActive,
     aiKnowledgeUrl: input.aiKnowledgeUrl,
-    aiKnowledgeSyncedAt: input.aiKnowledgeSyncedAt ?? null
+    aiKnowledgeSyncedAt: input.aiKnowledgeSyncedAt ?? null,
   });
 
   if (
@@ -94,10 +95,9 @@ async function seedProject(
       contentHash: "hash",
       metadataJson: {},
       sourceLastEditedAt: null,
-      syncedAt:
-        input.aiKnowledgeSyncedAt ?? "2026-04-20T15:00:00.000Z",
+      syncedAt: input.aiKnowledgeSyncedAt ?? "2026-04-20T15:00:00.000Z",
       createdAt: "2026-04-20T15:00:00.000Z",
-      updatedAt: "2026-04-20T15:00:00.000Z"
+      updatedAt: "2026-04-20T15:00:00.000Z",
     });
   }
 
@@ -110,7 +110,7 @@ async function seedProject(
       createdAt: new Date(`2026-04-20T15:0${String(index)}:00.000Z`),
       updatedAt: new Date(`2026-04-20T15:0${String(index)}:00.000Z`),
       createdBy: null,
-      updatedBy: null
+      updatedBy: null,
     });
   }
 
@@ -123,7 +123,7 @@ async function seedProject(
       primaryEmail: null,
       primaryPhone: null,
       createdAt: "2026-04-20T15:00:00.000Z",
-      updatedAt: "2026-04-20T15:00:00.000Z"
+      updatedAt: "2026-04-20T15:00:00.000Z",
     });
     await runtime.context.repositories.contactMemberships.upsert({
       id: `${input.projectId}:membership:${String(index)}`,
@@ -148,7 +148,7 @@ async function seedSourceEvidenceCollision(
     readonly losingId: string;
     readonly winningReceivedAt: string;
     readonly losingAttemptedAt: string;
-  }
+  },
 ): Promise<void> {
   await runtime.context.repositories.sourceEvidence.append({
     id: input.winningId,
@@ -159,7 +159,7 @@ async function seedSourceEvidenceCollision(
     occurredAt: input.winningReceivedAt,
     payloadRef: `payloads/${input.provider}/${input.winningId}.json`,
     idempotencyKey: input.idempotencyKey,
-    checksum: `${input.winningId}:checksum`
+    checksum: `${input.winningId}:checksum`,
   });
   await runtime.context.repositories.sourceEvidenceQuarantine.record({
     provider: input.provider,
@@ -177,8 +177,8 @@ async function seedSourceEvidenceCollision(
       occurredAt: input.losingAttemptedAt,
       payloadRef: `payloads/${input.provider}/${input.losingId}.json`,
       idempotencyKey: input.idempotencyKey,
-      checksum: `${input.losingId}:checksum`
-    }
+      checksum: `${input.losingId}:checksum`,
+    },
   });
 }
 
@@ -197,7 +197,7 @@ async function seedMailchimpCampaignEvent(
     readonly campaignId: string;
     readonly campaignName: string;
     readonly occurredAt: string;
-  }
+  },
 ): Promise<void> {
   await runtime.context.normalization.applyNormalizedCanonicalEvent({
     sourceEvidence: {
@@ -209,7 +209,7 @@ async function seedMailchimpCampaignEvent(
       occurredAt: input.occurredAt,
       payloadRef: `payloads/mailchimp/${input.providerRecordId}.json`,
       idempotencyKey: `mailchimp:${input.providerRecordId}`,
-      checksum: `checksum:${input.providerRecordId}`
+      checksum: `checksum:${input.providerRecordId}`,
     },
     canonicalEvent: {
       id: input.canonicalEventId,
@@ -217,7 +217,7 @@ async function seedMailchimpCampaignEvent(
       occurredAt: input.occurredAt,
       idempotencyKey: `canonical:${input.providerRecordId}`,
       summary: `Mailchimp ${input.activityType}`,
-      snippet: ""
+      snippet: "",
     },
     identity: {
       salesforceContactId: null,
@@ -243,7 +243,8 @@ describe("settings selectors", () => {
   let runtime: Stage1WebTestRuntime | null = null;
   const originalSmsEnabled = process.env.SMS_ENABLED;
   const originalTwilioRate = process.env.TWILIO_OUTBOUND_RATE_USD_PER_SEGMENT;
-  const originalMailchimpCaptureBaseUrl = process.env.MAILCHIMP_CAPTURE_BASE_URL;
+  const originalMailchimpCaptureBaseUrl =
+    process.env.MAILCHIMP_CAPTURE_BASE_URL;
 
   beforeEach(async () => {
     vi.useFakeTimers();
@@ -252,7 +253,7 @@ describe("settings selectors", () => {
     getCurrentUser.mockReset();
     getCurrentUser.mockResolvedValue({
       id: "user:admin",
-      role: "admin"
+      role: "admin",
     });
     process.env.SMS_ENABLED = "true";
     process.env.TWILIO_OUTBOUND_RATE_USD_PER_SEGMENT = "0.0079";
@@ -291,7 +292,7 @@ describe("settings selectors", () => {
       isActive: true,
       aiKnowledgeUrl: "https://www.notion.so/ready",
       emails: ["ready@asc.internal"],
-      memberCount: 2
+      memberCount: 2,
     });
     await seedProject(runtime, {
       projectId: "project:active-missing-knowledge",
@@ -299,7 +300,7 @@ describe("settings selectors", () => {
       isActive: true,
       aiKnowledgeUrl: null,
       emails: ["missing@asc.internal"],
-      memberCount: 1
+      memberCount: 1,
     });
     await seedProject(runtime, {
       projectId: "project:inactive",
@@ -307,11 +308,11 @@ describe("settings selectors", () => {
       isActive: false,
       aiKnowledgeUrl: "https://www.notion.so/inactive",
       emails: ["inactive@asc.internal"],
-      memberCount: 3
+      memberCount: 3,
     });
 
     const viewModel = await loadProjectsSettings({
-      filter: "active"
+      filter: "active",
     });
 
     expect(viewModel.active).toHaveLength(2);
@@ -320,7 +321,7 @@ describe("settings selectors", () => {
     expect(viewModel.counts).toEqual({
       active: 2,
       inactive: 0,
-      total: 2
+      total: 2,
     });
   });
 
@@ -336,7 +337,7 @@ describe("settings selectors", () => {
       aiKnowledgeUrl: "https://www.notion.so/ready",
       aiKnowledgeSyncedAt: "2026-04-20T15:00:00.000Z",
       emails: ["ready@asc.internal"],
-      memberCount: 1
+      memberCount: 1,
     });
     await seedProject(runtime, {
       projectId: "project:no-knowledge",
@@ -344,7 +345,7 @@ describe("settings selectors", () => {
       isActive: true,
       aiKnowledgeUrl: "https://www.notion.so/no-knowledge",
       emails: ["knowledge-missing@asc.internal"],
-      memberCount: 1
+      memberCount: 1,
     });
     await seedProject(runtime, {
       projectId: "project:no-email",
@@ -354,33 +355,33 @@ describe("settings selectors", () => {
       aiKnowledgeUrl: "https://www.notion.so/no-email",
       aiKnowledgeSyncedAt: "2026-04-20T15:00:00.000Z",
       emails: [],
-      memberCount: 0
+      memberCount: 0,
     });
 
     const viewModel = await loadProjectsSettings({
-      filter: "all"
+      filter: "all",
     });
     const projects = [...viewModel.active, ...viewModel.inactive];
 
     expect(
       projects.find((project) => project.projectId === "project:ready")
-        ?.activationRequirementsMet
+        ?.activationRequirementsMet,
     ).toBe(true);
     expect(
       projects.find((project) => project.projectId === "project:ready")
-        ?.projectAlias
+        ?.projectAlias,
     ).toBe("Ready Project");
     expect(
       projects.find((project) => project.projectId === "project:ready")
-        ?.suggestedAlias
+        ?.suggestedAlias,
     ).toBe("Ready Project");
     expect(
       projects.find((project) => project.projectId === "project:no-knowledge")
-        ?.activationRequirementsMet
+        ?.activationRequirementsMet,
     ).toBe(false);
     expect(
       projects.find((project) => project.projectId === "project:no-email")
-        ?.activationRequirementsMet
+        ?.activationRequirementsMet,
     ).toBe(false);
   });
 
@@ -397,16 +398,16 @@ describe("settings selectors", () => {
       aiKnowledgeUrl: "https://www.notion.so/whales",
       aiKnowledgeSyncedAt: "2026-04-20T15:00:00.000Z",
       emails: ["whales@asc.internal"],
-      memberCount: 1
+      memberCount: 1,
     });
 
     const byAlias = await loadProjectsSettings({
       filter: "all",
-      search: "sfkw"
+      search: "sfkw",
     });
 
     expect(byAlias.active.map((project) => project.projectId)).toEqual([
-      "project:alias-search"
+      "project:alias-search",
     ]);
   });
 
@@ -422,7 +423,7 @@ describe("settings selectors", () => {
       aiKnowledgeUrl: "https://www.notion.so/white-oak",
       aiKnowledgeSyncedAt: "2026-04-20T15:00:00.000Z",
       emails: ["white-oak@asc.internal"],
-      memberCount: 1
+      memberCount: 1,
     });
     await seedProject(runtime, {
       projectId: "project:prefix",
@@ -430,26 +431,27 @@ describe("settings selectors", () => {
       isActive: false,
       aiKnowledgeUrl: "https://www.notion.so/whales",
       emails: ["whales@asc.internal"],
-      memberCount: 0
+      memberCount: 0,
     });
 
     const viewModel = await loadProjectsSettings({
-      filter: "all"
+      filter: "all",
     });
 
     expect(
       viewModel.active.find((project) => project.projectId === "project:colon")
-        ?.suggestedAlias
+        ?.suggestedAlias,
     ).toBe("White Oak Savanna");
     expect(
-      viewModel.inactive.find((project) => project.projectId === "project:prefix")
-        ?.suggestedAlias
+      viewModel.inactive.find(
+        (project) => project.projectId === "project:prefix",
+      )?.suggestedAlias,
     ).toBe("Killer Whales 2025/2026");
   });
 
   it("returns null when project detail is requested for an unknown id", async () => {
     await expect(
-      loadProjectSettingsDetail("project:does-not-exist")
+      loadProjectSettingsDetail("project:does-not-exist"),
     ).resolves.toBeNull();
   });
 
@@ -463,61 +465,61 @@ describe("settings selectors", () => {
         id: "user:admin",
         email: "admin@adventurescientists.org",
         role: "admin",
-        emailVerified: null
-      })
+        emailVerified: null,
+      }),
     );
     await runtime.context.settings.users.upsert(
       buildUser({
         id: "user:admin-secondary",
         email: "admin.secondary@adventurescientists.org",
         role: "admin",
-        emailVerified: null
-      })
+        emailVerified: null,
+      }),
     );
     await runtime.context.settings.users.upsert(
       buildUser({
         id: "user:operator-active",
         email: "operator.active@adventurescientists.org",
-        role: "operator"
-      })
+        role: "operator",
+      }),
     );
     await runtime.context.settings.users.upsert(
       buildUser({
         id: "user:operator-pending",
         email: "operator.pending@adventurescientists.org",
         role: "operator",
-        emailVerified: null
-      })
+        emailVerified: null,
+      }),
     );
 
     const viewModel = await loadAccessSettings();
 
     expect(viewModel.admins.map((user) => user.userId)).toEqual([
       "user:admin",
-      "user:admin-secondary"
+      "user:admin-secondary",
     ]);
     expect(viewModel.admins.map((user) => user.status)).toEqual([
       "active",
-      "active"
+      "active",
     ]);
     expect(viewModel.internalUsers.map((user) => user.userId)).toEqual([
       "user:operator-active",
-      "user:operator-pending"
+      "user:operator-pending",
     ]);
     expect(viewModel.internalUsers.map((user) => user.role)).toEqual([
       "internal_user",
-      "internal_user"
+      "internal_user",
     ]);
     expect(viewModel.internalUsers.map((user) => user.status)).toEqual([
       "active",
-      "pending"
+      "pending",
     ]);
   });
 
   it("rejects non-admin callers from loading access settings", async () => {
     getCurrentUser.mockResolvedValueOnce({
       id: "user:operator",
-      role: "operator"
+      role: "operator",
     });
 
     await expect(loadAccessSettings()).rejects.toThrow("FORBIDDEN");
@@ -526,24 +528,18 @@ describe("settings selectors", () => {
   it("returns the visible seeded integrations in stable order on first read", async () => {
     const viewModel = await loadIntegrationHealth();
 
-    expect(viewModel.integrations.map((integration) => integration.serviceName)).toEqual(
-      [
-        "salesforce",
-        "gmail",
-        "mailchimp",
-        "notion",
-        "openai"
-      ]
-    );
-    expect(viewModel.integrations.map((integration) => integration.status)).toEqual(
-      [
-        "not_checked",
-        "not_checked",
-        "not_configured",
-        "not_configured",
-        "not_configured"
-      ]
-    );
+    expect(
+      viewModel.integrations.map((integration) => integration.serviceName),
+    ).toEqual(["salesforce", "gmail", "mailchimp", "notion", "openai"]);
+    expect(
+      viewModel.integrations.map((integration) => integration.status),
+    ).toEqual([
+      "not_checked",
+      "not_checked",
+      "not_configured",
+      "not_configured",
+      "not_configured",
+    ]);
   });
 
   it("derives Mailchimp connected health from the latest successful transition sync and canonical events", async () => {
@@ -594,7 +590,7 @@ describe("settings selectors", () => {
 
     const viewModel = await loadIntegrationHealth();
     const mailchimp = viewModel.integrations.find(
-      (integration) => integration.serviceName === "mailchimp"
+      (integration) => integration.serviceName === "mailchimp",
     );
 
     expect(mailchimp).toMatchObject({
@@ -630,7 +626,7 @@ describe("settings selectors", () => {
 
     const viewModel = await loadIntegrationHealth();
     const mailchimp = viewModel.integrations.find(
-      (integration) => integration.serviceName === "mailchimp"
+      (integration) => integration.serviceName === "mailchimp",
     );
 
     expect(mailchimp).toMatchObject({
@@ -650,7 +646,8 @@ describe("settings selectors", () => {
       throw new Error("runtime not initialized");
     }
 
-    process.env.MAILCHIMP_CAPTURE_BASE_URL = "https://mailchimp-capture.internal";
+    process.env.MAILCHIMP_CAPTURE_BASE_URL =
+      "https://mailchimp-capture.internal";
 
     await runtime.context.repositories.syncState.upsert({
       id: "sync:mailchimp:transition:stale",
@@ -673,7 +670,7 @@ describe("settings selectors", () => {
 
     const viewModel = await loadIntegrationHealth();
     const mailchimp = viewModel.integrations.find(
-      (integration) => integration.serviceName === "mailchimp"
+      (integration) => integration.serviceName === "mailchimp",
     );
 
     expect(mailchimp).toMatchObject({
@@ -716,14 +713,16 @@ describe("settings selectors", () => {
       primaryEmail: null,
       primaryPhone: "+14065550123",
       createdAt: "2026-05-01T00:00:00.000Z",
-      updatedAt: "2026-05-01T00:00:00.000Z"
+      updatedAt: "2026-05-01T00:00:00.000Z",
     });
 
-    await runtime.context.settings.users.upsert(buildUser({
-      id: "user:admin",
-      email: "admin@example.org",
-      role: "admin"
-    }));
+    await runtime.context.settings.users.upsert(
+      buildUser({
+        id: "user:admin",
+        email: "admin@example.org",
+        role: "admin",
+      }),
+    );
 
     await runtime.context.repositories.smsMessages.insert({
       id: "sms:outbound:current-month",
@@ -817,7 +816,7 @@ describe("settings selectors", () => {
       winningId: "sev-newer-winning",
       losingId: "sev-newer-losing",
       winningReceivedAt: "2026-04-20T14:00:00.000Z",
-      losingAttemptedAt: "2026-04-20T14:05:00.000Z"
+      losingAttemptedAt: "2026-04-20T14:05:00.000Z",
     });
     await seedSourceEvidenceCollision(runtime, {
       provider: "salesforce",
@@ -825,7 +824,7 @@ describe("settings selectors", () => {
       winningId: "sev-older-winning",
       losingId: "sev-older-losing",
       winningReceivedAt: "2026-04-20T13:00:00.000Z",
-      losingAttemptedAt: "2026-04-20T13:05:00.000Z"
+      losingAttemptedAt: "2026-04-20T13:05:00.000Z",
     });
     for (let index = 0; index < 24; index += 1) {
       const minute = String(index).padStart(2, "0");
@@ -835,21 +834,22 @@ describe("settings selectors", () => {
         winningId: `sev-extra-winning-${minute}`,
         losingId: `sev-extra-losing-${minute}`,
         winningReceivedAt: `2026-04-20T12:${minute}:00.000Z`,
-        losingAttemptedAt: `2026-04-20T12:${minute}:30.000Z`
+        losingAttemptedAt: `2026-04-20T12:${minute}:30.000Z`,
       });
     }
 
     const viewModel = await loadLogsSettings({
       streamId: "source-evidence-quarantine",
-      beforeTimestamp: null
+      beforeTimestamp: null,
     });
 
     expect(viewModel.streams).toEqual([
       {
         id: "source-evidence-quarantine",
         label: "Source-evidence duplicates",
-        description: "Provider replay collisions kept out of canonical history."
-      }
+        description:
+          "Provider replay collisions kept out of canonical history.",
+      },
     ]);
     expect(viewModel.activeStreamId).toBe("source-evidence-quarantine");
     expect(viewModel.entries[0]).toMatchObject({
@@ -864,15 +864,15 @@ describe("settings selectors", () => {
         winning: {
           sourceEvidenceId: "sev-newer-winning",
           checksum: "sev-newer-winning:checksum",
-          receivedAt: "2026-04-20T14:00:00.000Z"
+          receivedAt: "2026-04-20T14:00:00.000Z",
         },
         losing: [
           {
             checksum: "sev-newer-losing:checksum",
-            attemptedAt: "2026-04-20T14:05:00.000Z"
-          }
-        ]
-      }
+            attemptedAt: "2026-04-20T14:05:00.000Z",
+          },
+        ],
+      },
     });
     const firstLosingDetail = (
       viewModel.entries[0]?.detail as {

--- a/apps/web/tests/unit/settings-selectors.test.ts
+++ b/apps/web/tests/unit/settings-selectors.test.ts
@@ -462,7 +462,16 @@ describe("settings selectors", () => {
       buildUser({
         id: "user:admin",
         email: "admin@adventurescientists.org",
-        role: "admin"
+        role: "admin",
+        emailVerified: null
+      })
+    );
+    await runtime.context.settings.users.upsert(
+      buildUser({
+        id: "user:admin-secondary",
+        email: "admin.secondary@adventurescientists.org",
+        role: "admin",
+        emailVerified: null
       })
     );
     await runtime.context.settings.users.upsert(
@@ -483,7 +492,14 @@ describe("settings selectors", () => {
 
     const viewModel = await loadAccessSettings();
 
-    expect(viewModel.admins.map((user) => user.userId)).toEqual(["user:admin"]);
+    expect(viewModel.admins.map((user) => user.userId)).toEqual([
+      "user:admin",
+      "user:admin-secondary"
+    ]);
+    expect(viewModel.admins.map((user) => user.status)).toEqual([
+      "active",
+      "active"
+    ]);
     expect(viewModel.internalUsers.map((user) => user.userId)).toEqual([
       "user:operator-active",
       "user:operator-pending"
@@ -491,6 +507,10 @@ describe("settings selectors", () => {
     expect(viewModel.internalUsers.map((user) => user.role)).toEqual([
       "internal_user",
       "internal_user"
+    ]);
+    expect(viewModel.internalUsers.map((user) => user.status)).toEqual([
+      "active",
+      "pending"
     ]);
   });
 
@@ -503,14 +523,13 @@ describe("settings selectors", () => {
     await expect(loadAccessSettings()).rejects.toThrow("FORBIDDEN");
   });
 
-  it("returns the six seeded integrations in stable order on first read", async () => {
+  it("returns the visible seeded integrations in stable order on first read", async () => {
     const viewModel = await loadIntegrationHealth();
 
     expect(viewModel.integrations.map((integration) => integration.serviceName)).toEqual(
       [
         "salesforce",
         "gmail",
-        "simpletexting",
         "mailchimp",
         "notion",
         "openai"
@@ -520,7 +539,6 @@ describe("settings selectors", () => {
       [
         "not_checked",
         "not_checked",
-        "not_configured",
         "not_configured",
         "not_configured",
         "not_configured"
@@ -533,7 +551,7 @@ describe("settings selectors", () => {
       throw new Error("runtime not initialized");
     }
 
-    process.env.MAILCHIMP_CAPTURE_BASE_URL = "https://mailchimp-capture.internal";
+    delete process.env.MAILCHIMP_CAPTURE_BASE_URL;
 
     await seedMailchimpCampaignEvent(runtime, {
       sourceEvidenceId: "sev-mailchimp-sent",
@@ -588,6 +606,41 @@ describe("settings selectors", () => {
         lastCampaignName: "Spring Update",
         lastCampaignSentAt: "2026-05-03T11:15:00.000Z",
         lastBatchRecipientCount: 2,
+      },
+    });
+  });
+
+  it("keeps recent Mailchimp campaign evidence stale instead of not configured when web env is unset", async () => {
+    if (!runtime) {
+      throw new Error("runtime not initialized");
+    }
+
+    delete process.env.MAILCHIMP_CAPTURE_BASE_URL;
+
+    await seedMailchimpCampaignEvent(runtime, {
+      sourceEvidenceId: "sev-mailchimp-recent-sent",
+      providerRecordId: "campaign-recent:member-1:sent",
+      canonicalEventId: "evt-mailchimp-recent-sent",
+      activityType: "sent",
+      eventType: "campaign.email.sent",
+      campaignId: "campaign-recent",
+      campaignName: "Recent Campaign",
+      occurredAt: "2026-05-01T12:00:00.000Z",
+    });
+
+    const viewModel = await loadIntegrationHealth();
+    const mailchimp = viewModel.integrations.find(
+      (integration) => integration.serviceName === "mailchimp"
+    );
+
+    expect(mailchimp).toMatchObject({
+      status: "needs_attention",
+      mailchimp: {
+        status: "stale",
+        lastSuccessfulSyncAt: null,
+        lastCampaignName: "Recent Campaign",
+        lastCampaignSentAt: "2026-05-01T12:00:00.000Z",
+        lastBatchRecipientCount: null,
       },
     });
   });

--- a/packages/domain/src/normalization.ts
+++ b/packages/domain/src/normalization.ts
@@ -50,15 +50,14 @@ import {
   type SalesforceCommunicationDetailRecord,
   type SimpleTextingMessageDetailRecord,
   type SourceEvidenceRecord,
+  type SupportingSourceReference,
   type SyncStateRecord,
   type SyncStateUpdateInput,
   type TimelineProjectionApplyInput,
-  type TimelineProjectionRow
+  type TimelineProjectionRow,
 } from "@as-comms/contracts";
 
-import {
-  qualifiesForInboxProjection
-} from "./inbox-driving.js";
+import { qualifiesForInboxProjection } from "./inbox-driving.js";
 import {
   buildIncomingContentFingerprintSource,
   buildIncomingOutboundEmailFingerprintSource,
@@ -71,7 +70,7 @@ import {
   resolveOutboundEmailMergedWinnerDecision,
   salesforceSnippetClusterWindowMs,
   selectOutboundEmailDuplicateWinner,
-  selectSalesforceSelfDuplicateWinner
+  selectSalesforceSelfDuplicateWinner,
 } from "./outbound-email-dedup.js";
 import type { Stage1PersistenceService } from "./persistence.js";
 
@@ -87,7 +86,7 @@ const [
   lifecycleSignedUpEventType,
   lifecycleReceivedTrainingEventType,
   lifecycleCompletedTrainingEventType,
-  lifecycleSubmittedFirstDataEventType
+  lifecycleSubmittedFirstDataEventType,
 ] = canonicalEventTypeValues;
 
 const lifecycleTimelineOrdinalByEventType: Partial<
@@ -96,15 +95,17 @@ const lifecycleTimelineOrdinalByEventType: Partial<
   [lifecycleSignedUpEventType]: "01",
   [lifecycleReceivedTrainingEventType]: "02",
   [lifecycleCompletedTrainingEventType]: "03",
-  [lifecycleSubmittedFirstDataEventType]: "04"
+  [lifecycleSubmittedFirstDataEventType]: "04",
 };
 
 interface IdentityResolutionContext {
   loadContactsForIdentityKind(
     kind: ContactIdentityKind,
-    values: readonly string[]
+    values: readonly string[],
   ): Promise<ContactLookupMap>;
-  findAnchoredContact(salesforceContactId: string): Promise<ContactRecord | null>;
+  findAnchoredContact(
+    salesforceContactId: string,
+  ): Promise<ContactRecord | null>;
   clear(): void;
 }
 
@@ -122,7 +123,7 @@ export class CanonicalContactAmbiguityError extends Error {
     readonly candidateContactIds: readonly string[];
   }) {
     super(
-      `Normalized email ${input.normalizedEmail} maps to multiple contacts.`
+      `Normalized email ${input.normalizedEmail} maps to multiple contacts.`,
     );
     this.name = "CanonicalContactAmbiguityError";
     this.normalizedEmail = input.normalizedEmail;
@@ -251,7 +252,7 @@ export type NormalizedCanonicalEventResult =
 export interface Stage1NormalizationService {
   readonly persistence: Stage1PersistenceService;
   recordNormalizedSourceEvidence(
-    input: NormalizedSourceEvidenceIntake
+    input: NormalizedSourceEvidenceIntake,
   ): Promise<NormalizedSourceEvidenceResult>;
   ensureCanonicalContactForEmail(input: {
     readonly emailAddress: string;
@@ -259,40 +260,40 @@ export interface Stage1NormalizationService {
     readonly source?: ContactIdentityRecord["source"];
   }): Promise<ContactRecord>;
   upsertNormalizedContactGraph(
-    input: NormalizedContactGraphUpsertInput
+    input: NormalizedContactGraphUpsertInput,
   ): Promise<NormalizedContactGraphResult>;
   saveIdentityAmbiguityCase(
-    input: IdentityAmbiguityInput
+    input: IdentityAmbiguityInput,
   ): Promise<ReviewCaseSaveResult<IdentityResolutionCase>>;
   saveRoutingAmbiguityCase(
-    input: RoutingAmbiguityInput
+    input: RoutingAmbiguityInput,
   ): Promise<ReviewCaseSaveResult<RoutingReviewCase>>;
   applyTimelineProjection(
-    input: TimelineProjectionApplyInput
+    input: TimelineProjectionApplyInput,
   ): Promise<TimelineProjectionRow>;
   applyInboxProjection(
-    input: InboxProjectionApplyInput
+    input: InboxProjectionApplyInput,
   ): Promise<InboxProjectionRow | null>;
   refreshInboxReviewOverlay(
-    input: InboxReviewOverlayRefreshInput
+    input: InboxReviewOverlayRefreshInput,
   ): Promise<InboxProjectionRow | null>;
   updateSyncState(input: SyncStateUpdateInput): Promise<SyncStateRecord>;
   applyNormalizedCanonicalEvent(
     input: NormalizedCanonicalEventIntake,
     options?: {
       readonly overwriteDuplicateGmailMessageDetail?: boolean;
-    }
+    },
   ): Promise<NormalizedCanonicalEventResult>;
 }
 
 function uniqueStrings(values: readonly string[]): string[] {
   return Array.from(new Set(values)).sort((left, right) =>
-    left.localeCompare(right)
+    left.localeCompare(right),
   );
 }
 
 function uniqueById<T extends { readonly id: string }>(
-  values: readonly T[]
+  values: readonly T[],
 ): T[] {
   const deduped = new Map<string, T>();
 
@@ -301,13 +302,13 @@ function uniqueById<T extends { readonly id: string }>(
   }
 
   return Array.from(deduped.values()).sort((left, right) =>
-    left.id.localeCompare(right.id)
+    left.id.localeCompare(right.id),
   );
 }
 
 function uniqueByKey<T>(
   values: readonly T[],
-  getKey: (value: T) => string
+  getKey: (value: T) => string,
 ): T[] {
   const deduped = new Map<string, T>();
 
@@ -327,16 +328,13 @@ function requireValue<T>(value: T | undefined, message: string): T {
 }
 
 function assertVolunteerScopedSalesforceContactGraph(
-  input: NormalizedContactGraphUpsertInput
+  input: NormalizedContactGraphUpsertInput,
 ): void {
   const memberships = input.memberships ?? [];
 
-  if (
-    input.contact.salesforceContactId !== null &&
-    memberships.length === 0
-  ) {
+  if (input.contact.salesforceContactId !== null && memberships.length === 0) {
     throw new Error(
-      `Salesforce contact ${input.contact.salesforceContactId} is missing expedition memberships and cannot be upserted into the Stage 1 volunteer contact graph.`
+      `Salesforce contact ${input.contact.salesforceContactId} is missing expedition memberships and cannot be upserted into the Stage 1 volunteer contact graph.`,
     );
   }
 }
@@ -349,7 +347,7 @@ function isInboundEvent(eventType: CanonicalEventRecord["eventType"]): boolean {
 }
 
 function isOutboundProjectionEvent(
-  eventType: CanonicalEventRecord["eventType"]
+  eventType: CanonicalEventRecord["eventType"],
 ): boolean {
   return (
     eventType === "communication.email.outbound" ||
@@ -360,7 +358,7 @@ function isOutboundProjectionEvent(
 
 function compareCanonicalEventRecency(
   left: Pick<CanonicalEventRecord, "id" | "occurredAt">,
-  right: Pick<CanonicalEventRecord, "id" | "occurredAt">
+  right: Pick<CanonicalEventRecord, "id" | "occurredAt">,
 ): number {
   if (left.occurredAt !== right.occurredAt) {
     return left.occurredAt.localeCompare(right.occurredAt);
@@ -371,9 +369,10 @@ function compareCanonicalEventRecency(
 
 function latestTimestampWins(
   incoming: Pick<CanonicalEventRecord, "id" | "occurredAt">,
-  existing:
-    | Pick<InboxProjectionRow, "lastActivityAt" | "lastCanonicalEventId">
-    | null
+  existing: Pick<
+    InboxProjectionRow,
+    "lastActivityAt" | "lastCanonicalEventId"
+  > | null,
 ): boolean {
   if (existing === null) {
     return true;
@@ -393,22 +392,33 @@ function buildTimelineProjectionId(canonicalEventId: string): string {
 }
 
 function resolveTimelineSortOrdinal(
-  eventType: CanonicalEventRecord["eventType"]
+  eventType: CanonicalEventRecord["eventType"],
 ): string {
   return lifecycleTimelineOrdinalByEventType[eventType] ?? "00";
+}
+
+function resolveTimelineSortOccurredAt(
+  occurredAt: string,
+  eventType: CanonicalEventRecord["eventType"],
+): string {
+  if (lifecycleTimelineOrdinalByEventType[eventType] === undefined) {
+    return occurredAt;
+  }
+
+  return `${occurredAt.slice(0, 10)}T00:00:00.000Z`;
 }
 
 export function buildTimelineSortKey(
   canonicalEventId: string,
   occurredAt: string,
-  eventType: CanonicalEventRecord["eventType"]
+  eventType: CanonicalEventRecord["eventType"],
 ): string {
-  return `${occurredAt}::${resolveTimelineSortOrdinal(eventType)}::${canonicalEventId}`;
+  return `${resolveTimelineSortOccurredAt(occurredAt, eventType)}::${resolveTimelineSortOrdinal(eventType)}::${canonicalEventId}`;
 }
 
 function buildIdentityCaseId(
   sourceEvidenceId: string,
-  reasonCode: IdentityResolutionCase["reasonCode"]
+  reasonCode: IdentityResolutionCase["reasonCode"],
 ): string {
   return `identity-review:${sourceEvidenceId}:${reasonCode}`;
 }
@@ -416,7 +426,7 @@ function buildIdentityCaseId(
 function buildRoutingCaseId(
   sourceEvidenceId: string,
   contactId: string,
-  reasonCode: RoutingReviewCase["reasonCode"]
+  reasonCode: RoutingReviewCase["reasonCode"],
 ): string {
   return `routing-review:${sourceEvidenceId}:${contactId}:${reasonCode}`;
 }
@@ -424,7 +434,7 @@ function buildRoutingCaseId(
 function buildQuarantineAuditId(
   entityType: string,
   entityId: string,
-  reasonCode: QuarantineReasonCode
+  reasonCode: QuarantineReasonCode,
 ): string {
   return `audit:${entityType}:${entityId}:${reasonCode}`;
 }
@@ -432,7 +442,7 @@ function buildQuarantineAuditId(
 function buildSkipAuditId(
   entityType: string,
   entityId: string,
-  action: "skipped_non_volunteer_task"
+  action: "skipped_non_volunteer_task",
 ): string {
   return `audit:${entityType}:${entityId}:${action}`;
 }
@@ -449,7 +459,9 @@ function buildSyntheticContactId(input: {
     return `contact:phone:${input.normalizedPhone}`;
   }
 
-  throw new Error("Cannot build a synthetic contact id without an email or phone.");
+  throw new Error(
+    "Cannot build a synthetic contact id without an email or phone.",
+  );
 }
 
 function buildSyntheticContactGraphInput(input: {
@@ -460,7 +472,7 @@ function buildSyntheticContactGraphInput(input: {
 }): NormalizedContactGraphUpsertInput {
   const contactId = buildSyntheticContactId({
     normalizedEmail: input.normalizedEmail,
-    normalizedPhone: input.normalizedPhone
+    normalizedPhone: input.normalizedPhone,
   });
 
   const identities: ContactIdentityRecord[] = [];
@@ -474,8 +486,8 @@ function buildSyntheticContactGraphInput(input: {
         normalizedValue: input.normalizedEmail,
         isPrimary: true,
         source: input.source,
-        verifiedAt: input.createdAt
-      })
+        verifiedAt: input.createdAt,
+      }),
     );
   }
 
@@ -488,8 +500,8 @@ function buildSyntheticContactGraphInput(input: {
         normalizedValue: input.normalizedPhone,
         isPrimary: true,
         source: input.source,
-        verifiedAt: input.createdAt
-      })
+        verifiedAt: input.createdAt,
+      }),
     );
   }
 
@@ -497,14 +509,15 @@ function buildSyntheticContactGraphInput(input: {
     contact: contactSchema.parse({
       id: contactId,
       salesforceContactId: null,
-      displayName: input.normalizedEmail ?? input.normalizedPhone ?? "(unknown)",
+      displayName:
+        input.normalizedEmail ?? input.normalizedPhone ?? "(unknown)",
       primaryEmail: input.normalizedEmail,
       primaryPhone: input.normalizedPhone,
       createdAt: input.createdAt,
-      updatedAt: input.createdAt
+      updatedAt: input.createdAt,
     }),
     identities,
-    memberships: []
+    memberships: [],
   };
 }
 
@@ -520,8 +533,8 @@ function logStructuredEvent(input: {
   console.log(
     JSON.stringify({
       event: input.event,
-      ...input.metadata
-    })
+      ...input.metadata,
+    }),
   );
 }
 
@@ -530,7 +543,7 @@ async function reconcilePendingComposerOutbound(
   input: {
     readonly sourceEvidence: SourceEvidenceRecord;
     readonly canonicalEvent: CanonicalEventRecord;
-  }
+  },
 ): Promise<void> {
   if (
     input.sourceEvidence.provider !== "gmail" ||
@@ -548,15 +561,16 @@ async function reconcilePendingComposerOutbound(
         reason: "missing_fingerprint",
         canonicalEventId: input.canonicalEvent.id,
         sourceEvidenceId: input.sourceEvidence.id,
-        providerRecordId: input.sourceEvidence.providerRecordId
-      }
+        providerRecordId: input.sourceEvidence.providerRecordId,
+      },
     });
     return;
   }
 
-  const pending = await persistence.repositories.pendingOutbounds.findByFingerprint(
-    fingerprint
-  );
+  const pending =
+    await persistence.repositories.pendingOutbounds.findByFingerprint(
+      fingerprint,
+    );
 
   if (
     pending !== null &&
@@ -565,7 +579,7 @@ async function reconcilePendingComposerOutbound(
   ) {
     const via = pending.status === "pending" ? "fingerprint" : "event_link";
     await persistence.repositories.pendingOutbounds.markConfirmed(pending.id, {
-      reconciledEventId: input.canonicalEvent.id
+      reconciledEventId: input.canonicalEvent.id,
     });
     logStructuredEvent({
       event: "composer.reconciliation.matched",
@@ -575,8 +589,8 @@ async function reconcilePendingComposerOutbound(
         canonicalEventId: input.canonicalEvent.id,
         sourceEvidenceId: input.sourceEvidence.id,
         providerRecordId: input.sourceEvidence.providerRecordId,
-        via
-      }
+        via,
+      },
     });
     return;
   }
@@ -589,14 +603,14 @@ async function reconcilePendingComposerOutbound(
       sourceEvidenceId: input.sourceEvidence.id,
       providerRecordId: input.sourceEvidence.providerRecordId,
       pendingOutboundId: pending?.id ?? null,
-      pendingStatus: pending?.status ?? null
-    }
+      pendingStatus: pending?.status ?? null,
+    },
   });
 }
 
 function newestTimestamp(
   left: string | null,
-  right: string | null
+  right: string | null,
 ): string | null {
   if (left === null) {
     return right;
@@ -613,14 +627,14 @@ const FORWARDED_SUBJECT_PATTERN = /^\s*fwd?:/i;
 const FORWARDED_BODY_PATTERNS = [
   /(?:\n|^)\s*-{2,}\s*forwarded message\s*-{2,}\s*(?:\n|$)/i,
   /(?:\n|^)\s*forwarded message:/i,
-  /(?:\n|^)\s*begin forwarded message:/i
+  /(?:\n|^)\s*begin forwarded message:/i,
 ];
 
 function detectInboxProjectionExclusionReason(
   input: Pick<
     NormalizedCanonicalEventIntake,
     "canonicalEvent" | "gmailMessageDetail" | "sourceEvidence"
-  >
+  >,
 ): "forwarded_chain" | null {
   if (
     input.sourceEvidence.provider !== "gmail" ||
@@ -645,7 +659,7 @@ function detectInboxProjectionExclusionReason(
 
   const previewCandidates = [
     gmailMessageDetail.bodyTextPreview,
-    gmailMessageDetail.snippetClean
+    gmailMessageDetail.snippetClean,
   ];
 
   for (const preview of previewCandidates) {
@@ -660,13 +674,15 @@ function detectInboxProjectionExclusionReason(
 }
 
 function buildNormalizedIdentityValues(
-  identity: NormalizedIdentityEvidence
+  identity: NormalizedIdentityEvidence,
 ): string[] {
   return uniqueStrings([
-    ...(identity.salesforceContactId === null ? [] : [identity.salesforceContactId]),
+    ...(identity.salesforceContactId === null
+      ? []
+      : [identity.salesforceContactId]),
     ...identity.volunteerIdPlainValues,
     ...identity.normalizedEmails,
-    ...identity.normalizedPhones
+    ...identity.normalizedPhones,
   ]);
 }
 
@@ -687,16 +703,13 @@ function pickCanonicalReviewState(input: {
 
 function mergeCanonicalReviewState(
   left: CanonicalEventRecord["reviewState"],
-  right: CanonicalEventRecord["reviewState"]
+  right: CanonicalEventRecord["reviewState"],
 ): CanonicalEventRecord["reviewState"] {
   if (left === "quarantined" || right === "quarantined") {
     return "quarantined";
   }
 
-  if (
-    left === "needs_identity_review" ||
-    right === "needs_identity_review"
-  ) {
+  if (left === "needs_identity_review" || right === "needs_identity_review") {
     return "needs_identity_review";
   }
 
@@ -707,61 +720,63 @@ function mergeCanonicalReviewState(
   return "clear";
 }
 
-function mapBySourceEvidenceId<TValue extends { readonly sourceEvidenceId: string }>(
-  values: readonly TValue[]
-): ReadonlyMap<string, TValue> {
+function mapBySourceEvidenceId<
+  TValue extends { readonly sourceEvidenceId: string },
+>(values: readonly TValue[]): ReadonlyMap<string, TValue> {
   return new Map(values.map((value) => [value.sourceEvidenceId, value]));
 }
 
 async function loadProviderDetailMaps(
   persistence: Stage1PersistenceService,
-  sourceEvidenceIds: readonly string[]
+  sourceEvidenceIds: readonly string[],
 ): Promise<ProviderDetailMaps> {
   const uniqueSourceEvidenceIds = uniqueStrings(sourceEvidenceIds);
-  const [gmailMessageDetails, salesforceCommunicationDetails, simpleTextingMessageDetails] =
-    await Promise.all([
-      persistence.repositories.gmailMessageDetails.listBySourceEvidenceIds(
-        uniqueSourceEvidenceIds
-      ),
-      persistence.repositories.salesforceCommunicationDetails.listBySourceEvidenceIds(
-        uniqueSourceEvidenceIds
-      ),
-      persistence.repositories.simpleTextingMessageDetails.listBySourceEvidenceIds(
-        uniqueSourceEvidenceIds
-      )
-    ]);
+  const [
+    gmailMessageDetails,
+    salesforceCommunicationDetails,
+    simpleTextingMessageDetails,
+  ] = await Promise.all([
+    persistence.repositories.gmailMessageDetails.listBySourceEvidenceIds(
+      uniqueSourceEvidenceIds,
+    ),
+    persistence.repositories.salesforceCommunicationDetails.listBySourceEvidenceIds(
+      uniqueSourceEvidenceIds,
+    ),
+    persistence.repositories.simpleTextingMessageDetails.listBySourceEvidenceIds(
+      uniqueSourceEvidenceIds,
+    ),
+  ]);
 
   return {
-    gmailMessageDetailBySourceEvidenceId: mapBySourceEvidenceId(gmailMessageDetails),
+    gmailMessageDetailBySourceEvidenceId:
+      mapBySourceEvidenceId(gmailMessageDetails),
     salesforceCommunicationDetailBySourceEvidenceId: mapBySourceEvidenceId(
-      salesforceCommunicationDetails
+      salesforceCommunicationDetails,
     ),
     simpleTextingMessageDetailBySourceEvidenceId: mapBySourceEvidenceId(
-      simpleTextingMessageDetails
-    )
+      simpleTextingMessageDetails,
+    ),
   };
 }
 
 function findCanonicalEventForSourceEvidence(
   events: readonly CanonicalEventRecord[],
-  sourceEvidenceId: string
+  sourceEvidenceId: string,
 ): CanonicalEventRecord | null {
   return (
     events.find(
       (event) =>
         event.sourceEvidenceId === sourceEvidenceId ||
-        event.provenance.supportingSourceEvidenceIds.includes(sourceEvidenceId)
+        event.provenance.supportingSourceEvidenceIds.includes(sourceEvidenceId),
     ) ?? null
   );
 }
 
 function compareDuplicateCandidateEvents(
   left: CanonicalEventRecord,
-  right: CanonicalEventRecord
+  right: CanonicalEventRecord,
 ): number {
-  if (
-    left.provenance.primaryProvider !== right.provenance.primaryProvider
-  ) {
+  if (left.provenance.primaryProvider !== right.provenance.primaryProvider) {
     return left.provenance.primaryProvider === "gmail" ? -1 : 1;
   }
 
@@ -785,7 +800,7 @@ async function findOutboundEmailDuplicateMatch(
       | "gmailMessageDetail"
       | "salesforceCommunicationDetail"
     >;
-  }
+  },
 ): Promise<OutboundEmailDuplicateMatch | null> {
   if (
     input.incoming.canonicalEvent.eventType !== "communication.email.outbound"
@@ -794,7 +809,7 @@ async function findOutboundEmailDuplicateMatch(
   }
 
   const incomingSource = buildIncomingOutboundEmailFingerprintSource(
-    input.incoming
+    input.incoming,
   );
 
   if (incomingSource === null) {
@@ -803,7 +818,7 @@ async function findOutboundEmailDuplicateMatch(
 
   const incomingFingerprint = buildOutboundEmailDuplicateFingerprint({
     subject: incomingSource.subject,
-    body: incomingSource.body
+    body: incomingSource.body,
   });
 
   if (incomingFingerprint === null) {
@@ -818,8 +833,8 @@ async function findOutboundEmailDuplicateMatch(
           event.provenance.primaryProvider === "salesforce") &&
         isWithinOutboundEmailFingerprintWindow({
           leftOccurredAt: event.occurredAt,
-          rightOccurredAt: input.incoming.canonicalEvent.occurredAt
-        })
+          rightOccurredAt: input.incoming.canonicalEvent.occurredAt,
+        }),
     )
     .sort(compareDuplicateCandidateEvents);
 
@@ -829,7 +844,7 @@ async function findOutboundEmailDuplicateMatch(
 
   const detailMaps = await loadProviderDetailMaps(
     persistence,
-    candidateEvents.map((event) => event.sourceEvidenceId)
+    candidateEvents.map((event) => event.sourceEvidenceId),
   );
 
   for (const existingEvent of candidateEvents) {
@@ -838,7 +853,7 @@ async function findOutboundEmailDuplicateMatch(
       gmailMessageDetailBySourceEvidenceId:
         detailMaps.gmailMessageDetailBySourceEvidenceId,
       salesforceCommunicationDetailBySourceEvidenceId:
-        detailMaps.salesforceCommunicationDetailBySourceEvidenceId
+        detailMaps.salesforceCommunicationDetailBySourceEvidenceId,
     });
 
     if (existingSource === null) {
@@ -847,22 +862,25 @@ async function findOutboundEmailDuplicateMatch(
 
     const existingFingerprint = buildOutboundEmailDuplicateFingerprint({
       subject: existingSource.subject,
-      body: existingSource.body
+      body: existingSource.body,
     });
 
-    if (existingFingerprint === null || existingFingerprint !== incomingFingerprint) {
+    if (
+      existingFingerprint === null ||
+      existingFingerprint !== incomingFingerprint
+    ) {
       continue;
     }
 
     const winnerSelection = selectOutboundEmailDuplicateWinner({
       incoming: {
         provider: input.incoming.sourceEvidence.provider,
-        occurredAt: input.incoming.canonicalEvent.occurredAt
+        occurredAt: input.incoming.canonicalEvent.occurredAt,
       },
       existing: {
         provider: existingEvent.provenance.primaryProvider,
-        occurredAt: existingEvent.occurredAt
-      }
+        occurredAt: existingEvent.occurredAt,
+      },
     });
 
     if (winnerSelection === null) {
@@ -873,49 +891,50 @@ async function findOutboundEmailDuplicateMatch(
       existingEvent,
       existingTimelineProjection:
         await persistence.repositories.timelineProjection.findByCanonicalEventId(
-          existingEvent.id
+          existingEvent.id,
         ),
       winner: {
         winnerReason: winnerSelection.winnerReason,
         notes: winnerSelection.notes,
-        keepIncomingAsPrimary: winnerSelection.winner === "incoming"
-      }
+        keepIncomingAsPrimary: winnerSelection.winner === "incoming",
+      },
     };
   }
 
-  const incomingContentFingerprintSource = buildIncomingContentFingerprintSource(
-    input.incoming
-  );
+  const incomingContentFingerprintSource =
+    buildIncomingContentFingerprintSource(input.incoming);
   const incomingContentFingerprint =
     incomingContentFingerprintSource === null
       ? null
       : computeContentFingerprint({
           ...incomingContentFingerprintSource,
-          contactId: input.contactId
+          contactId: input.contactId,
         });
 
   if (incomingContentFingerprint !== null) {
     const fingerprintCandidates =
-      await persistence.repositories.canonicalEvents.listByContentFingerprintWindow({
-        contactId: input.contactId,
-        channel: "email",
-        contentFingerprint: incomingContentFingerprint,
-        occurredAt: input.incoming.canonicalEvent.occurredAt,
-        windowMinutes: 5
-      });
+      await persistence.repositories.canonicalEvents.listByContentFingerprintWindow(
+        {
+          contactId: input.contactId,
+          channel: "email",
+          contentFingerprint: incomingContentFingerprint,
+          occurredAt: input.incoming.canonicalEvent.occurredAt,
+          windowMinutes: 5,
+        },
+      );
 
     for (const existingEvent of [...fingerprintCandidates].sort(
-      compareDuplicateCandidateEvents
+      compareDuplicateCandidateEvents,
     )) {
       const winnerSelection = selectOutboundEmailDuplicateWinner({
         incoming: {
           provider: input.incoming.sourceEvidence.provider,
-          occurredAt: input.incoming.canonicalEvent.occurredAt
+          occurredAt: input.incoming.canonicalEvent.occurredAt,
         },
         existing: {
           provider: existingEvent.provenance.primaryProvider,
-          occurredAt: existingEvent.occurredAt
-        }
+          occurredAt: existingEvent.occurredAt,
+        },
       });
 
       if (winnerSelection === null) {
@@ -926,13 +945,13 @@ async function findOutboundEmailDuplicateMatch(
         existingEvent,
         existingTimelineProjection:
           await persistence.repositories.timelineProjection.findByCanonicalEventId(
-            existingEvent.id
+            existingEvent.id,
           ),
         winner: {
           winnerReason: winnerSelection.winnerReason,
           notes: winnerSelection.notes,
-          keepIncomingAsPrimary: winnerSelection.winner === "incoming"
-        }
+          keepIncomingAsPrimary: winnerSelection.winner === "incoming",
+        },
       };
     }
   }
@@ -950,7 +969,7 @@ async function findOutboundEmailDuplicateMatch(
         "",
       contactId: input.contactId,
       channel: "email",
-      direction: input.incoming.communicationClassification?.direction ?? null
+      direction: input.incoming.communicationClassification?.direction ?? null,
     });
 
   if (salesforceSnippetClusterFingerprint === null) {
@@ -965,8 +984,8 @@ async function findOutboundEmailDuplicateMatch(
         isWithinContentFingerprintWindow({
           leftOccurredAt: event.occurredAt,
           rightOccurredAt: input.incoming.canonicalEvent.occurredAt,
-          windowMs: salesforceSnippetClusterWindowMs
-        })
+          windowMs: salesforceSnippetClusterWindowMs,
+        }),
     )
     .sort(compareDuplicateCandidateEvents);
 
@@ -976,13 +995,13 @@ async function findOutboundEmailDuplicateMatch(
 
   const salesforceDetailMaps = await loadProviderDetailMaps(
     persistence,
-    salesforceCandidateEvents.map((event) => event.sourceEvidenceId)
+    salesforceCandidateEvents.map((event) => event.sourceEvidenceId),
   );
 
   for (const existingEvent of salesforceCandidateEvents) {
     const existingDetail =
       salesforceDetailMaps.salesforceCommunicationDetailBySourceEvidenceId.get(
-        existingEvent.sourceEvidenceId
+        existingEvent.sourceEvidenceId,
       );
 
     if (existingDetail === undefined) {
@@ -995,7 +1014,7 @@ async function findOutboundEmailDuplicateMatch(
         snippet: existingDetail.snippet,
         contactId: input.contactId,
         channel: existingEvent.channel,
-        direction: existingEvent.provenance.direction
+        direction: existingEvent.provenance.direction,
       });
 
     if (
@@ -1009,21 +1028,21 @@ async function findOutboundEmailDuplicateMatch(
     const keepIncomingAsPrimary =
       selectSalesforceSelfDuplicateWinner({
         incomingOccurredAt: input.incoming.canonicalEvent.occurredAt,
-        existingOccurredAt: existingEvent.occurredAt
+        existingOccurredAt: existingEvent.occurredAt,
       }) === "incoming";
 
     return {
       existingEvent,
       existingTimelineProjection:
         await persistence.repositories.timelineProjection.findByCanonicalEventId(
-          existingEvent.id
+          existingEvent.id,
         ),
       winner: {
         winnerReason: "salesforce_only_best_evidence",
         notes:
           "The earliest Salesforce Task remained canonical for the same subject and snippet within the 10 minute Flow double-fire window.",
-        keepIncomingAsPrimary
-      }
+        keepIncomingAsPrimary,
+      },
     };
   }
 
@@ -1032,11 +1051,11 @@ async function findOutboundEmailDuplicateMatch(
 
 function resolveInboxSnippet(
   event: CanonicalEventRecord,
-  detailMaps: ProviderDetailMaps
+  detailMaps: ProviderDetailMaps,
 ): string {
   if (event.provenance.primaryProvider === "gmail") {
     const detail = detailMaps.gmailMessageDetailBySourceEvidenceId.get(
-      event.sourceEvidenceId
+      event.sourceEvidenceId,
     );
 
     if (detail === undefined) {
@@ -1051,7 +1070,7 @@ function resolveInboxSnippet(
   if (event.provenance.primaryProvider === "salesforce") {
     return (
       detailMaps.salesforceCommunicationDetailBySourceEvidenceId.get(
-        event.sourceEvidenceId
+        event.sourceEvidenceId,
       )?.snippet ?? ""
     );
   }
@@ -1059,7 +1078,7 @@ function resolveInboxSnippet(
   if (event.provenance.primaryProvider === "simpletexting") {
     return (
       detailMaps.simpleTextingMessageDetailBySourceEvidenceId.get(
-        event.sourceEvidenceId
+        event.sourceEvidenceId,
       )?.messageTextPreview ?? ""
     );
   }
@@ -1069,21 +1088,21 @@ function resolveInboxSnippet(
 
 async function rebuildInboxProjectionForContact(
   persistence: Stage1PersistenceService,
-  contactId: string
+  contactId: string,
 ): Promise<InboxProjectionRow | null> {
-  const existing = await persistence.repositories.inboxProjection.findByContactId(
-    contactId
-  );
-  const events = await persistence.repositories.canonicalEvents.listByContactId(
-    contactId
-  );
+  const existing =
+    await persistence.repositories.inboxProjection.findByContactId(contactId);
+  const events =
+    await persistence.repositories.canonicalEvents.listByContactId(contactId);
   const qualifyingEvents = events.filter((event) =>
-    qualifiesForInboxProjection(event)
+    qualifiesForInboxProjection(event),
   );
 
   if (qualifyingEvents.length === 0) {
     if (existing !== null) {
-      await persistence.repositories.inboxProjection.deleteByContactId(contactId);
+      await persistence.repositories.inboxProjection.deleteByContactId(
+        contactId,
+      );
     }
 
     return null;
@@ -1091,19 +1110,19 @@ async function rebuildInboxProjectionForContact(
 
   const detailMaps = await loadProviderDetailMaps(
     persistence,
-    qualifyingEvents.map((event) => event.sourceEvidenceId)
+    qualifyingEvents.map((event) => event.sourceEvidenceId),
   );
   const latestEvent = qualifyingEvents.reduce<CanonicalEventRecord | null>(
     (latest, event) =>
       latest === null || compareCanonicalEventRecency(event, latest) > 0
         ? event
         : latest,
-    null
+    null,
   );
 
   if (latestEvent === null) {
     throw new Error(
-      "Expected a qualifying event when rebuilding inbox projection."
+      "Expected a qualifying event when rebuilding inbox projection.",
     );
   }
   let lastInboundAt: string | null = null;
@@ -1134,8 +1153,8 @@ async function rebuildInboxProjectionForContact(
     contactId,
     bucket: hasNewerInbound
       ? "New"
-      : existing?.bucket ??
-        (isInboundEvent(latestEvent.eventType) ? "New" : "Opened"),
+      : (existing?.bucket ??
+        (isInboundEvent(latestEvent.eventType) ? "New" : "Opened")),
     needsFollowUp: existing?.needsFollowUp ?? false,
     hasUnresolved: await contactHasUnresolved(persistence, contactId),
     lastInboundAt,
@@ -1144,12 +1163,12 @@ async function rebuildInboxProjectionForContact(
     snippet: resolveInboxSnippet(latestEvent, detailMaps),
     archivedAt: existing?.archivedAt ?? null,
     lastCanonicalEventId: latestEvent.id,
-    lastEventType: latestEvent.eventType
+    lastEventType: latestEvent.eventType,
   });
 }
 
 function buildIdentityMissingAnchorExplanation(
-  identity: NormalizedIdentityEvidence
+  identity: NormalizedIdentityEvidence,
 ): string {
   if (identity.salesforceContactId !== null) {
     return `Salesforce Contact ID ${identity.salesforceContactId} did not resolve to an existing canonical contact.`;
@@ -1159,7 +1178,7 @@ function buildIdentityMissingAnchorExplanation(
 }
 
 function buildIdentityConflictExplanation(
-  reasonCode: IdentityResolutionCase["reasonCode"]
+  reasonCode: IdentityResolutionCase["reasonCode"],
 ): string {
   switch (reasonCode) {
     case "identity_multi_candidate":
@@ -1170,11 +1189,13 @@ function buildIdentityConflictExplanation(
       return "Salesforce Contact ID resolved safely, but weaker identity evidence points at a different canonical contact.";
     case "identity_missing_anchor":
       return "No safe canonical contact could be selected from the available identity evidence.";
+    default:
+      return "Identity evidence could not be safely resolved.";
   }
 }
 
 function buildRoutingExplanation(
-  reasonCode: RoutingReviewCase["reasonCode"]
+  reasonCode: RoutingReviewCase["reasonCode"],
 ): string {
   switch (reasonCode) {
     case "routing_missing_membership":
@@ -1183,11 +1204,13 @@ function buildRoutingExplanation(
       return "More than one canonical membership is plausible for this activity.";
     case "routing_context_conflict":
       return "Provider-supplied routing context conflicts with canonical membership state.";
+    default:
+      return "Routing could not be safely resolved.";
   }
 }
 
 function isSalesforceTaskCommunicationIntake(
-  input: Pick<NormalizedCanonicalEventIntake, "sourceEvidence">
+  input: Pick<NormalizedCanonicalEventIntake, "sourceEvidence">,
 ): boolean {
   return (
     input.sourceEvidence.provider === "salesforce" &&
@@ -1200,10 +1223,12 @@ function buildSkippedNonVolunteerTaskExplanation(): string {
 }
 
 function decideDuplicateCollapse(
-  input: NormalizedCanonicalEventIntake
+  input: NormalizedCanonicalEventIntake,
 ): DuplicateCollapseDecision {
   const supportingProviders = new Set(
-    (input.supportingSources ?? []).map((entry) => entry.provider)
+    (
+      (input.supportingSources ?? []) as readonly SupportingSourceReference[]
+    ).map((entry) => entry.provider),
   );
   const primaryProvider = input.sourceEvidence.provider;
   const { eventType } = input.canonicalEvent;
@@ -1215,8 +1240,8 @@ function decideDuplicateCollapse(
         winner: {
           winnerReason: "gmail_wins_duplicate_collapse",
           notes:
-            "Gmail remained the primary provenance winner over Salesforce for the same outbound one-to-one email."
-        }
+            "Gmail remained the primary provenance winner over Salesforce for the same outbound one-to-one email.",
+        },
       };
     }
 
@@ -1225,7 +1250,7 @@ function decideDuplicateCollapse(
         outcome: "quarantined",
         reasonCode: "duplicate_collapse_conflict",
         explanation:
-          "Gmail must win duplicate collapse when Gmail and Salesforce describe the same outbound one-to-one email."
+          "Gmail must win duplicate collapse when Gmail and Salesforce describe the same outbound one-to-one email.",
       };
     }
   }
@@ -1240,8 +1265,8 @@ function decideDuplicateCollapse(
         winner: {
           winnerReason: "simpletexting_wins_duplicate_collapse",
           notes:
-            "SimpleTexting remained the primary provenance winner over Salesforce for the same outbound SMS."
-        }
+            "SimpleTexting remained the primary provenance winner over Salesforce for the same outbound SMS.",
+        },
       };
     }
 
@@ -1253,7 +1278,7 @@ function decideDuplicateCollapse(
         outcome: "quarantined",
         reasonCode: "duplicate_collapse_conflict",
         explanation:
-          "SimpleTexting must remain the primary transport winner when Salesforce also describes the same outbound SMS."
+          "SimpleTexting must remain the primary transport winner when Salesforce also describes the same outbound SMS.",
       };
     }
   }
@@ -1269,8 +1294,8 @@ function decideDuplicateCollapse(
       winner: {
         winnerReason: "salesforce_only_best_evidence",
         notes:
-          "Salesforce was retained because no stronger transport evidence was attached."
-      }
+          "Salesforce was retained because no stronger transport evidence was attached.",
+      },
     };
   }
 
@@ -1278,13 +1303,13 @@ function decideDuplicateCollapse(
     outcome: "accepted",
     winner: {
       winnerReason: "single_source",
-      notes: null
-    }
+      notes: null,
+    },
   };
 }
 
 function createIdentityResolutionContext(
-  persistence: Stage1PersistenceService
+  persistence: Stage1PersistenceService,
 ): IdentityResolutionContext {
   const contactByIdCache = new Map<string, Promise<ContactRecord | null>>();
   const contactsByIdentityValueCache = new Map<
@@ -1293,7 +1318,9 @@ function createIdentityResolutionContext(
   >();
   const anchoredContactCache = new Map<string, Promise<ContactRecord | null>>();
 
-  const loadContactById = (contactId: string): Promise<ContactRecord | null> => {
+  const loadContactById = (
+    contactId: string,
+  ): Promise<ContactRecord | null> => {
     const cached = contactByIdCache.get(contactId);
 
     if (cached !== undefined) {
@@ -1318,30 +1345,35 @@ function createIdentityResolutionContext(
 
           const lookup = (async () => {
             const identities =
-              await persistence.repositories.contactIdentities.listByNormalizedValue({
-                kind,
-                normalizedValue
-              });
+              await persistence.repositories.contactIdentities.listByNormalizedValue(
+                {
+                  kind,
+                  normalizedValue,
+                },
+              );
             const contacts = await Promise.all(
-              uniqueStrings(identities.map((identity) => identity.contactId)).map(
-                loadContactById
-              )
+              uniqueStrings(
+                identities.map((identity) => identity.contactId),
+              ).map(loadContactById),
             );
 
             return uniqueById(
               contacts.filter(
-                (contact): contact is ContactRecord => contact !== null
-              )
+                (contact: ContactRecord | null): contact is ContactRecord =>
+                  contact !== null,
+              ),
             );
           })();
 
           contactsByIdentityValueCache.set(cacheKey, lookup);
           return lookup;
-        })
+        }),
       );
 
       return new Map(
-        uniqueById(contactGroups.flat()).map((contact) => [contact.id, contact] as const)
+        uniqueById(contactGroups.flat()).map(
+          (contact) => [contact.id, contact] as const,
+        ),
       );
     },
 
@@ -1354,7 +1386,7 @@ function createIdentityResolutionContext(
 
       const lookup =
         persistence.repositories.contacts.findBySalesforceContactId(
-          salesforceContactId
+          salesforceContactId,
         );
       anchoredContactCache.set(salesforceContactId, lookup);
       return lookup;
@@ -1364,7 +1396,7 @@ function createIdentityResolutionContext(
       contactByIdCache.clear();
       contactsByIdentityValueCache.clear();
       anchoredContactCache.clear();
-    }
+    },
   };
 }
 
@@ -1373,28 +1405,25 @@ async function resolveIdentityDecision(
   sourceEvidenceId: string,
   openedAt: string,
   identity: NormalizedIdentityEvidence,
-  provider: Provider
+  provider: Provider,
 ): Promise<IdentityResolutionDecision> {
   const emailMatches = await context.loadContactsForIdentityKind(
     "email",
-    identity.normalizedEmails
+    identity.normalizedEmails,
   );
   const phoneMatches = await context.loadContactsForIdentityKind(
     "phone",
-    identity.normalizedPhones
+    identity.normalizedPhones,
   );
   const volunteerMatches = await context.loadContactsForIdentityKind(
     "volunteer_id_plain",
-    identity.volunteerIdPlainValues
+    identity.volunteerIdPlainValues,
   );
   const normalizedIdentityValues = buildNormalizedIdentityValues(identity);
 
-  if (
-    identity.salesforceContactId !== null &&
-    provider === "salesforce"
-  ) {
+  if (identity.salesforceContactId !== null && provider === "salesforce") {
     const anchored = await context.findAnchoredContact(
-      identity.salesforceContactId
+      identity.salesforceContactId,
     );
 
     if (anchored === null) {
@@ -1405,21 +1434,23 @@ async function resolveIdentityDecision(
           candidateContactIds: uniqueStrings([
             ...emailMatches.keys(),
             ...phoneMatches.keys(),
-            ...volunteerMatches.keys()
+            ...volunteerMatches.keys(),
           ]),
           reasonCode: "identity_missing_anchor",
           openedAt,
           normalizedIdentityValues,
           anchoredContactId: null,
-          explanation: buildIdentityMissingAnchorExplanation(identity)
-        })
+          explanation: buildIdentityMissingAnchorExplanation(identity),
+        }),
       };
     }
 
     const conflictingContactIds = uniqueStrings(
-      [...emailMatches.keys(), ...phoneMatches.keys(), ...volunteerMatches.keys()].filter(
-        (contactId) => contactId !== anchored.id
-      )
+      [
+        ...emailMatches.keys(),
+        ...phoneMatches.keys(),
+        ...volunteerMatches.keys(),
+      ].filter((contactId) => contactId !== anchored.id),
     );
 
     if (conflictingContactIds.length > 0) {
@@ -1434,16 +1465,16 @@ async function resolveIdentityDecision(
           normalizedIdentityValues,
           anchoredContactId: anchored.id,
           explanation: buildIdentityConflictExplanation(
-            "identity_anchor_mismatch"
-          )
-        })
+            "identity_anchor_mismatch",
+          ),
+        }),
       };
     }
 
     return {
       outcome: "resolved",
       contact: anchored,
-      reviewInput: null
+      reviewInput: null,
     };
   }
 
@@ -1460,15 +1491,17 @@ async function resolveIdentityDecision(
         openedAt,
         normalizedIdentityValues,
         anchoredContactId: null,
-        explanation: buildIdentityConflictExplanation("identity_multi_candidate")
-      })
+        explanation: buildIdentityConflictExplanation(
+          "identity_multi_candidate",
+        ),
+      }),
     };
   }
 
   if (emailMatchesList.length === 1) {
     const emailContact = requireValue(
       emailMatchesList[0],
-      "Expected a single email-matched contact."
+      "Expected a single email-matched contact.",
     );
 
     if (
@@ -1476,19 +1509,19 @@ async function resolveIdentityDecision(
       (phoneMatchesList.length === 1 &&
         requireValue(
           phoneMatchesList[0],
-          "Expected a single phone-matched contact."
+          "Expected a single phone-matched contact.",
         ).id === emailContact.id)
     ) {
       return {
         outcome: "resolved",
         contact: emailContact,
-        reviewInput: null
+        reviewInput: null,
       };
     }
 
     const candidateContactIds = uniqueStrings([
       emailContact.id,
-      ...phoneMatchesList.map((contact) => contact.id)
+      ...phoneMatchesList.map((contact) => contact.id),
     ]);
 
     return {
@@ -1506,9 +1539,9 @@ async function resolveIdentityDecision(
         explanation: buildIdentityConflictExplanation(
           phoneMatchesList.length === 1
             ? "identity_conflict"
-            : "identity_multi_candidate"
-        )
-      })
+            : "identity_multi_candidate",
+        ),
+      }),
     };
   }
 
@@ -1522,21 +1555,23 @@ async function resolveIdentityDecision(
         openedAt,
         normalizedIdentityValues,
         anchoredContactId: null,
-        explanation: buildIdentityConflictExplanation("identity_multi_candidate")
-      })
+        explanation: buildIdentityConflictExplanation(
+          "identity_multi_candidate",
+        ),
+      }),
     };
   }
 
   if (phoneMatchesList.length === 1) {
     const phoneContact = requireValue(
       phoneMatchesList[0],
-      "Expected a single phone-matched contact."
+      "Expected a single phone-matched contact.",
     );
 
     return {
       outcome: "resolved",
       contact: phoneContact,
-      reviewInput: null
+      reviewInput: null,
     };
   }
 
@@ -1551,8 +1586,8 @@ async function resolveIdentityDecision(
         normalizedIdentityValues,
         anchoredContactId: null,
         explanation:
-          "More than one external email participant was present and no safe canonical contact could be selected."
-      })
+          "More than one external email participant was present and no safe canonical contact could be selected.",
+      }),
     };
   }
 
@@ -1563,7 +1598,7 @@ async function resolveIdentityDecision(
     return {
       outcome: "create_new_contact",
       normalizedEmail: fallbackNormalizedEmail,
-      normalizedPhone: fallbackNormalizedPhone
+      normalizedPhone: fallbackNormalizedPhone,
     };
   }
 
@@ -1576,8 +1611,8 @@ async function resolveIdentityDecision(
       openedAt,
       normalizedIdentityValues,
       anchoredContactId: null,
-      explanation: buildIdentityMissingAnchorExplanation(identity)
-    })
+      explanation: buildIdentityMissingAnchorExplanation(identity),
+    }),
   };
 }
 
@@ -1590,18 +1625,19 @@ async function resolveRoutingDecision(
     readonly routing:
       | NonNullable<NormalizedCanonicalEventIntake["routing"]>
       | undefined;
-  }
+  },
 ): Promise<RoutingResolutionDecision> {
   if (!input.routing?.required) {
     return {
       outcome: "clear",
-      reviewInput: null
+      reviewInput: null,
     };
   }
 
-  const memberships = await persistence.repositories.contactMemberships.listByContactId(
-    input.contactId
-  );
+  const memberships =
+    await persistence.repositories.contactMemberships.listByContactId(
+      input.contactId,
+    );
 
   if (memberships.length === 0) {
     return {
@@ -1612,8 +1648,8 @@ async function resolveRoutingDecision(
         reasonCode: "routing_missing_membership",
         openedAt: input.openedAt,
         candidateMembershipIds: [],
-        explanation: buildRoutingExplanation("routing_missing_membership")
-      })
+        explanation: buildRoutingExplanation("routing_missing_membership"),
+      }),
     };
   }
 
@@ -1636,7 +1672,7 @@ async function resolveRoutingDecision(
     if (matchingMemberships.length === 1) {
       return {
         outcome: "clear",
-        reviewInput: null
+        reviewInput: null,
       };
     }
 
@@ -1649,10 +1685,10 @@ async function resolveRoutingDecision(
           reasonCode: "routing_multiple_memberships",
           openedAt: input.openedAt,
           candidateMembershipIds: matchingMemberships.map(
-            (membership) => membership.id
+            (membership) => membership.id,
           ),
-          explanation: buildRoutingExplanation("routing_multiple_memberships")
-        })
+          explanation: buildRoutingExplanation("routing_multiple_memberships"),
+        }),
       };
     }
 
@@ -1664,15 +1700,15 @@ async function resolveRoutingDecision(
         reasonCode: "routing_context_conflict",
         openedAt: input.openedAt,
         candidateMembershipIds: memberships.map((membership) => membership.id),
-        explanation: buildRoutingExplanation("routing_context_conflict")
-      })
+        explanation: buildRoutingExplanation("routing_context_conflict"),
+      }),
     };
   }
 
   if (memberships.length === 1) {
     return {
       outcome: "clear",
-      reviewInput: null
+      reviewInput: null,
     };
   }
 
@@ -1684,8 +1720,8 @@ async function resolveRoutingDecision(
       reasonCode: "routing_multiple_memberships",
       openedAt: input.openedAt,
       candidateMembershipIds: memberships.map((membership) => membership.id),
-      explanation: buildRoutingExplanation("routing_multiple_memberships")
-    })
+      explanation: buildRoutingExplanation("routing_multiple_memberships"),
+    }),
   };
 }
 
@@ -1695,7 +1731,7 @@ async function resolveNonVolunteerSalesforceTaskSkip(
   input: Pick<
     NormalizedCanonicalEventIntake,
     "identity" | "salesforceEventContext" | "sourceEvidence"
-  >
+  >,
 ): Promise<
   | {
       readonly outcome: "continue";
@@ -1707,7 +1743,7 @@ async function resolveNonVolunteerSalesforceTaskSkip(
 > {
   if (!isSalesforceTaskCommunicationIntake(input)) {
     return {
-      outcome: "continue"
+      outcome: "continue",
     };
   }
 
@@ -1718,7 +1754,7 @@ async function resolveNonVolunteerSalesforceTaskSkip(
 
   if (whoId === null) {
     return {
-      outcome: "continue"
+      outcome: "continue",
     };
   }
 
@@ -1727,67 +1763,70 @@ async function resolveNonVolunteerSalesforceTaskSkip(
   if (anchoredContact === null) {
     return {
       outcome: "skipped",
-      whoId
+      whoId,
     };
   }
 
-  const memberships = await persistence.repositories.contactMemberships.listByContactId(
-    anchoredContact.id
-  );
+  const memberships =
+    await persistence.repositories.contactMemberships.listByContactId(
+      anchoredContact.id,
+    );
 
   if (memberships.length > 0) {
     return {
-      outcome: "continue"
+      outcome: "continue",
     };
   }
 
   return {
     outcome: "skipped",
-    whoId
+    whoId,
   };
 }
 
 async function listOpenIdentityCasesForContact(
   persistence: Stage1PersistenceService,
-  contactId: string
+  contactId: string,
 ): Promise<readonly IdentityResolutionCase[]> {
   const casesByReason = await Promise.all(
     identityResolutionReasonCodeValues.map((reasonCode) =>
       persistence.repositories.identityResolutionQueue.listOpenByReasonCode(
-        reasonCode
-      )
-    )
+        reasonCode,
+      ),
+    ),
   );
 
   return uniqueById(
     casesByReason
       .flat()
-      .filter((record) => record.anchoredContactId === contactId)
+      .filter((record) => record.anchoredContactId === contactId),
   );
 }
 
 async function listOpenRoutingCasesForContact(
   persistence: Stage1PersistenceService,
-  contactId: string
+  contactId: string,
 ): Promise<readonly RoutingReviewCase[]> {
   const casesByReason = await Promise.all(
     routingReviewReasonCodeValues.map((reasonCode) =>
-      persistence.repositories.routingReviewQueue.listOpenByReasonCode(reasonCode)
-    )
+      persistence.repositories.routingReviewQueue.listOpenByReasonCode(
+        reasonCode,
+      ),
+    ),
   );
 
   return uniqueById(
-    casesByReason.flat().filter((record) => record.contactId === contactId)
+    casesByReason.flat().filter((record) => record.contactId === contactId),
   );
 }
 
 async function contactHasUnresolved(
   persistence: Stage1PersistenceService,
-  contactId: string
+  contactId: string,
 ): Promise<boolean> {
   const [identityCases, routingCases] = await Promise.all([
     listOpenIdentityCasesForContact(persistence, contactId),
-    listOpenRoutingCasesForContact(persistence, contactId)
+    listOpenRoutingCasesForContact(persistence, contactId),
   ]);
 
   return identityCases.length > 0 || routingCases.length > 0;
@@ -1802,15 +1841,16 @@ async function recordQuarantineAuditOnce(
     readonly reasonCode: QuarantineReasonCode;
     readonly action: string;
     readonly metadataJson: Record<string, unknown>;
-  }
+  },
 ): Promise<AuditEvidenceRecord> {
   const policyCode = `stage1.quarantine.${input.reasonCode}`;
-  const existingRecords = await persistence.repositories.auditEvidence.listByEntity({
-    entityType: input.entityType,
-    entityId: input.entityId
-  });
+  const existingRecords =
+    await persistence.repositories.auditEvidence.listByEntity({
+      entityType: input.entityType,
+      entityId: input.entityId,
+    });
   const existingRecord = existingRecords.find(
-    (record) => record.policyCode === policyCode
+    (record) => record.policyCode === policyCode,
   );
 
   if (existingRecord !== undefined) {
@@ -1821,7 +1861,7 @@ async function recordQuarantineAuditOnce(
     id: buildQuarantineAuditId(
       input.entityType,
       input.entityId,
-      input.reasonCode
+      input.reasonCode,
     ),
     actorType: "system",
     actorId: "stage1-normalization",
@@ -1831,7 +1871,7 @@ async function recordQuarantineAuditOnce(
     occurredAt: input.occurredAt,
     result: "recorded",
     policyCode,
-    metadataJson: input.metadataJson
+    metadataJson: input.metadataJson,
   });
 }
 
@@ -1843,15 +1883,16 @@ async function recordSkipAuditOnce(
     readonly occurredAt: string;
     readonly action: "skipped_non_volunteer_task";
     readonly metadataJson: Record<string, unknown>;
-  }
+  },
 ): Promise<AuditEvidenceRecord> {
   const policyCode = `stage1.skip.${input.action}`;
-  const existingRecords = await persistence.repositories.auditEvidence.listByEntity({
-    entityType: input.entityType,
-    entityId: input.entityId
-  });
+  const existingRecords =
+    await persistence.repositories.auditEvidence.listByEntity({
+      entityType: input.entityType,
+      entityId: input.entityId,
+    });
   const existingRecord = existingRecords.find(
-    (record) => record.policyCode === policyCode
+    (record) => record.policyCode === policyCode,
   );
 
   if (existingRecord !== undefined) {
@@ -1868,7 +1909,7 @@ async function recordSkipAuditOnce(
     occurredAt: input.occurredAt,
     result: "recorded",
     policyCode,
-    metadataJson: input.metadataJson
+    metadataJson: input.metadataJson,
   });
 }
 
@@ -1877,23 +1918,23 @@ async function upsertProjectAndExpeditionDimensions(
   input: {
     readonly projectDimensions: readonly ProjectDimensionRecord[];
     readonly expeditionDimensions: readonly ExpeditionDimensionRecord[];
-  }
+  },
 ): Promise<void> {
   for (const projectDimension of uniqueByKey(
     input.projectDimensions,
-    (record) => record.projectId
+    (record) => record.projectId,
   )) {
     await persistence.upsertProjectDimension(
-      projectDimensionSchema.parse(projectDimension)
+      projectDimensionSchema.parse(projectDimension),
     );
   }
 
   for (const expeditionDimension of uniqueByKey(
     input.expeditionDimensions,
-    (record) => record.expeditionId
+    (record) => record.expeditionId,
   )) {
     await persistence.upsertExpeditionDimension(
-      expeditionDimensionSchema.parse(expeditionDimension)
+      expeditionDimensionSchema.parse(expeditionDimension),
     );
   }
 }
@@ -1913,11 +1954,11 @@ async function upsertProviderPresentationDetails(
   >,
   options?: {
     readonly allowDuplicateGmailMessageDetailOverwrite?: boolean;
-  }
+  },
 ): Promise<void> {
   await upsertProjectAndExpeditionDimensions(persistence, {
     projectDimensions: input.projectDimensions ?? [],
-    expeditionDimensions: input.expeditionDimensions ?? []
+    expeditionDimensions: input.expeditionDimensions ?? [],
   });
 
   if (
@@ -1925,46 +1966,48 @@ async function upsertProviderPresentationDetails(
     (options?.allowDuplicateGmailMessageDetailOverwrite ?? true)
   ) {
     await persistence.upsertGmailMessageDetail(
-      gmailMessageDetailSchema.parse(input.gmailMessageDetail)
+      gmailMessageDetailSchema.parse(input.gmailMessageDetail),
     );
   }
 
   if (input.salesforceCommunicationDetail !== undefined) {
     await persistence.upsertSalesforceCommunicationDetail(
-      salesforceCommunicationDetailSchema.parse(input.salesforceCommunicationDetail)
+      salesforceCommunicationDetailSchema.parse(
+        input.salesforceCommunicationDetail,
+      ),
     );
   }
 
   if (input.simpleTextingMessageDetail !== undefined) {
     await persistence.upsertSimpleTextingMessageDetail(
-      simpleTextingMessageDetailSchema.parse(input.simpleTextingMessageDetail)
+      simpleTextingMessageDetailSchema.parse(input.simpleTextingMessageDetail),
     );
   }
 
   if (input.mailchimpCampaignActivityDetail !== undefined) {
     await persistence.upsertMailchimpCampaignActivityDetail(
       mailchimpCampaignActivityDetailSchema.parse(
-        input.mailchimpCampaignActivityDetail
-      )
+        input.mailchimpCampaignActivityDetail,
+      ),
     );
   }
 
   if (input.manualNoteDetail !== undefined) {
     await persistence.upsertManualNoteDetail(
-      manualNoteDetailSchema.parse(input.manualNoteDetail)
+      manualNoteDetailSchema.parse(input.manualNoteDetail),
     );
   }
 
   if (input.salesforceEventContext !== undefined) {
     await persistence.upsertSalesforceEventContext(
-      salesforceEventContextSchema.parse(input.salesforceEventContext)
+      salesforceEventContextSchema.parse(input.salesforceEventContext),
     );
   }
 }
 
 async function upsertMissingDuplicateGmailMessageDetail(
   persistence: Stage1PersistenceService,
-  gmailMessageDetail: NormalizedCanonicalEventIntake["gmailMessageDetail"]
+  gmailMessageDetail: NormalizedCanonicalEventIntake["gmailMessageDetail"],
 ): Promise<void> {
   if (gmailMessageDetail === undefined) {
     return;
@@ -1972,7 +2015,7 @@ async function upsertMissingDuplicateGmailMessageDetail(
 
   const existingDetails =
     await persistence.repositories.gmailMessageDetails.listBySourceEvidenceIds([
-      gmailMessageDetail.sourceEvidenceId
+      gmailMessageDetail.sourceEvidenceId,
     ]);
 
   if (existingDetails.length > 0) {
@@ -1980,20 +2023,23 @@ async function upsertMissingDuplicateGmailMessageDetail(
   }
 
   await persistence.upsertGmailMessageDetail(
-    gmailMessageDetailSchema.parse(gmailMessageDetail)
+    gmailMessageDetailSchema.parse(gmailMessageDetail),
   );
 }
 
 export function createStage1NormalizationService(
-  persistence: Stage1PersistenceService
+  persistence: Stage1PersistenceService,
 ): Stage1NormalizationService {
-  const identityResolutionContext = createIdentityResolutionContext(persistence);
+  const identityResolutionContext =
+    createIdentityResolutionContext(persistence);
   const service: Stage1NormalizationService = {
     persistence,
 
     async recordNormalizedSourceEvidence(input) {
       const parsed = normalizedSourceEvidenceIntakeSchema.parse(input);
-      const result = await persistence.recordSourceEvidence(parsed.sourceEvidence);
+      const result = await persistence.recordSourceEvidence(
+        parsed.sourceEvidence,
+      );
 
       if (result.outcome === "conflict") {
         const auditEvidence = await recordQuarantineAuditOnce(persistence, {
@@ -2006,10 +2052,10 @@ export function createStage1NormalizationService(
             incomingId: parsed.sourceEvidence.id,
             incomingIdempotencyKey: parsed.sourceEvidence.idempotencyKey,
             conflictingRecordIds: result.conflictingRecords.map(
-              (record) => record.id
+              (record) => record.id,
             ),
-            conflictReason: result.reason
-          }
+            conflictReason: result.reason,
+          },
         });
 
         return {
@@ -2017,14 +2063,14 @@ export function createStage1NormalizationService(
           incoming: parsed.sourceEvidence,
           conflictingRecords: result.conflictingRecords,
           reasonCode: "replay_checksum_mismatch",
-          auditEvidence
+          auditEvidence,
         };
       }
 
       return {
         outcome: result.outcome,
         record: result.record,
-        auditEvidence: null
+        auditEvidence: null,
       };
     },
 
@@ -2032,7 +2078,7 @@ export function createStage1NormalizationService(
       const parsed = normalizedContactGraphUpsertInputSchema.parse(input);
       assertVolunteerScopedSalesforceContactGraph(parsed);
       const contact = await persistence.upsertCanonicalContact(
-        contactSchema.parse(parsed.contact)
+        contactSchema.parse(parsed.contact),
       );
 
       const identities: ContactIdentityRecord[] = [];
@@ -2041,21 +2087,21 @@ export function createStage1NormalizationService(
 
         if (parsedIdentity.contactId !== parsed.contact.id) {
           throw new Error(
-            `Contact identity ${parsedIdentity.id} does not belong to contact ${parsed.contact.id}.`
+            `Contact identity ${parsedIdentity.id} does not belong to contact ${parsed.contact.id}.`,
           );
         }
 
         identities.push(
           await persistence.upsertContactIdentity({
             ...parsedIdentity,
-            contactId: contact.id
-          })
+            contactId: contact.id,
+          }),
         );
       }
 
       await upsertProjectAndExpeditionDimensions(persistence, {
         projectDimensions: parsed.projectDimensions,
-        expeditionDimensions: parsed.expeditionDimensions
+        expeditionDimensions: parsed.expeditionDimensions,
       });
 
       const memberships: ContactMembershipRecord[] = [];
@@ -2064,15 +2110,15 @@ export function createStage1NormalizationService(
 
         if (parsedMembership.contactId !== parsed.contact.id) {
           throw new Error(
-            `Contact membership ${parsedMembership.id} does not belong to contact ${parsed.contact.id}.`
+            `Contact membership ${parsedMembership.id} does not belong to contact ${parsed.contact.id}.`,
           );
         }
 
         memberships.push(
           await persistence.upsertContactMembership({
             ...parsedMembership,
-            contactId: contact.id
-          })
+            contactId: contact.id,
+          }),
         );
       }
       identityResolutionContext.clear();
@@ -2080,7 +2126,7 @@ export function createStage1NormalizationService(
       return {
         contact,
         identities,
-        memberships
+        memberships,
       };
     },
 
@@ -2100,30 +2146,34 @@ export function createStage1NormalizationService(
         (
           await Promise.all(
             uniqueStrings(identities.map((identity) => identity.contactId)).map(
-              (contactId) => persistence.repositories.contacts.findById(contactId)
-            )
+              (contactId) =>
+                persistence.repositories.contacts.findById(contactId),
+            ),
           )
-        ).filter((contact): contact is ContactRecord => contact !== null)
+        ).filter(
+          (contact: ContactRecord | null): contact is ContactRecord =>
+            contact !== null,
+        ),
       );
 
       if (existingContacts.length > 0) {
         const [existingContact] = existingContacts;
 
-      if (existingContact === undefined) {
-        throw new Error(
-          "Expected an existing contact when normalized email matches."
-        );
-      }
+        if (existingContact === undefined) {
+          throw new Error(
+            "Expected an existing contact when normalized email matches.",
+          );
+        }
 
-      if (existingContacts.length > 1) {
-        throw new CanonicalContactAmbiguityError({
-          normalizedEmail,
-          candidateContactIds: existingContacts.map((contact) => contact.id)
-        });
-      }
+        if (existingContacts.length > 1) {
+          throw new CanonicalContactAmbiguityError({
+            normalizedEmail,
+            candidateContactIds: existingContacts.map((contact) => contact.id),
+          });
+        }
 
-      return existingContact;
-    }
+        return existingContact;
+      }
 
       return (
         await service.upsertNormalizedContactGraph(
@@ -2132,7 +2182,7 @@ export function createStage1NormalizationService(
             normalizedPhone: null,
             createdAt: input.createdAt ?? new Date().toISOString(),
             source: input.source ?? "manual",
-          })
+          }),
         )
       ).contact;
     },
@@ -2141,18 +2191,18 @@ export function createStage1NormalizationService(
       const parsed = identityAmbiguityInputSchema.parse(input);
       const caseRecord = await persistence.saveIdentityResolutionCase({
         id: buildIdentityCaseId(parsed.sourceEvidenceId, parsed.reasonCode),
-        ...parsed
+        ...parsed,
       });
       const inboxProjection =
         parsed.anchoredContactId === null
           ? null
           : await service.refreshInboxReviewOverlay({
-              contactId: parsed.anchoredContactId
+              contactId: parsed.anchoredContactId,
             });
 
       return {
         caseRecord,
-        inboxProjection
+        inboxProjection,
       };
     },
 
@@ -2162,17 +2212,17 @@ export function createStage1NormalizationService(
         id: buildRoutingCaseId(
           parsed.sourceEvidenceId,
           parsed.contactId,
-          parsed.reasonCode
+          parsed.reasonCode,
         ),
-        ...parsed
+        ...parsed,
       });
       const inboxProjection = await service.refreshInboxReviewOverlay({
-        contactId: parsed.contactId
+        contactId: parsed.contactId,
       });
 
       return {
         caseRecord,
-        inboxProjection
+        inboxProjection,
       };
     },
 
@@ -2187,13 +2237,13 @@ export function createStage1NormalizationService(
         sortKey: buildTimelineSortKey(
           parsed.canonicalEvent.id,
           parsed.canonicalEvent.occurredAt,
-          parsed.canonicalEvent.eventType
+          parsed.canonicalEvent.eventType,
         ),
         eventType: parsed.canonicalEvent.eventType,
         summary: parsed.summary,
         channel: parsed.canonicalEvent.channel,
         primaryProvider: parsed.canonicalEvent.provenance.primaryProvider,
-        reviewState: parsed.canonicalEvent.reviewState
+        reviewState: parsed.canonicalEvent.reviewState,
       });
     },
 
@@ -2202,36 +2252,37 @@ export function createStage1NormalizationService(
 
       if (!qualifiesForInboxProjection(parsed.canonicalEvent)) {
         return persistence.repositories.inboxProjection.findByContactId(
-          parsed.canonicalEvent.contactId
+          parsed.canonicalEvent.contactId,
         );
       }
 
-      const existing = await persistence.repositories.inboxProjection.findByContactId(
-        parsed.canonicalEvent.contactId
-      );
+      const existing =
+        await persistence.repositories.inboxProjection.findByContactId(
+          parsed.canonicalEvent.contactId,
+        );
       const incomingIsInbound = isInboundEvent(parsed.canonicalEvent.eventType);
       const incomingIsOutboundProjectionEvent = isOutboundProjectionEvent(
-        parsed.canonicalEvent.eventType
+        parsed.canonicalEvent.eventType,
       );
       const lastInboundAt = incomingIsInbound
         ? newestTimestamp(
             existing?.lastInboundAt ?? null,
-            parsed.canonicalEvent.occurredAt
+            parsed.canonicalEvent.occurredAt,
           )
-        : existing?.lastInboundAt ?? null;
+        : (existing?.lastInboundAt ?? null);
       const lastOutboundAt = incomingIsOutboundProjectionEvent
         ? newestTimestamp(
             existing?.lastOutboundAt ?? null,
-            parsed.canonicalEvent.occurredAt
+            parsed.canonicalEvent.occurredAt,
           )
-        : existing?.lastOutboundAt ?? null;
+        : (existing?.lastOutboundAt ?? null);
       const lastActivityAt = newestTimestamp(
         existing?.lastActivityAt ?? null,
-        parsed.canonicalEvent.occurredAt
+        parsed.canonicalEvent.occurredAt,
       );
       const incomingIsLatestKnown = latestTimestampWins(
         parsed.canonicalEvent,
-        existing
+        existing,
       );
 
       if (lastActivityAt === null) {
@@ -2239,7 +2290,7 @@ export function createStage1NormalizationService(
       }
       const hasUnresolved = await contactHasUnresolved(
         persistence,
-        parsed.canonicalEvent.contactId
+        parsed.canonicalEvent.contactId,
       );
       const bucket =
         existing === null
@@ -2262,22 +2313,23 @@ export function createStage1NormalizationService(
         lastActivityAt,
         snippet: incomingIsLatestKnown
           ? parsed.snippet
-          : existing?.snippet ?? parsed.snippet,
+          : (existing?.snippet ?? parsed.snippet),
         archivedAt: existing?.archivedAt ?? null,
         lastCanonicalEventId: incomingIsLatestKnown
           ? parsed.canonicalEvent.id
-          : existing?.lastCanonicalEventId ?? parsed.canonicalEvent.id,
+          : (existing?.lastCanonicalEventId ?? parsed.canonicalEvent.id),
         lastEventType: incomingIsLatestKnown
           ? parsed.canonicalEvent.eventType
-          : existing?.lastEventType ?? parsed.canonicalEvent.eventType
+          : (existing?.lastEventType ?? parsed.canonicalEvent.eventType),
       });
     },
 
     async refreshInboxReviewOverlay(input) {
       const parsed = inboxReviewOverlayRefreshInputSchema.parse(input);
-      const existing = await persistence.repositories.inboxProjection.findByContactId(
-        parsed.contactId
-      );
+      const existing =
+        await persistence.repositories.inboxProjection.findByContactId(
+          parsed.contactId,
+        );
 
       if (existing === null) {
         return null;
@@ -2285,7 +2337,7 @@ export function createStage1NormalizationService(
 
       const hasUnresolved = await contactHasUnresolved(
         persistence,
-        parsed.contactId
+        parsed.contactId,
       );
 
       if (existing.hasUnresolved === hasUnresolved) {
@@ -2294,7 +2346,7 @@ export function createStage1NormalizationService(
 
       return persistence.saveInboxProjection({
         ...existing,
-        hasUnresolved
+        hasUnresolved,
       });
     },
 
@@ -2306,9 +2358,11 @@ export function createStage1NormalizationService(
 
     async applyNormalizedCanonicalEvent(input, options) {
       const parsed = normalizedCanonicalEventIntakeSchema.parse(input);
-      const sourceEvidenceResult = await service.recordNormalizedSourceEvidence({
-        sourceEvidence: parsed.sourceEvidence
-      });
+      const sourceEvidenceResult = await service.recordNormalizedSourceEvidence(
+        {
+          sourceEvidence: parsed.sourceEvidence,
+        },
+      );
 
       if (sourceEvidenceResult.outcome === "quarantined") {
         return {
@@ -2318,7 +2372,7 @@ export function createStage1NormalizationService(
           explanation:
             "The incoming source evidence replay conflicted with previously recorded evidence.",
           existingCanonicalEvent: null,
-          auditEvidence: sourceEvidenceResult.auditEvidence
+          auditEvidence: sourceEvidenceResult.auditEvidence,
         };
       }
 
@@ -2328,39 +2382,39 @@ export function createStage1NormalizationService(
       ) {
         await upsertMissingDuplicateGmailMessageDetail(
           persistence,
-          parsed.gmailMessageDetail
+          parsed.gmailMessageDetail,
         );
 
         const existingCanonicalEvent =
           await persistence.findCanonicalEventByIdempotencyKey(
-            parsed.canonicalEvent.idempotencyKey
+            parsed.canonicalEvent.idempotencyKey,
           );
 
         if (
           existingCanonicalEvent !== null &&
           findCanonicalEventForSourceEvidence(
             [existingCanonicalEvent],
-            sourceEvidenceResult.record.id
+            sourceEvidenceResult.record.id,
           ) !== null
         ) {
           const existingTimelineProjection =
             await persistence.repositories.timelineProjection.findByCanonicalEventId(
-              existingCanonicalEvent.id
+              existingCanonicalEvent.id,
             );
           const timelineProjection =
             existingTimelineProjection ??
             (await service.applyTimelineProjection({
               canonicalEvent: existingCanonicalEvent,
-              summary: parsed.canonicalEvent.summary
+              summary: parsed.canonicalEvent.summary,
             }));
           const inboxProjection = qualifiesForInboxProjection(
-            existingCanonicalEvent
+            existingCanonicalEvent,
           )
             ? await persistence.repositories.inboxProjection.findByContactId(
-                existingCanonicalEvent.contactId
+                existingCanonicalEvent.contactId,
               )
             : await service.refreshInboxReviewOverlay({
-                contactId: existingCanonicalEvent.contactId
+                contactId: existingCanonicalEvent.contactId,
               });
 
           return {
@@ -2371,7 +2425,7 @@ export function createStage1NormalizationService(
             inboxProjection,
             identityCase: null,
             routingCase: null,
-            auditEvidence: null
+            auditEvidence: null,
           };
         }
       }
@@ -2380,7 +2434,7 @@ export function createStage1NormalizationService(
         await resolveNonVolunteerSalesforceTaskSkip(
           persistence,
           identityResolutionContext,
-          parsed
+          parsed,
         );
 
       if (nonVolunteerTaskDecision.outcome === "skipped") {
@@ -2391,8 +2445,8 @@ export function createStage1NormalizationService(
           action: "skipped_non_volunteer_task",
           metadataJson: {
             salesforceTaskId: parsed.sourceEvidence.providerRecordId,
-            whoId: nonVolunteerTaskDecision.whoId
-          }
+            whoId: nonVolunteerTaskDecision.whoId,
+          },
         });
 
         return {
@@ -2400,24 +2454,29 @@ export function createStage1NormalizationService(
           sourceEvidence: sourceEvidenceResult.record,
           reasonCode: "skipped_non_volunteer_task",
           explanation: buildSkippedNonVolunteerTaskExplanation(),
-          auditEvidence
+          auditEvidence,
         };
       }
 
-      await upsertProviderPresentationDetails(persistence, {
-        gmailMessageDetail: parsed.gmailMessageDetail,
-        salesforceCommunicationDetail: parsed.salesforceCommunicationDetail,
-        simpleTextingMessageDetail: parsed.simpleTextingMessageDetail,
-        mailchimpCampaignActivityDetail: parsed.mailchimpCampaignActivityDetail,
-        manualNoteDetail: parsed.manualNoteDetail,
-        salesforceEventContext: parsed.salesforceEventContext,
-        projectDimensions: parsed.projectDimensions,
-        expeditionDimensions: parsed.expeditionDimensions
-      }, {
-        allowDuplicateGmailMessageDetailOverwrite:
-          sourceEvidenceResult.outcome !== "duplicate" ||
-          (options?.overwriteDuplicateGmailMessageDetail ?? true)
-      });
+      await upsertProviderPresentationDetails(
+        persistence,
+        {
+          gmailMessageDetail: parsed.gmailMessageDetail,
+          salesforceCommunicationDetail: parsed.salesforceCommunicationDetail,
+          simpleTextingMessageDetail: parsed.simpleTextingMessageDetail,
+          mailchimpCampaignActivityDetail:
+            parsed.mailchimpCampaignActivityDetail,
+          manualNoteDetail: parsed.manualNoteDetail,
+          salesforceEventContext: parsed.salesforceEventContext,
+          projectDimensions: parsed.projectDimensions,
+          expeditionDimensions: parsed.expeditionDimensions,
+        },
+        {
+          allowDuplicateGmailMessageDetailOverwrite:
+            sourceEvidenceResult.outcome !== "duplicate" ||
+            (options?.overwriteDuplicateGmailMessageDetail ?? true),
+        },
+      );
 
       const duplicateCollapseDecision = decideDuplicateCollapse(parsed);
 
@@ -2432,10 +2491,10 @@ export function createStage1NormalizationService(
             canonicalEventId: parsed.canonicalEvent.id,
             eventType: parsed.canonicalEvent.eventType,
             primaryProvider: parsed.sourceEvidence.provider,
-            supportingProviders: parsed.supportingSources.map(
-              (entry) => entry.provider
-            )
-          }
+            supportingProviders: (
+              parsed.supportingSources as readonly SupportingSourceReference[]
+            ).map((entry) => entry.provider),
+          },
         });
 
         return {
@@ -2444,7 +2503,7 @@ export function createStage1NormalizationService(
           reasonCode: duplicateCollapseDecision.reasonCode,
           explanation: duplicateCollapseDecision.explanation,
           existingCanonicalEvent: null,
-          auditEvidence
+          auditEvidence,
         };
       }
 
@@ -2453,19 +2512,19 @@ export function createStage1NormalizationService(
         sourceEvidenceResult.record.id,
         parsed.sourceEvidence.receivedAt,
         parsed.identity,
-        parsed.sourceEvidence.provider
+        parsed.sourceEvidence.provider,
       );
 
       if (identityDecision.outcome === "needs_identity_review") {
         const { caseRecord } = await service.saveIdentityAmbiguityCase(
-          identityDecision.reviewInput
+          identityDecision.reviewInput,
         );
 
         return {
           outcome: "needs_identity_review",
           sourceEvidence: sourceEvidenceResult.record,
           identityCase: caseRecord,
-          auditEvidence: null
+          auditEvidence: null,
         };
       }
 
@@ -2477,8 +2536,8 @@ export function createStage1NormalizationService(
                   normalizedEmail: identityDecision.normalizedEmail,
                   normalizedPhone: identityDecision.normalizedPhone,
                   createdAt: parsed.sourceEvidence.receivedAt,
-                  source: parsed.sourceEvidence.provider
-                })
+                  source: parsed.sourceEvidence.provider,
+                }),
               )
             ).contact
           : identityDecision.contact;
@@ -2491,28 +2550,29 @@ export function createStage1NormalizationService(
         contactId: resolvedContact.id,
         sourceEvidenceId: sourceEvidenceResult.record.id,
         openedAt: parsed.sourceEvidence.receivedAt,
-        routing: parsed.routing
+        routing: parsed.routing,
       });
       const reviewState = pickCanonicalReviewState({
         hasIdentityReview: identityReviewInput !== null,
-        hasRoutingReview: routingDecision.reviewInput !== null
+        hasRoutingReview: routingDecision.reviewInput !== null,
       });
       const supportingSourceEvidenceIds = uniqueStrings(
-        parsed.supportingSources.map((entry) => entry.sourceEvidenceId)
+        (parsed.supportingSources as readonly SupportingSourceReference[]).map(
+          (entry) => entry.sourceEvidenceId,
+        ),
       );
       const communicationClassification =
         parsed.communicationClassification ?? null;
       const inboxProjectionExclusionReason =
         detectInboxProjectionExclusionReason(parsed);
-      const contentFingerprintSource = buildIncomingContentFingerprintSource(
-        parsed
-      );
+      const contentFingerprintSource =
+        buildIncomingContentFingerprintSource(parsed);
       const contentFingerprint =
         contentFingerprintSource === null
           ? null
           : computeContentFingerprint({
               ...contentFingerprintSource,
-              contactId: resolvedContact.id
+              contactId: resolvedContact.id,
             });
       const canonicalEvent = canonicalEventSchema.parse({
         id: parsed.canonicalEvent.id,
@@ -2541,9 +2601,9 @@ export function createStage1NormalizationService(
           ...(inboxProjectionExclusionReason === null
             ? {}
             : { inboxProjectionExclusionReason }),
-          notes: duplicateCollapseDecision.winner.notes
+          notes: duplicateCollapseDecision.winner.notes,
         },
-        reviewState
+        reviewState,
       });
       let contactEvents: readonly CanonicalEventRecord[] | null = null;
       const getContactEvents = async (): Promise<
@@ -2553,16 +2613,17 @@ export function createStage1NormalizationService(
           return contactEvents;
         }
 
-        contactEvents = await persistence.repositories.canonicalEvents.listByContactId(
-          resolvedContact.id
-        );
+        contactEvents =
+          await persistence.repositories.canonicalEvents.listByContactId(
+            resolvedContact.id,
+          );
         return contactEvents;
       };
       const alreadyMergedEvent =
         sourceEvidenceResult.outcome === "duplicate"
           ? findCanonicalEventForSourceEvidence(
               await getContactEvents(),
-              sourceEvidenceResult.record.id
+              sourceEvidenceResult.record.id,
             )
           : null;
 
@@ -2574,53 +2635,49 @@ export function createStage1NormalizationService(
                 ...alreadyMergedEvent,
                 reviewState: mergeCanonicalReviewState(
                   alreadyMergedEvent.reviewState,
-                  reviewState
-                )
+                  reviewState,
+                ),
               });
         const identityCase =
           identityReviewInput === null
             ? null
-            : (
-                await service.saveIdentityAmbiguityCase(
-                  identityReviewInput
-                )
-              ).caseRecord;
+            : (await service.saveIdentityAmbiguityCase(identityReviewInput))
+                .caseRecord;
         const routingCase =
           routingDecision.reviewInput === null
             ? null
             : (
                 await service.saveRoutingAmbiguityCase(
-                  routingDecision.reviewInput
+                  routingDecision.reviewInput,
                 )
-              )
-                .caseRecord;
+              ).caseRecord;
         const existingTimelineProjection =
           await persistence.repositories.timelineProjection.findByCanonicalEventId(
-            persistedEvent.id
+            persistedEvent.id,
           );
         const timelineProjection =
           existingTimelineProjection === null
             ? await service.applyTimelineProjection({
                 canonicalEvent: persistedEvent,
-                summary: parsed.canonicalEvent.summary
+                summary: parsed.canonicalEvent.summary,
               })
             : persistedEvent.reviewState === alreadyMergedEvent.reviewState
               ? existingTimelineProjection
               : await service.applyTimelineProjection({
                   canonicalEvent: persistedEvent,
-                  summary: existingTimelineProjection.summary
+                  summary: existingTimelineProjection.summary,
                 });
         const inboxProjection = qualifiesForInboxProjection(persistedEvent)
           ? await rebuildInboxProjectionForContact(
               persistence,
-              persistedEvent.contactId
+              persistedEvent.contactId,
             )
           : await service.refreshInboxReviewOverlay({
-              contactId: persistedEvent.contactId
+              contactId: persistedEvent.contactId,
             });
         await reconcilePendingComposerOutbound(persistence, {
           sourceEvidence: sourceEvidenceResult.record,
-          canonicalEvent: persistedEvent
+          canonicalEvent: persistedEvent,
         });
 
         return {
@@ -2631,7 +2688,7 @@ export function createStage1NormalizationService(
           inboxProjection,
           identityCase,
           routingCase,
-          auditEvidence: null
+          auditEvidence: null,
         };
       }
 
@@ -2643,39 +2700,41 @@ export function createStage1NormalizationService(
               incoming: {
                 canonicalEvent: {
                   ...parsed.canonicalEvent,
-                  contentFingerprint
+                  contentFingerprint,
                 },
-                ...(communicationClassification === null
-                  ? {}
-                  : { communicationClassification }),
+                communicationClassification:
+                  communicationClassification ?? undefined,
                 sourceEvidence: sourceEvidenceResult.record,
                 gmailMessageDetail: parsed.gmailMessageDetail,
                 salesforceCommunicationDetail:
-                  parsed.salesforceCommunicationDetail
-              }
+                  parsed.salesforceCommunicationDetail,
+              },
             })
           : null;
 
       if (duplicateMatch !== null) {
         const mergedSupportingSourceEvidenceIds = uniqueStrings([
-          ...duplicateMatch.existingEvent.provenance.supportingSourceEvidenceIds,
+          ...duplicateMatch.existingEvent.provenance
+            .supportingSourceEvidenceIds,
           ...supportingSourceEvidenceIds,
           duplicateMatch.existingEvent.sourceEvidenceId,
-          sourceEvidenceResult.record.id
+          sourceEvidenceResult.record.id,
         ]).filter(
           (sourceEvidenceId) =>
             sourceEvidenceId !==
             (duplicateMatch.winner.keepIncomingAsPrimary
               ? sourceEvidenceResult.record.id
-              : duplicateMatch.existingEvent.sourceEvidenceId)
+              : duplicateMatch.existingEvent.sourceEvidenceId),
         );
         const supportingProviders = new Set<
           CanonicalEventRecord["provenance"]["primaryProvider"]
         >([
-          ...parsed.supportingSources.map((entry) => entry.provider),
+          ...(
+            parsed.supportingSources as readonly SupportingSourceReference[]
+          ).map((entry) => entry.provider),
           duplicateMatch.winner.keepIncomingAsPrimary
             ? duplicateMatch.existingEvent.provenance.primaryProvider
-            : parsed.sourceEvidence.provider
+            : parsed.sourceEvidence.provider,
         ]);
 
         if (
@@ -2697,104 +2756,103 @@ export function createStage1NormalizationService(
             ? canonicalEvent.provenance.primaryProvider
             : duplicateMatch.existingEvent.provenance.primaryProvider,
           supportingProviders: [...supportingProviders],
-          fallback: duplicateMatch.winner
+          fallback: duplicateMatch.winner,
         });
-        const persistedEvent = await persistence.repositories.canonicalEvents.upsert(
-          canonicalEventSchema.parse({
-            id: duplicateMatch.existingEvent.id,
-            contactId: resolvedContact.id,
-            eventType: canonicalEvent.eventType,
-            channel: canonicalEvent.channel,
-            occurredAt: duplicateMatch.winner.keepIncomingAsPrimary
-              ? canonicalEvent.occurredAt
-              : duplicateMatch.existingEvent.occurredAt,
-            contentFingerprint: duplicateMatch.winner.keepIncomingAsPrimary
-              ? canonicalEvent.contentFingerprint
-              : duplicateMatch.existingEvent.contentFingerprint,
-            sourceEvidenceId: duplicateMatch.winner.keepIncomingAsPrimary
-              ? sourceEvidenceResult.record.id
-              : duplicateMatch.existingEvent.sourceEvidenceId,
-            idempotencyKey: duplicateMatch.winner.keepIncomingAsPrimary
-              ? canonicalEvent.idempotencyKey
-              : duplicateMatch.existingEvent.idempotencyKey,
-            provenance: {
-              primaryProvider: duplicateMatch.winner.keepIncomingAsPrimary
-                ? canonicalEvent.provenance.primaryProvider
-                : duplicateMatch.existingEvent.provenance.primaryProvider,
-              primarySourceEvidenceId: duplicateMatch.winner.keepIncomingAsPrimary
+        const persistedEvent =
+          await persistence.repositories.canonicalEvents.upsert(
+            canonicalEventSchema.parse({
+              id: duplicateMatch.existingEvent.id,
+              contactId: resolvedContact.id,
+              eventType: canonicalEvent.eventType,
+              channel: canonicalEvent.channel,
+              occurredAt: duplicateMatch.winner.keepIncomingAsPrimary
+                ? canonicalEvent.occurredAt
+                : duplicateMatch.existingEvent.occurredAt,
+              contentFingerprint: duplicateMatch.winner.keepIncomingAsPrimary
+                ? canonicalEvent.contentFingerprint
+                : duplicateMatch.existingEvent.contentFingerprint,
+              sourceEvidenceId: duplicateMatch.winner.keepIncomingAsPrimary
                 ? sourceEvidenceResult.record.id
                 : duplicateMatch.existingEvent.sourceEvidenceId,
-              supportingSourceEvidenceIds: mergedSupportingSourceEvidenceIds,
-              winnerReason: mergedWinner.winnerReason,
-              sourceRecordType: duplicateMatch.winner.keepIncomingAsPrimary
-                ? canonicalEvent.provenance.sourceRecordType
-                : duplicateMatch.existingEvent.provenance.sourceRecordType,
-              sourceRecordId: duplicateMatch.winner.keepIncomingAsPrimary
-                ? canonicalEvent.provenance.sourceRecordId
-                : duplicateMatch.existingEvent.provenance.sourceRecordId,
-              messageKind: duplicateMatch.winner.keepIncomingAsPrimary
-                ? canonicalEvent.provenance.messageKind
-                : duplicateMatch.existingEvent.provenance.messageKind,
-              campaignRef: duplicateMatch.winner.keepIncomingAsPrimary
-                ? canonicalEvent.provenance.campaignRef
-                : duplicateMatch.existingEvent.provenance.campaignRef,
-              threadRef: duplicateMatch.winner.keepIncomingAsPrimary
-                ? canonicalEvent.provenance.threadRef
-                : duplicateMatch.existingEvent.provenance.threadRef,
-              direction: duplicateMatch.winner.keepIncomingAsPrimary
-                ? canonicalEvent.provenance.direction
-                : duplicateMatch.existingEvent.provenance.direction,
-              ...((duplicateMatch.winner.keepIncomingAsPrimary
-                ? canonicalEvent.provenance.inboxProjectionExclusionReason
-                : duplicateMatch.existingEvent.provenance
-                    .inboxProjectionExclusionReason) === undefined
-                ? {}
-                : {
-                    inboxProjectionExclusionReason:
-                      duplicateMatch.winner.keepIncomingAsPrimary
-                        ? canonicalEvent.provenance.inboxProjectionExclusionReason
-                        : duplicateMatch.existingEvent.provenance
+              idempotencyKey: duplicateMatch.winner.keepIncomingAsPrimary
+                ? canonicalEvent.idempotencyKey
+                : duplicateMatch.existingEvent.idempotencyKey,
+              provenance: {
+                primaryProvider: duplicateMatch.winner.keepIncomingAsPrimary
+                  ? canonicalEvent.provenance.primaryProvider
+                  : duplicateMatch.existingEvent.provenance.primaryProvider,
+                primarySourceEvidenceId: duplicateMatch.winner
+                  .keepIncomingAsPrimary
+                  ? sourceEvidenceResult.record.id
+                  : duplicateMatch.existingEvent.sourceEvidenceId,
+                supportingSourceEvidenceIds: mergedSupportingSourceEvidenceIds,
+                winnerReason: mergedWinner.winnerReason,
+                sourceRecordType: duplicateMatch.winner.keepIncomingAsPrimary
+                  ? canonicalEvent.provenance.sourceRecordType
+                  : duplicateMatch.existingEvent.provenance.sourceRecordType,
+                sourceRecordId: duplicateMatch.winner.keepIncomingAsPrimary
+                  ? canonicalEvent.provenance.sourceRecordId
+                  : duplicateMatch.existingEvent.provenance.sourceRecordId,
+                messageKind: duplicateMatch.winner.keepIncomingAsPrimary
+                  ? canonicalEvent.provenance.messageKind
+                  : duplicateMatch.existingEvent.provenance.messageKind,
+                campaignRef: duplicateMatch.winner.keepIncomingAsPrimary
+                  ? canonicalEvent.provenance.campaignRef
+                  : duplicateMatch.existingEvent.provenance.campaignRef,
+                threadRef: duplicateMatch.winner.keepIncomingAsPrimary
+                  ? canonicalEvent.provenance.threadRef
+                  : duplicateMatch.existingEvent.provenance.threadRef,
+                direction: duplicateMatch.winner.keepIncomingAsPrimary
+                  ? canonicalEvent.provenance.direction
+                  : duplicateMatch.existingEvent.provenance.direction,
+                ...((duplicateMatch.winner.keepIncomingAsPrimary
+                  ? canonicalEvent.provenance.inboxProjectionExclusionReason
+                  : duplicateMatch.existingEvent.provenance
+                      .inboxProjectionExclusionReason) === undefined
+                  ? {}
+                  : {
+                      inboxProjectionExclusionReason: duplicateMatch.winner
+                        .keepIncomingAsPrimary
+                        ? canonicalEvent.provenance
                             .inboxProjectionExclusionReason
-                  }),
-              notes: mergedWinner.notes
-            },
-            reviewState: mergeCanonicalReviewState(
-              duplicateMatch.existingEvent.reviewState,
-              canonicalEvent.reviewState
-            )
-          })
-        );
+                        : duplicateMatch.existingEvent.provenance
+                            .inboxProjectionExclusionReason,
+                    }),
+                notes: mergedWinner.notes,
+              },
+              reviewState: mergeCanonicalReviewState(
+                duplicateMatch.existingEvent.reviewState,
+                canonicalEvent.reviewState,
+              ),
+            }),
+          );
         const identityCase =
           identityReviewInput === null
             ? null
-            : (
-                await service.saveIdentityAmbiguityCase(
-                  identityReviewInput
-                )
-              ).caseRecord;
+            : (await service.saveIdentityAmbiguityCase(identityReviewInput))
+                .caseRecord;
         const routingCase =
           routingDecision.reviewInput === null
             ? null
             : (
                 await service.saveRoutingAmbiguityCase(
-                  routingDecision.reviewInput
+                  routingDecision.reviewInput,
                 )
-              )
-                .caseRecord;
+              ).caseRecord;
         const timelineProjection = await service.applyTimelineProjection({
           canonicalEvent: persistedEvent,
           summary: duplicateMatch.winner.keepIncomingAsPrimary
             ? parsed.canonicalEvent.summary
-            : duplicateMatch.existingTimelineProjection?.summary ??
-              parsed.canonicalEvent.summary
+            : (duplicateMatch.existingTimelineProjection?.summary ??
+              parsed.canonicalEvent.summary),
         });
         const inboxProjection = await rebuildInboxProjectionForContact(
           persistence,
-          persistedEvent.contactId
+          persistedEvent.contactId,
         );
         await reconcilePendingComposerOutbound(persistence, {
           sourceEvidence: sourceEvidenceResult.record,
-          canonicalEvent: persistedEvent
+          canonicalEvent: persistedEvent,
         });
 
         return {
@@ -2805,11 +2863,12 @@ export function createStage1NormalizationService(
           inboxProjection,
           identityCase,
           routingCase,
-          auditEvidence: null
+          auditEvidence: null,
         };
       }
 
-      const eventWriteResult = await persistence.persistCanonicalEvent(canonicalEvent);
+      const eventWriteResult =
+        await persistence.persistCanonicalEvent(canonicalEvent);
 
       if (eventWriteResult.outcome === "conflict") {
         const auditEvidence = await recordQuarantineAuditOnce(persistence, {
@@ -2821,8 +2880,8 @@ export function createStage1NormalizationService(
           metadataJson: {
             incomingCanonicalEventId: parsed.canonicalEvent.id,
             existingCanonicalEventId: eventWriteResult.existing.id,
-            reason: eventWriteResult.reason
-          }
+            reason: eventWriteResult.reason,
+          },
         });
 
         return {
@@ -2832,7 +2891,7 @@ export function createStage1NormalizationService(
           explanation:
             "The canonical event idempotency key already exists with a different canonical interpretation.",
           existingCanonicalEvent: eventWriteResult.existing,
-          auditEvidence
+          auditEvidence,
         };
       }
 
@@ -2840,48 +2899,45 @@ export function createStage1NormalizationService(
       const identityCase =
         identityReviewInput === null
           ? null
-          : (
-              await service.saveIdentityAmbiguityCase(
-                identityReviewInput
-              )
-            ).caseRecord;
+          : (await service.saveIdentityAmbiguityCase(identityReviewInput))
+              .caseRecord;
       const routingCase =
         routingDecision.reviewInput === null
           ? null
           : (
               await service.saveRoutingAmbiguityCase(
-                routingDecision.reviewInput
+                routingDecision.reviewInput,
               )
-            )
-              .caseRecord;
+            ).caseRecord;
       const timelineProjection = await service.applyTimelineProjection({
         canonicalEvent: persistedEvent,
-        summary: parsed.canonicalEvent.summary
+        summary: parsed.canonicalEvent.summary,
       });
       const inboxProjection = qualifiesForInboxProjection(persistedEvent)
         ? await service.applyInboxProjection({
             canonicalEvent: persistedEvent,
-            snippet: parsed.canonicalEvent.snippet
+            snippet: parsed.canonicalEvent.snippet,
           })
         : await service.refreshInboxReviewOverlay({
-            contactId: persistedEvent.contactId
+            contactId: persistedEvent.contactId,
           });
       await reconcilePendingComposerOutbound(persistence, {
         sourceEvidence: sourceEvidenceResult.record,
-        canonicalEvent: persistedEvent
+        canonicalEvent: persistedEvent,
       });
 
       return {
-        outcome: eventWriteResult.outcome === "inserted" ? "applied" : "duplicate",
+        outcome:
+          eventWriteResult.outcome === "inserted" ? "applied" : "duplicate",
         sourceEvidence: sourceEvidenceResult.record,
         canonicalEvent: persistedEvent,
         timelineProjection,
         inboxProjection,
         identityCase,
         routingCase,
-        auditEvidence: null
+        auditEvidence: null,
       };
-    }
+    },
   };
 
   return service;

--- a/packages/domain/test/timeline-sort-key.test.ts
+++ b/packages/domain/test/timeline-sort-key.test.ts
@@ -13,7 +13,7 @@ const [
   ,
   lifecycleSignedUpEventType,
   lifecycleReceivedTrainingEventType,
-  lifecycleCompletedTrainingEventType
+  lifecycleCompletedTrainingEventType,
 ] = canonicalEventTypeValues;
 
 describe("buildTimelineSortKey", () => {
@@ -25,17 +25,17 @@ describe("buildTimelineSortKey", () => {
         sortKey: buildTimelineSortKey(
           "evt:received-training",
           occurredAt,
-          lifecycleReceivedTrainingEventType
-        )
+          lifecycleReceivedTrainingEventType,
+        ),
       },
       {
         canonicalEventId: "evt:signed-up",
         sortKey: buildTimelineSortKey(
           "evt:signed-up",
           occurredAt,
-          lifecycleSignedUpEventType
-        )
-      }
+          lifecycleSignedUpEventType,
+        ),
+      },
     ];
 
     const orderedIds = rows
@@ -46,32 +46,31 @@ describe("buildTimelineSortKey", () => {
   });
 
   it("orders multiple same-day lifecycle events by the locked lifecycle sequence", () => {
-    const occurredAt = "2025-11-17T00:00:00.000Z";
     const rows = [
       {
         canonicalEventId: "evt:completed-training",
         sortKey: buildTimelineSortKey(
           "evt:completed-training",
-          occurredAt,
-          lifecycleCompletedTrainingEventType
-        )
+          "2025-11-17T08:30:00.000Z",
+          lifecycleCompletedTrainingEventType,
+        ),
       },
       {
         canonicalEventId: "evt:signed-up",
         sortKey: buildTimelineSortKey(
           "evt:signed-up",
-          occurredAt,
-          lifecycleSignedUpEventType
-        )
+          "2025-11-17T18:45:00.000Z",
+          lifecycleSignedUpEventType,
+        ),
       },
       {
         canonicalEventId: "evt:received-training",
         sortKey: buildTimelineSortKey(
           "evt:received-training",
-          occurredAt,
-          lifecycleReceivedTrainingEventType
-        )
-      }
+          "2025-11-17T23:00:00.000Z",
+          lifecycleReceivedTrainingEventType,
+        ),
+      },
     ];
 
     const orderedIds = rows
@@ -81,20 +80,28 @@ describe("buildTimelineSortKey", () => {
     expect(orderedIds).toEqual([
       "evt:signed-up",
       "evt:received-training",
-      "evt:completed-training"
+      "evt:completed-training",
     ]);
   });
 
   it("preserves non-lifecycle ordering by occurredAt then canonicalEventId", () => {
     const occurredAt = "2025-11-17T00:00:00.000Z";
     const rows = [
-      buildTimelineSortKey("evt:b", occurredAt, communicationEmailInboundEventType),
-      buildTimelineSortKey("evt:a", occurredAt, communicationEmailInboundEventType)
+      buildTimelineSortKey(
+        "evt:b",
+        occurredAt,
+        communicationEmailInboundEventType,
+      ),
+      buildTimelineSortKey(
+        "evt:a",
+        occurredAt,
+        communicationEmailInboundEventType,
+      ),
     ].sort((left, right) => left.localeCompare(right));
 
     expect(rows).toEqual([
       `${occurredAt}::00::evt:a`,
-      `${occurredAt}::00::evt:b`
+      `${occurredAt}::00::evt:b`,
     ]);
   });
 
@@ -104,18 +111,18 @@ describe("buildTimelineSortKey", () => {
       buildTimelineSortKey(
         "evt:lifecycle",
         occurredAt,
-        lifecycleSignedUpEventType
+        lifecycleSignedUpEventType,
       ),
       buildTimelineSortKey(
         "evt:email",
         occurredAt,
-        communicationEmailInboundEventType
-      )
+        communicationEmailInboundEventType,
+      ),
     ].sort((left, right) => left.localeCompare(right));
 
     expect(rows).toEqual([
       `${occurredAt}::00::evt:email`,
-      `${occurredAt}::01::evt:lifecycle`
+      `${occurredAt}::01::evt:lifecycle`,
     ]);
   });
 });

--- a/packages/integrations/src/providers/gmail-record-builder.ts
+++ b/packages/integrations/src/providers/gmail-record-builder.ts
@@ -2,10 +2,7 @@ import { createHash } from "node:crypto";
 
 import libmime from "libmime";
 
-import {
-  gmailMessageRecordSchema,
-  type GmailRecord
-} from "./gmail.js";
+import { gmailMessageRecordSchema, type GmailRecord } from "./gmail.js";
 import type { GmailAttachmentMetadata } from "./gmail-body.js";
 
 export interface GmailProviderCloseMessageInput {
@@ -51,18 +48,16 @@ function uniqueEmails(values: readonly string[]): string[] {
     new Set(
       values
         .map((value) => normalizeEmail(value))
-        .filter((value): value is string => value !== null)
-    )
+        .filter((value): value is string => value !== null),
+    ),
   ).sort((left, right) => left.localeCompare(right));
 }
 
 function uniqueLabelIds(values: readonly string[]): string[] {
   return Array.from(
     new Set(
-      values
-        .map((value) => value.trim())
-        .filter((value) => value.length > 0)
-    )
+      values.map((value) => value.trim()).filter((value) => value.length > 0),
+    ),
   ).sort((left, right) => left.localeCompare(right));
 }
 
@@ -81,7 +76,7 @@ function normalizeHeaderValue(value: string | null | undefined): string | null {
 
 function isInternalEmail(
   email: string,
-  internalAddresses: ReadonlySet<string>
+  internalAddresses: ReadonlySet<string>,
 ): boolean {
   const normalized = email.toLowerCase();
 
@@ -89,6 +84,14 @@ function isInternalEmail(
     internalAddresses.has(normalized) ||
     normalized.endsWith(ADVENTURE_SCIENTISTS_DOMAIN)
   );
+}
+
+function hasEmail(values: readonly string[], value: string | null): boolean {
+  if (value === null) {
+    return false;
+  }
+
+  return values.some((email) => email.toLowerCase() === value.toLowerCase());
 }
 
 export function parseHeaderEmailList(value: string | undefined): string[] {
@@ -99,8 +102,8 @@ export function parseHeaderEmailList(value: string | undefined): string[] {
   return uniqueEmails(
     Array.from(
       value.matchAll(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/giu),
-      (match) => match[0]
-    )
+      (match) => match[0],
+    ),
   );
 }
 
@@ -119,13 +122,13 @@ function resolveProjectInboxAlias(input: {
   }
 
   const aliasSet = new Set(
-    uniqueEmails(input.projectInboxAliases).map((alias) => alias.toLowerCase())
+    uniqueEmails(input.projectInboxAliases).map((alias) => alias.toLowerCase()),
   );
   const candidateAddresses = [
     ...input.fromEmails,
     ...input.toEmails,
     ...input.ccEmails,
-    ...input.bccEmails
+    ...input.bccEmails,
   ];
 
   for (const address of candidateAddresses) {
@@ -143,7 +146,9 @@ function resolveProjectInboxAlias(input: {
     : null;
 }
 
-export function toSafeIsoTimestamp(value: string | number | undefined): string | null {
+export function toSafeIsoTimestamp(
+  value: string | number | undefined,
+): string | null {
   if (value === undefined) {
     return null;
   }
@@ -166,7 +171,7 @@ export function sha256Text(value: string): string {
 }
 
 export function normalizeGmailSubject(
-  value: string | null | undefined
+  value: string | null | undefined,
 ): string | null {
   if (typeof value !== "string") {
     return null;
@@ -187,7 +192,7 @@ export function normalizeGmailSubject(
 }
 
 export function buildGmailMessageRecord(
-  input: GmailProviderCloseMessageInput
+  input: GmailProviderCloseMessageInput,
 ): GmailRecord {
   const fromHeader = normalizeHeaderValue(input.headers.From);
   const toHeader = normalizeHeaderValue(input.headers.To);
@@ -197,7 +202,7 @@ export function buildGmailMessageRecord(
   const ccEmails = parseHeaderEmailList(input.headers.Cc);
   const bccEmails = parseHeaderEmailList(input.headers.Bcc);
   const internalAddresses = new Set(
-    uniqueEmails(input.internalAddresses).map((value) => value.toLowerCase())
+    uniqueEmails(input.internalAddresses).map((value) => value.toLowerCase()),
   );
   const projectInboxAlias = resolveProjectInboxAlias({
     capturedMailbox: input.capturedMailbox,
@@ -206,29 +211,36 @@ export function buildGmailMessageRecord(
     ccEmails,
     bccEmails,
     projectInboxAliases: input.projectInboxAliases,
-    projectInboxAliasOverride:
-      normalizeEmail(input.projectInboxAliasOverride ?? null),
+    projectInboxAliasOverride: normalizeEmail(
+      input.projectInboxAliasOverride ?? null,
+    ),
     treatCapturedMailboxAsProjectInbox:
-      input.treatCapturedMailboxAsProjectInbox ?? false
+      input.treatCapturedMailboxAsProjectInbox ?? false,
   });
   const externalParticipantEmails = uniqueEmails(
     [...fromEmails, ...toEmails, ...ccEmails, ...bccEmails].filter(
-      (email) => !isInternalEmail(email, internalAddresses)
-    )
+      (email) => !isInternalEmail(email, internalAddresses),
+    ),
   );
 
   if (externalParticipantEmails.length === 0) {
     return {
       recordType: "internal_only_message",
-      recordId: input.recordId
+      recordId: input.recordId,
     };
   }
 
-  const direction = fromEmails.some((email) =>
-    isInternalEmail(email, internalAddresses)
-  )
-    ? "outbound"
-    : "inbound";
+  const senderIsInternal = fromEmails.some((email) =>
+    isInternalEmail(email, internalAddresses),
+  );
+  const projectInboxCopyRecipient =
+    projectInboxAlias !== null &&
+    !hasEmail(fromEmails, projectInboxAlias) &&
+    (hasEmail(toEmails, projectInboxAlias) ||
+      hasEmail(ccEmails, projectInboxAlias) ||
+      hasEmail(bccEmails, projectInboxAlias));
+  const direction =
+    senderIsInternal && !projectInboxCopyRecipient ? "outbound" : "inbound";
   const labelIds =
     input.labelIds === undefined || input.labelIds === null
       ? null
@@ -272,7 +284,9 @@ export function buildGmailMessageRecord(
     normalizedPhones: [],
     supportingRecords: [],
     crossProviderCollapseKey:
-      rfc822MessageId === null ? null : `rfc822:${rfc822MessageId.toLowerCase()}`,
+      rfc822MessageId === null
+        ? null
+        : `rfc822:${rfc822MessageId.toLowerCase()}`,
     attachmentMetadata: input.attachmentMetadata ?? [],
     htmlBodyCidReferences: input.htmlBodyCidReferences ?? [],
   });

--- a/packages/integrations/test/stage1-gmail-mbox.test.ts
+++ b/packages/integrations/test/stage1-gmail-mbox.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildGmailMessageRecord,
   importGmailMboxRecords,
-  mapGmailRecord
+  mapGmailRecord,
 } from "../src/index.js";
 
 const mboxText = `From MAILER-DAEMON Fri Jan 03 00:00:00 2026
@@ -24,7 +24,7 @@ describe("Stage 1 Gmail .mbox import", () => {
       capturedMailbox: "project-antarctica@example.org",
       liveAccount: "volunteers@adventurescientists.org",
       projectInboxAliases: ["project-antarctica@example.org"],
-      receivedAt: "2026-01-03T00:05:00.000Z"
+      receivedAt: "2026-01-03T00:05:00.000Z",
     });
 
     expect(records).toEqual([
@@ -37,24 +37,28 @@ describe("Stage 1 Gmail .mbox import", () => {
         capturedMailbox: "project-antarctica@example.org",
         projectInboxAlias: "project-antarctica@example.org",
         normalizedParticipantEmails: ["volunteer@example.org"],
-        crossProviderCollapseKey: "rfc822:<gmail-mbox-1@example.org>"
-      })
+        crossProviderCollapseKey: "rfc822:<gmail-mbox-1@example.org>",
+      }),
     ]);
   });
 
   it("converges with live Gmail API records through the same downstream mapper contract", async () => {
-    const historicalRecord = (await importGmailMboxRecords({
-      mboxText,
-      mboxPath: "/tmp/project-antarctica.mbox",
-      capturedMailbox: "project-antarctica@example.org",
-      liveAccount: "volunteers@adventurescientists.org",
-      projectInboxAliases: ["project-antarctica@example.org"],
-      receivedAt: "2026-01-03T00:05:00.000Z"
-    }))[0];
+    const historicalRecord = (
+      await importGmailMboxRecords({
+        mboxText,
+        mboxPath: "/tmp/project-antarctica.mbox",
+        capturedMailbox: "project-antarctica@example.org",
+        liveAccount: "volunteers@adventurescientists.org",
+        projectInboxAliases: ["project-antarctica@example.org"],
+        receivedAt: "2026-01-03T00:05:00.000Z",
+      })
+    )[0];
 
     expect(historicalRecord).toBeDefined();
     if (historicalRecord === undefined) {
-      throw new Error("Expected a historical Gmail record from the .mbox import.");
+      throw new Error(
+        "Expected a historical Gmail record from the .mbox import.",
+      );
     }
 
     const liveRecord = buildGmailMessageRecord({
@@ -66,17 +70,18 @@ describe("Stage 1 Gmail .mbox import", () => {
         Date: "Fri, 03 Jan 2026 00:00:00 +0000",
         From: "Volunteer <volunteer@example.org>",
         To: "Project Antarctica <project-antarctica@example.org>",
-        "Message-ID": "<gmail-mbox-1@example.org>"
+        "Message-ID": "<gmail-mbox-1@example.org>",
       },
-      payloadRef: "gmail://volunteers@adventurescientists.org/messages/gmail-live-1",
+      payloadRef:
+        "gmail://volunteers@adventurescientists.org/messages/gmail-live-1",
       checksum: "checksum-live-1",
       capturedMailbox: "volunteers@adventurescientists.org",
       receivedAt: "2026-01-03T00:05:00.000Z",
       internalAddresses: [
         "volunteers@adventurescientists.org",
-        "project-antarctica@example.org"
+        "project-antarctica@example.org",
       ],
-      projectInboxAliases: ["project-antarctica@example.org"]
+      projectInboxAliases: ["project-antarctica@example.org"],
     });
 
     const historicalResult = mapGmailRecord(historicalRecord);
@@ -84,7 +89,10 @@ describe("Stage 1 Gmail .mbox import", () => {
 
     expect(historicalResult.outcome).toBe("command");
     expect(liveResult.outcome).toBe("command");
-    if (historicalResult.outcome === "command" && liveResult.outcome === "command") {
+    if (
+      historicalResult.outcome === "command" &&
+      liveResult.outcome === "command"
+    ) {
       expect(historicalResult.command.kind).toBe("canonical_event");
       expect(liveResult.command.kind).toBe("canonical_event");
 
@@ -93,16 +101,16 @@ describe("Stage 1 Gmail .mbox import", () => {
         liveResult.command.kind === "canonical_event"
       ) {
         expect(historicalResult.command.input.canonicalEvent.eventType).toBe(
-          "communication.email.inbound"
+          "communication.email.inbound",
         );
         expect(liveResult.command.input.canonicalEvent.eventType).toBe(
-          historicalResult.command.input.canonicalEvent.eventType
+          historicalResult.command.input.canonicalEvent.eventType,
         );
         expect(liveResult.command.input.canonicalEvent.idempotencyKey).toBe(
-          historicalResult.command.input.canonicalEvent.idempotencyKey
+          historicalResult.command.input.canonicalEvent.idempotencyKey,
         );
         expect(liveResult.command.input.identity.normalizedEmails).toEqual(
-          historicalResult.command.input.identity.normalizedEmails
+          historicalResult.command.input.identity.normalizedEmails,
         );
       }
     }
@@ -122,14 +130,14 @@ Hello from an exported mailbox.
       capturedMailbox: "project-antarctica@example.org",
       liveAccount: "volunteers@adventurescientists.org",
       projectInboxAliases: ["project-antarctica@example.org"],
-      receivedAt: "2026-01-03T00:05:00.000Z"
+      receivedAt: "2026-01-03T00:05:00.000Z",
     });
 
     expect(records).toEqual([
       expect.objectContaining({
         recordType: "message",
-        subject: null
-      })
+        subject: null,
+      }),
     ]);
   });
 
@@ -146,10 +154,10 @@ Hello from an exported mailbox.
         Cc: [
           "Ricky Jones <ricky@adventurescientists.org>",
           "Samantha Doe <samantha@adventurescientists.org>",
-          "Outside Partner <partner@example.org>"
+          "Outside Partner <partner@example.org>",
         ].join(", "),
         Subject: "Re: Update on Hex 43191",
-        "Message-ID": "<gmail-third-party-1@example.org>"
+        "Message-ID": "<gmail-third-party-1@example.org>",
       },
       payloadRef:
         "gmail://volunteers@adventurescientists.org/messages/gmail-third-party-1",
@@ -158,9 +166,9 @@ Hello from an exported mailbox.
       receivedAt: "2026-04-22T00:01:00.000Z",
       internalAddresses: [
         "volunteers@adventurescientists.org",
-        "pnwbio@adventurescientists.org"
+        "pnwbio@adventurescientists.org",
       ],
-      projectInboxAliases: ["pnwbio@adventurescientists.org"]
+      projectInboxAliases: ["pnwbio@adventurescientists.org"],
     });
 
     expect(record).toMatchObject({
@@ -170,12 +178,74 @@ Hello from an exported mailbox.
       ccHeader: [
         "Ricky Jones <ricky@adventurescientists.org>",
         "Samantha Doe <samantha@adventurescientists.org>",
-        "Outside Partner <partner@example.org>"
+        "Outside Partner <partner@example.org>",
       ].join(", "),
       normalizedParticipantEmails: [
         "partner@example.org",
-        "shaina.dotson@gmail.com"
-      ]
+        "shaina.dotson@gmail.com",
+      ],
+    });
+  });
+
+  it("treats team-originated messages copied to a project inbox as inbound attention", () => {
+    const copiedRecord = buildGmailMessageRecord({
+      recordId: "gmail-team-copy-1",
+      threadId: "thread-team-copy-1",
+      snippet: "Scotty looped the project inbox into the volunteer thread.",
+      internalDate: "2026-04-22T00:00:00.000Z",
+      headers: {
+        Date: "Wed, 22 Apr 2026 00:00:00 +0000",
+        From: "Scotty <scotty@adventurescientists.org>",
+        To: "Shaina Dotson <shaina.dotson@gmail.com>",
+        Cc: "PNW Biodiversity <pnwbio@adventurescientists.org>",
+        Subject: "Re: Update on Hex 43191",
+        "Message-ID": "<gmail-team-copy-1@example.org>",
+      },
+      payloadRef:
+        "gmail://pnwbio@adventurescientists.org/messages/gmail-team-copy-1",
+      checksum: "checksum-team-copy-1",
+      capturedMailbox: "pnwbio@adventurescientists.org",
+      receivedAt: "2026-04-22T00:01:00.000Z",
+      internalAddresses: [
+        "volunteers@adventurescientists.org",
+        "pnwbio@adventurescientists.org",
+      ],
+      projectInboxAliases: ["pnwbio@adventurescientists.org"],
+    });
+    const platformSentRecord = buildGmailMessageRecord({
+      recordId: "gmail-platform-sent-1",
+      threadId: "thread-platform-sent-1",
+      snippet: "The platform sent from the project inbox.",
+      internalDate: "2026-04-22T00:02:00.000Z",
+      headers: {
+        Date: "Wed, 22 Apr 2026 00:02:00 +0000",
+        From: "PNW Biodiversity <pnwbio@adventurescientists.org>",
+        To: "Shaina Dotson <shaina.dotson@gmail.com>",
+        Subject: "Re: Update on Hex 43191",
+        "Message-ID": "<gmail-platform-sent-1@example.org>",
+      },
+      payloadRef:
+        "gmail://pnwbio@adventurescientists.org/messages/gmail-platform-sent-1",
+      checksum: "checksum-platform-sent-1",
+      capturedMailbox: "pnwbio@adventurescientists.org",
+      receivedAt: "2026-04-22T00:03:00.000Z",
+      internalAddresses: [
+        "volunteers@adventurescientists.org",
+        "pnwbio@adventurescientists.org",
+      ],
+      projectInboxAliases: ["pnwbio@adventurescientists.org"],
+    });
+
+    expect(copiedRecord).toMatchObject({
+      recordType: "message",
+      direction: "inbound",
+      fromHeader: "Scotty <scotty@adventurescientists.org>",
+      projectInboxAlias: "pnwbio@adventurescientists.org",
+    });
+    expect(platformSentRecord).toMatchObject({
+      recordType: "message",
+      direction: "outbound",
+      projectInboxAlias: "pnwbio@adventurescientists.org",
     });
   });
 
@@ -184,29 +254,29 @@ Hello from an exported mailbox.
       {
         name: "quoted-printable",
         subjectHeader: "=?utf-8?Q?Re:_Training_=3D_=E2=9C=85?=",
-        expectedSubject: "Re: Training = ✅"
+        expectedSubject: "Re: Training = ✅",
       },
       {
         name: "base64",
         subjectHeader: "=?utf-8?B?UmU6IEludml0YXRpb24=?=",
-        expectedSubject: "Re: Invitation"
+        expectedSubject: "Re: Invitation",
       },
       {
         name: "chained-words",
         subjectHeader: "=?utf-8?Q?Hi?= =?utf-8?Q?_world?=",
-        expectedSubject: "Hi world"
+        expectedSubject: "Hi world",
       },
       {
         name: "mixed-charsets",
         subjectHeader:
           "=?iso-8859-1?Q?Ol=E1?= =?windows-1252?Q?_price_=80100?=",
-        expectedSubject: "Olá price €100"
+        expectedSubject: "Olá price €100",
       },
       {
         name: "unknown-charset-fallback",
         subjectHeader: "=?x-unknown?Q?Re:_caf=C3=A9?=",
-        expectedSubject: "Re: café"
-      }
+        expectedSubject: "Re: café",
+      },
     ] as const;
 
     for (const testCase of cases) {
@@ -223,7 +293,7 @@ Message-ID: <gmail-mbox-${testCase.name}@example.org>
         capturedMailbox: "project-antarctica@example.org",
         liveAccount: "volunteers@adventurescientists.org",
         projectInboxAliases: ["project-antarctica@example.org"],
-        receivedAt: "2026-01-03T00:05:00.000Z"
+        receivedAt: "2026-01-03T00:05:00.000Z",
       });
 
       expect(records).toEqual([
@@ -231,35 +301,39 @@ Message-ID: <gmail-mbox-${testCase.name}@example.org>
           recordType: "message",
           subject: testCase.expectedSubject,
           snippet: testCase.expectedSubject,
-          snippetClean: testCase.expectedSubject
-        })
+          snippetClean: testCase.expectedSubject,
+        }),
       ]);
     }
   });
 
   it("uses Message-ID to keep mbox record ids stable across captured mailbox changes", async () => {
-    const firstRecord = (await importGmailMboxRecords({
-      mboxText,
-      mboxPath: "/tmp/project-antarctica-a.mbox",
-      capturedMailbox: "project-antarctica@example.org",
-      liveAccount: "volunteers@adventurescientists.org",
-      projectInboxAliases: ["project-antarctica@example.org"],
-      receivedAt: "2026-01-03T00:05:00.000Z"
-    }))[0];
-    const secondRecord = (await importGmailMboxRecords({
-      mboxText,
-      mboxPath: "/tmp/project-antarctica-b.mbox",
-      capturedMailbox: "volunteers@adventurescientists.org",
-      liveAccount: "volunteers@adventurescientists.org",
-      projectInboxAliases: ["project-antarctica@example.org"],
-      receivedAt: "2026-01-03T00:06:00.000Z"
-    }))[0];
+    const firstRecord = (
+      await importGmailMboxRecords({
+        mboxText,
+        mboxPath: "/tmp/project-antarctica-a.mbox",
+        capturedMailbox: "project-antarctica@example.org",
+        liveAccount: "volunteers@adventurescientists.org",
+        projectInboxAliases: ["project-antarctica@example.org"],
+        receivedAt: "2026-01-03T00:05:00.000Z",
+      })
+    )[0];
+    const secondRecord = (
+      await importGmailMboxRecords({
+        mboxText,
+        mboxPath: "/tmp/project-antarctica-b.mbox",
+        capturedMailbox: "volunteers@adventurescientists.org",
+        liveAccount: "volunteers@adventurescientists.org",
+        projectInboxAliases: ["project-antarctica@example.org"],
+        receivedAt: "2026-01-03T00:06:00.000Z",
+      })
+    )[0];
 
     expect(firstRecord).toMatchObject({
-      recordType: "message"
+      recordType: "message",
     });
     expect(secondRecord).toMatchObject({
-      recordType: "message"
+      recordType: "message",
     });
 
     if (
@@ -276,8 +350,9 @@ Message-ID: <gmail-mbox-${testCase.name}@example.org>
   });
 
   it("falls back to content hashing when Message-ID is absent", async () => {
-    const firstRecord = (await importGmailMboxRecords({
-      mboxText: `From MAILER-DAEMON Fri Jan 03 00:00:00 2026
+    const firstRecord = (
+      await importGmailMboxRecords({
+        mboxText: `From MAILER-DAEMON Fri Jan 03 00:00:00 2026
 Date: Fri, 03 Jan 2026 00:00:00 +0000
 From: Volunteer <volunteer@example.org>
 To: Project Antarctica <project-antarctica@example.org>
@@ -285,14 +360,16 @@ Subject: Historical volunteer reply
 
 Hello from an exported mailbox.
 `,
-      mboxPath: "/tmp/project-antarctica-no-id-a.mbox",
-      capturedMailbox: "project-antarctica@example.org",
-      liveAccount: "volunteers@adventurescientists.org",
-      projectInboxAliases: ["project-antarctica@example.org"],
-      receivedAt: "2026-01-03T00:05:00.000Z"
-    }))[0];
-    const secondRecord = (await importGmailMboxRecords({
-      mboxText: `From MAILER-DAEMON Fri Jan 03 00:00:00 2026
+        mboxPath: "/tmp/project-antarctica-no-id-a.mbox",
+        capturedMailbox: "project-antarctica@example.org",
+        liveAccount: "volunteers@adventurescientists.org",
+        projectInboxAliases: ["project-antarctica@example.org"],
+        receivedAt: "2026-01-03T00:05:00.000Z",
+      })
+    )[0];
+    const secondRecord = (
+      await importGmailMboxRecords({
+        mboxText: `From MAILER-DAEMON Fri Jan 03 00:00:00 2026
 Date: Fri, 03 Jan 2026 00:00:00 +0000
 From: Volunteer <volunteer@example.org>
 To: Project Antarctica <project-antarctica@example.org>
@@ -300,18 +377,19 @@ Subject: Historical volunteer reply
 
 Hello from a different exported mailbox body.
 `,
-      mboxPath: "/tmp/project-antarctica-no-id-b.mbox",
-      capturedMailbox: "project-antarctica@example.org",
-      liveAccount: "volunteers@adventurescientists.org",
-      projectInboxAliases: ["project-antarctica@example.org"],
-      receivedAt: "2026-01-03T00:06:00.000Z"
-    }))[0];
+        mboxPath: "/tmp/project-antarctica-no-id-b.mbox",
+        capturedMailbox: "project-antarctica@example.org",
+        liveAccount: "volunteers@adventurescientists.org",
+        projectInboxAliases: ["project-antarctica@example.org"],
+        receivedAt: "2026-01-03T00:06:00.000Z",
+      })
+    )[0];
 
     expect(firstRecord).toMatchObject({
-      recordType: "message"
+      recordType: "message",
     });
     expect(secondRecord).toMatchObject({
-      recordType: "message"
+      recordType: "message",
     });
 
     if (
@@ -335,9 +413,9 @@ Hello from a different exported mailbox body.
           Date: "Fri, 03 Jan 2026 00:00:00 +0000",
           From: "Project Antarctica <project-antarctica@example.org>",
           To: "Volunteer <volunteer@example.org>",
-          "Message-ID": "<gmail-live-missing@example.org>"
+          "Message-ID": "<gmail-live-missing@example.org>",
         },
-        expectedSubject: null
+        expectedSubject: null,
       },
       {
         name: "empty subject",
@@ -346,9 +424,9 @@ Hello from a different exported mailbox body.
           From: "Project Antarctica <project-antarctica@example.org>",
           To: "Volunteer <volunteer@example.org>",
           Subject: "",
-          "Message-ID": "<gmail-live-empty@example.org>"
+          "Message-ID": "<gmail-live-empty@example.org>",
         },
-        expectedSubject: null
+        expectedSubject: null,
       },
       {
         name: "whitespace-only subject",
@@ -357,9 +435,9 @@ Hello from a different exported mailbox body.
           From: "Project Antarctica <project-antarctica@example.org>",
           To: "Volunteer <volunteer@example.org>",
           Subject: "   ",
-          "Message-ID": "<gmail-live-whitespace@example.org>"
+          "Message-ID": "<gmail-live-whitespace@example.org>",
         },
-        expectedSubject: null
+        expectedSubject: null,
       },
       {
         name: "normal subject",
@@ -368,9 +446,9 @@ Hello from a different exported mailbox body.
           From: "Project Antarctica <project-antarctica@example.org>",
           To: "Volunteer <volunteer@example.org>",
           Subject: "Status update",
-          "Message-ID": "<gmail-live-normal@example.org>"
+          "Message-ID": "<gmail-live-normal@example.org>",
         },
-        expectedSubject: "Status update"
+        expectedSubject: "Status update",
       },
       {
         name: "quoted-printable",
@@ -379,9 +457,9 @@ Hello from a different exported mailbox body.
           From: "Project Antarctica <project-antarctica@example.org>",
           To: "Volunteer <volunteer@example.org>",
           Subject: "=?utf-8?Q?Re:_Training_=3D_=E2=9C=85?=",
-          "Message-ID": "<gmail-live-qp@example.org>"
+          "Message-ID": "<gmail-live-qp@example.org>",
         },
-        expectedSubject: "Re: Training = ✅"
+        expectedSubject: "Re: Training = ✅",
       },
       {
         name: "base64",
@@ -390,9 +468,9 @@ Hello from a different exported mailbox body.
           From: "Project Antarctica <project-antarctica@example.org>",
           To: "Volunteer <volunteer@example.org>",
           Subject: "=?utf-8?B?UmU6IEludml0YXRpb24=?=",
-          "Message-ID": "<gmail-live-b64@example.org>"
+          "Message-ID": "<gmail-live-b64@example.org>",
         },
-        expectedSubject: "Re: Invitation"
+        expectedSubject: "Re: Invitation",
       },
       {
         name: "chained-words",
@@ -401,9 +479,9 @@ Hello from a different exported mailbox body.
           From: "Project Antarctica <project-antarctica@example.org>",
           To: "Volunteer <volunteer@example.org>",
           Subject: "=?utf-8?Q?Hi?= =?utf-8?Q?_world?=",
-          "Message-ID": "<gmail-live-chained@example.org>"
+          "Message-ID": "<gmail-live-chained@example.org>",
         },
-        expectedSubject: "Hi world"
+        expectedSubject: "Hi world",
       },
       {
         name: "mixed-charsets",
@@ -411,11 +489,10 @@ Hello from a different exported mailbox body.
           Date: "Fri, 03 Jan 2026 00:00:00 +0000",
           From: "Project Antarctica <project-antarctica@example.org>",
           To: "Volunteer <volunteer@example.org>",
-          Subject:
-            "=?iso-8859-1?Q?Ol=E1?= =?windows-1252?Q?_price_=80100?=",
-          "Message-ID": "<gmail-live-mixed@example.org>"
+          Subject: "=?iso-8859-1?Q?Ol=E1?= =?windows-1252?Q?_price_=80100?=",
+          "Message-ID": "<gmail-live-mixed@example.org>",
         },
-        expectedSubject: "Olá price €100"
+        expectedSubject: "Olá price €100",
       },
       {
         name: "unknown-charset-fallback",
@@ -424,10 +501,10 @@ Hello from a different exported mailbox body.
           From: "Project Antarctica <project-antarctica@example.org>",
           To: "Volunteer <volunteer@example.org>",
           Subject: "=?x-unknown?Q?Re:_caf=C3=A9?=",
-          "Message-ID": "<gmail-live-unknown@example.org>"
+          "Message-ID": "<gmail-live-unknown@example.org>",
         },
-        expectedSubject: "Re: café"
-      }
+        expectedSubject: "Re: café",
+      },
     ] as const;
 
     for (const testCase of cases) {
@@ -438,21 +515,21 @@ Hello from a different exported mailbox body.
         internalDate: "2026-01-03T00:00:00.000Z",
         headers: testCase.headers,
         payloadRef: `gmail://volunteers@adventurescientists.org/messages/${encodeURIComponent(
-          testCase.name
+          testCase.name,
         )}`,
         checksum: `checksum:${testCase.name}`,
         capturedMailbox: "volunteers@adventurescientists.org",
         receivedAt: "2026-01-03T00:05:00.000Z",
         internalAddresses: [
           "volunteers@adventurescientists.org",
-          "project-antarctica@example.org"
+          "project-antarctica@example.org",
         ],
-        projectInboxAliases: ["project-antarctica@example.org"]
+        projectInboxAliases: ["project-antarctica@example.org"],
       });
 
       expect(record).toMatchObject({
         recordType: "message",
-        subject: testCase.expectedSubject
+        subject: testCase.expectedSubject,
       });
     }
   });


### PR DESCRIPTION
## Summary

This PR completes the inbox/settings trust recovery batch covering the eight reported issues from May 6:

- force same-day Salesforce lifecycle ordering as signed up, received training, completed training, submitted first data in both timeline surfaces
- keep coordinator/team-originated copied emails attention-driving while showing the human sender and preserving outbound-style visual presentation when the volunteer is the recipient
- repair unread/inbox pagination so filtered views page through the repository slice instead of filtering only the first inbox page
- soften outbound SMS bubbles and keep links readable
- rebuild inbox loading skeletons to match the real content geometry
- remove the SimpleTexting integration card while preserving historical provider/data handling
- derive Mailchimp integration status from durable sync/campaign evidence before marking it not configured
- show non-deactivated admins as Active instead of Pending without sending invites

## Validation

Local checks passed:

- `pnpm --filter @as-comms/web typecheck`
- `pnpm --filter @as-comms/domain typecheck`
- `pnpm --filter @as-comms/integrations typecheck`
- `pnpm --filter @as-comms/web lint`
- `pnpm --filter @as-comms/web build`
- `git diff --check`

Targeted Vitest commands were attempted locally but blocked before tests ran by a local macOS native Rollup optional dependency Team ID/code-signature failure for `@rollup/rollup-darwin-arm64`. CI should provide the clean Vitest signal.

## Safety

No emails, SMS, invites, or external capture jobs were sent or triggered.
