### PR TITLE
fix(inbox-loading): scope welcome skeleton to the welcome panel only

### DIFF
--- a/apps/web/app/inbox/loading.tsx
+++ b/apps/web/app/inbox/loading.tsx
@@ -1,5 +1,5 @@
-import { InboxAppLoading } from "./_components/inbox-loading";
+import { WelcomeWorkloadSkeleton } from "./_components/inbox-loading";
 
 export default function InboxLoading() {
-  return <InboxAppLoading />;
+  return <WelcomeWorkloadSkeleton />;
 }


### PR DESCRIPTION
## Summary
The /inbox welcome route was using the full 3-column \`InboxAppLoading\` skeleton instead of the welcome-only \`WelcomeWorkloadSkeleton\`. That made the loading state mock 3 columns of content while the welcome screen is a single dashboard panel.

## Root cause
\`apps/web/app/inbox/loading.tsx\` rendered \`InboxAppLoading\` (the full app shell) at the route segment level. The detail route (\`/inbox/[contactId]/loading.tsx\`) correctly used \`InboxDetailLoading\`, but the base \`/inbox\` route inherited the wrong skeleton.

## Fix
Switched \`apps/web/app/inbox/loading.tsx\` to render \`WelcomeWorkloadSkeleton\` instead. Now the welcome route shows skeleton placeholders only inside the welcome panel.

## Validation
- \`pnpm --filter @as-comms/web typecheck\`: passed
- \`pnpm --filter @as-comms/web lint\`: passed
- Build: skipped locally due to fresh-worktree workspace resolution noise unrelated to this change; CI will verify

## Files
- \`apps/web/app/inbox/loading.tsx\` — 2 lines changed