### PR TITLE
fix(ops): reconcile-stale-canonical skips already-resolved keys at SQL layer

### DIFF
--- a/apps/worker/src/ops/reconcile-stale-canonical.ts
+++ b/apps/worker/src/ops/reconcile-stale-canonical.ts
@@ -106,14 +106,26 @@ export function buildLoadQuarantineSql(input: {
   // collision set, we replay the most recent loser — earlier losers either had
   // an identical checksum (already represented) or were superseded by the
   // newer one upstream in SF.
-  return `SELECT DISTINCT ON (idempotency_key)
-  idempotency_key,
-  provider,
-  attempted_at,
-  details_jsonb
-FROM source_evidence_quarantine
-WHERE ${where}
-ORDER BY idempotency_key, attempted_at DESC${limitClause}`;
+  //
+  // The NOT EXISTS clause skips keys whose most-recent loser has already been
+  // propagated forward — i.e. there's a `superseded_canonical` audit row at
+  // or after that loser's attempted_at. Without this, every re-run wastes
+  // budget churning through already-done keys as duplicates.
+  return `SELECT DISTINCT ON (q.idempotency_key)
+  q.idempotency_key,
+  q.provider,
+  q.attempted_at,
+  q.details_jsonb
+FROM source_evidence_quarantine q
+WHERE ${where.replaceAll("provider =", "q.provider =").replaceAll("idempotency_key LIKE", "q.idempotency_key LIKE").replaceAll("reason =", "q.reason =")}
+  AND NOT EXISTS (
+    SELECT 1
+    FROM source_evidence_quarantine resolved
+    WHERE resolved.idempotency_key = q.idempotency_key
+      AND resolved.reason = 'superseded_canonical'
+      AND resolved.attempted_at >= q.attempted_at
+  )
+ORDER BY q.idempotency_key, q.attempted_at DESC${limitClause}`;
 }
 
 export async function loadReconcileTargets(input: {

--- a/apps/worker/test/reconcile-stale-canonical.test.ts
+++ b/apps/worker/test/reconcile-stale-canonical.test.ts
@@ -85,20 +85,31 @@ describe("reconcile-stale-canonical", () => {
         recordType: null,
         limit: null,
       });
-      expect(sqlAll).toContain("reason = 'checksum_mismatch'");
-      expect(sqlAll).not.toContain("provider =");
-      expect(sqlAll).not.toContain("LIKE");
+      expect(sqlAll).toContain("q.reason = 'checksum_mismatch'");
+      expect(sqlAll).not.toContain("q.provider =");
+      expect(sqlAll).not.toContain("idempotency_key LIKE");
 
       const sqlScoped = buildLoadQuarantineSql({
         provider: "salesforce",
         recordType: "lifecycle_milestone",
         limit: 250,
       });
-      expect(sqlScoped).toContain("provider = 'salesforce'");
+      expect(sqlScoped).toContain("q.provider = 'salesforce'");
       expect(sqlScoped).toContain(
-        "idempotency_key LIKE 'source-evidence:%:lifecycle_milestone:%'",
+        "q.idempotency_key LIKE 'source-evidence:%:lifecycle_milestone:%'",
       );
       expect(sqlScoped).toContain("LIMIT 250");
+    });
+
+    it("skips keys already propagated forward via a superseded_canonical row", () => {
+      const sql = buildLoadQuarantineSql({
+        provider: null,
+        recordType: null,
+        limit: null,
+      });
+      expect(sql).toContain("NOT EXISTS");
+      expect(sql).toContain("resolved.reason = 'superseded_canonical'");
+      expect(sql).toContain("resolved.attempted_at >= q.attempted_at");
     });
 
     it("escapes single quotes in filters", () => {
@@ -107,7 +118,7 @@ describe("reconcile-stale-canonical", () => {
         recordType: null,
         limit: null,
       });
-      expect(sql).toContain("provider = 'sales''force'");
+      expect(sql).toContain("q.provider = 'sales''force'");
     });
   });
 


### PR DESCRIPTION
## Summary

Operational follow-up after the lifecycle_milestone (53 keys) and task_communication (3,273 keys) drains landed today. Without this filter, every re-run of `reconcile-stale-canonical` revisits keys that already have a `superseded_canonical` row from a prior pass — wasting the foreground budget on duplicate-skip checks instead of net-new supersede work.

The fix: add a \`NOT EXISTS\` subquery to \`buildLoadQuarantineSql\` that filters out keys whose latest \`checksum_mismatch\` loser has already been propagated forward (i.e. there's a \`superseded_canonical\` row at or after the loser's \`attempted_at\`).

## Why this matters operationally

Today's task_communication drain (3,273 keys) had to be split across multiple 400-key chunks because the harness foreground budget caps at 10 minutes. Without this filter, the second chunk would have started by re-checking all 446 already-done keys (~5 min of duplicate-skip churn) before doing any net-new work — leaving only ~5 min of budget for actual supersede progress. With the filter, each chunk does exactly N net-new keys.

Final task_communication drain results:
\`\`\`
superseded: 3273
duplicate: 0
conflict: 0
invalid: 0
errors: 0
\`\`\`

## Tests

- New unit case in \`buildLoadQuarantineSql\` test asserts the SQL contains the \`NOT EXISTS\` clause + the correct \`resolved.attempted_at >= q.attempted_at\` comparison.
- Existing \`applyReconcileTarget\` "re-applying same target after supersede returns duplicate" test still passes (it re-uses the target object directly, doesn't re-call \`loadReconcileTargets\`).
- All 156 worker unit tests pass.

## Scope

Pure operational ergonomics. No schema change, no behavioral change for first-run cases (a key with no \`superseded_canonical\` row gets returned exactly as before). Only affects re-runs.

## Test plan

- [x] \`pnpm --filter @as-comms/worker typecheck\` — clean
- [x] \`pnpm --filter @as-comms/worker lint\` — clean
- [x] \`pnpm --filter @as-comms/worker run test:unit\` — 44 files / 156 tests pass
- [x] Verified end-to-end against production: 6 × 400-key chunks + 1 × 422-key tail successfully drained the task_communication backlog with zero waste
- [ ] CI green
- [ ] Architect review

🤖 Generated with [Claude Code](https://claude.com/claude-code)