### PR TITLE
fix(inbox-rail): newest-first events, scrollable column, year tag on past projects

### DIFF
--- a/apps/web/app/inbox/_components/inbox-contact-rail.tsx
+++ b/apps/web/app/inbox/_components/inbox-contact-rail.tsx
@@ -49,7 +49,7 @@ export function InboxContactRail({ contact, onClose }: RailProps) {
   return (
     <aside
       id="inbox-contact-rail"
-      className={`flex min-h-0 ${LAYOUT.railWidth} shrink-0 flex-col ${TONE_CLASSES.slate.subtle}`}
+      className={`flex h-full min-h-0 ${LAYOUT.railWidth} shrink-0 flex-col ${TONE_CLASSES.slate.subtle}`}
       aria-label="Contact details"
     >
       <header className={`flex ${LAYOUT.headerHeight} shrink-0 items-center gap-2 border-b border-slate-200 bg-white px-5`}>

--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -479,7 +479,7 @@ export function InboxDetail({ detail, timelineSlot }: DetailProps) {
             : "w-0 border-transparent opacity-0",
         )}
       >
-        <div className={`min-h-0 ${LAYOUT.railWidth}`}>
+        <div className={`flex h-full min-h-0 flex-col ${LAYOUT.railWidth}`}>
           <InboxContactRail
             contact={contact}
             onClose={() => {

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -1539,14 +1539,13 @@ function buildRecentActivity(
       item.family === "salesforce_event",
   );
 
-  const orderedLifecycleItems = [...lifecycleItems].sort(
+  const ascendingLifecycleItems = [...lifecycleItems].sort(
     compareLifecycleActivityAscending,
   );
-  const mostRecentItemId =
-    [...lifecycleItems].sort(compareLifecycleActivityAscending).at(-1)?.id ??
-    null;
+  const mostRecentItemId = ascendingLifecycleItems.at(-1)?.id ?? null;
 
-  return orderedLifecycleItems.map((item) => ({
+  // Reverse to newest-first for the rail display.
+  return [...ascendingLifecycleItems].reverse().map((item) => ({
     id: item.id,
     label: lifecycleRailActivityLabel(item),
     occurredAtLabel: formatUtcRailEventDate(item.occurredAt, referenceNowIso),

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -4488,17 +4488,17 @@ describe("real inbox selectors", () => {
     const detail = await getInboxDetail("contact:sarah-martinez");
 
     expect(detail?.contact.recentActivity.map((entry) => entry.label)).toEqual([
-      "Signed up - Amazon Basin Research",
-      "Received training - Amazon Basin Research",
-      "Completed training - Amazon Basin Research",
       "Submitted first data - Amazon Basin Research",
+      "Completed training - Amazon Basin Research",
+      "Received training - Amazon Basin Research",
+      "Signed up - Amazon Basin Research",
     ]);
     expect(
       detail?.contact.recentActivity.map((entry) => entry.occurredAtLabel),
-    ).toEqual(["Apr 8", "Apr 9", "Apr 10", "Apr 11"]);
+    ).toEqual(["Apr 11", "Apr 10", "Apr 9", "Apr 8"]);
     expect(
       detail?.contact.recentActivity.map((entry) => entry.isMostRecent),
-    ).toEqual([false, false, false, true]);
+    ).toEqual([true, false, false, false]);
   });
 
   it("returns all lifecycle activity items and does not hard-cap the rail feed at five", async () => {
@@ -4559,12 +4559,12 @@ describe("real inbox selectors", () => {
 
     expect(detail?.contact.recentActivity).toHaveLength(6);
     expect(detail?.contact.recentActivity.map((entry) => entry.label)).toEqual([
-      "Signed up - Amazon Basin Research",
-      "Received training - Amazon Basin Research",
       "Completed training - Amazon Basin Research",
+      "Received training - Amazon Basin Research",
       "Submitted first data - Amazon Basin Research",
-      "Received training - Amazon Basin Research",
       "Completed training - Amazon Basin Research",
+      "Received training - Amazon Basin Research",
+      "Signed up - Amazon Basin Research",
     ]);
   });
 
@@ -4593,8 +4593,8 @@ describe("real inbox selectors", () => {
     const detail = await getInboxDetail("contact:sarah-martinez");
 
     expect(detail?.contact.recentActivity.map((entry) => entry.label)).toEqual([
-      "Signed up - Amazon Basin Research",
       "Completed training - Amazon Basin Research",
+      "Signed up - Amazon Basin Research",
     ]);
   });
 
@@ -4638,13 +4638,14 @@ describe("real inbox selectors", () => {
 
     const detail = await getInboxDetail("contact:sarah-martinez");
 
-    // Cross-day order follows the recorded Salesforce day. Within the Oct 27
-    // group, training events share a UTC day so they sort by canonical ordinal.
+    // Rail renders newest-first. Underlying sort is by Salesforce day with a
+    // canonical-ordinal tiebreak for same-UTC-day events, then reversed for
+    // display.
     expect(detail?.contact.recentActivity.map((entry) => entry.label)).toEqual([
-      "Received training - Amazon Basin Research",
-      "Completed training - Amazon Basin Research",
-      "Signed up - Amazon Basin Research",
       "Submitted first data - Amazon Basin Research",
+      "Signed up - Amazon Basin Research",
+      "Completed training - Amazon Basin Research",
+      "Received training - Amazon Basin Research",
     ]);
   });
 
@@ -4681,9 +4682,9 @@ describe("real inbox selectors", () => {
     const detail = await getInboxDetail("contact:sarah-martinez");
 
     expect(detail?.contact.recentActivity.map((entry) => entry.label)).toEqual([
-      "Signed up - Amazon Basin Research",
-      "Received training - Amazon Basin Research",
       "Completed training - Amazon Basin Research",
+      "Received training - Amazon Basin Research",
+      "Signed up - Amazon Basin Research",
     ]);
     // Filter to lifecycle pills only — the shared runtime seeds non-lifecycle
     // sarah events that are unrelated to this same-day-canonical-order check.
@@ -6657,9 +6658,9 @@ describe("real inbox selectors", () => {
       "Completed training for PNW Biodiversity",
     ]);
     expect(detail?.contact.recentActivity.map((entry) => entry.label)).toEqual([
-      "Signed up - PNW Biodiversity",
-      "Received training - PNW Biodiversity",
       "Completed training - PNW Biodiversity",
+      "Received training - PNW Biodiversity",
+      "Signed up - PNW Biodiversity",
     ]);
   });
 


### PR DESCRIPTION
## Summary

Three contact rail fixes targeting the right-column detail panel.

### Fix 1 — Newest-first activity events

**File:** `apps/web/app/inbox/_lib/selectors.ts` — `buildRecentActivity` (~line 1542)

The `orderedLifecycleItems` array was sorted ascending (`compareLifecycleActivityAscending`) and returned as-is, placing the oldest event at the top. Now the array is reversed before mapping to view models so the newest lifecycle event appears first. The `mostRecentItemId` computation (used to highlight the sky dot) still reads `.at(-1)` on the ascending sort, so the highlight remains correct.

### Fix 2 — Scrollable right column

**Files:**
- `apps/web/app/inbox/_components/inbox-detail.tsx` — wrapper div at ~line 482
- `apps/web/app/inbox/_components/inbox-contact-rail.tsx` — `<aside>` element at ~line 52

The `overflow-y-auto` div inside the rail already existed from PR #314, but the `<aside>` had no defined height so `flex-1` had nothing to push against. Root cause: the wrapper `<div>` in `inbox-detail.tsx` lacked `flex flex-col`, so height didn't flow down to the `<aside>`. Fixed by adding `flex flex-col h-full` to the wrapper div and `h-full` to the `<aside>` itself.

### Fix 3 — Year tag on past projects

**Already implemented** as of PR #251 / PR #315. The `InboxProjectMembershipViewModel.signupYear` field is populated in `buildProjectMembershipViewModel` (selectors.ts ~line 970) using the earliest salesforce event for the project, with fallbacks to the first contact event and then `contact.createdAt`. The component (`inbox-contact-rail.tsx` lines 220–227) already renders the year for past-section entries where `signupYear !== null`. No change required.

## Validation

- `pnpm --filter @as-comms/web typecheck` — pass
- `pnpm --filter @as-comms/web lint` — pass
- `pnpm --filter @as-comms/web test:unit tests/unit/inbox-contact-rail.test.tsx` — 2/2 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)