### PR TITLE
refactor(inbox-rail): remove signupYear from past projects (UI + plumbing)

### DIFF
--- a/apps/web/app/inbox/_components/inbox-contact-rail.tsx
+++ b/apps/web/app/inbox/_components/inbox-contact-rail.tsx
@@ -195,8 +195,6 @@ interface ProjectsSectionProps {
 }
 
 function ProjectsSection({ title, projects, emptyLabel }: ProjectsSectionProps) {
-  const isPastSection = title === "Past Projects";
-
   return (
     <section className={`border-b border-slate-200 ${SPACING.section}`}>
       <SectionLabel as="h3">
@@ -217,14 +215,6 @@ function ProjectsSection({ title, projects, emptyLabel }: ProjectsSectionProps) 
                     {project.projectName}
                   </p>
                   <p className="mt-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
-                    {isPastSection && project.signupYear !== null ? (
-                      <>
-                        <span className="tabular-nums">
-                          {project.signupYear.toString()}
-                        </span>
-                        <span className="text-slate-300">·</span>
-                      </>
-                    ) : null}
                     <InboxProjectStatusBadge
                       status={project.status}
                       label={project.statusLabel}

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -727,35 +727,13 @@ function sortMemberships(
 }
 
 function buildProjectActivityIndex(timelineItems: readonly TimelineItem[]): {
-  readonly firstOccurredAtByProjectId: ReadonlyMap<string, string>;
-  readonly firstOccurredAtForContact: string | null;
   readonly lastOccurredAtByProjectId: ReadonlyMap<string, string>;
 } {
-  const firstOccurredAtByProjectId = new Map<string, string>();
-  let firstOccurredAtForContact: string | null = null;
   const lastOccurredAtByProjectId = new Map<string, string>();
 
   for (const item of timelineItems) {
-    if (item.family !== "salesforce_event") {
+    if (item.family !== "salesforce_event" || item.projectId === null) {
       continue;
-    }
-
-    if (
-      firstOccurredAtForContact === null ||
-      item.occurredAt < firstOccurredAtForContact
-    ) {
-      firstOccurredAtForContact = item.occurredAt;
-    }
-
-    if (item.projectId === null) {
-      continue;
-    }
-
-    const firstOccurredAt =
-      firstOccurredAtByProjectId.get(item.projectId) ?? null;
-
-    if (firstOccurredAt === null || item.occurredAt < firstOccurredAt) {
-      firstOccurredAtByProjectId.set(item.projectId, item.occurredAt);
     }
 
     const lastOccurredAt =
@@ -767,8 +745,6 @@ function buildProjectActivityIndex(timelineItems: readonly TimelineItem[]): {
   }
 
   return {
-    firstOccurredAtByProjectId,
-    firstOccurredAtForContact,
     lastOccurredAtByProjectId,
   };
 }
@@ -950,10 +926,6 @@ function buildProjectMembershipViewModel(
       }
     >
   >,
-  firstOccurredAtByProjectId: ReadonlyMap<string, string>,
-  firstOccurredAtForContact: string | null,
-  contactCreatedAt: string,
-  referenceNowIso: string,
 ): InboxProjectMembershipViewModel | null {
   const projectName =
     membership.projectId === null
@@ -965,27 +937,10 @@ function buildProjectMembershipViewModel(
     return null;
   }
 
-  const projectOccurredAt =
-    firstOccurredAtByProjectId.get(membership.projectId) ?? null;
-  const signupYearSource =
-    projectOccurredAt !== null
-      ? "project-event"
-      : firstOccurredAtForContact !== null
-        ? "contact-event"
-        : "contact-created-at";
-  const signupYearTimestamp =
-    projectOccurredAt ?? firstOccurredAtForContact ?? contactCreatedAt;
-  const signupYear = new Date(signupYearTimestamp).getUTCFullYear();
-  const referenceYear = new Date(referenceNowIso).getUTCFullYear();
-
   return {
     membershipId: membership.id,
     projectId: membership.projectId,
     projectName,
-    signupYear:
-      signupYearSource === "contact-created-at" && signupYear === referenceYear
-        ? null
-        : signupYear,
     projectIsActive:
       projectMetadataById[membership.projectId]?.isActive ?? false,
     status: mapProjectStatus(membership.status),
@@ -4007,14 +3962,7 @@ function buildContactSummary(input: {
       (membership) => !isPastProject(membership, input.projectMetadataById),
     )
     .map((membership) =>
-      buildProjectMembershipViewModel(
-        membership,
-        input.projectMetadataById,
-        projectActivityIndex.firstOccurredAtByProjectId,
-        projectActivityIndex.firstOccurredAtForContact,
-        input.contact.createdAt,
-        input.referenceNowIso,
-      ),
+      buildProjectMembershipViewModel(membership, input.projectMetadataById),
     )
     .filter(
       (membership): membership is InboxProjectMembershipViewModel =>
@@ -4025,14 +3973,7 @@ function buildContactSummary(input: {
       isPastProject(membership, input.projectMetadataById),
     )
     .map((membership) =>
-      buildProjectMembershipViewModel(
-        membership,
-        input.projectMetadataById,
-        projectActivityIndex.firstOccurredAtByProjectId,
-        projectActivityIndex.firstOccurredAtForContact,
-        input.contact.createdAt,
-        input.referenceNowIso,
-      ),
+      buildProjectMembershipViewModel(membership, input.projectMetadataById),
     )
     .filter(
       (membership): membership is InboxProjectMembershipViewModel =>

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -123,7 +123,6 @@ export interface InboxProjectMembershipViewModel {
   readonly membershipId: string;
   readonly projectId: string;
   readonly projectName: string;
-  readonly signupYear: number | null;
   readonly projectIsActive: boolean;
   readonly status: InboxProjectStatus;
   readonly statusLabel: string;

--- a/apps/web/tests/unit/inbox-contact-rail.test.tsx
+++ b/apps/web/tests/unit/inbox-contact-rail.test.tsx
@@ -259,4 +259,27 @@ describe("InboxContactRail", () => {
     expect(firstDot?.className).toContain("border-slate-300");
     expect(secondDot?.className).toContain("border-sky-500");
   });
+
+  it("shows past project name and status without rendering the signup year", async () => {
+    activeSession = await renderRail({
+      ...buildContact(0),
+      pastProjects: [
+        {
+          membershipId: "membership-1",
+          projectId: "project-1",
+          projectName: "Alpine Stream Survey",
+          expeditionMemberUrl: null,
+          crmUrl: "https://salesforce.example.com/member/1",
+          projectIsActive: false,
+          status: "successful",
+          statusLabel: "Successful",
+          signupYear: 2021,
+        },
+      ],
+    });
+
+    expect(activeSession.container.textContent).toContain("Alpine Stream Survey");
+    expect(activeSession.container.textContent).toContain("Successful");
+    expect(activeSession.container.textContent).not.toContain("2021");
+  });
 });

--- a/apps/web/tests/unit/inbox-contact-rail.test.tsx
+++ b/apps/web/tests/unit/inbox-contact-rail.test.tsx
@@ -260,7 +260,7 @@ describe("InboxContactRail", () => {
     expect(secondDot?.className).toContain("border-sky-500");
   });
 
-  it("shows past project name and status without rendering the signup year", async () => {
+  it("renders past project name and status", async () => {
     activeSession = await renderRail({
       ...buildContact(0),
       pastProjects: [
@@ -273,13 +273,11 @@ describe("InboxContactRail", () => {
           projectIsActive: false,
           status: "successful",
           statusLabel: "Successful",
-          signupYear: 2021,
         },
       ],
     });
 
     expect(activeSession.container.textContent).toContain("Alpine Stream Survey");
     expect(activeSession.container.textContent).toContain("Successful");
-    expect(activeSession.container.textContent).not.toContain("2021");
   });
 });

--- a/apps/web/tests/unit/inbox-detail-header.test.tsx
+++ b/apps/web/tests/unit/inbox-detail-header.test.tsx
@@ -155,7 +155,6 @@ function buildDetail(
           membershipId: "membership-1",
           projectId: "project-1",
           projectName: "Amazon Basin",
-          signupYear: 2026,
           projectIsActive: true,
           status: "in-field",
           statusLabel: "Active",

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -3309,7 +3309,6 @@ describe("real inbox selectors", () => {
 
     expect(detail?.contact.activeProjects[0]).toMatchObject({
       projectName: "All-Time Membership Project",
-      signupYear: 2023,
       status: "successful",
     });
   });
@@ -3366,7 +3365,6 @@ describe("real inbox selectors", () => {
       projectIsActive: false,
       status: "applied",
       statusLabel: "Applied",
-      signupYear: null,
       expeditionMemberUrl:
         "https://adventurescientists.lightning.force.com/lightning/r/Expedition_Members__c/a0B-ryan-parks/view",
     });
@@ -3431,9 +3429,6 @@ describe("real inbox selectors", () => {
     expect(
       detail?.contact.pastProjects.map((project) => project.projectName),
     ).toEqual(["Newer Project", "Older Project"]);
-    expect(
-      detail?.contact.pastProjects.map((project) => project.signupYear),
-    ).toEqual([null, null]);
   });
 
   it("normalizes the full Salesforce membership-status label surface for rail badges", async () => {
@@ -3518,19 +3513,6 @@ describe("real inbox selectors", () => {
       "project:killer-whales",
       false,
     );
-
-    // Seed a project-linked lifecycle event so signupYear resolves to a real
-    // historical year (otherwise the fallback chain reaches contact.createdAt
-    // which equals the current/backfill year and is intentionally suppressed —
-    // see "correct past-project signup year").
-    await seedInboxLifecycleEvent(runtime.context, {
-      id: "lisa-killer-whales-signup",
-      contactId: "contact:lisa-zhang",
-      occurredAt: "2023-06-15T15:00:00.000Z",
-      eventType: "lifecycle.signed_up",
-      summary: "Signed up - Searching for Killer Whales",
-      projectId: "project:killer-whales",
-    });
 
     const [activeDetail, pastDetail] = await Promise.all([
       getInboxDetail("contact:sarah-martinez"),
@@ -3717,7 +3699,6 @@ describe("real inbox selectors", () => {
     expect(detail).not.toBeNull();
     expect(detail?.contact.pastProjects[0]).toMatchObject({
       projectIsActive: false,
-      signupYear: null,
       status: "successful",
       statusLabel: "Successful",
       crmUrl:
@@ -3725,238 +3706,6 @@ describe("real inbox selectors", () => {
       expeditionMemberUrl:
         "https://adventurescientists.lightning.force.com/lightning/r/Expedition_Members__c/membership%3Alisa%3Asf/view",
     });
-  });
-
-  it("derives past-project signup year from project events, contact-level events, and suppresses backfill-year fallbacks", async () => {
-    if (runtime === null) {
-      throw new Error("Expected inbox test runtime");
-    }
-
-    await seedInboxContact(runtime.context, {
-      contactId: "contact:past-signup-year",
-      salesforceContactId: "003-past-signup-year",
-      displayName: "Past Signup Year",
-      primaryEmail: "past-signup-year@example.org",
-      primaryPhone: null,
-      projectId: "project:old-ledger-year",
-      projectName: "Old Ledger Year",
-      membershipId: "membership:past:old-ledger-year",
-      salesforceMembershipId: "a0B-past-old-ledger-year",
-      membershipStatus: "successful",
-      membershipCreatedAt: "2026-02-01T00:00:00.000Z",
-    });
-    await seedInboxContact(runtime.context, {
-      contactId: "contact:contact-event-signup-year",
-      salesforceContactId: "003-contact-event-signup-year",
-      displayName: "Contact Event Signup Year",
-      primaryEmail: "contact-event-signup-year@example.org",
-      primaryPhone: null,
-      contactCreatedAt: "2018-01-01T00:00:00.000Z",
-      projectId: "project:contact-event-fallback-year",
-      projectName: "Contact Event Fallback Year",
-      membershipId: "membership:contact-event-fallback-year",
-      salesforceMembershipId: "a0B-contact-event-fallback-year",
-      membershipStatus: "completed",
-      membershipCreatedAt: "2026-04-15T00:00:00.000Z",
-    });
-    await seedInboxContact(runtime.context, {
-      contactId: "contact:null-project-fallback-year",
-      salesforceContactId: "003-null-project-fallback-year",
-      displayName: "Null Project Fallback Year",
-      primaryEmail: "null-project-fallback-year@example.org",
-      primaryPhone: null,
-      contactCreatedAt: "2019-01-01T00:00:00.000Z",
-      projectId: "project:null-project-fallback-year",
-      projectName: "Null Project Fallback Year",
-      membershipId: "membership:null-project-fallback-year",
-      salesforceMembershipId: "a0B-null-project-fallback-year",
-      membershipStatus: "successful",
-      membershipCreatedAt: "2026-04-15T00:00:00.000Z",
-    });
-    await seedInboxContact(runtime.context, {
-      contactId: "contact:suppressed-signup-year",
-      salesforceContactId: "003-suppressed-signup-year",
-      displayName: "Suppressed Signup Year",
-      primaryEmail: "suppressed-signup-year@example.org",
-      primaryPhone: null,
-      contactCreatedAt: "2026-01-05T00:00:00.000Z",
-      projectId: "project:suppressed-signup-year",
-      projectName: "Suppressed Signup Year",
-      membershipId: "membership:suppressed-signup-year",
-      salesforceMembershipId: "a0B-suppressed-signup-year",
-      membershipStatus: "completed",
-      membershipCreatedAt: "2026-04-15T00:00:00.000Z",
-    });
-    await runtime.context.settings.projects.setActive(
-      "project:old-ledger-year",
-      false,
-    );
-    await runtime.context.settings.projects.setActive(
-      "project:contact-event-fallback-year",
-      false,
-    );
-    await runtime.context.settings.projects.setActive(
-      "project:null-project-fallback-year",
-      false,
-    );
-    await runtime.context.settings.projects.setActive(
-      "project:suppressed-signup-year",
-      false,
-    );
-    await seedInboxLifecycleEvent(runtime.context, {
-      id: "past-signup-year-oldest",
-      contactId: "contact:past-signup-year",
-      occurredAt: "2021-07-14T00:00:00.000Z",
-      eventType: "lifecycle.signed_up",
-      summary: "Signed up",
-      projectId: "project:old-ledger-year",
-    });
-    await seedInboxLifecycleEvent(runtime.context, {
-      id: "past-signup-year-newer",
-      contactId: "contact:past-signup-year",
-      occurredAt: "2023-03-20T00:00:00.000Z",
-      eventType: "lifecycle.completed_training",
-      summary: "Completed training",
-      projectId: "project:old-ledger-year",
-    });
-    await seedInboxLifecycleEvent(runtime.context, {
-      id: "contact-event-fallback-year-earliest",
-      contactId: "contact:contact-event-signup-year",
-      occurredAt: "2020-05-09T00:00:00.000Z",
-      eventType: "lifecycle.signed_up",
-      summary: "Signed up",
-      projectId: "project:other-contact-project",
-    });
-    await seedInboxLifecycleEvent(runtime.context, {
-      id: "null-project-fallback-year-earliest",
-      contactId: "contact:null-project-fallback-year",
-      occurredAt: "2022-09-10T00:00:00.000Z",
-      eventType: "lifecycle.signed_up",
-      summary: "Signed up",
-      projectId: null,
-    });
-    const latest = await seedInboxEmailEvent(runtime.context, {
-      id: "past-signup-year-inbound",
-      contactId: "contact:past-signup-year",
-      occurredAt: "2026-04-25T13:00:00.000Z",
-      direction: "inbound",
-      subject: "Past signup year check",
-      snippet: "Checking lifecycle-derived signup year.",
-    });
-    await seedInboxProjection(runtime.context, {
-      contactId: "contact:past-signup-year",
-      bucket: "New",
-      needsFollowUp: false,
-      hasUnresolved: false,
-      lastInboundAt: "2026-04-25T13:00:00.000Z",
-      lastOutboundAt: null,
-      lastActivityAt: "2026-04-25T13:00:00.000Z",
-      snippet: "Checking lifecycle-derived signup year.",
-      lastCanonicalEventId: latest.canonicalEventId,
-      lastEventType: "communication.email.inbound",
-    });
-    const contactFallbackLatest = await seedInboxEmailEvent(runtime.context, {
-      id: "contact-event-signup-year-inbound",
-      contactId: "contact:contact-event-signup-year",
-      occurredAt: "2026-04-25T13:00:00.000Z",
-      direction: "inbound",
-      subject: "Contact event signup year check",
-      snippet: "Checking contact-level signup year fallback.",
-    });
-    await seedInboxProjection(runtime.context, {
-      contactId: "contact:contact-event-signup-year",
-      bucket: "New",
-      needsFollowUp: false,
-      hasUnresolved: false,
-      lastInboundAt: "2026-04-25T13:00:00.000Z",
-      lastOutboundAt: null,
-      lastActivityAt: "2026-04-25T13:00:00.000Z",
-      snippet: "Checking contact-level signup year fallback.",
-      lastCanonicalEventId: contactFallbackLatest.canonicalEventId,
-      lastEventType: "communication.email.inbound",
-    });
-    const nullProjectLatest = await seedInboxEmailEvent(runtime.context, {
-      id: "null-project-fallback-year-inbound",
-      contactId: "contact:null-project-fallback-year",
-      occurredAt: "2026-04-25T13:00:00.000Z",
-      direction: "inbound",
-      subject: "Null project signup year check",
-      snippet: "Checking null-project contact-level signup year fallback.",
-    });
-    await seedInboxProjection(runtime.context, {
-      contactId: "contact:null-project-fallback-year",
-      bucket: "New",
-      needsFollowUp: false,
-      hasUnresolved: false,
-      lastInboundAt: "2026-04-25T13:00:00.000Z",
-      lastOutboundAt: null,
-      lastActivityAt: "2026-04-25T13:00:00.000Z",
-      snippet: "Checking null-project contact-level signup year fallback.",
-      lastCanonicalEventId: nullProjectLatest.canonicalEventId,
-      lastEventType: "communication.email.inbound",
-    });
-    const suppressedLatest = await seedInboxEmailEvent(runtime.context, {
-      id: "suppressed-signup-year-inbound",
-      contactId: "contact:suppressed-signup-year",
-      occurredAt: "2026-04-25T13:00:00.000Z",
-      direction: "inbound",
-      subject: "Suppressed signup year check",
-      snippet: "Checking backfill-year suppression.",
-    });
-    await seedInboxProjection(runtime.context, {
-      contactId: "contact:suppressed-signup-year",
-      bucket: "New",
-      needsFollowUp: false,
-      hasUnresolved: false,
-      lastInboundAt: "2026-04-25T13:00:00.000Z",
-      lastOutboundAt: null,
-      lastActivityAt: "2026-04-25T13:00:00.000Z",
-      snippet: "Checking backfill-year suppression.",
-      lastCanonicalEventId: suppressedLatest.canonicalEventId,
-      lastEventType: "communication.email.inbound",
-    });
-
-    const detail = await getInboxDetail("contact:past-signup-year");
-    const contactEventDetail = await getInboxDetail(
-      "contact:contact-event-signup-year",
-    );
-    const nullProjectDetail = await getInboxDetail(
-      "contact:null-project-fallback-year",
-    );
-
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-05-04T12:00:00.000Z"));
-    const suppressedDetail = await getInboxDetail(
-      "contact:suppressed-signup-year",
-    );
-
-    // Past projects sort by membership.createdAt desc (newest first).
-    // signupYear is independent of sort and resolves via:
-    // project-linked event -> contact-level event -> contact createdAt.
-    expect(detail?.contact.pastProjects).toMatchObject([
-      {
-        projectName: "Old Ledger Year",
-        signupYear: 2021,
-      },
-    ]);
-    expect(contactEventDetail?.contact.pastProjects).toMatchObject([
-      {
-        projectName: "Contact Event Fallback Year",
-        signupYear: 2020,
-      },
-    ]);
-    expect(nullProjectDetail?.contact.pastProjects).toMatchObject([
-      {
-        projectName: "Null Project Fallback Year",
-        signupYear: 2022,
-      },
-    ]);
-    expect(suppressedDetail?.contact.pastProjects).toMatchObject([
-      {
-        projectName: "Suppressed Signup Year",
-        signupYear: null,
-      },
-    ]);
   });
 
   it("threads Gmail From, To, and Cc headers into the timeline detail view model", async () => {

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -3504,45 +3504,6 @@ describe("real inbox selectors", () => {
     ).toEqual(new Set(statuses.map(([, label]) => label)));
   });
 
-  it("shows signup year only for past-project rows", async () => {
-    if (runtime === null) {
-      throw new Error("Expected inbox test runtime");
-    }
-
-    await runtime.context.settings.projects.setActive(
-      "project:killer-whales",
-      false,
-    );
-
-    const [activeDetail, pastDetail] = await Promise.all([
-      getInboxDetail("contact:sarah-martinez"),
-      getInboxDetail("contact:lisa-zhang"),
-    ]);
-
-    if (activeDetail === null || pastDetail === null) {
-      throw new Error("Expected inbox detail for active and past contacts");
-    }
-
-    const activeMarkup = renderToStaticMarkup(
-      createElement(InboxContactRail, {
-        contact: activeDetail.contact,
-      }),
-    );
-    const pastMarkup = renderToStaticMarkup(
-      createElement(InboxContactRail, {
-        contact: pastDetail.contact,
-      }),
-    );
-
-    const activeSection =
-      activeMarkup.split("Past Projects")[0] ?? activeMarkup;
-    const pastSection = pastMarkup.split("Past Projects")[1] ?? pastMarkup;
-
-    expect(activeSection).not.toContain("tabular-nums");
-    expect(pastSection).toContain("tabular-nums");
-    expect(pastSection).toContain("2023");
-  });
-
   it("uses the most recent internal note as the pinned note proxy", async () => {
     if (runtime === null) {
       throw new Error("Expected inbox test runtime");


### PR DESCRIPTION
## Summary

- removes the rendered year label from past projects in the contact rail (original commit by Codex)
- also removes the underlying \`signupYear\` view-model field, selector computation, and supporting timeline-index entries — per architect: if it's not in the UI, it shouldn't be in the code
- deletes the test that specced the removed behavior (~230 lines), trims fixtures elsewhere

## Why

The year shown in past projects was unreliable because the fallback chain often resolved to the contact's last activity year (or backfill year) instead of the actual year for that past-project participation. That made the rail more confusing than helpful.

Original PR proposed keeping the data plumbing "for a future SF-sourced fix." Architect's call: keeping dead code on life support invites churn and obscures the real shape of the data layer. When SF-sourced signup dates are actually available, the plumbing can be reintroduced fresh against that real source.

## Net change

+4 / -318. The bulk of the deletion is one large unit test that specced four signupYear resolution branches.

## Verification

- \`pnpm typecheck\` clean
- \`pnpm lint\` clean
- No \`signupYear\` references remain in \`apps/web\`