### PR TITLE
fix(inbox): hide inline signature images from attachments list

### DIFF
--- a/apps/gmail-capture/src/attachments.ts
+++ b/apps/gmail-capture/src/attachments.ts
@@ -70,15 +70,17 @@ function normalizeContentId(value: string | null | undefined): string | null {
   return normalized.length > 0 ? normalized : null;
 }
 
-function hasInlineContentDisposition(
+function resolveContentDispositionType(
   contentDisposition: string | null | undefined,
-): boolean {
+): string | null {
   if (typeof contentDisposition !== "string") {
-    return false;
+    return null;
   }
 
   const dispositionType = contentDisposition.split(";")[0]?.trim().toLowerCase();
-  return dispositionType === "inline";
+  return dispositionType && dispositionType.length > 0
+    ? dispositionType
+    : null;
 }
 
 function isInlineAttachment(input: {
@@ -88,14 +90,17 @@ function isInlineAttachment(input: {
   };
   readonly htmlBodyCidReferences: ReadonlySet<string>;
 }): boolean {
-  if (hasInlineContentDisposition(input.attachment.contentDisposition)) {
-    return true;
+  const normalizedContentId = normalizeContentId(input.attachment.contentId);
+  if (
+    normalizedContentId === null ||
+    !input.htmlBodyCidReferences.has(normalizedContentId)
+  ) {
+    return false;
   }
 
-  const normalizedContentId = normalizeContentId(input.attachment.contentId);
   return (
-    normalizedContentId !== null &&
-    input.htmlBodyCidReferences.has(normalizedContentId)
+    resolveContentDispositionType(input.attachment.contentDisposition) !==
+    "attachment"
   );
 }
 

--- a/apps/gmail-capture/test/attachments.test.ts
+++ b/apps/gmail-capture/test/attachments.test.ts
@@ -270,7 +270,7 @@ describe("gmail attachment sync", () => {
     }
   });
 
-  it("marks Content-Disposition inline attachments as inline", async () => {
+  it("keeps inline disposition attachments visible when the HTML body does not reference their CID", async () => {
     const context = await createTestStage1Context();
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "gmail-attachments-"));
     const attachmentBytes = Buffer.from("inline-image", "utf8");
@@ -311,6 +311,58 @@ describe("gmail attachment sync", () => {
       ).resolves.toMatchObject([
         {
           sourceEvidenceId,
+          isInline: false,
+        },
+      ]);
+    } finally {
+      await context.dispose();
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("marks inline disposition attachments as inline when the HTML body references their CID", async () => {
+    const context = await createTestStage1Context();
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "gmail-attachments-"));
+    const attachmentBytes = Buffer.from("inline-image", "utf8");
+
+    try {
+      const record = buildGmailRecord({
+        direction: "inbound",
+        recordId: "gmail-inline-disposition-cid-1",
+        attachmentSizeBytes: attachmentBytes.length,
+        contentDisposition: "inline; filename=\"image001.png\"",
+        contentId: "<logo123>",
+        htmlBodyCidReferences: ["logo123"],
+      });
+      const sourceEvidenceId = buildSourceEvidenceId(
+        "gmail",
+        "message",
+        "gmail-inline-disposition-cid-1",
+      );
+
+      await syncGmailMessageAttachments({
+        records: [record],
+        repositories: context.repositories,
+        serviceConfig: {
+          liveAccount: "volunteers@example.org",
+          oauthClientId: "gmail-oauth-client-id",
+          oauthClientSecret: "gmail-oauth-client-secret",
+          oauthRefreshToken: "gmail-oauth-refresh-token",
+          tokenUri: "https://oauth2.googleapis.com/token",
+          timeoutMs: 15_000,
+        },
+        runtimeConfig: {
+          attachmentVolumePath: tempDir,
+          maxAttachmentBytesPerAttachment: 52_428_800,
+        },
+        fetchImplementation: buildSuccessfulFetchImplementation(attachmentBytes),
+      });
+
+      await expect(
+        context.repositories.messageAttachments.findByMessageIds([sourceEvidenceId]),
+      ).resolves.toMatchObject([
+        {
+          sourceEvidenceId,
           isInline: true,
         },
       ]);
@@ -320,7 +372,7 @@ describe("gmail attachment sync", () => {
     }
   });
 
-  it("marks Content-ID attachments referenced by sibling HTML as inline", async () => {
+  it("marks Content-ID attachments referenced by sibling HTML as inline when disposition is missing", async () => {
     const context = await createTestStage1Context();
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "gmail-attachments-"));
     const attachmentBytes = Buffer.from("cid-image", "utf8");
@@ -371,7 +423,7 @@ describe("gmail attachment sync", () => {
     }
   });
 
-  it("keeps plain attachments non-inline when no inline MIME signals are present", async () => {
+  it("keeps attachment disposition attachments visible even when their CID appears in the HTML body", async () => {
     const context = await createTestStage1Context();
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "gmail-attachments-"));
     const attachmentBytes = Buffer.from("plain-attachment", "utf8");
@@ -382,12 +434,63 @@ describe("gmail attachment sync", () => {
         recordId: "gmail-plain-attachment-1",
         attachmentSizeBytes: attachmentBytes.length,
         contentDisposition: "attachment; filename=\"field-photo.jpg\"",
-        contentId: "<not-referenced@example.org>",
+        contentId: "<field-photo@example.org>",
+        htmlBodyCidReferences: ["field-photo@example.org"],
       });
       const sourceEvidenceId = buildSourceEvidenceId(
         "gmail",
         "message",
         "gmail-plain-attachment-1",
+      );
+
+      await syncGmailMessageAttachments({
+        records: [record],
+        repositories: context.repositories,
+        serviceConfig: {
+          liveAccount: "volunteers@example.org",
+          oauthClientId: "gmail-oauth-client-id",
+          oauthClientSecret: "gmail-oauth-client-secret",
+          oauthRefreshToken: "gmail-oauth-refresh-token",
+          tokenUri: "https://oauth2.googleapis.com/token",
+          timeoutMs: 15_000,
+        },
+        runtimeConfig: {
+          attachmentVolumePath: tempDir,
+          maxAttachmentBytesPerAttachment: 52_428_800,
+        },
+        fetchImplementation: buildSuccessfulFetchImplementation(attachmentBytes),
+      });
+
+      await expect(
+        context.repositories.messageAttachments.findByMessageIds([sourceEvidenceId]),
+      ).resolves.toMatchObject([
+        {
+          sourceEvidenceId,
+          isInline: false,
+        },
+      ]);
+    } finally {
+      await context.dispose();
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps missing disposition attachments visible when their CID is not referenced by the HTML body", async () => {
+    const context = await createTestStage1Context();
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "gmail-attachments-"));
+    const attachmentBytes = Buffer.from("plain-attachment", "utf8");
+
+    try {
+      const record = buildGmailRecord({
+        direction: "inbound",
+        recordId: "gmail-missing-disposition-no-cid-1",
+        attachmentSizeBytes: attachmentBytes.length,
+        contentId: "<not-referenced@example.org>",
+      });
+      const sourceEvidenceId = buildSourceEvidenceId(
+        "gmail",
+        "message",
+        "gmail-missing-disposition-no-cid-1",
       );
 
       await syncGmailMessageAttachments({


### PR DESCRIPTION
## Summary
- tighten Gmail inline-image classification so only CID-referenced body images are hidden from the attachments list
- keep inline-disposition parts visible when the HTML body does not reference their CID
- add focused fixture coverage for the five disposition/CID cases

## Path choice
I did not ship the `packages/integrations/src/providers/gmail.ts` ingest-time drop. I also could not safely ship the requested web render-time filter as-is from this workspace because the current web selector only sees materialized `message_attachments` rows, and those rows do not carry the `Content-Disposition`, `Content-ID`, or HTML CID-reference set needed to re-classify already-stored attachments without widening schema/read scope.

Instead, I tightened the existing Gmail attachment materialization predicate in `apps/gmail-capture/src/attachments.ts`, which is the point in the current pipeline where both signals already exist together (`attachmentMetadata` + `htmlBodyCidReferences`). The new rule is:
- hide only when the attachment CID is referenced by the HTML body and the disposition is not `attachment`
- keep explicit `attachment` parts visible even if they have a `Content-ID`
- keep `inline` parts visible when they are not actually referenced by `cid:` in the HTML body

This keeps the fix narrow and matches the requested operator-visible behavior for newly captured mail without widening the Inbox read model.

## Validation
- `pnpm --filter @as-comms/web typecheck`
- `pnpm --filter @as-comms/web lint`
- `pnpm --filter @as-comms/gmail-capture typecheck`
- `pnpm --filter @as-comms/gmail-capture test:unit -- apps/gmail-capture/test/attachments.test.ts`
