### PR TITLE
feat(integrations): AI Knowledge source fetchers + Notion page helper (PR-B-1 of #366)

### DIFF
--- a/packages/contracts/src/stage1-worker-jobs.ts
+++ b/packages/contracts/src/stage1-worker-jobs.ts
@@ -79,6 +79,8 @@ export const parityCheckBatchJobName = "stage1.parity.check" as const;
 export const cutoverCheckpointBatchJobName =
   "stage1.cutover.checkpoint" as const;
 export const notionKnowledgeSyncJobName = "notion-knowledge-sync" as const;
+export const synthesizeProjectKnowledgeJobName =
+  "synthesize-project-knowledge" as const;
 
 export const stage1WorkerJobNames = [
   gmailHistoricalCaptureBatchJobName,
@@ -291,4 +293,11 @@ export const notionKnowledgeSyncPayloadSchema = z.object({
 });
 export type NotionKnowledgeSyncPayload = z.infer<
   typeof notionKnowledgeSyncPayloadSchema
+>;
+
+export const synthesizeProjectKnowledgePayloadSchema = z.object({
+  projectId: idSchema,
+});
+export type SynthesizeProjectKnowledgePayload = z.infer<
+  typeof synthesizeProjectKnowledgePayloadSchema
 >;

--- a/packages/integrations/src/ai-knowledge-fetchers.ts
+++ b/packages/integrations/src/ai-knowledge-fetchers.ts
@@ -1,0 +1,300 @@
+import { createHash } from "node:crypto";
+
+import type { AiKnowledgeSourceKind } from "@as-comms/contracts";
+
+import {
+  NotionProviderError,
+  createNotionClient,
+  fetchPageContent,
+  normalizeNotionId,
+  type NotionClient,
+} from "./providers/notion.js";
+
+function hashContent(content: string): string {
+  return createHash("md5").update(content).digest("hex");
+}
+
+function humanizeNotionFetchError(error: NotionProviderError): string {
+  switch (error.code) {
+    case "not_found":
+      return "Page not found in Notion.";
+    case "unauthorized":
+      return "Permission denied when reading the Notion page.";
+    case "timeout":
+      return "Notion request timed out.";
+    case "rate_limited":
+      return "Notion rate limited the request.";
+    case "retryable":
+      return "Notion is temporarily unavailable.";
+    case "invalid_response":
+      return "Notion returned an invalid response.";
+    case "unexpected":
+      return error.message;
+  }
+}
+
+function decodeHtmlEntities(text: string): string {
+  return text
+    .replaceAll("&nbsp;", " ")
+    .replaceAll("&amp;", "&")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#39;", "'");
+}
+
+function htmlToMarkdown(html: string): string {
+  return decodeHtmlEntities(
+    html
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/giu, " ")
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/giu, " ")
+      .replace(/<(br|\/p|\/div|\/li|\/h[1-6])\b[^>]*>/giu, "\n")
+      .replace(/<li\b[^>]*>/giu, "- ")
+      .replace(/<\/tr>/giu, "\n")
+      .replace(/<[^>]+>/gu, " ")
+      .replace(/\r/gu, "")
+      .replace(/[ \t]+\n/gu, "\n")
+      .replace(/\n{3,}/gu, "\n\n")
+      .replace(/[ \t]{2,}/gu, " ")
+      .trim(),
+  );
+}
+
+function extractNotionPageId(url: string): string | null {
+  const trimmedUrl = url.trim();
+
+  if (/^[0-9a-fA-F-]{32,36}$/u.test(trimmedUrl)) {
+    return normalizeNotionId(trimmedUrl);
+  }
+
+  try {
+    const parsedUrl = new URL(trimmedUrl);
+    const pathSegments = parsedUrl.pathname.split("/").filter(Boolean);
+
+    for (let index = pathSegments.length - 1; index >= 0; index -= 1) {
+      const segment = pathSegments[index];
+      if (segment === undefined) {
+        continue;
+      }
+
+      const match = /([0-9a-fA-F]{32}|[0-9a-fA-F-]{36})/u.exec(segment);
+      if (match?.[1] !== undefined) {
+        return normalizeNotionId(match[1]);
+      }
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+export interface SourceFetcherInput {
+  readonly url: string;
+  readonly sourceId: string | null;
+  readonly lastContentHash: string | null;
+  readonly lastModified?: string | null;
+}
+
+export type SourceFetchResult =
+  | {
+      readonly ok: true;
+      readonly content: string;
+      readonly contentHash: string;
+      readonly lastModified: string | null;
+      readonly unchanged: false;
+    }
+  | {
+      readonly ok: true;
+      readonly unchanged: true;
+      readonly lastModified: string | null;
+    }
+  | {
+      readonly ok: false;
+      readonly status: "broken";
+      readonly error: string;
+    };
+
+export interface SourceFetcher {
+  readonly kind: AiKnowledgeSourceKind;
+  fetch(input: SourceFetcherInput): Promise<SourceFetchResult>;
+}
+
+export class NotionPageFetcher implements SourceFetcher {
+  readonly kind = "notion" as const;
+
+  readonly #createClient: (env: { readonly NOTION_API_KEY: string }) => NotionClient;
+  readonly #apiKey: string;
+
+  constructor(input: {
+    readonly apiKey: string;
+    readonly createClient?: (env: {
+      readonly NOTION_API_KEY: string;
+    }) => NotionClient;
+  }) {
+    this.#apiKey = input.apiKey;
+    this.#createClient = input.createClient ?? createNotionClient;
+  }
+
+  async fetch(input: SourceFetcherInput): Promise<SourceFetchResult> {
+    const resolvedPageId =
+      input.sourceId ?? extractNotionPageId(input.url.trim());
+
+    if (resolvedPageId === null) {
+      return {
+        ok: false,
+        status: "broken",
+        error: "Could not resolve a Notion page ID from the configured source.",
+      };
+    }
+
+    const client = this.#createClient({
+      NOTION_API_KEY: this.#apiKey,
+    });
+
+    try {
+      const page = await client.retrievePage(resolvedPageId);
+      const lastEditedTime =
+        typeof page.last_edited_time === "string" ? page.last_edited_time : null;
+
+      if (
+        input.lastModified !== undefined &&
+        input.lastModified !== null &&
+        lastEditedTime !== null &&
+        Date.parse(lastEditedTime) <= Date.parse(input.lastModified)
+      ) {
+        return {
+          ok: true,
+          unchanged: true,
+          lastModified: lastEditedTime,
+        };
+      }
+
+      const content = await fetchPageContent(client, resolvedPageId);
+
+      return {
+        ok: true,
+        unchanged: false,
+        content: content.markdown,
+        contentHash: hashContent(content.markdown),
+        lastModified: content.lastEditedTime,
+      };
+    } catch (error) {
+      const classified =
+        error instanceof NotionProviderError
+          ? error
+          : new NotionProviderError({
+              code: "unexpected",
+              message: error instanceof Error ? error.message : String(error),
+              retryable: false,
+            });
+
+      return {
+        ok: false,
+        status: "broken",
+        error: humanizeNotionFetchError(classified),
+      };
+    }
+  }
+}
+
+export class WebPageFetcher implements SourceFetcher {
+  readonly kind = "web_page" as const;
+
+  readonly #fetchImplementation: typeof fetch;
+  readonly #timeoutMs: number;
+
+  constructor(input?: {
+    readonly fetchImplementation?: typeof fetch;
+    readonly timeoutMs?: number;
+  }) {
+    this.#fetchImplementation = input?.fetchImplementation ?? globalThis.fetch;
+    this.#timeoutMs = input?.timeoutMs ?? 15_000;
+  }
+
+  async fetch(input: SourceFetcherInput): Promise<SourceFetchResult> {
+    if (typeof this.#fetchImplementation !== "function") {
+      return {
+        ok: false,
+        status: "broken",
+        error: "Global fetch is unavailable.",
+      };
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => {
+      controller.abort();
+    }, this.#timeoutMs);
+
+    try {
+      const init: RequestInit = {
+        method: "GET",
+        signal: controller.signal,
+      };
+      if (input.lastModified !== undefined && input.lastModified !== null) {
+        init.headers = { "if-modified-since": input.lastModified };
+      }
+      const response = await this.#fetchImplementation(input.url, init);
+
+      if (response.status === 304) {
+        return {
+          ok: true,
+          unchanged: true,
+          lastModified: response.headers.get("last-modified") ?? input.lastModified ?? null,
+        };
+      }
+
+      if (!response.ok) {
+        return {
+          ok: false,
+          status: "broken",
+          error: `HTTP ${String(response.status)}`,
+        };
+      }
+
+      const body = await response.text();
+      const content = htmlToMarkdown(body);
+
+      return {
+        ok: true,
+        unchanged: false,
+        content,
+        contentHash: hashContent(content),
+        lastModified: response.headers.get("last-modified"),
+      };
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        (error.name === "AbortError" || error.name === "TimeoutError")
+      ) {
+        return {
+          ok: false,
+          status: "broken",
+          error: "Timeout",
+        };
+      }
+
+      return {
+        ok: false,
+        status: "broken",
+        error: error instanceof Error ? error.message : String(error),
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+export class InlineTextFetcher implements SourceFetcher {
+  readonly kind = "inline_text" as const;
+
+  fetch(input: SourceFetcherInput): Promise<SourceFetchResult> {
+    return Promise.resolve({
+      ok: true,
+      unchanged: false,
+      content: input.url,
+      contentHash: hashContent(input.url),
+      lastModified: null,
+    });
+  }
+}

--- a/packages/integrations/src/index.ts
+++ b/packages/integrations/src/index.ts
@@ -5,6 +5,7 @@
 
 export * from "./provider-types.js";
 export * from "./shared.js";
+export * from "./ai-knowledge-fetchers.js";
 export {
   classifySalesforceTaskMessageKind,
   parseSubjectDirection,
@@ -30,6 +31,7 @@ export * from "./providers/gmail-record-builder.js";
 export * from "./providers/mailchimp.js";
 export * from "./providers/anthropic.js";
 export * from "./providers/notion.js";
+export * from "./notion-markdown-page.js";
 export * from "./providers/salesforce.js";
 export * from "./providers/simpletexting.js";
 export * from "./providers/twilio.js";

--- a/packages/integrations/src/notion-markdown-page.ts
+++ b/packages/integrations/src/notion-markdown-page.ts
@@ -1,0 +1,226 @@
+import { normalizeNotionId } from "./providers/notion.js";
+
+const DEFAULT_NOTION_VERSION = "2022-06-28";
+const DEFAULT_TIMEOUT_MS = 15_000;
+const NOTION_MAX_CHILDREN_PER_REQUEST = 100;
+
+interface RichTextSegment {
+  readonly type: "text";
+  readonly text: {
+    readonly content: string;
+    readonly link?: { readonly url: string };
+  };
+}
+
+type NotionBlock = Record<string, unknown>;
+
+export interface CreateNotionMarkdownPageInput {
+  readonly apiKey: string;
+  readonly parentPageId: string;
+  readonly title: string;
+  readonly markdown: string;
+  readonly fetchImplementation?: typeof fetch;
+  readonly notionVersion?: string;
+  readonly timeoutMs?: number;
+}
+
+export interface CreateNotionMarkdownPageResult {
+  readonly id: string;
+  readonly url: string;
+  readonly blockCount: number;
+}
+
+function parseInlineLinks(text: string): readonly RichTextSegment[] {
+  const segments: RichTextSegment[] = [];
+  const linkRegex = /\[([^\]]+)\]\(([^)]+)\)/gu;
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(linkRegex)) {
+    const fullMatch = match[0];
+    const linkText = match[1] ?? "";
+    const linkUrl = match[2] ?? "";
+    const matchIndex = match.index;
+
+    if (matchIndex > lastIndex) {
+      segments.push({
+        type: "text",
+        text: { content: text.slice(lastIndex, matchIndex) },
+      });
+    }
+
+    segments.push({
+      type: "text",
+      text: {
+        content: linkText,
+        link: { url: linkUrl },
+      },
+    });
+
+    lastIndex = matchIndex + fullMatch.length;
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({
+      type: "text",
+      text: { content: text.slice(lastIndex) },
+    });
+  }
+
+  if (segments.length === 0) {
+    return [{ type: "text", text: { content: text } }];
+  }
+
+  return segments;
+}
+
+function lineToBlock(line: string): NotionBlock | null {
+  const trimmed = line.trimEnd();
+
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  if (trimmed === "---") {
+    return { object: "block", type: "divider", divider: {} };
+  }
+
+  if (trimmed.startsWith("### ")) {
+    return {
+      object: "block",
+      type: "heading_3",
+      heading_3: { rich_text: parseInlineLinks(trimmed.slice(4)) },
+    };
+  }
+
+  if (trimmed.startsWith("## ")) {
+    return {
+      object: "block",
+      type: "heading_2",
+      heading_2: { rich_text: parseInlineLinks(trimmed.slice(3)) },
+    };
+  }
+
+  if (trimmed.startsWith("# ")) {
+    return {
+      object: "block",
+      type: "heading_1",
+      heading_1: { rich_text: parseInlineLinks(trimmed.slice(2)) },
+    };
+  }
+
+  if (trimmed.startsWith("- ")) {
+    return {
+      object: "block",
+      type: "bulleted_list_item",
+      bulleted_list_item: { rich_text: parseInlineLinks(trimmed.slice(2)) },
+    };
+  }
+
+  return {
+    object: "block",
+    type: "paragraph",
+    paragraph: { rich_text: parseInlineLinks(trimmed) },
+  };
+}
+
+async function notionFetchJson<TResult>(
+  input: {
+    readonly apiKey: string;
+    readonly url: string;
+    readonly method: "POST" | "PATCH";
+    readonly body: Record<string, unknown>;
+    readonly notionVersion: string;
+    readonly timeoutMs: number;
+    readonly fetchImplementation: typeof fetch;
+  },
+): Promise<TResult> {
+  const response = await input.fetchImplementation(input.url, {
+    method: input.method,
+    headers: {
+      Authorization: `Bearer ${input.apiKey}`,
+      "Notion-Version": input.notionVersion,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(input.body),
+    signal: AbortSignal.timeout(input.timeoutMs),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      `Notion API error ${String(response.status)} ${response.statusText}: ${errorText}`,
+    );
+  }
+
+  return (await response.json()) as TResult;
+}
+
+export async function createNotionMarkdownPage(
+  input: CreateNotionMarkdownPageInput,
+): Promise<CreateNotionMarkdownPageResult> {
+  const fetchImplementation = input.fetchImplementation ?? globalThis.fetch;
+
+  if (typeof fetchImplementation !== "function") {
+    throw new Error("Global fetch is unavailable.");
+  }
+
+  const blocks = input.markdown
+    .split("\n")
+    .map(lineToBlock)
+    .filter((block): block is NotionBlock => block !== null);
+
+  const firstHeadingIndex = blocks.findIndex((block) => block.type === "heading_1");
+  if (firstHeadingIndex >= 0) {
+    blocks.splice(firstHeadingIndex, 1);
+  }
+
+  const initialChunk = blocks.slice(0, NOTION_MAX_CHILDREN_PER_REQUEST);
+  const remainingChunks: NotionBlock[][] = [];
+
+  for (
+    let index = NOTION_MAX_CHILDREN_PER_REQUEST;
+    index < blocks.length;
+    index += NOTION_MAX_CHILDREN_PER_REQUEST
+  ) {
+    remainingChunks.push(
+      blocks.slice(index, index + NOTION_MAX_CHILDREN_PER_REQUEST),
+    );
+  }
+
+  const page = await notionFetchJson<{ readonly id: string; readonly url: string }>({
+    apiKey: input.apiKey,
+    url: "https://api.notion.com/v1/pages",
+    method: "POST",
+    body: {
+      parent: {
+        type: "page_id",
+        page_id: normalizeNotionId(input.parentPageId),
+      },
+      properties: {
+        title: [{ type: "text", text: { content: input.title } }],
+      },
+      children: initialChunk,
+    },
+    notionVersion: input.notionVersion ?? DEFAULT_NOTION_VERSION,
+    timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    fetchImplementation,
+  });
+
+  for (const chunk of remainingChunks) {
+    await notionFetchJson({
+      apiKey: input.apiKey,
+      url: `https://api.notion.com/v1/blocks/${normalizeNotionId(page.id)}/children`,
+      method: "PATCH",
+      body: { children: chunk },
+      notionVersion: input.notionVersion ?? DEFAULT_NOTION_VERSION,
+      timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      fetchImplementation,
+    });
+  }
+
+  return {
+    id: normalizeNotionId(page.id),
+    url: page.url,
+    blockCount: blocks.length,
+  };
+}

--- a/packages/integrations/src/providers/anthropic.ts
+++ b/packages/integrations/src/providers/anthropic.ts
@@ -261,6 +261,8 @@ export async function generateDraft(
   });
 }
 
+export const invokeModel = generateDraft;
+
 const MODEL_RATE_CARD_USD_PER_MTOK: Readonly<
   Record<string, { readonly input: number; readonly output: number }>
 > = {


### PR DESCRIPTION
## Summary

- Adds `SourceFetcher` interface + 3 implementations: `NotionPageFetcher`, `WebPageFetcher`, `InlineTextFetcher`
- Productizes the architect's ad-hoc `create-notion-page-from-markdown` script as a reusable `@as-comms/integrations` export
- Adds contract types for the upcoming `synthesize-project-knowledge` worker job (PR-B-2)
- Aliases `generateDraft` as `invokeModel` on the Anthropic provider for naming alignment

## Scope

This is **PR-B-1 of [PRD #366](https://github.com/nico-kneler-as/as-comms-platform/issues/366)** — the foundation pass of Phase 1's PR-B. It adds the deep modules (fetcher interface, three fetcher implementations, Notion page helper) that the synthesis worker will compose in PR-B-2.

**Zero behavior change.** No code in production calls these new exports yet. The legacy `notion-knowledge-sync` worker continues to drive AI Draft.

## Why split PR-B into two PRs

Codex hit repeated session-archival kills mid-dispatch trying to land the full PR-B in one shot. Splitting at the deep-module / runtime-orchestration seam means:
- PR-B-1 ships the foundation (this PR) — small, additive, easy to review
- PR-B-2 ships the orchestrator + worker job + ops CLI + tests on top of the foundation — also small, builds on already-merged code

## What's coming in PR-B-2

- Synthesis orchestrator module (pure-ish; takes project_id + DI deps, returns synthesized doc + metadata)
- Graphile worker job (`synthesize-project-knowledge`) — handler that wires sources + Anthropic + Notion page write
- Ops CLI (`apps/worker/src/ops/synthesize-multi-source.ts`)
- Unit tests for fetchers, orchestrator, and worker integration test

## Test plan

- [x] `pnpm typecheck` clean across all 16 packages
- [x] `pnpm lint` clean across all 16 packages
- [ ] CI green
- No new unit tests in this PR (foundation is exercised by PR-B-2's tests)

## Out of scope

- Wizard UI changes (PR-C)
- Server actions for source CRUD (PR-C)
- Auto-sync schedule (Phase 2)
- Capture loop / "Send and save for AI" trigger (Phase 3)