### PR TITLE
feat(inbox): AS green chip for staff-origin conversations

### DIFF
--- a/apps/web/app/inbox/_components/inbox-row.tsx
+++ b/apps/web/app/inbox/_components/inbox-row.tsx
@@ -31,15 +31,25 @@ export function InboxRow({ item, isActive }: RowProps) {
   const prefetchedRef = useRef(false);
   const isUnread = item.isUnread;
   const ChannelIcon = item.latestChannel === "email" ? MailIcon : PhoneIcon;
-  const showExternalBadge =
+  const isNonVolunteerWithoutProject =
     item.projectLabel === null && item.volunteerStage === "non-volunteer";
+  const isAdventuresScientistsContact =
+    item.primaryEmail !== null &&
+    /@adventurescientists\.org$/i.test(item.primaryEmail);
+  const showAsBadge =
+    isNonVolunteerWithoutProject && isAdventuresScientistsContact;
+  const showExternalBadge =
+    isNonVolunteerWithoutProject && !isAdventuresScientistsContact;
   const queryString = searchParams.toString();
   const href = queryString.length > 0
     ? `/inbox/${encodeURIComponent(item.contactId)}?${queryString}`
     : `/inbox/${encodeURIComponent(item.contactId)}`;
 
   const showBadges =
-    Boolean(item.projectLabel) || showExternalBadge || item.needsFollowUp;
+    Boolean(item.projectLabel) ||
+    showAsBadge ||
+    showExternalBadge ||
+    item.needsFollowUp;
 
   const prefetchDetail = useCallback(() => {
     if (prefetchedRef.current) {
@@ -119,6 +129,11 @@ export function InboxRow({ item, isActive }: RowProps) {
               {item.projectLabel ? (
                 <span className="inline-flex items-center rounded bg-slate-100 px-1.5 py-0.5 text-[10px] text-slate-600">
                   {item.projectLabel}
+                </span>
+              ) : null}
+              {showAsBadge ? (
+                <span className="inline-flex items-center rounded bg-emerald-50 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 ring-1 ring-inset ring-emerald-200">
+                  AS
                 </span>
               ) : null}
               {showExternalBadge ? (

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -3930,6 +3930,7 @@ function toListItemViewModel(
   return {
     contactId: row.contact.id,
     displayName: row.contact.displayName,
+    primaryEmail: row.contact.primaryEmail,
     initials: toInitials(row.contact.displayName),
     avatarTone: avatarToneForContact(row.contact.id),
     latestSubject: defaultLatestSubject(

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -72,6 +72,7 @@ export type InboxAvatarTone =
 export interface InboxListItemViewModel {
   readonly contactId: string;
   readonly displayName: string;
+  readonly primaryEmail: string | null;
   readonly initials: string;
   readonly avatarTone: InboxAvatarTone;
   readonly latestSubject: string;

--- a/apps/web/tests/unit/inbox-list-shell.test.tsx
+++ b/apps/web/tests/unit/inbox-list-shell.test.tsx
@@ -210,6 +210,7 @@ function buildList(
       {
         contactId: "contact-1",
         displayName: "Riley Carter",
+        primaryEmail: "riley@example.org",
         initials: "RC",
         avatarTone: "sky",
         latestSubject: "Re: Field report",
@@ -742,7 +743,7 @@ describe("Inbox list shell", () => {
     expect(row?.textContent).not.toContain("+2");
   });
 
-  it("renders non-volunteer rows with an External chip", async () => {
+  it("renders staff-origin non-volunteer rows with an AS chip", async () => {
     fetchInboxListPageMock.mockResolvedValue(buildList());
     const baseItem = buildList().items[0];
 
@@ -757,6 +758,7 @@ describe("Inbox list shell", () => {
             ...baseItem,
             contactId: "contact:email:admin@adventurescientists.org",
             displayName: "admin@adventurescientists.org",
+            primaryEmail: "admin@adventurescientists.org",
             initials: "AD",
             projectLabel: null,
             volunteerStage: "non-volunteer",
@@ -767,7 +769,40 @@ describe("Inbox list shell", () => {
 
     const row = activeSession.container.querySelector("[data-inbox-row='true']");
 
-    expect(row?.textContent).toContain("External");
+    expect(row?.textContent).toContain("AS");
     expect(row?.textContent).not.toContain("Amazon Basin");
+    expect(row?.innerHTML).toContain("bg-emerald-50");
+    expect(row?.innerHTML).not.toContain("External");
+  });
+
+  it("keeps genuine non-volunteer external rows on the External chip", async () => {
+    fetchInboxListPageMock.mockResolvedValue(buildList());
+    const baseItem = buildList().items[0];
+
+    if (baseItem === undefined) {
+      throw new Error("Expected an inbox list fixture item");
+    }
+
+    activeSession = await mountInboxList(
+      buildList({
+        items: [
+          {
+            ...baseItem,
+            contactId: "contact:email:partner@example.org",
+            displayName: "Pat Partner",
+            primaryEmail: "partner@example.org",
+            initials: "PP",
+            projectLabel: null,
+            volunteerStage: "non-volunteer",
+          },
+        ],
+      }),
+    );
+
+    const row = activeSession.container.querySelector("[data-inbox-row='true']");
+
+    expect(row?.textContent).toContain("External");
+    expect(row?.innerHTML).toContain("bg-amber-50");
+    expect(row?.innerHTML).not.toContain(">AS<");
   });
 });

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -108,6 +108,7 @@ function buildItem(
   return {
     contactId: overrides.contactId ?? "contact_1",
     displayName: overrides.displayName ?? "Contact One",
+    primaryEmail: overrides.primaryEmail ?? "contact.one@example.org",
     initials: overrides.initials ?? "CO",
     avatarTone: overrides.avatarTone ?? "indigo",
     latestSubject: overrides.latestSubject ?? "Subject",

--- a/docs/02-bundles/inbox-bundle.md
+++ b/docs/02-bundles/inbox-bundle.md
@@ -70,6 +70,7 @@ Build the one-to-one operator workspace on top of canonical projections.
 - campaign events do not mutate Inbox bucket state
 - inbox server views render dynamically (D-040): `revalidateInboxContact` is preserved as an integration point but currently a no-op; interactive actions call `router.refresh()` to re-read fresh server-rendered state without disturbing client editor / composer state
 - staff/admin Gmail delivered to the monitored inbox counts as inbound attention unless it is sent from the monitored mailbox/project alias itself (D-041); do not broaden the default Inbox beyond inbound 1:1 communication rows
+- non-volunteer rows render as `AS` (green) when the contact's primary email is `@adventurescientists.org`, otherwise as `External` (amber)
 
 ## Common Failure Modes
 


### PR DESCRIPTION
## Summary
- expose each inbox row contact's primary email in the inbox list view-model
- render a green `AS` chip for non-volunteer rows with an `@adventurescientists.org` primary email and keep amber `External` for genuine outside contacts
- update the inbox bundle acceptance note to clarify the split

## Test Coverage
- update the inbox list shell test so staff-origin rows assert the green `AS` chip
- add a genuine external non-volunteer case that still asserts the amber `External` chip
- validated with `pnpm --filter @as-comms/web typecheck`, `pnpm --filter @as-comms/web lint`, and `pnpm --filter @as-comms/web test:unit tests/unit/inbox-list-shell.test.tsx`