### PR TITLE
fix(mailchimp): keep transition sync incremental

### DIFF
--- a/apps/worker/src/orchestration/tasks.ts
+++ b/apps/worker/src/orchestration/tasks.ts
@@ -42,7 +42,8 @@ export const pollSalesforceLiveJobName = "poll-salesforce-live" as const;
 export const pollIntegrationHealthJobName = "poll-integration-health" as const;
 const polledIntegrationServices = [
   "salesforce",
-  "gmail"
+  "gmail",
+  "mailchimp"
 ] as const satisfies readonly IntegrationHealthRecord["id"][];
 const integrationHealthAlertCooldownMs = 60 * 60 * 1000;
 
@@ -51,6 +52,7 @@ export interface IntegrationHealthTaskDependencies {
   readonly captureBaseUrls: {
     readonly gmail: string;
     readonly salesforce: string;
+    readonly mailchimp: string | null;
   };
   readonly fetchImplementation?: typeof fetch;
   readonly alertSender?: IntegrationHealthAlertSender;
@@ -156,6 +158,11 @@ function readCaptureBaseUrl(
     case "salesforce":
       return captureBaseUrls.salesforce.trim().length > 0
         ? captureBaseUrls.salesforce
+        : null;
+    case "mailchimp":
+      return captureBaseUrls.mailchimp !== null &&
+        captureBaseUrls.mailchimp.trim().length > 0
+        ? captureBaseUrls.mailchimp
         : null;
     default:
       return null;

--- a/apps/worker/src/runtime.ts
+++ b/apps/worker/src/runtime.ts
@@ -421,6 +421,7 @@ export async function createStage1WorkerRuntimeServices(
         captureBaseUrls: {
           gmail: config.capture.gmail.baseUrl,
           salesforce: config.capture.salesforce.baseUrl,
+          mailchimp: config.capture.mailchimp?.baseUrl ?? null,
         },
         fetchImplementation,
       },

--- a/apps/worker/test/integration-health-task.test.ts
+++ b/apps/worker/test/integration-health-task.test.ts
@@ -51,6 +51,26 @@ describe("integration health poller task", () => {
           );
         }
 
+        if (url === "https://mailchimp-capture.example.test/health") {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                service: "mailchimp",
+                status: "healthy",
+                checkedAt: "2026-04-20T16:00:00.000Z",
+                detail: null,
+                version: "mailchimp-sha"
+              }),
+              {
+                status: 200,
+                headers: {
+                  "content-type": "application/json"
+                }
+              }
+            )
+          );
+        }
+
         return Promise.reject(new Error(`Unexpected health request: ${url}`));
       }
     );
@@ -62,7 +82,8 @@ describe("integration health poller task", () => {
           integrationHealth: context.settings.integrationHealth,
           captureBaseUrls: {
             gmail: "https://gmail-capture.example.test",
-            salesforce: "https://salesforce-capture.example.test"
+            salesforce: "https://salesforce-capture.example.test",
+            mailchimp: "https://mailchimp-capture.example.test"
           },
           fetchImplementation
         }
@@ -106,7 +127,15 @@ describe("integration health poller task", () => {
       expect(salesforceRecord.lastAlertSentAt).toBeNull();
       expect(salesforceRecord.detail).toBe("Health endpoint returned status 503.");
       expect(typeof salesforceRecord.lastCheckedAt).toBe("string");
-      expect(fetchImplementation).toHaveBeenCalledTimes(2);
+      const mailchimpRecord =
+        await context.settings.integrationHealth.findById("mailchimp");
+      expect(mailchimpRecord).not.toBeNull();
+      expect(mailchimpRecord?.status).toBe("healthy");
+      expect(mailchimpRecord?.metadataJson).toMatchObject({
+        checkedAt: "2026-04-20T16:00:00.000Z",
+        version: "mailchimp-sha"
+      });
+      expect(fetchImplementation).toHaveBeenCalledTimes(3);
     } finally {
       await context.dispose();
     }
@@ -116,7 +145,11 @@ describe("integration health poller task", () => {
     const fetchImplementation = vi.fn(
       (input: string | URL | Request): Promise<Response> => {
         const url = toRequestUrl(input);
-        const service = url.includes("gmail") ? "gmail" : "salesforce";
+        const service = url.includes("gmail")
+          ? "gmail"
+          : url.includes("mailchimp")
+            ? "mailchimp"
+            : "salesforce";
 
         return Promise.resolve(
           new Response(
@@ -170,7 +203,8 @@ describe("integration health poller task", () => {
           integrationHealth: context.settings.integrationHealth,
           captureBaseUrls: {
             gmail: "https://gmail-capture.example.test",
-            salesforce: "https://salesforce-capture.example.test"
+            salesforce: "https://salesforce-capture.example.test",
+            mailchimp: "https://mailchimp-capture.example.test"
           },
           fetchImplementation,
           alertSender,

--- a/packages/integrations/src/capture-services/mailchimp.ts
+++ b/packages/integrations/src/capture-services/mailchimp.ts
@@ -1067,8 +1067,20 @@ function buildTransitionCampaignWindow(
     throw new CaptureServiceBadRequestError("windowEnd must be a valid timestamp.")
   }
 
-  const windowStart = new Date(windowEnd.getTime())
-  windowStart.setUTCDate(windowStart.getUTCDate() - 30)
+  const windowStart =
+    payload.windowStart === null
+      ? new Date(windowEnd.getTime() - 30 * 24 * 60 * 60 * 1000)
+      : new Date(payload.windowStart)
+
+  if (Number.isNaN(windowStart.getTime())) {
+    throw new CaptureServiceBadRequestError("windowStart must be a valid timestamp.")
+  }
+
+  if (windowStart >= windowEnd) {
+    throw new CaptureServiceBadRequestError(
+      "windowStart must be earlier than windowEnd.",
+    )
+  }
 
   return {
     windowStart: windowStart.toISOString(),

--- a/packages/integrations/test/stage1-mailchimp-capture-service.test.ts
+++ b/packages/integrations/test/stage1-mailchimp-capture-service.test.ts
@@ -259,6 +259,7 @@ describe("Mailchimp capture service", () => {
 
   it("filters transition batches to activity strictly after windowStart", async () => {
     const fixtures = await createMailchimpFixtureResponses()
+    const fetchImplementation = createFetchFromFixtures(fixtures)
     const service = createMailchimpCaptureService(
       {
         bearerToken: "mailchimp-token",
@@ -266,9 +267,7 @@ describe("Mailchimp capture service", () => {
         activityPageSize: 1,
       },
       {
-        fetchImplementation: createFetchFromFixtures(
-          fixtures,
-        ) as unknown as typeof fetch,
+        fetchImplementation: fetchImplementation as unknown as typeof fetch,
         now: () => new Date("2026-02-03T00:00:00.000Z"),
       },
     )
@@ -297,5 +296,23 @@ describe("Mailchimp capture service", () => {
       "clicked",
       "unsubscribed",
     ])
+    const campaignRequest = fetchImplementation.mock.calls.find((call) => {
+      const url = new URL(resolveRequestUrl(call[0]))
+
+      return url.pathname === "/3.0/campaigns"
+    })
+
+    expect(campaignRequest).toBeDefined()
+    if (campaignRequest === undefined) {
+      throw new Error("Expected transition capture to list campaigns.")
+    }
+
+    const campaignRequestUrl = new URL(resolveRequestUrl(campaignRequest[0]))
+    expect(campaignRequestUrl.searchParams.get("since_send_time")).toBe(
+      "2026-02-01T15:11:00.000Z",
+    )
+    expect(campaignRequestUrl.searchParams.get("before_send_time")).toBe(
+      "2026-02-03T00:00:00.000Z",
+    )
   })
 })


### PR DESCRIPTION
## Summary
- make Mailchimp transition capture respect the saved discovery cursor instead of re-scanning the prior 30 days every hourly run
- add Mailchimp to the worker integration-health poller so Settings can show the real capture-service status
- cover the incremental campaign window and Mailchimp health row in unit tests

## Root cause
The worker scheduler was correctly passing the saved Mailchimp discovery cursor as `windowStart`, but the Mailchimp capture service ignored it and rebuilt every transition request as a rolling 30-day campaign scan. In production that made the hourly sync hit the worker timeout, so the latest campaign import stayed stale. Mailchimp was also omitted from the integration-health poller list, leaving Settings stuck at `Not Configured` even when the capture service itself was configured.

## Validation
- `pnpm --filter @as-comms/worker test:unit -- test/integration-health-task.test.ts test/stage1-mailchimp-transition-scheduler.test.ts`
- `pnpm --filter @as-comms/integrations test:unit -- test/stage1-mailchimp-capture-service.test.ts`
- `pnpm --filter @as-comms/integrations typecheck`
- `pnpm --filter @as-comms/worker typecheck`
- `pnpm --filter @as-comms/integrations lint`
- `pnpm --filter @as-comms/worker lint`
