### PR TITLE
feat(worker): synthesis orchestrator + worker job + ops CLI (PR-B-2 of #366)

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -30,6 +30,7 @@
     "ops:migrate-notion-child-dbs-to-project-knowledge": "tsx src/ops/migrate-notion-child-dbs-to-project-knowledge.ts",
     "ops:dump-notion-page": "tsx src/ops/dump-notion-page.ts",
     "ops:create-notion-page-from-markdown": "tsx src/ops/create-notion-page-from-markdown.ts",
+    "ops:synthesize-multi-source": "tsx src/ops/synthesize-multi-source.ts",
     "ops:synthesize-project-knowledge": "tsx src/ops/synthesize-project-knowledge.ts",
     "ops:enqueue": "tsx src/ops/cli.ts enqueue",
     "ops:import-gmail-mbox": "tsx src/ops/cli.ts import-gmail-mbox",

--- a/apps/worker/src/jobs/synthesize-project-knowledge/index.ts
+++ b/apps/worker/src/jobs/synthesize-project-knowledge/index.ts
@@ -1,0 +1,234 @@
+import type { Task } from "graphile-worker";
+
+import {
+  synthesizeProjectKnowledgeJobName,
+  synthesizeProjectKnowledgePayloadSchema,
+  type ProjectDimensionRecord,
+  type SynthesizeProjectKnowledgePayload,
+} from "@as-comms/contracts";
+import type {
+  ProjectDimensionRepository,
+  SettingsProjectsRepository,
+} from "@as-comms/domain";
+import {
+  createNotionMarkdownPage,
+  createNotionClient,
+  normalizeNotionId,
+  type CreateNotionMarkdownPageResult,
+  type NotionClient,
+} from "@as-comms/integrations";
+
+import {
+  synthesizeProjectKnowledgeOrchestrator,
+  type SynthesizeProjectKnowledgeOrchestratorDependencies,
+} from "./orchestrator.js";
+
+const DEFAULT_SYNTHESIZED_PAGE_ROOT_ID = "3278a912921180598688fce711ab0509";
+
+function readRecord(
+  value: unknown,
+): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function extractNotionPageId(url: string | null): string | null {
+  if (url === null) {
+    return null;
+  }
+
+  const match =
+    /([0-9a-f]{32}|[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12})/iu.exec(url);
+
+  if (match?.[1] === undefined) {
+    return null;
+  }
+
+  try {
+    return normalizeNotionId(match[1]);
+  } catch {
+    return null;
+  }
+}
+
+async function resolveNotionParentPageId(input: {
+  readonly apiKey: string;
+  readonly createClient: (env: { readonly NOTION_API_KEY: string }) => NotionClient;
+  readonly fallbackParentPageId: string;
+  readonly logger: Pick<Console, "warn">;
+  readonly project: ProjectDimensionRecord;
+}): Promise<string> {
+  const currentPageId = extractNotionPageId(input.project.aiKnowledgeUrl ?? null);
+
+  if (currentPageId === null) {
+    return input.fallbackParentPageId;
+  }
+
+  try {
+    const client = input.createClient({
+      NOTION_API_KEY: input.apiKey,
+    });
+    const page = await client.retrievePage(currentPageId);
+    const parent = readRecord(page.parent);
+    const parentType = typeof parent?.type === "string" ? parent.type : null;
+    const parentPageId =
+      parentType === "page_id" && typeof parent?.page_id === "string"
+        ? normalizeNotionId(parent.page_id)
+        : null;
+
+    return parentPageId ?? input.fallbackParentPageId;
+  } catch (error) {
+    input.logger.warn(
+      `Falling back to default Notion parent for ${input.project.projectId}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return input.fallbackParentPageId;
+  }
+}
+
+export interface SynthesizeProjectKnowledgeDependencies
+  extends SynthesizeProjectKnowledgeOrchestratorDependencies {
+  readonly notion: {
+    readonly apiKey: string;
+    readonly createClient?: (env: { readonly NOTION_API_KEY: string }) => NotionClient;
+    readonly createMarkdownPage?: (input: {
+      readonly apiKey: string;
+      readonly parentPageId: string;
+      readonly title: string;
+      readonly markdown: string;
+    }) => Promise<CreateNotionMarkdownPageResult>;
+    readonly rootPageId?: string;
+  };
+  readonly repositories: SynthesizeProjectKnowledgeOrchestratorDependencies["repositories"] & {
+    readonly projectDimensions: Pick<
+      ProjectDimensionRepository,
+      "findById" | "getAiKnowledgeSources" | "setAiKnowledgeSources" | "setSynthesisMetadata"
+    >;
+    readonly settingsProjects: Pick<SettingsProjectsRepository, "setAiKnowledgeUrl">;
+  };
+}
+
+export type SynthesizeProjectKnowledgeResult =
+  | {
+      readonly ok: true;
+      readonly content: string;
+      readonly costUsd: number;
+      readonly inputHash: string | null;
+      readonly model: string;
+      readonly notionPageId: string;
+      readonly notionUrl: string;
+      readonly projectId: string;
+      readonly sourcesUsed: number;
+      readonly tokensIn: number;
+      readonly tokensOut: number;
+    }
+  | {
+      readonly ok: false;
+      readonly code:
+        | "llm_failed"
+        | "no_healthy_sources"
+        | "project_missing"
+        | "publish_failed";
+      readonly error?: unknown;
+      readonly message: string;
+      readonly projectId: string;
+    };
+
+export async function runSynthesizeProjectKnowledge(
+  deps: SynthesizeProjectKnowledgeDependencies,
+  payload: SynthesizeProjectKnowledgePayload,
+): Promise<SynthesizeProjectKnowledgeResult> {
+  const logger = deps.logger ?? console;
+  const now = deps.now ?? (() => new Date());
+  const orchestratorResult = await synthesizeProjectKnowledgeOrchestrator(
+    deps,
+    payload,
+  );
+
+  if (!orchestratorResult.ok) {
+    return {
+      ...orchestratorResult,
+      projectId: payload.projectId,
+    };
+  }
+
+  const createClient = deps.notion.createClient ?? createNotionClient;
+  const createMarkdownPage =
+    deps.notion.createMarkdownPage ?? createNotionMarkdownPage;
+  const parentPageId = await resolveNotionParentPageId({
+    apiKey: deps.notion.apiKey,
+    createClient,
+    fallbackParentPageId:
+      deps.notion.rootPageId ?? DEFAULT_SYNTHESIZED_PAGE_ROOT_ID,
+    logger,
+    project: orchestratorResult.project,
+  });
+  const synthesizedAt = now();
+  const pageTitle = `${orchestratorResult.project.projectAlias ?? orchestratorResult.project.projectName} — AI Knowledge (synthesized ${synthesizedAt.toISOString().slice(0, 16)})`;
+
+  try {
+    const notionPage = await createMarkdownPage({
+      apiKey: deps.notion.apiKey,
+      parentPageId,
+      title: pageTitle,
+      markdown: orchestratorResult.content,
+    });
+
+    await deps.repositories.settingsProjects.setAiKnowledgeUrl(
+      payload.projectId,
+      notionPage.url,
+    );
+    await deps.repositories.projectDimensions.setSynthesisMetadata(
+      payload.projectId,
+      {
+        synthesizedAt: synthesizedAt.toISOString(),
+        inputHash: orchestratorResult.inputHash,
+      },
+    );
+
+    return {
+      ok: true,
+      projectId: payload.projectId,
+      notionPageId: notionPage.id,
+      notionUrl: notionPage.url,
+      content: orchestratorResult.content,
+      inputHash: orchestratorResult.inputHash,
+      tokensIn: orchestratorResult.tokensIn,
+      tokensOut: orchestratorResult.tokensOut,
+      costUsd: orchestratorResult.costUsd,
+      model: orchestratorResult.model,
+      sourcesUsed: orchestratorResult.sourcesUsed,
+    };
+  } catch (error) {
+    logger.error(
+      `Publishing synthesized AI knowledge failed for ${payload.projectId}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+
+    return {
+      ok: false,
+      code: "publish_failed",
+      error,
+      message: `Publishing synthesized AI knowledge failed for ${payload.projectId}.`,
+      projectId: payload.projectId,
+    };
+  }
+}
+
+export function createSynthesizeProjectKnowledgeTask(
+  dependencies: SynthesizeProjectKnowledgeDependencies,
+): Task {
+  return async (payload) => {
+    const result = await runSynthesizeProjectKnowledge(
+      dependencies,
+      synthesizeProjectKnowledgePayloadSchema.parse(payload),
+    );
+
+    if (!result.ok) {
+      throw new Error(
+        `[synthesize-project-knowledge] ${result.code}: ${result.message}`,
+      );
+    }
+  };
+}
+
+export { synthesizeProjectKnowledgeJobName, synthesizeProjectKnowledgePayloadSchema };

--- a/apps/worker/src/jobs/synthesize-project-knowledge/orchestrator.ts
+++ b/apps/worker/src/jobs/synthesize-project-knowledge/orchestrator.ts
@@ -1,0 +1,348 @@
+import type {
+  AiKnowledgeSource,
+  ProjectDimensionRecord,
+} from "@as-comms/contracts";
+import { inputHashFromSources, markSourceSyncResult } from "@as-comms/db";
+import type { ProjectDimensionRepository } from "@as-comms/domain";
+import {
+  estimateCostUsd,
+  type GenerateDraftResult,
+  type SourceFetchResult,
+} from "@as-comms/integrations";
+
+const DEFAULT_MODEL = "claude-sonnet-4-6";
+const DEFAULT_MAX_TOKENS = 16_000;
+const DEFAULT_TEMPERATURE = 0.3;
+
+export const SYNTHESIS_SYSTEM_PROMPT = `You are organizing an AI training document for a volunteer communications assistant. Your output will be used by an AI to draft replies to volunteers for a specific project.
+
+INPUTS:
+- An existing AI Knowledge document (operator-curated; may be partially structured or terse)
+- Optionally one or more additional source documents (e.g., volunteer homepage, field protocol PDF, training course content)
+- A corpus of past sent replies from this project's volunteer alias(es)
+
+PRODUCE: a comprehensive, self-contained updated AI Knowledge document organized in the following standard structure (adapt section content to the project — but keep these section names and order):
+
+1. **Intro paragraph** — what this page is, what it excludes (internal-only material), what sources were merged.
+
+2. **## What this project is** — 4-6 sentence description of the project (mission, geographic scope, partners, target species/output, how the volunteer experience is shaped).
+
+3. **## What this AI assistant should help with** — bullet list of the AI's scope (volunteer-facing topics it should address, what to prefer, when to be careful about seasonality).
+
+4. **## Tone signals from real volunteer messages** — 6-12 bullets distilled from the email corpus. Cover dominant emotional patterns, common support themes, recurring frustrations, things operators handle gracefully. Keep the most insightful observations from the existing doc's equivalent section if the new corpus confirms them.
+
+5. **## Common volunteer questions and approved answer patterns** — the new corpus-derived section. 8-15 clusters ordered by frequency. For each:
+   ### {Topic name as a noun phrase}
+   - **Volunteer typically asks:** {paraphrased pattern, anonymized}
+   - **Approved answer pattern:** {synthesized voice, 2-4 sentences, based on how operators actually responded}
+   - **Tone notes:** {tone signals for this topic}
+   - **Approximate frequency:** {very common (>20), common (10-20), occasional (5-10), uncommon but recurring}
+
+6. **## Volunteer-facing facts** — sectioned by topic. Use H3 subsections (### Getting started, ### Fieldwork, ### Equipment, ### Species/target identification, ### Navigation, ### Project timing, etc.) as appropriate for the project. Pull facts from the existing doc AND the additional source documents, deduplicating.
+
+7. **## Phrase these carefully (date-bound or contingent)** — bullets of claims the AI should hedge.
+
+8. **## Never share with volunteers** — bullets of operator-only material.
+
+9. **## Escalate to a human teammate when** — handoff conditions.
+
+10. **## Contact** — project email, general lines, mailing address.
+
+INTEGRATION RULES:
+- Treat the existing AI Knowledge doc as authoritative for the project's tone-curated sections (phrase carefully, never share, escalate). Preserve their content; you may rephrase for clarity but do not drop items.
+- Treat additional source documents as fact sources. Integrate their unique facts into the appropriate "Volunteer-facing facts" subsections. Do not preserve them verbatim.
+- If an additional source contains a knowledge check / quiz, the topics in the quiz indicate what volunteers must know.
+- De-duplicate content across all inputs.
+
+PII MASKING in corpus-derived content:
+- Replace volunteer first names with {NAME}
+- Replace full email addresses with {EMAIL}
+- Replace phone numbers with {PHONE}
+- Preserve project-specific terms (app names, geographic names, species names, dates, elevations, etc.)
+
+NEVER:
+- Invent facts not present in any input
+- Include specific volunteer names or PII
+- Include one-off operational issues that don't generalize
+- Include internal/operator-only commentary
+- Add sections beyond what's specified
+
+OUTPUT FORMAT: markdown with H1, H2, H3 headings and bullet lists. Output ONLY the markdown — no preamble, no closing remarks.`;
+
+export interface SynthesizeProjectKnowledgePayload {
+  readonly projectId: string;
+}
+
+export interface SynthesizeProjectKnowledgeOrchestratorDependencies {
+  readonly fetchers: {
+    readonly notion: {
+      fetch(input: {
+        readonly url: string;
+        readonly sourceId: string | null;
+        readonly lastContentHash: string | null;
+      }): Promise<SourceFetchResult>;
+    };
+    readonly web_page: {
+      fetch(input: {
+        readonly url: string;
+        readonly sourceId: string | null;
+        readonly lastContentHash: string | null;
+      }): Promise<SourceFetchResult>;
+    };
+    readonly inline_text: {
+      fetch(input: {
+        readonly url: string;
+        readonly sourceId: string | null;
+        readonly lastContentHash: string | null;
+      }): Promise<SourceFetchResult>;
+    };
+  };
+  readonly invokeModel: (input: {
+    readonly model: string;
+    readonly system: string;
+    readonly messages: readonly {
+      readonly role: "user" | "assistant";
+      readonly content: string;
+    }[];
+    readonly maxTokens: number;
+    readonly temperature: number;
+  }) => Promise<GenerateDraftResult>;
+  readonly logger?: Pick<Console, "info" | "warn" | "error">;
+  readonly model?: string;
+  readonly now?: () => Date;
+  readonly maxTokens?: number;
+  readonly repositories: {
+    readonly projectDimensions: Pick<
+      ProjectDimensionRepository,
+      "findById" | "getAiKnowledgeSources" | "setAiKnowledgeSources"
+    >;
+  };
+  readonly temperature?: number;
+}
+
+export type SynthesizeProjectKnowledgeOrchestratorResult =
+  | {
+      readonly ok: true;
+      readonly content: string;
+      readonly costUsd: number;
+      readonly inputHash: string | null;
+      readonly model: string;
+      readonly project: ProjectDimensionRecord;
+      readonly sourcesUsed: number;
+      readonly tokensIn: number;
+      readonly tokensOut: number;
+    }
+  | {
+      readonly ok: false;
+      readonly code: "project_missing" | "no_healthy_sources";
+      readonly message: string;
+    }
+  | {
+      readonly ok: false;
+      readonly code: "llm_failed";
+      readonly error: unknown;
+      readonly message: string;
+    };
+
+interface HealthySourceContent {
+  readonly content: string;
+  readonly source: AiKnowledgeSource;
+}
+
+function buildAdditionalSourcesBlock(
+  sources: readonly HealthySourceContent[],
+): string {
+  const externalSources = sources.filter(
+    (source) =>
+      source.source.kind === "notion" || source.source.kind === "web_page",
+  );
+
+  return externalSources
+    .map((source, index) => {
+      const label = source.source.label ?? source.source.url;
+      const tagName = `ADDITIONAL_SOURCE_${String(index + 1)}`;
+      return `<${tagName} path="${label}">
+${source.content}
+</${tagName}>`;
+    })
+    .join("\n\n");
+}
+
+function buildUserContent(input: {
+  readonly healthySources: readonly HealthySourceContent[];
+}): string {
+  const inlineDocs = input.healthySources
+    .filter((source) => source.source.kind === "inline_text")
+    .map((source) => source.content.trim())
+    .filter((content) => content.length > 0);
+  const existingDoc =
+    inlineDocs.length === 0 ? "(none)" : inlineDocs.join("\n\n---\n\n");
+  const additionalSourcesBlock = buildAdditionalSourcesBlock(
+    input.healthySources,
+  );
+  const externalSourceCount = input.healthySources.filter(
+    (source) =>
+      source.source.kind === "notion" || source.source.kind === "web_page",
+  ).length;
+  const additionalSourcesNote =
+    additionalSourcesBlock.length === 0
+      ? ""
+      : `
+
+Here are ${String(externalSourceCount)} additional source document(s) for this project (e.g., training course content, supplementary protocols). Integrate any unique facts from these into the appropriate sections of the AI Knowledge doc. Do not preserve them verbatim — overlap with the existing doc is expected and should be deduplicated. If the additional source contains a knowledge check / quiz, treat the quiz topics as a signal of what volunteers must know (and what the AI should be ready to support).
+
+${additionalSourcesBlock}`;
+
+  return `Here is the existing AI Knowledge document for the project:
+
+<EXISTING_DOC>
+${existingDoc}
+</EXISTING_DOC>${additionalSourcesNote}
+
+Here is the corpus of 0 past sent replies from this project's volunteer alias(es), most recent first:
+
+<EMAIL_CORPUS>
+</EMAIL_CORPUS>
+
+Produce the updated AI Knowledge document per the system instructions. Output ONLY the markdown.`;
+}
+
+function applyFetchResult(
+  sources: readonly AiKnowledgeSource[],
+  source: AiKnowledgeSource,
+  result: SourceFetchResult,
+): readonly AiKnowledgeSource[] {
+  if (!result.ok) {
+    return markSourceSyncResult(sources, source.id, {
+      last_sync_status: "broken",
+      last_sync_error: result.error,
+      source_content_hash: null,
+    });
+  }
+
+  if (result.unchanged) {
+    return markSourceSyncResult(sources, source.id, {
+      last_sync_status: "healthy",
+      last_sync_error: null,
+      source_content_hash: source.source_content_hash,
+    });
+  }
+
+  if (result.content.trim().length === 0) {
+    return markSourceSyncResult(sources, source.id, {
+      last_sync_status: "stale",
+      last_sync_error: "Fetched source content was empty.",
+      source_content_hash: null,
+    });
+  }
+
+  return markSourceSyncResult(sources, source.id, {
+    last_sync_status: "healthy",
+    last_sync_error: null,
+    source_content_hash: result.contentHash,
+  });
+}
+
+export async function synthesizeProjectKnowledgeOrchestrator(
+  deps: SynthesizeProjectKnowledgeOrchestratorDependencies,
+  payload: SynthesizeProjectKnowledgePayload,
+): Promise<SynthesizeProjectKnowledgeOrchestratorResult> {
+  const logger = deps.logger ?? console;
+  const project = await deps.repositories.projectDimensions.findById(
+    payload.projectId,
+  );
+
+  if (project === null) {
+    return {
+      ok: false,
+      code: "project_missing",
+      message: `Project ${payload.projectId} was not found.`,
+    };
+  }
+
+  const sources = await deps.repositories.projectDimensions.getAiKnowledgeSources(
+    payload.projectId,
+  );
+  const enabledSources = sources.filter((source) => source.enabled);
+  let nextSources = sources;
+  const healthySources: HealthySourceContent[] = [];
+
+  for (const source of enabledSources) {
+    const fetcher = deps.fetchers[source.kind];
+    const result = await fetcher.fetch({
+      url: source.url,
+      sourceId: source.source_id,
+      lastContentHash: source.source_content_hash,
+    });
+
+    nextSources = applyFetchResult(nextSources, source, result);
+
+    if (!result.ok || result.unchanged || result.content.trim().length === 0) {
+      continue;
+    }
+
+    healthySources.push({
+      source,
+      content: result.content,
+    });
+  }
+
+  await deps.repositories.projectDimensions.setAiKnowledgeSources(
+    payload.projectId,
+    nextSources,
+  );
+
+  if (healthySources.length === 0) {
+    return {
+      ok: false,
+      code: "no_healthy_sources",
+      message: `Project ${payload.projectId} has no healthy AI knowledge sources to synthesize.`,
+    };
+  }
+
+  const healthyRegistrySources = nextSources.filter(
+    (source) =>
+      source.enabled &&
+      source.last_sync_status === "healthy" &&
+      source.source_content_hash !== null,
+  );
+
+  try {
+    const model = deps.model ?? DEFAULT_MODEL;
+    const response = await deps.invokeModel({
+      model,
+      system: SYNTHESIS_SYSTEM_PROMPT,
+      messages: [
+        {
+          role: "user",
+          content: buildUserContent({ healthySources }),
+        },
+      ],
+      maxTokens: deps.maxTokens ?? DEFAULT_MAX_TOKENS,
+      temperature: deps.temperature ?? DEFAULT_TEMPERATURE,
+    });
+
+    return {
+      ok: true,
+      project,
+      content: response.text,
+      inputHash: inputHashFromSources(healthyRegistrySources),
+      tokensIn: response.usage.inputTokens,
+      tokensOut: response.usage.outputTokens,
+      costUsd: estimateCostUsd(response.usage, response.model),
+      model: response.model,
+      sourcesUsed: healthySources.length,
+    };
+  } catch (error) {
+    logger.error(
+      `AI knowledge synthesis failed for ${payload.projectId}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+
+    return {
+      ok: false,
+      code: "llm_failed",
+      error,
+      message: `AI knowledge synthesis failed for ${payload.projectId}.`,
+    };
+  }
+}

--- a/apps/worker/src/ops/synthesize-multi-source.ts
+++ b/apps/worker/src/ops/synthesize-multi-source.ts
@@ -1,0 +1,116 @@
+#!/usr/bin/env tsx
+import process from "node:process";
+
+import {
+  closeDatabaseConnection,
+  createDatabaseConnection,
+  createStage1RepositoryBundleFromConnection,
+  createStage2RepositoryBundleFromConnection,
+} from "@as-comms/db";
+import {
+  createAnthropicClient,
+  invokeModel,
+  InlineTextFetcher,
+  NotionPageFetcher,
+  WebPageFetcher,
+} from "@as-comms/integrations";
+
+import {
+  runSynthesizeProjectKnowledge,
+  type SynthesizeProjectKnowledgeDependencies,
+} from "../jobs/synthesize-project-knowledge/index.js";
+
+function readRequiredEnv(
+  key: "ANTHROPIC_API_KEY" | "DATABASE_URL" | "NOTION_API_KEY",
+): string {
+  const value = process.env[key]?.trim();
+
+  if (value === undefined || value.length === 0) {
+    throw new Error(`${key} is required.`);
+  }
+
+  return value;
+}
+
+function readAnthropicModel(): string {
+  const value = process.env.ANTHROPIC_MODEL?.trim();
+  return value && value.length > 0 ? value : "claude-sonnet-4-6";
+}
+
+function buildDependencies(): SynthesizeProjectKnowledgeDependencies {
+  const connection = createDatabaseConnection({
+    connectionString: readRequiredEnv("DATABASE_URL"),
+  });
+  const repositories = createStage1RepositoryBundleFromConnection(connection);
+  const settings = createStage2RepositoryBundleFromConnection(connection);
+  const anthropicClient = createAnthropicClient({
+    ANTHROPIC_API_KEY: readRequiredEnv("ANTHROPIC_API_KEY"),
+  });
+  const notionApiKey = readRequiredEnv("NOTION_API_KEY");
+
+  const base: SynthesizeProjectKnowledgeDependencies = {
+    repositories: {
+      projectDimensions: repositories.projectDimensions,
+      settingsProjects: settings.projects,
+    },
+    fetchers: {
+      notion: new NotionPageFetcher({ apiKey: notionApiKey }),
+      web_page: new WebPageFetcher(),
+      inline_text: new InlineTextFetcher(),
+    },
+    notion: {
+      apiKey: notionApiKey,
+    },
+    model: readAnthropicModel(),
+    invokeModel: (input) => invokeModel(anthropicClient, input),
+  };
+
+  return Object.assign(base, {
+    async dispose() {
+      await closeDatabaseConnection(connection);
+    },
+  }) as SynthesizeProjectKnowledgeDependencies & {
+    dispose(): Promise<void>;
+  };
+}
+
+async function main(): Promise<void> {
+  const projectId = process.argv[2];
+
+  if (projectId === undefined || projectId.trim().length === 0) {
+    throw new Error("Usage: tsx src/ops/synthesize-multi-source.ts <project_id>");
+  }
+
+  const dependencies = buildDependencies() as SynthesizeProjectKnowledgeDependencies & {
+    dispose(): Promise<void>;
+  };
+
+  try {
+    const result = await runSynthesizeProjectKnowledge(dependencies, {
+      projectId,
+    });
+
+    if (!result.ok) {
+      console.error(`Synthesis failed: ${result.code}`);
+      console.error(result.message);
+      if (result.error !== undefined) {
+        console.error(result.error);
+      }
+      process.exitCode = 1;
+      return;
+    }
+
+    console.info(`Notion URL: ${result.notionUrl}`);
+    console.info(`Model: ${result.model}`);
+    console.info(`Sources used: ${String(result.sourcesUsed)}`);
+    console.info(`Tokens: ${String(result.tokensIn)} in, ${String(result.tokensOut)} out`);
+    console.info(`Estimated cost: $${result.costUsd.toFixed(3)}`);
+  } finally {
+    await dependencies.dispose();
+  }
+}
+
+void main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/apps/worker/src/runtime.ts
+++ b/apps/worker/src/runtime.ts
@@ -15,12 +15,17 @@ import {
 } from "@as-comms/domain";
 import {
   capturePortHttpConfigSchema,
+  createAnthropicClient,
   createGmailCapturePort,
   createMailchimpCapturePort,
+  InlineTextFetcher,
+  invokeModel,
+  NotionPageFetcher,
   createSalesforceCapturePort,
   createSimpleTextingCapturePort,
   ProviderCaptureConfigError,
   type FetchImplementation,
+  WebPageFetcher,
 } from "@as-comms/integrations";
 
 import { createStage1IngestService } from "./ingest/index.js";
@@ -35,6 +40,7 @@ import { readNotionKnowledgeSyncConfig } from "./jobs/notion-knowledge-sync/inde
 import { dedupHistoricalLedgerJobName } from "./jobs/dedup-historical-ledger.js";
 import { reconcileCaptureGapsJobName } from "./jobs/reconcile-capture-gaps.js";
 import { reconcileRoutingReviewQueueJobName } from "./jobs/reconcile-routing-review-queue.js";
+import { type SynthesizeProjectKnowledgeDependencies } from "./jobs/synthesize-project-knowledge/index.js";
 import {
   createStage1SyncStateService,
   createStage1WorkerOrchestrationService,
@@ -53,6 +59,7 @@ import { sweepPendingOutboundsJobName } from "./jobs/sweep-pending-outbounds.js"
 
 const defaultSyncStateLeaseThresholdMs = 5 * 60 * 1000;
 const mailchimpTransitionDiscoverySeedLookbackDays = 35;
+const defaultSynthesisRootPageId = "3278a912921180598688fce711ab0509";
 
 function parseBooleanEnv(value: unknown): boolean {
   // Pass booleans through unchanged. The schema this preprocess feeds is
@@ -159,6 +166,62 @@ function buildDefaultMailchimpTransitionDiscoverySeed(now = new Date()): string 
     now.getTime() -
       mailchimpTransitionDiscoverySeedLookbackDays * 24 * 60 * 60 * 1000,
   ).toISOString();
+}
+
+function readOptionalTrimmedEnv(
+  value: string | undefined,
+): string | null {
+  if (value === undefined) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+function buildSynthesizeProjectKnowledgeDependencies(input: {
+  readonly env: NodeJS.ProcessEnv;
+  readonly fetchImplementation: FetchImplementation;
+  readonly repositories: ReturnType<typeof createStage1RepositoryBundleFromConnection>;
+  readonly settings: ReturnType<typeof createStage2RepositoryBundleFromConnection>;
+}): SynthesizeProjectKnowledgeDependencies | undefined {
+  const notionApiKey = readOptionalTrimmedEnv(input.env.NOTION_API_KEY);
+  const anthropicApiKey = readOptionalTrimmedEnv(input.env.ANTHROPIC_API_KEY);
+
+  if (notionApiKey === null || anthropicApiKey === null) {
+    console.warn(
+      "Skipping synthesize-project-knowledge wiring because NOTION_API_KEY or ANTHROPIC_API_KEY is missing.",
+    );
+    return undefined;
+  }
+
+  const anthropicClient = createAnthropicClient({
+    ANTHROPIC_API_KEY: anthropicApiKey,
+  });
+  const model =
+    readOptionalTrimmedEnv(input.env.ANTHROPIC_MODEL) ?? "claude-sonnet-4-6";
+
+  return {
+    repositories: {
+      projectDimensions: input.repositories.projectDimensions,
+      settingsProjects: input.settings.projects,
+    },
+    fetchers: {
+      notion: new NotionPageFetcher({ apiKey: notionApiKey }),
+      web_page: new WebPageFetcher({
+        fetchImplementation: input.fetchImplementation,
+      }),
+      inline_text: new InlineTextFetcher(),
+    },
+    notion: {
+      apiKey: notionApiKey,
+      rootPageId:
+        readOptionalTrimmedEnv(input.env.AI_ASSISTANT_TRAINING_ROOT_PAGE_ID) ??
+        defaultSynthesisRootPageId,
+    },
+    model,
+    invokeModel: (payload) => invokeModel(anthropicClient, payload),
+  };
 }
 
 function readMailchimpTransitionConfig(
@@ -369,6 +432,14 @@ export async function createStage1WorkerRuntimeServices(
         };
   const fetchImplementation = input?.fetchImplementation ?? fetch;
   const leaseThresholdMs = readSyncStateLeaseThresholdMs(input?.env ?? process.env);
+  const synthesizeProjectKnowledge = buildSynthesizeProjectKnowledgeDependencies(
+    {
+      env: input?.env ?? process.env,
+      fetchImplementation,
+      repositories,
+      settings,
+    },
+  );
   const capture = {
     gmail: createGmailCapturePort(config.capture.gmail, fetchOptions),
     salesforce: createSalesforceCapturePort(
@@ -432,6 +503,11 @@ export async function createStage1WorkerRuntimeServices(
         integrationHealth: settings.integrationHealth,
         notion: notionKnowledgeSync,
       },
+      ...(synthesizeProjectKnowledge === undefined
+        ? {}
+        : {
+            synthesizeProjectKnowledge,
+          }),
       pendingOutboundSweep: {
         pendingOutbounds: repositories.pendingOutbounds,
       },

--- a/apps/worker/src/tasks.ts
+++ b/apps/worker/src/tasks.ts
@@ -37,6 +37,11 @@ import {
   notionKnowledgeSyncJobName,
   type NotionKnowledgeSyncDependencies,
 } from "./jobs/notion-knowledge-sync/index.js";
+import {
+  createSynthesizeProjectKnowledgeTask,
+  synthesizeProjectKnowledgeJobName,
+  type SynthesizeProjectKnowledgeDependencies,
+} from "./jobs/synthesize-project-knowledge/index.js";
 import { runStage0NoopJob } from "./jobs/noop.js";
 import {
   createStage1TaskList,
@@ -55,6 +60,7 @@ export function createTaskList(
     readonly reconcileRoutingReviewQueue?: ReconcileRoutingReviewQueueTaskDependencies;
     readonly reconcileCaptureGaps?: ReconcileCaptureGapsTaskDependencies;
     readonly reconcileStaleRunning?: ReconcileStaleRunningTaskDependencies;
+    readonly synthesizeProjectKnowledge?: SynthesizeProjectKnowledgeDependencies;
   },
 ): TaskList {
   return {
@@ -108,6 +114,14 @@ export function createTaskList(
           [notionKnowledgeSyncJobName]: createNotionKnowledgeSyncTask(
             input.notionKnowledgeSync,
           ),
+        }),
+    ...(input?.synthesizeProjectKnowledge === undefined
+      ? {}
+      : {
+          [synthesizeProjectKnowledgeJobName]:
+            createSynthesizeProjectKnowledgeTask(
+              input.synthesizeProjectKnowledge,
+            ),
         }),
     ...(orchestration ? createStage1TaskList(orchestration, input) : {}),
   };

--- a/apps/worker/test/synthesize-project-knowledge-orchestrator.test.ts
+++ b/apps/worker/test/synthesize-project-knowledge-orchestrator.test.ts
@@ -1,0 +1,357 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  AiKnowledgeSource,
+  ProjectDimensionRecord,
+} from "@as-comms/contracts";
+import type { GenerateDraftResult, SourceFetchResult } from "@as-comms/integrations";
+
+import { synthesizeProjectKnowledgeOrchestrator } from "../src/jobs/synthesize-project-knowledge/orchestrator.js";
+
+function buildProject(): ProjectDimensionRecord {
+  return {
+    projectId: "project:orcas",
+    projectName: "Orcas",
+    projectAlias: "Orcas",
+    source: "salesforce",
+    isActive: true,
+    aiKnowledgeUrl: null,
+    aiKnowledgeSyncedAt: null,
+    aiKnowledgeSources: [],
+    aiOperatingContext: "",
+    aiOptimizedSynthesizedAt: null,
+    aiOptimizedInputHash: null,
+  };
+}
+
+function buildSource(input: Partial<AiKnowledgeSource> & {
+  readonly id: string;
+  readonly kind: AiKnowledgeSource["kind"];
+  readonly url: string;
+}): AiKnowledgeSource {
+  return {
+    id: input.id,
+    url: input.url,
+    kind: input.kind,
+    label: input.label ?? null,
+    enabled: input.enabled ?? true,
+    last_synced_at: input.last_synced_at ?? null,
+    last_sync_status: input.last_sync_status ?? null,
+    last_sync_error: input.last_sync_error ?? null,
+    source_id: input.source_id ?? null,
+    source_content_hash: input.source_content_hash ?? null,
+    created_at: input.created_at ?? "2026-05-09T12:00:00.000Z",
+    updated_at: input.updated_at ?? "2026-05-09T12:00:00.000Z",
+  };
+}
+
+function healthyContent(content: string): SourceFetchResult {
+  return {
+    ok: true,
+    unchanged: false,
+    content,
+    contentHash: `hash:${content}`,
+    lastModified: null,
+  };
+}
+
+function buildDraftResult(text: string): GenerateDraftResult {
+  return {
+    text,
+    usage: {
+      inputTokens: 120,
+      outputTokens: 45,
+    },
+    stopReason: "end_turn",
+    model: "claude-sonnet-4-6",
+  };
+}
+
+function readPromptFromInvokeModelMock(
+  invokeModel: ReturnType<typeof vi.fn>,
+): string {
+  const firstCall = invokeModel.mock.calls[0];
+  const firstArg = firstCall?.[0] as
+    | {
+        readonly messages: readonly {
+          readonly content: string;
+        }[];
+      }
+    | undefined;
+
+  return firstArg?.messages[0]?.content ?? "";
+}
+
+describe("synthesizeProjectKnowledgeOrchestrator", () => {
+  it("synthesizes from healthy sources and passes all source content into the prompt", async () => {
+    const project = buildProject();
+    const sources = [
+      buildSource({
+        id: "11111111-1111-4111-8111-111111111111",
+        kind: "inline_text",
+        url: "https://example.test/inline-1",
+      }),
+      buildSource({
+        id: "22222222-2222-4222-8222-222222222222",
+        kind: "notion",
+        url: "https://www.notion.so/source",
+      }),
+      buildSource({
+        id: "33333333-3333-4333-8333-333333333333",
+        kind: "web_page",
+        url: "https://example.test/project",
+      }),
+    ];
+    const invokeModel = vi.fn().mockResolvedValue(buildDraftResult("# Synthesized"));
+    const setAiKnowledgeSources = vi.fn().mockResolvedValue(undefined);
+
+    const result = await synthesizeProjectKnowledgeOrchestrator(
+      {
+        repositories: {
+          projectDimensions: {
+            findById: vi.fn().mockResolvedValue(project),
+            getAiKnowledgeSources: vi.fn().mockResolvedValue(sources),
+            setAiKnowledgeSources,
+          },
+        },
+        fetchers: {
+          inline_text: { fetch: vi.fn().mockResolvedValue(healthyContent("Inline operator context")) },
+          notion: { fetch: vi.fn().mockResolvedValue(healthyContent("Notion source content")) },
+          web_page: { fetch: vi.fn().mockResolvedValue(healthyContent("Web source content")) },
+        },
+        invokeModel,
+      },
+      {
+        projectId: project.projectId,
+      },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      content: "# Synthesized",
+      tokensIn: 120,
+      tokensOut: 45,
+      model: "claude-sonnet-4-6",
+      sourcesUsed: 3,
+    });
+    expect(invokeModel).toHaveBeenCalledTimes(1);
+    const prompt = readPromptFromInvokeModelMock(invokeModel);
+    expect(prompt).toContain("Inline operator context");
+    expect(prompt).toContain("Notion source content");
+    expect(prompt).toContain("Web source content");
+    expect(setAiKnowledgeSources).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists broken sources but only sends healthy sources to the model", async () => {
+    const project = buildProject();
+    const sources = [
+      buildSource({
+        id: "11111111-1111-4111-8111-111111111111",
+        kind: "inline_text",
+        url: "https://example.test/inline-1",
+      }),
+      buildSource({
+        id: "22222222-2222-4222-8222-222222222222",
+        kind: "notion",
+        url: "https://www.notion.so/source",
+      }),
+      buildSource({
+        id: "33333333-3333-4333-8333-333333333333",
+        kind: "web_page",
+        url: "https://example.test/project",
+      }),
+    ];
+    const setAiKnowledgeSources = vi.fn().mockResolvedValue(undefined);
+    const invokeModel = vi.fn().mockResolvedValue(buildDraftResult("# Synthesized"));
+
+    await synthesizeProjectKnowledgeOrchestrator(
+      {
+        repositories: {
+          projectDimensions: {
+            findById: vi.fn().mockResolvedValue(project),
+            getAiKnowledgeSources: vi.fn().mockResolvedValue(sources),
+            setAiKnowledgeSources,
+          },
+        },
+        fetchers: {
+          inline_text: { fetch: vi.fn().mockResolvedValue(healthyContent("Inline operator context")) },
+          notion: { fetch: vi.fn().mockResolvedValue(healthyContent("Notion source content")) },
+          web_page: {
+            fetch: vi.fn().mockResolvedValue({
+              ok: false,
+              status: "broken",
+              error: "HTTP 500",
+            } satisfies SourceFetchResult),
+          },
+        },
+        invokeModel,
+      },
+      {
+        projectId: project.projectId,
+      },
+    );
+
+    const persistedSources = setAiKnowledgeSources.mock.calls[0]?.[1] as
+      | readonly AiKnowledgeSource[]
+      | undefined;
+    expect(
+      persistedSources?.find(
+        (source) => source.id === "33333333-3333-4333-8333-333333333333",
+      ),
+    ).toMatchObject({
+      last_sync_status: "broken",
+      last_sync_error: "HTTP 500",
+      source_content_hash: null,
+    });
+    const prompt = readPromptFromInvokeModelMock(invokeModel);
+    expect(prompt).toContain("Inline operator context");
+    expect(prompt).toContain("Notion source content");
+    expect(prompt).not.toContain("HTTP 500");
+  });
+
+  it("returns no_healthy_sources when the source list is empty or all sources fail", async () => {
+    const project = buildProject();
+    const emptyResult = await synthesizeProjectKnowledgeOrchestrator(
+      {
+        repositories: {
+          projectDimensions: {
+            findById: vi.fn().mockResolvedValue(project),
+            getAiKnowledgeSources: vi.fn().mockResolvedValue([]),
+            setAiKnowledgeSources: vi.fn().mockResolvedValue(undefined),
+          },
+        },
+        fetchers: {
+          inline_text: { fetch: vi.fn() },
+          notion: { fetch: vi.fn() },
+          web_page: { fetch: vi.fn() },
+        },
+        invokeModel: vi.fn(),
+      },
+      {
+        projectId: project.projectId,
+      },
+    );
+
+    expect(emptyResult).toMatchObject({
+      ok: false,
+      code: "no_healthy_sources",
+    });
+
+    const brokenResult = await synthesizeProjectKnowledgeOrchestrator(
+      {
+        repositories: {
+          projectDimensions: {
+            findById: vi.fn().mockResolvedValue(project),
+            getAiKnowledgeSources: vi.fn().mockResolvedValue([
+              buildSource({
+                id: "44444444-4444-4444-8444-444444444444",
+                kind: "web_page",
+                url: "https://example.test/project",
+              }),
+            ]),
+            setAiKnowledgeSources: vi.fn().mockResolvedValue(undefined),
+          },
+        },
+        fetchers: {
+          inline_text: { fetch: vi.fn() },
+          notion: { fetch: vi.fn() },
+          web_page: {
+            fetch: vi.fn().mockResolvedValue({
+              ok: false,
+              status: "broken",
+              error: "HTTP 500",
+            } satisfies SourceFetchResult),
+          },
+        },
+        invokeModel: vi.fn(),
+      },
+      {
+        projectId: project.projectId,
+      },
+    );
+
+    expect(brokenResult).toMatchObject({
+      ok: false,
+      code: "no_healthy_sources",
+    });
+  });
+
+  it("returns llm_failed and still persists source state when the model errors", async () => {
+    const project = buildProject();
+    const setAiKnowledgeSources = vi.fn().mockResolvedValue(undefined);
+
+    const result = await synthesizeProjectKnowledgeOrchestrator(
+      {
+        repositories: {
+          projectDimensions: {
+            findById: vi.fn().mockResolvedValue(project),
+            getAiKnowledgeSources: vi.fn().mockResolvedValue([
+              buildSource({
+                id: "55555555-5555-4555-8555-555555555555",
+                kind: "inline_text",
+                url: "https://example.test/inline-2",
+              }),
+            ]),
+            setAiKnowledgeSources,
+          },
+        },
+        fetchers: {
+          inline_text: { fetch: vi.fn().mockResolvedValue(healthyContent("Inline operator context")) },
+          notion: { fetch: vi.fn() },
+          web_page: { fetch: vi.fn() },
+        },
+        invokeModel: vi.fn().mockRejectedValue(new Error("Anthropic down")),
+      },
+      {
+        projectId: project.projectId,
+      },
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "llm_failed",
+    });
+    expect(setAiKnowledgeSources).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips disabled sources", async () => {
+    const project = buildProject();
+    const disabledSource = buildSource({
+      id: "66666666-6666-4666-8666-666666666666",
+      kind: "web_page",
+      url: "https://example.test/project",
+      enabled: false,
+    });
+    const webFetch = vi.fn();
+
+    await synthesizeProjectKnowledgeOrchestrator(
+      {
+        repositories: {
+          projectDimensions: {
+            findById: vi.fn().mockResolvedValue(project),
+            getAiKnowledgeSources: vi.fn().mockResolvedValue([
+              disabledSource,
+              buildSource({
+                id: "77777777-7777-4777-8777-777777777777",
+                kind: "inline_text",
+                url: "https://example.test/inline-3",
+              }),
+            ]),
+            setAiKnowledgeSources: vi.fn().mockResolvedValue(undefined),
+          },
+        },
+        fetchers: {
+          inline_text: { fetch: vi.fn().mockResolvedValue(healthyContent("Inline operator context")) },
+          notion: { fetch: vi.fn() },
+          web_page: { fetch: webFetch },
+        },
+        invokeModel: vi.fn().mockResolvedValue(buildDraftResult("# Synthesized")),
+      },
+      {
+        projectId: project.projectId,
+      },
+    );
+
+    expect(webFetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/worker/test/synthesize-project-knowledge.test.ts
+++ b/apps/worker/test/synthesize-project-knowledge.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { eq } from "drizzle-orm";
+
+import { projectDimensions } from "@as-comms/db";
+import type { AiKnowledgeSource } from "@as-comms/contracts";
+
+import { runSynthesizeProjectKnowledge } from "../src/jobs/synthesize-project-knowledge/index.js";
+import { createTestWorkerContext } from "./helpers.js";
+
+function buildSource(input: {
+  readonly id: string;
+  readonly kind: AiKnowledgeSource["kind"];
+  readonly url: string;
+  readonly label?: string | null;
+  readonly sourceId?: string | null;
+}): AiKnowledgeSource {
+  return {
+    id: input.id,
+    url: input.url,
+    kind: input.kind,
+    label: input.label ?? null,
+    enabled: true,
+    last_synced_at: null,
+    last_sync_status: null,
+    last_sync_error: null,
+    source_id: input.sourceId ?? null,
+    source_content_hash: null,
+    created_at: "2026-05-09T12:00:00.000Z",
+    updated_at: "2026-05-09T12:00:00.000Z",
+  };
+}
+
+describe("runSynthesizeProjectKnowledge", () => {
+  it("persists synthesis metadata, source fetch state, and the new Notion URL", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await context.repositories.projectDimensions.upsert({
+        projectId: "project:synth",
+        projectName: "Synth Project",
+        projectAlias: "Synth",
+        source: "salesforce",
+        aiKnowledgeUrl: null,
+        aiKnowledgeSyncedAt: null,
+        aiKnowledgeSources: [
+          buildSource({
+            id: "11111111-1111-4111-8111-111111111111",
+            kind: "inline_text",
+            url: "https://example.test/inline-1",
+          }),
+          buildSource({
+            id: "22222222-2222-4222-8222-222222222222",
+            kind: "notion",
+            url: "https://www.notion.so/project-source",
+            sourceId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          }),
+          buildSource({
+            id: "33333333-3333-4333-8333-333333333333",
+            kind: "web_page",
+            url: "https://example.test/project",
+            sourceId: "hash:web",
+          }),
+        ],
+      });
+
+      const result = await runSynthesizeProjectKnowledge(
+        {
+          repositories: {
+            projectDimensions: context.repositories.projectDimensions,
+            settingsProjects: context.settings.projects,
+          },
+          fetchers: {
+            inline_text: {
+              fetch: vi.fn().mockResolvedValue({
+                ok: true,
+                unchanged: false,
+                content: "Operator context",
+                contentHash: "hash:inline",
+                lastModified: null,
+              }),
+            },
+            notion: {
+              fetch: vi.fn().mockResolvedValue({
+                ok: true,
+                unchanged: false,
+                content: "Notion context",
+                contentHash: "hash:notion",
+                lastModified: null,
+              }),
+            },
+            web_page: {
+              fetch: vi.fn().mockResolvedValue({
+                ok: true,
+                unchanged: false,
+                content: "Web context",
+                contentHash: "hash:web",
+                lastModified: null,
+              }),
+            },
+          },
+          invokeModel: vi.fn().mockResolvedValue({
+            text: "# Synthesized AI Knowledge",
+            usage: {
+              inputTokens: 210,
+              outputTokens: 90,
+            },
+            stopReason: "end_turn",
+            model: "claude-sonnet-4-6",
+          }),
+          notion: {
+            apiKey: "notion-key",
+            createMarkdownPage: vi.fn().mockResolvedValue({
+              id: "new-notion-page-id",
+              url: "https://www.notion.so/new-synthesized-page",
+              blockCount: 12,
+            }),
+          },
+          now: () => new Date("2026-05-09T15:30:00.000Z"),
+        },
+        {
+          projectId: "project:synth",
+        },
+      );
+
+      expect(result).toMatchObject({
+        ok: true,
+        notionUrl: "https://www.notion.so/new-synthesized-page",
+        tokensIn: 210,
+        tokensOut: 90,
+      });
+
+      const [row] = await context.db
+        .select()
+        .from(projectDimensions)
+        .where(eq(projectDimensions.projectId, "project:synth"));
+      expect(row?.aiOptimizedSynthesizedAt).toEqual(
+        new Date("2026-05-09T15:30:00.000Z"),
+      );
+      expect(row?.aiOptimizedInputHash).toBeTruthy();
+      expect(row?.aiKnowledgeUrl).toBe(
+        "https://www.notion.so/new-synthesized-page",
+      );
+
+      const updatedSources =
+        await context.repositories.projectDimensions.getAiKnowledgeSources(
+          "project:synth",
+        );
+      expect(updatedSources).toHaveLength(3);
+      for (const source of updatedSources) {
+        expect(source.last_synced_at).toBeTruthy();
+        expect(source.last_sync_status).toBe("healthy");
+        expect(source.source_content_hash).toBeTruthy();
+      }
+    } finally {
+      await context.dispose();
+    }
+  });
+});

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -2121,6 +2121,16 @@ function createStage1RepositoriesInternal(
     ...smsRepositories,
 
     projectDimensions: {
+      async findById(projectId) {
+        const [row] = await db
+          .select()
+          .from(projectDimensions)
+          .where(eq(projectDimensions.projectId, projectId))
+          .limit(1);
+
+        return row === undefined ? null : mapProjectDimensionRow(row);
+      },
+
       async listAll() {
         const rows = await db
           .select()

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -255,6 +255,7 @@ export interface SmsSenderRepository {
 }
 
 export interface ProjectDimensionRepository {
+  findById(projectId: string): Promise<ProjectDimensionRecord | null>;
   listAll(): Promise<readonly ProjectDimensionRecord[]>;
   listActive(): Promise<readonly ProjectDimensionRecord[]>;
   listByIds(

--- a/packages/domain/test/normalization.test.ts
+++ b/packages/domain/test/normalization.test.ts
@@ -497,6 +497,7 @@ function buildContext(input: {
       getActiveUsageSnapshot: () => Promise.resolve(null),
     },
     projectDimensions: {
+      findById: () => Promise.resolve(null),
       listAll: () => Promise.resolve([]),
       listActive: () => Promise.resolve([]),
       listByIds: () => Promise.resolve([]),

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -107,6 +107,7 @@ describe("defineStage1RepositoryBundle", () => {
         getActiveUsageSnapshot: () => Promise.resolve(null),
       },
       projectDimensions: {
+        findById: () => Promise.resolve(null),
         listAll: () => Promise.resolve([]),
         listActive: () => Promise.resolve([]),
         listByIds: () => Promise.resolve([]),

--- a/packages/domain/test/stage3-last-inbound-alias.test.ts
+++ b/packages/domain/test/stage3-last-inbound-alias.test.ts
@@ -126,6 +126,7 @@ function buildRepositoryBundle(input: {
       getActiveUsageSnapshot: () => Promise.resolve(null),
     },
     projectDimensions: {
+      findById: () => Promise.resolve(null),
       listAll: () => Promise.resolve([]),
       listActive: () => Promise.resolve([]),
       listByIds: () => Promise.resolve([]),

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -203,6 +203,7 @@ function createRepositoryBundle(input: {
       getActiveUsageSnapshot: () => Promise.resolve(null),
     },
     projectDimensions: {
+      findById: () => Promise.resolve(null),
       listAll: () => Promise.resolve([]),
       listActive: () => Promise.resolve([]),
       listByIds: () => Promise.resolve([]),

--- a/packages/integrations/test/ai-knowledge-fetchers.test.ts
+++ b/packages/integrations/test/ai-knowledge-fetchers.test.ts
@@ -1,0 +1,335 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  InlineTextFetcher,
+  NotionPageFetcher,
+  NotionProviderError,
+  normalizeNotionId,
+  WebPageFetcher,
+  type NotionClient,
+} from "../src/index.js";
+
+function buildRichText(text: string) {
+  return [
+    {
+      plain_text: text,
+      href: null,
+      annotations: {
+        bold: false,
+        italic: false,
+        strikethrough: false,
+        code: false,
+      },
+    },
+  ];
+}
+
+function buildPage(input: {
+  readonly id: string;
+  readonly lastEditedTime: string;
+  readonly title: string;
+  readonly url: string;
+}) {
+  return {
+    id: normalizeNotionId(input.id),
+    url: input.url,
+    last_edited_time: input.lastEditedTime,
+    properties: {
+      title: {
+        type: "title",
+        title: buildRichText(input.title),
+      },
+    },
+  };
+}
+
+function buildParagraphBlock(id: string, text: string) {
+  return {
+    id: normalizeNotionId(id),
+    type: "paragraph",
+    has_children: false,
+    paragraph: {
+      rich_text: buildRichText(text),
+    },
+  };
+}
+
+function createFakeNotionClient(input: {
+  readonly page?: Record<string, unknown>;
+  readonly pageError?: Error;
+  readonly blocks?: readonly Record<string, unknown>[];
+}): NotionClient {
+  return {
+    retrievePage() {
+      if (input.pageError !== undefined) {
+        return Promise.reject(input.pageError);
+      }
+
+      if (input.page === undefined) {
+        return Promise.reject(new Error("Missing page fixture."));
+      }
+
+      return Promise.resolve(input.page);
+    },
+    listBlockChildren() {
+      return Promise.resolve({
+        results: input.blocks ?? [],
+        has_more: false,
+        next_cursor: null,
+      });
+    },
+    queryDatabase() {
+      return Promise.resolve({
+        results: [],
+        has_more: false,
+        next_cursor: null,
+      });
+    },
+  };
+}
+
+describe("AI knowledge fetchers", () => {
+  it("fetches Notion page markdown and metadata", async () => {
+    const pageId = normalizeNotionId("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    const fetcher = new NotionPageFetcher({
+      apiKey: "test-key",
+      createClient: () =>
+        createFakeNotionClient({
+          page: buildPage({
+            id: pageId,
+            title: "Project guide",
+            lastEditedTime: "2026-05-08T12:00:00.000Z",
+            url: "https://www.notion.so/project-guide",
+          }),
+          blocks: [buildParagraphBlock(pageId, "Volunteer overview")],
+        }),
+    });
+
+    await expect(
+      fetcher.fetch({
+        url: `https://www.notion.so/${pageId.replace(/-/gu, "")}`,
+        sourceId: pageId,
+        lastContentHash: null,
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      unchanged: false,
+      content: "Volunteer overview",
+      lastModified: "2026-05-08T12:00:00.000Z",
+    });
+  });
+
+  it("returns unchanged for Notion pages when the last modified timestamp matches", async () => {
+    const pageId = normalizeNotionId("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    const fetcher = new NotionPageFetcher({
+      apiKey: "test-key",
+      createClient: () =>
+        createFakeNotionClient({
+          page: buildPage({
+            id: pageId,
+            title: "Project guide",
+            lastEditedTime: "2026-05-08T12:00:00.000Z",
+            url: "https://www.notion.so/project-guide",
+          }),
+        }),
+    });
+
+    await expect(
+      fetcher.fetch({
+        url: `https://www.notion.so/${pageId.replace(/-/gu, "")}`,
+        sourceId: pageId,
+        lastContentHash: "ignored",
+        lastModified: "2026-05-08T12:00:00.000Z",
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      unchanged: true,
+      lastModified: "2026-05-08T12:00:00.000Z",
+    });
+  });
+
+  it("maps Notion permission and not-found errors into broken sources", async () => {
+    const unauthorizedFetcher = new NotionPageFetcher({
+      apiKey: "test-key",
+      createClient: () =>
+        createFakeNotionClient({
+          pageError: new NotionProviderError({
+            code: "unauthorized",
+            message: "Forbidden",
+            retryable: false,
+          }),
+        }),
+    });
+    const notFoundFetcher = new NotionPageFetcher({
+      apiKey: "test-key",
+      createClient: () =>
+        createFakeNotionClient({
+          pageError: new NotionProviderError({
+            code: "not_found",
+            message: "Missing",
+            retryable: false,
+          }),
+        }),
+    });
+
+    await expect(
+      unauthorizedFetcher.fetch({
+        url: "https://www.notion.so/missing",
+        sourceId: normalizeNotionId("cccccccccccccccccccccccccccccccc"),
+        lastContentHash: null,
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      status: "broken",
+      error: "Permission denied when reading the Notion page.",
+    });
+
+    await expect(
+      notFoundFetcher.fetch({
+        url: "https://www.notion.so/missing",
+        sourceId: normalizeNotionId("dddddddddddddddddddddddddddddddd"),
+        lastContentHash: null,
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      status: "broken",
+      error: "Page not found in Notion.",
+    });
+  });
+
+  it("fetches web pages, detects 304s, and classifies HTTP/network failures", async () => {
+    const okFetcher = new WebPageFetcher({
+      fetchImplementation: vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({
+          "last-modified": "Sat, 09 May 2026 12:00:00 GMT",
+        }),
+        text: () => Promise.resolve("<h1>Overview</h1><p>Volunteer help</p>"),
+      } satisfies Partial<Response>),
+    });
+    const unchangedFetcher = new WebPageFetcher({
+      fetchImplementation: vi.fn().mockResolvedValue({
+        ok: false,
+        status: 304,
+        headers: new Headers(),
+      } satisfies Partial<Response>),
+    });
+    const brokenFetcher = new WebPageFetcher({
+      fetchImplementation: vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        headers: new Headers(),
+      } satisfies Partial<Response>),
+    });
+    const thrownFetcher = new WebPageFetcher({
+      fetchImplementation: vi
+        .fn()
+        .mockRejectedValue(new Error("socket hang up")),
+    });
+
+    await expect(
+      okFetcher.fetch({
+        url: "https://example.test/project",
+        sourceId: "source:web",
+        lastContentHash: null,
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      unchanged: false,
+      content: "Overview\n Volunteer help",
+    });
+
+    await expect(
+      unchangedFetcher.fetch({
+        url: "https://example.test/project",
+        sourceId: "source:web",
+        lastContentHash: null,
+        lastModified: "Sat, 09 May 2026 11:00:00 GMT",
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      unchanged: true,
+      lastModified: "Sat, 09 May 2026 11:00:00 GMT",
+    });
+
+    await expect(
+      brokenFetcher.fetch({
+        url: "https://example.test/project",
+        sourceId: "source:web",
+        lastContentHash: null,
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      status: "broken",
+      error: "HTTP 404",
+    });
+
+    await expect(
+      thrownFetcher.fetch({
+        url: "https://example.test/project",
+        sourceId: "source:web",
+        lastContentHash: null,
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      status: "broken",
+      error: "socket hang up",
+    });
+  });
+
+  it("times out slow web fetches", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const hangingFetch: typeof fetch = (_input, init) => {
+        const signal = init?.signal;
+
+        return new Promise<Response>((_, reject) => {
+          signal?.addEventListener("abort", () => {
+            const error = new Error("aborted");
+            error.name = "AbortError";
+            reject(error);
+          });
+        });
+      };
+      const fetcher = new WebPageFetcher({
+        timeoutMs: 15_000,
+        fetchImplementation: hangingFetch,
+      });
+
+      const promise = fetcher.fetch({
+        url: "https://example.test/slow",
+        sourceId: "source:web",
+        lastContentHash: null,
+      });
+
+      await vi.runAllTimersAsync();
+
+      await expect(promise).resolves.toEqual({
+        ok: false,
+        status: "broken",
+        error: "Timeout",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns inline text verbatim with a content hash", async () => {
+    const fetcher = new InlineTextFetcher();
+
+    await expect(
+      fetcher.fetch({
+        url: "Operator note one\nOperator note two",
+        sourceId: null,
+        lastContentHash: null,
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      unchanged: false,
+      content: "Operator note one\nOperator note two",
+      lastModified: null,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Synthesis orchestrator** — pure-ish module that loads enabled sources, dispatches per-kind fetchers, persists per-source sync metadata, calls Anthropic via `invokeModel`, returns synthesized doc + token/cost/inputHash metadata
- **Graphile worker job** — wraps the orchestrator; creates a fresh Notion page from the synthesized markdown, updates `ai_knowledge_url`, stamps synthesis metadata on `project_dimensions`
- **Ops CLI** — `railway run -- pnpm --filter @as-comms/worker ops:synthesize-multi-source <project_id>` for architect manual runs
- **Tests** at all 3 layers: per-kind fetchers (Notion / web / inline), orchestrator unit, worker integration via PGlite

## Scope

This is **PR-B-2 (runtime pass) of [PRD #366](https://github.com/nico-kneler-as/as-comms-platform/issues/366)** — completes Phase 1's PR-B by wiring the deep modules from PR-B-1 into a working synthesis pipeline.

**Predecessors merged:**
- PR-A `56145f6e` — schema + data layer
- PR-B-1 `db4a9262` — fetcher interface + 3 implementations + Notion page helper

## What runs after this merges

The architect can exercise the full pipeline against any project's source registry:

```bash
railway run -- pnpm --filter @as-comms/worker ops:synthesize-multi-source <project_id>
```

This: loads sources, fetches each in parallel, calls Anthropic Sonnet, writes a fresh Notion page, updates `ai_knowledge_url` (so the existing `notion-knowledge-sync` worker re-syncs the cache from the new page), and stamps `ai_optimized_synthesized_at` + `ai_optimized_input_hash`.

## No UX changes

AI Draft continues to use the legacy `notion-knowledge-sync` worker until **PR-C** wires the new flow into Settings (wizard step + project detail UI + server actions for source CRUD).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm --filter @as-comms/integrations test:unit` passes
- [x] `pnpm --filter @as-comms/worker test:unit` passes
- [ ] CI green

## What's still ahead in Phase 1

- **PR-C** — wizard step redesign (multi-line URL input) + project detail UI section (per-row source management) + server actions for source CRUD + operating-context textarea field

## Out of scope

- UI changes (PR-C)
- Server actions for source CRUD (PR-C)
- Auto-sync schedule (Phase 2)
- Capture loop / "Send and save for AI" trigger (Phase 3)
- Email-history fold-in into synthesis (later brief; current scope handles operator-curated sources)

## Architectural notes

- Adds `ProjectDimensionRepository.findById` (extends the existing `listAll` / `listActive` / `listByIds` API) — domain test mocks updated accordingly
- The orchestrator persists per-source sync metadata even on LLM failure (so operators can see which sources broke regardless of whether synthesis completed)
- Synthesis output → new Notion page (each run creates a fresh page; `ai_knowledge_url` is updated to point at it). The existing `notion-knowledge-sync` worker then refreshes the cache from the new page on its next run. This means **PR-B-2's output flows into AI Draft via the legacy cache path** without any cache-layer changes.