### PR TITLE
chore(db): add ai_knowledge_sources registry schema + data layer (PR-A of #366)

### DIFF
--- a/apps/worker/test/stage1-orchestration.test.ts
+++ b/apps/worker/test/stage1-orchestration.test.ts
@@ -498,7 +498,11 @@ Alias drift outbound message.
           source: "salesforce",
           isActive: false,
           aiKnowledgeUrl: null,
-          aiKnowledgeSyncedAt: null
+          aiKnowledgeSyncedAt: null,
+          aiKnowledgeSources: [],
+          aiOperatingContext: "",
+          aiOptimizedSynthesizedAt: null,
+          aiOptimizedInputHash: null
         }
       ]);
       await expect(

--- a/packages/contracts/src/stage1-records.ts
+++ b/packages/contracts/src/stage1-records.ts
@@ -157,8 +157,48 @@ export const projectDimensionSchema = z.object({
   isActive: z.boolean().optional(),
   aiKnowledgeUrl: nullableStringSchema.optional(),
   aiKnowledgeSyncedAt: optionalTimestampSchema.optional(),
+  aiKnowledgeSources: z.lazy(() => aiKnowledgeSourcesSchema).optional(),
+  aiOperatingContext: z.string().optional(),
+  aiOptimizedSynthesizedAt: optionalTimestampSchema.optional(),
+  aiOptimizedInputHash: nullableStringSchema.optional(),
 });
 export type ProjectDimensionRecord = z.infer<typeof projectDimensionSchema>;
+
+export const aiKnowledgeSourceKindSchema = z.enum([
+  "notion",
+  "web_page",
+  "inline_text",
+]);
+export type AiKnowledgeSourceKind = z.infer<typeof aiKnowledgeSourceKindSchema>;
+
+export const aiKnowledgeSourceSyncStatusSchema = z.enum([
+  "pending",
+  "healthy",
+  "stale",
+  "broken",
+]);
+export type AiKnowledgeSourceSyncStatus = z.infer<
+  typeof aiKnowledgeSourceSyncStatusSchema
+>;
+
+export const aiKnowledgeSourceSchema = z.object({
+  id: z.string().uuid(),
+  url: z.string().url(),
+  kind: aiKnowledgeSourceKindSchema,
+  label: z.string().nullable(),
+  enabled: z.boolean(),
+  last_synced_at: z.string().datetime().nullable(),
+  last_sync_status: aiKnowledgeSourceSyncStatusSchema.nullable(),
+  last_sync_error: z.string().nullable(),
+  source_id: z.string().nullable(),
+  source_content_hash: z.string().nullable(),
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
+});
+export type AiKnowledgeSource = z.infer<typeof aiKnowledgeSourceSchema>;
+
+export const aiKnowledgeSourcesSchema = z.array(aiKnowledgeSourceSchema);
+export type AiKnowledgeSources = z.infer<typeof aiKnowledgeSourcesSchema>;
 
 export const aiKnowledgeEntrySchema = z.object({
   id: idSchema,

--- a/packages/contracts/test/ai-knowledge-sources.test.ts
+++ b/packages/contracts/test/ai-knowledge-sources.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  aiKnowledgeSourceKindSchema,
+  aiKnowledgeSourceSchema,
+  aiKnowledgeSourcesSchema,
+  aiKnowledgeSourceSyncStatusSchema,
+} from "../src/index.js";
+
+describe("AI knowledge source contracts", () => {
+  it("parses a valid source entry", () => {
+    const result = aiKnowledgeSourceSchema.parse({
+      id: "4f84c4cb-7ee4-4df4-b0c6-385a3b6d3d70",
+      url: "https://www.notion.so/3278a9129211804baa72c76a86d084d0",
+      kind: "notion",
+      label: null,
+      enabled: true,
+      last_synced_at: "2026-05-01T12:00:00.000Z",
+      last_sync_status: "healthy",
+      last_sync_error: null,
+      source_id: "3278a9129211804baa72c76a86d084d0",
+      source_content_hash: "md5:content",
+      created_at: "2026-05-01T12:00:00.000Z",
+      updated_at: "2026-05-01T12:00:00.000Z",
+    });
+
+    expect(result.kind).toBe("notion");
+    expect(aiKnowledgeSourceKindSchema.options).toEqual([
+      "notion",
+      "web_page",
+      "inline_text",
+    ]);
+    expect(aiKnowledgeSourceSyncStatusSchema.options).toEqual([
+      "pending",
+      "healthy",
+      "stale",
+      "broken",
+    ]);
+  });
+
+  it("rejects malformed source entries", () => {
+    const malformed = aiKnowledgeSourceSchema.safeParse({
+      id: "not-a-uuid",
+      url: "not-a-url",
+      kind: "notion",
+      label: null,
+      enabled: true,
+      last_synced_at: null,
+      last_sync_status: null,
+      last_sync_error: null,
+      source_id: null,
+      source_content_hash: null,
+      created_at: "not-a-date",
+      updated_at: "2026-05-01T12:00:00.000Z",
+    });
+
+    expect(malformed.success).toBe(false);
+  });
+
+  it("parses arrays of source entries", () => {
+    const sources = aiKnowledgeSourcesSchema.parse([
+      {
+        id: "4f84c4cb-7ee4-4df4-b0c6-385a3b6d3d70",
+        url: "https://www.adventurescientists.org/project",
+        kind: "web_page",
+        label: "Project page",
+        enabled: true,
+        last_synced_at: null,
+        last_sync_status: "pending",
+        last_sync_error: null,
+        source_id: "hash:web",
+        source_content_hash: null,
+        created_at: "2026-05-01T12:00:00.000Z",
+        updated_at: "2026-05-01T12:00:00.000Z",
+      },
+    ]);
+
+    expect(sources).toHaveLength(1);
+  });
+});

--- a/packages/db/drizzle/0054_ai_knowledge_source_registry.sql
+++ b/packages/db/drizzle/0054_ai_knowledge_source_registry.sql
@@ -1,0 +1,65 @@
+ALTER TABLE "project_dimensions"
+  ADD COLUMN "ai_knowledge_sources" jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+ALTER TABLE "project_dimensions"
+  ADD COLUMN "ai_operating_context" text NOT NULL DEFAULT '';
+
+ALTER TABLE "project_dimensions"
+  ADD COLUMN "ai_optimized_synthesized_at" timestamp with time zone;
+
+ALTER TABLE "project_dimensions"
+  ADD COLUMN "ai_optimized_input_hash" text;
+
+WITH project_cache AS (
+  SELECT
+    pd."project_id",
+    pd."ai_knowledge_url",
+    pd."ai_knowledge_synced_at",
+    ake."content_hash" AS "source_content_hash",
+    LOWER(
+      SUBSTRING(
+        REPLACE(pd."ai_knowledge_url", '-', '')
+        FROM '([0-9a-fA-F]{32})'
+      )
+    ) AS "source_id"
+  FROM "project_dimensions" pd
+  LEFT JOIN "ai_knowledge_entries" ake
+    ON ake."scope" = 'project'
+   AND ake."scope_key" = pd."project_id"
+   AND ake."source_provider" = 'notion'
+  WHERE pd."is_active" = true
+    AND pd."ai_knowledge_url" IS NOT NULL
+)
+UPDATE "project_dimensions" pd
+SET
+  "ai_knowledge_sources" = jsonb_build_array(
+    jsonb_build_object(
+      'id', gen_random_uuid()::text,
+      'url', project_cache."ai_knowledge_url",
+      'kind', 'notion',
+      'label', NULL,
+      'enabled', true,
+      'last_synced_at', CASE
+        WHEN project_cache."ai_knowledge_synced_at" IS NULL THEN NULL
+        ELSE to_char(
+          project_cache."ai_knowledge_synced_at" AT TIME ZONE 'UTC',
+          'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
+        )
+      END,
+      'last_sync_status', 'healthy',
+      'last_sync_error', NULL,
+      'source_id', project_cache."source_id",
+      'source_content_hash', project_cache."source_content_hash",
+      'created_at', to_char(
+        NOW() AT TIME ZONE 'UTC',
+        'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
+      ),
+      'updated_at', to_char(
+        NOW() AT TIME ZONE 'UTC',
+        'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
+      )
+    )
+  ),
+  "updated_at" = NOW()
+FROM project_cache
+WHERE pd."project_id" = project_cache."project_id";

--- a/packages/db/src/ai-knowledge-sources.ts
+++ b/packages/db/src/ai-knowledge-sources.ts
@@ -1,0 +1,312 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import {
+  aiKnowledgeSourceSchema,
+  aiKnowledgeSourcesSchema,
+  type AiKnowledgeSource,
+  type AiKnowledgeSourceSyncStatus,
+} from "@as-comms/contracts";
+
+const NOTION_HOST_PATTERN = /(^|\.)notion\.so$/u;
+const NOTION_ID_PATTERN =
+  /([0-9a-f]{32}|[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12})/iu;
+
+function hashText(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function normalizeUrlInput(value: string): string {
+  return value.trim();
+}
+
+function normalizeWebUrl(url: URL): string {
+  url.hash = "";
+  url.protocol = url.protocol.toLowerCase();
+  url.hostname = url.hostname.toLowerCase();
+
+  if (
+    (url.protocol === "https:" && url.port === "443") ||
+    (url.protocol === "http:" && url.port === "80")
+  ) {
+    url.port = "";
+  }
+
+  return url.toString();
+}
+
+function normalizeNotionSourceId(value: string): string {
+  const normalized = value.trim().replace(/-/gu, "").toLowerCase();
+
+  if (!/^[0-9a-f]{32}$/u.test(normalized)) {
+    throw new AiKnowledgeSourceValidationError({
+      code: "invalid_url",
+      message: `Invalid Notion page ID: ${value}`,
+    });
+  }
+
+  return normalized;
+}
+
+function isNotionHost(hostname: string): boolean {
+  return NOTION_HOST_PATTERN.test(hostname.toLowerCase());
+}
+
+function findSourceIndex(
+  sources: readonly AiKnowledgeSource[],
+  sourceId: string,
+): number {
+  return sources.findIndex((source) => source.id === sourceId);
+}
+
+function assertSourceExists(
+  sources: readonly AiKnowledgeSource[],
+  sourceId: string,
+): number {
+  const index = findSourceIndex(sources, sourceId);
+
+  if (index === -1) {
+    throw new AiKnowledgeSourceValidationError({
+      code: "source_not_found",
+      message: `AI knowledge source ${sourceId} was not found.`,
+    });
+  }
+
+  return index;
+}
+
+function assertNoDuplicate(
+  sources: readonly AiKnowledgeSource[],
+  candidate: { readonly kind: string; readonly sourceId: string | null },
+  ignoreId?: string,
+): void {
+  const duplicate = sources.find(
+    (source) =>
+      source.id !== ignoreId &&
+      source.kind === candidate.kind &&
+      source.source_id === candidate.sourceId,
+  );
+
+  if (duplicate !== undefined) {
+    throw new AiKnowledgeSourceValidationError({
+      code: "duplicate_source",
+      message: `AI knowledge source ${duplicate.id} already exists for this project.`,
+    });
+  }
+}
+
+function replaceSourceAt(
+  sources: readonly AiKnowledgeSource[],
+  index: number,
+  nextSource: AiKnowledgeSource,
+): readonly AiKnowledgeSource[] {
+  return sources.map((source, sourceIndex) =>
+    sourceIndex === index ? nextSource : source,
+  );
+}
+
+export class AiKnowledgeSourceValidationError extends Error {
+  readonly code:
+    | "duplicate_source"
+    | "invalid_url"
+    | "source_not_found";
+
+  constructor(input: {
+    readonly code: AiKnowledgeSourceValidationError["code"];
+    readonly message: string;
+  }) {
+    super(input.message);
+    this.name = "AiKnowledgeSourceValidationError";
+    this.code = input.code;
+  }
+}
+
+export function parseSourceUrl(url: string): {
+  readonly kind: "notion" | "web_page";
+  readonly source_id: string | null;
+  readonly normalized_url: string;
+} {
+  const trimmedUrl = normalizeUrlInput(url);
+
+  if (trimmedUrl.length === 0) {
+    throw new AiKnowledgeSourceValidationError({
+      code: "invalid_url",
+      message: "AI knowledge source URL is required.",
+    });
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(trimmedUrl);
+  } catch {
+    throw new AiKnowledgeSourceValidationError({
+      code: "invalid_url",
+      message: `Invalid AI knowledge source URL: ${url}`,
+    });
+  }
+
+  if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+    throw new AiKnowledgeSourceValidationError({
+      code: "invalid_url",
+      message: `Unsupported AI knowledge source URL scheme: ${parsedUrl.protocol}`,
+    });
+  }
+
+  if (isNotionHost(parsedUrl.hostname)) {
+    const notionIdMatch = NOTION_ID_PATTERN.exec(parsedUrl.pathname);
+    const notionId = notionIdMatch?.[1];
+
+    if (notionId === undefined) {
+      throw new AiKnowledgeSourceValidationError({
+        code: "invalid_url",
+        message: `Could not extract a Notion page ID from URL: ${url}`,
+      });
+    }
+
+    const sourceId = normalizeNotionSourceId(notionId);
+    return {
+      kind: "notion",
+      source_id: sourceId,
+      normalized_url: `https://www.notion.so/${sourceId}`,
+    };
+  }
+
+  const normalizedUrl = normalizeWebUrl(parsedUrl);
+  return {
+    kind: "web_page",
+    source_id: hashText(normalizedUrl),
+    normalized_url: normalizedUrl,
+  };
+}
+
+export interface AddAiKnowledgeSourceInput {
+  readonly url: string;
+  readonly label?: string | null;
+  readonly enabled?: boolean;
+  readonly now?: string;
+}
+
+export function addSource(
+  sources: readonly AiKnowledgeSource[],
+  input: AddAiKnowledgeSourceInput,
+): readonly AiKnowledgeSource[] {
+  const parsedSources = aiKnowledgeSourcesSchema.parse(sources);
+  const parsedUrl = parseSourceUrl(input.url);
+
+  assertNoDuplicate(parsedSources, {
+    kind: parsedUrl.kind,
+    sourceId: parsedUrl.source_id,
+  });
+
+  const now = input.now ?? new Date().toISOString();
+  const nextSource = aiKnowledgeSourceSchema.parse({
+    id: randomUUID(),
+    url: parsedUrl.normalized_url,
+    kind: parsedUrl.kind,
+    label: input.label ?? null,
+    enabled: input.enabled ?? true,
+    last_synced_at: null,
+    last_sync_status: null,
+    last_sync_error: null,
+    source_id: parsedUrl.source_id,
+    source_content_hash: null,
+    created_at: now,
+    updated_at: now,
+  });
+
+  return [...parsedSources, nextSource];
+}
+
+export function updateSource(
+  sources: readonly AiKnowledgeSource[],
+  sourceId: string,
+  patch: Partial<Omit<AiKnowledgeSource, "id" | "created_at" | "updated_at">>,
+): readonly AiKnowledgeSource[] {
+  const parsedSources = aiKnowledgeSourcesSchema.parse(sources);
+  const index = assertSourceExists(parsedSources, sourceId);
+  const existing = parsedSources[index];
+  if (existing === undefined) {
+    throw new AiKnowledgeSourceValidationError({
+      code: "source_not_found",
+      message: `AI knowledge source ${sourceId} was not found.`,
+    });
+  }
+  const nextUpdatedAt = new Date().toISOString();
+
+  let nextUrl = existing.url;
+  let nextKind = existing.kind;
+  let nextSourceId = existing.source_id;
+
+  if (patch.url !== undefined) {
+    const parsedUrl = parseSourceUrl(patch.url);
+    nextUrl = parsedUrl.normalized_url;
+    nextKind = parsedUrl.kind;
+    nextSourceId = parsedUrl.source_id;
+    assertNoDuplicate(
+      parsedSources,
+      { kind: nextKind, sourceId: nextSourceId },
+      existing.id,
+    );
+  }
+
+  const nextSource = aiKnowledgeSourceSchema.parse({
+    ...existing,
+    ...patch,
+    url: nextUrl,
+    kind: nextKind,
+    source_id: nextSourceId,
+    updated_at: nextUpdatedAt,
+  });
+
+  return replaceSourceAt(parsedSources, index, nextSource);
+}
+
+export function removeSource(
+  sources: readonly AiKnowledgeSource[],
+  sourceId: string,
+): readonly AiKnowledgeSource[] {
+  const parsedSources = aiKnowledgeSourcesSchema.parse(sources);
+  return parsedSources.filter((source) => source.id !== sourceId);
+}
+
+export function setSourceEnabled(
+  sources: readonly AiKnowledgeSource[],
+  sourceId: string,
+  enabled: boolean,
+): readonly AiKnowledgeSource[] {
+  return updateSource(sources, sourceId, { enabled });
+}
+
+export interface MarkAiKnowledgeSourceSyncResultInput {
+  readonly last_synced_at?: string;
+  readonly last_sync_status: AiKnowledgeSourceSyncStatus;
+  readonly last_sync_error: string | null;
+  readonly source_content_hash: string | null;
+}
+
+export function markSourceSyncResult(
+  sources: readonly AiKnowledgeSource[],
+  sourceId: string,
+  result: MarkAiKnowledgeSourceSyncResultInput,
+): readonly AiKnowledgeSource[] {
+  return updateSource(sources, sourceId, {
+    last_synced_at: result.last_synced_at ?? new Date().toISOString(),
+    last_sync_status: result.last_sync_status,
+    last_sync_error: result.last_sync_error,
+    source_content_hash: result.source_content_hash,
+  });
+}
+
+export function inputHashFromSources(
+  sources: readonly AiKnowledgeSource[],
+): string | null {
+  const parsedSources = aiKnowledgeSourcesSchema.parse(sources);
+  const enabledHashes = parsedSources
+    .filter((source) => source.enabled && source.source_content_hash !== null)
+    .map((source) => source.source_content_hash);
+
+  if (enabledHashes.length === 0) {
+    return null;
+  }
+
+  return hashText(enabledHashes.join("\n"));
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./ai-knowledge-sources.js";
 export * from "./client.js";
 export * from "./mappers.js";
 export * from "./migrator.js";

--- a/packages/db/src/mappers.ts
+++ b/packages/db/src/mappers.ts
@@ -1,4 +1,5 @@
 import {
+  aiKnowledgeSourcesSchema,
   aiKnowledgeEntrySchema,
   auditEvidenceSchema,
   canonicalEventSchema,
@@ -540,6 +541,10 @@ export function mapProjectDimensionRow(
     isActive: row.isActive,
     aiKnowledgeUrl: row.aiKnowledgeUrl,
     aiKnowledgeSyncedAt: fromDate(row.aiKnowledgeSyncedAt),
+    aiKnowledgeSources: aiKnowledgeSourcesSchema.parse(row.aiKnowledgeSources),
+    aiOperatingContext: row.aiOperatingContext,
+    aiOptimizedSynthesizedAt: fromDate(row.aiOptimizedSynthesizedAt),
+    aiOptimizedInputHash: row.aiOptimizedInputHash,
   });
 }
 
@@ -559,6 +564,18 @@ export function mapProjectDimensionToInsert(
       parsed.aiKnowledgeSyncedAt === null
         ? null
         : toDate(parsed.aiKnowledgeSyncedAt),
+    aiKnowledgeSources: parsed.aiKnowledgeSources ?? undefined,
+    aiOperatingContext: parsed.aiOperatingContext ?? undefined,
+    aiOptimizedSynthesizedAt:
+      parsed.aiOptimizedSynthesizedAt === undefined
+        ? undefined
+        : parsed.aiOptimizedSynthesizedAt === null
+          ? null
+          : toDate(parsed.aiOptimizedSynthesizedAt),
+    aiOptimizedInputHash:
+      parsed.aiOptimizedInputHash === undefined
+        ? undefined
+        : parsed.aiOptimizedInputHash,
     source: parsed.source,
   };
 }

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -29,6 +29,7 @@ import {
   defineStage1RepositoryBundle,
   defineStage2RepositoryBundle,
 } from "@as-comms/domain";
+import { aiKnowledgeSourcesSchema } from "@as-comms/contracts";
 
 import type { DatabaseConnection } from "./client.js";
 import {
@@ -2153,6 +2154,52 @@ function createStage1RepositoriesInternal(
         return rows.map(mapProjectDimensionRow);
       },
 
+      async getAiKnowledgeSources(projectId) {
+        const [row] = await db
+          .select({
+            aiKnowledgeSources: projectDimensions.aiKnowledgeSources,
+          })
+          .from(projectDimensions)
+          .where(eq(projectDimensions.projectId, projectId))
+          .limit(1);
+
+        return aiKnowledgeSourcesSchema.parse(row?.aiKnowledgeSources ?? []);
+      },
+
+      async setAiKnowledgeSources(projectId, sources) {
+        const parsedSources = aiKnowledgeSourcesSchema.parse(sources);
+
+        await db
+          .update(projectDimensions)
+          .set({
+            aiKnowledgeSources: parsedSources,
+            updatedAt: new Date(),
+          })
+          .where(eq(projectDimensions.projectId, projectId));
+      },
+
+      async updateOperatingContext(projectId, context) {
+        await db
+          .update(projectDimensions)
+          .set({
+            aiOperatingContext: context,
+            updatedAt: new Date(),
+          })
+          .where(eq(projectDimensions.projectId, projectId));
+      },
+
+      async setSynthesisMetadata(projectId, input) {
+        await db
+          .update(projectDimensions)
+          .set({
+            aiOptimizedSynthesizedAt:
+              input.synthesizedAt === null ? null : new Date(input.synthesizedAt),
+            aiOptimizedInputHash: input.inputHash,
+            updatedAt: new Date(),
+          })
+          .where(eq(projectDimensions.projectId, projectId));
+      },
+
       async upsert(record) {
         const values = mapProjectDimensionToInsert(record);
         const [row] = await db
@@ -2173,6 +2220,18 @@ function createStage1RepositoriesInternal(
               // and Salesforce capture must not overwrite that app-owned state.
               aiKnowledgeUrl: values.aiKnowledgeUrl,
               aiKnowledgeSyncedAt: values.aiKnowledgeSyncedAt,
+              aiKnowledgeSources:
+                values.aiKnowledgeSources ?? projectDimensions.aiKnowledgeSources,
+              aiOperatingContext:
+                values.aiOperatingContext ?? projectDimensions.aiOperatingContext,
+              aiOptimizedSynthesizedAt:
+                values.aiOptimizedSynthesizedAt === undefined
+                  ? projectDimensions.aiOptimizedSynthesizedAt
+                  : values.aiOptimizedSynthesizedAt,
+              aiOptimizedInputHash:
+                values.aiOptimizedInputHash === undefined
+                  ? projectDimensions.aiOptimizedInputHash
+                  : values.aiOptimizedInputHash,
               source: values.source,
               updatedAt: new Date(),
             },

--- a/packages/db/src/schema/tables.ts
+++ b/packages/db/src/schema/tables.ts
@@ -1,5 +1,6 @@
 import { isNotNull, sql } from "drizzle-orm";
 import type {
+  AiKnowledgeSource,
   CanonicalEventProvenance,
   IntegrationHealthCategory,
   IntegrationHealthStatus,
@@ -227,6 +228,16 @@ export const projectDimensions = pgTable(
       mode: "date",
       withTimezone: true,
     }),
+    aiKnowledgeSources: jsonb("ai_knowledge_sources")
+      .$type<readonly AiKnowledgeSource[]>()
+      .notNull()
+      .default([]),
+    aiOperatingContext: text("ai_operating_context").notNull().default(""),
+    aiOptimizedSynthesizedAt: timestamp("ai_optimized_synthesized_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    aiOptimizedInputHash: text("ai_optimized_input_hash"),
     source: recordSourceEnum("source").notNull(),
     createdAt: createdAtColumn,
     updatedAt: updatedAtColumn,

--- a/packages/db/test/ai-knowledge-sources.test.ts
+++ b/packages/db/test/ai-knowledge-sources.test.ts
@@ -1,0 +1,441 @@
+import { readdir, readFile } from "node:fs/promises";
+
+import { PGlite } from "@electric-sql/pglite";
+import { describe, expect, it } from "vitest";
+
+import { and, eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/pglite";
+import { ZodError } from "zod";
+
+import { aiKnowledgeSourcesSchema, type AiKnowledgeSource } from "@as-comms/contracts";
+
+import {
+  addSource,
+  aiKnowledgeEntries,
+  inputHashFromSources,
+  markSourceSyncResult,
+  parseSourceUrl,
+  projectDimensions,
+  removeSource,
+  setSourceEnabled,
+  type Stage1Database,
+  updateSource,
+} from "../src/index.js";
+import { createTestStage1Context } from "./helpers.js";
+
+function buildSource(input: {
+  readonly id?: string;
+  readonly url?: string;
+  readonly kind?: AiKnowledgeSource["kind"];
+  readonly label?: string | null;
+  readonly enabled?: boolean;
+  readonly last_synced_at?: string | null;
+  readonly last_sync_status?: AiKnowledgeSource["last_sync_status"];
+  readonly last_sync_error?: string | null;
+  readonly source_id?: string | null;
+  readonly source_content_hash?: string | null;
+  readonly created_at?: string;
+  readonly updated_at?: string;
+} = {}): AiKnowledgeSource {
+  return aiKnowledgeSourcesSchema.element.parse({
+    id: input.id ?? "4f84c4cb-7ee4-4df4-b0c6-385a3b6d3d70",
+    url:
+      input.url ?? "https://www.notion.so/3278a9129211804baa72c76a86d084d0",
+    kind: input.kind ?? "notion",
+    label: input.label ?? "Training page",
+    enabled: input.enabled ?? true,
+    last_synced_at: input.last_synced_at ?? null,
+    last_sync_status: input.last_sync_status ?? null,
+    last_sync_error: input.last_sync_error ?? null,
+    source_id: input.source_id ?? "3278a9129211804baa72c76a86d084d0",
+    source_content_hash: input.source_content_hash ?? null,
+    created_at: input.created_at ?? "2026-05-01T12:00:00.000Z",
+    updated_at: input.updated_at ?? "2026-05-01T12:00:00.000Z",
+  });
+}
+
+async function applyMigrationsThrough(
+  client: PGlite,
+  migrationName: string,
+): Promise<void> {
+  const drizzleDirectoryUrl = new URL("../src/../drizzle/", import.meta.url);
+  const migrationFiles = (await readdir(drizzleDirectoryUrl))
+    .filter((fileName) => fileName.endsWith(".sql"))
+    .sort((left, right) => left.localeCompare(right));
+
+  for (const migrationFile of migrationFiles) {
+    const migrationSql = await readFile(
+      new URL(migrationFile, drizzleDirectoryUrl),
+      "utf8",
+    );
+    await client.exec(migrationSql);
+
+    if (migrationFile === migrationName) {
+      return;
+    }
+  }
+
+  throw new Error(`Migration ${migrationName} was not found.`);
+}
+
+async function applySingleMigration(
+  client: PGlite,
+  migrationName: string,
+): Promise<void> {
+  const drizzleDirectoryUrl = new URL("../src/../drizzle/", import.meta.url);
+  const migrationSql = await readFile(
+    new URL(migrationName, drizzleDirectoryUrl),
+    "utf8",
+  );
+
+  await client.exec(migrationSql);
+}
+
+describe("AI knowledge source registry helpers", () => {
+  it("parses notion URLs and stable web URLs", () => {
+    const expectedSourceId = "3278a9129211804baa72c76a86d084d0";
+    const notionUrls = [
+      "https://www.notion.so/Project-Training-3278a9129211804baa72c76a86d084d0",
+      "https://notion.so/Project-Training-3278a912-9211-804b-aa72-c76a86d084d0",
+      "https://workspace.notion.so/3278a9129211804baa72c76a86d084d0?source=copy_link",
+      "https://www.notion.so/3278a9129211804baa72c76a86d084d0",
+    ];
+
+    for (const notionUrl of notionUrls) {
+      expect(parseSourceUrl(notionUrl)).toEqual({
+        kind: "notion",
+        source_id: expectedSourceId,
+        normalized_url: `https://www.notion.so/${expectedSourceId}`,
+      });
+    }
+
+    const firstWeb = parseSourceUrl(
+      "https://www.adventurescientists.org/project/whitebark-pine",
+    );
+    const secondWeb = parseSourceUrl(
+      "https://www.adventurescientists.org/project/whitebark-pine",
+    );
+
+    expect(firstWeb.kind).toBe("web_page");
+    expect(firstWeb.source_id).toBe(secondWeb.source_id);
+    expect(firstWeb.normalized_url).toBe(
+      "https://www.adventurescientists.org/project/whitebark-pine",
+    );
+  });
+
+  it("rejects invalid source URLs with a typed validation error", () => {
+    expect(() => parseSourceUrl("")).toThrowError(/required/i);
+    expect(() => parseSourceUrl("not-a-url")).toThrowError(/invalid/i);
+    expect(() => parseSourceUrl("ftp://example.com")).toThrowError(/scheme/i);
+    expect(() => parseSourceUrl("mailto:test@example.com")).toThrowError(
+      /scheme/i,
+    );
+  });
+
+  it("adds, updates, removes, toggles, and hashes sources immutably", () => {
+    const original = [
+      buildSource(),
+      buildSource({
+        id: "0a749d74-0a10-4dd1-b787-a3b74ef296b3",
+        url: "https://www.adventurescientists.org/project/whitebark-pine",
+        kind: "web_page",
+        source_id:
+          "67999feeb13b36758c2f4665755cb1e9bc02ecc57b544f50b217df2e3d898ca6",
+        source_content_hash: "hash:web",
+      }),
+    ] as const;
+
+    const appended = addSource([], {
+      url: "https://www.notion.so/Project-Training-3278a9129211804baa72c76a86d084d0",
+      label: "Training page",
+      now: "2026-05-02T09:00:00.000Z",
+    });
+    expect(appended[0]).toBeDefined();
+    expect(appended).toHaveLength(1);
+
+    expect(() =>
+      addSource(original, {
+        url: "https://notion.so/Project-Training-3278a912-9211-804b-aa72-c76a86d084d0",
+      }),
+    ).toThrowError(/already exists/i);
+
+    const updated = updateSource(original, original[0].id, {
+      label: "Updated label",
+    });
+    const [updatedFirst, updatedSecond] = updated;
+    expect(updatedFirst?.label).toBe("Updated label");
+    expect(updatedFirst?.updated_at).not.toBe(original[0].updated_at);
+    expect(updatedSecond).toEqual(original[1]);
+
+    const toggled = setSourceEnabled(original, original[1].id, false);
+    const [, toggledSecond] = toggled;
+    expect(toggledSecond?.enabled).toBe(false);
+    expect(toggledSecond?.url).toBe(original[1].url);
+
+    const synced = markSourceSyncResult(original, original[0].id, {
+      last_synced_at: "2026-05-03T10:00:00.000Z",
+      last_sync_status: "healthy",
+      last_sync_error: null,
+      source_content_hash: "hash:notion",
+    });
+    expect(synced[0]).toMatchObject({
+      last_synced_at: "2026-05-03T10:00:00.000Z",
+      last_sync_status: "healthy",
+      last_sync_error: null,
+      source_content_hash: "hash:notion",
+    });
+
+    const removed = removeSource(original, original[0].id);
+    expect(removed).toEqual([original[1]]);
+
+    const firstHash = inputHashFromSources([
+      buildSource({ source_content_hash: "hash:notion" }),
+      buildSource({
+        id: "0a749d74-0a10-4dd1-b787-a3b74ef296b3",
+        url: "https://www.adventurescientists.org/project/whitebark-pine",
+        kind: "web_page",
+        source_id: "hash:web-page",
+        source_content_hash: "hash:web",
+      }),
+      buildSource({
+        id: "f612ec45-3a7f-4d87-b013-941ab8086e75",
+        enabled: false,
+        source_content_hash: "hash:disabled",
+      }),
+      buildSource({
+        id: "44f57c08-f7fe-4e05-baa1-8ecb5abfa568",
+        source_content_hash: null,
+      }),
+    ]);
+    const secondHash = inputHashFromSources([
+      buildSource({ source_content_hash: "hash:notion" }),
+      buildSource({
+        id: "0a749d74-0a10-4dd1-b787-a3b74ef296b3",
+        url: "https://www.adventurescientists.org/project/whitebark-pine",
+        kind: "web_page",
+        source_id: "hash:web-page",
+        source_content_hash: "hash:web",
+      }),
+      buildSource({
+        id: "f612ec45-3a7f-4d87-b013-941ab8086e75",
+        enabled: false,
+        source_content_hash: "hash:disabled",
+      }),
+      buildSource({
+        id: "44f57c08-f7fe-4e05-baa1-8ecb5abfa568",
+        source_content_hash: null,
+      }),
+    ]);
+
+    expect(firstHash).toBe(secondHash);
+    expect(firstHash).not.toBeNull();
+    expect(inputHashFromSources([])).toBeNull();
+  });
+});
+
+describe("AI knowledge source registry repository methods", () => {
+  it("round-trips JSONB sources and metadata through project_dimensions", async () => {
+    const context = await createTestStage1Context();
+
+    try {
+      await context.repositories.projectDimensions.upsert({
+        projectId: "project:registry",
+        projectName: "Registry Project",
+        source: "salesforce",
+      });
+
+      const sources = [
+        buildSource({
+          source_content_hash: "hash:notion",
+          last_synced_at: "2026-05-01T13:00:00.000Z",
+          last_sync_status: "healthy",
+        }),
+      ];
+
+      await context.repositories.projectDimensions.setAiKnowledgeSources(
+        "project:registry",
+        sources,
+      );
+
+      await expect(
+        context.repositories.projectDimensions.getAiKnowledgeSources(
+          "project:registry",
+        ),
+      ).resolves.toEqual(sources);
+
+      await context.repositories.projectDimensions.updateOperatingContext(
+        "project:registry",
+        "Crew brief refreshed today.",
+      );
+      await context.repositories.projectDimensions.setSynthesisMetadata(
+        "project:registry",
+        {
+          synthesizedAt: "2026-05-04T08:30:00.000Z",
+          inputHash: "hash:input",
+        },
+      );
+
+      const [row] = await context.db
+        .select()
+        .from(projectDimensions)
+        .where(eq(projectDimensions.projectId, "project:registry"));
+
+      expect(row?.aiOperatingContext).toBe("Crew brief refreshed today.");
+      expect(row?.aiOptimizedInputHash).toBe("hash:input");
+      expect(row?.aiOptimizedSynthesizedAt?.toISOString()).toBe(
+        "2026-05-04T08:30:00.000Z",
+      );
+
+      await context.repositories.projectDimensions.setSynthesisMetadata(
+        "project:registry",
+        {
+          synthesizedAt: null,
+          inputHash: null,
+        },
+      );
+
+      const [clearedRow] = await context.db
+        .select()
+        .from(projectDimensions)
+        .where(eq(projectDimensions.projectId, "project:registry"));
+      expect(clearedRow?.aiOptimizedSynthesizedAt).toBeNull();
+      expect(clearedRow?.aiOptimizedInputHash).toBeNull();
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("rejects malformed source arrays via zod", async () => {
+    const context = await createTestStage1Context();
+
+    try {
+      await context.repositories.projectDimensions.upsert({
+        projectId: "project:invalid",
+        projectName: "Invalid Project",
+        source: "salesforce",
+      });
+
+      await expect(
+        context.repositories.projectDimensions.setAiKnowledgeSources(
+          "project:invalid",
+          [
+            {
+              id: "not-a-uuid",
+              url: "not-a-url",
+            },
+          ] as unknown as readonly AiKnowledgeSource[],
+        ),
+      ).rejects.toBeInstanceOf(ZodError);
+    } finally {
+      await context.dispose();
+    }
+  });
+});
+
+describe("0054_ai_knowledge_source_registry migration", () => {
+  it("backfills active project URLs into ai_knowledge_sources without touching legacy fields", async () => {
+    const client = new PGlite();
+
+    try {
+      await applyMigrationsThrough(client, "0053_mailchimp_campaign_tail_state.sql");
+      await client.exec(`
+        insert into "project_dimensions" (
+          "project_id",
+          "project_name",
+          "project_alias",
+          "is_active",
+          "ai_knowledge_url",
+          "ai_knowledge_synced_at",
+          "source"
+        ) values
+          (
+            'project:alpha',
+            'Project Alpha',
+            'Alpha',
+            true,
+            'https://www.notion.so/Project-Training-3278a9129211804baa72c76a86d084d0',
+            '2026-05-01T12:00:00.000Z',
+            'salesforce'
+          ),
+          (
+            'project:beta',
+            'Project Beta',
+            'Beta',
+            false,
+            null,
+            null,
+            'salesforce'
+          );
+
+        insert into "ai_knowledge_entries" (
+          "id",
+          "scope",
+          "scope_key",
+          "source_provider",
+          "source_id",
+          "source_url",
+          "title",
+          "content",
+          "content_hash",
+          "metadata_json",
+          "source_last_edited_at",
+          "synced_at"
+        ) values (
+          'ai_knowledge:notion:project-alpha',
+          'project',
+          'project:alpha',
+          'notion',
+          '3278a912-9211-804b-aa72-c76a86d084d0',
+          'https://www.notion.so/Project-Training-3278a9129211804baa72c76a86d084d0',
+          null,
+          'Cached notion markdown',
+          'hash:legacy-cache',
+          '{}'::jsonb,
+          '2026-05-01T11:59:00.000Z',
+          '2026-05-01T12:00:00.000Z'
+        );
+      `);
+
+      await applySingleMigration(client, "0054_ai_knowledge_source_registry.sql");
+
+      const db = drizzle(client) as Stage1Database;
+      const [projectWithSource] = await db
+        .select()
+        .from(projectDimensions)
+        .where(eq(projectDimensions.projectId, "project:alpha"));
+      const [projectWithoutSource] = await db
+        .select()
+        .from(projectDimensions)
+        .where(eq(projectDimensions.projectId, "project:beta"));
+      const [legacyEntry] = await db
+        .select()
+        .from(aiKnowledgeEntries)
+        .where(
+          and(
+            eq(aiKnowledgeEntries.scope, "project"),
+            eq(aiKnowledgeEntries.scopeKey, "project:alpha"),
+          ),
+        );
+
+      const sources = aiKnowledgeSourcesSchema.parse(
+        projectWithSource?.aiKnowledgeSources ?? [],
+      );
+      expect(sources).toHaveLength(1);
+      expect(sources[0]).toMatchObject({
+        url: "https://www.notion.so/Project-Training-3278a9129211804baa72c76a86d084d0",
+        kind: "notion",
+        source_id: "3278a9129211804baa72c76a86d084d0",
+        last_synced_at: "2026-05-01T12:00:00.000Z",
+        last_sync_status: "healthy",
+        source_content_hash: "hash:legacy-cache",
+      });
+      expect(projectWithoutSource?.aiKnowledgeSources).toEqual([]);
+      expect(projectWithSource?.aiKnowledgeUrl).toBe(
+        "https://www.notion.so/Project-Training-3278a9129211804baa72c76a86d084d0",
+      );
+      expect(legacyEntry?.contentHash).toBe("hash:legacy-cache");
+    } finally {
+      await client.close();
+    }
+  });
+});

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -1,4 +1,5 @@
 import type {
+  AiKnowledgeSource,
   AiKnowledgeEntryRecord,
   AuditEvidenceRecord,
   CanonicalEventRecord,
@@ -259,6 +260,21 @@ export interface ProjectDimensionRepository {
   listByIds(
     projectIds: readonly string[],
   ): Promise<readonly ProjectDimensionRecord[]>;
+  getAiKnowledgeSources(
+    projectId: string,
+  ): Promise<readonly AiKnowledgeSource[]>;
+  setAiKnowledgeSources(
+    projectId: string,
+    sources: readonly AiKnowledgeSource[],
+  ): Promise<void>;
+  updateOperatingContext(projectId: string, context: string): Promise<void>;
+  setSynthesisMetadata(
+    projectId: string,
+    input: {
+      readonly synthesizedAt: string | null;
+      readonly inputHash: string | null;
+    },
+  ): Promise<void>;
   upsert(record: ProjectDimensionRecord): Promise<ProjectDimensionRecord>;
 }
 

--- a/packages/domain/test/normalization.test.ts
+++ b/packages/domain/test/normalization.test.ts
@@ -500,6 +500,10 @@ function buildContext(input: {
       listAll: () => Promise.resolve([]),
       listActive: () => Promise.resolve([]),
       listByIds: () => Promise.resolve([]),
+      getAiKnowledgeSources: () => Promise.resolve([]),
+      setAiKnowledgeSources: () => Promise.resolve(),
+      updateOperatingContext: () => Promise.resolve(),
+      setSynthesisMetadata: () => Promise.resolve(),
       upsert: (record: ProjectDimensionRecord) => {
         input.onProjectDimensionUpsert?.(record);
         return Promise.resolve(record);

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -110,6 +110,10 @@ describe("defineStage1RepositoryBundle", () => {
         listAll: () => Promise.resolve([]),
         listActive: () => Promise.resolve([]),
         listByIds: () => Promise.resolve([]),
+        getAiKnowledgeSources: () => Promise.resolve([]),
+        setAiKnowledgeSources: () => Promise.resolve(),
+        updateOperatingContext: () => Promise.resolve(),
+        setSynthesisMetadata: () => Promise.resolve(),
         upsert: (record) => Promise.resolve(record),
       },
       expeditionDimensions: {

--- a/packages/domain/test/stage3-last-inbound-alias.test.ts
+++ b/packages/domain/test/stage3-last-inbound-alias.test.ts
@@ -129,6 +129,10 @@ function buildRepositoryBundle(input: {
       listAll: () => Promise.resolve([]),
       listActive: () => Promise.resolve([]),
       listByIds: () => Promise.resolve([]),
+      getAiKnowledgeSources: () => Promise.resolve([]),
+      setAiKnowledgeSources: () => Promise.resolve(),
+      updateOperatingContext: () => Promise.resolve(),
+      setSynthesisMetadata: () => Promise.resolve(),
       upsert: (record) => Promise.resolve(record),
     },
     expeditionDimensions: {

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -206,6 +206,10 @@ function createRepositoryBundle(input: {
       listAll: () => Promise.resolve([]),
       listActive: () => Promise.resolve([]),
       listByIds: () => Promise.resolve([]),
+      getAiKnowledgeSources: () => Promise.resolve([]),
+      setAiKnowledgeSources: () => Promise.resolve(),
+      updateOperatingContext: () => Promise.resolve(),
+      setSynthesisMetadata: () => Promise.resolve(),
       upsert: (record) => Promise.resolve(record),
     },
     expeditionDimensions: {


### PR DESCRIPTION
## Summary

- Adds new schema columns on `project_dimensions`: `ai_knowledge_sources` (JSONB), `ai_operating_context` (text), `ai_optimized_synthesized_at` (timestamptz), `ai_optimized_input_hash` (text)
- Adds `@as-comms/contracts` Zod schemas + `@as-comms/db` pure data module for source registry manipulation (URL parsing, kind detection, immutable list edits, sync-result stamping, input hashing)
- Migration `0054` backfills the 4 active projects' single-Notion-URL setup into one-entry registry arrays each; inactive projects get the empty-array default

## Scope

This is **PR-A of [PRD #366](https://github.com/nico-kneler-as/as-comms-platform/issues/366)** — Phase 1 of the multi-source AI Knowledge architecture rebuild. PR-A is the foundational data layer; PR-B (synthesis worker) and PR-C (wizard + project detail UI + server actions) follow.

## Migration semantics

**Purely additive.** The legacy `ai_knowledge_url` and `ai_knowledge_synced_at` columns are untouched, the existing `notion-knowledge-sync` worker is unchanged, and runtime AI Draft behavior is identical before and after this merge. The new schema sits alongside the old until PR-B and PR-C cut over.

After this migrates to prod, the four active projects will have:
- Whitebark Pine (`a0tVK00000BV3GDYA1`) — one `notion` source entry
- Killer Whales (`a0tVK00000EG0jyYAD`) — one `notion` source entry
- PNW Biodiversity (`a0tVK00000AeJqzYAF`) — one `notion` source entry
- Beech & Butternut (`a0tVK00001QqBuPYAV`) — one `notion` source entry

Each entry's `source_id` is extracted from the existing URL, `last_synced_at` carries forward the existing `ai_knowledge_synced_at`, `last_sync_status` is `'healthy'`, and `source_content_hash` is copied from the matching `ai_knowledge_entries` cache row.

## Test plan

- [x] `pnpm typecheck` clean across all workspaces
- [x] `pnpm lint` clean across all workspaces
- [x] `pnpm --filter @as-comms/contracts test:unit` passes (Zod parser tests for the new schema)
- [x] `pnpm --filter @as-comms/db test:unit` passes (pure-helper unit tests + repository round-trip + end-to-end PGlite migration test)
- [ ] CI green

## No UX or runtime changes

The AI Draft button continues to use the existing single-URL flow. Operators can't see the new schema yet (no UI). PR-C will add that surface.

## Out of scope

- PR-B: source fetcher interface + Notion/web/inline impls, synthesis worker job
- PR-C: wizard step redesign + project detail UI + server actions for source CRUD
- Phase 2 (auto-sync) and Phase 3 (capture loop) — separate briefs after Phase 1 ships