### PR TITLE
fix(inbox-rail): correct year tag on past projects (use signup date, not last activity)

### DIFF
--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -967,15 +967,23 @@ function buildProjectMembershipViewModel(
 
   const projectOccurredAt =
     firstOccurredAtByProjectId.get(membership.projectId) ?? null;
+  const parsedProjectNameYear = parseTrailingProjectYear(
+    projectName,
+    referenceNowIso,
+  );
   const signupYearSource =
     projectOccurredAt !== null
       ? "project-event"
+      : parsedProjectNameYear !== null
+        ? "project-name"
       : firstOccurredAtForContact !== null
         ? "contact-event"
         : "contact-created-at";
-  const signupYearTimestamp =
-    projectOccurredAt ?? firstOccurredAtForContact ?? contactCreatedAt;
-  const signupYear = new Date(signupYearTimestamp).getUTCFullYear();
+  const signupYear =
+    projectOccurredAt !== null
+      ? new Date(projectOccurredAt).getUTCFullYear()
+      : parsedProjectNameYear ??
+        new Date(firstOccurredAtForContact ?? contactCreatedAt).getUTCFullYear();
   const referenceYear = new Date(referenceNowIso).getUTCFullYear();
 
   return {
@@ -999,6 +1007,32 @@ function buildProjectMembershipViewModel(
         )}/view`
       : null,
   };
+}
+
+function parseTrailingProjectYear(
+  projectName: string,
+  referenceNowIso: string,
+): number | null {
+  const match = /\((\d{4})\)\s*$/.exec(projectName);
+
+  if (match === null) {
+    return null;
+  }
+
+  const yearText = match[1];
+
+  if (yearText === undefined) {
+    return null;
+  }
+
+  const year = Number.parseInt(yearText, 10);
+  const maxYear = new Date(referenceNowIso).getUTCFullYear() + 1;
+
+  if (!Number.isFinite(year) || year < 2015 || year > maxYear) {
+    return null;
+  }
+
+  return year;
 }
 
 function isPastProject(

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -3753,7 +3753,7 @@ describe("real inbox selectors", () => {
       primaryPhone: null,
       contactCreatedAt: "2018-01-01T00:00:00.000Z",
       projectId: "project:contact-event-fallback-year",
-      projectName: "Contact Event Fallback Year",
+      projectName: "Contact Event Fallback Year (2024)",
       membershipId: "membership:contact-event-fallback-year",
       salesforceMembershipId: "a0B-contact-event-fallback-year",
       membershipStatus: "completed",
@@ -3767,7 +3767,7 @@ describe("real inbox selectors", () => {
       primaryPhone: null,
       contactCreatedAt: "2019-01-01T00:00:00.000Z",
       projectId: "project:null-project-fallback-year",
-      projectName: "Null Project Fallback Year",
+      projectName: "Null Project Fallback Year (2022)",
       membershipId: "membership:null-project-fallback-year",
       salesforceMembershipId: "a0B-null-project-fallback-year",
       membershipStatus: "successful",
@@ -3941,13 +3941,13 @@ describe("real inbox selectors", () => {
     ]);
     expect(contactEventDetail?.contact.pastProjects).toMatchObject([
       {
-        projectName: "Contact Event Fallback Year",
-        signupYear: 2020,
+        projectName: "Contact Event Fallback Year (2024)",
+        signupYear: 2024,
       },
     ]);
     expect(nullProjectDetail?.contact.pastProjects).toMatchObject([
       {
-        projectName: "Null Project Fallback Year",
+        projectName: "Null Project Fallback Year (2022)",
         signupYear: 2022,
       },
     ]);


### PR DESCRIPTION
## Summary

Chose Path B (parse year from project name) because the current Salesforce membership capture path does not yet expose or persist a membership signup-date field. In this branch, the past-project year now prefers a trailing project-name year like `California Biodiversity (2024)` when there is no project-scoped canonical lifecycle event, which prevents unrelated 2025 contact activity from leaking into old memberships.

## Why Path B

- Path A would require a wider integration change across Salesforce capture config, provider-close membership records, contracts, DB schema/mappers, repository upserts, and likely a data backfill.
- I investigated the current repo surfaces and found no signup-like membership field already wired through those layers, so shipping Path A today would require a broader Salesforce schema dive and carry higher delivery risk.
- Path B fixes the trust bug in the common case immediately while preserving the existing priority for true project-scoped canonical events.

## File Changes

- `apps/web/app/inbox/_lib/selectors.ts`: added a narrow `(<year>)` parser for past-project labels and used it ahead of the cross-project/contact-created fallback, while still preferring project-specific canonical event dates when available.
- `apps/web/tests/unit/inbox-selectors.test.ts`: updated coverage to prove project-scoped events still win and encoded project-name years rescue memberships that lack project lifecycle history.

## Data Assumptions

- Project names that end with `(<year>)` and fall between 2015 and current year + 1 are treated as safe year hints for this UI fallback.
- If a project-scoped canonical lifecycle event exists for the membership, that event year still wins over the project-name year.
- The repo does not currently show a membership `signup_date`/`signupDate` field already flowing from Salesforce into `contact_memberships`, so this PR does not add schema or backfill changes.
- Memberships without project-scoped lifecycle events and without a parseable trailing project-name year still fall back to the existing contact-level chain.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @as-comms/web typecheck`
- `pnpm --filter @as-comms/web lint`
- `pnpm --filter @as-comms/web test:unit tests/unit/inbox-contact-rail.test.tsx`
- `pnpm --filter @as-comms/web test:unit tests/unit/inbox-selectors.test.ts`
