### PR TITLE
chore(nav): hide Campaigns from primary rail until Stage 5A

### DIFF
--- a/apps/web/app/_components/primary-icon-rail.tsx
+++ b/apps/web/app/_components/primary-icon-rail.tsx
@@ -7,7 +7,6 @@ import type { LucideIcon } from "lucide-react";
 import {
   Inbox as InboxIcon,
   LogOut as LogOutIcon,
-  Megaphone as MegaphoneIcon,
   Settings as SettingsIcon
 } from "lucide-react";
 
@@ -57,13 +56,6 @@ const ITEMS: readonly RailItem[] = [
     Icon: InboxIcon,
     href: "/inbox",
     activePrefixes: ["/inbox"]
-  },
-  {
-    id: "campaigns",
-    label: "Campaigns",
-    Icon: MegaphoneIcon,
-    href: null,
-    activePrefixes: ["/campaigns"]
   },
   {
     id: "settings",


### PR DESCRIPTION
## Summary
- remove the disabled Campaigns item from the primary icon rail on /inbox
- remove the now-unused `MegaphoneIcon` import from `primary-icon-rail.tsx`
- keep Campaigns routes untouched for later Stage 5A work

## Why
- Campaigns ships in Stage 5A, which is deferred per canon decision `D-031`
- the primary rail should only show currently available navigation targets: Inbox and Settings

## Validation
- `pnpm --filter @as-comms/web typecheck`
- `pnpm --filter @as-comms/web lint`