### PR TITLE
[codex] align inbox composer UI

### DIFF
--- a/apps/web/app/inbox/_components/composer-ai-draft-window.tsx
+++ b/apps/web/app/inbox/_components/composer-ai-draft-window.tsx
@@ -21,6 +21,35 @@ import {
 } from "./icons";
 import type { AiDraftState } from "./inbox-client-provider";
 
+type AiDraftAccent = "violet" | "sky";
+
+const AI_DRAFT_ACCENT_CLASSES = {
+  violet: {
+    section: "border-violet-200 ring-violet-100",
+    header: "border-violet-100 bg-violet-50/40",
+    iconWrap: "bg-violet-100 text-violet-700",
+    icon: "text-violet-500",
+    textareaFocus: "focus:ring-violet-300",
+    repromptPlaceholder: "placeholder:text-violet-400/80",
+    repromptRing: "ring-violet-200 focus:ring-violet-400",
+    primary:
+      "bg-violet-600 text-white hover:bg-violet-700 disabled:bg-violet-300 disabled:text-white",
+    footer: "border-violet-100 bg-violet-50/40",
+  },
+  sky: {
+    section: "border-sky-200 ring-sky-100",
+    header: "border-sky-100 bg-sky-50/50",
+    iconWrap: "bg-sky-100 text-sky-700",
+    icon: "text-sky-500",
+    textareaFocus: "focus:ring-sky-300",
+    repromptPlaceholder: "placeholder:text-sky-400/80",
+    repromptRing: "ring-sky-200 focus:ring-sky-400",
+    primary:
+      "bg-sky-600 text-white hover:bg-sky-700 disabled:bg-sky-300 disabled:text-white",
+    footer: "border-sky-100 bg-sky-50/50",
+  },
+} as const;
+
 function DraftSkeleton() {
   return (
     <div className="space-y-1.5 rounded-md bg-slate-50/60 px-3 py-2.5 ring-1 ring-inset ring-slate-200">
@@ -37,12 +66,16 @@ function AiDraftActionButton({
   disabled = false,
   onClick,
   tone = "ghost",
+  accent = "violet",
 }: {
   readonly children: ReactNode;
   readonly disabled?: boolean;
   readonly onClick: () => void;
   readonly tone?: "ghost" | "danger" | "primary";
+  readonly accent?: AiDraftAccent;
 }) {
+  const accentClasses = AI_DRAFT_ACCENT_CLASSES[accent];
+
   return (
     <button
       type="button"
@@ -51,7 +84,7 @@ function AiDraftActionButton({
       className={cn(
         `inline-flex min-h-8 items-center gap-1.5 rounded-md px-2 py-1 text-[11.5px] font-medium ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion}`,
         tone === "primary"
-          ? "bg-violet-600 text-white hover:bg-violet-700 disabled:bg-violet-300 disabled:text-white"
+          ? accentClasses.primary
           : tone === "danger"
             ? "text-rose-600 hover:bg-rose-50 disabled:text-rose-300"
             : "text-slate-700 hover:bg-white disabled:text-slate-300",
@@ -76,18 +109,24 @@ function DraftActionTrigger({
   disabledReason,
   isGenerating,
   onRun,
+  accent = "violet",
 }: {
   readonly disabled: boolean;
   readonly disabledReason: string | null;
   readonly isGenerating: boolean;
   readonly onRun: () => void;
+  readonly accent?: AiDraftAccent;
 }) {
+  const accentClasses = AI_DRAFT_ACCENT_CLASSES[accent];
   const button = (
     <Button
       type="button"
       disabled={disabled}
       onClick={onRun}
-      className="h-8 shrink-0 rounded-md bg-violet-600 px-3 text-[12px] font-medium text-white shadow-sm hover:bg-violet-700 disabled:bg-violet-300"
+      className={cn(
+        "h-8 shrink-0 rounded-md px-3 text-[12px] font-medium shadow-sm",
+        accentClasses.primary,
+      )}
     >
       {isGenerating ? (
         <>
@@ -120,7 +159,8 @@ function DraftActionTrigger({
 }
 
 export function ComposerAiDraftWindow({
-  directivePlaceholder = 'Optional: nudge the draft (e.g. "keep it brief, offer May 14 slot"). Or just click Draft with AI.',
+  tone = "email",
+  directivePlaceholder = 'Provide an intent first, or click the "Draft with AI" button directly',
   aiDraft,
   directiveText,
   repromptText,
@@ -136,6 +176,7 @@ export function ComposerAiDraftWindow({
   onDiscard,
   onApprove,
 }: {
+  readonly tone?: "email" | "sms";
   readonly directivePlaceholder?: string;
   readonly aiDraft: AiDraftState;
   readonly directiveText: string;
@@ -160,19 +201,36 @@ export function ComposerAiDraftWindow({
   const canSubmitReprompt = trimmedReprompt.length > 0 && !isGeneratingAi;
   const canApprove = !isGeneratingAi && (!isReprompting || trimmedReprompt.length === 0);
   const canUseDraftActions = !isGeneratingAi;
+  const accent: AiDraftAccent = tone === "sms" ? "sky" : "violet";
+  const accentClasses = AI_DRAFT_ACCENT_CLASSES[accent];
 
   return (
-    <section className="mx-4 mt-3 overflow-hidden rounded-xl border border-violet-200 bg-white ring-1 ring-violet-100">
-      <div className="flex items-center gap-2 border-b border-violet-100 bg-violet-50/40 px-3 py-2">
-        <div className="flex size-5 items-center justify-center rounded-md bg-violet-100 text-violet-700">
-          <SparkleIcon className="size-3.5 text-violet-500" />
+    <section
+      className={cn(
+        "mx-4 mt-3 min-w-0 overflow-hidden rounded-lg border bg-white ring-1",
+        accentClasses.section,
+      )}
+    >
+      <div
+        className={cn(
+          "flex items-center gap-2 border-b px-3 py-1.5",
+          accentClasses.header,
+        )}
+      >
+        <div
+          className={cn(
+            "flex size-5 items-center justify-center rounded-md",
+            accentClasses.iconWrap,
+          )}
+        >
+          <SparkleIcon className={cn("size-3.5", accentClasses.icon)} />
         </div>
         <p className="text-[12px] font-semibold text-slate-800">AI draft</p>
       </div>
 
-      <div className="px-3 pb-3 pt-2">
+      <div className="min-w-0 px-3 pb-2.5 pt-2">
         {showsEmptyState ? (
-          <div className="flex items-start gap-2">
+          <div className="flex min-w-0 items-start gap-2">
             <textarea
               value={directiveText}
               onChange={(event) => {
@@ -191,13 +249,17 @@ export function ComposerAiDraftWindow({
               placeholder={directivePlaceholder}
               rows={2}
               disabled={isGeneratingAi}
-              className={`flex-1 resize-none rounded-md bg-slate-50/60 px-2.5 py-2 text-[12.5px] leading-relaxed text-slate-800 placeholder:text-slate-400 ring-1 ring-inset ring-slate-200 focus:outline-none focus:ring-violet-300 disabled:opacity-60 ${TRANSITION.reduceMotion}`}
+              className={cn(
+                `min-h-[44px] min-w-0 flex-1 resize-none rounded-md bg-slate-50/60 px-2.5 py-2 text-[12.5px] leading-relaxed text-slate-800 placeholder:text-slate-400 ring-1 ring-inset ring-slate-200 focus:outline-none disabled:opacity-60 ${TRANSITION.reduceMotion}`,
+                accentClasses.textareaFocus,
+              )}
             />
             <DraftActionTrigger
               disabled={runDraftDisabled}
               disabledReason={runDraftDisabledReason}
               isGenerating={isGeneratingAi}
               onRun={onRunDraft}
+              accent={accent}
             />
           </div>
         ) : null}
@@ -213,7 +275,7 @@ export function ComposerAiDraftWindow({
             <DraftPreview text={aiDraft.generatedText} />
 
             {isReprompting ? (
-              <div className="flex items-start gap-2">
+              <div className="flex min-w-0 items-start gap-2">
                 <textarea
                   autoFocus
                   value={repromptText}
@@ -236,14 +298,21 @@ export function ComposerAiDraftWindow({
                   }}
                   placeholder='Reprompt — "shorter", "warmer tone", "add the meeting link"...'
                   disabled={isGeneratingAi}
-                  className={`min-h-[64px] flex-1 resize-none rounded-md bg-white px-2.5 py-2 text-[12.5px] leading-relaxed text-slate-800 placeholder:text-violet-400/80 ring-1 ring-inset ring-violet-200 focus:outline-none focus:ring-violet-400 disabled:opacity-60 ${TRANSITION.reduceMotion}`}
+                  className={cn(
+                    `min-h-[64px] min-w-0 flex-1 resize-none rounded-md bg-white px-2.5 py-2 text-[12.5px] leading-relaxed text-slate-800 ring-1 ring-inset focus:outline-none disabled:opacity-60 ${TRANSITION.reduceMotion}`,
+                    accentClasses.repromptPlaceholder,
+                    accentClasses.repromptRing,
+                  )}
                 />
                 <button
                   type="button"
                   aria-label="Regenerate AI draft"
                   disabled={!canSubmitReprompt}
                   onClick={onSubmitReprompt}
-                  className={`inline-flex size-9 shrink-0 items-center justify-center rounded-md bg-violet-600 p-2 text-white shadow-sm hover:bg-violet-700 disabled:cursor-not-allowed disabled:bg-violet-300 ${FOCUS_RING} ${TRANSITION.fast} ${TRANSITION.reduceMotion}`}
+                  className={cn(
+                    `inline-flex size-9 shrink-0 items-center justify-center rounded-md p-2 shadow-sm disabled:cursor-not-allowed ${FOCUS_RING} ${TRANSITION.fast} ${TRANSITION.reduceMotion}`,
+                    accentClasses.primary,
+                  )}
                 >
                   <RotateCwIcon className="size-4" />
                 </button>
@@ -254,7 +323,12 @@ export function ComposerAiDraftWindow({
       </div>
 
       {showsDraft ? (
-        <div className="flex items-center gap-2 border-t border-violet-100 bg-violet-50/40 px-3 py-1.5">
+        <div
+          className={cn(
+            "flex items-center gap-2 border-t px-3 py-1.5",
+            accentClasses.footer,
+          )}
+        >
           <div className="ml-auto flex items-center gap-1">
             <AiDraftActionButton
               onClick={isReprompting ? onCancelReprompt : onOpenReprompt}
@@ -272,6 +346,7 @@ export function ComposerAiDraftWindow({
               Discard
             </AiDraftActionButton>
             <AiDraftActionButton
+              accent={accent}
               tone="primary"
               onClick={onApprove}
               disabled={!canApprove}

--- a/apps/web/app/inbox/_components/composer-collapsed-pill.tsx
+++ b/apps/web/app/inbox/_components/composer-collapsed-pill.tsx
@@ -37,7 +37,7 @@ export function ComposerCollapsedPill({
           className={`flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-[13px] text-slate-500 ${SHADOW.sm} ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion} hover:border-amber-300 hover:bg-amber-50/50 hover:text-amber-700`}
         >
           <NoteIcon className="size-3.5 shrink-0" />
-          <span>Note</span>
+          <span>Leave Note</span>
         </button>
       </div>
     </div>

--- a/apps/web/app/inbox/_components/composer-detail-surfaces.tsx
+++ b/apps/web/app/inbox/_components/composer-detail-surfaces.tsx
@@ -2,7 +2,7 @@
 
 import type { RefObject } from "react";
 
-import type { SmsMetrics } from "@as-comms/domain";
+import { smsMetrics, type SmsMetrics } from "@as-comms/domain/sms-segments";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -19,11 +19,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import { RADIUS, SHADOW, TYPE } from "@/app/_lib/design-tokens-v2";
-import {
-  estimateSmsCostUsd,
-  formatSmsEstimatedCostUsd,
-} from "@/src/lib/sms-pricing";
+import { TYPE } from "@/app/_lib/design-tokens-v2";
 
 import { ComposerAiDraftWindow } from "./composer-ai-draft-window";
 import {
@@ -41,6 +37,8 @@ import { ComposerToolbar } from "./composer-toolbar";
 import {
   BookOpenIcon,
   ChevronDownIcon,
+  ImageIcon,
+  LinkIcon,
   LoaderIcon,
   MailIcon,
   NoteIcon,
@@ -62,22 +60,26 @@ import type {
 import { ComposerSmsRecipientPicker } from "./composer-sms-recipient-picker";
 import { SendFromPhoneChip } from "./composer-send-from-phone-chip";
 
-function KnowledgeIndicator({
-  tooltipMessage = "AI Draft will use voice instructions only — no project-specific context.",
+function KnowledgeBaseIndicator({
+  hasKnowledge,
+  projectName,
 }: {
-  readonly tooltipMessage?: string;
+  readonly hasKnowledge: boolean;
+  readonly projectName: string | null;
 }) {
+  const isLinked = hasKnowledge && projectName !== null;
+  const label = isLinked ? `${projectName} Knowledge Base` : "Without Knowledge Base";
+
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span className="inline-flex items-center gap-1 text-[11px] font-medium text-slate-500">
-          No project knowledge linked yet
-        </span>
-      </TooltipTrigger>
-      <TooltipContent side="top" className="max-w-64 text-pretty">
-        {tooltipMessage}
-      </TooltipContent>
-    </Tooltip>
+    <span
+      className={cn(
+        `inline-flex min-w-0 items-center justify-center gap-1.5 truncate ${TYPE.caption}`,
+        isLinked ? "text-emerald-600" : "text-slate-400",
+      )}
+    >
+      <BookOpenIcon className="size-3.5 shrink-0" />
+      <span className="truncate">{label}</span>
+    </span>
   );
 }
 
@@ -126,6 +128,41 @@ function SendAndSaveMenuItem({
       <TooltipContent side="left">{tooltipMessage}</TooltipContent>
     </Tooltip>
   );
+}
+
+const SMS_COMPOSER_LENGTH_LIMIT = 320;
+
+function clampSmsComposerBody(value: string): string {
+  if (smsMetrics(value).length <= SMS_COMPOSER_LENGTH_LIMIT) {
+    return value;
+  }
+
+  let nextValue = "";
+
+  for (const char of Array.from(value)) {
+    const candidate = `${nextValue}${char}`;
+    if (smsMetrics(candidate).length > SMS_COMPOSER_LENGTH_LIMIT) {
+      break;
+    }
+
+    nextValue = candidate;
+  }
+
+  return nextValue;
+}
+
+function formatUsPhoneLabel(phoneE164: string): string {
+  const digits = phoneE164.replace(/\D/g, "");
+  const nationalNumber =
+    digits.length === 11 && digits.startsWith("1")
+      ? digits.slice(1)
+      : digits.length === 10
+        ? digits
+        : null;
+
+  return nationalNumber === null
+    ? phoneE164
+    : `(${nationalNumber.slice(0, 3)}) ${nationalNumber.slice(3, 6)}-${nationalNumber.slice(6)}`;
 }
 
 export function ComposerPaneChrome({
@@ -326,24 +363,29 @@ export function ComposerEmailSurface({
   readonly onSend: (sendKind: ComposerSendKind) => void;
   readonly onCancel: () => void;
 }) {
-  const knowledgeTooltip =
-    "AI Draft will use voice instructions only — no project-specific context is linked yet. Add a Notion URL in Settings → Projects to enable project knowledge.";
   const sendAndSaveDisabled = isSendDisabled || !canSendAndSaveForAi;
   const sendAndSaveTooltipMessage =
     canSendAndSaveForAi || sendAndSaveDisabledReason === null
       ? null
       : sendAndSaveDisabledReason;
+  const knowledgeIndicator = (
+    <KnowledgeBaseIndicator
+      hasKnowledge={selectedAliasHasCachedContent}
+      projectName={selectedAliasProjectName}
+    />
+  );
 
   return (
     <TooltipProvider delayDuration={200}>
-      <ComposerField label="FROM">
-        <ComposerSendFromChip
-          value={selectedAlias}
-          aliases={composerAliases}
-          onChange={onAliasChange}
-          {...(aliasError?.message ? { errorMessage: aliasError.message } : {})}
-        />
-      </ComposerField>
+      <div className="flex min-h-full flex-col">
+        <ComposerField label="FROM">
+          <ComposerSendFromChip
+            value={selectedAlias}
+            aliases={composerAliases}
+            onChange={onAliasChange}
+            {...(aliasError?.message ? { errorMessage: aliasError.message } : {})}
+          />
+        </ComposerField>
 
       <ComposerField label="TO">
         <div className="rounded-md bg-white">
@@ -445,7 +487,7 @@ export function ComposerEmailSurface({
           }}
           placeholder="Subject"
           className={cn(
-            "h-9 border-0 px-0 text-[13.5px] font-medium shadow-none focus-visible:ring-0",
+            "h-8 border-0 px-0 text-[13px] font-medium shadow-none focus-visible:ring-0",
             subjectError ? "text-rose-900" : "",
           )}
         />
@@ -455,6 +497,9 @@ export function ComposerEmailSurface({
       </ComposerField>
 
       <RichTextComposerEditor
+        className="flex min-h-0 flex-1 flex-col"
+        frameClassName="flex min-h-0 flex-1 flex-col border-x-0 border-b-0 shadow-none"
+        contentClassName="min-h-0 flex-1"
         bodyPlaintext={body}
         errorMessage={bodyError?.message}
         onChange={(nextBody) => {
@@ -466,6 +511,7 @@ export function ComposerEmailSurface({
         onClearErrors={onClearErrors}
         topSlot={
           <ComposerAiDraftWindow
+            tone="email"
             aiDraft={aiDraft}
             directiveText={aiDirective}
             repromptText={repromptText}
@@ -484,7 +530,7 @@ export function ComposerEmailSurface({
         }
         bottomSlot={
           selectedAliasSignature.length > 0 ? (
-            <div className="px-4 pb-4 pt-3 whitespace-pre-line text-[13px] leading-relaxed text-slate-500">
+            <div className="px-4 pb-3 pt-2 whitespace-pre-line text-[13px] leading-relaxed text-slate-500">
               {selectedAliasSignature}
             </div>
           ) : undefined
@@ -518,34 +564,31 @@ export function ComposerEmailSurface({
               />
             ) : null}
 
-            <div className="flex flex-wrap items-center gap-2">
-              <ComposerToolbar
-                activeCommands={activeCommands}
-                onCommand={onCommand}
-              />
+            <div className="flex min-w-0 items-center gap-2">
+              <div className="shrink-0">
+                <ComposerToolbar
+                  activeCommands={activeCommands}
+                  onCommand={onCommand}
+                />
+              </div>
 
               <Button
                 type="button"
                 variant="ghost"
-                className="gap-1.5 border-l border-slate-200 pl-3 text-[11.5px] font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+                className="shrink-0 gap-1.5 border-l border-slate-200 pl-3 text-[11.5px] font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900"
                 onClick={onAttachmentClick}
               >
                 <PaperclipIcon className="size-3.5" />
                 Attach
               </Button>
 
-              {selectedAliasHasCachedContent && selectedAliasProjectName !== null ? (
-                <span
-                  className={`inline-flex items-center gap-1.5 ${TYPE.caption} text-slate-500`}
-                >
-                  <BookOpenIcon className="size-3.5" />
-                  Uses {selectedAliasProjectName} knowledge
-                </span>
-              ) : selectedAliasProjectName !== null ? (
-                <KnowledgeIndicator tooltipMessage={knowledgeTooltip} />
-              ) : null}
+              <div className="hidden min-w-0 max-w-[18rem] items-center border-l border-slate-200 pl-3 md:flex">
+                {knowledgeIndicator}
+              </div>
 
-              <div className="ml-auto flex items-center gap-2">
+              <div className="min-w-0 flex-1" />
+
+              <div className="flex shrink-0 items-center gap-2">
                 <Button
                   type="button"
                   variant="ghost"
@@ -617,6 +660,8 @@ export function ComposerEmailSurface({
                 </div>
               </div>
             </div>
+
+            <div className="mt-2 md:hidden">{knowledgeIndicator}</div>
           </div>
         )}
       />
@@ -626,11 +671,12 @@ export function ComposerEmailSurface({
           {aiWarningMessage}
         </div>
       ) : null}
-      {bodyError ? (
-        <div className="px-4 py-2 text-xs text-rose-700">
-          {bodyError.message}
-        </div>
-      ) : null}
+        {bodyError ? (
+          <div className="px-4 py-2 text-xs text-rose-700">
+            {bodyError.message}
+          </div>
+        ) : null}
+      </div>
     </TooltipProvider>
   );
 }
@@ -641,8 +687,8 @@ function resolveSmsRecipientLabel(recipient: ComposerSmsRecipient | null): strin
   }
 
   return recipient.kind === "contact"
-    ? `${recipient.displayName} (${recipient.phoneE164})`
-    : recipient.phoneE164;
+    ? `${recipient.displayName} (${formatUsPhoneLabel(recipient.phoneE164)})`
+    : formatUsPhoneLabel(recipient.phoneE164);
 }
 
 export function ComposerSmsSurface({
@@ -652,15 +698,15 @@ export function ComposerSmsSurface({
   recipient,
   lockedRecipient,
   body,
-  selectedAliasSignature,
   segmentMetrics,
-  outboundRateUsdPerSegment,
   aiDraft,
   aiDirective,
   repromptText,
   isGeneratingAi,
   runAiDraftDisabled,
   runAiDraftDisabledReason,
+  selectedAliasHasCachedContent,
+  selectedAliasProjectName,
   canSendAndSaveForAi,
   sendAndSaveDisabledReason,
   sendDisabledReason,
@@ -689,15 +735,15 @@ export function ComposerSmsSurface({
   readonly recipient: ComposerSmsRecipient | null;
   readonly lockedRecipient: boolean;
   readonly body: string;
-  readonly selectedAliasSignature: string;
   readonly segmentMetrics: SmsMetrics;
-  readonly outboundRateUsdPerSegment: number;
   readonly aiDraft: AiDraftState;
   readonly aiDirective: string;
   readonly repromptText: string;
   readonly isGeneratingAi: boolean;
   readonly runAiDraftDisabled: boolean;
   readonly runAiDraftDisabledReason: string | null;
+  readonly selectedAliasHasCachedContent: boolean;
+  readonly selectedAliasProjectName: string | null;
   readonly canSendAndSaveForAi: boolean;
   readonly sendAndSaveDisabledReason: string | null;
   readonly sendDisabledReason: string | null;
@@ -724,13 +770,6 @@ export function ComposerSmsSurface({
     smsSenders.find((sender) => sender.id === selectedSenderId) ??
     smsSenders[0] ??
     null;
-  const estimatedCostUsd =
-    segmentMetrics.segments > 0
-      ? estimateSmsCostUsd(
-          segmentMetrics.segments,
-          outboundRateUsdPerSegment,
-        )
-      : null;
   const sendAndSaveDisabled = !canSendAndSaveForAi || isSending;
   const sendAndSaveTooltipMessage =
     sendAndSaveDisabledReason ??
@@ -738,6 +777,16 @@ export function ComposerSmsSurface({
   const sendSmsDisabledReason = !smsEnabled
     ? "SMS sending isn't wired up yet — coming soon"
     : sendDisabledReason;
+  const smsLengthLimit =
+    segmentMetrics.length <= 160 ? 160 : SMS_COMPOSER_LENGTH_LIMIT;
+  const smsLengthIsExtended = segmentMetrics.length > 160;
+  const smsLengthLabel = `${String(segmentMetrics.length)}/${String(smsLengthLimit)}`;
+  const knowledgeIndicator = (
+    <KnowledgeBaseIndicator
+      hasKnowledge={selectedAliasHasCachedContent}
+      projectName={selectedAliasProjectName}
+    />
+  );
   const sendButton = (
     <div className="inline-flex items-stretch overflow-hidden rounded-md shadow-sm">
       <Button
@@ -799,6 +848,7 @@ export function ComposerSmsSurface({
 
   return (
     <TooltipProvider delayDuration={200}>
+      <div className="flex min-h-full flex-col">
       <ComposerField label="FROM">
         <SendFromPhoneChip
           sender={selectedSender}
@@ -817,9 +867,18 @@ export function ComposerSmsSurface({
         />
       </ComposerField>
 
-      <div className="px-4 py-4">
+      <ComposerField label="SUBJ">
+        <div
+          aria-hidden="true"
+          className="flex h-8 items-center text-[13px] font-medium text-slate-300"
+        >
+          Subject
+        </div>
+      </ComposerField>
+
+      <div className="flex min-h-0 flex-1 flex-col border-t border-slate-100">
         <ComposerAiDraftWindow
-          directivePlaceholder='Optional: nudge the SMS draft (e.g. "remind them about Wed training, keep under 140 chars"). Or just click Draft with AI.'
+          tone="sms"
           aiDraft={aiDraft}
           directiveText={aiDirective}
           repromptText={repromptText}
@@ -835,32 +894,40 @@ export function ComposerSmsSurface({
           onDiscard={onDiscardAi}
           onApprove={onApproveAi}
         />
-        <textarea
-          rows={8}
-          value={body}
-          onChange={(event) => {
-            onBodyChange(event.currentTarget.value);
-            if (aiDraft.status === "inserted") {
-              onAiEdited();
-            }
-          }}
-          placeholder="Write an SMS reply"
-          className={cn(
-            `min-h-52 w-full resize-none border border-slate-200 bg-white px-4 py-3 text-sm leading-6 text-slate-900 ${RADIUS.md} focus:outline-none focus:ring-1 focus:ring-slate-300`,
-            bodyError ? "border-rose-300 ring-1 ring-rose-200" : "",
-          )}
-        />
-        {bodyError ? (
-          <p className="mt-2 text-xs text-rose-700">{bodyError.message}</p>
-        ) : null}
-        {selectedAliasSignature.length > 0 ? (
-          <div className="mt-3 whitespace-pre-line text-[13px] leading-relaxed text-slate-500">
-            {selectedAliasSignature}
+        <div className="relative min-h-0 flex-1 px-4 pb-3 pt-2">
+          <textarea
+            rows={7}
+            value={body}
+            onChange={(event) => {
+              onBodyChange(clampSmsComposerBody(event.currentTarget.value));
+              if (aiDraft.status === "inserted") {
+                onAiEdited();
+              }
+            }}
+            placeholder="Write an SMS reply"
+            className={cn(
+              "h-full min-h-0 w-full resize-none border-0 bg-white px-0 py-3 pb-8 text-sm leading-6 text-slate-900 shadow-none focus:outline-none focus:ring-0",
+              bodyError ? "text-rose-900" : "",
+            )}
+            aria-describedby="sms-composer-character-count"
+          />
+          <div
+            id="sms-composer-character-count"
+            className={cn(
+              "pointer-events-none absolute bottom-5 right-5 text-[11.5px] font-medium tabular-nums",
+              smsLengthIsExtended ? "text-rose-600" : "text-slate-400",
+            )}
+            aria-live="polite"
+          >
+            {smsLengthLabel}
           </div>
-        ) : null}
+          {bodyError ? (
+            <p className="mt-2 text-xs text-rose-700">{bodyError.message}</p>
+          ) : null}
+        </div>
       </div>
 
-      <div className="border-t border-slate-200 px-4 py-4">
+      <div className="border-t border-slate-200 px-4 py-[12.5px]">
         {inlineError ? (
           <InlineErrorBanner
             message={inlineError.message}
@@ -869,17 +936,24 @@ export function ComposerSmsSurface({
           />
         ) : null}
 
-        <div className="flex flex-wrap items-center gap-2">
-          <div className="flex flex-wrap items-center gap-1.5 text-[11.5px] text-slate-500">
-            <span className="font-medium text-slate-700">
-              {segmentMetrics.segments === 0 ? "0 segments" : `${String(segmentMetrics.segments)} segments`}
-            </span>
-            {` · ${segmentMetrics.encoding} · ${String(segmentMetrics.remaining)} remaining`}
-            {estimatedCostUsd === null ? null : (
-              <span className="font-medium tabular-nums text-slate-500">
-                · Est. ${formatSmsEstimatedCostUsd(estimatedCostUsd)}
-              </span>
-            )}
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <div className="flex shrink-0 items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              className="h-8 gap-1.5 border-sky-200 bg-white px-2.5 text-[12px] font-medium text-sky-700 hover:bg-sky-50 hover:text-sky-800"
+            >
+              <ImageIcon className="size-3.5" />
+              Add MMS
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              className="h-8 gap-1.5 border-slate-200 bg-white px-2.5 text-[12px] font-medium text-slate-600 hover:bg-slate-50 hover:text-slate-800"
+            >
+              <LinkIcon className="size-3.5" />
+              Shorten links
+            </Button>
           </div>
 
           {recipientError?.message ? (
@@ -888,7 +962,13 @@ export function ComposerSmsSurface({
             </span>
           ) : null}
 
-          <div className="ml-auto flex items-center gap-2">
+          <div className="hidden min-w-0 max-w-[18rem] items-center border-l border-slate-200 pl-3 md:flex">
+            {knowledgeIndicator}
+          </div>
+
+          <div className="mt-1 w-full md:hidden">{knowledgeIndicator}</div>
+
+          <div className="ml-auto flex shrink-0 items-center gap-2">
             <Button
               type="button"
               variant="ghost"
@@ -912,11 +992,13 @@ export function ComposerSmsSurface({
           </div>
         </div>
       </div>
+      </div>
     </TooltipProvider>
   );
 }
 
 export function ComposerNoteSurface({
+  contactDisplayName,
   body,
   bodyError,
   isSavingNote,
@@ -927,7 +1009,10 @@ export function ComposerNoteSurface({
   onTextareaInput,
   onSaveNote,
   onCancel,
+  onMinimize,
+  onClose,
 }: {
+  readonly contactDisplayName: string;
   readonly body: string;
   readonly bodyError?: ComposerValidationError;
   readonly isSavingNote: boolean;
@@ -938,40 +1023,56 @@ export function ComposerNoteSurface({
   readonly onTextareaInput: (target: HTMLTextAreaElement) => void;
   readonly onSaveNote: () => void;
   readonly onCancel: () => void;
+  readonly onMinimize: () => void;
+  readonly onClose: () => void;
 }) {
+  const noteRecipient =
+    contactDisplayName.trim().length > 0 ? contactDisplayName : "this contact";
+
   return (
-    <>
-      <div
-        className={`border-l-4 border-amber-300 bg-amber-50/50 px-4 py-4 ${SHADOW.sm}`}
-      >
-        <div className="mb-3 flex items-center justify-between gap-3">
-          <div>
-            <p className="text-sm font-semibold text-amber-900">
-              Internal note
-            </p>
-            <p className={`mt-1 ${TYPE.caption} text-amber-800`}>
-              Team-visible note only. This will not be sent to the contact.
-            </p>
-          </div>
-          <Button
+    <section
+      role="region"
+      aria-label="Internal note composer"
+      className="absolute inset-x-0 bottom-0 z-40 border-t border-amber-200 bg-amber-50 shadow-[0_-12px_30px_rgba(15,23,42,0.08)]"
+    >
+      <div className="flex min-h-10 items-center justify-between gap-3 border-b border-amber-200 bg-amber-50 px-5 py-2">
+        <p className="flex min-w-0 items-center gap-2 text-[13px] text-amber-700">
+          <NoteIcon className="size-3.5 shrink-0" />
+          <span className="shrink-0 font-semibold text-amber-800">
+            Internal note
+          </span>
+          <span className="truncate">
+            — visible to teammates only. Not sent to {noteRecipient}.
+          </span>
+        </p>
+        <div className="flex shrink-0 items-center gap-1">
+          <button
             type="button"
-            disabled={isSaveNoteDisabled}
-            onClick={onSaveNote}
-            className="bg-amber-600 hover:bg-amber-700"
+            aria-label="Minimize note composer"
+            className="inline-flex size-8 items-center justify-center rounded-md text-amber-600 hover:bg-amber-100 hover:text-amber-800"
+            onClick={onMinimize}
           >
-            {isSavingNote ? (
-              <>
-                <LoaderIcon className="size-4 animate-spin" />
-                Saving...
-              </>
-            ) : (
-              <>
-                <NoteIcon className="size-4" />
-                Save note
-              </>
-            )}
-          </Button>
+            <ChevronDownIcon className="size-4" />
+          </button>
+          <button
+            type="button"
+            aria-label="Close note composer"
+            className="inline-flex size-8 items-center justify-center rounded-md text-amber-600 hover:bg-amber-100 hover:text-amber-800"
+            onClick={onClose}
+          >
+            <XIcon className="size-4" />
+          </button>
         </div>
+      </div>
+
+      <div className="bg-white px-5 py-4">
+        {inlineError ? (
+          <InlineErrorBanner
+            message={inlineError.message}
+            retryable={inlineError.retryable}
+            onRetry={onSaveNote}
+          />
+        ) : null}
         <textarea
           ref={textareaRef}
           rows={6}
@@ -982,10 +1083,10 @@ export function ComposerNoteSurface({
           onInput={(event) => {
             onTextareaInput(event.currentTarget);
           }}
-          placeholder="Write a team-visible note"
+          placeholder={`Add a note about ${noteRecipient} for your team...`}
           className={cn(
-            `max-h-[30rem] min-h-48 w-full resize-none border border-amber-300 bg-amber-50/40 px-4 py-3 text-sm leading-6 text-slate-900 ${RADIUS.md} focus:outline-none focus:ring-1 focus:ring-amber-300`,
-            bodyError ? "border-rose-300 ring-1 ring-rose-200" : "",
+            "h-40 w-full resize-none border-0 bg-transparent px-0 py-1 text-sm leading-6 text-slate-900 shadow-none placeholder:text-amber-700/45 focus:outline-none focus:ring-0",
+            bodyError ? "text-rose-900" : "",
           )}
         />
         {bodyError ? (
@@ -993,37 +1094,34 @@ export function ComposerNoteSurface({
         ) : null}
       </div>
 
-      <div className="border-t border-slate-200 px-4 py-4">
-        {inlineError ? (
-          <InlineErrorBanner
-            message={inlineError.message}
-            retryable={inlineError.retryable}
-            onRetry={onSaveNote}
-          />
-        ) : null}
-        <div className="flex items-center justify-end gap-2">
-          <Button type="button" variant="ghost" onClick={onCancel}>
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            disabled={isSaveNoteDisabled}
-            onClick={onSaveNote}
-          >
-            {isSavingNote ? (
-              <>
-                <LoaderIcon className="size-4 animate-spin" />
-                Saving...
-              </>
-            ) : (
-              <>
-                <NoteIcon className="size-4" />
-                Save note
-              </>
-            )}
-          </Button>
-        </div>
+      <div className="flex items-center justify-end gap-2 border-t border-amber-200 bg-amber-50 px-5 py-3">
+        <Button
+          type="button"
+          variant="ghost"
+          className="text-[13px] text-slate-500 hover:bg-amber-100/70 hover:text-amber-800"
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          disabled={isSaveNoteDisabled}
+          onClick={onSaveNote}
+          className="h-9 bg-amber-700 px-4 text-[13px] text-white hover:bg-amber-800 disabled:bg-amber-300"
+        >
+          {isSavingNote ? (
+            <>
+              <LoaderIcon className="size-4 animate-spin" />
+              Saving...
+            </>
+          ) : (
+            <>
+              <NoteIcon className="size-4" />
+              Save note
+            </>
+          )}
+        </Button>
       </div>
-    </>
+    </section>
   );
 }

--- a/apps/web/app/inbox/_components/composer-editor-surface.tsx
+++ b/apps/web/app/inbox/_components/composer-editor-surface.tsx
@@ -47,8 +47,8 @@ export function ComposerField({
   readonly children: React.ReactNode;
 }) {
   return (
-    <div className="flex items-start gap-3 border-b border-slate-100 px-4 py-1.5">
-      <span className={`mt-1 w-8 shrink-0 ${TYPE.label}`}>{label}</span>
+    <div className="flex items-center gap-3 border-b border-slate-100 px-4 py-1.5">
+      <span className={`w-8 shrink-0 ${TYPE.label}`}>{label}</span>
       <div className="min-w-0 flex-1">{children}</div>
     </div>
   );
@@ -147,6 +147,9 @@ export function RichTextComposerEditor({
   topSlot,
   bottomSlot,
   toolbarFooter,
+  className,
+  frameClassName,
+  contentClassName,
   onChange,
   onClearErrors,
 }: {
@@ -158,6 +161,9 @@ export function RichTextComposerEditor({
     readonly activeCommands: ReadonlySet<ComposerToolbarCommand>;
     readonly onCommand: (command: ComposerToolbarCommand) => void;
   }) => React.ReactNode;
+  readonly className?: string;
+  readonly frameClassName?: string;
+  readonly contentClassName?: string;
   readonly onChange: (value: {
     readonly bodyPlaintext: string;
     readonly bodyHtml: string;
@@ -190,7 +196,7 @@ export function RichTextComposerEditor({
         "aria-multiline": "true",
         ...(errorMessage ? { "aria-invalid": "true" } : {}),
         class: cn(
-          "min-h-48 w-full px-4 py-4 text-sm leading-6 text-slate-900 focus:outline-none [&_a]:text-sky-700 [&_a]:underline [&_blockquote]:border-l-2 [&_blockquote]:border-slate-200 [&_blockquote]:pl-3 [&_blockquote]:text-slate-600 [&_ol]:ml-5 [&_ol]:list-decimal [&_ul]:ml-5 [&_ul]:list-disc",
+          "min-h-44 w-full px-4 py-3 text-sm leading-6 text-slate-900 focus:outline-none [&_a]:text-sky-700 [&_a]:underline [&_blockquote]:border-l-2 [&_blockquote]:border-slate-200 [&_blockquote]:pl-3 [&_blockquote]:text-slate-600 [&_ol]:ml-5 [&_ol]:list-decimal [&_ul]:ml-5 [&_ul]:list-disc",
           errorMessage ? "bg-rose-50/40" : "",
         ),
       },
@@ -284,16 +290,24 @@ export function RichTextComposerEditor({
   const showPlaceholder = bodyPlaintext.length === 0;
 
   return (
-    <>
-      <div className={`border border-slate-200 bg-white ${SHADOW.sm}`}>
+    <div className={cn(className)}>
+      <div
+        className={cn(
+          `border border-slate-200 bg-white ${SHADOW.sm}`,
+          frameClassName,
+        )}
+      >
         {toolbarFooter ? null : (
           <ComposerToolbar activeCommands={activeCommands} onCommand={runCommand} />
         )}
         {topSlot}
-        <div className="relative min-h-48" onKeyDown={handleKeyDown}>
-          <EditorContent editor={editor} />
+        <div
+          className={cn("relative min-h-44", contentClassName)}
+          onKeyDown={handleKeyDown}
+        >
+          <EditorContent editor={editor} className="h-full" />
           {showPlaceholder ? (
-            <span className="pointer-events-none absolute left-4 top-4 text-sm leading-6 text-slate-400">
+            <span className="pointer-events-none absolute left-4 top-3 text-sm leading-6 text-slate-400">
               Write your message
             </span>
           ) : null}
@@ -306,6 +320,6 @@ export function RichTextComposerEditor({
             onCommand: runCommand,
           })
         : null}
-    </>
+    </div>
   );
 }

--- a/apps/web/app/inbox/_components/composer-recipient-picker.tsx
+++ b/apps/web/app/inbox/_components/composer-recipient-picker.tsx
@@ -12,10 +12,7 @@ import {
   TRANSITION,
 } from "@/app/_lib/design-tokens-v2";
 
-import {
-  formatContactRecipientLabel,
-  resolveTypedEmailRecipient,
-} from "../_lib/composer-ui";
+import { resolveTypedEmailRecipient } from "../_lib/composer-ui";
 import {
   searchContactsAction,
   type ContactSearchResult,
@@ -72,11 +69,25 @@ function isSameRecipient(
   return false;
 }
 
+function getContactInitials(displayName: string): string {
+  const parts = displayName
+    .trim()
+    .split(/\s+/u)
+    .filter((part) => part.length > 0);
+
+  const initials =
+    parts.length > 1
+      ? `${parts[0]?.[0] ?? ""}${parts[parts.length - 1]?.[0] ?? ""}`
+      : (parts[0]?.slice(0, 2) ?? "");
+
+  return initials.toUpperCase();
+}
+
 export function ComposerRecipientPicker({
   recipients,
   locked = false,
   single = false,
-  placeholder = "Search Salesforce contacts or type an email",
+  placeholder = "Search contacts",
   rightSlot,
   onRecipientsChange,
 }: {
@@ -92,8 +103,30 @@ export function ComposerRecipientPicker({
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<readonly ContactSearchResult[]>([]);
   const [isSearching, setIsSearching] = useState(false);
+  const [isResultsOpen, setIsResultsOpen] = useState(false);
   const activeSearchIdRef = useRef(0);
+  const rootRef = useRef<HTMLDivElement>(null);
   const listboxId = useId();
+
+  useEffect(() => {
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node)) {
+        return;
+      }
+
+      if (rootRef.current?.contains(target) === true) {
+        return;
+      }
+
+      setIsResultsOpen(false);
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+    };
+  }, []);
 
   useEffect(() => {
     if (locked || (single && recipients.length > 0)) {
@@ -101,6 +134,7 @@ export function ComposerRecipientPicker({
       setQuery("");
       setResults([]);
       setIsSearching(false);
+      setIsResultsOpen(false);
       return undefined;
     }
 
@@ -110,6 +144,7 @@ export function ComposerRecipientPicker({
       activeSearchIdRef.current += 1;
       setResults([]);
       setIsSearching(false);
+      setIsResultsOpen(false);
       return undefined;
     }
 
@@ -142,6 +177,7 @@ export function ComposerRecipientPicker({
 
   const shouldShowInput = !locked && (!single || recipients.length === 0);
   const shouldShowResults =
+    isResultsOpen &&
     shouldShowInput &&
     (isSearching || results.length > 0 || query.trim().length >= 2);
 
@@ -159,10 +195,10 @@ export function ComposerRecipientPicker({
   };
 
   return (
-    <div className="relative">
+    <div ref={rootRef} className="relative">
       <div
         className={cn(
-          `flex min-h-9 flex-wrap items-center gap-1.5 rounded-md px-0 py-0.5`,
+          `flex min-h-8 flex-wrap items-center gap-1.5 rounded-md px-0 py-0.5`,
           !shouldShowInput && recipients.length > 0 ? "" : "pr-2",
         )}
       >
@@ -190,12 +226,18 @@ export function ComposerRecipientPicker({
         {shouldShowInput ? (
           <div className="flex min-w-[14rem] flex-1 items-center">
             {recipients.length === 0 ? (
-              <SearchIcon className="pointer-events-none mr-2 size-4 shrink-0 text-slate-400" />
+              <SearchIcon className="pointer-events-none mr-2 size-3.5 shrink-0 text-slate-400" />
             ) : null}
             <Input
               value={query}
               onChange={(event) => {
                 setQuery(event.currentTarget.value);
+                setIsResultsOpen(true);
+              }}
+              onFocus={() => {
+                if (query.trim().length >= 2 || results.length > 0) {
+                  setIsResultsOpen(true);
+                }
               }}
               onKeyDown={(event) => {
                 if (event.key !== "Enter") {
@@ -222,13 +264,14 @@ export function ComposerRecipientPicker({
                 commitRecipient(typedEmailRecipient);
                 setQuery("");
                 setResults([]);
+                setIsResultsOpen(false);
               }}
               placeholder={recipients.length === 0 ? placeholder : ""}
               aria-expanded={shouldShowResults}
               aria-controls={shouldShowResults ? listboxId : undefined}
               aria-autocomplete="list"
               className={cn(
-                `h-8 flex-1 border-0 bg-transparent px-0 text-[13px] shadow-none ${FOCUS_RING}`,
+                `h-7 flex-1 border-0 bg-transparent px-0 text-[13px] shadow-none ${FOCUS_RING}`,
                 recipients.length === 0 ? "pl-0" : "",
               )}
             />
@@ -236,7 +279,7 @@ export function ComposerRecipientPicker({
         ) : null}
 
         {rightSlot ? (
-          <div className="ml-auto flex items-center self-start pt-1">
+          <div className="ml-auto flex items-center self-center">
             {rightSlot}
           </div>
         ) : null}
@@ -244,7 +287,7 @@ export function ComposerRecipientPicker({
 
       {shouldShowResults ? (
         <div
-          className={`absolute inset-x-0 top-full z-20 mt-2 overflow-hidden border border-slate-200 bg-white ${RADIUS.md} ${SHADOW.md}`}
+          className={`absolute inset-x-0 top-full z-20 mt-1 overflow-hidden border border-slate-200 bg-white ${RADIUS.md} ${SHADOW.md}`}
         >
           {isSearching ? (
             <div className="px-3 py-3 text-sm text-slate-500">
@@ -254,7 +297,7 @@ export function ComposerRecipientPicker({
             <ul
               id={listboxId}
               role="listbox"
-              className="max-h-72 divide-y divide-slate-100 overflow-y-auto"
+              className="max-h-64 divide-y divide-slate-100 overflow-y-auto"
             >
               {results.map((result) => (
                 <li key={result.id}>
@@ -264,25 +307,27 @@ export function ComposerRecipientPicker({
                       commitRecipient(toContactRecipient(result));
                       setQuery("");
                       setResults([]);
+                      setIsResultsOpen(false);
                     }}
-                    className={`flex w-full items-start justify-between gap-3 px-3 py-3 text-left ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion} hover:bg-slate-50`}
+                    className={`flex w-full items-center gap-3 px-3 py-1.5 text-left ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion} hover:bg-slate-50`}
                   >
-                    <div className="min-w-0">
-                      <span className="block truncate text-sm font-medium text-slate-900">
-                        {formatContactRecipientLabel({
-                          displayName: result.displayName,
-                          primaryEmail: result.primaryEmail,
-                        })}
+                    <div className="flex min-w-0 flex-1 items-center gap-2.5">
+                      <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-sky-50 text-[10px] font-semibold text-sky-700">
+                        {getContactInitials(result.displayName)}
                       </span>
-                      <span className="mt-1 block text-xs text-slate-500">
-                        {result.primaryProjectName ?? "Contact recipient"}
+                      <span className="min-w-0">
+                        <span className="flex min-w-0 items-baseline gap-2">
+                          <span className="truncate text-[13px] font-semibold leading-4 text-slate-900">
+                            {result.displayName}
+                          </span>
+                          {result.primaryEmail ? (
+                            <span className="truncate text-[12px] leading-4 text-slate-500">
+                              {result.primaryEmail}
+                            </span>
+                          ) : null}
+                        </span>
                       </span>
                     </div>
-                    {result.salesforceContactId ? (
-                      <Chip tone="neutral" className="uppercase">
-                        SF
-                      </Chip>
-                    ) : null}
                   </button>
                 </li>
               ))}
@@ -311,11 +356,15 @@ function RecipientChip({
     <span className="inline-flex max-w-full items-center gap-1.5 rounded-full border border-slate-200 bg-slate-50 py-0.5 pl-2 pr-1.5 text-[12px] text-slate-700">
       <span className="min-w-0">
         {recipient.kind === "contact" ? (
-          <span className="block truncate font-medium text-slate-900">
-            {formatContactRecipientLabel({
-              displayName: recipient.displayName,
-              primaryEmail: recipient.primaryEmail,
-            })}
+          <span className="flex min-w-0 items-baseline gap-1.5">
+            <span className="truncate font-medium text-slate-900">
+              {recipient.displayName}
+            </span>
+            {recipient.primaryEmail ? (
+              <span className="truncate text-slate-500">
+                {recipient.primaryEmail}
+              </span>
+            ) : null}
           </span>
         ) : (
           <span className="flex min-w-0 items-center gap-2">

--- a/apps/web/app/inbox/_components/composer-send-from-chip.tsx
+++ b/apps/web/app/inbox/_components/composer-send-from-chip.tsx
@@ -42,7 +42,7 @@ export function ComposerSendFromChip({
             type="button"
             aria-invalid={errorMessage ? true : undefined}
             className={cn(
-              `flex min-h-11 w-full items-center justify-between gap-3 border border-slate-200 bg-white px-3 py-2 text-left ${RADIUS.md} ${SHADOW.sm} ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion} hover:border-slate-300`,
+              `inline-flex min-h-8 max-w-full items-center gap-2 border border-slate-200 bg-white px-2.5 py-1 text-left ${RADIUS.md} ${SHADOW.sm} ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion} hover:border-slate-300`,
               errorMessage ? "border-rose-300 ring-1 ring-rose-200" : "",
             )}
           >
@@ -56,9 +56,6 @@ export function ComposerSendFromChip({
                     />
                     <span className="truncate">{selectedAlias.alias}</span>
                   </span>
-                  <span className={`mt-0.5 flex items-center gap-1.5 ${TYPE.caption}`}>
-                    <span className="truncate">{selectedAlias.projectName}</span>
-                  </span>
                 </span>
               ) : (
                 <span className="text-[13px] text-slate-400">
@@ -66,7 +63,7 @@ export function ComposerSendFromChip({
                 </span>
               )}
             </span>
-            <ChevronDownIcon className="size-4 shrink-0 text-slate-400" />
+            <ChevronDownIcon className="size-3.5 shrink-0 text-slate-400" />
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent

--- a/apps/web/app/inbox/_components/composer-send-from-phone-chip.tsx
+++ b/apps/web/app/inbox/_components/composer-send-from-phone-chip.tsx
@@ -6,7 +6,6 @@ import {
   RADIUS,
   SHADOW,
   TRANSITION,
-  TYPE,
 } from "@/app/_lib/design-tokens-v2";
 
 import type { InboxSmsSenderOption } from "../_lib/view-models";
@@ -23,16 +22,18 @@ export function SendFromPhoneChip({
       <div
         aria-invalid={errorMessage ? true : undefined}
         className={cn(
-          `flex min-h-11 w-full items-center justify-between gap-3 border border-slate-200 bg-white px-3 py-2 text-left ${RADIUS.md} ${SHADOW.sm} ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion}`,
+          `inline-flex min-h-8 max-w-full items-center gap-2 border border-slate-200 bg-white px-2.5 py-1 text-left ${RADIUS.md} ${SHADOW.sm} ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion}`,
           errorMessage ? "border-rose-300 ring-1 ring-rose-200" : "",
         )}
       >
         {sender ? (
-          <span className="block min-w-0">
-            <span className="block truncate text-[13px] font-medium text-slate-900">
+          <span className="flex min-w-0 items-center gap-2">
+            <span className="size-2 shrink-0 rounded-full bg-sky-400" />
+            <span className="truncate text-[13px] font-medium text-slate-900">
               {sender.phoneE164}
             </span>
-            <span className={`mt-0.5 block truncate ${TYPE.caption}`}>
+            <span className="shrink-0 text-[13px] text-slate-400">·</span>
+            <span className="truncate text-[13px] text-slate-600">
               {sender.displayName}
             </span>
           </span>

--- a/apps/web/app/inbox/_components/composer-sms-recipient-picker.tsx
+++ b/apps/web/app/inbox/_components/composer-sms-recipient-picker.tsx
@@ -34,13 +34,17 @@ function toSmsContactResult(
 }
 
 function formatPhoneLabel(phoneE164: string): string {
-  const match = /^\+1(\d{3})(\d{3})(\d{4})$/.exec(phoneE164);
-  const area = match?.[1];
-  const prefix = match?.[2];
-  const line = match?.[3];
-  return match === null
+  const digits = phoneE164.replace(/\D/g, "");
+  const nationalNumber =
+    digits.length === 11 && digits.startsWith("1")
+      ? digits.slice(1)
+      : digits.length === 10
+        ? digits
+        : null;
+
+  return nationalNumber === null
     ? phoneE164
-    : `+1 (${area ?? ""}) ${prefix ?? ""}-${line ?? ""}`;
+    : `(${nationalNumber.slice(0, 3)}) ${nationalNumber.slice(3, 6)}-${nationalNumber.slice(6)}`;
 }
 
 function isSameRecipient(
@@ -58,6 +62,20 @@ function isSameRecipient(
   return left.phoneE164 === right.phoneE164;
 }
 
+function getContactInitials(displayName: string): string {
+  const parts = displayName
+    .trim()
+    .split(/\s+/u)
+    .filter((part) => part.length > 0);
+
+  const initials =
+    parts.length > 1
+      ? `${parts[0]?.[0] ?? ""}${parts[parts.length - 1]?.[0] ?? ""}`
+      : (parts[0]?.slice(0, 2) ?? "");
+
+  return initials.toUpperCase();
+}
+
 export function ComposerSmsRecipientPicker({
   recipient,
   locked = false,
@@ -72,8 +90,30 @@ export function ComposerSmsRecipientPicker({
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<readonly SmsContactSearchResult[]>([]);
   const [isSearching, setIsSearching] = useState(false);
+  const [isResultsOpen, setIsResultsOpen] = useState(false);
   const activeSearchIdRef = useRef(0);
+  const rootRef = useRef<HTMLDivElement>(null);
   const listboxId = useId();
+
+  useEffect(() => {
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node)) {
+        return;
+      }
+
+      if (rootRef.current?.contains(target) === true) {
+        return;
+      }
+
+      setIsResultsOpen(false);
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+    };
+  }, []);
 
   useEffect(() => {
     if (locked || recipient !== null) {
@@ -81,6 +121,7 @@ export function ComposerSmsRecipientPicker({
       setQuery("");
       setResults([]);
       setIsSearching(false);
+      setIsResultsOpen(false);
       return undefined;
     }
 
@@ -89,6 +130,7 @@ export function ComposerSmsRecipientPicker({
       activeSearchIdRef.current += 1;
       setResults([]);
       setIsSearching(false);
+      setIsResultsOpen(false);
       return undefined;
     }
 
@@ -145,21 +187,23 @@ export function ComposerSmsRecipientPicker({
     onRecipientChange(nextRecipient);
     setQuery("");
     setResults([]);
+    setIsResultsOpen(false);
     return true;
   };
 
   const shouldShowInput = !locked && recipient === null;
   const shouldShowResults =
+    isResultsOpen &&
     shouldShowInput &&
     (isSearching || results.length > 0 || query.trim().length >= 2);
 
   return (
     <div className="space-y-1.5">
-      <div className="relative">
+      <div ref={rootRef} className="relative">
         <div
           className={cn(
-            `flex min-h-11 flex-wrap items-center gap-1.5 rounded-md border border-slate-200 bg-white px-3 py-2 ${RADIUS.md} ${SHADOW.sm}`,
-            errorMessage ? "border-rose-300 ring-1 ring-rose-200" : "",
+            `flex min-h-8 flex-wrap items-center gap-1.5 rounded-md bg-white px-0 py-0.5`,
+            errorMessage ? "border border-rose-300 px-2 ring-1 ring-rose-200" : "",
           )}
         >
           {recipient ? (
@@ -176,11 +220,17 @@ export function ComposerSmsRecipientPicker({
 
           {shouldShowInput ? (
             <div className="flex min-w-[14rem] flex-1 items-center">
-              <SearchIcon className="pointer-events-none mr-2 size-4 shrink-0 text-slate-400" />
+              <SearchIcon className="pointer-events-none mr-2 size-3.5 shrink-0 text-slate-400" />
               <Input
                 value={query}
                 onChange={(event) => {
                   setQuery(event.currentTarget.value);
+                  setIsResultsOpen(true);
+                }}
+                onFocus={() => {
+                  if (query.trim().length >= 2 || results.length > 0) {
+                    setIsResultsOpen(true);
+                  }
                 }}
                 onBlur={() => {
                   void commitTypedPhone();
@@ -193,12 +243,12 @@ export function ComposerSmsRecipientPicker({
                   event.preventDefault();
                   void commitTypedPhone();
                 }}
-                placeholder="Search contacts or type a phone number"
+                placeholder="Search contacts"
                 aria-expanded={shouldShowResults}
                 aria-controls={shouldShowResults ? listboxId : undefined}
                 aria-autocomplete="list"
                 className={cn(
-                  `h-8 flex-1 border-0 bg-transparent px-0 text-[13px] shadow-none ${FOCUS_RING}`,
+                  `h-7 flex-1 border-0 bg-transparent px-0 text-[13px] shadow-none ${FOCUS_RING}`,
                 )}
               />
             </div>
@@ -207,7 +257,7 @@ export function ComposerSmsRecipientPicker({
 
         {shouldShowResults ? (
           <div
-            className={`absolute inset-x-0 top-full z-20 mt-2 overflow-hidden border border-slate-200 bg-white ${RADIUS.md} ${SHADOW.md}`}
+            className={`absolute inset-x-0 top-full z-20 mt-1 overflow-hidden border border-slate-200 bg-white ${RADIUS.md} ${SHADOW.md}`}
           >
             {isSearching ? (
               <div className="px-3 py-3 text-sm text-slate-500">
@@ -217,7 +267,7 @@ export function ComposerSmsRecipientPicker({
               <ul
                 id={listboxId}
                 role="listbox"
-                className="max-h-72 divide-y divide-slate-100 overflow-y-auto"
+                className="max-h-64 divide-y divide-slate-100 overflow-y-auto"
               >
                 {results.map((result) => (
                   <li key={result.id}>
@@ -235,22 +285,25 @@ export function ComposerSmsRecipientPicker({
                         });
                         setQuery("");
                         setResults([]);
+                        setIsResultsOpen(false);
                       }}
-                      className={`flex w-full items-start justify-between gap-3 px-3 py-3 text-left ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion} hover:bg-slate-50`}
+                      className={`flex w-full items-center gap-3 px-3 py-1.5 text-left ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion} hover:bg-slate-50`}
                     >
-                      <div className="min-w-0">
-                        <span className="block truncate text-sm font-medium text-slate-900">
-                          {result.displayName}
+                      <div className="flex min-w-0 flex-1 items-center gap-2.5">
+                        <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-sky-50 text-[10px] font-semibold text-sky-700">
+                          {getContactInitials(result.displayName)}
                         </span>
-                        <span className="mt-1 block text-xs text-slate-500">
-                          {formatPhoneLabel(result.primaryPhone)}
+                        <span className="min-w-0">
+                          <span className="flex min-w-0 items-baseline gap-2">
+                            <span className="truncate text-[13px] font-semibold leading-4 text-slate-900">
+                              {result.displayName}
+                            </span>
+                            <span className="truncate text-[12px] leading-4 text-slate-500">
+                              {formatPhoneLabel(result.primaryPhone)}
+                            </span>
+                          </span>
                         </span>
                       </div>
-                      {result.salesforceContactId ? (
-                        <Chip tone="neutral" className="uppercase">
-                          SF
-                        </Chip>
-                      ) : null}
                     </button>
                   </li>
                 ))}
@@ -280,7 +333,7 @@ function RecipientChip({
   const label =
     recipient.kind === "contact"
       ? `${recipient.displayName} (${formatPhoneLabel(recipient.phoneE164)})`
-      : recipient.phoneE164;
+      : formatPhoneLabel(recipient.phoneE164);
 
   return (
     <span className="inline-flex max-w-full items-center gap-1.5 rounded-full border border-slate-200 bg-slate-50 py-0.5 pl-2 pr-1.5 text-[12px] text-slate-700">

--- a/apps/web/app/inbox/_components/inbox-composer.tsx
+++ b/apps/web/app/inbox/_components/inbox-composer.tsx
@@ -8,7 +8,6 @@ import { smsMetrics } from "@as-comms/domain/sms-segments";
 import {
   FOCUS_RING,
   TRANSITION,
-  TYPE,
 } from "@/app/_lib/design-tokens-v2";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
@@ -31,7 +30,7 @@ import {
 import { useInboxClient } from "./inbox-client-provider";
 import type { InboxSmsSenderOption } from "../_lib/view-models";
 import { resolveSmsConsentAction } from "../actions";
-import { ChevronDownIcon, MailIcon, NoteIcon, PhoneIcon, XIcon } from "./icons";
+import { ChevronDownIcon, MailIcon, PhoneIcon, XIcon } from "./icons";
 import { useAiDraftRun } from "../_hooks/use-ai-draft-run";
 import { useAttachmentIntake } from "../_hooks/use-attachment-intake";
 import { useComposerDraftState } from "../_hooks/use-composer-draft-state";
@@ -65,28 +64,19 @@ function resolveReplyTitle(input: {
   return /^re:/iu.test(base) ? base : `Re: ${base}`;
 }
 
-function appendComposerSignature(body: string, signature: string): string {
-  return signature.length > 0 ? `${body}\n\n${signature}` : body;
-}
-
 function ComposerModeTabs({
   activeTab,
-  canUseNoteTab,
   onEmail,
   onSms,
-  onNote,
 }: {
-  readonly activeTab: "email" | "sms" | "note";
-  readonly canUseNoteTab: boolean;
+  readonly activeTab: "email" | "sms";
   readonly onEmail: () => void;
   readonly onSms: () => void;
-  readonly onNote: () => void;
 }) {
-  const isNote = activeTab === "note";
   const isSms = activeTab === "sms";
 
   return (
-    <div className="border-b border-slate-200 px-4 py-2.5">
+    <div>
       <div
         role="tablist"
         aria-label="Composer type"
@@ -100,8 +90,8 @@ function ComposerModeTabs({
           className={cn(
             `inline-flex items-center gap-1.5 rounded px-2.5 py-1 font-medium ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion}`,
             activeTab === "email"
-              ? "bg-white text-slate-900 shadow-sm ring-1 ring-slate-200"
-              : "text-slate-500",
+              ? "bg-violet-50 text-violet-700 shadow-sm ring-1 ring-violet-200"
+              : "text-slate-400 hover:bg-slate-50 hover:text-slate-600",
           )}
           onClick={onEmail}
         >
@@ -116,39 +106,20 @@ function ComposerModeTabs({
           className={cn(
             `inline-flex items-center gap-1.5 rounded px-2.5 py-1 font-medium ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion}`,
             isSms
-              ? "bg-white text-slate-900 shadow-sm ring-1 ring-slate-200"
-              : "text-slate-500",
+              ? "bg-sky-50 text-sky-700 shadow-sm ring-1 ring-sky-200"
+              : "text-slate-400 hover:bg-slate-50 hover:text-slate-600",
           )}
           onClick={onSms}
         >
           <PhoneIcon className="size-3.5" />
           SMS
         </button>
-        {canUseNoteTab ? (
-          <button
-            type="button"
-            role="tab"
-            aria-selected={isNote}
-            tabIndex={0}
-            className={cn(
-              `inline-flex items-center gap-1.5 rounded px-2.5 py-1 font-medium ${FOCUS_RING}`,
-              isNote
-                ? "bg-white text-amber-700 shadow-sm ring-1 ring-amber-200"
-                : "text-amber-700",
-            )}
-            onClick={onNote}
-          >
-            <NoteIcon className="size-3.5" />
-            Note
-          </button>
-        ) : null}
       </div>
     </div>
   );
 }
 
 export function InboxComposerDetailPane({
-  outboundRateUsdPerSegment,
   smsEnabled = false,
   smsSenders = [],
 }: {
@@ -335,14 +306,12 @@ export function InboxComposerDetailPane({
     (error) => error.field === "attachments",
   );
   const modalTitle =
-    state.activeTab === "note"
-      ? "Note"
-      : isReplying && replyContext !== null
-        ? resolveReplyTitle({
-            subject: replyContext.subject,
-            fallbackName: replyContext.contactDisplayName,
-          })
-        : null;
+    isReplying && replyContext !== null
+      ? resolveReplyTitle({
+          subject: replyContext.subject,
+          fallbackName: replyContext.contactDisplayName,
+        })
+      : null;
   const handleFilesSelected = useAttachmentIntake({
     attachmentBytes,
     dispatch,
@@ -397,11 +366,7 @@ export function InboxComposerDetailPane({
     smsSenders.find((sender) => sender.id === state.smsSelectedSenderId) ??
     smsSenders[0] ??
     null;
-  const smsBodyWithSignature = appendComposerSignature(
-    state.smsBody,
-    selectedAliasSignature,
-  );
-  const smsMetricsValue = smsMetrics(smsBodyWithSignature);
+  const smsMetricsValue = smsMetrics(state.smsBody);
   const smsSendDisabledReason =
     state.smsRecipient === null
       ? "Choose a phone recipient first."
@@ -415,9 +380,37 @@ export function InboxComposerDetailPane({
             : "SMS requires prior inbound or recorded opt-in."
           : selectedSmsSender === null
             ? "No active SMS sender is configured."
-            : smsMetricsValue.segments > 10
-              ? "SMS messages are limited to 10 segments."
+            : smsMetricsValue.length > 320
+              ? "SMS messages are limited to 320 encoded characters."
               : null;
+
+  if (state.activeTab === "note") {
+    if (composerView !== "modal") {
+      return null;
+    }
+
+    return (
+      <ComposerNoteSurface
+        contactDisplayName={replyContext?.contactDisplayName ?? "this contact"}
+        body={state.body}
+        isSavingNote={isSavingNote}
+        isSaveNoteDisabled={isSaveNoteDisabled}
+        inlineError={state.inlineError}
+        textareaRef={bodyRef}
+        onBodyChange={(value) => {
+          dispatch({ type: "SET_BODY", body: value, bodyHtml: "" });
+          dispatch({ type: "CLEAR_ERRORS" });
+          setComposerErrors([]);
+        }}
+        onTextareaInput={autoResizeTextarea}
+        onSaveNote={saveNote}
+        onCancel={cancel}
+        onMinimize={minimizeComposer}
+        onClose={closeComposer}
+        {...(bodyError ? { bodyError } : {})}
+      />
+    );
+  }
 
   return (
     <Dialog
@@ -430,32 +423,23 @@ export function InboxComposerDetailPane({
     >
       <DialogContent
         className={cn(
-          `flex max-h-[92vh] w-[calc(100vw-2rem)] max-w-[820px] flex-col gap-0 overflow-hidden border-slate-200 bg-white p-0 shadow-2xl ring-1 ring-slate-900/5 sm:rounded-xl [&>button:last-child]:hidden`,
+          `flex h-[656px] max-h-[84vh] w-[calc(100vw-2rem)] max-w-[1144px] flex-col gap-0 overflow-hidden border-slate-200 bg-white p-0 shadow-2xl ring-1 ring-slate-900/5 data-[state=closed]:!animate-none data-[state=open]:!animate-none sm:rounded-xl [&>button:last-child]:hidden`,
         )}
+        style={{ transform: "translate(-50%, -50%)" }}
       >
         <DialogTitle className="sr-only">
           {modalTitle ?? "Message composer"}
         </DialogTitle>
-        <header className="flex items-center justify-between gap-3 border-b border-slate-200 bg-white px-4 py-3">
-          {modalTitle !== null ? (
-            <div className="flex min-w-0 items-center gap-2">
-              <span
-                aria-hidden="true"
-                className="inline-flex size-7 shrink-0 items-center justify-center rounded-md bg-slate-900 text-white"
-              >
-                {state.activeTab === "note" ? (
-                  <NoteIcon className="size-3.5" />
-                ) : state.activeTab === "sms" ? (
-                  <PhoneIcon className="size-3.5" />
-                ) : (
-                  <MailIcon className="size-3.5" />
-                )}
-              </span>
-              <h2 className={`truncate ${TYPE.headingMd}`}>{modalTitle}</h2>
-            </div>
-          ) : (
-            <span aria-hidden="true" />
-          )}
+        <header className="flex items-center justify-between gap-3 border-b border-slate-200 bg-white px-4 py-2.5">
+          <ComposerModeTabs
+            activeTab={state.activeTab}
+            onEmail={() => {
+              dispatch({ type: "SET_ACTIVE_TAB", tab: "email" });
+            }}
+            onSms={() => {
+              dispatch({ type: "SET_ACTIVE_TAB", tab: "sms" });
+            }}
+          />
           <div className="flex items-center gap-1">
             <button
               type="button"
@@ -481,20 +465,6 @@ export function InboxComposerDetailPane({
         </header>
 
         <div className="min-h-0 flex-1 overflow-y-auto bg-white">
-          <ComposerModeTabs
-            activeTab={state.activeTab}
-            canUseNoteTab={canUseNoteTab}
-            onEmail={() => {
-              dispatch({ type: "SET_ACTIVE_TAB", tab: "email" });
-            }}
-            onSms={() => {
-              dispatch({ type: "SET_ACTIVE_TAB", tab: "sms" });
-            }}
-            onNote={() => {
-              dispatch({ type: "SET_ACTIVE_TAB", tab: "note" });
-            }}
-          />
-
           {state.activeTab === "email" ? (
             <ComposerEmailSurface
               composerAliases={composerAliases}
@@ -598,7 +568,7 @@ export function InboxComposerDetailPane({
               {...(bodyError ? { bodyError } : {})}
               {...(attachmentError ? { attachmentError } : {})}
             />
-          ) : state.activeTab === "sms" ? (
+          ) : (
             <ComposerSmsSurface
               smsSenders={smsSenders}
               smsEnabled={smsEnabled}
@@ -608,15 +578,19 @@ export function InboxComposerDetailPane({
                 isReplying && replyContext?.contactPrimaryPhone !== null
               }
               body={state.smsBody}
-              selectedAliasSignature={selectedAliasSignature}
               segmentMetrics={smsMetricsValue}
-              outboundRateUsdPerSegment={outboundRateUsdPerSegment}
               aiDraft={aiDraft}
               aiDirective={state.aiDirective}
               repromptText={state.repromptText}
               isGeneratingAi={isGeneratingAi}
               runAiDraftDisabled={runAiDraftDisabled}
               runAiDraftDisabledReason={runAiDraftDisabledReason}
+              selectedAliasHasCachedContent={
+                selectedAliasRecord?.hasCachedContent === true
+              }
+              selectedAliasProjectName={
+                selectedAliasRecord?.projectName ?? null
+              }
               canSendAndSaveForAi={smsSendAndSaveAvailability.enabled}
               sendAndSaveDisabledReason={
                 smsSendAndSaveAvailability.disabledReason
@@ -682,30 +656,13 @@ export function InboxComposerDetailPane({
               {...(senderError ? { senderError } : {})}
               {...(bodyError ? { bodyError } : {})}
             />
-          ) : (
-            <ComposerNoteSurface
-              body={state.body}
-              isSavingNote={isSavingNote}
-              isSaveNoteDisabled={isSaveNoteDisabled}
-              inlineError={state.inlineError}
-              textareaRef={bodyRef}
-              onBodyChange={(value) => {
-                dispatch({ type: "SET_BODY", body: value, bodyHtml: "" });
-                dispatch({ type: "CLEAR_ERRORS" });
-                setComposerErrors([]);
-              }}
-              onTextareaInput={autoResizeTextarea}
-              onSaveNote={saveNote}
-              onCancel={cancel}
-              {...(bodyError ? { bodyError } : {})}
-            />
           )}
 
           <input
             ref={attachmentInputRef}
             type="file"
             multiple
-            className="hidden"
+            className="sr-only"
             onChange={handleFilesSelected}
           />
         </div>

--- a/apps/web/app/inbox/_hooks/use-composer-submit.ts
+++ b/apps/web/app/inbox/_hooks/use-composer-submit.ts
@@ -1,6 +1,8 @@
 import type { Dispatch, TransitionStartFunction } from "react";
 import type { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
 
+import { smsMetrics } from "@as-comms/domain/sms-segments";
+
 import {
   createNoteAction,
   sendComposerAction,
@@ -77,10 +79,6 @@ function toOptimisticAttachment(attachment: AttachmentDraft, index: number) {
         ? ""
         : `data:${attachment.contentType};base64,${attachment.contentBase64}`,
   };
-}
-
-function appendComposerSignature(body: string, signature: string): string {
-  return signature.length > 0 ? `${body}\n\n${signature}` : body;
 }
 
 export function useComposerSubmit({
@@ -353,6 +351,16 @@ export function useComposerSubmit({
       return;
     }
 
+    if (smsMetrics(body).length > 320) {
+      const message = "SMS messages are limited to 320 encoded characters.";
+      setErrors({
+        message,
+        retryable: false,
+        fieldErrors: [{ field: "body", message }],
+      });
+      return;
+    }
+
     const clientGeneratedId = crypto.randomUUID();
     const smsRecipient = state.smsRecipient;
     const smsSenderId = state.smsSelectedSenderId;
@@ -361,8 +369,7 @@ export function useComposerSubmit({
         ? null
         : (composerAliases.find((alias) => alias.alias === state.selectedAlias) ??
           null);
-    const signature = selectedAliasRecord?.signature ?? "";
-    const smsBody = appendComposerSignature(body, signature);
+    const smsBody = body;
     const occurredAt = new Date().toISOString();
     const recipientLabel =
       smsRecipient.kind === "contact"

--- a/apps/web/tests/unit/composer-canonical-modal.test.tsx
+++ b/apps/web/tests/unit/composer-canonical-modal.test.tsx
@@ -835,6 +835,22 @@ describe("composer canonical modal", () => {
     expect(document.body.textContent).toContain("SMS");
   });
 
+  it("renders channel tabs and composer window controls in one header row", async () => {
+    await mount(<TestApp />);
+
+    await click(getByText("Open new draft"));
+
+    const tablist = document.querySelector("[role='tablist']");
+    const header = tablist?.closest("header");
+
+    expect(header).not.toBeNull();
+    expect(tablist?.textContent).toContain("Email");
+    expect(tablist?.textContent).toContain("SMS");
+    expect(tablist?.textContent).not.toContain("Note");
+    expect(header?.querySelector("button[aria-label='Minimize composer']")).not.toBeNull();
+    expect(header?.querySelector("button[aria-label='Close composer']")).not.toBeNull();
+  });
+
   it("keeps the SMS tab visible when SMS sending is disabled and disables send", async () => {
     await mount(<TestApp />);
 
@@ -866,7 +882,8 @@ describe("composer canonical modal", () => {
     await click(getByText("Open note draft"));
 
     expect(getStateText()).toBe("replying:modal");
-    expect(document.body.textContent).toContain("Note");
+    expect(document.querySelector("[role='dialog']")).toBeNull();
+    expect(document.querySelector("[role='tablist']")).toBeNull();
     expect(getTextarea("Internal note body").value).toBe("");
   });
 

--- a/apps/web/tests/unit/composer-recipient-picker.test.tsx
+++ b/apps/web/tests/unit/composer-recipient-picker.test.tsx
@@ -1,0 +1,188 @@
+import React, { act, createElement, type InputHTMLAttributes } from "react";
+
+Object.assign(globalThis, { React });
+
+import { createRequire } from "node:module";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+const workerRequire = createRequire(
+  new URL("../../../worker/package.json", import.meta.url),
+);
+const { JSDOM } = workerRequire("jsdom") as {
+  readonly JSDOM: new (
+    html: string,
+    options: { readonly url: string },
+  ) => {
+    readonly window: Window &
+      typeof globalThis & {
+        close: () => void;
+      };
+  };
+};
+
+beforeAll(() => {
+  const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+    url: "http://localhost/",
+  });
+  const w = dom.window;
+  const entries = {
+    document: w.document,
+    Event: w.Event,
+    HTMLElement: w.HTMLElement,
+    HTMLInputElement: w.HTMLInputElement,
+    MouseEvent: w.MouseEvent,
+    Node: w.Node,
+    PointerEvent: w.PointerEvent,
+    window: w,
+  } as const;
+  for (const [key, value] of Object.entries(entries)) {
+    Object.defineProperty(globalThis, key, {
+      configurable: true,
+      value,
+      writable: true,
+    });
+  }
+  Object.defineProperty(w.HTMLElement.prototype, "attachEvent", {
+    configurable: true,
+    value: () => undefined,
+  });
+  Object.defineProperty(w.HTMLElement.prototype, "detachEvent", {
+    configurable: true,
+    value: () => undefined,
+  });
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+const searchContactsAction = vi.fn<
+  (query: string) => Promise<{ readonly ok: boolean; readonly data: readonly unknown[] }>
+>();
+
+vi.mock("../../app/inbox/actions", () => ({
+  searchContactsAction: (query: string) => searchContactsAction(query),
+}));
+
+vi.mock("@/components/ui/chip", () => ({
+  Chip: ({ children }: { readonly children: React.ReactNode }) =>
+    createElement("span", null, children),
+}));
+
+vi.mock("@/components/ui/input", () => ({
+  Input: (props: InputHTMLAttributes<HTMLInputElement>) =>
+    createElement("input", {
+      ...props,
+      onInput: props.onChange,
+    }),
+}));
+
+vi.mock("../../app/inbox/_components/icons", () => ({
+  SearchIcon: () => createElement("svg", { "data-icon": "search" }),
+  XIcon: () => createElement("svg", { "data-icon": "x" }),
+}));
+
+import { ComposerRecipientPicker } from "../../app/inbox/_components/composer-recipient-picker";
+import { ComposerSmsRecipientPicker } from "../../app/inbox/_components/composer-sms-recipient-picker";
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+async function mount(element: React.ReactElement): Promise<void> {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+
+  await act(async () => {
+    root?.render(element);
+    await Promise.resolve();
+  });
+}
+
+async function typeQuery(input: HTMLInputElement, value: string): Promise<void> {
+  const valueDescriptor = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    "value",
+  );
+
+  await act(async () => {
+    input.focus();
+    valueDescriptor?.set?.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+    await new Promise((resolve) => window.setTimeout(resolve, 300));
+    await Promise.resolve();
+  });
+}
+
+async function clickOutside(): Promise<void> {
+  await act(async () => {
+    document.body.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true }),
+    );
+    await Promise.resolve();
+  });
+}
+
+afterEach(async () => {
+  await act(async () => {
+    root?.unmount();
+    await Promise.resolve();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+  document.body.innerHTML = "";
+  searchContactsAction.mockReset();
+});
+
+describe("composer recipient pickers", () => {
+  it("collapses email search results after an outside click", async () => {
+    searchContactsAction.mockResolvedValue({ ok: true, data: [] });
+
+    await mount(
+      <ComposerRecipientPicker recipients={[]} onRecipientsChange={vi.fn()} />,
+    );
+
+    const input = document.querySelector("input");
+    expect(input).not.toBeNull();
+    if (input === null) {
+      throw new Error("Expected the email recipient input to render");
+    }
+
+    await typeQuery(input, "maya");
+
+    expect(document.body.textContent).toContain("No matching contacts.");
+
+    await clickOutside();
+
+    expect(document.body.textContent).not.toContain("No matching contacts.");
+  });
+
+  it("collapses SMS search results after an outside click", async () => {
+    searchContactsAction.mockResolvedValue({ ok: true, data: [] });
+
+    await mount(
+      <ComposerSmsRecipientPicker
+        recipient={null}
+        onRecipientChange={vi.fn()}
+      />,
+    );
+
+    const input = document.querySelector("input");
+    expect(input).not.toBeNull();
+    if (input === null) {
+      throw new Error("Expected the SMS recipient input to render");
+    }
+
+    await typeQuery(input, "maya");
+
+    expect(document.body.textContent).toContain("No matching phone contacts.");
+
+    await clickOutside();
+
+    expect(document.body.textContent).not.toContain(
+      "No matching phone contacts.",
+    );
+  });
+});

--- a/apps/web/tests/unit/inbox-composer-send-menu.test.tsx
+++ b/apps/web/tests/unit/inbox-composer-send-menu.test.tsx
@@ -258,6 +258,7 @@ vi.mock("../../app/inbox/_components/icons", () => ({
   BoldIcon: iconMock("Bold"),
   BookOpenIcon: iconMock("BookOpen"),
   ChevronDownIcon: iconMock("ChevronDown"),
+  ImageIcon: iconMock("Image"),
   ItalicIcon: iconMock("Italic"),
   LinkIcon: iconMock("Link"),
   ListIcon: iconMock("List"),
@@ -271,9 +272,13 @@ vi.mock("../../app/inbox/_components/icons", () => ({
   XIcon: iconMock("X"),
 }));
 
-import { ComposerEmailSurface } from "../../app/inbox/_components/composer-detail-surfaces";
+import {
+  ComposerEmailSurface,
+  ComposerSmsSurface,
+} from "../../app/inbox/_components/composer-detail-surfaces";
 
 type ComposerEmailSurfaceProps = React.ComponentProps<typeof ComposerEmailSurface>;
+type ComposerSmsSurfaceProps = React.ComponentProps<typeof ComposerSmsSurface>;
 
 const baseProps: ComposerEmailSurfaceProps = {
   composerAliases: [
@@ -356,6 +361,59 @@ const baseProps: ComposerEmailSurfaceProps = {
   onCancel: vi.fn(),
 };
 
+const baseSmsProps: ComposerSmsSurfaceProps = {
+  smsSenders: [
+    {
+      id: "sender-1",
+      phoneE164: "+14065550142",
+      displayName: "Whitebark Pine",
+    },
+  ],
+  smsEnabled: true,
+  selectedSenderId: "sender-1",
+  recipient: {
+    kind: "contact" as const,
+    contactId: "contact-1",
+    displayName: "Maya Lee",
+    phoneE164: "+15555550100",
+  },
+  lockedRecipient: false,
+  body: "SMS body",
+  segmentMetrics: {
+    encoding: "GSM-7",
+    length: 8,
+    remaining: 152,
+    segments: 1,
+    segmentCap: 160,
+  },
+  aiDraft: baseProps.aiDraft,
+  aiDirective: "",
+  repromptText: "",
+  isGeneratingAi: false,
+  runAiDraftDisabled: false,
+  runAiDraftDisabledReason: null,
+  selectedAliasHasCachedContent: true,
+  selectedAliasProjectName: "Coastal Survey",
+  canSendAndSaveForAi: true,
+  sendAndSaveDisabledReason: null,
+  sendDisabledReason: null,
+  inlineError: null,
+  isSending: false,
+  onRecipientChange: vi.fn(),
+  onBodyChange: vi.fn(),
+  onAiDirectiveChange: vi.fn(),
+  onAiEdited: vi.fn(),
+  onDiscardAi: vi.fn(),
+  onOpenReprompt: vi.fn(),
+  onCancelReprompt: vi.fn(),
+  onApproveAi: vi.fn(),
+  onRunAiDraft: vi.fn(),
+  onRepromptTextChange: vi.fn(),
+  onReprompt: vi.fn(),
+  onSend: vi.fn(),
+  onCancel: vi.fn(),
+};
+
 let root: Root | null = null;
 let container: HTMLDivElement | null = null;
 
@@ -368,6 +426,19 @@ async function mount(
 
   await act(async () => {
     root?.render(<ComposerEmailSurface {...baseProps} {...overrides} />);
+    await Promise.resolve();
+  });
+}
+
+async function mountSms(
+  overrides: Partial<ComposerSmsSurfaceProps> = {},
+): Promise<void> {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+
+  await act(async () => {
+    root?.render(<ComposerSmsSurface {...baseSmsProps} {...overrides} />);
     await Promise.resolve();
   });
 }
@@ -413,10 +484,8 @@ describe("composer send menu", () => {
       selectedAliasHasCachedContent: true,
     });
 
-    expect(document.body.textContent).toContain("Uses Coastal Survey knowledge");
-    expect(document.body.textContent).not.toContain(
-      "No project knowledge linked yet",
-    );
+    expect(document.body.textContent).toContain("Coastal Survey Knowledge Base");
+    expect(document.body.textContent).not.toContain("Without Knowledge Base");
   });
 
   it("shows the soft knowledge indicator when project knowledge is not cached", async () => {
@@ -424,12 +493,8 @@ describe("composer send menu", () => {
       selectedAliasHasCachedContent: false,
     });
 
-    expect(document.body.textContent).toContain(
-      "No project knowledge linked yet",
-    );
-    expect(document.body.textContent).toContain(
-      "AI Draft will use voice instructions only",
-    );
+    expect(document.body.textContent).toContain("Without Knowledge Base");
+    expect(document.body.textContent).not.toContain("Coastal Survey Knowledge Base");
   });
 
   it("renders the selected alias signature below the editor and hides empty signatures", async () => {
@@ -499,5 +564,33 @@ describe("composer send menu", () => {
 
     await click(disabledItem);
     expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("does not show SMS segment metrics in the default composer footer", async () => {
+    await mountSms();
+
+    expect(document.body.textContent).toContain("Add MMS");
+    expect(document.body.textContent).toContain("Shorten links");
+    expect(document.body.textContent).toContain("8/160");
+    expect(document.body.textContent).not.toContain("segments");
+    expect(document.body.textContent).not.toContain("GSM-7");
+    expect(document.body.textContent).not.toContain("remaining");
+    expect(document.body.textContent).not.toContain("Est.");
+    expect(document.querySelector("button[aria-label='SMS send options']")).not.toBeNull();
+  });
+
+  it("shows an extended SMS character counter after 160 encoded characters", async () => {
+    await mountSms({
+      body: "a".repeat(161),
+      segmentMetrics: {
+        encoding: "GSM-7",
+        length: 161,
+        remaining: 145,
+        segments: 2,
+        segmentCap: 153,
+      },
+    });
+
+    expect(document.body.textContent).toContain("161/320");
   });
 });


### PR DESCRIPTION
## Summary
- Align the inbox composer modal with the reference UI across email, SMS, and note states.
- Pin the email composer footer to the bottom of the modal so it matches SMS instead of floating above empty space.
- Tighten sender/recipient controls, dropdown density, AI draft styling, SMS character limiting, knowledge base copy, and note composer activation.

## Validation
- `pnpm --filter @as-comms/web exec tsc --noEmit --pretty false`
- `pnpm --filter @as-comms/web test:unit tests/unit/composer-canonical-modal.test.tsx tests/unit/inbox-composer-send-menu.test.tsx tests/unit/composer-recipient-picker.test.tsx tests/unit/ai-draft-preview-approve.test.tsx`
- `pnpm --filter @as-comms/web lint`
- `git diff --check`

## Notes
- Local browser QA in the clean temporary worktree was blocked by a workspace module resolution issue for `@as-comms/db` in `next dev`, but the same code path had passed live localhost verification earlier in the primary checkout before the final footer pinning change.
