### PR TITLE
feat(composer): pixel-perfect deltas — alias auto-select, inline signature, knowledge footer, button polish

### DIFF
--- a/apps/web/app/inbox/_components/composer-detail-surfaces.tsx
+++ b/apps/web/app/inbox/_components/composer-detail-surfaces.tsx
@@ -524,17 +524,28 @@ export function ComposerEmailSurface({
                 onCommand={onCommand}
               />
 
-              <div className="ml-auto flex items-center gap-2">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  className="gap-1.5 border-l border-slate-200 pl-3 text-[11.5px] font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900"
-                  onClick={onAttachmentClick}
-                >
-                  <PaperclipIcon className="size-3.5" />
-                  Attach
-                </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                className="gap-1.5 border-l border-slate-200 pl-3 text-[11.5px] font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+                onClick={onAttachmentClick}
+              >
+                <PaperclipIcon className="size-3.5" />
+                Attach
+              </Button>
 
+              {selectedAliasHasCachedContent && selectedAliasProjectName !== null ? (
+                <span
+                  className={`inline-flex items-center gap-1.5 ${TYPE.caption} text-slate-500`}
+                >
+                  <BookOpenIcon className="size-3.5" />
+                  Uses {selectedAliasProjectName} knowledge
+                </span>
+              ) : selectedAliasProjectName !== null ? (
+                <KnowledgeIndicator tooltipMessage={knowledgeTooltip} />
+              ) : null}
+
+              <div className="ml-auto flex items-center gap-2">
                 <Button
                   type="button"
                   variant="ghost"
@@ -606,25 +617,6 @@ export function ComposerEmailSurface({
                 </div>
               </div>
             </div>
-
-            {selectedAliasHasCachedContent && selectedAliasProjectName !== null ? (
-              <span
-                className={`mt-2 hidden items-center gap-1.5 ${TYPE.caption} md:inline-flex`}
-              >
-                <BookOpenIcon className="size-3.5" />
-                Uses {selectedAliasProjectName} knowledge
-              </span>
-            ) : selectedAliasProjectName !== null ? (
-              <div className="mt-2 hidden md:block">
-                <KnowledgeIndicator tooltipMessage={knowledgeTooltip} />
-              </div>
-            ) : null}
-
-            {!selectedAliasHasCachedContent && selectedAliasProjectName !== null ? (
-              <div className="mt-2 md:hidden">
-                <KnowledgeIndicator tooltipMessage={knowledgeTooltip} />
-              </div>
-            ) : null}
           </div>
         )}
       />

--- a/apps/web/app/inbox/_components/composer-send-from-chip.tsx
+++ b/apps/web/app/inbox/_components/composer-send-from-chip.tsx
@@ -49,8 +49,12 @@ export function ComposerSendFromChip({
             <span className="min-w-0">
               {selectedAlias ? (
                 <span className="block min-w-0">
-                  <span className="block truncate text-[13px] font-medium text-slate-900">
-                    {selectedAlias.alias}
+                  <span className="flex items-center gap-1.5 truncate text-[13px] font-medium text-slate-900">
+                    <span
+                      aria-hidden="true"
+                      className="inline-block size-2 shrink-0 rounded-full bg-emerald-500"
+                    />
+                    <span className="truncate">{selectedAlias.alias}</span>
                   </span>
                   <span className={`mt-0.5 flex items-center gap-1.5 ${TYPE.caption}`}>
                     <span className="truncate">{selectedAlias.projectName}</span>

--- a/apps/web/app/inbox/_lib/composer-ui.ts
+++ b/apps/web/app/inbox/_lib/composer-ui.ts
@@ -121,6 +121,12 @@ export function resolveDefaultAlias(input: {
     | null;
   readonly aliases: readonly InboxComposerAliasOption[];
 }): string | null {
+  // When exactly one alias is available, always auto-select it —
+  // the operator can't send from anywhere else.
+  if (input.aliases.length === 1) {
+    return input.aliases[0]?.alias ?? null;
+  }
+
   const recipient = input.recipient;
 
   if (recipient?.kind !== "contact" || recipient.primaryProjectName === null) {


### PR DESCRIPTION
## Summary

Closes the remaining Claude Design v2 gaps in the inbox composer modal. All 5 tasks from the brief:

### Task 1 — FROM auto-select + green status dot
- **`composer-ui.ts`**: `resolveDefaultAlias` now auto-selects the single available alias immediately (before any recipient is typed). When exactly one alias is available, the operator has no other choice — so auto-selecting is correct. Multi-alias environments still use the project-name match path.
- **`composer-send-from-chip.tsx`**: Added an `emerald-500` filled dot (`size-2 rounded-full`) inline before the alias email address when an alias is selected.

### Task 2 — Inline signature (already shipped in PR #316)
The signature renders via `bottomSlot` in `RichTextComposerEditor` — already live. No change needed; verified it still works.

### Task 3 — Knowledge footer repositioned into the action bar
- **`composer-detail-surfaces.tsx`**: Moved the "Uses {project} knowledge" indicator out of a below-the-row stacked position and into the flex action bar row itself — between the Attach button and the ml-auto Cancel/Send cluster. Removed the `hidden md:inline-flex` / `md:hidden` responsive split that was suppressing visibility. The label is now always visible when the alias has cached project knowledge.

### Task 4 — AI Draft button styling (already correct in PR #316)
The `DraftActionTrigger` button uses `bg-violet-600` (active) and `disabled:bg-violet-300` (disabled). Styling was already correct. The greyed-out behavior was caused by the alias not auto-selecting (Task 1), which made `selectedAliasRecord === null` → `runAiDraftDisabled = true`. Task 1 fix unblocks this automatically.

### Task 5 — Send button dark filled (already shipped in PR #316)
The split-button uses `bg-slate-900 text-white` with a `ChevronDown` trigger on the right. Already live. No change needed.

## Files changed
- `apps/web/app/inbox/_lib/composer-ui.ts` — single-alias auto-select in `resolveDefaultAlias`
- `apps/web/app/inbox/_components/composer-send-from-chip.tsx` — green emerald status dot
- `apps/web/app/inbox/_components/composer-detail-surfaces.tsx` — knowledge footer repositioned into action bar row

## Test plan
- [x] `pnpm --filter @as-comms/web typecheck` — passes (0 errors)
- [x] `pnpm --filter @as-comms/web lint` — passes (0 warnings)
- [x] `pnpm --filter @as-comms/web test:unit tests/unit/inbox-composer-ai-button.test.tsx` — 5/5 pass
- [x] `pnpm --filter @as-comms/web test:unit tests/unit/composer-canonical-modal.test.tsx` — 8/8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)