### PR TITLE
[codex] Fix inbox lifecycle display order

### DIFF
--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -1539,8 +1539,8 @@ function buildRecentActivity(
       item.family === "salesforce_event",
   );
 
-  const orderedLifecycleItems = [...lifecycleItems].sort((left, right) =>
-    compareLifecycleActivityForRail(left, right),
+  const orderedLifecycleItems = [...lifecycleItems].sort(
+    compareLifecycleActivityAscending,
   );
   const mostRecentItemId =
     [...lifecycleItems].sort(compareLifecycleActivityAscending).at(-1)?.id ??
@@ -1594,58 +1594,32 @@ function compareLifecycleActivityAscending(
   return left.id.localeCompare(right.id);
 }
 
-function compareLifecycleActivityForRail(
-  left: Extract<TimelineItem, { family: "salesforce_event" }>,
-  right: Extract<TimelineItem, { family: "salesforce_event" }>,
-): number {
-  const leftDate = utcCalendarDate(left.occurredAt);
-  const rightDate = utcCalendarDate(right.occurredAt);
-
-  if (leftDate !== rightDate) {
-    return rightDate.localeCompare(leftDate);
-  }
-
-  return compareLifecycleActivityAscending(left, right);
-}
-
-function reorderSameDayLifecycleTimelineItems(
+function reorderLifecycleTimelineItems(
   timelineItems: readonly TimelineItem[],
 ): readonly TimelineItem[] {
-  const lifecycleByDate = new Map<
-    string,
-    Extract<TimelineItem, { family: "salesforce_event" }>[]
-  >();
+  const lifecycleItems: Extract<
+    TimelineItem,
+    { family: "salesforce_event" }
+  >[] = [];
 
   for (const item of timelineItems) {
     if (item.family !== "salesforce_event") {
       continue;
     }
 
-    const date = utcCalendarDate(item.occurredAt);
-    const existing = lifecycleByDate.get(date) ?? [];
-    existing.push(item);
-    lifecycleByDate.set(date, existing);
+    lifecycleItems.push(item);
   }
 
-  const orderedLifecycleByDate = new Map<
-    string,
-    Extract<TimelineItem, { family: "salesforce_event" }>[]
-  >();
-
-  for (const [date, items] of lifecycleByDate) {
-    orderedLifecycleByDate.set(
-      date,
-      [...items].sort(compareLifecycleActivityAscending),
-    );
-  }
+  const orderedLifecycleItems = lifecycleItems.sort(
+    compareLifecycleActivityAscending,
+  );
 
   return timelineItems.map((item) => {
     if (item.family !== "salesforce_event") {
       return item;
     }
 
-    const date = utcCalendarDate(item.occurredAt);
-    const next = orderedLifecycleByDate.get(date)?.shift();
+    const next = orderedLifecycleItems.shift();
     return next ?? item;
   });
 }
@@ -3444,8 +3418,9 @@ async function readInboxDetailCacheData(
   const visibleTimelineItems = hasPostCutoverActivity
     ? filterItemsAtOrAfterPlatformFullCaptureCutover(activityTimelineItems)
     : activityTimelineItems;
-  const orderedTimelineItems =
-    reorderSameDayLifecycleTimelineItems(visibleTimelineItems);
+  const orderedTimelineItems = reorderLifecycleTimelineItems(
+    visibleTimelineItems,
+  );
   const timelinePage = paginateTimelineItems({
     timelineItems: orderedTimelineItems,
     limit: input.timelineLimit,

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -4446,7 +4446,7 @@ describe("real inbox selectors", () => {
     ]);
   });
 
-  it("builds right-rail lifecycle activity newest-first within the active project", async () => {
+  it("builds right-rail lifecycle activity in visible lifecycle order within the active project", async () => {
     if (runtime === null) {
       throw new Error("Expected inbox test runtime");
     }
@@ -4487,17 +4487,17 @@ describe("real inbox selectors", () => {
     const detail = await getInboxDetail("contact:sarah-martinez");
 
     expect(detail?.contact.recentActivity.map((entry) => entry.label)).toEqual([
-      "Submitted first data - Amazon Basin Research",
-      "Completed training - Amazon Basin Research",
-      "Received training - Amazon Basin Research",
       "Signed up - Amazon Basin Research",
+      "Received training - Amazon Basin Research",
+      "Completed training - Amazon Basin Research",
+      "Submitted first data - Amazon Basin Research",
     ]);
     expect(
       detail?.contact.recentActivity.map((entry) => entry.occurredAtLabel),
-    ).toEqual(["Apr 11", "Apr 10", "Apr 9", "Apr 8"]);
+    ).toEqual(["Apr 8", "Apr 9", "Apr 10", "Apr 11"]);
     expect(
       detail?.contact.recentActivity.map((entry) => entry.isMostRecent),
-    ).toEqual([true, false, false, false]);
+    ).toEqual([false, false, false, true]);
   });
 
   it("returns all lifecycle activity items and does not hard-cap the rail feed at five", async () => {
@@ -4558,12 +4558,12 @@ describe("real inbox selectors", () => {
 
     expect(detail?.contact.recentActivity).toHaveLength(6);
     expect(detail?.contact.recentActivity.map((entry) => entry.label)).toEqual([
-      "Completed training - Amazon Basin Research",
-      "Received training - Amazon Basin Research",
-      "Submitted first data - Amazon Basin Research",
-      "Completed training - Amazon Basin Research",
-      "Received training - Amazon Basin Research",
       "Signed up - Amazon Basin Research",
+      "Received training - Amazon Basin Research",
+      "Completed training - Amazon Basin Research",
+      "Submitted first data - Amazon Basin Research",
+      "Received training - Amazon Basin Research",
+      "Completed training - Amazon Basin Research",
     ]);
   });
 
@@ -4592,12 +4592,12 @@ describe("real inbox selectors", () => {
     const detail = await getInboxDetail("contact:sarah-martinez");
 
     expect(detail?.contact.recentActivity.map((entry) => entry.label)).toEqual([
-      "Completed training - Amazon Basin Research",
       "Signed up - Amazon Basin Research",
+      "Completed training - Amazon Basin Research",
     ]);
   });
 
-  it("orders lifecycle events by UTC day desc + canonical ordinal asc within day, faithful to SF cross-day timestamps", async () => {
+  it("orders lifecycle events by UTC day asc + canonical ordinal asc within day", async () => {
     if (runtime === null) {
       throw new Error("Expected inbox test runtime");
     }
@@ -4637,14 +4637,13 @@ describe("real inbox selectors", () => {
 
     const detail = await getInboxDetail("contact:sarah-martinez");
 
-    // Cross-day order is faithful to SF timestamps (SF anomaly: training stamped
-    // before signup). Within the Oct 27 group, both training events share a
-    // UTC day so they sort by canonical ordinal asc (received before completed).
+    // Cross-day order follows the recorded Salesforce day. Within the Oct 27
+    // group, training events share a UTC day so they sort by canonical ordinal.
     expect(detail?.contact.recentActivity.map((entry) => entry.label)).toEqual([
-      "Submitted first data - Amazon Basin Research",
-      "Signed up - Amazon Basin Research",
       "Received training - Amazon Basin Research",
       "Completed training - Amazon Basin Research",
+      "Signed up - Amazon Basin Research",
+      "Submitted first data - Amazon Basin Research",
     ]);
   });
 
@@ -4681,9 +4680,9 @@ describe("real inbox selectors", () => {
     const detail = await getInboxDetail("contact:sarah-martinez");
 
     expect(detail?.contact.recentActivity.map((entry) => entry.label)).toEqual([
-      "Completed training - Amazon Basin Research",
       "Signed up - Amazon Basin Research",
       "Received training - Amazon Basin Research",
+      "Completed training - Amazon Basin Research",
     ]);
     // Filter to lifecycle pills only — the shared runtime seeds non-lifecycle
     // sarah events that are unrelated to this same-day-canonical-order check.


### PR DESCRIPTION
## Summary
- display right-rail lifecycle activity in chronological lifecycle order instead of newest-first
- apply the same lifecycle ordering to lifecycle slots in the inbox message history
- update selector expectations to match the requested signed-up -> received training -> completed training flow

## Checks
- pnpm --filter @as-comms/web typecheck
- pnpm --filter @as-comms/web lint
- git diff --check

Vitest is still blocked locally by the Rollup darwin-arm64 native optional dependency code-signature issue, so GitHub CI should be treated as the unit-test gate.