### PR TITLE
Fix Gmail live inbox parity

### DIFF
--- a/packages/integrations/src/capture-services/gmail.ts
+++ b/packages/integrations/src/capture-services/gmail.ts
@@ -97,7 +97,7 @@ const gmailApiMessagePartSchema: GmailApiMessagePartSchema = z.lazy(
     body: z
       .object({
         attachmentId: z.string().min(1).nullable().optional(),
-        data: z.string().min(1).nullable().optional(),
+        data: z.string().nullable().optional(),
         size: z.number().int().nonnegative().nullable().optional()
       })
       .nullable()

--- a/packages/integrations/src/providers/gmail-record-builder.ts
+++ b/packages/integrations/src/providers/gmail-record-builder.ts
@@ -222,6 +222,30 @@ export function buildGmailMessageRecord(
       (email) => !isInternalEmail(email, internalAddresses),
     ),
   );
+  const senderIsInternal = fromEmails.some((email) =>
+    isInternalEmail(email, internalAddresses),
+  );
+  const externalSenderEmails = uniqueEmails(
+    fromEmails.filter((email) => !isInternalEmail(email, internalAddresses)),
+  );
+  const externalPrimaryRecipientEmails = uniqueEmails(
+    toEmails.filter((email) => !isInternalEmail(email, internalAddresses)),
+  );
+  const externalCopiedRecipientEmails = uniqueEmails(
+    [...ccEmails, ...bccEmails].filter(
+      (email) => !isInternalEmail(email, internalAddresses),
+    ),
+  );
+  const externalRecipientEmails =
+    externalPrimaryRecipientEmails.length > 0
+      ? externalPrimaryRecipientEmails
+      : externalCopiedRecipientEmails;
+  const identityParticipantEmails =
+    senderIsInternal && externalRecipientEmails.length > 0
+      ? externalRecipientEmails
+      : externalSenderEmails.length > 0
+        ? externalSenderEmails
+        : externalParticipantEmails;
 
   if (externalParticipantEmails.length === 0) {
     return {
@@ -230,9 +254,6 @@ export function buildGmailMessageRecord(
     };
   }
 
-  const senderIsInternal = fromEmails.some((email) =>
-    isInternalEmail(email, internalAddresses),
-  );
   const projectInboxCopyRecipient =
     projectInboxAlias !== null &&
     !hasEmail(fromEmails, projectInboxAlias) &&
@@ -278,7 +299,7 @@ export function buildGmailMessageRecord(
     rfc822MessageId,
     capturedMailbox: input.capturedMailbox,
     projectInboxAlias,
-    normalizedParticipantEmails: externalParticipantEmails,
+    normalizedParticipantEmails: identityParticipantEmails,
     salesforceContactId: null,
     volunteerIdPlainValues: [],
     normalizedPhones: [],

--- a/packages/integrations/test/stage1-gmail-capture-service.test.ts
+++ b/packages/integrations/test/stage1-gmail-capture-service.test.ts
@@ -537,4 +537,111 @@ describe("Gmail capture service", () => {
       "/gmail/v1/users/volunteers%40example.org/messages"
     );
   });
+
+  it("accepts Gmail API message parts with empty body data", async () => {
+    const client = createGmailMailboxApiClient(
+      {
+        bearerToken: "gmail-token",
+        liveAccount: "volunteers@example.org",
+        projectInboxAliases: ["project-antarctica@example.org"],
+        oauthClientId: "gmail-oauth-client-id",
+        oauthClientSecret: "gmail-oauth-client-secret",
+        oauthRefreshToken: "gmail-oauth-refresh-token"
+      },
+      {
+        fetchImplementation: (input) => {
+          const url = resolveRequestUrl(input);
+
+          if (url === "https://oauth2.googleapis.com/token") {
+            return Promise.resolve(
+              new Response(
+                JSON.stringify({
+                  access_token: "gmail-access-token",
+                  expires_in: 3600
+                }),
+                {
+                  status: 200,
+                  headers: {
+                    "content-type": "application/json"
+                  }
+                }
+              )
+            );
+          }
+
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                id: "gmail-empty-part-1",
+                threadId: "thread-empty-part-1",
+                labelIds: ["INBOX"],
+                snippet: "Kirsten claimed Hex 11142.",
+                internalDate: String(Date.parse("2026-05-07T02:26:39.000Z")),
+                payload: {
+                  mimeType: "multipart/alternative",
+                  filename: "",
+                  headers: [
+                    {
+                      name: "Date",
+                      value: "Thu, 7 May 2026 02:26:39 +0000"
+                    },
+                    {
+                      name: "From",
+                      value: "Admin <admin@adventurescientists.org>"
+                    },
+                    {
+                      name: "To",
+                      value: "PNW <project-antarctica@example.org>"
+                    },
+                    {
+                      name: "Subject",
+                      value: "Hex Claimed - Required Further Coordination"
+                    }
+                  ],
+                  body: {
+                    size: 0
+                  },
+                  parts: [
+                    {
+                      mimeType: "text/plain",
+                      filename: "",
+                      headers: [],
+                      body: {
+                        data: "",
+                        size: 0
+                      }
+                    }
+                  ]
+                }
+              }),
+              {
+                status: 200,
+                headers: {
+                  "content-type": "application/json"
+                }
+              }
+            )
+          );
+        }
+      }
+    );
+
+    await expect(
+      client.getMessage({
+        mailbox: "volunteers@example.org",
+        messageId: "gmail-empty-part-1"
+      })
+    ).resolves.toMatchObject({
+      id: "gmail-empty-part-1",
+      payload: {
+        parts: [
+          {
+            body: {
+              data: ""
+            }
+          }
+        ]
+      }
+    });
+  });
 });

--- a/packages/integrations/test/stage1-gmail-mbox.test.ts
+++ b/packages/integrations/test/stage1-gmail-mbox.test.ts
@@ -180,10 +180,40 @@ Hello from an exported mailbox.
         "Samantha Doe <samantha@adventurescientists.org>",
         "Outside Partner <partner@example.org>",
       ].join(", "),
-      normalizedParticipantEmails: [
-        "partner@example.org",
-        "shaina.dotson@gmail.com",
+      normalizedParticipantEmails: ["shaina.dotson@gmail.com"],
+    });
+  });
+
+  it("uses the external sender as identity evidence for inbound mail with external cc recipients", () => {
+    const record = buildGmailMessageRecord({
+      recordId: "gmail-inbound-with-external-cc-1",
+      threadId: "thread-inbound-with-external-cc-1",
+      snippet: "Chris is writing from Kirsten's email account.",
+      internalDate: "2026-05-07T02:53:27.000Z",
+      headers: {
+        Date: "Wed, 6 May 2026 19:53:27 -0700",
+        From: "Kirsten Wert <kirsten.wert@gmail.com>",
+        To: "PNW Forest Biodiversity <pnwbio@adventurescientists.org>",
+        Cc: "Christopher McCafferty <christopher.e.mccafferty@gmail.com>",
+        Subject: "Re: Hex 11142 (Date Pending)",
+        "Message-ID": "<gmail-inbound-with-external-cc-1@example.org>",
+      },
+      payloadRef:
+        "gmail://volunteers@adventurescientists.org/messages/gmail-inbound-with-external-cc-1",
+      checksum: "checksum-inbound-with-external-cc-1",
+      capturedMailbox: "volunteers@adventurescientists.org",
+      receivedAt: "2026-05-07T02:54:00.000Z",
+      internalAddresses: [
+        "volunteers@adventurescientists.org",
+        "pnwbio@adventurescientists.org",
       ],
+      projectInboxAliases: ["pnwbio@adventurescientists.org"],
+    });
+
+    expect(record).toMatchObject({
+      recordType: "message",
+      direction: "inbound",
+      normalizedParticipantEmails: ["kirsten.wert@gmail.com"],
     });
   });
 


### PR DESCRIPTION
## Summary
- accept Gmail API parts with empty body data so valid messages do not fail live capture windows
- resolve Gmail identity evidence from the conversation side (external sender, or primary external recipients for team-originated mail) instead of every external Cc
- add regression coverage for the production empty-body payload and Kirsten-style external Cc identity case

## Checks
- pnpm --filter @as-comms/integrations test:unit -- test/stage1-gmail-capture-service.test.ts test/stage1-gmail-mbox.test.ts
- pnpm --filter @as-comms/integrations typecheck
- pnpm --filter @as-comms/integrations lint