### PR TITLE
feat(persistence): supersede source-evidence on checksum mismatch (#360)

### DIFF
--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -1232,6 +1232,34 @@ function createStage1RepositoriesInternal(
         );
       },
 
+      async replaceByIdempotencyKey(record) {
+        const values = mapSourceEvidenceToInsert(record);
+        const [updated] = await db
+          .update(sourceEvidenceLog)
+          .set({
+            providerRecordType: values.providerRecordType,
+            providerRecordId: values.providerRecordId,
+            receivedAt: values.receivedAt,
+            occurredAt: values.occurredAt,
+            payloadRef: values.payloadRef,
+            checksum: values.checksum,
+          })
+          .where(
+            and(
+              eq(sourceEvidenceLog.provider, values.provider),
+              eq(sourceEvidenceLog.idempotencyKey, values.idempotencyKey),
+            ),
+          )
+          .returning();
+
+        return mapSourceEvidenceRow(
+          requireRow(
+            updated,
+            "Expected an existing source evidence row to replace by idempotency key.",
+          ),
+        );
+      },
+
       async findById(id) {
         const [row] = await db
           .select()

--- a/packages/db/test/stage1-persistence.test.ts
+++ b/packages/db/test/stage1-persistence.test.ts
@@ -126,50 +126,64 @@ describe("Stage 1 persistence service", () => {
     });
   });
 
-  it("recordSourceEvidence quarantines a different-checksum collision and returns conflict", async () => {
+  it("recordSourceEvidence supersedes a different-checksum collision and parks the prior canonical", async () => {
     const { persistence, repositories } = await createTestStage1Context();
 
     const firstResult = await persistence.recordSourceEvidence({
-      id: "sev_quarantine_winner",
+      id: "sev_supersede_prior",
       provider: "gmail",
       providerRecordType: "message",
-      providerRecordId: "gmail-quarantine-winner",
+      providerRecordId: "gmail-supersede-target",
       receivedAt: "2026-01-03T00:01:00.000Z",
       occurredAt: "2026-01-03T00:00:00.000Z",
-      payloadRef: "payloads/gmail/gmail-quarantine-winner.json",
-      idempotencyKey: "gmail:message:gmail-quarantine",
+      payloadRef: "payloads/gmail/gmail-supersede-prior.json",
+      idempotencyKey: "gmail:message:gmail-supersede",
       checksum: "checksum-a"
     });
 
     if (firstResult.outcome !== "inserted") {
-      throw new Error("Expected the winning source evidence row to insert.");
+      throw new Error("Expected the prior canonical row to insert.");
     }
 
     const result = await persistence.recordSourceEvidence({
-      id: "sev_quarantine_loser",
+      id: "sev_supersede_corrected",
       provider: "gmail",
       providerRecordType: "message",
-      providerRecordId: "gmail-quarantine-winner",
+      providerRecordId: "gmail-supersede-target",
       receivedAt: "2026-01-03T00:02:00.000Z",
       occurredAt: "2026-01-03T00:00:00.000Z",
-      payloadRef: "payloads/gmail/gmail-quarantine-loser.json",
-      idempotencyKey: "gmail:message:gmail-quarantine",
+      payloadRef: "payloads/gmail/gmail-supersede-corrected.json",
+      idempotencyKey: "gmail:message:gmail-supersede",
       checksum: "checksum-b"
     });
 
-    expect(result.outcome).toBe("conflict");
-    if (result.outcome === "conflict") {
-      expect(result.reason).toBe("idempotency_key_mismatch");
-      expect(result.conflictingRecords).toEqual([firstResult.record]);
+    expect(result.outcome).toBe("superseded");
+    if (result.outcome === "superseded") {
+      // Canonical row id is preserved across supersede so downstream FK
+      // references (canonical_event_ledger.source_evidence_id, *_details
+      // tables joined on source_evidence_id) stay valid.
+      expect(result.record.id).toBe(firstResult.record.id);
+      expect(result.record.checksum).toBe("checksum-b");
+      expect(result.record.payloadRef).toBe(
+        "payloads/gmail/gmail-supersede-corrected.json"
+      );
+      expect(result.record.receivedAt).toBe("2026-01-03T00:02:00.000Z");
     }
+
+    const canonicalAfterSupersede =
+      await persistence.findSourceEvidenceByIdempotencyKey(
+        "gmail:message:gmail-supersede"
+      );
+    expect(canonicalAfterSupersede?.id).toBe(firstResult.record.id);
+    expect(canonicalAfterSupersede?.checksum).toBe("checksum-b");
 
     await expect(
       repositories.sourceEvidence.listByProviderRecord({
         provider: "gmail",
         providerRecordType: "message",
-        providerRecordId: "gmail-quarantine-winner"
+        providerRecordId: "gmail-supersede-target"
       })
-    ).resolves.toEqual([firstResult.record]);
+    ).resolves.toEqual([canonicalAfterSupersede]);
 
     const quarantineRows = await repositories.sourceEvidenceQuarantine.listRecent({
       limit: 10
@@ -177,20 +191,73 @@ describe("Stage 1 persistence service", () => {
     expect(quarantineRows.entries).toHaveLength(1);
     expect(quarantineRows.entries[0]).toMatchObject({
       provider: "gmail",
-      idempotencyKey: "gmail:message:gmail-quarantine",
-      checksum: "checksum-b",
+      idempotencyKey: "gmail:message:gmail-supersede",
+      checksum: "checksum-a",
       attemptedAt: new Date("2026-01-03T00:02:00.000Z"),
-      reason: "checksum_mismatch",
-      payloadRef: "payloads/gmail/gmail-quarantine-loser.json",
+      reason: "superseded_canonical",
+      payloadRef: "payloads/gmail/gmail-supersede-prior.json",
       details: {
         provider: "gmail",
         providerRecordType: "message",
-        providerRecordId: "gmail-quarantine-winner",
-        payloadRef: "payloads/gmail/gmail-quarantine-loser.json",
-        idempotencyKey: "gmail:message:gmail-quarantine",
-        checksum: "checksum-b"
+        providerRecordId: "gmail-supersede-target",
+        payloadRef: "payloads/gmail/gmail-supersede-prior.json",
+        idempotencyKey: "gmail:message:gmail-supersede",
+        checksum: "checksum-a"
       }
     });
+  });
+
+  it("recordSourceEvidence supersede is idempotent across repeated checksum-stable replays", async () => {
+    const { persistence, repositories } = await createTestStage1Context();
+
+    await persistence.recordSourceEvidence({
+      id: "sev_idemp_prior",
+      provider: "gmail",
+      providerRecordType: "message",
+      providerRecordId: "gmail-idemp",
+      receivedAt: "2026-01-03T00:01:00.000Z",
+      occurredAt: "2026-01-03T00:00:00.000Z",
+      payloadRef: "payloads/gmail/gmail-idemp-prior.json",
+      idempotencyKey: "gmail:message:gmail-idemp",
+      checksum: "checksum-old"
+    });
+
+    const supersedeResult = await persistence.recordSourceEvidence({
+      id: "sev_idemp_corrected",
+      provider: "gmail",
+      providerRecordType: "message",
+      providerRecordId: "gmail-idemp",
+      receivedAt: "2026-01-03T00:02:00.000Z",
+      occurredAt: "2026-01-03T00:00:00.000Z",
+      payloadRef: "payloads/gmail/gmail-idemp-corrected.json",
+      idempotencyKey: "gmail:message:gmail-idemp",
+      checksum: "checksum-new"
+    });
+
+    expect(supersedeResult.outcome).toBe("superseded");
+
+    // A subsequent replay of the same corrected payload must come back as a
+    // duplicate, not another supersede; otherwise quarantine would grow on
+    // every live-poll cycle that re-fetches a stable corrected record.
+    const replayResult = await persistence.recordSourceEvidence({
+      id: "sev_idemp_replay",
+      provider: "gmail",
+      providerRecordType: "message",
+      providerRecordId: "gmail-idemp",
+      receivedAt: "2026-01-03T00:03:00.000Z",
+      occurredAt: "2026-01-03T00:00:00.000Z",
+      payloadRef: "payloads/gmail/gmail-idemp-corrected.json",
+      idempotencyKey: "gmail:message:gmail-idemp",
+      checksum: "checksum-new"
+    });
+
+    expect(replayResult.outcome).toBe("duplicate");
+
+    const quarantineRows = await repositories.sourceEvidenceQuarantine.listRecent({
+      limit: 10
+    });
+    expect(quarantineRows.entries).toHaveLength(1);
+    expect(quarantineRows.entries[0]?.reason).toBe("superseded_canonical");
   });
 
   it("recordSourceEvidence handles DB-layer race losers via post-append re-read", async () => {

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -12,4 +12,5 @@ export * from "./records.js";
 export * from "./repositories.js";
 export * from "./settings/index.js";
 export * from "./sms-segments.js";
+export * from "./source-evidence-supersede-policy.js";
 export * from "./timeline.js";

--- a/packages/domain/src/normalization.ts
+++ b/packages/domain/src/normalization.ts
@@ -193,7 +193,7 @@ type RoutingResolutionDecision =
 
 export type NormalizedSourceEvidenceResult =
   | {
-      readonly outcome: "inserted" | "duplicate";
+      readonly outcome: "inserted" | "duplicate" | "superseded";
       readonly record: SourceEvidenceRecord;
       readonly auditEvidence: null;
     }

--- a/packages/domain/src/persistence.ts
+++ b/packages/domain/src/persistence.ts
@@ -40,6 +40,10 @@ import {
 } from "@as-comms/contracts";
 
 import type { Stage1RepositoryBundle } from "./repositories.js";
+import {
+  decideSourceEvidenceSupersede,
+  sameSourceEvidenceRecord,
+} from "./source-evidence-supersede-policy.js";
 
 export type SourceEvidenceConflictReason =
   | "idempotency_key_mismatch"
@@ -49,7 +53,7 @@ export type CanonicalEventConflictReason = "idempotency_key_mismatch";
 
 export type SourceEvidenceWriteResult =
   | {
-      readonly outcome: "inserted" | "duplicate";
+      readonly outcome: "inserted" | "duplicate" | "superseded";
       readonly record: SourceEvidenceRecord;
     }
   | {
@@ -137,20 +141,6 @@ function arraysEqual(
   }
 
   return left.every((value, index) => value === right[index]);
-}
-
-function sameSourceEvidenceRecord(
-  incoming: SourceEvidenceRecord,
-  existing: SourceEvidenceRecord
-): boolean {
-  return (
-    incoming.provider === existing.provider &&
-    incoming.providerRecordType === existing.providerRecordType &&
-    incoming.providerRecordId === existing.providerRecordId &&
-    incoming.occurredAt === existing.occurredAt &&
-    incoming.idempotencyKey === existing.idempotencyKey &&
-    incoming.checksum === existing.checksum
-  );
 }
 
 function sameCanonicalEventRecord(
@@ -243,28 +233,38 @@ export function createStage1PersistenceService(
         );
 
       if (existingByIdempotency) {
-        if (sameSourceEvidenceRecord(parsed, existingByIdempotency)) {
+        const decision = decideSourceEvidenceSupersede(
+          existingByIdempotency,
+          parsed
+        );
+
+        if (decision.kind === "duplicate") {
           return {
             outcome: "duplicate",
             record: existingByIdempotency
           };
         }
 
+        // Supersede: park the prior canonical in quarantine for audit, then
+        // replace canonical in place. The replacement preserves the existing
+        // row id so downstream FK references (canonical_event_ledger and the
+        // *_details tables that join on source_evidence_id) stay valid.
         await repositories.sourceEvidenceQuarantine.record({
-          provider: parsed.provider,
-          idempotencyKey: parsed.idempotencyKey,
-          checksum: parsed.checksum,
+          provider: existingByIdempotency.provider,
+          idempotencyKey: existingByIdempotency.idempotencyKey,
+          checksum: existingByIdempotency.checksum,
           attemptedAt: new Date(parsed.receivedAt),
-          reason: "checksum_mismatch",
-          payloadRef: parsed.payloadRef,
-          details: buildSourceEvidenceQuarantineDetails(parsed)
+          reason: "superseded_canonical",
+          payloadRef: existingByIdempotency.payloadRef,
+          details: buildSourceEvidenceQuarantineDetails(existingByIdempotency)
         });
 
+        const updated =
+          await repositories.sourceEvidence.replaceByIdempotencyKey(parsed);
+
         return {
-          outcome: "conflict",
-          incoming: parsed,
-          conflictingRecords: [existingByIdempotency],
-          reason: "idempotency_key_mismatch"
+          outcome: "superseded",
+          record: updated
         };
       }
 

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -37,8 +37,20 @@ import type {
   SmsSenderRecord,
 } from "./records.js";
 
+export type SourceEvidenceQuarantineReason =
+  | "checksum_mismatch"
+  | "superseded_canonical";
+
 export interface SourceEvidenceRepository {
   append(record: SourceEvidenceRecord): Promise<SourceEvidenceRecord>;
+  // Replaces the canonical row matched by (provider, idempotency_key) with
+  // the incoming record's mutable fields, preserving the existing row id.
+  // Used by the supersede branch in recordSourceEvidence so downstream FK
+  // references to source_evidence_id stay valid across capture-mapper
+  // refinements.
+  replaceByIdempotencyKey(
+    record: SourceEvidenceRecord,
+  ): Promise<SourceEvidenceRecord>;
   findById(id: string): Promise<SourceEvidenceRecord | null>;
   listByIds(ids: readonly string[]): Promise<readonly SourceEvidenceRecord[]>;
   findByIdempotencyKey(
@@ -64,7 +76,7 @@ export interface SourceEvidenceQuarantineInput {
   readonly idempotencyKey: string;
   readonly checksum: string;
   readonly attemptedAt: Date;
-  readonly reason: "checksum_mismatch";
+  readonly reason: SourceEvidenceQuarantineReason;
   readonly payloadRef: string;
   readonly details: Readonly<Record<string, unknown>>;
 }

--- a/packages/domain/src/source-evidence-supersede-policy.ts
+++ b/packages/domain/src/source-evidence-supersede-policy.ts
@@ -1,0 +1,35 @@
+import type { SourceEvidenceRecord } from "@as-comms/contracts";
+
+export type SourceEvidenceSupersedeDecision =
+  | { readonly kind: "duplicate" }
+  | { readonly kind: "supersede" };
+
+export function sameSourceEvidenceRecord(
+  incoming: SourceEvidenceRecord,
+  existing: SourceEvidenceRecord
+): boolean {
+  return (
+    incoming.provider === existing.provider &&
+    incoming.providerRecordType === existing.providerRecordType &&
+    incoming.providerRecordId === existing.providerRecordId &&
+    incoming.occurredAt === existing.occurredAt &&
+    incoming.idempotencyKey === existing.idempotencyKey &&
+    incoming.checksum === existing.checksum
+  );
+}
+
+// When a re-capture of an existing canonical produces a different checksum,
+// supersede replaces the canonical in place. The prior canonical is preserved
+// in source_evidence_quarantine with reason "superseded_canonical" by the
+// caller. This keeps capture-mapper iteration (channel classification,
+// description capping, etc.) safe: corrected payloads land on canonical
+// instead of being silently dropped on the floor.
+export function decideSourceEvidenceSupersede(
+  existing: SourceEvidenceRecord,
+  incoming: SourceEvidenceRecord
+): SourceEvidenceSupersedeDecision {
+  if (sameSourceEvidenceRecord(incoming, existing)) {
+    return { kind: "duplicate" };
+  }
+  return { kind: "supersede" };
+}

--- a/packages/domain/test/normalization.test.ts
+++ b/packages/domain/test/normalization.test.ts
@@ -295,7 +295,7 @@ function buildContext(input: {
     idempotencyKey: string;
     checksum: string;
     attemptedAt: Date;
-    reason: "checksum_mismatch";
+    reason: "checksum_mismatch" | "superseded_canonical";
     payloadRef: string;
     details: Readonly<Record<string, unknown>>;
     createdAt: Date;
@@ -309,6 +309,15 @@ function buildContext(input: {
         sourceEvidenceById.set(record.id, record);
         sourceEvidenceByIdempotencyKey.set(record.idempotencyKey, record);
         return Promise.resolve(record);
+      },
+      replaceByIdempotencyKey: (record) => {
+        const existing = sourceEvidenceByIdempotencyKey.get(
+          record.idempotencyKey,
+        );
+        const updated = existing === undefined ? record : { ...record, id: existing.id };
+        sourceEvidenceById.set(updated.id, updated);
+        sourceEvidenceByIdempotencyKey.set(updated.idempotencyKey, updated);
+        return Promise.resolve(updated);
       },
       findById: (id) => Promise.resolve(sourceEvidenceById.get(id) ?? null),
       listByIds: (ids) =>

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -23,6 +23,7 @@ describe("defineStage1RepositoryBundle", () => {
     const bundle: Stage1RepositoryBundle = defineStage1RepositoryBundle({
       sourceEvidence: {
         append: (record) => Promise.resolve(record),
+        replaceByIdempotencyKey: (record) => Promise.resolve(record),
         findById: () => Promise.resolve(null),
         listByIds: () => Promise.resolve([]),
         findByIdempotencyKey: () => Promise.resolve(null),

--- a/packages/domain/test/source-evidence-supersede-policy.test.ts
+++ b/packages/domain/test/source-evidence-supersede-policy.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import type { SourceEvidenceRecord } from "@as-comms/contracts";
+
+import {
+  decideSourceEvidenceSupersede,
+  sameSourceEvidenceRecord,
+} from "../src/source-evidence-supersede-policy.js";
+
+const baseRecord: SourceEvidenceRecord = {
+  id: "sev_supersede_baseline",
+  provider: "salesforce",
+  providerRecordType: "task_communication",
+  providerRecordId: "00TVK00000lqsXc2AI",
+  receivedAt: "2026-04-04T23:45:53.149Z",
+  occurredAt: "2025-10-10T00:16:54.000Z",
+  payloadRef: "salesforce://Task/00TVK00000lqsXc2AI",
+  idempotencyKey:
+    "source-evidence:salesforce:task_communication:00TVK00000lqsXc2AI",
+  checksum: "0dda81118c60c0ffeebabe000000000000000000000000000000000000000001",
+};
+
+describe("decideSourceEvidenceSupersede", () => {
+  it("returns duplicate when records match by all checksum-bearing fields", () => {
+    const decision = decideSourceEvidenceSupersede(baseRecord, baseRecord);
+
+    expect(decision).toEqual({ kind: "duplicate" });
+  });
+
+  it("returns duplicate when only payloadRef differs (not checksum-bearing)", () => {
+    const movedPayload: SourceEvidenceRecord = {
+      ...baseRecord,
+      payloadRef: "salesforce://Task/00TVK00000lqsXc2AI?archived=true",
+    };
+
+    expect(decideSourceEvidenceSupersede(baseRecord, movedPayload)).toEqual({
+      kind: "duplicate",
+    });
+  });
+
+  it("returns duplicate when only receivedAt differs (re-poll same payload)", () => {
+    const replay: SourceEvidenceRecord = {
+      ...baseRecord,
+      receivedAt: "2026-05-01T04:37:15.471Z",
+    };
+
+    expect(decideSourceEvidenceSupersede(baseRecord, replay)).toEqual({
+      kind: "duplicate",
+    });
+  });
+
+  it("returns duplicate when only id differs (post-restart fresh id, identical content)", () => {
+    const fresh: SourceEvidenceRecord = {
+      ...baseRecord,
+      id: "sev_post_restart",
+    };
+
+    expect(decideSourceEvidenceSupersede(baseRecord, fresh)).toEqual({
+      kind: "duplicate",
+    });
+  });
+
+  it("returns supersede when checksum differs (capture-mapper change)", () => {
+    const corrected: SourceEvidenceRecord = {
+      ...baseRecord,
+      checksum:
+        "3b9ae90e1191c0ffeebabe000000000000000000000000000000000000000002",
+    };
+
+    expect(decideSourceEvidenceSupersede(baseRecord, corrected)).toEqual({
+      kind: "supersede",
+    });
+  });
+
+  it("returns supersede when occurredAt differs (SF date corrected upstream)", () => {
+    const dateCorrected: SourceEvidenceRecord = {
+      ...baseRecord,
+      occurredAt: "2025-10-11T00:16:54.000Z",
+    };
+
+    expect(decideSourceEvidenceSupersede(baseRecord, dateCorrected)).toEqual({
+      kind: "supersede",
+    });
+  });
+
+  it("returns supersede when providerRecordType differs (record reclassified)", () => {
+    const reclassified: SourceEvidenceRecord = {
+      ...baseRecord,
+      providerRecordType: "lifecycle_milestone",
+    };
+
+    expect(decideSourceEvidenceSupersede(baseRecord, reclassified)).toEqual({
+      kind: "supersede",
+    });
+  });
+});
+
+describe("sameSourceEvidenceRecord", () => {
+  it("ignores id, payloadRef, and receivedAt", () => {
+    const reshaped: SourceEvidenceRecord = {
+      ...baseRecord,
+      id: "sev_other",
+      payloadRef: "salesforce://Task/00TVK00000lqsXc2AI?v=2",
+      receivedAt: "2026-09-01T00:00:00.000Z",
+    };
+
+    expect(sameSourceEvidenceRecord(baseRecord, reshaped)).toBe(true);
+  });
+
+  it("rejects records with mismatched checksum", () => {
+    const corrected: SourceEvidenceRecord = {
+      ...baseRecord,
+      checksum:
+        "3b9ae90e1191c0ffeebabe000000000000000000000000000000000000000002",
+    };
+
+    expect(sameSourceEvidenceRecord(baseRecord, corrected)).toBe(false);
+  });
+});

--- a/packages/domain/test/stage3-last-inbound-alias.test.ts
+++ b/packages/domain/test/stage3-last-inbound-alias.test.ts
@@ -32,6 +32,7 @@ function buildRepositoryBundle(input: {
   return defineStage1RepositoryBundle({
     sourceEvidence: {
       append: (record) => Promise.resolve(record),
+      replaceByIdempotencyKey: (record) => Promise.resolve(record),
       findById: () => Promise.resolve(null),
       listByIds: () => Promise.resolve([]),
       findByIdempotencyKey: () => Promise.resolve(null),

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -106,6 +106,7 @@ function createRepositoryBundle(input: {
           }),
         ),
       findByIdempotencyKey: () => Promise.resolve(null),
+      replaceByIdempotencyKey: (record) => Promise.resolve(record),
       listIdempotencyChecksumCollisions: () =>
         Promise.resolve({ entries: [], hasMore: false }),
       countByProvider: () => Promise.resolve(0),


### PR DESCRIPTION
## Summary

Implements PR (1) of the supersede plan from [#360](https://github.com/nico-kneler-as/as-comms-platform/issues/360): when `recordSourceEvidence` is called with an idempotency key that matches an existing canonical but the checksum differs, the canonical is now **updated in place**; the prior canonical is parked in `source_evidence_quarantine` with reason `"superseded_canonical"` for audit.

Previously this path quarantined the *new* payload and returned `conflict` — silently dropping every capture-mapper correction (channel classification, description capping, occurred_at fix, etc.) on the floor while the canonical drifted further from truth on each iteration. PRD problem statement and full impact assessment in #360.

## What changed

- **New deep module** [`packages/domain/src/source-evidence-supersede-policy.ts`](packages/domain/src/source-evidence-supersede-policy.ts) — pure function `decideSourceEvidenceSupersede(existing, incoming) → { kind: "duplicate" | "supersede" }`. No IO, no DB, unit-tested in isolation. Future policy evolution (record-type carve-outs, received_at guards) lands here without touching the persistence wrapper.
- **New repo method** `SourceEvidenceRepository.replaceByIdempotencyKey(record)` — updates mutable fields (provider_record_*, received_at, occurred_at, payload_ref, checksum) while preserving the row id, so downstream FK references (`canonical_event_ledger.source_evidence_id`, `*_details` tables) stay valid.
- **Quarantine reason union widened** — `"checksum_mismatch" | "superseded_canonical"`. Schema column is `text`, no migration needed.
- **`SourceEvidenceWriteResult` gains `"superseded"`** in the success shape (uniform `{ outcome, record }`).
- **`NormalizedSourceEvidenceResult` widened** to thread "superseded" through the wrapper. Existing call sites that branch on `outcome === "duplicate"` already treat `"superseded"` correctly (it's not a duplicate, so the gmail-detail overwrite + canonical-event-derivation paths run).

## What didn't change

- The DB-layer race-loser branch (post-append re-read at [persistence.ts:300](packages/domain/src/persistence.ts#L300)) keeps the existing `checksum_mismatch` + `conflict` semantics. That path covers concurrent writers, not capture-mapper drift.
- The provider-record-mismatch branch is untouched.
- Reconcile of the May 1 task_communication backlog (3,273 stale canonicals) and the lifecycle_milestone drift (~51 keys) is the **follow-up PR (2)**, not this one.

## Tests

- **New** [`packages/domain/test/source-evidence-supersede-policy.test.ts`](packages/domain/test/source-evidence-supersede-policy.test.ts) — 9 unit cases covering duplicate vs supersede decisions, including non-checksum-bearing fields (id, payloadRef, receivedAt) correctly classifying as duplicate.
- **Updated** [`packages/db/test/stage1-persistence.test.ts`](packages/db/test/stage1-persistence.test.ts) — the existing "quarantines a different-checksum collision and returns conflict" case is rewritten to assert supersede semantics: id preserved, canonical replaced, prior canonical in quarantine with reason `"superseded_canonical"`.
- **New idempotency case** in `stage1-persistence.test.ts` — verifies that re-polling a stable corrected record after supersede returns `duplicate` (not another supersede), so quarantine doesn't grow on every live-poll cycle.
- **In-memory fakes updated** in `repositories.test.ts`, `timeline.test.ts`, `stage3-last-inbound-alias.test.ts`, `normalization.test.ts` to satisfy the widened `SourceEvidenceRepository` interface.

## Test plan

- [x] `pnpm --filter @as-comms/domain typecheck` — clean
- [x] `pnpm --filter @as-comms/db typecheck` — clean
- [x] `pnpm typecheck` (full workspace, 16 tasks) — all green
- [x] `pnpm --filter @as-comms/domain run test:unit` — 14 files / 97 tests pass (incl. 9 new policy tests)
- [x] `pnpm --filter @as-comms/db run test:unit` — 14 files / 86 tests pass (incl. updated supersede integration tests)
- [x] `pnpm --filter @as-comms/domain --filter @as-comms/db lint` — clean
- [ ] CI green
- [ ] Architect review

🤖 Generated with [Claude Code](https://claude.com/claude-code)