### PR TITLE
fix(inbox-loading): align welcome skeleton with real content + consistency pass

### DIFF
--- a/apps/web/app/inbox/_components/inbox-loading.tsx
+++ b/apps/web/app/inbox/_components/inbox-loading.tsx
@@ -8,6 +8,9 @@ import {
   TIMELINE_OUTER_MAX_W,
 } from "./inbox-timeline-bubble";
 
+const SKELETON_BASE = "bg-slate-200/80";
+const SKELETON_SECONDARY = "bg-slate-200/70";
+
 /**
  * Full-screen app loading skeleton for the inbox home (`/inbox`).
  * Mirrors the 3-column shell + welcome dashboard so the user sees a
@@ -21,13 +24,13 @@ export function InboxAppLoading() {
       <div
         className={`flex ${LAYOUT.iconRailWidth} shrink-0 flex-col items-center border-r border-slate-200 bg-white py-4`}
       >
-        <Skeleton className="size-9 rounded-xl" />
+        <Skeleton className={`size-9 rounded-xl ${SKELETON_BASE}`} />
         <div className="mt-4 flex flex-1 flex-col items-center gap-1">
-          <Skeleton className="size-10 rounded-xl" />
-          <Skeleton className="size-10 rounded-xl" />
-          <Skeleton className="size-10 rounded-xl" />
+          <Skeleton className={`size-10 rounded-xl ${SKELETON_BASE}`} />
+          <Skeleton className={`size-10 rounded-xl ${SKELETON_BASE}`} />
+          <Skeleton className={`size-10 rounded-xl ${SKELETON_BASE}`} />
         </div>
-        <Skeleton className="mt-2 size-9 rounded-full" />
+        <Skeleton className={`mt-2 size-9 rounded-full ${SKELETON_BASE}`} />
       </div>
 
       {/* List column skeleton */}
@@ -36,12 +39,12 @@ export function InboxAppLoading() {
       >
         <div className="border-b border-slate-200 px-4">
           <div className={`flex ${LAYOUT.headerHeight} items-center gap-2`}>
-            <Skeleton className="h-5 w-24" />
+            <Skeleton className={`h-5 w-24 ${SKELETON_BASE}`} />
             <div className="flex-1" />
-            <Skeleton className="size-8 rounded-lg" />
+            <Skeleton className={`size-8 rounded-lg ${SKELETON_BASE}`} />
           </div>
           <div className="py-2.5">
-            <Skeleton className="h-8 w-full rounded-lg" />
+            <Skeleton className={`h-8 w-full rounded-lg ${SKELETON_BASE}`} />
           </div>
         </div>
         <div className="flex-1 overflow-hidden px-0">
@@ -65,42 +68,43 @@ export function InboxAppLoading() {
 export function WelcomeWorkloadSkeleton() {
   return (
     <section
-      className="flex min-h-0 flex-1 flex-col overflow-hidden bg-slate-50/40"
+      className="flex min-h-0 flex-1 flex-col overflow-y-auto bg-slate-50/40"
       role="status"
       aria-label="Loading welcome dashboard"
     >
       {/* Header strip — matches `Welcome back, X` + sync indicator */}
       <header
-        className={`flex ${LAYOUT.welcomeHeaderHeight} shrink-0 items-center border-b border-slate-200 bg-white px-10`}
+        className={`sticky top-0 z-10 flex ${LAYOUT.welcomeHeaderHeight} shrink-0 items-center border-b border-slate-200 bg-white px-10`}
       >
         <div className="flex w-full items-baseline justify-between gap-4">
           <div className="min-w-0 space-y-2">
-            <Skeleton className="h-5 w-56" />
-            <Skeleton className="h-3 w-40" />
+            <Skeleton className={`h-5 w-56 ${SKELETON_BASE}`} />
+            <Skeleton className={`h-3 w-40 ${SKELETON_SECONDARY}`} />
           </div>
-          <Skeleton className="h-3 w-28" />
+          <Skeleton className={`h-6 w-28 rounded-full ${SKELETON_BASE}`} />
         </div>
       </header>
 
       <div className="mx-auto w-full max-w-[920px] space-y-8 px-10 py-8">
         {/* Quote card */}
-        <div className="rounded-xl border border-slate-200 bg-white p-7">
-          <div className="flex items-start gap-5">
-            <Skeleton className="size-10 shrink-0 rounded-full" />
+        <div className="relative overflow-hidden rounded-xl border border-slate-200 bg-white">
+          <div className="flex items-start gap-5 p-7">
+            <Skeleton className={`size-10 shrink-0 rounded-full ${SKELETON_BASE}`} />
             <div className="min-w-0 flex-1 space-y-3">
-              <Skeleton className="h-3 w-36" />
-              <Skeleton className="h-5 w-full" />
-              <Skeleton className="h-5 w-[80%]" />
-              <Skeleton className="h-3 w-24" />
+              <Skeleton className={`h-3 w-36 ${SKELETON_BASE}`} />
+              <Skeleton className={`h-6 w-full ${SKELETON_BASE}`} />
+              <Skeleton className={`h-6 w-[82%] ${SKELETON_BASE}`} />
+              <Skeleton className={`h-3 w-24 ${SKELETON_SECONDARY}`} />
             </div>
+            <Skeleton className={`size-4 shrink-0 rounded-full ${SKELETON_SECONDARY}`} />
           </div>
         </div>
 
-        {/* Active project lifecycle tiles — 3 stacked full-width tiles */}
+        {/* Active project lifecycle tiles */}
         <div>
-          <Skeleton className="h-3 w-44" />
+          <Skeleton className={`h-3 w-44 ${SKELETON_BASE}`} />
           <div className="mt-3 space-y-3">
-            {Array.from({ length: 3 }).map((_, i) => (
+            {Array.from({ length: 2 }).map((_, i) => (
               <ProjectLifecycleTileSkeleton key={i} />
             ))}
           </div>
@@ -109,8 +113,8 @@ export function WelcomeWorkloadSkeleton() {
         {/* Follow-up rail — section label + 3 rows */}
         <div>
           <div className="flex items-baseline justify-between gap-4">
-            <Skeleton className="h-3 w-52" />
-            <Skeleton className="h-3 w-16" />
+            <Skeleton className={`h-3 w-52 ${SKELETON_BASE}`} />
+            <Skeleton className={`h-3 w-16 ${SKELETON_SECONDARY}`} />
           </div>
           <div className="mt-3 overflow-hidden rounded-xl border border-slate-200 bg-white">
             <div className="divide-y divide-slate-100">
@@ -132,12 +136,12 @@ function ProjectLifecycleTileSkeleton() {
     <article className="relative overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
       <span
         aria-hidden="true"
-        className="absolute inset-y-0 left-0 w-1.5 bg-slate-200"
+        className={`absolute inset-y-0 left-0 w-1.5 ${SKELETON_BASE}`}
       />
       <div className="grid gap-4 py-5 pl-6 pr-5 lg:grid-cols-[minmax(0,220px)_1fr]">
         <div className="flex min-w-0 flex-col items-start gap-2 rounded-xl px-2 py-1">
-          <Skeleton className="h-5 w-40" />
-          <Skeleton className="h-3 w-20" />
+          <Skeleton className={`h-5 w-40 ${SKELETON_BASE}`} />
+          <Skeleton className={`h-3 w-20 ${SKELETON_SECONDARY}`} />
         </div>
 
         <div className="grid gap-3 sm:grid-cols-3">
@@ -153,14 +157,17 @@ function ProjectLifecycleTileSkeleton() {
 function ProjectMetricTileSkeleton() {
   return (
     <div className="rounded-xl border border-slate-200 px-3 py-3">
-      <Skeleton className="h-3 w-16" />
+      <Skeleton className={`h-3 w-16 ${SKELETON_BASE}`} />
       <div className="mt-2 flex items-baseline gap-2">
-        <Skeleton className="h-7 w-12" />
-        <Skeleton className="h-3 w-12" />
+        <Skeleton className={`h-7 w-12 ${SKELETON_BASE}`} />
+        <Skeleton className={`h-3 w-12 ${SKELETON_SECONDARY}`} />
       </div>
       <div className="mt-3 flex items-end gap-1">
         {Array.from({ length: 7 }).map((_, i) => (
-          <Skeleton key={i} className="h-3 w-1.5" />
+          <Skeleton
+            key={i}
+            className={`h-3 w-1.5 rounded-full ${SKELETON_SECONDARY}`}
+          />
         ))}
       </div>
     </div>
@@ -170,16 +177,16 @@ function ProjectMetricTileSkeleton() {
 function FollowUpRailRowSkeleton() {
   return (
     <div className="flex items-center gap-3 px-4 py-3">
-      <Skeleton className="size-8 shrink-0 rounded-full" />
+      <Skeleton className={`size-8 shrink-0 rounded-full ${SKELETON_BASE}`} />
       <div className="min-w-0 flex-1 space-y-2">
         <div className="flex items-center gap-2">
-          <Skeleton className="h-3.5 w-32" />
-          <Skeleton className="h-3 w-24 rounded-full" />
+          <Skeleton className={`h-3.5 w-32 ${SKELETON_BASE}`} />
+          <Skeleton className={`h-5 w-24 rounded-full ${SKELETON_BASE}`} />
         </div>
-        <Skeleton className="h-3 w-56 max-w-full" />
+        <Skeleton className={`h-3 w-56 max-w-full ${SKELETON_SECONDARY}`} />
       </div>
-      <Skeleton className="h-3 w-10 shrink-0" />
-      <Skeleton className="size-3.5 shrink-0 rounded-sm" />
+      <Skeleton className={`h-3 w-10 shrink-0 ${SKELETON_SECONDARY}`} />
+      <Skeleton className={`size-3.5 shrink-0 rounded-sm ${SKELETON_SECONDARY}`} />
     </div>
   );
 }
@@ -200,19 +207,21 @@ export function InboxDetailLoading() {
           className={`flex ${LAYOUT.headerHeight} shrink-0 items-center justify-between gap-4 border-b border-slate-200 px-5`}
         >
           <div className="flex min-w-0 items-center gap-3.5">
-            <Skeleton className="size-7 shrink-0 rounded-full bg-slate-200/80" />
+            <Skeleton className={`size-7 shrink-0 rounded-full ${SKELETON_BASE}`} />
             <div className="min-w-0 space-y-1.5">
-              <Skeleton className="h-4 w-40 max-w-[42vw] bg-slate-200/80" />
+              <Skeleton className={`h-4 w-40 max-w-[42vw] ${SKELETON_BASE}`} />
               <div className="flex items-center gap-2">
-                <Skeleton className="h-3 w-32 bg-slate-200/70" />
-                <Skeleton className="h-5 w-16 rounded-full bg-slate-200/70" />
+                <Skeleton className={`h-3 w-32 ${SKELETON_SECONDARY}`} />
+                <Skeleton
+                  className={`h-5 w-16 rounded-full ${SKELETON_SECONDARY}`}
+                />
               </div>
             </div>
           </div>
           <div className="flex shrink-0 items-center gap-2">
-            <Skeleton className="size-8 rounded-md bg-slate-200/70" />
-            <Skeleton className="size-8 rounded-md bg-slate-200/70" />
-            <Skeleton className="size-8 rounded-md bg-slate-200/70" />
+            <Skeleton className={`size-8 rounded-md ${SKELETON_BASE}`} />
+            <Skeleton className={`size-8 rounded-md ${SKELETON_BASE}`} />
+            <Skeleton className={`size-8 rounded-md ${SKELETON_BASE}`} />
           </div>
         </header>
         <div
@@ -223,10 +232,12 @@ export function InboxDetailLoading() {
         <div className="shrink-0 border-t border-slate-200 bg-white px-5 py-3">
           <div className="flex items-center justify-between gap-3 rounded-lg bg-slate-50 px-3 py-2">
             <div className="min-w-0 space-y-1.5">
-              <Skeleton className="h-3.5 w-48 max-w-full bg-slate-200/70" />
-              <Skeleton className="h-3 w-32 max-w-full bg-slate-200/60" />
+              <Skeleton className={`h-3.5 w-48 max-w-full ${SKELETON_BASE}`} />
+              <Skeleton className={`h-3 w-32 max-w-full ${SKELETON_SECONDARY}`} />
             </div>
-            <Skeleton className="h-8 w-24 shrink-0 rounded-md bg-slate-200/70" />
+            <Skeleton
+              className={`h-8 w-24 shrink-0 rounded-md ${SKELETON_BASE}`}
+            />
           </div>
         </div>
       </section>
@@ -243,20 +254,22 @@ export function QueueRowSkeleton() {
     <div
       className={`flex min-h-[88px] gap-3 border-b border-slate-100 ${SPACING.listItem}`}
     >
-      <Skeleton className="size-9 shrink-0 rounded-full bg-slate-200/80" />
+      <Skeleton className={`size-9 shrink-0 rounded-full ${SKELETON_BASE}`} />
       <div className="min-w-0 flex-1">
         <div className="flex items-center justify-between gap-2">
-          <Skeleton className="h-3.5 w-36 bg-slate-200/80" />
-          <Skeleton className="h-3 w-11 shrink-0 bg-slate-200/70" />
+          <Skeleton className={`h-3.5 w-36 ${SKELETON_BASE}`} />
+          <Skeleton className={`h-3 w-11 shrink-0 ${SKELETON_SECONDARY}`} />
         </div>
         <div className="mt-2 flex items-center gap-1.5">
-          <Skeleton className="size-3 shrink-0 rounded-sm bg-slate-200/70" />
-          <Skeleton className="h-3 w-40 max-w-[72%] bg-slate-200/70" />
+          <Skeleton
+            className={`size-3 shrink-0 rounded-sm ${SKELETON_SECONDARY}`}
+          />
+          <Skeleton className={`h-3 w-40 max-w-[72%] ${SKELETON_SECONDARY}`} />
         </div>
-        <Skeleton className="mt-2 h-2.5 w-52 max-w-[86%] bg-slate-200/60" />
+        <Skeleton className={`mt-2 h-2.5 w-52 max-w-[86%] ${SKELETON_SECONDARY}`} />
         <div className="mt-2 flex items-center gap-1.5">
-          <Skeleton className="h-5 w-20 rounded bg-slate-200/60" />
-          <Skeleton className="h-5 w-16 rounded bg-slate-200/50" />
+          <Skeleton className={`h-5 w-20 rounded-md ${SKELETON_BASE}`} />
+          <Skeleton className={`h-5 w-16 rounded-md ${SKELETON_SECONDARY}`} />
         </div>
       </div>
     </div>
@@ -320,7 +333,9 @@ export function TimelineSkeleton() {
         <li className={`col-span-3 grid ${TIMELINE_GRID_COLUMNS}`}>
           <div className="col-start-2 flex py-1">
             <div className="inline-flex items-center rounded-full border border-slate-200 bg-white px-4 py-2 shadow-sm">
-              <Skeleton className="h-3 w-40 rounded-full bg-slate-200/70" />
+              <Skeleton
+                className={`h-3 w-40 rounded-full ${SKELETON_SECONDARY}`}
+              />
             </div>
           </div>
         </li>
@@ -354,7 +369,7 @@ function TimelineEmailBubbleSkeleton({
       >
         <Skeleton
           aria-hidden="true"
-          className="size-8 rounded-full bg-slate-200/80"
+          className={`size-8 rounded-full ${SKELETON_BASE}`}
         />
       </div>
       <div
@@ -364,13 +379,13 @@ function TimelineEmailBubbleSkeleton({
       >
         <div className="w-full overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
           <div className="border-b border-slate-100 px-4 py-2.5">
-            <Skeleton className="h-3 w-44 max-w-full bg-slate-200/70" />
+            <Skeleton className={`h-3 w-44 max-w-full ${SKELETON_BASE}`} />
           </div>
           <div className="space-y-2 px-4 py-3">
             {lineWidths.map((width, index) => (
               <Skeleton
                 key={`${direction}-${index.toString()}`}
-                className={`h-3 ${width} bg-slate-200/70`}
+                className={`h-3 ${width} ${SKELETON_SECONDARY}`}
               />
             ))}
           </div>
@@ -398,7 +413,7 @@ function TimelineSmsBubbleSkeleton({
         } w-full ${SMS_BUBBLE_MAX_W}`}
       >
         <div className="mb-1 px-1">
-          <Skeleton className="h-3 w-10 bg-slate-200/70" />
+          <Skeleton className={`h-3 w-10 ${SKELETON_SECONDARY}`} />
         </div>
         <div
           className={`w-full rounded-2xl border px-4 py-3 shadow-sm ${
@@ -412,14 +427,14 @@ function TimelineSmsBubbleSkeleton({
               <Skeleton
                 key={`${direction}-sms-${index.toString()}`}
                 className={`h-3 ${width} ${
-                  isInbound ? "bg-slate-200/70" : "bg-sky-200/70"
+                  isInbound ? SKELETON_SECONDARY : "bg-sky-200/70"
                 }`}
               />
             ))}
           </div>
           <Skeleton
             className={`mt-3 h-3 w-16 ${
-              isInbound ? "bg-slate-200/60" : "bg-sky-200/60"
+              isInbound ? SKELETON_SECONDARY : "bg-sky-200/60"
             }`}
           />
         </div>


### PR DESCRIPTION
## What changed
- `WelcomeWorkloadSkeleton`: matched the live welcome pane more closely by making the right pane scrollable/sticky like the real header, switching the freshness placeholder to a pill, tightening the quote card chrome/rhythm, reducing project tile placeholders to 2 variable-style tiles, and keeping the follow-up rail at the real inline limit of 3 rows.
- `ProjectLifecycleTileSkeleton`: kept the live tile container shape, border, left accent rail, and metric-card rhythm aligned with `ProjectLifecycleTile`.
- `FollowUpRailRowSkeleton`: adjusted pill, timestamp, and action placeholders to better match the live row proportions.
- `InboxAppLoading`: normalized icon-rail and list-header placeholder tone/radius usage to the shared slate baseline.
- `QueueRowSkeleton`: standardized placeholder tones and pill/card radii while preserving row dimensions.
- `InboxDetailLoading`: standardized header/composer placeholder tones and pill/button radii.
- `TimelineSkeleton`, `TimelineEmailBubbleSkeleton`, `TimelineSmsBubbleSkeleton`: normalized slate placeholder tones across timeline states while preserving the deliberate outbound sky tint for SMS bubbles.
- `QueueLoadingSkeleton`, `QueueLoadMoreSkeleton`: kept their structure but now inherit the updated queue row styling consistently.

## Validation
- `pnpm --filter @as-comms/web typecheck`
- `pnpm --filter @as-comms/web lint`