### PR TITLE
fix(settings): integrations page layout + Anthropic live status

### DIFF
--- a/apps/web/app/settings/_components/integrations-section.tsx
+++ b/apps/web/app/settings/_components/integrations-section.tsx
@@ -270,8 +270,9 @@ export function IntegrationsSection({ viewModel }: IntegrationsSectionProps) {
               </li>
             );
           })}
+          {/* Twilio is rendered inside the same grid so all 6 cards share equal column widths */}
+          <TwilioConnectorCard viewModel={viewModel.twilioCard} />
         </ul>
-        <TwilioConnectorCard viewModel={viewModel.twilioCard} />
       </SettingsSection>
     </TooltipProvider>
   );
@@ -348,9 +349,9 @@ function TwilioConnectorCard({
     viewModel.monthToDateSegments !== null;
 
   return (
-    <div
+    <li
       className={cn(
-        "mt-4 flex min-h-full flex-col gap-3 border border-slate-200 bg-white p-4",
+        "flex min-h-full flex-col gap-3 border border-slate-200 bg-white p-4",
         RADIUS.lg,
         SHADOW.sm,
       )}
@@ -433,7 +434,7 @@ function TwilioConnectorCard({
           ) : null}
         </div>
       ) : null}
-    </div>
+    </li>
   );
 }
 

--- a/apps/web/src/server/settings/selectors.ts
+++ b/apps/web/src/server/settings/selectors.ts
@@ -713,12 +713,26 @@ async function readIntegrationHealth(): Promise<
       continue;
     }
 
+    // TODO(anthropic-health-probe): The `openai` (Anthropic) row stays at
+    // `not_configured` seed status because there is no HTTP capture-service
+    // endpoint to poll — Anthropic is a direct API client. A real probe would
+    // need to hit the Anthropic API directly (e.g. GET /v1/models) or check
+    // the AI draft ledger for a successful call within a rolling window.
+    // Until that worker probe lands, we surface `not_checked` when the API key
+    // is present so the card doesn't falsely show "Not configured".
+    const effectiveStatus =
+      serviceName === "openai" &&
+      record.status === "not_configured" &&
+      (process.env.ANTHROPIC_API_KEY?.trim().length ?? 0) > 0
+        ? ("not_checked" as const)
+        : record.status;
+
     integrations.push({
       serviceName: record.serviceName,
       displayName: meta.displayName,
       description: meta.description,
       category: record.category,
-      status: record.status,
+      status: effectiveStatus,
       lastCheckedAt: record.lastCheckedAt,
       detail: record.detail,
       supportsRefresh: meta.supportsRefresh,


### PR DESCRIPTION
## What changed

### Issue 1 — Layout fix
`TwilioConnectorCard` was previously rendered outside the grid `<ul>` as a standalone `<div>` with `mt-4`, causing it to span the full width while the other five cards shared the 2-column layout. This PR moves Twilio inside the `<ul>` as a `<li>`, so all six cards (Salesforce, Gmail, Mailchimp, Notion, Anthropic, Twilio) participate in the same `grid-cols-1 sm:grid-cols-2` grid with equal-width columns and consistent vertical rhythm.

### Issue 2 — Anthropic status
The Anthropic integration (`openai` service name in the DB) seeds with `not_configured` and has no live poller. The existing health-check mechanism calls `GET /health` on a capture-service microservice URL — Anthropic is a direct API client with no such endpoint, so adding it to `polledIntegrationServices` would require a new probe function, new `captureBaseUrls` entry in `IntegrationHealthTaskDependencies`, runtime.ts wiring, and test updates (>50 LOC). This is scoped out per the brief.

Instead, the selector now applies a minimal key-presence heuristic: if `ANTHROPIC_API_KEY` is set in the environment, the status is overridden from `not_configured` to `not_checked`. This surfaces "Not checked" (grey) rather than "Not configured" (also grey but semantically wrong) while the Refresh button remains disabled. A detailed `TODO(anthropic-health-probe)` comment in `selectors.ts` explains what a real probe would need.

## Scoped out
Worker-level Anthropic health probe. Follow-up PR should add a dedicated probe that calls the Anthropic API (e.g. `GET api.anthropic.com/v1/models`) or reads the AI draft ledger for a recent successful call, adds `"openai"` to `polledIntegrationServices`, and extends `IntegrationHealthTaskDependencies` with an `anthropic` base URL (or a custom probe function since there is no capture-service microservice for this provider).

## Test plan
- [ ] `/settings/integrations` renders 3 rows of 2 cards each (no full-width Twilio orphan)
- [ ] Twilio card is visually identical to before — just grid-positioned
- [ ] Anthropic card shows "Not checked" when `ANTHROPIC_API_KEY` is set; "Not configured" when key is absent
- `pnpm --filter @as-comms/web typecheck` — passes
- `pnpm --filter @as-comms/web lint` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)