### PR TITLE
feat(settings): wizard + project detail AI Knowledge UI + server actions (PR-C of #366)

### DIFF
--- a/apps/web/app/settings/_components/activation-wizard/index.tsx
+++ b/apps/web/app/settings/_components/activation-wizard/index.tsx
@@ -6,7 +6,7 @@ import { ArrowLeft, ChevronRight, RefreshCw, X } from "lucide-react";
 import {
   type ActivationWizardInput,
   activateProjectFromWizardAction,
-  updateProjectAiKnowledgeAction
+  submitWizardAiKnowledgeSourcesAction
 } from "@/app/settings/actions";
 import {
   Dialog,
@@ -26,7 +26,8 @@ import {
   getStepOneValid,
   getStepThreeValid,
   getStepTwoValid,
-  isNotionUrlLike,
+  getAiKnowledgeSourceLineErrors,
+  splitAiKnowledgeSourceLines,
   normalizeSignatureDraft
 } from "./shared";
 import {
@@ -71,7 +72,9 @@ export function ActivationWizard({
     }),
     1: getStepTwoValid(state.aliases),
     2: getStepThreeValid(state.signatureDraft),
-    3: state.knowledgeStatus === "done"
+    3:
+      state.skipKnowledgeSetup ||
+      state.knowledgeStatus === "done"
   } as const;
   const canContinue =
     state.step === 0
@@ -94,19 +97,41 @@ export function ActivationWizard({
     : ACTIVATION_WIZARD_STEPS[state.step].subtitle;
 
   async function handleSync() {
-    if (selectedProject === null || !isNotionUrlLike(state.notionUrl)) {
+    if (selectedProject === null) {
       dispatch({
         type: "sync-error",
-        message: "Enter a Notion page URL."
+        message: "Choose a project before saving AI Knowledge sources."
+      });
+      return;
+    }
+
+    if (state.skipKnowledgeSetup) {
+      dispatch({ type: "sync-done" });
+      return;
+    }
+
+    const sourceLines = splitAiKnowledgeSourceLines(state.knowledgeSourcesText);
+    if (sourceLines.length === 0) {
+      dispatch({
+        type: "sync-error",
+        message: "Add at least one AI Knowledge source or skip this step."
+      });
+      return;
+    }
+
+    if (Object.keys(getAiKnowledgeSourceLineErrors(state.knowledgeSourcesText)).length > 0) {
+      dispatch({
+        type: "sync-error",
+        message: "Fix the invalid AI Knowledge source URLs before continuing."
       });
       return;
     }
 
     dispatch({ type: "sync-start" });
 
-    const result = await updateProjectAiKnowledgeAction(
+    const result = await submitWizardAiKnowledgeSourcesAction(
       selectedProject.projectId,
-      state.notionUrl
+      sourceLines
     );
     if (!result.ok) {
       dispatch({
@@ -274,13 +299,23 @@ export function ActivationWizard({
 
               {!isActivated && state.step === 3 ? (
                 <StepKnowledge
-                  notionUrl={state.notionUrl}
+                  knowledgeSourcesText={state.knowledgeSourcesText}
+                  skipKnowledgeSetup={state.skipKnowledgeSetup}
                   knowledgeStatus={state.knowledgeStatus}
                   knowledgeMessage={state.knowledgeMessage}
-                  onNotionUrlChange={(nextValue) => {
-                    dispatch({ type: "set-notion-url", notionUrl: nextValue });
+                  onKnowledgeSourcesTextChange={(nextValue) => {
+                    dispatch({
+                      type: "set-knowledge-sources-text",
+                      value: nextValue
+                    });
                   }}
-                  onSync={() => {
+                  onSkipKnowledgeSetupChange={(checked) => {
+                    dispatch({
+                      type: "set-skip-knowledge-setup",
+                      checked
+                    });
+                  }}
+                  onSubmit={() => {
                     void handleSync();
                   }}
                 />
@@ -291,7 +326,8 @@ export function ActivationWizard({
                   selectedProject={selectedProject}
                   aliasDraft={state.aliasDraft}
                   aliases={state.aliases}
-                  notionUrl={state.notionUrl}
+                  knowledgeSourcesText={state.knowledgeSourcesText}
+                  skipKnowledgeSetup={state.skipKnowledgeSetup}
                   signatureDraft={state.signatureDraft}
                   activationError={state.activationMessage}
                 />

--- a/apps/web/app/settings/_components/activation-wizard/shared.ts
+++ b/apps/web/app/settings/_components/activation-wizard/shared.ts
@@ -1,5 +1,5 @@
 import type { ProjectRowViewModel } from "@/src/server/settings/selectors";
-import { parseSourceUrl } from "@as-comms/db";
+import { parseSourceUrl } from "@as-comms/db/parse-source-url";
 
 import {
   getProjectAliasSignatureValidationError,

--- a/apps/web/app/settings/_components/activation-wizard/shared.ts
+++ b/apps/web/app/settings/_components/activation-wizard/shared.ts
@@ -1,4 +1,5 @@
 import type { ProjectRowViewModel } from "@/src/server/settings/selectors";
+import { parseSourceUrl } from "@as-comms/db";
 
 import {
   getProjectAliasSignatureValidationError,
@@ -33,7 +34,7 @@ export const ACTIVATION_WIZARD_STEPS = [
   },
   {
     title: "AI knowledge",
-    subtitle: "Link the Notion page used for AI draft context."
+    subtitle: "Add the sources the AI should learn from, or skip for now."
   },
   {
     title: "Review & activate",
@@ -148,12 +149,35 @@ export function isBasicEmailAddress(value: string): boolean {
   return /^\S+@\S+\.\S+$/.test(value.trim());
 }
 
-export function isNotionUrlLike(value: string): boolean {
-  const normalized = value.trim();
-  return (
-    normalized.startsWith("https://www.notion.so/") ||
-    normalized.startsWith("https://notion.so/")
-  );
+export function splitAiKnowledgeSourceLines(value: string): readonly string[] {
+  return value
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+export function getAiKnowledgeSourceLineErrors(
+  value: string
+): Readonly<Record<number, string>> {
+  const lines = value.split(/\r?\n/u);
+  const errors: Record<number, string> = {};
+
+  for (const [index, line] of lines.entries()) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+
+    try {
+      parseSourceUrl(trimmed);
+    } catch (error) {
+      if (error instanceof Error) {
+        errors[index] = error.message;
+      }
+    }
+  }
+
+  return errors;
 }
 
 export function normalizeAliasAddress(value: string): string {

--- a/apps/web/app/settings/_components/activation-wizard/state.ts
+++ b/apps/web/app/settings/_components/activation-wizard/state.ts
@@ -17,7 +17,8 @@ export interface WizardState {
   readonly aliasDraft: string;
   readonly aliases: readonly AliasDraft[];
   readonly signatureDraft: string;
-  readonly notionUrl: string;
+  readonly knowledgeSourcesText: string;
+  readonly skipKnowledgeSetup: boolean;
   readonly knowledgeStatus: KnowledgeStatus;
   readonly knowledgeMessage: string | null;
   readonly activationStatus: "idle" | "pending" | "error";
@@ -35,7 +36,8 @@ export type WizardAction =
   | { readonly type: "remove-alias"; readonly address: string }
   | { readonly type: "make-primary"; readonly address: string }
   | { readonly type: "set-signature"; readonly signatureDraft: string }
-  | { readonly type: "set-notion-url"; readonly notionUrl: string }
+  | { readonly type: "set-knowledge-sources-text"; readonly value: string }
+  | { readonly type: "set-skip-knowledge-setup"; readonly checked: boolean }
   | { readonly type: "sync-start" }
   | { readonly type: "sync-done" }
   | { readonly type: "sync-error"; readonly message: string }
@@ -56,7 +58,8 @@ export function createInitialState(
     aliasDraft: buildInitialAliasDraft(initialProject),
     aliases: buildInitialAliases(initialProject),
     signatureDraft: "",
-    notionUrl: initialProject?.aiKnowledgeUrl ?? "",
+    knowledgeSourcesText: initialProject?.aiKnowledgeUrl ?? "",
+    skipKnowledgeSetup: false,
     knowledgeStatus: "idle",
     knowledgeMessage: null,
     activationStatus: "idle",
@@ -127,7 +130,8 @@ export function activationWizardReducer(
         aliasDraft: buildInitialAliasDraft(action.project),
         aliases: buildInitialAliases(action.project),
         signatureDraft: "",
-        notionUrl: action.project.aiKnowledgeUrl ?? "",
+        knowledgeSourcesText: action.project.aiKnowledgeUrl ?? "",
+        skipKnowledgeSetup: false,
         knowledgeStatus: "idle",
         knowledgeMessage: null,
         activationStatus: "idle",
@@ -197,14 +201,22 @@ export function activationWizardReducer(
         activationMessage: null,
         activationStatus: "idle"
       };
-    case "set-notion-url":
-      if (state.notionUrl === action.notionUrl) {
+    case "set-knowledge-sources-text":
+      if (state.knowledgeSourcesText === action.value) {
         return state;
       }
 
       return {
         ...resetKnowledgeState(state),
-        notionUrl: action.notionUrl,
+        knowledgeSourcesText: action.value,
+        skipKnowledgeSetup: false,
+        activationMessage: null,
+        activationStatus: "idle"
+      };
+    case "set-skip-knowledge-setup":
+      return {
+        ...resetKnowledgeState(state),
+        skipKnowledgeSetup: action.checked,
         activationMessage: null,
         activationStatus: "idle"
       };

--- a/apps/web/app/settings/_components/activation-wizard/step-knowledge.tsx
+++ b/apps/web/app/settings/_components/activation-wizard/step-knowledge.tsx
@@ -4,71 +4,104 @@ import * as React from "react";
 import { Check, RefreshCw } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 
-import { isNotionUrlLike } from "./shared";
+import {
+  getAiKnowledgeSourceLineErrors,
+  splitAiKnowledgeSourceLines
+} from "./shared";
 
 type KnowledgeStatus = "idle" | "syncing" | "done" | "error";
 
 export function StepKnowledge({
-  notionUrl,
+  knowledgeSourcesText,
+  skipKnowledgeSetup,
   knowledgeStatus,
   knowledgeMessage,
-  onNotionUrlChange,
-  onSync
+  onKnowledgeSourcesTextChange,
+  onSkipKnowledgeSetupChange,
+  onSubmit
 }: {
-  readonly notionUrl: string;
+  readonly knowledgeSourcesText: string;
+  readonly skipKnowledgeSetup: boolean;
   readonly knowledgeStatus: KnowledgeStatus;
   readonly knowledgeMessage: string | null;
-  readonly onNotionUrlChange: (nextValue: string) => void;
-  readonly onSync: () => void;
+  readonly onKnowledgeSourcesTextChange: (nextValue: string) => void;
+  readonly onSkipKnowledgeSetupChange: (checked: boolean) => void;
+  readonly onSubmit: () => void;
 }) {
-  const canSync = knowledgeStatus !== "syncing" && isNotionUrlLike(notionUrl);
+  const lineErrors = getAiKnowledgeSourceLineErrors(knowledgeSourcesText);
+  const sourceLines = splitAiKnowledgeSourceLines(knowledgeSourcesText);
+  const hasInvalidLines = Object.keys(lineErrors).length > 0;
+  const canSubmit =
+    !skipKnowledgeSetup &&
+    knowledgeStatus !== "syncing" &&
+    sourceLines.length > 0 &&
+    !hasInvalidLines;
 
   return (
     <div className="flex flex-col gap-6">
       <div>
         <p className="text-[10px] font-semibold uppercase text-slate-500">
-          AI knowledge source
+          AI Knowledge sources
         </p>
         <p className="mt-1 text-[12px] text-slate-500">
-          Paste the Notion page URL we&apos;ll sync into this project&apos;s
-          knowledge base.
+          Paste links to Notion pages, public web pages, or any source the AI
+          should learn from. The system will fetch each one and synthesize them
+          into the project&apos;s AI Knowledge.
         </p>
       </div>
 
       <div className="rounded-xl border border-slate-200 bg-white p-4">
-        <Input
-          value={notionUrl}
+        <label htmlFor="activation-ai-knowledge-sources" className="sr-only">
+          AI Knowledge sources
+        </label>
+        <textarea
+          id="activation-ai-knowledge-sources"
+          value={knowledgeSourcesText}
           onChange={(event) => {
-            onNotionUrlChange(event.target.value);
+            onKnowledgeSourcesTextChange(event.target.value);
           }}
-          disabled={knowledgeStatus === "syncing"}
-          placeholder="https://www.notion.so/your-workspace/Page-Name"
-          className="h-10 rounded-lg border-slate-200 text-[12.5px] text-slate-800"
+          disabled={knowledgeStatus === "syncing" || skipKnowledgeSetup}
+          rows={8}
+          placeholder={"https://www.notion.so/...\nhttps://www.adventurescientists.org/..."}
+          className="w-full resize-y rounded-lg border border-slate-200 px-3 py-2.5 text-[12.5px] text-slate-800 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200 disabled:bg-slate-50"
         />
+        {Object.entries(lineErrors).length > 0 ? (
+          <div className="mt-3 flex flex-col gap-1 text-[11.5px] text-rose-600">
+            {Object.entries(lineErrors).map(([lineIndex, message]) => (
+              <p key={lineIndex}>Line {String(Number(lineIndex) + 1)}: {message}</p>
+            ))}
+          </div>
+        ) : null}
         {knowledgeStatus === "error" && knowledgeMessage !== null ? (
-          <p className="mt-2 text-[11.5px] text-rose-600">{knowledgeMessage}</p>
+          <p className="mt-3 text-[11.5px] text-rose-600">{knowledgeMessage}</p>
         ) : null}
-        {knowledgeStatus !== "error" &&
-        notionUrl.trim().length > 0 &&
-        !isNotionUrlLike(notionUrl) ? (
-          <p className="mt-2 text-[11.5px] text-rose-600">
-            Enter a Notion page URL.
-          </p>
+        <label className="mt-4 flex items-start gap-2 text-[12px] text-slate-600">
+          <input
+            type="checkbox"
+            checked={skipKnowledgeSetup}
+            onChange={(event) => {
+              onSkipKnowledgeSetupChange(event.target.checked);
+            }}
+            disabled={knowledgeStatus === "syncing"}
+            className="mt-0.5 size-4 rounded border-slate-300"
+          />
+          <span>Skip - set up AI Knowledge later</span>
+        </label>
+        {!skipKnowledgeSetup ? (
+          <div className="mt-4 flex justify-end">
+            <Button
+              type="button"
+              onClick={onSubmit}
+              disabled={!canSubmit}
+              className="min-w-[140px]"
+            >
+              <RefreshCw className="size-3.5" aria-hidden="true" />
+              Save sources
+            </Button>
+          </div>
         ) : null}
-        <div className="mt-4 flex justify-end">
-          <Button
-            type="button"
-            onClick={onSync}
-            disabled={!canSync}
-            className="min-w-[140px]"
-          >
-            <RefreshCw className="size-3.5" aria-hidden="true" />
-            Save and sync
-          </Button>
-        </div>
       </div>
 
       <div
@@ -87,14 +120,15 @@ export function StepKnowledge({
                 aria-hidden="true"
               />
               <div>
-              <p className="text-[13px] font-semibold text-slate-900">
-                Saving and queueing your Notion sync...
-              </p>
-              <p className="mt-1 text-[12px] text-slate-600">
-                We&apos;ll use this page as project context for AI drafts.
-              </p>
+                <p className="text-[13px] font-semibold text-slate-900">
+                  Saving sources and queueing synthesis...
+                </p>
+                <p className="mt-1 text-[12px] text-slate-600">
+                  The worker will fetch each source and synthesize the result in
+                  the background.
+                </p>
+              </div>
             </div>
-          </div>
             <div className="h-2 overflow-hidden rounded-full bg-slate-100">
               <div className="h-full w-2/5 animate-pulse rounded-full bg-[#253746]" />
             </div>
@@ -106,24 +140,33 @@ export function StepKnowledge({
             <Check className="mt-0.5 size-4 text-emerald-600" aria-hidden="true" />
             <div>
               <p className="text-[13px] font-semibold text-slate-900">
-                Saved. Sync queued.
+                Sources saved. Synthesis queued.
               </p>
               <p className="mt-1 text-[12px] text-slate-600">
-                Future AI drafts will use this Notion page as project context.
+                The activation can continue while the worker fetches these
+                sources in the background.
               </p>
             </div>
           </div>
         ) : null}
 
-        {knowledgeStatus === "idle" && knowledgeMessage === null ? (
+        {knowledgeStatus === "idle" && skipKnowledgeSetup ? (
           <p className="text-[12px] text-slate-500">
-            Start a sync after you paste a Notion page URL.
+            AI Knowledge setup is skipped for now. You can manage sources from the
+            project detail page later.
+          </p>
+        ) : null}
+
+        {knowledgeStatus === "idle" && !skipKnowledgeSetup && knowledgeMessage === null ? (
+          <p className="text-[12px] text-slate-500">
+            Add one source per line, then save them before continuing.
           </p>
         ) : null}
 
         {knowledgeStatus === "error" && knowledgeMessage !== null ? (
           <p className="text-[12px] text-slate-700">
-            Update the URL or try syncing again once the worker is healthy.
+            Correct the invalid lines or try submitting again once the worker is
+            healthy.
           </p>
         ) : null}
       </div>

--- a/apps/web/app/settings/_components/activation-wizard/step-review.tsx
+++ b/apps/web/app/settings/_components/activation-wizard/step-review.tsx
@@ -14,14 +14,16 @@ export function StepReview({
   selectedProject,
   aliasDraft,
   aliases,
-  notionUrl,
+  knowledgeSourcesText,
+  skipKnowledgeSetup,
   signatureDraft,
   activationError
 }: {
   readonly selectedProject: ProjectRowViewModel | null;
   readonly aliasDraft: string;
   readonly aliases: readonly AliasDraft[];
-  readonly notionUrl: string;
+  readonly knowledgeSourcesText: string;
+  readonly skipKnowledgeSetup: boolean;
   readonly signatureDraft: string;
   readonly activationError: string | null;
 }) {
@@ -46,14 +48,20 @@ export function StepReview({
         <ReviewRow
           label="AI knowledge"
           value={
-            <span className="flex items-center gap-2">
-              <span className="truncate">{notionUrl}</span>
-              <StatusBadge
-                label="Synced"
-                colorClasses="bg-emerald-50 text-emerald-700 ring-emerald-200"
-                variant="soft"
-              />
-            </span>
+            skipKnowledgeSetup ? (
+              <span className="text-slate-500">Skipped for now</span>
+            ) : (
+              <span className="flex items-center gap-2">
+                <span className="truncate">
+                  {`${String(knowledgeSourcesText.split(/\r?\n/u).filter((line) => line.trim().length > 0).length)} source(s) saved`}
+                </span>
+                <StatusBadge
+                  label="Queued"
+                  colorClasses="bg-emerald-50 text-emerald-700 ring-emerald-200"
+                  variant="soft"
+                />
+              </span>
+            )
           }
         />
         <ReviewRow
@@ -76,7 +84,7 @@ export function StepReview({
           </li>
           <li className="flex gap-2">
             <Check className="mt-0.5 size-3 text-emerald-600" aria-hidden="true" />
-            Future AI drafts use the synced Notion knowledge.
+            AI Knowledge can be managed later from the project detail page.
           </li>
         </ul>
       </div>

--- a/apps/web/app/settings/_components/project-ai-knowledge-section.tsx
+++ b/apps/web/app/settings/_components/project-ai-knowledge-section.tsx
@@ -1,0 +1,653 @@
+"use client";
+
+import * as React from "react";
+import { useState, useTransition } from "react";
+import {
+  AlertTriangle,
+  Check,
+  Circle,
+  Pencil,
+  Plus,
+  RefreshCw,
+  RotateCw,
+  Trash2
+} from "lucide-react";
+
+import type { AiKnowledgeSource } from "@as-comms/contracts";
+
+import { TYPE } from "@/app/_lib/design-tokens-v2";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { StatusBadge } from "@/components/ui/status-badge";
+import { cn } from "@/lib/utils";
+
+import {
+  addAiKnowledgeSourceAction,
+  removeAiKnowledgeSourceAction,
+  syncOneAiKnowledgeSourceAction,
+  triggerProjectKnowledgeSynthesisAction,
+  updateAiKnowledgeSourceAction,
+  updateOperatingContextAction
+} from "../actions";
+
+interface FeedbackState {
+  readonly kind: "success" | "error";
+  readonly message: string;
+}
+
+function formatTimestamp(value: string | null): string {
+  if (value === null) {
+    return "Never";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "Unknown";
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short"
+  }).format(date);
+}
+
+function buildSourceLabel(source: AiKnowledgeSource): string {
+  const trimmedLabel = source.label?.trim() ?? null;
+  if (trimmedLabel !== null && trimmedLabel.length > 0) {
+    return trimmedLabel;
+  }
+
+  try {
+    return new URL(source.url).hostname;
+  } catch {
+    return source.url;
+  }
+}
+
+function getSourceStatus(source: AiKnowledgeSource): {
+  readonly label: string;
+  readonly icon: typeof Circle;
+  readonly classes: string;
+} {
+  if (!source.enabled) {
+    return {
+      label: "Disabled",
+      icon: Circle,
+      classes: "bg-slate-100 text-slate-600 ring-slate-200"
+    };
+  }
+
+  switch (source.last_sync_status) {
+    case "healthy":
+      return {
+        label: "Healthy",
+        icon: Check,
+        classes: "bg-emerald-50 text-emerald-700 ring-emerald-200"
+      };
+    case "stale":
+      return {
+        label: "Stale",
+        icon: RotateCw,
+        classes: "bg-amber-50 text-amber-800 ring-amber-200"
+      };
+    case "broken":
+      return {
+        label: "Broken",
+        icon: AlertTriangle,
+        classes: "bg-rose-50 text-rose-700 ring-rose-200"
+      };
+    case "pending":
+    default:
+      return {
+        label: "Pending",
+        icon: RefreshCw,
+        classes: "bg-sky-50 text-sky-700 ring-sky-200"
+      };
+  }
+}
+
+export function ProjectAiKnowledgeSection({
+  projectId,
+  isAdmin,
+  initialSources,
+  initialOperatingContext,
+  aiOptimizedSynthesizedAt,
+  aiKnowledgeSynthesisStale
+}: {
+  readonly projectId: string;
+  readonly isAdmin: boolean;
+  readonly initialSources: readonly AiKnowledgeSource[];
+  readonly initialOperatingContext: string;
+  readonly aiOptimizedSynthesizedAt: string | null;
+  readonly aiKnowledgeSynthesisStale: boolean;
+}) {
+  const [sources, setSources] = useState(initialSources);
+  const [operatingContext, setOperatingContext] = useState(initialOperatingContext);
+  const [savedOperatingContext, setSavedOperatingContext] = useState(
+    initialOperatingContext
+  );
+  const [feedback, setFeedback] = useState<FeedbackState | null>(null);
+  const [expandedSourceId, setExpandedSourceId] = useState<string | null>(null);
+  const [editingSource, setEditingSource] = useState<AiKnowledgeSource | null>(null);
+  const [editingUrl, setEditingUrl] = useState("");
+  const [editingLabel, setEditingLabel] = useState("");
+  const [addOpen, setAddOpen] = useState(false);
+  const [addUrl, setAddUrl] = useState("");
+  const [addLabel, setAddLabel] = useState("");
+  const [pendingSourceId, setPendingSourceId] = useState<string | null>(null);
+  const [rowPending, startRowTransition] = useTransition();
+  const [saveContextPending, startSaveContextTransition] = useTransition();
+  const [syncAllPending, startSyncAllTransition] = useTransition();
+
+  function announce(message: string, kind: FeedbackState["kind"] = "success") {
+    setFeedback({ kind, message });
+    window.setTimeout(() => {
+      setFeedback(null);
+    }, 3500);
+  }
+
+  const enabledHealthySources = sources.filter(
+    (source) => source.enabled && source.last_sync_status === "healthy"
+  );
+  const sourcesDirty = operatingContext.trim() !== savedOperatingContext.trim();
+
+  function handleSyncAll() {
+    startSyncAllTransition(async () => {
+      const result = await triggerProjectKnowledgeSynthesisAction(projectId);
+      if (!result.ok) {
+        announce(result.message, "error");
+        return;
+      }
+
+      announce("Queued a full AI Knowledge re-sync.");
+    });
+  }
+
+  function handleSaveOperatingContext() {
+    startSaveContextTransition(async () => {
+      const result = await updateOperatingContextAction(projectId, operatingContext);
+      if (!result.ok) {
+        announce(result.message, "error");
+        return;
+      }
+
+      setOperatingContext(result.data.content);
+      setSavedOperatingContext(result.data.content);
+      announce("Saved the operating context.");
+    });
+  }
+
+  function beginEdit(source: AiKnowledgeSource) {
+    setEditingSource(source);
+    setEditingUrl(source.url);
+    setEditingLabel(source.label ?? "");
+  }
+
+  function handleSaveEdit() {
+    if (editingSource === null) {
+      return;
+    }
+
+    const sourceId = editingSource.id;
+    setPendingSourceId(sourceId);
+    startRowTransition(async () => {
+      const result = await updateAiKnowledgeSourceAction(projectId, sourceId, {
+        url: editingUrl,
+        label: editingLabel
+      });
+      setPendingSourceId(null);
+
+      if (!result.ok) {
+        announce(result.message, "error");
+        return;
+      }
+
+      setSources((current) =>
+        current.map((source) =>
+          source.id === sourceId ? result.data.source : source
+        )
+      );
+      setEditingSource(null);
+      announce("Updated the AI Knowledge source.");
+    });
+  }
+
+  function handleAddSource() {
+    startRowTransition(async () => {
+      const result = await addAiKnowledgeSourceAction(projectId, {
+        url: addUrl,
+        label: addLabel
+      });
+      if (!result.ok) {
+        announce(result.message, "error");
+        return;
+      }
+
+      setSources((current) => [...current, result.data.source]);
+      setAddOpen(false);
+      setAddUrl("");
+      setAddLabel("");
+      announce("Added a new AI Knowledge source.");
+    });
+  }
+
+  function handleRemoveSource(sourceId: string) {
+    setPendingSourceId(sourceId);
+    startRowTransition(async () => {
+      const result = await removeAiKnowledgeSourceAction(projectId, sourceId);
+      setPendingSourceId(null);
+
+      if (!result.ok) {
+        announce(result.message, "error");
+        return;
+      }
+
+      setSources((current) => current.filter((source) => source.id !== sourceId));
+      announce("Removed the AI Knowledge source.");
+    });
+  }
+
+  function handleToggleEnabled(source: AiKnowledgeSource, enabled: boolean) {
+    setPendingSourceId(source.id);
+    startRowTransition(async () => {
+      const result = await updateAiKnowledgeSourceAction(projectId, source.id, {
+        enabled
+      });
+      setPendingSourceId(null);
+
+      if (!result.ok) {
+        announce(result.message, "error");
+        return;
+      }
+
+      setSources((current) =>
+        current.map((item) => (item.id === source.id ? result.data.source : item))
+      );
+      announce(enabled ? "Re-enabled the source." : "Disabled the source.");
+    });
+  }
+
+  function handleSyncOne(sourceId: string) {
+    setPendingSourceId(sourceId);
+    startRowTransition(async () => {
+      const result = await syncOneAiKnowledgeSourceAction(projectId, sourceId);
+      setPendingSourceId(null);
+
+      if (!result.ok) {
+        announce(result.message, "error");
+        return;
+      }
+
+      announce("Queued a project synthesis run.");
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      {feedback ? (
+        <div
+          role="status"
+          aria-live="polite"
+          className={cn(
+            "rounded-md px-3 py-2 text-sm",
+            feedback.kind === "success"
+              ? "bg-emerald-50 text-emerald-800 ring-1 ring-inset ring-emerald-200"
+              : "bg-rose-50 text-rose-800 ring-1 ring-inset ring-rose-200"
+          )}
+        >
+          {feedback.message}
+        </div>
+      ) : null}
+
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-sm font-medium text-slate-900">AI Knowledge</p>
+            <p className={cn(TYPE.caption, "mt-1 max-w-2xl text-slate-500")}>
+              Manage the sources the synthesis worker fetches and combines into
+              the project&apos;s AI Knowledge.
+            </p>
+          </div>
+          {isAdmin ? (
+            <div className="flex flex-wrap items-center gap-2">
+              <Dialog open={addOpen} onOpenChange={setAddOpen}>
+                <DialogTrigger asChild>
+                  <Button type="button" size="sm" variant="outline">
+                    <Plus className="size-3.5" aria-hidden="true" />
+                    Add source
+                  </Button>
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>Add AI Knowledge source</DialogTitle>
+                    <DialogDescription>
+                      Add a Notion page or public web page to this project.
+                    </DialogDescription>
+                  </DialogHeader>
+                  <div className="flex flex-col gap-3 py-2">
+                    <div className="flex flex-col gap-1.5">
+                      <label htmlFor="add-ai-knowledge-url" className={TYPE.label}>
+                        Source URL
+                      </label>
+                      <Input
+                        id="add-ai-knowledge-url"
+                        value={addUrl}
+                        onChange={(event) => {
+                          setAddUrl(event.target.value);
+                        }}
+                        placeholder="https://..."
+                      />
+                    </div>
+                    <div className="flex flex-col gap-1.5">
+                      <label htmlFor="add-ai-knowledge-label" className={TYPE.label}>
+                        Label
+                      </label>
+                      <Input
+                        id="add-ai-knowledge-label"
+                        value={addLabel}
+                        onChange={(event) => {
+                          setAddLabel(event.target.value);
+                        }}
+                        placeholder="Optional operator label"
+                      />
+                    </div>
+                  </div>
+                  <DialogFooter>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={() => {
+                        setAddOpen(false);
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      onClick={handleAddSource}
+                      disabled={rowPending || addUrl.trim().length === 0}
+                    >
+                      Save source
+                    </Button>
+                  </DialogFooter>
+                </DialogContent>
+              </Dialog>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={handleSyncAll}
+                disabled={syncAllPending}
+              >
+                Re-sync all
+              </Button>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="overflow-hidden rounded-xl border border-slate-200">
+          <table className="w-full border-collapse text-left text-[12.5px]">
+            <thead className="bg-slate-50 text-slate-500">
+              <tr>
+                <th className="px-3 py-2 font-medium">Status</th>
+                <th className="px-3 py-2 font-medium">Kind</th>
+                <th className="px-3 py-2 font-medium">Label</th>
+                <th className="px-3 py-2 font-medium">URL</th>
+                <th className="px-3 py-2 font-medium">Last synced</th>
+                <th className="px-3 py-2 font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100 bg-white">
+              {sources.map((source) => {
+                const status = getSourceStatus(source);
+                const StatusIcon = status.icon;
+                const isExpanded = expandedSourceId === source.id;
+                const isPending = rowPending && pendingSourceId === source.id;
+
+                return (
+                  <tr
+                    key={source.id}
+                    className={cn(!source.enabled && "opacity-70", isPending && "opacity-60")}
+                  >
+                    <td className="px-3 py-3">
+                      <span className="inline-flex items-center gap-1.5">
+                        <StatusIcon className="size-3 text-slate-500" aria-hidden="true" />
+                        <StatusBadge
+                          label={status.label}
+                          colorClasses={status.classes}
+                          variant="soft"
+                        />
+                      </span>
+                    </td>
+                    <td className="px-3 py-3">
+                      <StatusBadge
+                        label={source.kind}
+                        colorClasses="bg-slate-100 text-slate-700 ring-slate-200"
+                        variant="soft"
+                      />
+                    </td>
+                    <td className="px-3 py-3 font-medium text-slate-900">
+                      {buildSourceLabel(source)}
+                    </td>
+                    <td className="max-w-[280px] px-3 py-3">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setExpandedSourceId((current) =>
+                            current === source.id ? null : source.id
+                          );
+                        }}
+                        className={cn(
+                          "w-full text-left text-slate-600 hover:text-slate-900",
+                          !isExpanded && "truncate"
+                        )}
+                        title={source.url}
+                      >
+                        {source.url}
+                      </button>
+                    </td>
+                    <td className="px-3 py-3 text-slate-600">
+                      {formatTimestamp(source.last_synced_at)}
+                    </td>
+                    <td className="px-3 py-3">
+                      {isAdmin ? (
+                        <div className="flex flex-wrap items-center gap-2">
+                          <button
+                            type="button"
+                            onClick={() => {
+                              beginEdit(source);
+                            }}
+                            className="text-slate-600 hover:text-slate-900"
+                          >
+                            <span className="sr-only">Edit</span>
+                            <Pencil className="size-3.5" aria-hidden="true" />
+                          </button>
+                          <button
+                            type="button"
+                            disabled={isPending}
+                            onClick={() => {
+                              handleSyncOne(source.id);
+                            }}
+                            className="text-slate-600 hover:text-slate-900 disabled:opacity-40"
+                          >
+                            Sync now
+                          </button>
+                          {!source.enabled ? (
+                            <button
+                              type="button"
+                              disabled={isPending}
+                              onClick={() => {
+                                handleToggleEnabled(source, true);
+                              }}
+                              className="text-slate-600 hover:text-slate-900 disabled:opacity-40"
+                            >
+                              Re-enable
+                            </button>
+                          ) : (
+                            <button
+                              type="button"
+                              disabled={isPending}
+                              onClick={() => {
+                                handleToggleEnabled(source, false);
+                              }}
+                              className="text-slate-600 hover:text-slate-900 disabled:opacity-40"
+                            >
+                              Disable
+                            </button>
+                          )}
+                          <button
+                            type="button"
+                            disabled={isPending}
+                            onClick={() => {
+                              handleRemoveSource(source.id);
+                            }}
+                            className="text-rose-600 hover:text-rose-700 disabled:opacity-40"
+                          >
+                            <Trash2 className="size-3.5" aria-hidden="true" />
+                          </button>
+                        </div>
+                      ) : null}
+                    </td>
+                  </tr>
+                );
+              })}
+              {sources.length === 0 ? (
+                <tr>
+                  <td colSpan={6} className="px-3 py-5 text-center text-slate-500">
+                    No AI Knowledge sources yet.
+                  </td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2 rounded-xl border border-slate-200 bg-slate-50/40 p-4">
+        <div>
+          <p className="text-sm font-medium text-slate-900">
+            Operating context (operator-maintained)
+          </p>
+          <p className={cn(TYPE.caption, "mt-1 text-slate-500")}>
+            What&apos;s true right now. The AI sees this every time it drafts. No
+            re-synthesis needed when you edit this.
+          </p>
+        </div>
+        <textarea
+          value={operatingContext}
+          onChange={(event) => {
+            setOperatingContext(event.target.value);
+          }}
+          rows={6}
+          disabled={!isAdmin || saveContextPending}
+          className="w-full resize-y rounded-md border border-slate-200 bg-white px-3 py-2.5 text-[12.5px] text-slate-800 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200"
+        />
+        {isAdmin ? (
+          <div className="flex justify-end">
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={handleSaveOperatingContext}
+              disabled={saveContextPending || !sourcesDirty}
+            >
+              Save context
+            </Button>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="rounded-xl border border-slate-200 bg-white p-4">
+        <p className="text-sm font-medium text-slate-900">Synthesis status</p>
+        <p className={cn(TYPE.caption, "mt-1 text-slate-600")}>
+          {aiOptimizedSynthesizedAt === null
+            ? "Not yet synthesized."
+            : `Last synthesized: ${formatTimestamp(aiOptimizedSynthesizedAt)} (${String(enabledHealthySources.length)} healthy enabled sources, model metadata unavailable).`}
+        </p>
+        {aiKnowledgeSynthesisStale ? (
+          <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[12px] text-amber-900">
+            Synthesis is stale. One or more source hashes no longer match the
+            last synthesized input. Re-sync recommended.
+          </div>
+        ) : null}
+      </div>
+
+      <Dialog
+        open={editingSource !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setEditingSource(null);
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit AI Knowledge source</DialogTitle>
+            <DialogDescription>
+              Update the source URL or operator label.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-3 py-2">
+            <div className="flex flex-col gap-1.5">
+              <label htmlFor="edit-ai-knowledge-url" className={TYPE.label}>
+                Source URL
+              </label>
+              <Input
+                id="edit-ai-knowledge-url"
+                value={editingUrl}
+                onChange={(event) => {
+                  setEditingUrl(event.target.value);
+                }}
+                placeholder="https://..."
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <label htmlFor="edit-ai-knowledge-label" className={TYPE.label}>
+                Label
+              </label>
+              <Input
+                id="edit-ai-knowledge-label"
+                value={editingLabel}
+                onChange={(event) => {
+                  setEditingLabel(event.target.value);
+                }}
+                placeholder="Optional operator label"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                setEditingSource(null);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              onClick={handleSaveEdit}
+              disabled={rowPending || editingUrl.trim().length === 0}
+            >
+              Save changes
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/web/app/settings/_components/project-detail.tsx
+++ b/apps/web/app/settings/_components/project-detail.tsx
@@ -33,9 +33,7 @@ import {
   type ProjectEmailInput,
   type ProjectEmailMutationData,
   type ProjectMutationData,
-  syncProjectAiKnowledgeAction,
   updateProjectAliasAction,
-  updateProjectAiKnowledgeAction,
   updateProjectAliasSignatureAction,
   updateProjectEmailsAction
 } from "../actions";
@@ -43,6 +41,7 @@ import {
   getProjectAliasSignatureValidationError,
   normalizeProjectAliasSignature
 } from "../_lib/project-alias-signature";
+import { ProjectAiKnowledgeSection } from "./project-ai-knowledge-section";
 
 interface FeedbackState {
   readonly kind: "success" | "error";
@@ -51,14 +50,9 @@ interface FeedbackState {
 
 function hasActivationRequirements(input: {
   readonly projectAlias: string | null;
-  readonly aiKnowledgeUrl: string | null;
   readonly emails: readonly ProjectEmailInput[];
 }): boolean {
-  return (
-    input.emails.length >= 1 &&
-    input.aiKnowledgeUrl !== null &&
-    (input.projectAlias?.trim().length ?? 0) > 0
-  );
+  return input.emails.length >= 1 && (input.projectAlias?.trim().length ?? 0) > 0;
 }
 
 function buildProjectState(
@@ -72,6 +66,10 @@ function buildProjectState(
     aiKnowledgeUrl: project.aiKnowledgeUrl,
     aiKnowledgeSyncedAt: project.aiKnowledgeSyncedAt,
     hasCachedAiKnowledge: project.hasCachedAiKnowledge,
+    aiKnowledgeSources: project.aiKnowledgeSources,
+    aiOperatingContext: project.aiOperatingContext,
+    aiOptimizedSynthesizedAt: project.aiOptimizedSynthesizedAt,
+    aiOptimizedInputHash: project.aiOptimizedInputHash,
     activationRequirementsMet: project.activationRequirementsMet,
     emails: project.emails
   };
@@ -98,7 +96,6 @@ function mergeProjectState(
     ...next,
     activationRequirementsMet: hasActivationRequirements({
       projectAlias: next.projectAlias,
-      aiKnowledgeUrl: next.aiKnowledgeUrl,
       emails: next.emails
     })
   };
@@ -161,25 +158,6 @@ function toProjectEmailInputs(
   }));
 }
 
-function formatLastSynced(iso: string | null): string {
-  return iso
-    ? `Knowledge last synced ${new Date(iso).toLocaleString()}`
-    : "Knowledge has not been synced yet.";
-}
-
-function getStalenessDays(iso: string | null): number | null {
-  if (iso === null) {
-    return null;
-  }
-
-  const elapsedMs = Date.now() - new Date(iso).getTime();
-  if (!Number.isFinite(elapsedMs) || elapsedMs < 0) {
-    return null;
-  }
-
-  return Math.floor(elapsedMs / (24 * 60 * 60 * 1000));
-}
-
 export function ProjectDetail({
   project
 }: {
@@ -190,7 +168,6 @@ export function ProjectDetail({
     projectState,
     mergeProjectState
   );
-  const [knowledgeDraft, setKnowledgeDraft] = useState(project.aiKnowledgeUrl ?? "");
   const [projectAliasDraft, setProjectAliasDraft] = useState(project.projectAlias ?? "");
   const [signatureDrafts, setSignatureDrafts] = useState(() =>
     buildSignatureDrafts(project.emails)
@@ -203,15 +180,11 @@ export function ProjectDetail({
   const [activationMessage, setActivationMessage] = useState<string | null>(null);
   const [pendingEmail, setPendingEmail] = useState<string | null>(null);
   const [pendingSignatureId, setPendingSignatureId] = useState<string | null>(null);
-  const [knowledgePending, startKnowledgeTransition] = useTransition();
   const [projectAliasPending, startProjectAliasTransition] = useTransition();
   const [emailPending, startEmailTransition] = useTransition();
   const [signaturePending, startSignatureTransition] = useTransition();
   const [activationPending, startActivationTransition] = useTransition();
   const [deactivateOpen, setDeactivateOpen] = useState(false);
-  const [knowledgeEditorOpen, setKnowledgeEditorOpen] = useState(
-    project.aiKnowledgeUrl === null
-  );
 
   function announce(message: string, kind: FeedbackState["kind"] = "success") {
     setFeedback({ kind, message });
@@ -222,7 +195,6 @@ export function ProjectDetail({
 
   function commitProject(nextProject: ProjectMutationData) {
     setProjectState(nextProject);
-    setKnowledgeDraft(nextProject.aiKnowledgeUrl ?? "");
     setProjectAliasDraft(nextProject.projectAlias ?? "");
     setSignatureDrafts((current) =>
       Object.fromEntries(
@@ -240,19 +212,6 @@ export function ProjectDetail({
       )
     );
     setActivationMessage(null);
-  }
-
-  function handleKnowledgeSync() {
-    startKnowledgeTransition(async () => {
-      const result = await syncProjectAiKnowledgeAction(project.projectId);
-
-      if (!result.ok) {
-        announce(result.message, "error");
-        return;
-      }
-
-      announce("Queued a fresh Notion sync.");
-    });
   }
 
   function handleAddEmail() {
@@ -419,36 +378,6 @@ export function ProjectDetail({
     });
   }
 
-  function handleSaveKnowledgeUrl(nextDraft = knowledgeDraft) {
-    const nextUrl = nextDraft.trim().length === 0 ? null : nextDraft.trim();
-
-    startKnowledgeTransition(async () => {
-      applyOptimisticProject({ aiKnowledgeUrl: nextUrl });
-      const result = await updateProjectAiKnowledgeAction(
-        project.projectId,
-        nextUrl
-      );
-
-      if (!result.ok) {
-        announce(result.message, "error");
-        return;
-      }
-
-      commitProject(result.data);
-      setKnowledgeEditorOpen(nextUrl === null);
-      announce(
-        nextUrl === null
-          ? "Cleared the AI knowledge URL."
-          : "Saved the Notion URL and queued a sync."
-      );
-    });
-  }
-
-  function handleUnlinkKnowledgeUrl() {
-    setKnowledgeDraft("");
-    handleSaveKnowledgeUrl("");
-  }
-
   function handleSaveProjectAlias() {
     const nextAlias =
       projectAliasDraft.trim().length === 0 ? null : projectAliasDraft.trim();
@@ -503,14 +432,12 @@ export function ProjectDetail({
     });
   }
 
-  const knowledgeDirty =
-    knowledgeDraft.trim() !== (optimisticProject.aiKnowledgeUrl ?? "");
   const projectAliasDirty =
     projectAliasDraft.trim() !== (optimisticProject.projectAlias ?? "");
   const inactiveActivationMessage =
     activationMessage ??
     (!optimisticProject.activationRequirementsMet
-      ? "Activation needs a short project alias, a project inbox alias, and a Notion page URL."
+      ? "Activation needs a short project alias and a project inbox alias."
       : null);
   const signatureEmails = [...optimisticProject.emails].sort((left, right) => {
     if (left.isPrimary !== right.isPrimary) {
@@ -521,14 +448,6 @@ export function ProjectDetail({
   });
   const signaturePlaceholderProjectName =
     optimisticProject.projectAlias ?? optimisticProject.projectName;
-  const showKnowledgeEditor =
-    project.isAdmin &&
-    (knowledgeEditorOpen || optimisticProject.aiKnowledgeUrl === null);
-  const staleDays = getStalenessDays(optimisticProject.aiKnowledgeSyncedAt);
-  const showKnowledgeStalenessWarning =
-    optimisticProject.aiKnowledgeUrl !== null &&
-    staleDays !== null &&
-    staleDays > 30;
 
   return (
     <div className="flex max-w-3xl flex-col gap-6">
@@ -780,109 +699,14 @@ export function ProjectDetail({
           </div>
         </div>
 
-        <div className="flex flex-col gap-1.5">
-          <span className={TYPE.label}>AI knowledge source</span>
-          <div className="flex flex-col gap-2">
-            <div className="flex flex-col gap-3 rounded-md border border-slate-200 bg-white px-3 py-2 sm:flex-row sm:items-center">
-              <span className="inline-flex size-4 shrink-0 items-center justify-center rounded bg-white text-[10px] font-semibold text-slate-900 ring-1 ring-slate-200">
-                N
-              </span>
-              <div className="min-w-0 flex-1">
-                <div className="truncate text-[12.5px] font-medium text-slate-800">
-                  {optimisticProject.aiKnowledgeUrl ?? "No knowledge source linked"}
-                </div>
-                <div className={cn(TYPE.micro, "truncate text-slate-500")}>
-                  {formatLastSynced(optimisticProject.aiKnowledgeSyncedAt)}
-                </div>
-              </div>
-              {project.isAdmin ? (
-                <div className="flex items-center gap-2">
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    onClick={handleKnowledgeSync}
-                    disabled={
-                      knowledgePending || optimisticProject.aiKnowledgeUrl === null
-                    }
-                  >
-                    Resync
-                  </Button>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="ghost"
-                    onClick={handleUnlinkKnowledgeUrl}
-                    disabled={
-                      knowledgePending || optimisticProject.aiKnowledgeUrl === null
-                    }
-                  >
-                    Unlink
-                  </Button>
-                </div>
-              ) : null}
-            </div>
-
-            {project.isAdmin ? (
-              <div className="flex flex-col gap-2">
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="ghost"
-                  className="w-fit px-0 text-slate-600 hover:bg-transparent hover:text-slate-900"
-                  onClick={() => {
-                    setKnowledgeEditorOpen((current) => !current);
-                  }}
-                >
-                  {showKnowledgeEditor ? "Hide URL editor" : "Edit URL"}
-                </Button>
-                {showKnowledgeEditor ? (
-                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-                    <label htmlFor="project-ai-knowledge-url" className="sr-only">
-                      AI knowledge URL
-                    </label>
-                    <Input
-                      id="project-ai-knowledge-url"
-                      value={knowledgeDraft}
-                      onChange={(event) => {
-                        setKnowledgeDraft(event.target.value);
-                        setActivationMessage(null);
-                      }}
-                      disabled={knowledgePending}
-                      placeholder="https://..."
-                      className="font-mono text-[13px]"
-                    />
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="outline"
-                      onClick={() => {
-                        handleSaveKnowledgeUrl();
-                      }}
-                      disabled={knowledgePending || !knowledgeDirty}
-                    >
-                      Save URL
-                    </Button>
-                  </div>
-                ) : null}
-              </div>
-            ) : null}
-            {showKnowledgeStalenessWarning ? (
-              <div className="flex items-center justify-between gap-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[12px] text-amber-900">
-                <span>Knowledge synced {String(staleDays)} days ago. Resync?</span>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  onClick={handleKnowledgeSync}
-                  disabled={knowledgePending}
-                >
-                  Resync
-                </Button>
-              </div>
-            ) : null}
-          </div>
-        </div>
+        <ProjectAiKnowledgeSection
+          projectId={project.projectId}
+          isAdmin={project.isAdmin}
+          initialSources={project.aiKnowledgeSources}
+          initialOperatingContext={project.aiOperatingContext}
+          aiOptimizedSynthesizedAt={project.aiOptimizedSynthesizedAt}
+          aiKnowledgeSynthesisStale={project.aiKnowledgeSynthesisStale}
+        />
 
         <div className="flex flex-col gap-4">
           <span className={TYPE.label}>Email signatures</span>

--- a/apps/web/app/settings/actions.ts
+++ b/apps/web/app/settings/actions.ts
@@ -6,6 +6,9 @@ import { z } from "zod";
 
 import {
   createProjectAliasSchema,
+  synthesizeProjectKnowledgeJobName,
+  synthesizeProjectKnowledgePayloadSchema,
+  type AiKnowledgeSource,
   deactivateUserSchema,
   demoteUserSchema,
   notionKnowledgeSyncJobName,
@@ -14,6 +17,13 @@ import {
   reactivateUserSchema,
   type IntegrationHealthRecord
 } from "@as-comms/contracts";
+import {
+  addSource,
+  AiKnowledgeSourceValidationError,
+  parseSourceUrl,
+  removeSource,
+  updateSource
+} from "@as-comms/db";
 
 import { resolveAdminSession } from "@/src/server/auth/api";
 import { appendSecurityAudit } from "@/src/server/security/audit";
@@ -141,6 +151,32 @@ const activationWizardInputSchema = z
     }
   });
 
+const wizardAiKnowledgeSourcesSchema = z.object({
+  projectId: z.string().trim().min(1, "Project is required."),
+  urls: z.array(z.string()).max(100, "Add no more than 100 sources.")
+});
+
+const addAiKnowledgeSourceSchema = z.object({
+  url: z.string().trim().min(1, "Source URL is required."),
+  label: z.string().trim().max(160, "Label must be 160 characters or fewer.").nullable().optional()
+});
+
+const updateAiKnowledgeSourceSchema = z
+  .object({
+    url: z.string().trim().min(1, "Source URL is required.").optional(),
+    label: z.string().trim().max(160, "Label must be 160 characters or fewer.").nullable().optional(),
+    enabled: z.boolean().optional()
+  })
+  .refine(
+    (value) =>
+      value.url !== undefined ||
+      value.label !== undefined ||
+      value.enabled !== undefined,
+    {
+      message: "At least one source field must be updated."
+    }
+  );
+
 export interface ProjectKnowledgeMutationData {
   readonly id: string;
 }
@@ -197,14 +233,9 @@ function errorResult(
 
 function hasActivationRequirements(input: {
   readonly projectAlias: string | null;
-  readonly aiKnowledgeUrl: string | null;
   readonly emails: readonly { readonly address: string; readonly isPrimary: boolean }[];
 }): boolean {
-  return (
-    input.emails.length >= 1 &&
-    input.aiKnowledgeUrl !== null &&
-    (input.projectAlias?.trim().length ?? 0) > 0
-  );
+  return input.emails.length >= 1 && (input.projectAlias?.trim().length ?? 0) > 0;
 }
 
 function serializeProjectMutationData(input: {
@@ -215,6 +246,10 @@ function serializeProjectMutationData(input: {
   readonly aiKnowledgeUrl: string | null;
   readonly aiKnowledgeSyncedAt: Date | null;
   readonly hasCachedAiKnowledge: boolean;
+  readonly aiKnowledgeSources?: readonly AiKnowledgeSource[];
+  readonly aiOperatingContext?: string;
+  readonly aiOptimizedSynthesizedAt?: Date | null;
+  readonly aiOptimizedInputHash?: string | null;
   readonly emails: readonly {
     readonly id: string;
     readonly address: string;
@@ -230,9 +265,13 @@ function serializeProjectMutationData(input: {
     aiKnowledgeUrl: input.aiKnowledgeUrl,
     aiKnowledgeSyncedAt: input.aiKnowledgeSyncedAt?.toISOString() ?? null,
     hasCachedAiKnowledge: input.hasCachedAiKnowledge,
+    aiKnowledgeSources: input.aiKnowledgeSources ?? [],
+    aiOperatingContext: input.aiOperatingContext ?? "",
+    aiOptimizedSynthesizedAt:
+      input.aiOptimizedSynthesizedAt?.toISOString() ?? null,
+    aiOptimizedInputHash: input.aiOptimizedInputHash ?? null,
     activationRequirementsMet: hasActivationRequirements({
       projectAlias: input.projectAlias,
-      aiKnowledgeUrl: input.aiKnowledgeUrl,
       emails: input.emails
     }),
     emails: input.emails.map((email) => ({
@@ -634,8 +673,24 @@ export interface ProjectMutationData {
   readonly aiKnowledgeUrl: string | null;
   readonly aiKnowledgeSyncedAt: string | null;
   readonly hasCachedAiKnowledge: boolean;
+  readonly aiKnowledgeSources: readonly AiKnowledgeSource[];
+  readonly aiOperatingContext: string;
+  readonly aiOptimizedSynthesizedAt: string | null;
+  readonly aiOptimizedInputHash: string | null;
   readonly activationRequirementsMet: boolean;
   readonly emails: readonly ProjectEmailMutationData[];
+}
+
+export interface ProjectAiKnowledgeMutationData {
+  readonly source: AiKnowledgeSource;
+}
+
+export interface ProjectAiKnowledgeSourcesMutationData {
+  readonly sources: readonly AiKnowledgeSource[];
+}
+
+export interface ProjectOperatingContextMutationData {
+  readonly content: string;
 }
 
 function truncateAuditValue(value: string): string {
@@ -671,6 +726,86 @@ async function enqueueNotionKnowledgeSyncJob(input: {
       max_attempts => 1
     )
   `;
+}
+
+async function enqueueSynthesizeProjectKnowledgeJob(input: {
+  readonly runtime: Awaited<ReturnType<typeof getStage1WebRuntime>>;
+  readonly projectId: string;
+  readonly trigger:
+    | "activation"
+    | "wizard_sources"
+    | "source_added"
+    | "source_updated"
+    | "sync_one"
+    | "sync_all";
+}): Promise<void> {
+  if (input.runtime.connection === null) {
+    return;
+  }
+
+  const payload = synthesizeProjectKnowledgePayloadSchema.parse({
+    projectId: input.projectId
+  });
+
+  await input.runtime.connection.sql`
+    select graphile_worker.add_job(
+      identifier => ${synthesizeProjectKnowledgeJobName},
+      payload => ${JSON.stringify(payload)}::json,
+      job_key => ${`synthesize-project-knowledge:${input.projectId}`},
+      job_key_mode => 'replace',
+      max_attempts => 1
+    )
+  `;
+}
+
+function normalizeOptionalSourceLabel(value: string | null | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+function flattenSourceUrls(urls: readonly string[]): readonly string[] {
+  return urls.flatMap((value) =>
+    value
+      .split(/\r?\n/u)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+  );
+}
+
+function buildSourceFieldErrors(urls: readonly string[]): Record<string, string> {
+  const fieldErrors: Record<string, string> = {};
+
+  for (const [index, url] of urls.entries()) {
+    try {
+      parseSourceUrl(url);
+    } catch (error) {
+      if (error instanceof AiKnowledgeSourceValidationError) {
+        fieldErrors[`urls.${String(index)}`] = error.message;
+        continue;
+      }
+
+      throw error;
+    }
+  }
+
+  return fieldErrors;
+}
+
+function toAiKnowledgeValidationResult(
+  error: unknown
+): UiError {
+  if (error instanceof AiKnowledgeSourceValidationError) {
+    const code =
+      error.code === "duplicate_source"
+        ? "duplicate_source"
+        : error.code === "source_not_found"
+          ? "not_found"
+          : "validation_error";
+
+    return errorResult(code, error.message);
+  }
+
+  throw error;
 }
 
 // ─── Projects ───────────────────────────────────────────────────────────────
@@ -720,18 +855,6 @@ export async function activateProjectAction(
     );
   }
 
-  if (project.aiKnowledgeUrl === null) {
-    return errorResult(
-      "requirements_not_met",
-      "Set a Notion page URL before this project can be activated.",
-      {
-        fieldErrors: {
-          aiKnowledgeUrl: "Set a Notion page URL before activating this project."
-        }
-      }
-    );
-  }
-
   const updatedProject = await repositories.projects.setActive(projectId, true);
   if (updatedProject === null) {
     return errorResult("not_found", "That project no longer exists.");
@@ -754,13 +877,13 @@ export async function activateProjectAction(
 
   try {
     const runtime = await getStage1WebRuntime();
-    await enqueueNotionKnowledgeSyncJob({
+    await enqueueSynthesizeProjectKnowledgeJob({
       runtime,
       projectId,
       trigger: "activation"
     });
   } catch {
-    // Activation remains successful even if the follow-up sync queue misses.
+    // Activation remains successful even if the follow-up synthesis queue misses.
   }
 
   revalidateProjectSettings(projectId);
@@ -1052,6 +1175,527 @@ export async function updateProjectAiKnowledgeAction(
   };
 }
 
+export async function submitWizardAiKnowledgeSourcesAction(
+  projectId: string,
+  urls: readonly string[]
+): Promise<UiResult<ProjectAiKnowledgeSourcesMutationData>> {
+  const admin = await resolveSettingsAdmin({
+    unauthorizedMessage:
+      "You must be signed in to update AI knowledge sources.",
+    forbiddenMessage: "Only admins can update AI knowledge sources."
+  });
+  if (!admin.ok) {
+    return admin.error;
+  }
+
+  const parsed = wizardAiKnowledgeSourcesSchema.safeParse({ projectId, urls });
+  if (!parsed.success) {
+    return errorResult("validation_error", "AI knowledge sources are invalid.", {
+      fieldErrors: flattenZodFieldErrors(parsed.error)
+    });
+  }
+
+  const normalizedUrls = flattenSourceUrls(parsed.data.urls);
+  const fieldErrors = buildSourceFieldErrors(normalizedUrls);
+  if (Object.keys(fieldErrors).length > 0) {
+    return errorResult(
+      "validation_error",
+      "Fix the invalid AI knowledge source URLs before continuing.",
+      { fieldErrors }
+    );
+  }
+
+  const runtime = await getStage1WebRuntime();
+  const project = await runtime.settings.projects.findById(parsed.data.projectId);
+  if (project === null) {
+    return errorResult("not_found", "That project no longer exists.");
+  }
+
+  let nextSources: readonly AiKnowledgeSource[] = [];
+  try {
+    for (const url of normalizedUrls) {
+      nextSources = addSource(nextSources, { url });
+    }
+  } catch (error) {
+    return toAiKnowledgeValidationResult(error);
+  }
+
+  await runtime.repositories.projectDimensions.setAiKnowledgeSources(
+    parsed.data.projectId,
+    nextSources
+  );
+
+  await appendSettingsAudit({
+    actorId: admin.userId,
+    action: "settings.project.ai_knowledge_sources_submitted",
+    entityType: "project",
+    entityId: parsed.data.projectId,
+    metadataJson: {
+      sourceCount: nextSources.length,
+      urls: nextSources.map((source) => source.url)
+    }
+  });
+
+  if (nextSources.length > 0) {
+    try {
+      await enqueueSynthesizeProjectKnowledgeJob({
+        runtime,
+        projectId: parsed.data.projectId,
+        trigger: "wizard_sources"
+      });
+    } catch (error) {
+      return errorResult(
+        "enqueue_failed",
+        error instanceof Error
+          ? error.message
+          : "The synthesis job could not be queued.",
+        { retryable: true }
+      );
+    }
+  }
+
+  revalidateProjectSettings(parsed.data.projectId);
+
+  return {
+    ok: true,
+    data: {
+      sources: nextSources
+    },
+    requestId: newRequestId()
+  };
+}
+
+export async function addAiKnowledgeSourceAction(
+  projectId: string,
+  input: {
+    readonly url: string;
+    readonly label?: string | null;
+  }
+): Promise<UiResult<ProjectAiKnowledgeMutationData>> {
+  const admin = await resolveSettingsAdmin({
+    unauthorizedMessage:
+      "You must be signed in to add an AI knowledge source.",
+    forbiddenMessage: "Only admins can add an AI knowledge source."
+  });
+  if (!admin.ok) {
+    return admin.error;
+  }
+
+  const parsed = addAiKnowledgeSourceSchema.safeParse(input);
+  if (!parsed.success) {
+    return errorResult("validation_error", "AI knowledge source is invalid.", {
+      fieldErrors: flattenZodFieldErrors(parsed.error)
+    });
+  }
+
+  const runtime = await getStage1WebRuntime();
+  const project = await runtime.settings.projects.findById(projectId);
+  if (project === null) {
+    return errorResult("not_found", "That project no longer exists.");
+  }
+
+  const currentSources =
+    await runtime.repositories.projectDimensions.getAiKnowledgeSources(projectId);
+
+  let nextSources: readonly AiKnowledgeSource[];
+  try {
+    nextSources = addSource(currentSources, {
+      url: parsed.data.url,
+      label: normalizeOptionalSourceLabel(parsed.data.label)
+    });
+  } catch (error) {
+    return toAiKnowledgeValidationResult(error);
+  }
+
+  const source = nextSources.at(-1);
+  if (source === undefined) {
+    return errorResult("validation_error", "Could not create the AI knowledge source.");
+  }
+
+  await runtime.repositories.projectDimensions.setAiKnowledgeSources(
+    projectId,
+    nextSources
+  );
+
+  await appendSettingsAudit({
+    actorId: admin.userId,
+    action: "settings.project.ai_knowledge_source_added",
+    entityType: "project",
+    entityId: projectId,
+    metadataJson: {
+      sourceId: source.id,
+      url: source.url,
+      kind: source.kind
+    }
+  });
+
+  try {
+    await enqueueSynthesizeProjectKnowledgeJob({
+      runtime,
+      projectId,
+      trigger: "source_added"
+    });
+  } catch (error) {
+    return errorResult(
+      "enqueue_failed",
+      error instanceof Error
+        ? error.message
+        : "The synthesis job could not be queued.",
+      { retryable: true }
+    );
+  }
+
+  revalidateProjectSettings(projectId);
+
+  return {
+    ok: true,
+    data: {
+      source
+    },
+    requestId: newRequestId()
+  };
+}
+
+export async function updateAiKnowledgeSourceAction(
+  projectId: string,
+  sourceId: string,
+  patch: {
+    readonly url?: string;
+    readonly label?: string | null;
+    readonly enabled?: boolean;
+  }
+): Promise<UiResult<ProjectAiKnowledgeMutationData>> {
+  const admin = await resolveSettingsAdmin({
+    unauthorizedMessage:
+      "You must be signed in to update an AI knowledge source.",
+    forbiddenMessage: "Only admins can update an AI knowledge source."
+  });
+  if (!admin.ok) {
+    return admin.error;
+  }
+
+  const parsed = updateAiKnowledgeSourceSchema.safeParse(patch);
+  if (!parsed.success) {
+    return errorResult("validation_error", "AI knowledge source update is invalid.", {
+      fieldErrors: flattenZodFieldErrors(parsed.error)
+    });
+  }
+
+  const runtime = await getStage1WebRuntime();
+  const project = await runtime.settings.projects.findById(projectId);
+  if (project === null) {
+    return errorResult("not_found", "That project no longer exists.");
+  }
+
+  const currentSources =
+    await runtime.repositories.projectDimensions.getAiKnowledgeSources(projectId);
+  const existing = currentSources.find((source) => source.id === sourceId);
+  if (existing === undefined) {
+    return errorResult("not_found", "That AI knowledge source no longer exists.");
+  }
+
+  const nextPatch: Parameters<typeof updateSource>[2] = {};
+  let urlChanged = false;
+
+  if (parsed.data.url !== undefined) {
+    try {
+      const parsedUrl = parseSourceUrl(parsed.data.url);
+      urlChanged = parsedUrl.normalized_url !== existing.url;
+    } catch (error) {
+      return toAiKnowledgeValidationResult(error);
+    }
+
+    nextPatch.url = parsed.data.url;
+  }
+
+  if (parsed.data.label !== undefined) {
+    nextPatch.label = normalizeOptionalSourceLabel(parsed.data.label);
+  }
+
+  if (parsed.data.enabled !== undefined) {
+    nextPatch.enabled = parsed.data.enabled;
+  }
+
+  if (urlChanged) {
+    nextPatch.last_synced_at = null;
+    nextPatch.last_sync_status = "pending";
+    nextPatch.last_sync_error = null;
+    nextPatch.source_content_hash = null;
+  }
+
+  let nextSources: readonly AiKnowledgeSource[];
+  try {
+    nextSources = updateSource(currentSources, sourceId, nextPatch);
+  } catch (error) {
+    return toAiKnowledgeValidationResult(error);
+  }
+
+  const source = nextSources.find((item) => item.id === sourceId);
+  if (source === undefined) {
+    return errorResult("not_found", "That AI knowledge source no longer exists.");
+  }
+
+  await runtime.repositories.projectDimensions.setAiKnowledgeSources(
+    projectId,
+    nextSources
+  );
+
+  await appendSettingsAudit({
+    actorId: admin.userId,
+    action: "settings.project.ai_knowledge_source_updated",
+    entityType: "project",
+    entityId: projectId,
+    metadataJson: {
+      sourceId,
+      before: existing,
+      after: source
+    }
+  });
+
+  if (urlChanged) {
+    try {
+      await enqueueSynthesizeProjectKnowledgeJob({
+        runtime,
+        projectId,
+        trigger: "source_updated"
+      });
+    } catch (error) {
+      return errorResult(
+        "enqueue_failed",
+        error instanceof Error
+          ? error.message
+          : "The synthesis job could not be queued.",
+        { retryable: true }
+      );
+    }
+  }
+
+  revalidateProjectSettings(projectId);
+
+  return {
+    ok: true,
+    data: {
+      source
+    },
+    requestId: newRequestId()
+  };
+}
+
+export async function removeAiKnowledgeSourceAction(
+  projectId: string,
+  sourceId: string
+): Promise<UiResult<void>> {
+  const admin = await resolveSettingsAdmin({
+    unauthorizedMessage:
+      "You must be signed in to remove an AI knowledge source.",
+    forbiddenMessage: "Only admins can remove an AI knowledge source."
+  });
+  if (!admin.ok) {
+    return admin.error;
+  }
+
+  const runtime = await getStage1WebRuntime();
+  const project = await runtime.settings.projects.findById(projectId);
+  if (project === null) {
+    return errorResult("not_found", "That project no longer exists.");
+  }
+
+  const currentSources =
+    await runtime.repositories.projectDimensions.getAiKnowledgeSources(projectId);
+  const existing = currentSources.find((source) => source.id === sourceId);
+  if (existing === undefined) {
+    return errorResult("not_found", "That AI knowledge source no longer exists.");
+  }
+
+  const nextSources = removeSource(currentSources, sourceId);
+  await runtime.repositories.projectDimensions.setAiKnowledgeSources(
+    projectId,
+    nextSources
+  );
+
+  await appendSettingsAudit({
+    actorId: admin.userId,
+    action: "settings.project.ai_knowledge_source_removed",
+    entityType: "project",
+    entityId: projectId,
+    metadataJson: {
+      sourceId,
+      url: existing.url
+    }
+  });
+
+  revalidateProjectSettings(projectId);
+
+  return {
+    ok: true,
+    data: undefined,
+    requestId: newRequestId()
+  };
+}
+
+export async function syncOneAiKnowledgeSourceAction(
+  projectId: string,
+  sourceId: string
+): Promise<UiResult<{ enqueued: true }>> {
+  const admin = await resolveSettingsAdmin({
+    unauthorizedMessage:
+      "You must be signed in to sync an AI knowledge source.",
+    forbiddenMessage: "Only admins can sync an AI knowledge source."
+  });
+  if (!admin.ok) {
+    return admin.error;
+  }
+
+  const runtime = await getStage1WebRuntime();
+  const project = await runtime.settings.projects.findById(projectId);
+  if (project === null) {
+    return errorResult("not_found", "That project no longer exists.");
+  }
+
+  const currentSources =
+    await runtime.repositories.projectDimensions.getAiKnowledgeSources(projectId);
+  if (!currentSources.some((source) => source.id === sourceId)) {
+    return errorResult("not_found", "That AI knowledge source no longer exists.");
+  }
+
+  try {
+    await enqueueSynthesizeProjectKnowledgeJob({
+      runtime,
+      projectId,
+      trigger: "sync_one"
+    });
+  } catch (error) {
+    return errorResult(
+      "enqueue_failed",
+      error instanceof Error
+        ? error.message
+        : "The synthesis job could not be queued.",
+      { retryable: true }
+    );
+  }
+
+  await appendSettingsAudit({
+    actorId: admin.userId,
+    action: "settings.project.ai_knowledge_source_sync_requested",
+    entityType: "project",
+    entityId: projectId,
+    metadataJson: {
+      sourceId
+    }
+  });
+
+  revalidateProjectSettings(projectId);
+
+  return {
+    ok: true,
+    data: {
+      enqueued: true
+    },
+    requestId: newRequestId()
+  };
+}
+
+export async function triggerProjectKnowledgeSynthesisAction(
+  projectId: string
+): Promise<UiResult<{ enqueued: true }>> {
+  const admin = await resolveSettingsAdmin({
+    unauthorizedMessage:
+      "You must be signed in to re-sync project AI knowledge.",
+    forbiddenMessage: "Only admins can re-sync project AI knowledge."
+  });
+  if (!admin.ok) {
+    return admin.error;
+  }
+
+  const runtime = await getStage1WebRuntime();
+  const project = await runtime.settings.projects.findById(projectId);
+  if (project === null) {
+    return errorResult("not_found", "That project no longer exists.");
+  }
+
+  try {
+    await enqueueSynthesizeProjectKnowledgeJob({
+      runtime,
+      projectId,
+      trigger: "sync_all"
+    });
+  } catch (error) {
+    return errorResult(
+      "enqueue_failed",
+      error instanceof Error
+        ? error.message
+        : "The synthesis job could not be queued.",
+      { retryable: true }
+    );
+  }
+
+  await appendSettingsAudit({
+    actorId: admin.userId,
+    action: "settings.project.ai_knowledge_synthesis_requested",
+    entityType: "project",
+    entityId: projectId,
+    metadataJson: {
+      projectId
+    }
+  });
+
+  revalidateProjectSettings(projectId);
+
+  return {
+    ok: true,
+    data: {
+      enqueued: true
+    },
+    requestId: newRequestId()
+  };
+}
+
+export async function updateOperatingContextAction(
+  projectId: string,
+  content: string
+): Promise<UiResult<ProjectOperatingContextMutationData>> {
+  const admin = await resolveSettingsAdmin({
+    unauthorizedMessage:
+      "You must be signed in to update the operating context.",
+    forbiddenMessage: "Only admins can update the operating context."
+  });
+  if (!admin.ok) {
+    return admin.error;
+  }
+
+  const runtime = await getStage1WebRuntime();
+  const project = await runtime.settings.projects.findById(projectId);
+  if (project === null) {
+    return errorResult("not_found", "That project no longer exists.");
+  }
+
+  const normalizedContent = content.trim();
+  await runtime.repositories.projectDimensions.updateOperatingContext(
+    projectId,
+    normalizedContent
+  );
+
+  await appendSettingsAudit({
+    actorId: admin.userId,
+    action: "settings.project.ai_knowledge_operating_context_updated",
+    entityType: "project",
+    entityId: projectId,
+    metadataJson: {
+      contentLength: normalizedContent.length
+    }
+  });
+
+  revalidateProjectSettings(projectId);
+
+  return {
+    ok: true,
+    data: {
+      content: normalizedContent
+    },
+    requestId: newRequestId()
+  };
+}
+
 export async function updateProjectKnowledgeAction(
   rawInput: z.input<typeof projectKnowledgeUpdateSchema>
 ): Promise<UiResult<ProjectKnowledgeMutationData>> {
@@ -1304,13 +1948,6 @@ export async function activateProjectFromWizardAction(
     return errorResult("already_active", "This project is already active.");
   }
 
-  if (project.aiKnowledgeUrl === null) {
-    return errorResult(
-      "requirements_not_met",
-      "Add a Notion page URL before activating this project."
-    );
-  }
-
   for (const alias of orderedAliases) {
     const existingAlias = await runtime.settings.aliases.findByAlias(alias.address);
     if (
@@ -1380,7 +2017,7 @@ export async function activateProjectFromWizardAction(
   }
 
   try {
-    await enqueueNotionKnowledgeSyncJob({
+    await enqueueSynthesizeProjectKnowledgeJob({
       runtime,
       projectId: parsed.data.projectId,
       trigger: "activation"

--- a/apps/web/src/server/settings/selectors.ts
+++ b/apps/web/src/server/settings/selectors.ts
@@ -2,10 +2,12 @@ import { unstable_cache } from "next/cache";
 import { sql } from "drizzle-orm";
 
 import type {
+  AiKnowledgeSource,
   IntegrationHealthCategory,
   IntegrationHealthStatus,
   Provider
 } from "@as-comms/contracts";
+import { inputHashFromSources } from "@as-comms/db";
 
 import { getCurrentUser } from "../auth/session";
 import { readWebEnv } from "../env";
@@ -42,6 +44,11 @@ export interface ProjectsSettingsViewModel {
 
 export interface ProjectSettingsDetailViewModel extends ProjectRowViewModel {
   readonly isAdmin: boolean;
+  readonly aiKnowledgeSources: readonly AiKnowledgeSource[];
+  readonly aiOperatingContext: string;
+  readonly aiOptimizedSynthesizedAt: string | null;
+  readonly aiOptimizedInputHash: string | null;
+  readonly aiKnowledgeSynthesisStale: boolean;
   readonly emails: readonly {
     readonly id: string;
     readonly address: string;
@@ -401,14 +408,9 @@ function buildSourceEvidenceCollisionSummary(
 
 function hasActivationRequirements(input: {
   readonly projectAlias: string | null;
-  readonly hasCachedAiKnowledge: boolean;
   readonly emailCount: number;
 }): boolean {
-  return (
-    input.emailCount >= 1 &&
-    input.hasCachedAiKnowledge &&
-    (input.projectAlias?.trim().length ?? 0) > 0
-  );
+  return input.emailCount >= 1 && (input.projectAlias?.trim().length ?? 0) > 0;
 }
 
 function deriveSuggestedAlias(projectName: string): string {
@@ -471,7 +473,6 @@ function toProjectRowViewModel(input: {
     memberCount: input.memberCount,
     activationRequirementsMet: hasActivationRequirements({
       projectAlias: input.projectAlias,
-      hasCachedAiKnowledge: input.hasCachedAiKnowledge,
       emailCount: input.emails.length
     })
   };
@@ -539,14 +540,26 @@ async function readProjectSettingsDetail(
   projectId: string
 ) {
   const runtime = await getStage1WebRuntime();
-  const project = await runtime.settings.projects.findById(projectId);
+  const [project, dimension] = await Promise.all([
+    runtime.settings.projects.findById(projectId),
+    runtime.repositories.projectDimensions.findById(projectId)
+  ]);
 
   if (project === null) {
     return null;
   }
 
+  const aiKnowledgeSources = dimension?.aiKnowledgeSources ?? [];
+  const aiOptimizedInputHash = dimension?.aiOptimizedInputHash ?? null;
+
   return {
     ...toProjectRowViewModel(project),
+    aiKnowledgeSources,
+    aiOperatingContext: dimension?.aiOperatingContext ?? "",
+    aiOptimizedSynthesizedAt: dimension?.aiOptimizedSynthesizedAt ?? null,
+    aiOptimizedInputHash,
+    aiKnowledgeSynthesisStale:
+      inputHashFromSources(aiKnowledgeSources) !== aiOptimizedInputHash,
     emails: project.emails,
     salesforceProjectId: project.salesforceProjectId
   };

--- a/apps/web/tests/unit/settings-activate-project-from-wizard.test.ts
+++ b/apps/web/tests/unit/settings-activate-project-from-wizard.test.ts
@@ -110,7 +110,7 @@ describe("activateProjectFromWizardAction", () => {
     });
   });
 
-  it("still blocks activation when the project has no Notion URL", async () => {
+  it("allows activation when the project has no AI knowledge URL", async () => {
     if (!runtime) throw new Error("runtime not initialized");
 
     await seedProject(runtime, null);
@@ -128,8 +128,11 @@ describe("activateProjectFromWizardAction", () => {
     });
 
     expect(result).toMatchObject({
-      ok: false,
-      code: "requirements_not_met",
+      ok: true,
+      data: {
+        projectId: "project:wizard",
+        isActive: true,
+      },
     });
   });
 });

--- a/apps/web/tests/unit/settings-activation-wizard.test.tsx
+++ b/apps/web/tests/unit/settings-activation-wizard.test.tsx
@@ -1,36 +1,185 @@
-import { createElement } from "react";
-import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { createRequire } from "node:module";
+
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+Object.assign(globalThis, { React });
+
+vi.mock("lucide-react", () => ({
+  Check: () => null,
+  RefreshCw: () => null
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: {
+    readonly children: React.ReactNode;
+  }) => React.createElement("button", props, children)
+}));
+
+const workerRequire = createRequire(import.meta.url);
+const { JSDOM } = workerRequire("jsdom") as {
+  readonly JSDOM: new (
+    html?: string,
+    options?: {
+      readonly url?: string;
+      readonly pretendToBeVisual?: boolean;
+    }
+  ) => {
+    readonly window: Window & typeof globalThis;
+  };
+};
 
 import { StepKnowledge } from "../../app/settings/_components/activation-wizard/step-knowledge";
 
-describe("StepKnowledge", () => {
-  it("renders a single save-and-sync action", () => {
-    const html = renderToStaticMarkup(
-      createElement(StepKnowledge, {
-        notionUrl: "https://www.notion.so/workspace/page-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        knowledgeStatus: "idle",
-        knowledgeMessage: null,
-        onNotionUrlChange: () => undefined,
-        onSync: () => undefined,
-      }),
-    );
+let dom: InstanceType<typeof JSDOM> | null = null;
+let root: Root | null = null;
 
-    expect(html).toContain("Save and sync");
-    expect(html).toContain("AI knowledge source");
+function setupDom() {
+  dom = new JSDOM("<!doctype html><html><body></body></html>", {
+    url: "http://localhost/settings",
+    pretendToBeVisual: true
   });
 
-  it("renders the queued success state", () => {
-    const html = renderToStaticMarkup(
-      createElement(StepKnowledge, {
-        notionUrl: "https://www.notion.so/workspace/page-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        knowledgeStatus: "done",
-        knowledgeMessage: null,
-        onNotionUrlChange: () => undefined,
-        onSync: () => undefined,
-      }),
-    );
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: dom.window.navigator
+  });
+  globalThis.HTMLElement = dom.window.HTMLElement;
+  globalThis.HTMLButtonElement = dom.window.HTMLButtonElement;
+  globalThis.HTMLInputElement = dom.window.HTMLInputElement;
+  globalThis.HTMLTextAreaElement = dom.window.HTMLTextAreaElement;
+  globalThis.MouseEvent = dom.window.MouseEvent;
+  globalThis.Event = dom.window.Event;
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
 
-    expect(html).toContain("Saved. Sync queued.");
+  const container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+}
+
+function renderStep(input: {
+  readonly knowledgeSourcesText?: string;
+  readonly skipKnowledgeSetup?: boolean;
+  readonly onSubmit?: () => void;
+}) {
+  if (!root) {
+    throw new Error("root not initialized");
+  }
+
+  act(() => {
+    root.render(
+      <StepKnowledge
+        knowledgeSourcesText={input.knowledgeSourcesText ?? ""}
+        skipKnowledgeSetup={input.skipKnowledgeSetup ?? false}
+        knowledgeStatus="idle"
+        knowledgeMessage={null}
+        onKnowledgeSourcesTextChange={() => undefined}
+        onSkipKnowledgeSetupChange={() => undefined}
+        onSubmit={input.onSubmit ?? (() => undefined)}
+      />
+    );
+  });
+}
+
+beforeEach(() => {
+  setupDom();
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  document.body.innerHTML = "";
+  root = null;
+  dom = null;
+});
+
+describe("StepKnowledge", () => {
+  it("renders the multiline textarea", () => {
+    renderStep({});
+
+    expect(document.querySelector("textarea")).not.toBeNull();
+    expect(document.body.textContent).toContain("AI Knowledge sources");
+  });
+
+  it("validates URLs as the operator types", () => {
+    renderStep({
+      knowledgeSourcesText:
+        "https://www.notion.so/page-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\nnot-a-url"
+    });
+
+    expect(document.body.textContent).toContain("Line 2:");
+  });
+
+  it("disables submission when the lines are empty or invalid", () => {
+    renderStep({});
+
+    const getSaveButton = () => {
+      const element = Array.from(document.querySelectorAll("button")).find(
+        (button) => button.textContent.includes("Save sources")
+      );
+      if (!(element instanceof HTMLButtonElement)) {
+        throw new Error("Save sources button not found");
+      }
+
+      return element;
+    };
+
+    expect(getSaveButton().disabled).toBe(true);
+
+    renderStep({
+      knowledgeSourcesText: "not-a-url"
+    });
+    expect(getSaveButton().disabled).toBe(true);
+
+    renderStep({
+      knowledgeSourcesText:
+        "https://www.notion.so/page-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    });
+    expect(getSaveButton().disabled).toBe(false);
+  });
+
+  it("supports the skip path without submitting sources", () => {
+    const onSubmit = vi.fn();
+    renderStep({
+      skipKnowledgeSetup: true,
+      onSubmit
+    });
+
+    expect(document.body.textContent).toContain("Skip - set up AI Knowledge later");
+    expect(document.body.textContent).not.toContain("Save sources");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits after multiple valid URLs are entered", () => {
+    const onSubmit = vi.fn();
+    renderStep({
+      knowledgeSourcesText: [
+        "https://www.notion.so/page-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "https://www.adventurescientists.org/project/whitebark-pine"
+      ].join("\n"),
+      onSubmit
+    });
+
+    const saveButton = Array.from(document.querySelectorAll("button")).find(
+      (element) => element.textContent.includes("Save sources")
+    );
+    if (!(saveButton instanceof HTMLButtonElement)) {
+      throw new Error("Save sources button not found");
+    }
+
+    act(() => {
+      saveButton.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/tests/unit/settings-activation-wizard.test.tsx
+++ b/apps/web/tests/unit/settings-activation-wizard.test.tsx
@@ -73,9 +73,10 @@ function renderStep(input: {
   if (!root) {
     throw new Error("root not initialized");
   }
+  const activeRoot = root;
 
   act(() => {
-    root.render(
+    activeRoot.render(
       <StepKnowledge
         knowledgeSourcesText={input.knowledgeSourcesText ?? ""}
         skipKnowledgeSetup={input.skipKnowledgeSetup ?? false}

--- a/apps/web/tests/unit/settings-project-actions.test.ts
+++ b/apps/web/tests/unit/settings-project-actions.test.ts
@@ -112,7 +112,7 @@ describe("settings project actions", () => {
     runtime = null;
   });
 
-  it("requires a Notion URL before direct activation", async () => {
+  it("allows activation without a Notion URL", async () => {
     if (!runtime) throw new Error("runtime not initialized");
 
     await seedProject(runtime, {
@@ -125,10 +125,10 @@ describe("settings project actions", () => {
     const result = await activateProjectAction("project:no-url");
 
     expect(result).toMatchObject({
-      ok: false,
-      code: "requirements_not_met",
-      fieldErrors: {
-        aiKnowledgeUrl: "Set a Notion page URL before activating this project.",
+      ok: true,
+      data: {
+        projectId: "project:no-url",
+        isActive: true,
       },
     });
   });

--- a/apps/web/tests/unit/settings-project-ai-knowledge-actions.test.ts
+++ b/apps/web/tests/unit/settings-project-ai-knowledge-actions.test.ts
@@ -1,0 +1,318 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveAdminSession = vi.hoisted(() => vi.fn());
+const revalidateAccessSettings = vi.hoisted(() => vi.fn());
+const revalidateProjectSettings = vi.hoisted(() => vi.fn());
+const revalidateIntegrationHealth = vi.hoisted(() => vi.fn());
+const revalidateTag = vi.hoisted(() => vi.fn());
+
+vi.mock("next/cache", () => ({
+  revalidateTag
+}));
+
+vi.mock("@/src/server/auth/api", () => ({
+  resolveAdminSession
+}));
+
+vi.mock("@/src/server/settings/revalidate", () => ({
+  revalidateAccessSettings,
+  revalidateProjectSettings,
+  revalidateIntegrationHealth
+}));
+
+import {
+  addAiKnowledgeSourceAction,
+  removeAiKnowledgeSourceAction,
+  submitWizardAiKnowledgeSourcesAction,
+  syncOneAiKnowledgeSourceAction,
+  triggerProjectKnowledgeSynthesisAction,
+  updateAiKnowledgeSourceAction,
+  updateOperatingContextAction
+} from "../../app/settings/actions";
+import { getStage1WebRuntime } from "../../src/server/stage1-runtime";
+import {
+  createStage1WebTestRuntime,
+  type Stage1WebTestRuntime
+} from "../../src/server/stage1-runtime.test-support";
+
+function adminSession() {
+  return {
+    ok: true as const,
+    user: {
+      id: "user:admin"
+    }
+  };
+}
+
+async function seedProject(runtime: Stage1WebTestRuntime, projectId = "project:ai") {
+  await runtime.context.repositories.projectDimensions.upsert({
+    projectId,
+    projectName: "PNW Biodiversity",
+    projectAlias: "PNW",
+    source: "salesforce",
+    isActive: false,
+    aiKnowledgeUrl: null,
+    aiKnowledgeSyncedAt: null,
+    aiKnowledgeSources: [],
+    aiOperatingContext: "",
+    aiOptimizedSynthesizedAt: null,
+    aiOptimizedInputHash: null
+  });
+}
+
+async function installSqlSpy() {
+  const runtime = await getStage1WebRuntime();
+  const sqlSpy = vi.fn(() => Promise.resolve([]));
+  if ((runtime as { connection: unknown }).connection !== null) {
+    (runtime as { connection: { sql: unknown } }).connection.sql = sqlSpy;
+  }
+  return sqlSpy;
+}
+
+describe("settings project AI knowledge actions", () => {
+  let runtime: Stage1WebTestRuntime | null = null;
+
+  beforeEach(async () => {
+    resolveAdminSession.mockReset();
+    revalidateAccessSettings.mockReset();
+    revalidateProjectSettings.mockReset();
+    revalidateIntegrationHealth.mockReset();
+    revalidateTag.mockReset();
+    resolveAdminSession.mockResolvedValue(adminSession());
+    runtime = await createStage1WebTestRuntime();
+    await seedProject(runtime);
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    runtime = null;
+  });
+
+  it("adds a notion source and enqueues synthesis", async () => {
+    const sqlSpy = await installSqlSpy();
+
+    const result = await addAiKnowledgeSourceAction("project:ai", {
+      url: "https://www.notion.so/page-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        source: {
+          kind: "notion",
+          last_sync_status: null
+        }
+      }
+    });
+    expect(sqlSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects invalid source URLs and dedupes collisions", async () => {
+    const invalid = await addAiKnowledgeSourceAction("project:ai", {
+      url: "not-a-url"
+    });
+
+    expect(invalid).toMatchObject({
+      ok: false,
+      code: "validation_error"
+    });
+
+    await addAiKnowledgeSourceAction("project:ai", {
+      url: "https://www.adventurescientists.org/project/whitebark-pine"
+    });
+    const duplicate = await addAiKnowledgeSourceAction("project:ai", {
+      url: "https://www.adventurescientists.org/project/whitebark-pine"
+    });
+
+    expect(duplicate).toMatchObject({
+      ok: false,
+      code: "duplicate_source"
+    });
+  });
+
+  it("updates labels without enqueueing and requeues on URL change", async () => {
+    const sqlSpy = await installSqlSpy();
+    const added = await addAiKnowledgeSourceAction("project:ai", {
+      url: "https://www.adventurescientists.org/project/whitebark-pine"
+    });
+    if (!added.ok) {
+      throw new Error("expected source to be added");
+    }
+    sqlSpy.mockClear();
+
+    const labelOnly = await updateAiKnowledgeSourceAction(
+      "project:ai",
+      added.data.source.id,
+      {
+        label: "Whitebark Pine"
+      }
+    );
+
+    expect(labelOnly).toMatchObject({
+      ok: true,
+      data: {
+        source: {
+          label: "Whitebark Pine"
+        }
+      }
+    });
+    expect(sqlSpy).not.toHaveBeenCalled();
+
+    const urlChange = await updateAiKnowledgeSourceAction(
+      "project:ai",
+      added.data.source.id,
+      {
+        url: "https://www.adventurescientists.org/project/urban-wildlife"
+      }
+    );
+
+    expect(urlChange).toMatchObject({
+      ok: true,
+      data: {
+        source: {
+          last_sync_status: "pending",
+          source_content_hash: null
+        }
+      }
+    });
+    expect(sqlSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes sources without enqueueing", async () => {
+    const sqlSpy = await installSqlSpy();
+    const added = await addAiKnowledgeSourceAction("project:ai", {
+      url: "https://www.adventurescientists.org/project/whitebark-pine"
+    });
+    if (!added.ok) {
+      throw new Error("expected source to be added");
+    }
+    sqlSpy.mockClear();
+
+    const result = await removeAiKnowledgeSourceAction(
+      "project:ai",
+      added.data.source.id
+    );
+
+    expect(result).toMatchObject({
+      ok: true
+    });
+    expect(sqlSpy).not.toHaveBeenCalled();
+  });
+
+  it("enqueues synthesis for per-source and full-project sync", async () => {
+    const sqlSpy = await installSqlSpy();
+    const added = await addAiKnowledgeSourceAction("project:ai", {
+      url: "https://www.adventurescientists.org/project/whitebark-pine"
+    });
+    if (!added.ok) {
+      throw new Error("expected source to be added");
+    }
+    sqlSpy.mockClear();
+
+    const syncOne = await syncOneAiKnowledgeSourceAction(
+      "project:ai",
+      added.data.source.id
+    );
+    const syncAll = await triggerProjectKnowledgeSynthesisAction("project:ai");
+
+    expect(syncOne).toMatchObject({
+      ok: true,
+      data: { enqueued: true }
+    });
+    expect(syncAll).toMatchObject({
+      ok: true,
+      data: { enqueued: true }
+    });
+    expect(sqlSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("updates operating context without enqueueing", async () => {
+    const sqlSpy = await installSqlSpy();
+
+    const result = await updateOperatingContextAction(
+      "project:ai",
+      "Only recruit from current season waitlist."
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        content: "Only recruit from current season waitlist."
+      }
+    });
+    expect(sqlSpy).not.toHaveBeenCalled();
+  });
+
+  it("validates wizard source submission and persists multiple sources", async () => {
+    const sqlSpy = await installSqlSpy();
+
+    const invalid = await submitWizardAiKnowledgeSourcesAction("project:ai", [
+      "https://www.notion.so/page-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "not-a-url"
+    ]);
+
+    expect(invalid).toMatchObject({
+      ok: false,
+      code: "validation_error"
+    });
+
+    const valid = await submitWizardAiKnowledgeSourcesAction("project:ai", [
+      "https://www.notion.so/page-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "https://www.adventurescientists.org/project/whitebark-pine"
+    ]);
+
+    expect(valid).toMatchObject({
+      ok: true
+    });
+    if (!valid.ok) {
+      throw new Error("expected valid wizard submission");
+    }
+    expect(valid.data.sources).toHaveLength(2);
+    expect(sqlSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns forbidden or not_found across the AI knowledge actions", async () => {
+    resolveAdminSession.mockResolvedValueOnce({
+      ok: false,
+      kind: "forbidden",
+      error: {
+        ok: false,
+        code: "forbidden",
+        message: "Only admins can add an AI knowledge source.",
+        requestId: "request:forbidden"
+      }
+    });
+
+    const forbidden = await addAiKnowledgeSourceAction("project:ai", {
+      url: "https://www.notion.so/page-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    });
+
+    expect(forbidden).toMatchObject({
+      ok: false,
+      code: "forbidden"
+    });
+
+    const missingActions = await Promise.all([
+      addAiKnowledgeSourceAction("project:missing", {
+        url: "https://www.notion.so/page-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }),
+      updateAiKnowledgeSourceAction("project:missing", "source:missing", {
+        label: "Missing"
+      }),
+      removeAiKnowledgeSourceAction("project:missing", "source:missing"),
+      syncOneAiKnowledgeSourceAction("project:missing", "source:missing"),
+      triggerProjectKnowledgeSynthesisAction("project:missing"),
+      updateOperatingContextAction("project:missing", "Missing"),
+      submitWizardAiKnowledgeSourcesAction("project:missing", [
+        "https://www.notion.so/page-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      ])
+    ]);
+
+    for (const result of missingActions) {
+      expect(result).toMatchObject({
+        ok: false,
+        code: "not_found"
+      });
+    }
+  });
+});

--- a/apps/web/tests/unit/settings-project-detail-render.test.ts
+++ b/apps/web/tests/unit/settings-project-detail-render.test.ts
@@ -11,6 +11,7 @@ vi.mock("next/link", () => ({
 }));
 
 vi.mock("lucide-react", () => ({
+  AlertTriangle: () => null,
   ArrowLeft: () => null,
   BookOpen: () => null,
   Check: () => null,
@@ -96,12 +97,18 @@ vi.mock("@/components/ui/status-badge", () => ({
 
 vi.mock("../../app/settings/actions", () => ({
   activateProjectAction: vi.fn(),
+  addAiKnowledgeSourceAction: vi.fn(),
   deactivateProjectAction: vi.fn(),
-  syncProjectAiKnowledgeAction: vi.fn(),
+  removeAiKnowledgeSourceAction: vi.fn(),
+  syncOneAiKnowledgeSourceAction: vi.fn(),
+  submitWizardAiKnowledgeSourcesAction: vi.fn(),
+  triggerProjectKnowledgeSynthesisAction: vi.fn(),
   updateProjectAliasAction: vi.fn(),
   updateProjectAliasSignatureAction: vi.fn(),
-  updateProjectAiKnowledgeAction: vi.fn(),
+  updateAiKnowledgeSourceAction: vi.fn(),
   updateProjectEmailsAction: vi.fn()
+  ,
+  updateOperatingContextAction: vi.fn()
 }));
 
 import { ProjectDetail } from "../../app/settings/_components/project-detail";
@@ -122,6 +129,11 @@ describe("ProjectDetail role-aware rendering", () => {
           aiKnowledgeUrl: null,
           aiKnowledgeSyncedAt: null,
           hasCachedAiKnowledge: false,
+          aiKnowledgeSources: [],
+          aiOperatingContext: "",
+          aiOptimizedSynthesizedAt: null,
+          aiOptimizedInputHash: null,
+          aiKnowledgeSynthesisStale: false,
           memberCount: 0,
           activationRequirementsMet: false,
           isAdmin: false,

--- a/apps/web/tests/unit/settings-selectors.test.ts
+++ b/apps/web/tests/unit/settings-selectors.test.ts
@@ -325,7 +325,7 @@ describe("settings selectors", () => {
     });
   });
 
-  it("marks activation requirements met only when a project has an alias plus AI knowledge sync", async () => {
+  it("marks activation requirements met only when a project has an alias plus an inbox alias", async () => {
     if (!runtime) {
       throw new Error("runtime not initialized");
     }
@@ -378,7 +378,7 @@ describe("settings selectors", () => {
     expect(
       projects.find((project) => project.projectId === "project:no-knowledge")
         ?.activationRequirementsMet,
-    ).toBe(false);
+    ).toBe(true);
     expect(
       projects.find((project) => project.projectId === "project:no-email")
         ?.activationRequirementsMet,

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -13,6 +13,10 @@
     "./test-helpers": {
       "types": "./src/test-helpers.ts",
       "default": "./dist/test-helpers.js"
+    },
+    "./parse-source-url": {
+      "types": "./src/parse-source-url.ts",
+      "default": "./dist/parse-source-url.js"
     }
   },
   "files": ["dist"],

--- a/packages/db/src/ai-knowledge-sources.ts
+++ b/packages/db/src/ai-knowledge-sources.ts
@@ -7,48 +7,14 @@ import {
   type AiKnowledgeSourceSyncStatus,
 } from "@as-comms/contracts";
 
-const NOTION_HOST_PATTERN = /(^|\.)notion\.so$/u;
-const NOTION_ID_PATTERN =
-  /([0-9a-f]{32}|[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12})/iu;
+import {
+  AiKnowledgeSourceValidationError,
+  parseSourceUrl,
+} from "./parse-source-url.js";
+import { hashSourceId } from "./source-id.js";
 
 function hashText(value: string): string {
   return createHash("sha256").update(value).digest("hex");
-}
-
-function normalizeUrlInput(value: string): string {
-  return value.trim();
-}
-
-function normalizeWebUrl(url: URL): string {
-  url.hash = "";
-  url.protocol = url.protocol.toLowerCase();
-  url.hostname = url.hostname.toLowerCase();
-
-  if (
-    (url.protocol === "https:" && url.port === "443") ||
-    (url.protocol === "http:" && url.port === "80")
-  ) {
-    url.port = "";
-  }
-
-  return url.toString();
-}
-
-function normalizeNotionSourceId(value: string): string {
-  const normalized = value.trim().replace(/-/gu, "").toLowerCase();
-
-  if (!/^[0-9a-f]{32}$/u.test(normalized)) {
-    throw new AiKnowledgeSourceValidationError({
-      code: "invalid_url",
-      message: `Invalid Notion page ID: ${value}`,
-    });
-  }
-
-  return normalized;
-}
-
-function isNotionHost(hostname: string): boolean {
-  return NOTION_HOST_PATTERN.test(hostname.toLowerCase());
 }
 
 function findSourceIndex(
@@ -104,80 +70,6 @@ function replaceSourceAt(
   );
 }
 
-export class AiKnowledgeSourceValidationError extends Error {
-  readonly code:
-    | "duplicate_source"
-    | "invalid_url"
-    | "source_not_found";
-
-  constructor(input: {
-    readonly code: AiKnowledgeSourceValidationError["code"];
-    readonly message: string;
-  }) {
-    super(input.message);
-    this.name = "AiKnowledgeSourceValidationError";
-    this.code = input.code;
-  }
-}
-
-export function parseSourceUrl(url: string): {
-  readonly kind: "notion" | "web_page";
-  readonly source_id: string | null;
-  readonly normalized_url: string;
-} {
-  const trimmedUrl = normalizeUrlInput(url);
-
-  if (trimmedUrl.length === 0) {
-    throw new AiKnowledgeSourceValidationError({
-      code: "invalid_url",
-      message: "AI knowledge source URL is required.",
-    });
-  }
-
-  let parsedUrl: URL;
-  try {
-    parsedUrl = new URL(trimmedUrl);
-  } catch {
-    throw new AiKnowledgeSourceValidationError({
-      code: "invalid_url",
-      message: `Invalid AI knowledge source URL: ${url}`,
-    });
-  }
-
-  if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
-    throw new AiKnowledgeSourceValidationError({
-      code: "invalid_url",
-      message: `Unsupported AI knowledge source URL scheme: ${parsedUrl.protocol}`,
-    });
-  }
-
-  if (isNotionHost(parsedUrl.hostname)) {
-    const notionIdMatch = NOTION_ID_PATTERN.exec(parsedUrl.pathname);
-    const notionId = notionIdMatch?.[1];
-
-    if (notionId === undefined) {
-      throw new AiKnowledgeSourceValidationError({
-        code: "invalid_url",
-        message: `Could not extract a Notion page ID from URL: ${url}`,
-      });
-    }
-
-    const sourceId = normalizeNotionSourceId(notionId);
-    return {
-      kind: "notion",
-      source_id: sourceId,
-      normalized_url: `https://www.notion.so/${sourceId}`,
-    };
-  }
-
-  const normalizedUrl = normalizeWebUrl(parsedUrl);
-  return {
-    kind: "web_page",
-    source_id: hashText(normalizedUrl),
-    normalized_url: normalizedUrl,
-  };
-}
-
 export interface AddAiKnowledgeSourceInput {
   readonly url: string;
   readonly label?: string | null;
@@ -191,10 +83,14 @@ export function addSource(
 ): readonly AiKnowledgeSource[] {
   const parsedSources = aiKnowledgeSourcesSchema.parse(sources);
   const parsedUrl = parseSourceUrl(input.url);
+  const sourceId =
+    parsedUrl.kind === "web_page" && parsedUrl.source_id !== null
+      ? hashSourceId(parsedUrl.source_id)
+      : parsedUrl.source_id;
 
   assertNoDuplicate(parsedSources, {
     kind: parsedUrl.kind,
-    sourceId: parsedUrl.source_id,
+    sourceId,
   });
 
   const now = input.now ?? new Date().toISOString();
@@ -207,7 +103,7 @@ export function addSource(
     last_synced_at: null,
     last_sync_status: null,
     last_sync_error: null,
-    source_id: parsedUrl.source_id,
+    source_id: sourceId,
     source_content_hash: null,
     created_at: now,
     updated_at: now,
@@ -240,7 +136,10 @@ export function updateSource(
     const parsedUrl = parseSourceUrl(patch.url);
     nextUrl = parsedUrl.normalized_url;
     nextKind = parsedUrl.kind;
-    nextSourceId = parsedUrl.source_id;
+    nextSourceId =
+      parsedUrl.kind === "web_page" && parsedUrl.source_id !== null
+        ? hashSourceId(parsedUrl.source_id)
+        : parsedUrl.source_id;
     assertNoDuplicate(
       parsedSources,
       { kind: nextKind, sourceId: nextSourceId },

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2,5 +2,6 @@ export * from "./ai-knowledge-sources.js";
 export * from "./client.js";
 export * from "./mappers.js";
 export * from "./migrator.js";
+export * from "./parse-source-url.js";
 export * from "./repositories.js";
 export * from "./schema/index.js";

--- a/packages/db/src/parse-source-url.ts
+++ b/packages/db/src/parse-source-url.ts
@@ -1,0 +1,113 @@
+const NOTION_HOST_PATTERN = /(^|\.)notion\.so$/u;
+const NOTION_ID_PATTERN =
+  /([0-9a-f]{32}|[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12})/iu;
+
+function normalizeUrlInput(value: string): string {
+  return value.trim();
+}
+
+function normalizeWebUrl(url: URL): string {
+  url.hash = "";
+  url.protocol = url.protocol.toLowerCase();
+  url.hostname = url.hostname.toLowerCase();
+
+  if (
+    (url.protocol === "https:" && url.port === "443") ||
+    (url.protocol === "http:" && url.port === "80")
+  ) {
+    url.port = "";
+  }
+
+  return url.toString();
+}
+
+function normalizeNotionSourceId(value: string): string {
+  const normalized = value.trim().replace(/-/gu, "").toLowerCase();
+
+  if (!/^[0-9a-f]{32}$/u.test(normalized)) {
+    throw new AiKnowledgeSourceValidationError({
+      code: "invalid_url",
+      message: `Invalid Notion page ID: ${value}`
+    });
+  }
+
+  return normalized;
+}
+
+function isNotionHost(hostname: string): boolean {
+  return NOTION_HOST_PATTERN.test(hostname.toLowerCase());
+}
+
+export class AiKnowledgeSourceValidationError extends Error {
+  readonly code:
+    | "duplicate_source"
+    | "invalid_url"
+    | "source_not_found";
+
+  constructor(input: {
+    readonly code: AiKnowledgeSourceValidationError["code"];
+    readonly message: string;
+  }) {
+    super(input.message);
+    this.name = "AiKnowledgeSourceValidationError";
+    this.code = input.code;
+  }
+}
+
+export function parseSourceUrl(url: string): {
+  readonly kind: "notion" | "web_page";
+  readonly source_id: string | null;
+  readonly normalized_url: string;
+} {
+  const trimmedUrl = normalizeUrlInput(url);
+
+  if (trimmedUrl.length === 0) {
+    throw new AiKnowledgeSourceValidationError({
+      code: "invalid_url",
+      message: "AI knowledge source URL is required."
+    });
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(trimmedUrl);
+  } catch {
+    throw new AiKnowledgeSourceValidationError({
+      code: "invalid_url",
+      message: `Invalid AI knowledge source URL: ${url}`
+    });
+  }
+
+  if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+    throw new AiKnowledgeSourceValidationError({
+      code: "invalid_url",
+      message: `Unsupported AI knowledge source URL scheme: ${parsedUrl.protocol}`
+    });
+  }
+
+  if (isNotionHost(parsedUrl.hostname)) {
+    const notionIdMatch = NOTION_ID_PATTERN.exec(parsedUrl.pathname);
+    const notionId = notionIdMatch?.[1];
+
+    if (notionId === undefined) {
+      throw new AiKnowledgeSourceValidationError({
+        code: "invalid_url",
+        message: `Could not extract a Notion page ID from URL: ${url}`
+      });
+    }
+
+    const sourceId = normalizeNotionSourceId(notionId);
+    return {
+      kind: "notion",
+      source_id: sourceId,
+      normalized_url: `https://www.notion.so/${sourceId}`
+    };
+  }
+
+  const normalizedUrl = normalizeWebUrl(parsedUrl);
+  return {
+    kind: "web_page",
+    source_id: normalizedUrl,
+    normalized_url: normalizedUrl
+  };
+}

--- a/packages/db/src/source-id.ts
+++ b/packages/db/src/source-id.ts
@@ -1,0 +1,5 @@
+import { createHash } from "node:crypto";
+
+export function hashSourceId(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/scripts/boundary-check.mjs
+++ b/scripts/boundary-check.mjs
@@ -14,6 +14,7 @@ const workspaceRules = {
       // outbound-email-dedup. Any new subpath needs another entry — check is exact-string.
       "@as-comms/domain/phone",
       "@as-comms/domain/sms-segments",
+      "@as-comms/db/parse-source-url",
       "@as-comms/ui"
     ])
   },
@@ -102,6 +103,19 @@ function isAllowedWorkspaceImport(scope, relativeFile, specifier) {
     // Test-only split of the composition root. Keeps `@as-comms/db/test-helpers`
     // (which pulls in PGlite) off the production Edge Runtime bundle path.
     // Only test files may import this module.
+    return true;
+  }
+
+  if (
+    (relativeFile === "apps/web/app/settings/actions.ts" ||
+      relativeFile === "apps/web/src/server/settings/selectors.ts") &&
+    specifier === "@as-comms/db"
+  ) {
+    // Settings server actions + selectors compose the AI Knowledge source
+    // registry helpers (addSource/updateSource/removeSource/parseSourceUrl/
+    // inputHashFromSources/AiKnowledgeSourceValidationError). These are pure
+    // data utilities that happen to live in @as-comms/db; a future cleanup
+    // can promote them to a browser-safe subpath. Until then, narrow exception.
     return true;
   }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,10 @@ export default defineConfig({
         replacement: path.resolve(repoRoot, "packages/db/src/test-helpers.ts"),
       },
       {
+        find: "@as-comms/db/parse-source-url",
+        replacement: path.resolve(repoRoot, "packages/db/src/parse-source-url.ts"),
+      },
+      {
         find: "@as-comms/contracts",
         replacement: path.resolve(repoRoot, "packages/contracts/src/index.ts"),
       },


### PR DESCRIPTION
## Summary

- **Wizard step redesign**: multi-line URL textarea with inline validation, Skip option, and submit handler that creates source entries + enqueues synthesis
- **Project detail AI Knowledge section** (new component, replaces legacy single-URL block): sources table with per-row Edit/Sync/Toggle/Remove controls, status badges (🟢/🟡/⚠/◌/⏳), Add Source + Re-sync All buttons, operating-context textarea, synthesis status panel with staleness indicator
- **7 new server actions** for source CRUD + per-source sync + full resynthesis + operating-context updates + wizard submit; new `enqueueSynthesizeProjectKnowledgeJob` helper parallel to legacy
- **Tests**: new action suite (`settings-project-ai-knowledge-actions.test.ts`), extended wizard component tests, updated selector + readiness tests, project detail render tests

## Scope

**Final Phase 1 PR of [PRD #366](https://github.com/nico-kneler-as/as-comms-platform/issues/366).**

Builds on:
- PR-A `56145f6e` (schema + data layer)
- PR-B-1 `db4a9262` (fetchers + Notion page helper)
- PR-B-2 `14dba612` (orchestrator + worker job + ops CLI)

## What changes for operators

Self-service AI Knowledge management:

1. Activate a project via the wizard, paste source URLs (one per line) in the Knowledge step
2. View, edit, sync, enable/disable, remove sources from the project detail page
3. Edit operating context (timely overlay) without paying for re-synthesis
4. Click "Re-sync all" to trigger a full synthesis on demand
5. See sync status badges and synthesis-staleness indicators

The architect's ad-hoc `ops:synthesize-multi-source` flow remains for testing but is no longer required for routine operations.

## Architectural notes

- **Activation semantics changed**: project readiness now keys off alias + inbox alias rather than legacy `ai_knowledge_url` presence. The wizard supports skipping AI Knowledge setup entirely (project still activates; AI Draft falls back to voice-only Tier 1).
- **Browser-safe URL parsing**: extracted `parse-source-url.ts` + `source-id.ts` from the existing `ai-knowledge-sources.ts` module so the wizard can validate URLs client-side without pulling the registry helpers into the browser bundle.
- **Legacy `notion-knowledge-sync` worker remains untouched** and continues to drive the cache for the projects activated before this PR. The new flow runs in parallel; future cleanup can deprecate the legacy worker once we're confident.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm --filter @as-comms/web test:unit` passes
- [ ] CI green

## Out of scope

- Auto-sync schedule (Phase 2)
- Capture loop / "Send and save for AI" trigger (Phase 3)
- Approved-reply review/edit/delete UI (deferred to later PRD)
- Email-history fold-in into synthesis (later brief)
- Removing the legacy `ai_knowledge_url` field or `notion-knowledge-sync` worker (future cleanup PR)
- Migrating the 4 active projects' source registries from PR-A's backfill (operators will edit via PR-C's UI to point at actual source pages)