### PR TITLE
fix(mailchimp): coerce empty subject_line/etc to null in capture parse

### DIFF
--- a/packages/integrations/src/capture-services/mailchimp.ts
+++ b/packages/integrations/src/capture-services/mailchimp.ts
@@ -48,7 +48,16 @@ const MAILCHIMP_SENT_SNIPPET_MAX = 8_000
 const mailchimpCaptureServiceResponseSchema =
   createCapturedBatchResponseSchema(mailchimpRecordSchema)
 const jsonObjectSchema = z.record(z.string(), z.unknown())
-const nullableStringSchema = z.string().min(1).nullable()
+
+// Mailchimp's Marketing API returns empty strings (not null) for optional
+// campaign fields like subject_line, preview_text, send_time when they're
+// unset (e.g., test campaigns or auto-generated emails). A strict
+// `z.string().min(1).nullable()` rejects these and 400s the entire batch
+// (observed 2026-05-09: one campaign with subject_line="" stalled the
+// scheduler for 24+ hours). Coerce empty strings to null at parse time.
+const nullableStringSchema = z
+  .union([z.string(), z.null()])
+  .transform((value) => (value !== null && value.length > 0 ? value : null))
 
 const mailchimpCaptureServiceConfigSchema = z.object({
   bearerToken: z.string().min(1),


### PR DESCRIPTION
Mailchimp's Marketing API emits empty strings (not null) for optional fields like `subject_line`, `preview_text`, `send_time` when unset. Capture service rejected those with a strict `z.string().min(1).nullable()` and 400'd the entire transition batch.

**Production effect (observed 2026-05-09):** one campaign in the discovery window had `subject_line=""`. Scheduler 400'd hourly for 24h+, Mailchimp tile showed 'Sync stale', no new campaign events landed in volunteer timelines after 2026-05-08 14:00 UTC.

**Fix:** redefine the file-local `nullableStringSchema` as a lenient parser that accepts `string|null` and transforms `""` → `null`. Downstream code already uses `normalizeOptionalString` for nulls; just stop rejecting at the parse boundary.

After deploy, the next scheduler tick should succeed and the Mailchimp card should flip back to 'Healthy'.