### PR TITLE
feat(worker): reconcile capture gaps daily

### DIFF
--- a/apps/worker/src/jobs/reconcile-capture-gaps.ts
+++ b/apps/worker/src/jobs/reconcile-capture-gaps.ts
@@ -1,0 +1,91 @@
+import type { Task } from "graphile-worker";
+
+import {
+  gmailLiveCaptureBatchJobName,
+  salesforceLiveCaptureBatchJobName
+} from "@as-comms/contracts";
+import type { Stage1Database } from "@as-comms/db";
+import type { Stage1RepositoryBundle } from "@as-comms/domain";
+
+import {
+  reconcileCaptureGaps,
+  type CaptureGapRecoveryPlan
+} from "../ops/reconcile-capture-gaps.js";
+import { mailchimpTransitionSchedulerJobName } from "../orchestration/mailchimp-transition-scheduler.js";
+
+export const reconcileCaptureGapsJobName = "reconcile-capture-gaps" as const;
+
+export interface ReconcileCaptureGapsTaskDependencies {
+  readonly db: Stage1Database;
+  readonly repositories: Stage1RepositoryBundle;
+  readonly now?: () => Date;
+  readonly lookbackDays?: number;
+  readonly minimumAgeMinutes?: number;
+  readonly maxRecoveryWindowMinutes?: number;
+  readonly maxRecoveriesPerRun?: number;
+  readonly includeMailchimpScheduler?: boolean;
+  readonly logger?: Pick<Console, "log">;
+}
+
+function resolveRecoveryJobName(plan: CaptureGapRecoveryPlan): string {
+  switch (plan.provider) {
+    case "gmail":
+      return gmailLiveCaptureBatchJobName;
+    case "salesforce":
+      return salesforceLiveCaptureBatchJobName;
+  }
+}
+
+export function createReconcileCaptureGapsTask(
+  dependencies: ReconcileCaptureGapsTaskDependencies
+): Task {
+  const logger = dependencies.logger ?? console;
+
+  return (_rawPayload, helpers) =>
+    reconcileCaptureGaps({
+      db: dependencies.db,
+      repositories: dependencies.repositories,
+      ...(dependencies.now === undefined ? {} : { now: dependencies.now }),
+      ...(dependencies.lookbackDays === undefined
+        ? {}
+        : { lookbackDays: dependencies.lookbackDays }),
+      ...(dependencies.minimumAgeMinutes === undefined
+        ? {}
+        : { minimumAgeMinutes: dependencies.minimumAgeMinutes }),
+      ...(dependencies.maxRecoveryWindowMinutes === undefined
+        ? {}
+        : { maxRecoveryWindowMinutes: dependencies.maxRecoveryWindowMinutes }),
+      ...(dependencies.maxRecoveriesPerRun === undefined
+        ? {}
+        : { maxRecoveriesPerRun: dependencies.maxRecoveriesPerRun }),
+      ...(dependencies.includeMailchimpScheduler === undefined
+        ? {}
+        : { includeMailchimpScheduler: dependencies.includeMailchimpScheduler }),
+      scheduleRecovery: async (plan) => {
+        await helpers.addJob(resolveRecoveryJobName(plan), plan.payload, {
+          maxAttempts: 1
+        });
+      },
+      scheduleMailchimpTransition: async () => {
+        await helpers.addJob(mailchimpTransitionSchedulerJobName, {}, {
+          maxAttempts: 1
+        });
+      },
+      logger
+    }).then((report) => {
+      if (report.errors.length > 0) {
+        logger.log(
+          JSON.stringify({
+            event: "capture_gap_recovery.errors",
+            sample: report.errors.slice(0, 5)
+          })
+        );
+      }
+
+      if (report.errors.length > 0 && report.scheduled === 0) {
+        throw new Error(
+          `Capture gap recovery made no progress and produced ${report.errors.length.toString()} errors.`
+        );
+      }
+    });
+}

--- a/apps/worker/src/ops/reconcile-capture-gaps.ts
+++ b/apps/worker/src/ops/reconcile-capture-gaps.ts
@@ -1,0 +1,399 @@
+import { randomUUID } from "node:crypto";
+
+import { and, eq, gte, inArray, isNotNull, lt } from "drizzle-orm";
+
+import {
+  gmailLiveCaptureBatchPayloadSchema,
+  salesforceLiveCaptureBatchPayloadSchema,
+  stage1JobVersion,
+  type Provider,
+} from "@as-comms/contracts";
+import { syncState, type Stage1Database } from "@as-comms/db";
+import type { Stage1RepositoryBundle } from "@as-comms/domain";
+
+const defaultLookbackDays = 7;
+const defaultMinimumAgeMinutes = 5;
+const defaultMaxRecoveryWindowMinutes = 120;
+const defaultMaxRecoveriesPerRun = 50;
+const captureGapRecoveryPolicyCode = "stage1.capture_gap.recovery";
+
+export type CaptureGapRecoveryProvider = "gmail" | "salesforce";
+
+export interface CaptureGapRecoveryPlan {
+  readonly provider: CaptureGapRecoveryProvider;
+  readonly sourceSyncStateIds: readonly string[];
+  readonly windowStart: string;
+  readonly windowEnd: string;
+  readonly payload: unknown;
+}
+
+export interface CaptureGapRecoveryError {
+  readonly provider: CaptureGapRecoveryProvider | "mailchimp";
+  readonly sourceSyncStateIds: readonly string[];
+  readonly message: string;
+}
+
+export interface CaptureGapRecoveryReport {
+  readonly scanned: number;
+  readonly covered: number;
+  readonly skipped: number;
+  readonly planned: readonly CaptureGapRecoveryPlan[];
+  readonly scheduled: number;
+  readonly mailchimpSchedulerScheduled: boolean;
+  readonly errors: readonly CaptureGapRecoveryError[];
+  readonly auditEvidenceId: string | null;
+}
+
+interface CandidateWindow {
+  readonly provider: CaptureGapRecoveryProvider;
+  readonly syncStateId: string;
+  readonly windowStart: Date;
+  readonly windowEnd: Date;
+  readonly cursor: string | null;
+  readonly checkpoint: string | null;
+}
+
+interface CoalescedWindow {
+  readonly provider: CaptureGapRecoveryProvider;
+  readonly sourceSyncStateIds: readonly string[];
+  readonly windowStart: Date;
+  readonly windowEnd: Date;
+  readonly cursor: string | null;
+  readonly checkpoint: string | null;
+}
+
+interface SucceededWindow {
+  readonly provider: CaptureGapRecoveryProvider;
+  readonly windowStart: Date;
+  readonly windowEnd: Date;
+}
+
+interface ReconcileCaptureGapsDependencies {
+  readonly db: Stage1Database;
+  readonly repositories: Stage1RepositoryBundle;
+  readonly now?: () => Date;
+  readonly lookbackDays?: number;
+  readonly minimumAgeMinutes?: number;
+  readonly maxRecoveryWindowMinutes?: number;
+  readonly maxRecoveriesPerRun?: number;
+  readonly includeMailchimpScheduler?: boolean;
+  readonly scheduleRecovery: (plan: CaptureGapRecoveryPlan) => Promise<void>;
+  readonly scheduleMailchimpTransition?: () => Promise<void>;
+  readonly logger?: Pick<Console, "log">;
+}
+
+function subtractMs(date: Date, ms: number): Date {
+  return new Date(date.getTime() - ms);
+}
+
+function addMs(date: Date, ms: number): Date {
+  return new Date(date.getTime() + ms);
+}
+
+function buildOperationId(prefix: string): string {
+  return `${prefix}:${randomUUID()}`;
+}
+
+function isRecoveryProvider(provider: Provider | null): provider is CaptureGapRecoveryProvider {
+  return provider === "gmail" || provider === "salesforce";
+}
+
+function isWindowCovered(
+  candidate: CandidateWindow,
+  succeededWindows: readonly SucceededWindow[]
+): boolean {
+  return succeededWindows.some(
+    (window) =>
+      window.provider === candidate.provider &&
+      window.windowStart <= candidate.windowStart &&
+      window.windowEnd >= candidate.windowEnd
+  );
+}
+
+function coalesceCandidateWindows(
+  candidates: readonly CandidateWindow[]
+): readonly CoalescedWindow[] {
+  const ordered = [...candidates].sort((left, right) => {
+    const providerOrder = left.provider.localeCompare(right.provider);
+
+    if (providerOrder !== 0) {
+      return providerOrder;
+    }
+
+    return left.windowStart.getTime() - right.windowStart.getTime();
+  });
+  const coalesced: CoalescedWindow[] = [];
+
+  for (const candidate of ordered) {
+    const current = coalesced.at(-1);
+
+    if (
+      current?.provider !== candidate.provider ||
+      candidate.windowStart > current.windowEnd
+    ) {
+      coalesced.push({
+        provider: candidate.provider,
+        sourceSyncStateIds: [candidate.syncStateId],
+        windowStart: candidate.windowStart,
+        windowEnd: candidate.windowEnd,
+        cursor: candidate.cursor,
+        checkpoint: candidate.checkpoint
+      });
+      continue;
+    }
+
+    coalesced[coalesced.length - 1] = {
+      ...current,
+      sourceSyncStateIds: [...current.sourceSyncStateIds, candidate.syncStateId],
+      windowEnd:
+        candidate.windowEnd > current.windowEnd ? candidate.windowEnd : current.windowEnd
+    };
+  }
+
+  return coalesced;
+}
+
+function splitWindow(
+  window: CoalescedWindow,
+  maxWindowMs: number
+): readonly CoalescedWindow[] {
+  if (window.windowEnd.getTime() - window.windowStart.getTime() <= maxWindowMs) {
+    return [window];
+  }
+
+  const chunks: CoalescedWindow[] = [];
+  let chunkStart = window.windowStart;
+
+  while (chunkStart < window.windowEnd) {
+    const chunkEnd = new Date(
+      Math.min(addMs(chunkStart, maxWindowMs).getTime(), window.windowEnd.getTime())
+    );
+    chunks.push({
+      ...window,
+      windowStart: chunkStart,
+      windowEnd: chunkEnd
+    });
+    chunkStart = chunkEnd;
+  }
+
+  return chunks;
+}
+
+function buildRecoveryPayload(window: CoalescedWindow): unknown {
+  const windowStart = window.windowStart.toISOString();
+  const windowEnd = window.windowEnd.toISOString();
+
+  if (window.provider === "gmail") {
+    return gmailLiveCaptureBatchPayloadSchema.parse({
+      version: stage1JobVersion,
+      jobId: buildOperationId("stage1:gmail:gap-recovery:job"),
+      correlationId: buildOperationId("stage1:gmail:gap-recovery:correlation"),
+      batchId: buildOperationId("stage1:gmail:gap-recovery:batch"),
+      syncStateId: buildOperationId("stage1:gmail:gap-recovery:sync-state"),
+      provider: "gmail",
+      mode: "live",
+      jobType: "live_ingest",
+      cursor: null,
+      checkpoint: window.checkpoint ?? window.cursor ?? windowStart,
+      windowStart,
+      windowEnd,
+      maxRecords: 1000
+    });
+  }
+
+  return salesforceLiveCaptureBatchPayloadSchema.parse({
+    version: stage1JobVersion,
+    jobId: buildOperationId("stage1:salesforce:gap-recovery:job"),
+    correlationId: buildOperationId("stage1:salesforce:gap-recovery:correlation"),
+    batchId: buildOperationId("stage1:salesforce:gap-recovery:batch"),
+    syncStateId: buildOperationId("stage1:salesforce:gap-recovery:sync-state"),
+    provider: "salesforce",
+    mode: "live",
+    jobType: "live_ingest",
+    cursor: null,
+    checkpoint: window.checkpoint ?? window.cursor ?? windowStart,
+    windowStart,
+    windowEnd,
+    maxRecords: 1000
+  });
+}
+
+export async function reconcileCaptureGaps(
+  dependencies: ReconcileCaptureGapsDependencies
+): Promise<CaptureGapRecoveryReport> {
+  const now = dependencies.now ?? (() => new Date());
+  const logger = dependencies.logger ?? console;
+  const evaluatedAt = now();
+  const lookbackDays = dependencies.lookbackDays ?? defaultLookbackDays;
+  const minimumAgeMinutes =
+    dependencies.minimumAgeMinutes ?? defaultMinimumAgeMinutes;
+  const maxRecoveryWindowMinutes =
+    dependencies.maxRecoveryWindowMinutes ?? defaultMaxRecoveryWindowMinutes;
+  const maxRecoveriesPerRun =
+    dependencies.maxRecoveriesPerRun ?? defaultMaxRecoveriesPerRun;
+  const includeMailchimpScheduler =
+    dependencies.includeMailchimpScheduler ?? true;
+  const lookbackStart = subtractMs(evaluatedAt, lookbackDays * 24 * 60 * 60 * 1000);
+  const newestRecoverableWindowEnd = subtractMs(
+    evaluatedAt,
+    minimumAgeMinutes * 60 * 1000
+  );
+  const maxRecoveryWindowMs = maxRecoveryWindowMinutes * 60 * 1000;
+
+  const [failedRows, succeededRows] = await Promise.all([
+    dependencies.db
+      .select()
+      .from(syncState)
+      .where(
+        and(
+          eq(syncState.scope, "provider"),
+          eq(syncState.jobType, "live_ingest"),
+          inArray(syncState.provider, ["gmail", "salesforce"]),
+          inArray(syncState.status, ["failed", "quarantined"]),
+          isNotNull(syncState.windowStart),
+          isNotNull(syncState.windowEnd),
+          gte(syncState.windowEnd, lookbackStart),
+          lt(syncState.windowEnd, newestRecoverableWindowEnd)
+        )
+      ),
+    dependencies.db
+      .select()
+      .from(syncState)
+      .where(
+        and(
+          eq(syncState.scope, "provider"),
+          eq(syncState.jobType, "live_ingest"),
+          inArray(syncState.provider, ["gmail", "salesforce"]),
+          eq(syncState.status, "succeeded"),
+          isNotNull(syncState.windowStart),
+          isNotNull(syncState.windowEnd),
+          gte(syncState.windowEnd, lookbackStart)
+        )
+      )
+  ]);
+
+  const candidates: CandidateWindow[] = failedRows
+    .filter((row): row is typeof row & {
+      provider: CaptureGapRecoveryProvider;
+      windowStart: Date;
+      windowEnd: Date;
+    } => isRecoveryProvider(row.provider) && row.windowStart !== null && row.windowEnd !== null)
+    .filter((row) => row.windowStart < row.windowEnd)
+    .map((row) => ({
+      provider: row.provider,
+      syncStateId: row.id,
+      windowStart: row.windowStart,
+      windowEnd: row.windowEnd,
+      cursor: row.cursor,
+      checkpoint: row.cursor
+    }));
+  const succeededWindows: SucceededWindow[] = succeededRows
+    .filter((row): row is typeof row & {
+      provider: CaptureGapRecoveryProvider;
+      windowStart: Date;
+      windowEnd: Date;
+    } => isRecoveryProvider(row.provider) && row.windowStart !== null && row.windowEnd !== null)
+    .map((row) => ({
+      provider: row.provider,
+      windowStart: row.windowStart,
+      windowEnd: row.windowEnd
+    }));
+  const uncoveredCandidates = candidates.filter(
+    (candidate) => !isWindowCovered(candidate, succeededWindows)
+  );
+  const covered = candidates.length - uncoveredCandidates.length;
+  const recoveryWindows = coalesceCandidateWindows(uncoveredCandidates).flatMap(
+    (window) => splitWindow(window, maxRecoveryWindowMs)
+  );
+  const plannedWindows = recoveryWindows.slice(0, maxRecoveriesPerRun);
+  const skipped = recoveryWindows.length - plannedWindows.length;
+  const planned = plannedWindows.map((window) => ({
+    provider: window.provider,
+    sourceSyncStateIds: window.sourceSyncStateIds,
+    windowStart: window.windowStart.toISOString(),
+    windowEnd: window.windowEnd.toISOString(),
+    payload: buildRecoveryPayload(window)
+  }));
+  const errors: CaptureGapRecoveryError[] = [];
+  let scheduled = 0;
+  let mailchimpSchedulerScheduled = false;
+
+  for (const plan of planned) {
+    try {
+      await dependencies.scheduleRecovery(plan);
+      scheduled += 1;
+    } catch (error) {
+      errors.push({
+        provider: plan.provider,
+        sourceSyncStateIds: plan.sourceSyncStateIds,
+        message: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+
+  if (
+    includeMailchimpScheduler &&
+    dependencies.scheduleMailchimpTransition !== undefined
+  ) {
+    try {
+      await dependencies.scheduleMailchimpTransition();
+      mailchimpSchedulerScheduled = true;
+    } catch (error) {
+      errors.push({
+        provider: "mailchimp",
+        sourceSyncStateIds: [],
+        message: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+
+  const auditEvidence = await dependencies.repositories.auditEvidence.append({
+    id: `audit:capture-gap-recovery:${String(Date.parse(evaluatedAt.toISOString()))}:${randomUUID()}`,
+    actorType: "worker",
+    actorId: "capture-gap-reconciler",
+    action: "reconcile_capture_gaps",
+    entityType: "capture_gap_recovery",
+    entityId: evaluatedAt.toISOString().slice(0, 10),
+    occurredAt: evaluatedAt.toISOString(),
+    result: "recorded",
+    policyCode: captureGapRecoveryPolicyCode,
+    metadataJson: {
+      scanned: candidates.length,
+      covered,
+      skipped,
+      scheduled,
+      planned: planned.map((plan) => ({
+        provider: plan.provider,
+        sourceSyncStateIds: plan.sourceSyncStateIds,
+        windowStart: plan.windowStart,
+        windowEnd: plan.windowEnd
+      })),
+      mailchimpSchedulerScheduled,
+      errors: errors.length
+    }
+  });
+  const report: CaptureGapRecoveryReport = {
+    scanned: candidates.length,
+    covered,
+    skipped,
+    planned,
+    scheduled,
+    mailchimpSchedulerScheduled,
+    errors,
+    auditEvidenceId: auditEvidence.id
+  };
+
+  logger.log(
+    JSON.stringify({
+      event: "capture_gap_recovery.completed",
+      scanned: report.scanned,
+      covered: report.covered,
+      skipped: report.skipped,
+      scheduled: report.scheduled,
+      mailchimpSchedulerScheduled: report.mailchimpSchedulerScheduled,
+      errors: report.errors.length
+    })
+  );
+
+  return report;
+}

--- a/apps/worker/src/runtime.ts
+++ b/apps/worker/src/runtime.ts
@@ -33,6 +33,7 @@ import {
 } from "./ops/config.js";
 import { readNotionKnowledgeSyncConfig } from "./jobs/notion-knowledge-sync/index.js";
 import { dedupHistoricalLedgerJobName } from "./jobs/dedup-historical-ledger.js";
+import { reconcileCaptureGapsJobName } from "./jobs/reconcile-capture-gaps.js";
 import { reconcileRoutingReviewQueueJobName } from "./jobs/reconcile-routing-review-queue.js";
 import {
   createStage1SyncStateService,
@@ -135,6 +136,7 @@ export function buildWorkerCrontab(config: WorkerConfig): string {
     `* * * * * ${reconcileStaleRunningJobName} ?id=stale-running-sweep&max=1`,
     `*/15 * * * * ${reconcileIdentityQueueJobName} ?id=identity-queue-reconcile&max=1`,
     `0 10 * * * ${dedupHistoricalLedgerJobName} ?id=dedup-historical-ledger&max=1`,
+    `30 10 * * * ${reconcileCaptureGapsJobName} ?id=capture-gap-reconcile&max=1`,
     `*/15 * * * * ${reconcileRoutingReviewQueueJobName} ?id=routing-review-queue-reconcile&max=1`,
   ].join("\n");
 }
@@ -447,6 +449,10 @@ export async function createStage1WorkerRuntimeServices(
         },
       },
       reconcileRoutingReviewQueue: {
+        db: connection.db,
+        repositories,
+      },
+      reconcileCaptureGaps: {
         db: connection.db,
         repositories,
       },

--- a/apps/worker/src/tasks.ts
+++ b/apps/worker/src/tasks.ts
@@ -28,6 +28,11 @@ import {
   type ReconcileStaleRunningTaskDependencies,
 } from "./jobs/reconcile-stale-running.js";
 import {
+  createReconcileCaptureGapsTask,
+  reconcileCaptureGapsJobName,
+  type ReconcileCaptureGapsTaskDependencies,
+} from "./jobs/reconcile-capture-gaps.js";
+import {
   createNotionKnowledgeSyncTask,
   notionKnowledgeSyncJobName,
   type NotionKnowledgeSyncDependencies,
@@ -48,6 +53,7 @@ export function createTaskList(
     readonly pendingOutboundSweep?: PendingOutboundSweepTaskDependencies;
     readonly reconcileIdentityQueue?: ReconcileIdentityQueueTaskDependencies;
     readonly reconcileRoutingReviewQueue?: ReconcileRoutingReviewQueueTaskDependencies;
+    readonly reconcileCaptureGaps?: ReconcileCaptureGapsTaskDependencies;
     readonly reconcileStaleRunning?: ReconcileStaleRunningTaskDependencies;
   },
 ): TaskList {
@@ -81,6 +87,13 @@ export function createTaskList(
             createReconcileRoutingReviewQueueTask(
               input.reconcileRoutingReviewQueue,
             ),
+        }),
+    ...(input?.reconcileCaptureGaps === undefined
+      ? {}
+      : {
+          [reconcileCaptureGapsJobName]: createReconcileCaptureGapsTask(
+            input.reconcileCaptureGaps
+          )
         }),
     ...(input?.reconcileStaleRunning === undefined
       ? {}

--- a/apps/worker/test/jobs/reconcile-capture-gaps.test.ts
+++ b/apps/worker/test/jobs/reconcile-capture-gaps.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  gmailLiveCaptureBatchJobName,
+  salesforceLiveCaptureBatchJobName
+} from "@as-comms/contracts";
+
+import { createReconcileCaptureGapsTask, reconcileCaptureGapsJobName } from "../../src/jobs/reconcile-capture-gaps.js";
+import {
+  reconcileCaptureGaps,
+  type CaptureGapRecoveryPlan
+} from "../../src/ops/reconcile-capture-gaps.js";
+import { mailchimpTransitionSchedulerJobName } from "../../src/orchestration/mailchimp-transition-scheduler.js";
+import { createTaskList } from "../../src/tasks.js";
+import { createTestWorkerContext } from "../helpers.js";
+
+function syncStateFixture(input: {
+  readonly id: string;
+  readonly provider: "gmail" | "salesforce" | "mailchimp";
+  readonly status: "failed" | "quarantined" | "succeeded";
+  readonly windowStart: string;
+  readonly windowEnd: string;
+}) {
+  return {
+    id: input.id,
+    scope: "provider" as const,
+    provider: input.provider,
+    jobType: "live_ingest" as const,
+    cursor: input.windowStart,
+    windowStart: input.windowStart,
+    windowEnd: input.windowEnd,
+    status: input.status,
+    parityPercent: null,
+    freshnessP95Seconds: null,
+    freshnessP99Seconds: null,
+    lastSuccessfulAt:
+      input.status === "succeeded" ? input.windowEnd : null,
+    consecutiveFailureCount: input.status === "succeeded" ? 0 : 1,
+    leaseOwner: null,
+    heartbeatAt: null,
+    deadLetterCount: input.status === "quarantined" ? 1 : 0
+  };
+}
+
+describe("capture gap recovery", () => {
+  it("coalesces uncovered recent live failures and skips covered or old windows", async () => {
+    const context = await createTestWorkerContext();
+    const scheduled: CaptureGapRecoveryPlan[] = [];
+    let mailchimpScheduled = false;
+
+    try {
+      await Promise.all([
+        context.repositories.syncState.upsert(
+          syncStateFixture({
+            id: "sync:gmail:failed:1",
+            provider: "gmail",
+            status: "failed",
+            windowStart: "2026-05-07T02:15:00.000Z",
+            windowEnd: "2026-05-07T02:25:00.000Z"
+          })
+        ),
+        context.repositories.syncState.upsert(
+          syncStateFixture({
+            id: "sync:gmail:failed:2",
+            provider: "gmail",
+            status: "failed",
+            windowStart: "2026-05-07T02:25:00.000Z",
+            windowEnd: "2026-05-07T02:40:00.000Z"
+          })
+        ),
+        context.repositories.syncState.upsert(
+          syncStateFixture({
+            id: "sync:gmail:covered",
+            provider: "gmail",
+            status: "failed",
+            windowStart: "2026-05-07T04:00:00.000Z",
+            windowEnd: "2026-05-07T04:10:00.000Z"
+          })
+        ),
+        context.repositories.syncState.upsert(
+          syncStateFixture({
+            id: "sync:gmail:covering-success",
+            provider: "gmail",
+            status: "succeeded",
+            windowStart: "2026-05-07T03:55:00.000Z",
+            windowEnd: "2026-05-07T04:15:00.000Z"
+          })
+        ),
+        context.repositories.syncState.upsert(
+          syncStateFixture({
+            id: "sync:salesforce:failed",
+            provider: "salesforce",
+            status: "quarantined",
+            windowStart: "2026-05-06T23:00:00.000Z",
+            windowEnd: "2026-05-06T23:05:00.000Z"
+          })
+        ),
+        context.repositories.syncState.upsert(
+          syncStateFixture({
+            id: "sync:gmail:old",
+            provider: "gmail",
+            status: "failed",
+            windowStart: "2026-04-20T00:00:00.000Z",
+            windowEnd: "2026-04-20T00:10:00.000Z"
+          })
+        ),
+        context.repositories.syncState.upsert(
+          syncStateFixture({
+            id: "sync:mailchimp:ignored",
+            provider: "mailchimp",
+            status: "failed",
+            windowStart: "2026-05-07T02:00:00.000Z",
+            windowEnd: "2026-05-07T02:05:00.000Z"
+          })
+        )
+      ]);
+
+      const report = await reconcileCaptureGaps({
+        db: context.db,
+        repositories: context.repositories,
+        now: () => new Date("2026-05-07T12:00:00.000Z"),
+        scheduleRecovery: (plan) => {
+          scheduled.push(plan);
+          return Promise.resolve();
+        },
+        scheduleMailchimpTransition: () => {
+          mailchimpScheduled = true;
+          return Promise.resolve();
+        },
+        logger: {
+          log: () => undefined
+        }
+      });
+
+      expect(report.scanned).toBe(4);
+      expect(report.covered).toBe(1);
+      expect(report.scheduled).toBe(2);
+      expect(report.mailchimpSchedulerScheduled).toBe(true);
+      expect(mailchimpScheduled).toBe(true);
+      expect(scheduled).toHaveLength(2);
+      expect(scheduled[0]).toMatchObject({
+        provider: "gmail",
+        sourceSyncStateIds: ["sync:gmail:failed:1", "sync:gmail:failed:2"],
+        windowStart: "2026-05-07T02:15:00.000Z",
+        windowEnd: "2026-05-07T02:40:00.000Z",
+        payload: {
+          provider: "gmail",
+          mode: "live",
+          jobType: "live_ingest",
+          windowStart: "2026-05-07T02:15:00.000Z",
+          windowEnd: "2026-05-07T02:40:00.000Z",
+          maxRecords: 1000
+        }
+      });
+      expect(scheduled[1]).toMatchObject({
+        provider: "salesforce",
+        sourceSyncStateIds: ["sync:salesforce:failed"],
+        payload: {
+          provider: "salesforce",
+          mode: "live",
+          jobType: "live_ingest"
+        }
+      });
+      await expect(
+        context.repositories.auditEvidence.listByEntity({
+          entityType: "capture_gap_recovery",
+          entityId: "2026-05-07"
+        })
+      ).resolves.toHaveLength(1);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("registers a Graphile task that enqueues provider recovery jobs", async () => {
+    const context = await createTestWorkerContext();
+    const addJob = vi.fn(() => Promise.resolve(null));
+
+    try {
+      await context.repositories.syncState.upsert(
+        syncStateFixture({
+          id: "sync:gmail:failed:task",
+          provider: "gmail",
+          status: "failed",
+          windowStart: "2026-05-07T02:15:00.000Z",
+          windowEnd: "2026-05-07T02:25:00.000Z"
+        })
+      );
+
+      const task = createReconcileCaptureGapsTask({
+        db: context.db,
+        repositories: context.repositories,
+        now: () => new Date("2026-05-07T12:00:00.000Z"),
+        logger: {
+          log: () => undefined
+        }
+      });
+
+      await task({} as never, { addJob } as never);
+
+      expect(addJob).toHaveBeenCalledWith(
+        gmailLiveCaptureBatchJobName,
+        expect.objectContaining({
+          provider: "gmail",
+          windowStart: "2026-05-07T02:15:00.000Z",
+          windowEnd: "2026-05-07T02:25:00.000Z"
+        }),
+        { maxAttempts: 1 }
+      );
+      expect(addJob).toHaveBeenCalledWith(
+        mailchimpTransitionSchedulerJobName,
+        {},
+        { maxAttempts: 1 }
+      );
+
+      const taskList = createTaskList(undefined, {
+        reconcileCaptureGaps: {
+          db: context.db,
+          repositories: context.repositories
+        }
+      });
+
+      expect(taskList[reconcileCaptureGapsJobName]).toBeDefined();
+      expect(salesforceLiveCaptureBatchJobName).toBe("stage1.salesforce.capture.live");
+    } finally {
+      await context.dispose();
+    }
+  });
+});

--- a/apps/worker/test/stage1-runtime.test.ts
+++ b/apps/worker/test/stage1-runtime.test.ts
@@ -7,6 +7,7 @@ import {
 
 import { buildWorkerCrontab, readWorkerConfig } from "../src/runtime.js";
 import { dedupHistoricalLedgerJobName } from "../src/jobs/dedup-historical-ledger.js";
+import { reconcileCaptureGapsJobName } from "../src/jobs/reconcile-capture-gaps.js";
 import {
   pollGmailLiveJobName,
   pollIntegrationHealthJobName,
@@ -153,6 +154,7 @@ describe("Stage 1 worker runtime task registration", () => {
         `* * * * * ${reconcileStaleRunningJobName} ?id=stale-running-sweep&max=1`,
         "*/15 * * * * reconcile-identity-queue ?id=identity-queue-reconcile&max=1",
         `0 10 * * * ${dedupHistoricalLedgerJobName} ?id=dedup-historical-ledger&max=1`,
+        `30 10 * * * ${reconcileCaptureGapsJobName} ?id=capture-gap-reconcile&max=1`,
         "*/15 * * * * reconcile-routing-review-queue ?id=routing-review-queue-reconcile&max=1",
       ].join("\n"),
     );


### PR DESCRIPTION
## Summary
- add a daily worker reconciliation job for capture-service gap recovery
- scan recent failed/quarantined Gmail and Salesforce live-ingest windows, skip windows already covered by successful captures, coalesce bounded gaps, and enqueue idempotent recovery captures
- trigger the Mailchimp transition scheduler from the daily recovery job so campaign capture gets a second reliability path
- record an audit evidence row for each recovery scan

## Notes
This does not change Inbox semantics or broaden queue behavior. It only schedules provider capture/replay work from sync-state evidence. It does not send email or SMS.

SimpleTexting/Twilio are intentionally not replayed here because SimpleTexting has been retired and there is no active Twilio capture path in this Stage 1 worker surface.

## Validation
- `pnpm --filter @as-comms/worker test:unit -- test/jobs/reconcile-capture-gaps.test.ts test/stage1-runtime.test.ts`
- `pnpm --filter @as-comms/worker test:unit -- test/jobs/reconcile-capture-gaps.test.ts`
- `pnpm --filter @as-comms/worker typecheck`
- `pnpm --filter @as-comms/worker lint`
