### PR TITLE
fix(ops): guard cli-import side-effect in merge-email-only + mailchimp-historical

### DIFF
--- a/apps/worker/src/ops/mailchimp-capture-historical.ts
+++ b/apps/worker/src/ops/mailchimp-capture-historical.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env tsx
 import process from "node:process";
+import { pathToFileURL } from "node:url";
 
 import {
   mailchimpHistoricalCaptureBatchJobName,
@@ -390,11 +391,16 @@ async function main(): Promise<void> {
   await runMailchimpHistoricalCaptureCommand(process.argv.slice(2), process.env);
 }
 
-void main().catch((error: unknown) => {
-  console.error(
-    error instanceof Error
-      ? error.message
-      : "mailchimp-capture-historical failed."
-  );
-  process.exitCode = 1;
-});
+// Only auto-run when invoked as a CLI entry point. Without this guard,
+// importing this module from cli.ts re-runs main() on every CLI dispatch
+// — which trips the required `--since` flag check on unrelated commands.
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  void main().catch((error: unknown) => {
+    console.error(
+      error instanceof Error
+        ? error.message
+        : "mailchimp-capture-historical failed."
+    );
+    process.exitCode = 1;
+  });
+}

--- a/apps/worker/src/ops/merge-email-only-into-sf-anchored.ts
+++ b/apps/worker/src/ops/merge-email-only-into-sf-anchored.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env tsx
 import process from "node:process";
+import { pathToFileURL } from "node:url";
 
 import {
   closeDatabaseConnection,
@@ -635,11 +636,17 @@ export async function main(
   }
 }
 
-void main().catch((error: unknown) => {
-  console.error(
-    error instanceof Error
-      ? error.message
-      : "merge-email-only-into-sf-anchored failed.",
-  );
-  process.exitCode = 1;
-});
+// Only auto-run when invoked as a CLI entry point. Without this guard,
+// importing main() from cli.ts (or any other module) would re-trigger the
+// op as a side-effect — once let a `--execute` flag passed to a sibling op
+// accidentally drive a 3-pair merge during a reconcile-stale-canonical run.
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  void main().catch((error: unknown) => {
+    console.error(
+      error instanceof Error
+        ? error.message
+        : "merge-email-only-into-sf-anchored failed.",
+    );
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

Both `apps/worker/src/ops/merge-email-only-into-sf-anchored.ts` and `apps/worker/src/ops/mailchimp-capture-historical.ts` ended with an unguarded top-level `void main()`. `cli.ts` imports `main` / `runMergeEmailOnlyIntoSfAnchoredCommand` from these modules, so every cli.ts dispatch — including unrelated commands like `reconcile-stale-canonical` — re-ran both modules' `main()` at import time.

Two observed effects:

- `merge-email-only-into-sf-anchored` read the *same* `--execute` flag passed to a sibling op and applied a real 3-pair contact merge during a `reconcile-stale-canonical --execute` run today (~13:30 UTC). The merges themselves are valid candidates per #240's intent, but the timing was a side-effect, not an explicit operator action. Affected contacts (already merged successfully in prod, no rollback required):
  - `baisuzhen22@gmail.com` → SF `0031R00002i1p64QAA`
  - `reneevb@gmail.com` → SF `0031R00002BcwTuQAJ`
  - `theconservationhistorian@gmail.com` → SF `003VK0000050lC9YAI`
- `mailchimp-capture-historical` threw `Missing required flag --since.` on every cli.ts invocation — caught by `.catch`, never crashed the parent op, but spammed stderr.

## Fix

Standard ESM idiom: only run `main()` when the file is the actual entry point, not when imported.

```ts
if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
  void main().catch(...);
}
```

Applied to both affected files. The other 4 ops modules with top-level `void main()` (`audit-salesforce-task-ingest`, `create-notion-page-from-markdown`, `dump-notion-page`, `synthesize-project-knowledge`) are *not* imported by `cli.ts`, so they don't need the guard for the immediate bug. They can pick it up later if/when the pattern lands as a project-wide convention.

## Verification

Re-ran the dry-run that originally surfaced the bug:

```
$ tsx src/ops/cli.ts reconcile-stale-canonical \
    --provider salesforce --record-type lifecycle_milestone

# Before: merge_email_only_into_sf_anchored.pair logs + Missing-flag stderr
# After:  reconcile_stale_canonical.plan + reconcile_stale_canonical.completed only
```

## Test plan

- [x] `pnpm --filter @as-comms/worker typecheck` — clean
- [x] `pnpm --filter @as-comms/worker lint` — clean
- [x] `pnpm --filter @as-comms/worker run test:unit` — 44 files / 155 tests pass
- [x] Manual re-run of reconcile-stale-canonical dry-run against production — only reconcile events emitted, no side-effect ops
- [ ] CI green
- [ ] Architect review

## Why this is urgent

The next planned reconcile run is `reconcile-stale-canonical --execute --provider salesforce --record-type task_communication` (the May 1 backlog drain — ~3,273 keys). Without this guard, that run would re-fire `merge-email-only-into-sf-anchored` at import time. Any new email-only/SF-anchored pairs that have appeared since today would be silently merged as a side-effect again, in unauthorized timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)