### PR TITLE
fix(ui): swap brand color from #abb8c3 to logo dark slate #253746

### DIFF
--- a/apps/web/app/_components/primary-icon-rail.tsx
+++ b/apps/web/app/_components/primary-icon-rail.tsx
@@ -98,7 +98,7 @@ export function PrimaryIconRail({
             const active = isActive(pathname, item.activePrefixes);
             const baseClass = `flex size-10 items-center justify-center ${RADIUS.lg} ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion} ${
               active
-                ? "bg-[#abb8c3] text-slate-900"
+                ? "bg-[#253746] text-white"
                 : "text-slate-500 hover:bg-slate-100 hover:text-slate-900"
             }`;
 
@@ -129,7 +129,7 @@ export function PrimaryIconRail({
                 </TooltipTrigger>
                 <TooltipContent
                   side="right"
-                  className="rounded-md bg-slate-900 px-2 py-1 text-xs font-medium text-white"
+                  className="rounded-md bg-[#253746] px-2 py-1 text-xs font-medium text-white"
                 >
                   {item.label}
                 </TooltipContent>
@@ -168,7 +168,7 @@ function OperatorMenu({
             open && "border-slate-300 shadow-md"
           )}
         >
-          <span className="flex size-9 items-center justify-center rounded-full bg-[#abb8c3] text-[11px] font-semibold text-slate-900">
+          <span className="flex size-9 items-center justify-center rounded-full bg-[#253746] text-[11px] font-semibold text-white">
             {operator.initials}
           </span>
         </button>
@@ -176,7 +176,7 @@ function OperatorMenu({
       <DropdownMenuContent side="right" align="end" className="w-56">
         <DropdownMenuLabel className="font-normal">
           <div className="flex items-center gap-3">
-            <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-[#abb8c3] text-[11px] font-semibold text-slate-900">
+            <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-[#253746] text-[11px] font-semibold text-white">
               {operator.initials}
             </div>
             <div className="min-w-0">

--- a/apps/web/app/_lib/design-tokens.ts
+++ b/apps/web/app/_lib/design-tokens.ts
@@ -232,15 +232,15 @@ export const FOCUS_RING =
 
 // ─── Brand ──────────────────────────────────────────────────────────────────
 //
-// Adventure Scientists muted-slate brand color. Replaces near-black
-// (`bg-slate-900` / logo PNG fill) on icon backgrounds, primary buttons, the
-// operator avatar, and the company logo.
+// Adventure Scientists dark-slate brand color (sampled from the logo PNG).
+// Replaces `bg-slate-900` on primary buttons, active nav, operator avatar,
+// tooltips, and the company-logo CSS mask fill.
 
 export const BRAND = {
   /** Hex value — for inline `style` and CSS mask color. */
-  neutral: "#abb8c3",
+  neutral: "#253746",
   /** Tailwind background class. */
-  bg: "bg-[#abb8c3]",
+  bg: "bg-[#253746]",
   /** Tailwind text color class. */
-  text: "text-[#abb8c3]",
+  text: "text-[#253746]",
 } as const;

--- a/apps/web/app/inbox/_components/composer-detail-surfaces.tsx
+++ b/apps/web/app/inbox/_components/composer-detail-surfaces.tsx
@@ -211,7 +211,7 @@ export function ComposerPaneChrome({
             className={cn(
               "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium",
               activeTab === "email"
-                ? "bg-[#abb8c3] text-slate-900"
+                ? "bg-[#253746] text-white"
                 : "bg-slate-100 text-slate-600",
             )}
           >
@@ -601,7 +601,7 @@ export function ComposerEmailSurface({
                   <Button
                     type="button"
                     disabled={isSendDisabled}
-                    className="h-9 rounded-none rounded-l-md bg-[#abb8c3] px-3 text-[12.5px] font-medium text-slate-900 shadow-none hover:bg-[#bcc6cf]"
+                    className="h-9 rounded-none rounded-l-md bg-[#253746] px-3 text-[12.5px] font-medium text-white shadow-none hover:bg-[#324558]"
                     onClick={() => {
                       onSend("send");
                     }}
@@ -624,7 +624,7 @@ export function ComposerEmailSurface({
                         type="button"
                         aria-label="Send options"
                         disabled={isSending}
-                        className="h-9 rounded-none rounded-r-md border-l border-slate-400 bg-[#abb8c3] px-2 text-slate-900 shadow-none hover:bg-[#bcc6cf]"
+                        className="h-9 rounded-none rounded-r-md border-l border-slate-700 bg-[#253746] px-2 text-white shadow-none hover:bg-[#324558]"
                       >
                         <ChevronDownIcon className="size-4" />
                       </Button>
@@ -792,7 +792,7 @@ export function ComposerSmsSurface({
       <Button
         type="button"
         disabled={sendSmsDisabledReason !== null || isSending}
-        className="h-9 rounded-none rounded-l-md bg-[#abb8c3] px-3 text-[12.5px] font-medium text-slate-900 shadow-none hover:bg-[#bcc6cf]"
+        className="h-9 rounded-none rounded-l-md bg-[#253746] px-3 text-[12.5px] font-medium text-white shadow-none hover:bg-[#324558]"
         onClick={() => {
           onSend("send");
         }}
@@ -815,7 +815,7 @@ export function ComposerSmsSurface({
             type="button"
             aria-label="SMS send options"
             disabled={!smsEnabled || isSending}
-            className="h-9 rounded-none rounded-r-md border-l border-slate-400 bg-[#abb8c3] px-2 text-slate-900 shadow-none hover:bg-[#bcc6cf]"
+            className="h-9 rounded-none rounded-r-md border-l border-slate-700 bg-[#253746] px-2 text-white shadow-none hover:bg-[#324558]"
           >
             <ChevronDownIcon className="size-4" />
           </Button>

--- a/apps/web/app/inbox/_components/inbox-filter-list.tsx
+++ b/apps/web/app/inbox/_components/inbox-filter-list.tsx
@@ -207,7 +207,7 @@ function FilterRow(input: {
       className={cn(
         "group flex w-full items-center gap-2 rounded-md px-2 py-1 text-left text-[12.5px] transition-colors duration-150",
         isActive
-          ? "bg-[#abb8c3] text-slate-900"
+          ? "bg-[#253746] text-white"
           : "text-slate-700 hover:bg-slate-50",
       )}
     >

--- a/apps/web/app/inbox/_components/inbox-list.tsx
+++ b/apps/web/app/inbox/_components/inbox-list.tsx
@@ -588,7 +588,7 @@ export function InboxList({
             className={cn(
               "relative size-8 shrink-0",
               isFilterPaneOpen
-                ? "bg-[#abb8c3] text-slate-900 hover:bg-[#abb8c3] hover:text-slate-900"
+                ? "bg-[#253746] text-white hover:bg-[#253746] hover:text-white"
                 : hasActiveFilters
                   ? "bg-slate-100 text-slate-900 hover:bg-slate-100 hover:text-slate-900"
                   : "text-slate-900 hover:bg-slate-100 hover:text-slate-950",

--- a/apps/web/app/settings/_components/access-section.tsx
+++ b/apps/web/app/settings/_components/access-section.tsx
@@ -347,7 +347,7 @@ export function AccessSection({
                               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1",
                               "disabled:cursor-not-allowed disabled:opacity-40",
                               isEditing
-                                ? "bg-slate-900 text-white"
+                                ? "bg-[#253746] text-white"
                                 : "text-slate-400 hover:bg-slate-100 hover:text-slate-700",
                             )}
                           >
@@ -548,7 +548,7 @@ function RowEditPanel({
                     <span
                       className={cn(
                         "size-2 rounded-full",
-                        isSelected ? "bg-slate-900" : "bg-transparent",
+                        isSelected ? "bg-[#253746]" : "bg-transparent",
                       )}
                     />
                   </span>

--- a/apps/web/app/settings/_components/activation-wizard/sidebar-checklist.tsx
+++ b/apps/web/app/settings/_components/activation-wizard/sidebar-checklist.tsx
@@ -24,7 +24,7 @@ export function SidebarChecklist({
     <aside className="flex w-[280px] shrink-0 flex-col border-r border-slate-100 bg-slate-50/70">
       <div className="border-b border-slate-100 px-6 py-6">
         <div className="flex items-center gap-3">
-          <span className="flex size-8 items-center justify-center rounded-lg bg-slate-900 text-white">
+          <span className="flex size-8 items-center justify-center rounded-lg bg-[#253746] text-white">
             <Plus className="size-4" aria-hidden="true" />
           </span>
           <div>
@@ -76,7 +76,7 @@ export function SidebarChecklist({
                     state === "done"
                       ? "bg-emerald-500 text-white"
                       : state === "current"
-                        ? "bg-slate-900 text-white"
+                        ? "bg-[#253746] text-white"
                         : "bg-white text-slate-400 ring-1 ring-slate-200"
                   )}
                 >

--- a/apps/web/app/settings/_components/activation-wizard/step-knowledge.tsx
+++ b/apps/web/app/settings/_components/activation-wizard/step-knowledge.tsx
@@ -96,7 +96,7 @@ export function StepKnowledge({
             </div>
           </div>
             <div className="h-2 overflow-hidden rounded-full bg-slate-100">
-              <div className="h-full w-2/5 animate-pulse rounded-full bg-slate-900" />
+              <div className="h-full w-2/5 animate-pulse rounded-full bg-[#253746]" />
             </div>
           </div>
         ) : null}

--- a/apps/web/app/settings/_components/activation-wizard/step-pick-project.tsx
+++ b/apps/web/app/settings/_components/activation-wizard/step-pick-project.tsx
@@ -74,7 +74,7 @@ export function StepPickProject({
                 }}
                 className={cn(
                   "flex items-center gap-3 rounded-lg px-3 py-2 text-left transition-colors",
-                  isSelected ? "bg-slate-900 text-white" : "hover:bg-slate-50"
+                  isSelected ? "bg-[#253746] text-white" : "hover:bg-slate-50"
                 )}
               >
                 <span

--- a/apps/web/app/settings/_components/integrations-section.tsx
+++ b/apps/web/app/settings/_components/integrations-section.tsx
@@ -524,7 +524,7 @@ function SyncButton({
       </TooltipTrigger>
       <TooltipContent
         side="top"
-        className="rounded-md bg-slate-900 px-2 py-1 text-xs font-medium text-white"
+        className="rounded-md bg-[#253746] px-2 py-1 text-xs font-medium text-white"
       >
         Health checks are not wired for this provider yet.
       </TooltipContent>

--- a/apps/web/app/settings/_components/teammate-invite-modal.tsx
+++ b/apps/web/app/settings/_components/teammate-invite-modal.tsx
@@ -215,7 +215,7 @@ export function TeammateInviteModal({
                         className={cn(
                           "size-2 rounded-full",
                           role === option.value
-                            ? "bg-slate-900"
+                            ? "bg-[#253746]"
                             : "bg-transparent",
                         )}
                       />

--- a/apps/web/tests/unit/inbox-list-shell.test.tsx
+++ b/apps/web/tests/unit/inbox-list-shell.test.tsx
@@ -536,7 +536,7 @@ describe("Inbox list shell", () => {
     });
 
     expect(filterButton.getAttribute("aria-expanded")).toBe("true");
-    expect(filterButton.className).toContain("bg-[#abb8c3]");
+    expect(filterButton.className).toContain("bg-[#253746]");
     expect(session.container.textContent).toContain("State");
     expect(session.container.textContent).toContain("All projects");
     expect(session.container.textContent).not.toContain("Unresolved");


### PR DESCRIPTION
## Summary

The hex pasted into [#359](https://github.com/nico-kneler-as/as-comms-platform/pull/359) was wrong. Architect wanted the dark slate sampled from the company logo (`#253746`, RGB 37/55/70), not the light periwinkle (`#abb8c3`). This restores the original *visual* intent of #359 (white-on-dark-slate primary surfaces) and extends the swap to a few surfaces that were left on `bg-slate-900` last time.

## Changes

**Color swap** — every place #359 introduced `bg-[#abb8c3]`:

| File | What |
|---|---|
| `app/_lib/design-tokens.ts` | `BRAND.neutral` `#abb8c3` → `#253746`; `BRAND.bg` follows. Logo CSS mask picks up the new color automatically. |
| `app/_components/primary-icon-rail.tsx` | Active nav button + operator avatar (rail + popover). `text-slate-900` → `text-white`. Tooltip `bg-slate-900` → `bg-[#253746]`. |
| `app/inbox/_components/composer-detail-surfaces.tsx` | Email tab active state + Send / Send-options split buttons (email + SMS). `text-slate-900` → `text-white`. Split-button divider `border-slate-400` → `border-slate-700` (restored). Hover `#bcc6cf` → `#324558`. |
| `app/inbox/_components/inbox-list.tsx` | Filter toggle active state. |
| `app/inbox/_components/inbox-filter-list.tsx` | Filter list active row. |
| `tests/unit/inbox-list-shell.test.tsx` | Snapshot-style className assertion. |

**Broader sweep** — surfaces left on `bg-slate-900` in #359 because pairing white-text-on-dark already worked; including them now since the brand is dark again:

- `settings/_components/teammate-invite-modal.tsx`
- `settings/_components/access-section.tsx` (2 sites)
- `settings/_components/integrations-section.tsx` (tooltip)
- `settings/_components/activation-wizard/sidebar-checklist.tsx` (2 sites)
- `settings/_components/activation-wizard/step-pick-project.tsx`
- `settings/_components/activation-wizard/step-knowledge.tsx` (progress fill)

Showcase pages (`/inbox/states`, `/design-system`) and code-block backgrounds left alone — those are intentional darks.

## Validation

- `pnpm --filter @as-comms/web typecheck` clean
- `pnpm --filter @as-comms/web lint` clean
- `pnpm --filter @as-comms/web test:unit tests/unit/inbox-list-shell.test.tsx tests/unit/inbox-detail-header.test.tsx` — 21/21 pass
- Browser preview blocked locally: a different `next dev` was already running on :3000 from the main checkout (behind-main `codex/docs-capture-reliability`), so the preview tool latched onto that and rendered pre-#359 markup. Couldn't safely kill the architect's running dev process to stand mine up. Risk contained — pure CSS class swaps, no structural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)