### PR TITLE
feat(ai-knowledge): approved-reply weighting + threshold trigger (Phase 3 of #366)

### DIFF
--- a/apps/web/app/inbox/actions.ts
+++ b/apps/web/app/inbox/actions.ts
@@ -25,6 +25,7 @@ import {
   type AiDraftRequestPayload,
   type AiDraftResponse,
 } from "@/src/server/ai";
+import { enqueueSynthesizeProjectKnowledgeJob } from "@/src/server/ai/enqueue";
 import { getAiProviderConfig } from "@/src/server/ai/provider";
 import { readWebEnv } from "@/src/server/env";
 import { setInboxArchived } from "@/src/server/inbox/archive";
@@ -46,6 +47,17 @@ import type { MetricKey } from "./_lib/project-lifecycle-metrics";
 import type { UiResult } from "../../src/server/ui-result";
 
 const SMS_AI_MAX_TOKENS = 120;
+
+/**
+ * Phase 3 of PRD #366 — automatic AI Knowledge re-synthesis trigger.
+ *
+ * After this many "Send and save for AI" approvals accumulate for a project
+ * (since the last successful synthesis, or all-time if synthesis has never
+ * run), the inbox capture path enqueues a synthesis worker job so the
+ * AI's drafts continuously incorporate the operator's best work. Hardcoded
+ * for now; a future PR can make this per-project configurable.
+ */
+const AI_KNOWLEDGE_CAPTURE_TRIGGER_THRESHOLD = 5;
 
 const composerSendActionInputSchema = composerSendInputSchema.extend({
   saveAsKnowledge: z.boolean().optional(),
@@ -341,6 +353,13 @@ async function captureKnowledgeFromSend(input: {
           maskedExample: maskKnowledgeExample(input.bodyPlaintext),
         };
 
+  // Phase 3 of PRD #366: the operator's deliberate click on
+  // "Send and save for AI" IS the approval signal. The original spec assumed
+  // a separate review step (approvedForAi: false then a UI gate flips it),
+  // but that review UI was never built and is deferred to a later PRD. Per
+  // D-032 ("memory captured ONLY from human-approved sent replies"), this
+  // is consistent — the click is the human approval. Captures land
+  // approved-for-AI immediately and feed straight into synthesis weighting.
   await input.runtime.repositories.projectKnowledge.upsert({
     id: entryId,
     projectId: input.projectId,
@@ -351,13 +370,93 @@ async function captureKnowledgeFromSend(input: {
     replyStrategy: null,
     maskedExample: input.bodyPlaintext,
     sourceKind: "captured_from_send",
-    approvedForAi: false,
+    approvedForAi: true,
     sourceEventId: null,
     metadataJson,
     lastReviewedAt: null,
     createdAt: nowIso,
     updatedAt: nowIso,
   });
+
+  await maybeTriggerCaptureBasedSynthesis({
+    runtime: input.runtime,
+    projectId: input.projectId,
+  });
+}
+
+/**
+ * Phase 3 capture-trigger: after a successful "Send and save for AI" capture
+ * upsert, count how many approved-for-AI rows have accumulated since the
+ * last synthesis (or all-time if synthesis has never run). Once we cross
+ * the threshold AND the project has at least one enabled AI Knowledge
+ * source, enqueue the synthesis worker job.
+ *
+ * Failures here are logged but never thrown — the original Send-and-save
+ * action must remain successful even if the trigger queue is unavailable.
+ */
+async function maybeTriggerCaptureBasedSynthesis(input: {
+  readonly runtime: Awaited<ReturnType<typeof getStage1WebRuntime>>;
+  readonly projectId: string;
+}): Promise<void> {
+  try {
+    const project =
+      await input.runtime.repositories.projectDimensions.findById(
+        input.projectId,
+      );
+    if (project === null) {
+      return;
+    }
+
+    const lastSynthesizedAt = project.aiOptimizedSynthesizedAt;
+    const sinceDate =
+      typeof lastSynthesizedAt === "string" && lastSynthesizedAt.length > 0
+        ? new Date(lastSynthesizedAt)
+        : null;
+    const sinceForCount =
+      sinceDate !== null && Number.isFinite(sinceDate.getTime())
+        ? sinceDate
+        : null;
+
+    const approvedCount =
+      await input.runtime.repositories.projectKnowledge.countCapturedSinceTimestamp(
+        {
+          projectId: input.projectId,
+          since: sinceForCount,
+        },
+      );
+
+    if (approvedCount < AI_KNOWLEDGE_CAPTURE_TRIGGER_THRESHOLD) {
+      return;
+    }
+
+    const sources =
+      await input.runtime.repositories.projectDimensions.getAiKnowledgeSources(
+        input.projectId,
+      );
+    const hasEnabledSource = sources.some((source) => source.enabled);
+    if (!hasEnabledSource) {
+      return;
+    }
+
+    await enqueueSynthesizeProjectKnowledgeJob({
+      runtime: input.runtime,
+      projectId: input.projectId,
+      trigger: "capture_threshold",
+      // Approved-reply additions aren't part of the source-input hash — we
+      // explicitly want to re-synthesize even when Notion sources haven't
+      // changed because the new captures ARE the change signal.
+      skipIfHashUnchanged: false,
+      jobKey: `ai-knowledge-capture-trigger:${input.projectId}`,
+    });
+  } catch (error) {
+    console.warn(
+      "Capture-triggered AI knowledge synthesis enqueue failed; capture itself succeeded.",
+      {
+        projectId: input.projectId,
+        error,
+      },
+    );
+  }
 }
 
 function readSaveAsKnowledgeFlag(

--- a/apps/web/app/settings/actions.ts
+++ b/apps/web/app/settings/actions.ts
@@ -6,13 +6,9 @@ import { z } from "zod";
 
 import {
   createProjectAliasSchema,
-  synthesizeProjectKnowledgeJobName,
-  synthesizeProjectKnowledgePayloadSchema,
   type AiKnowledgeSource,
   deactivateUserSchema,
   demoteUserSchema,
-  notionKnowledgeSyncJobName,
-  notionKnowledgeSyncPayloadSchema,
   promoteUserSchema,
   reactivateUserSchema,
   type IntegrationHealthRecord
@@ -25,6 +21,10 @@ import {
   updateSource
 } from "@as-comms/db";
 
+import {
+  enqueueNotionKnowledgeSyncJob,
+  enqueueSynthesizeProjectKnowledgeJob
+} from "@/src/server/ai/enqueue";
 import { resolveAdminSession } from "@/src/server/auth/api";
 import { appendSecurityAudit } from "@/src/server/security/audit";
 import {
@@ -707,61 +707,6 @@ export interface ProjectAliasSignatureMutationData {
   readonly id: string;
   readonly alias: string;
   readonly signature: string;
-}
-
-async function enqueueNotionKnowledgeSyncJob(input: {
-  readonly runtime: Awaited<ReturnType<typeof getStage1WebRuntime>>;
-  readonly projectId: string;
-  readonly trigger: "manual" | "url_save" | "activation";
-}): Promise<void> {
-  if (input.runtime.connection === null) {
-    return;
-  }
-
-  const payload = notionKnowledgeSyncPayloadSchema.parse({
-    projectId: input.projectId,
-    trigger: input.trigger
-  });
-
-  await input.runtime.connection.sql`
-    select graphile_worker.add_job(
-      identifier => ${notionKnowledgeSyncJobName},
-      payload => ${JSON.stringify(payload)}::json,
-      job_key => ${`notion-knowledge-sync:${input.projectId}`},
-      job_key_mode => 'replace',
-      max_attempts => 1
-    )
-  `;
-}
-
-async function enqueueSynthesizeProjectKnowledgeJob(input: {
-  readonly runtime: Awaited<ReturnType<typeof getStage1WebRuntime>>;
-  readonly projectId: string;
-  readonly trigger:
-    | "activation"
-    | "wizard_sources"
-    | "source_added"
-    | "source_updated"
-    | "sync_one"
-    | "sync_all";
-}): Promise<void> {
-  if (input.runtime.connection === null) {
-    return;
-  }
-
-  const payload = synthesizeProjectKnowledgePayloadSchema.parse({
-    projectId: input.projectId
-  });
-
-  await input.runtime.connection.sql`
-    select graphile_worker.add_job(
-      identifier => ${synthesizeProjectKnowledgeJobName},
-      payload => ${JSON.stringify(payload)}::json,
-      job_key => ${`synthesize-project-knowledge:${input.projectId}`},
-      job_key_mode => 'replace',
-      max_attempts => 1
-    )
-  `;
 }
 
 function normalizeOptionalSourceLabel(value: string | null | undefined): string | null {

--- a/apps/web/src/server/ai/enqueue.ts
+++ b/apps/web/src/server/ai/enqueue.ts
@@ -1,0 +1,89 @@
+import {
+  notionKnowledgeSyncJobName,
+  notionKnowledgeSyncPayloadSchema,
+  synthesizeProjectKnowledgeJobName,
+  synthesizeProjectKnowledgePayloadSchema,
+} from "@as-comms/contracts";
+
+import type { getStage1WebRuntime } from "@/src/server/stage1-runtime";
+
+/**
+ * Shared worker-job enqueue helpers for AI Knowledge.
+ *
+ * These thin wrappers used to live inline in `apps/web/app/settings/actions.ts`,
+ * but Phase 3 of PRD #366 reuses
+ * {@link enqueueSynthesizeProjectKnowledgeJob} from the inbox capture path
+ * (apps/web/app/inbox/actions.ts -> captureKnowledgeFromSend) when the
+ * approved-reply threshold trips. Extracting them here keeps the trigger
+ * site free of boundary concerns.
+ *
+ * Production code should import from this module via the absolute alias:
+ *   `import { ... } from "@/src/server/ai/enqueue"`.
+ */
+type Stage1WebRuntime = Awaited<ReturnType<typeof getStage1WebRuntime>>;
+
+export async function enqueueNotionKnowledgeSyncJob(input: {
+  readonly runtime: Stage1WebRuntime;
+  readonly projectId: string;
+  readonly trigger: "manual" | "url_save" | "activation";
+}): Promise<void> {
+  if (input.runtime.connection === null) {
+    return;
+  }
+
+  const payload = notionKnowledgeSyncPayloadSchema.parse({
+    projectId: input.projectId,
+    trigger: input.trigger,
+  });
+
+  await input.runtime.connection.sql`
+    select graphile_worker.add_job(
+      identifier => ${notionKnowledgeSyncJobName},
+      payload => ${JSON.stringify(payload)}::json,
+      job_key => ${`notion-knowledge-sync:${input.projectId}`},
+      job_key_mode => 'replace',
+      max_attempts => 1
+    )
+  `;
+}
+
+export type SynthesizeProjectKnowledgeTrigger =
+  | "activation"
+  | "wizard_sources"
+  | "source_added"
+  | "source_updated"
+  | "sync_one"
+  | "sync_all"
+  | "capture_threshold";
+
+export async function enqueueSynthesizeProjectKnowledgeJob(input: {
+  readonly runtime: Stage1WebRuntime;
+  readonly projectId: string;
+  readonly trigger: SynthesizeProjectKnowledgeTrigger;
+  readonly skipIfHashUnchanged?: boolean;
+  readonly jobKey?: string;
+}): Promise<void> {
+  if (input.runtime.connection === null) {
+    return;
+  }
+
+  const payload = synthesizeProjectKnowledgePayloadSchema.parse(
+    input.skipIfHashUnchanged === undefined
+      ? { projectId: input.projectId }
+      : {
+          projectId: input.projectId,
+          skipIfHashUnchanged: input.skipIfHashUnchanged,
+        },
+  );
+  const jobKey = input.jobKey ?? `synthesize-project-knowledge:${input.projectId}`;
+
+  await input.runtime.connection.sql`
+    select graphile_worker.add_job(
+      identifier => ${synthesizeProjectKnowledgeJobName},
+      payload => ${JSON.stringify(payload)}::json,
+      job_key => ${jobKey},
+      job_key_mode => 'replace',
+      max_attempts => 1
+    )
+  `;
+}

--- a/apps/web/tests/unit/send-sms-action.test.ts
+++ b/apps/web/tests/unit/send-sms-action.test.ts
@@ -285,7 +285,9 @@ describe("sendSmsAction", () => {
     expect(entries[0]).toMatchObject({
       kind: "canonical_reply",
       sourceKind: "captured_from_send",
-      approvedForAi: false,
+      // Phase 3 of PRD #366: SMS captures land approved-for-AI immediately.
+      // The "Save for AI" toggle on send IS the approval signal.
+      approvedForAi: true,
       questionSummary: "SMS to Maya Lee",
       maskedExample: "Field update confirmed.",
     });

--- a/apps/web/tests/unit/stage3-send-action.test.ts
+++ b/apps/web/tests/unit/stage3-send-action.test.ts
@@ -20,6 +20,7 @@ import {
   type ComposerSendActionInput,
 } from "../../app/inbox/actions";
 import { resetSecurityRateLimiterForTests } from "../../src/server/security/rate-limit";
+import { getStage1WebRuntime } from "../../src/server/stage1-runtime";
 import {
   createStage1WebTestRuntime,
   type Stage1WebTestRuntime,
@@ -78,6 +79,73 @@ async function seedComposerFixture(runtime: Stage1WebTestRuntime): Promise<void>
     source: "manual",
     verifiedAt: now.toISOString(),
   });
+}
+
+async function installSqlSpy() {
+  const runtime = await getStage1WebRuntime();
+  const sqlSpy = vi.fn(() => Promise.resolve([]));
+  if ((runtime as { connection: unknown }).connection !== null) {
+    (runtime as { connection: { sql: unknown } }).connection.sql = sqlSpy;
+  }
+  return sqlSpy;
+}
+
+async function seedApprovedKnowledgeEntries(input: {
+  readonly runtime: Stage1WebTestRuntime;
+  readonly projectId: string;
+  readonly count: number;
+  readonly baseTimestamp?: string;
+}): Promise<void> {
+  const baseTimestamp = input.baseTimestamp ?? "2026-04-21T11:00:00.000Z";
+  for (let index = 0; index < input.count; index += 1) {
+    const minuteOffset = String(index).padStart(2, "0");
+    const isoTimestamp = `2026-04-21T11:${minuteOffset}:00.000Z`;
+    await input.runtime.context.repositories.projectKnowledge.upsert({
+      id: `project_knowledge:seed:${String(index)}`,
+      projectId: input.projectId,
+      kind: "canonical_reply",
+      issueType: null,
+      volunteerStage: null,
+      questionSummary: `Seeded approval ${String(index)}`,
+      replyStrategy: null,
+      maskedExample: `Seeded approved reply body ${String(index)}.`,
+      sourceKind: "captured_from_send",
+      approvedForAi: true,
+      sourceEventId: null,
+      metadataJson: { seedIndex: index },
+      lastReviewedAt: null,
+      createdAt: isoTimestamp,
+      updatedAt: isoTimestamp,
+    });
+  }
+  // Reference baseTimestamp so a future regression where it's relied upon
+  // surfaces via lint, not silently.
+  void baseTimestamp;
+}
+
+async function seedEnabledNotionSource(input: {
+  readonly runtime: Stage1WebTestRuntime;
+  readonly projectId: string;
+}): Promise<void> {
+  await input.runtime.context.repositories.projectDimensions.setAiKnowledgeSources(
+    input.projectId,
+    [
+      {
+        id: "11111111-1111-4111-8111-111111111111",
+        url: "https://www.notion.so/page-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        kind: "notion",
+        label: "Antarctica AI Knowledge",
+        enabled: true,
+        last_synced_at: null,
+        last_sync_status: "pending",
+        last_sync_error: null,
+        source_id: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        source_content_hash: null,
+        created_at: "2026-04-21T10:00:00.000Z",
+        updated_at: "2026-04-21T10:00:00.000Z",
+      },
+    ],
+  );
 }
 
 function buildInput(
@@ -255,7 +323,7 @@ describe("sendComposerAction", () => {
     ).resolves.toEqual([]);
   });
 
-  it("creates a pending-review project knowledge entry when saveAsKnowledge is true", async () => {
+  it("creates an approved-for-AI project knowledge entry when saveAsKnowledge is true", async () => {
     if (!runtime) {
       throw new Error("Expected runtime.");
     }
@@ -282,7 +350,9 @@ describe("sendComposerAction", () => {
     expect(entries[0]).toMatchObject({
       kind: "canonical_reply",
       sourceKind: "captured_from_send",
-      approvedForAi: false,
+      // Phase 3 of PRD #366: the operator's "Send and save for AI" click
+      // IS the approval signal. Captures land approved-for-AI immediately.
+      approvedForAi: true,
       questionSummary: "Field logistics",
       maskedExample: "Thanks again for confirming the field logistics.",
     });
@@ -320,6 +390,204 @@ describe("sendComposerAction", () => {
         projectId: "project:antarctica",
       }),
     ).resolves.toEqual([]);
+  });
+
+  it("does not enqueue synthesis when the capture count remains below the threshold", async () => {
+    if (!runtime) {
+      throw new Error("Expected runtime.");
+    }
+
+    await seedEnabledNotionSource({
+      runtime,
+      projectId: "project:antarctica",
+    });
+    // Pre-seed 3 approved replies; one new send brings the post-capture
+    // total to 4 — still under the threshold of 5.
+    await seedApprovedKnowledgeEntries({
+      runtime,
+      projectId: "project:antarctica",
+      count: 3,
+    });
+
+    const sqlSpy = await installSqlSpy();
+    sendComposerGmailMessage.mockResolvedValue({
+      kind: "success",
+      gmailMessageId: "gmail-message-below-threshold",
+      gmailThreadId: "gmail-thread-below-threshold",
+      rfc822MessageId: "<gmail-message-below-threshold@example.org>",
+    });
+
+    const result = await sendComposerAction({
+      ...buildInput({ subject: "Below threshold" }),
+      saveAsKnowledge: true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(sqlSpy).not.toHaveBeenCalled();
+  });
+
+  it("enqueues a single synthesis job once the capture threshold is reached and re-enqueues with replace mode on subsequent captures", async () => {
+    if (!runtime) {
+      throw new Error("Expected runtime.");
+    }
+
+    await seedEnabledNotionSource({
+      runtime,
+      projectId: "project:antarctica",
+    });
+    // Pre-seed 4 approved replies — the 5th capture below trips the threshold.
+    await seedApprovedKnowledgeEntries({
+      runtime,
+      projectId: "project:antarctica",
+      count: 4,
+    });
+
+    const sqlSpy = await installSqlSpy();
+    sendComposerGmailMessage.mockResolvedValue({
+      kind: "success",
+      gmailMessageId: "gmail-message-trigger",
+      gmailThreadId: "gmail-thread-trigger",
+      rfc822MessageId: "<gmail-message-trigger@example.org>",
+    });
+
+    const fifthResult = await sendComposerAction({
+      ...buildInput({ subject: "Trigger fifth capture" }),
+      saveAsKnowledge: true,
+    });
+
+    expect(fifthResult.ok).toBe(true);
+    expect(sqlSpy).toHaveBeenCalledTimes(1);
+
+    const firstCallArgs = sqlSpy.mock.calls[0] as readonly unknown[] | undefined;
+    const firstStrings = firstCallArgs?.[0] as readonly string[] | undefined;
+    const firstSqlTemplate = firstStrings?.join("|") ?? "";
+    // The tagged template structure is fixed by enqueueSynthesizeProjectKnowledgeJob.
+    // We assert on the literal pieces to lock in graphile add_job semantics.
+    expect(firstSqlTemplate).toContain("graphile_worker.add_job");
+    expect(firstSqlTemplate).toContain("identifier =>");
+    expect(firstSqlTemplate).toContain("job_key_mode => 'replace'");
+
+    const firstParams = firstCallArgs?.slice(1) ?? [];
+    expect(firstParams).toContain("synthesize-project-knowledge");
+    const firstJobKey = firstParams.find(
+      (param): param is string =>
+        typeof param === "string" &&
+        param.startsWith("ai-knowledge-capture-trigger:"),
+    );
+    expect(firstJobKey).toBe("ai-knowledge-capture-trigger:project:antarctica");
+    const firstPayload = firstParams.find(
+      (param): param is string =>
+        typeof param === "string" && param.startsWith("{"),
+    );
+    expect(firstPayload).toBeDefined();
+    if (firstPayload === undefined) {
+      throw new Error("Expected enqueue payload to be a JSON string.");
+    }
+    const parsedPayload = JSON.parse(firstPayload) as {
+      readonly skipIfHashUnchanged?: boolean;
+    };
+    expect(parsedPayload.skipIfHashUnchanged).toBe(false);
+
+    sqlSpy.mockClear();
+    sendComposerGmailMessage.mockResolvedValue({
+      kind: "success",
+      gmailMessageId: "gmail-message-trigger-2",
+      gmailThreadId: "gmail-thread-trigger-2",
+      rfc822MessageId: "<gmail-message-trigger-2@example.org>",
+    });
+
+    const sixthResult = await sendComposerAction({
+      ...buildInput({ subject: "Sixth capture re-enqueues" }),
+      saveAsKnowledge: true,
+    });
+
+    expect(sixthResult.ok).toBe(true);
+    // Each capture above threshold replays the enqueue with the same job
+    // key — graphile's job_key_mode=replace dedupes idle pending jobs.
+    expect(sqlSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not enqueue synthesis when the project has no enabled AI knowledge sources", async () => {
+    if (!runtime) {
+      throw new Error("Expected runtime.");
+    }
+
+    // Threshold is reached, but no enabled source registered → no synthesis.
+    await seedApprovedKnowledgeEntries({
+      runtime,
+      projectId: "project:antarctica",
+      count: 4,
+    });
+
+    const sqlSpy = await installSqlSpy();
+    sendComposerGmailMessage.mockResolvedValue({
+      kind: "success",
+      gmailMessageId: "gmail-message-no-sources",
+      gmailThreadId: "gmail-thread-no-sources",
+      rfc822MessageId: "<gmail-message-no-sources@example.org>",
+    });
+
+    const result = await sendComposerAction({
+      ...buildInput({ subject: "No sources registered" }),
+      saveAsKnowledge: true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(sqlSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps the capture successful even when the synthesis enqueue throws", async () => {
+    if (!runtime) {
+      throw new Error("Expected runtime.");
+    }
+
+    await seedEnabledNotionSource({
+      runtime,
+      projectId: "project:antarctica",
+    });
+    await seedApprovedKnowledgeEntries({
+      runtime,
+      projectId: "project:antarctica",
+      count: 4,
+    });
+
+    const runtimeForSpy = await getStage1WebRuntime();
+    const failingSql = vi.fn(() => {
+      throw new Error("graphile_worker.add_job is unavailable.");
+    });
+    if ((runtimeForSpy as { connection: unknown }).connection !== null) {
+      (runtimeForSpy as { connection: { sql: unknown } }).connection.sql =
+        failingSql;
+    }
+
+    sendComposerGmailMessage.mockResolvedValue({
+      kind: "success",
+      gmailMessageId: "gmail-message-enqueue-fail",
+      gmailThreadId: "gmail-thread-enqueue-fail",
+      rfc822MessageId: "<gmail-message-enqueue-fail@example.org>",
+    });
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+
+    const result = await sendComposerAction({
+      ...buildInput({ subject: "Enqueue failure does not block capture" }),
+      saveAsKnowledge: true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(failingSql).toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Capture-triggered AI knowledge synthesis enqueue failed; capture itself succeeded.",
+      expect.objectContaining({ projectId: "project:antarctica" }),
+    );
+    warnSpy.mockRestore();
+
+    const entries = await runtime.context.repositories.projectKnowledge.list({
+      projectId: "project:antarctica",
+    });
+    // 4 seeded + 1 new capture = 5 rows persisted (the capture itself succeeded).
+    expect(entries.length).toBe(5);
   });
 
   it("maps ambiguous net-new recipient emails to invalid_recipient", async () => {

--- a/apps/worker/src/jobs/synthesize-project-knowledge/orchestrator.ts
+++ b/apps/worker/src/jobs/synthesize-project-knowledge/orchestrator.ts
@@ -1,9 +1,13 @@
 import type {
   AiKnowledgeSource,
   ProjectDimensionRecord,
+  ProjectKnowledgeEntryRecord,
 } from "@as-comms/contracts";
 import { inputHashFromSources, markSourceSyncResult } from "@as-comms/db";
-import type { ProjectDimensionRepository } from "@as-comms/domain";
+import type {
+  ProjectDimensionRepository,
+  ProjectKnowledgeRepository,
+} from "@as-comms/domain";
 import {
   estimateCostUsd,
   type GenerateDraftResult,
@@ -13,6 +17,7 @@ import {
 const DEFAULT_MODEL = "claude-sonnet-4-6";
 const DEFAULT_MAX_TOKENS = 16_000;
 const DEFAULT_TEMPERATURE = 0.3;
+const APPROVED_REPLY_PROMPT_LIMIT = 50;
 
 export const SYNTHESIS_SYSTEM_PROMPT = `You are organizing an AI training document for a volunteer communications assistant. Your output will be used by an AI to draft replies to volunteers for a specific project.
 
@@ -120,6 +125,7 @@ export interface SynthesizeProjectKnowledgeOrchestratorDependencies {
       ProjectDimensionRepository,
       "findById" | "getAiKnowledgeSources" | "setAiKnowledgeSources"
     >;
+    readonly projectKnowledge: Pick<ProjectKnowledgeRepository, "list">;
   };
   readonly temperature?: number;
 }
@@ -184,8 +190,34 @@ ${source.content}
     .join("\n\n");
 }
 
+function buildApprovedReplyExamplesBlock(
+  approvedReplies: readonly ProjectKnowledgeEntryRecord[],
+): string {
+  if (approvedReplies.length === 0) {
+    return "";
+  }
+
+  const renderedExamples = approvedReplies
+    .map((reply, index) => {
+      const capturedAt = reply.createdAt.slice(0, 10);
+      const example = reply.maskedExample?.trim() ?? "";
+      return `--- Example ${String(index + 1)} (captured ${capturedAt}, kind=${reply.kind}) ---
+${example}`;
+    })
+    .join("\n\n");
+
+  return `
+
+Here are ${String(approvedReplies.length)} canonical reply examples that the operator has marked as exemplary via "Send and save for AI". These represent the gold standard for tone, structure, and approved phrasing for this project. Treat them as authoritative examples of how the team replies; weight them MORE HEAVILY than ordinary inbox-corpus patterns when synthesizing the FAQ section and tone signals.
+
+<APPROVED_REPLY_EXAMPLES>
+${renderedExamples}
+</APPROVED_REPLY_EXAMPLES>`;
+}
+
 function buildUserContent(input: {
   readonly healthySources: readonly HealthySourceContent[];
+  readonly approvedReplies: readonly ProjectKnowledgeEntryRecord[];
 }): string {
   const inlineDocs = input.healthySources
     .filter((source) => source.source.kind === "inline_text")
@@ -208,6 +240,9 @@ function buildUserContent(input: {
 Here are ${String(externalSourceCount)} additional source document(s) for this project (e.g., training course content, supplementary protocols). Integrate any unique facts from these into the appropriate sections of the AI Knowledge doc. Do not preserve them verbatim — overlap with the existing doc is expected and should be deduplicated. If the additional source contains a knowledge check / quiz, treat the quiz topics as a signal of what volunteers must know (and what the AI should be ready to support).
 
 ${additionalSourcesBlock}`;
+  const approvedRepliesNote = buildApprovedReplyExamplesBlock(
+    input.approvedReplies,
+  );
 
   return `Here is the existing AI Knowledge document for the project:
 
@@ -218,7 +253,7 @@ ${existingDoc}
 Here is the corpus of 0 past sent replies from this project's volunteer alias(es), most recent first:
 
 <EMAIL_CORPUS>
-</EMAIL_CORPUS>
+</EMAIL_CORPUS>${approvedRepliesNote}
 
 Produce the updated AI Knowledge document per the system instructions. Output ONLY the markdown.`;
 }
@@ -376,6 +411,19 @@ export async function synthesizeProjectKnowledgeOrchestrator(
     };
   }
 
+  // Phase 3 of PRD #366: weight operator-approved replies as canonical
+  // examples in synthesis. The capture path flips approvedForAi=true on
+  // every "Send and save for AI" click, so listing approved canonical
+  // replies returns the operator's curated tone/structure exemplars.
+  const allApprovedKnowledge =
+    await deps.repositories.projectKnowledge.list({
+      projectId: payload.projectId,
+      approvedOnly: true,
+    });
+  const approvedReplies = allApprovedKnowledge
+    .filter((entry) => entry.kind === "canonical_reply")
+    .slice(0, APPROVED_REPLY_PROMPT_LIMIT);
+
   try {
     const model = deps.model ?? DEFAULT_MODEL;
     const response = await deps.invokeModel({
@@ -384,7 +432,10 @@ export async function synthesizeProjectKnowledgeOrchestrator(
       messages: [
         {
           role: "user",
-          content: buildUserContent({ healthySources: syncPass.healthySources }),
+          content: buildUserContent({
+            healthySources: syncPass.healthySources,
+            approvedReplies,
+          }),
         },
       ],
       maxTokens: deps.maxTokens ?? DEFAULT_MAX_TOKENS,

--- a/apps/worker/src/ops/synthesize-multi-source.ts
+++ b/apps/worker/src/ops/synthesize-multi-source.ts
@@ -51,6 +51,7 @@ function buildDependencies(): SynthesizeProjectKnowledgeDependencies {
   const base: SynthesizeProjectKnowledgeDependencies = {
     repositories: {
       projectDimensions: repositories.projectDimensions,
+      projectKnowledge: repositories.projectKnowledge,
       settingsProjects: settings.projects,
     },
     fetchers: {

--- a/apps/worker/src/runtime.ts
+++ b/apps/worker/src/runtime.ts
@@ -206,6 +206,7 @@ function buildSynthesizeProjectKnowledgeDependencies(input: {
   return {
     repositories: {
       projectDimensions: input.repositories.projectDimensions,
+      projectKnowledge: input.repositories.projectKnowledge,
       settingsProjects: input.settings.projects,
     },
     fetchers: {

--- a/apps/worker/test/synthesize-project-knowledge-orchestrator.test.ts
+++ b/apps/worker/test/synthesize-project-knowledge-orchestrator.test.ts
@@ -3,11 +3,43 @@ import { describe, expect, it, vi } from "vitest";
 import type {
   AiKnowledgeSource,
   ProjectDimensionRecord,
+  ProjectKnowledgeEntryRecord,
 } from "@as-comms/contracts";
 import { inputHashFromSources } from "@as-comms/db";
 import type { GenerateDraftResult, SourceFetchResult } from "@as-comms/integrations";
 
 import { synthesizeProjectKnowledgeOrchestrator } from "../src/jobs/synthesize-project-knowledge/orchestrator.js";
+
+function buildEmptyProjectKnowledge() {
+  return {
+    list: vi.fn().mockResolvedValue([]),
+  };
+}
+
+function buildApprovedReply(input: {
+  readonly id: string;
+  readonly maskedExample: string;
+  readonly createdAt: string;
+  readonly kind?: ProjectKnowledgeEntryRecord["kind"];
+}): ProjectKnowledgeEntryRecord {
+  return {
+    id: input.id,
+    projectId: "project:orcas",
+    kind: input.kind ?? "canonical_reply",
+    issueType: null,
+    volunteerStage: null,
+    questionSummary: `Question for ${input.id}`,
+    replyStrategy: null,
+    maskedExample: input.maskedExample,
+    sourceKind: "captured_from_send",
+    approvedForAi: true,
+    sourceEventId: null,
+    metadataJson: {},
+    lastReviewedAt: null,
+    createdAt: input.createdAt,
+    updatedAt: input.createdAt,
+  };
+}
 
 function buildProject(): ProjectDimensionRecord {
   return {
@@ -115,6 +147,7 @@ describe("synthesizeProjectKnowledgeOrchestrator", () => {
             getAiKnowledgeSources: vi.fn().mockResolvedValue(sources),
             setAiKnowledgeSources,
           },
+          projectKnowledge: buildEmptyProjectKnowledge(),
         },
         fetchers: {
           inline_text: { fetch: vi.fn().mockResolvedValue(healthyContent("Inline operator context")) },
@@ -174,6 +207,7 @@ describe("synthesizeProjectKnowledgeOrchestrator", () => {
             getAiKnowledgeSources: vi.fn().mockResolvedValue(sources),
             setAiKnowledgeSources,
           },
+          projectKnowledge: buildEmptyProjectKnowledge(),
         },
         fetchers: {
           inline_text: { fetch: vi.fn().mockResolvedValue(healthyContent("Inline operator context")) },
@@ -221,6 +255,7 @@ describe("synthesizeProjectKnowledgeOrchestrator", () => {
             getAiKnowledgeSources: vi.fn().mockResolvedValue([]),
             setAiKnowledgeSources: vi.fn().mockResolvedValue(undefined),
           },
+          projectKnowledge: buildEmptyProjectKnowledge(),
         },
         fetchers: {
           inline_text: { fetch: vi.fn() },
@@ -253,6 +288,7 @@ describe("synthesizeProjectKnowledgeOrchestrator", () => {
             ]),
             setAiKnowledgeSources: vi.fn().mockResolvedValue(undefined),
           },
+          projectKnowledge: buildEmptyProjectKnowledge(),
         },
         fetchers: {
           inline_text: { fetch: vi.fn() },
@@ -296,6 +332,7 @@ describe("synthesizeProjectKnowledgeOrchestrator", () => {
             ]),
             setAiKnowledgeSources,
           },
+          projectKnowledge: buildEmptyProjectKnowledge(),
         },
         fetchers: {
           inline_text: { fetch: vi.fn().mockResolvedValue(healthyContent("Inline operator context")) },
@@ -358,6 +395,7 @@ describe("synthesizeProjectKnowledgeOrchestrator", () => {
             getAiKnowledgeSources: vi.fn().mockResolvedValue(sources),
             setAiKnowledgeSources,
           },
+          projectKnowledge: buildEmptyProjectKnowledge(),
         },
         fetchers: {
           inline_text: { fetch: vi.fn() },
@@ -416,6 +454,7 @@ describe("synthesizeProjectKnowledgeOrchestrator", () => {
             ]),
             setAiKnowledgeSources: vi.fn().mockResolvedValue(undefined),
           },
+          projectKnowledge: buildEmptyProjectKnowledge(),
         },
         fetchers: {
           inline_text: { fetch: vi.fn().mockResolvedValue(healthyContent("Inline operator context")) },
@@ -430,5 +469,225 @@ describe("synthesizeProjectKnowledgeOrchestrator", () => {
     );
 
     expect(webFetch).not.toHaveBeenCalled();
+  });
+
+  it("includes approved-reply examples in the synthesis prompt with weighting language", async () => {
+    const project = buildProject();
+    const sources = [
+      buildSource({
+        id: "11111111-1111-4111-8111-111111111111",
+        kind: "inline_text",
+        url: "https://example.test/inline-1",
+      }),
+    ];
+    const approvedReplies = [
+      buildApprovedReply({
+        id: "approved:1",
+        maskedExample: "Hi {NAME}, thanks for confirming the field logistics.",
+        createdAt: "2026-05-08T12:00:00.000Z",
+      }),
+      buildApprovedReply({
+        id: "approved:2",
+        maskedExample: "Welcome aboard! Your training kit ships next week.",
+        createdAt: "2026-05-07T12:00:00.000Z",
+      }),
+      buildApprovedReply({
+        id: "approved:3",
+        maskedExample: "Submit your data through the {APP} portal.",
+        createdAt: "2026-05-06T12:00:00.000Z",
+      }),
+    ];
+    const invokeModel = vi.fn().mockResolvedValue(buildDraftResult("# Synthesized"));
+    const list = vi.fn().mockResolvedValue(approvedReplies);
+
+    await synthesizeProjectKnowledgeOrchestrator(
+      {
+        repositories: {
+          projectDimensions: {
+            findById: vi.fn().mockResolvedValue(project),
+            getAiKnowledgeSources: vi.fn().mockResolvedValue(sources),
+            setAiKnowledgeSources: vi.fn().mockResolvedValue(undefined),
+          },
+          projectKnowledge: { list },
+        },
+        fetchers: {
+          inline_text: { fetch: vi.fn().mockResolvedValue(healthyContent("Inline operator context")) },
+          notion: { fetch: vi.fn() },
+          web_page: { fetch: vi.fn() },
+        },
+        invokeModel,
+      },
+      {
+        projectId: project.projectId,
+      },
+    );
+
+    expect(list).toHaveBeenCalledWith({
+      projectId: project.projectId,
+      approvedOnly: true,
+    });
+    const prompt = readPromptFromInvokeModelMock(invokeModel);
+    expect(prompt).toContain("<APPROVED_REPLY_EXAMPLES>");
+    expect(prompt).toContain("</APPROVED_REPLY_EXAMPLES>");
+    expect(prompt).toContain("3 canonical reply examples");
+    expect(prompt).toContain("weight them MORE HEAVILY");
+    expect(prompt).toContain(
+      "Hi {NAME}, thanks for confirming the field logistics.",
+    );
+    expect(prompt).toContain(
+      "Welcome aboard! Your training kit ships next week.",
+    );
+    expect(prompt).toContain("Submit your data through the {APP} portal.");
+    expect(prompt).toContain("--- Example 1 (captured 2026-05-08, kind=canonical_reply) ---");
+  });
+
+  it("omits the approved-reply block entirely when no approved replies exist", async () => {
+    const project = buildProject();
+    const sources = [
+      buildSource({
+        id: "11111111-1111-4111-8111-111111111111",
+        kind: "inline_text",
+        url: "https://example.test/inline-1",
+      }),
+    ];
+    const invokeModel = vi.fn().mockResolvedValue(buildDraftResult("# Synthesized"));
+
+    await synthesizeProjectKnowledgeOrchestrator(
+      {
+        repositories: {
+          projectDimensions: {
+            findById: vi.fn().mockResolvedValue(project),
+            getAiKnowledgeSources: vi.fn().mockResolvedValue(sources),
+            setAiKnowledgeSources: vi.fn().mockResolvedValue(undefined),
+          },
+          projectKnowledge: { list: vi.fn().mockResolvedValue([]) },
+        },
+        fetchers: {
+          inline_text: { fetch: vi.fn().mockResolvedValue(healthyContent("Inline operator context")) },
+          notion: { fetch: vi.fn() },
+          web_page: { fetch: vi.fn() },
+        },
+        invokeModel,
+      },
+      {
+        projectId: project.projectId,
+      },
+    );
+
+    const prompt = readPromptFromInvokeModelMock(invokeModel);
+    expect(prompt).not.toContain("<APPROVED_REPLY_EXAMPLES>");
+    expect(prompt).not.toContain("canonical reply examples");
+    expect(prompt).not.toContain("weight them MORE HEAVILY");
+  });
+
+  it("caps the approved-reply block at the 50 most recently returned entries", async () => {
+    const project = buildProject();
+    const sources = [
+      buildSource({
+        id: "11111111-1111-4111-8111-111111111111",
+        kind: "inline_text",
+        url: "https://example.test/inline-1",
+      }),
+    ];
+    // The repo returns rows already ordered by desc(updatedAt). The
+    // orchestrator should pick the first 50 — items 0..49 — and exclude
+    // the rest. We verify by tagging the bodies with their index.
+    const approvedReplies = Array.from({ length: 60 }, (_, index) =>
+      buildApprovedReply({
+        id: `approved:${String(index)}`,
+        maskedExample: `EXAMPLE_BODY_${String(index)}`,
+        createdAt: `2026-05-${String(8).padStart(2, "0")}T12:00:00.000Z`,
+      }),
+    );
+    const invokeModel = vi.fn().mockResolvedValue(buildDraftResult("# Synthesized"));
+
+    await synthesizeProjectKnowledgeOrchestrator(
+      {
+        repositories: {
+          projectDimensions: {
+            findById: vi.fn().mockResolvedValue(project),
+            getAiKnowledgeSources: vi.fn().mockResolvedValue(sources),
+            setAiKnowledgeSources: vi.fn().mockResolvedValue(undefined),
+          },
+          projectKnowledge: { list: vi.fn().mockResolvedValue(approvedReplies) },
+        },
+        fetchers: {
+          inline_text: { fetch: vi.fn().mockResolvedValue(healthyContent("Inline operator context")) },
+          notion: { fetch: vi.fn() },
+          web_page: { fetch: vi.fn() },
+        },
+        invokeModel,
+      },
+      {
+        projectId: project.projectId,
+      },
+    );
+
+    const prompt = readPromptFromInvokeModelMock(invokeModel);
+    expect(prompt).toContain("50 canonical reply examples");
+    expect(prompt).toContain("EXAMPLE_BODY_0");
+    expect(prompt).toContain("EXAMPLE_BODY_49");
+    expect(prompt).not.toContain("EXAMPLE_BODY_50");
+    expect(prompt).not.toContain("EXAMPLE_BODY_59");
+  });
+
+  it("excludes non-canonical_reply approved entries from the prompt block", async () => {
+    const project = buildProject();
+    const sources = [
+      buildSource({
+        id: "11111111-1111-4111-8111-111111111111",
+        kind: "inline_text",
+        url: "https://example.test/inline-1",
+      }),
+    ];
+    const approvedReplies = [
+      buildApprovedReply({
+        id: "approved:reply",
+        maskedExample: "CANONICAL_REPLY_BODY",
+        createdAt: "2026-05-08T12:00:00.000Z",
+        kind: "canonical_reply",
+      }),
+      buildApprovedReply({
+        id: "approved:snippet",
+        maskedExample: "SNIPPET_BODY",
+        createdAt: "2026-05-08T12:00:00.000Z",
+        kind: "snippet",
+      }),
+      buildApprovedReply({
+        id: "approved:pattern",
+        maskedExample: "PATTERN_BODY",
+        createdAt: "2026-05-08T12:00:00.000Z",
+        kind: "pattern",
+      }),
+    ];
+    const invokeModel = vi.fn().mockResolvedValue(buildDraftResult("# Synthesized"));
+
+    await synthesizeProjectKnowledgeOrchestrator(
+      {
+        repositories: {
+          projectDimensions: {
+            findById: vi.fn().mockResolvedValue(project),
+            getAiKnowledgeSources: vi.fn().mockResolvedValue(sources),
+            setAiKnowledgeSources: vi.fn().mockResolvedValue(undefined),
+          },
+          projectKnowledge: { list: vi.fn().mockResolvedValue(approvedReplies) },
+        },
+        fetchers: {
+          inline_text: { fetch: vi.fn().mockResolvedValue(healthyContent("Inline operator context")) },
+          notion: { fetch: vi.fn() },
+          web_page: { fetch: vi.fn() },
+        },
+        invokeModel,
+      },
+      {
+        projectId: project.projectId,
+      },
+    );
+
+    const prompt = readPromptFromInvokeModelMock(invokeModel);
+    expect(prompt).toContain("1 canonical reply examples");
+    expect(prompt).toContain("CANONICAL_REPLY_BODY");
+    expect(prompt).not.toContain("SNIPPET_BODY");
+    expect(prompt).not.toContain("PATTERN_BODY");
   });
 });

--- a/apps/worker/test/synthesize-project-knowledge.test.ts
+++ b/apps/worker/test/synthesize-project-knowledge.test.ts
@@ -68,6 +68,7 @@ describe("runSynthesizeProjectKnowledge", () => {
         {
           repositories: {
             projectDimensions: context.repositories.projectDimensions,
+            projectKnowledge: context.repositories.projectKnowledge,
             settingsProjects: context.settings.projects,
           },
           fetchers: {

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -5,6 +5,7 @@ import {
   countDistinct,
   desc,
   eq,
+  gt,
   inArray,
   isNotNull,
   isNull,
@@ -1899,6 +1900,24 @@ function createStage1RepositoriesInternal(
         return PROJECT_KNOWLEDGE_KINDS.flatMap(
           (kind) => rankedByKind.get(kind) ?? [],
         );
+      },
+
+      async countCapturedSinceTimestamp(input) {
+        const predicates: SQL[] = [
+          eq(projectKnowledgeEntries.projectId, input.projectId),
+          eq(projectKnowledgeEntries.approvedForAi, true),
+        ];
+
+        if (input.since !== null) {
+          predicates.push(gt(projectKnowledgeEntries.createdAt, input.since));
+        }
+
+        const [row] = await db
+          .select({ value: count() })
+          .from(projectKnowledgeEntries)
+          .where(and(...predicates));
+
+        return row?.value ?? 0;
       },
     },
 

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -174,6 +174,18 @@ export interface ProjectKnowledgeRepository {
     readonly keywordsLower: readonly string[];
     readonly limitPerKind: number;
   }): Promise<readonly ProjectKnowledgeEntryRecord[]>;
+  /**
+   * Count approved-for-AI rows for a project captured strictly after the
+   * given timestamp. Pass `null` to count every approved-for-AI row in the
+   * project (useful when synthesis has never run).
+   *
+   * Used by the Phase 3 capture-trigger path to decide whether enough new
+   * approved replies have accumulated to re-synthesize.
+   */
+  countCapturedSinceTimestamp(input: {
+    readonly projectId: string;
+    readonly since: Date | null;
+  }): Promise<number>;
 }
 
 export interface AllContactsSearchMembership {

--- a/packages/domain/test/normalization.test.ts
+++ b/packages/domain/test/normalization.test.ts
@@ -428,6 +428,7 @@ function buildContext(input: {
       setApproved: () => Promise.resolve(),
       deleteById: () => Promise.resolve(),
       getForRetrieval: () => Promise.resolve([]),
+      countCapturedSinceTimestamp: () => Promise.resolve(0),
     },
     contacts: {
       findById: (id) => Promise.resolve(contactsById.get(id) ?? null),

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -66,6 +66,7 @@ describe("defineStage1RepositoryBundle", () => {
         setApproved: () => Promise.resolve(),
         deleteById: () => Promise.resolve(),
         getForRetrieval: () => Promise.resolve([]),
+        countCapturedSinceTimestamp: () => Promise.resolve(0),
       },
       contacts: {
         findById: () => Promise.resolve(contact),

--- a/packages/domain/test/stage3-last-inbound-alias.test.ts
+++ b/packages/domain/test/stage3-last-inbound-alias.test.ts
@@ -85,6 +85,7 @@ function buildRepositoryBundle(input: {
       setApproved: () => Promise.resolve(),
       deleteById: () => Promise.resolve(),
       getForRetrieval: () => Promise.resolve([]),
+      countCapturedSinceTimestamp: () => Promise.resolve(0),
     },
     contacts: {
       findById: () => Promise.resolve(contact),

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -162,6 +162,7 @@ function createRepositoryBundle(input: {
       setApproved: () => Promise.resolve(),
       deleteById: () => Promise.resolve(),
       getForRetrieval: () => Promise.resolve([]),
+      countCapturedSinceTimestamp: () => Promise.resolve(0),
     },
     contacts: {
       findById: () => Promise.resolve(contact),


### PR DESCRIPTION
## Summary

- **Capture-flag flip** — `captureKnowledgeFromSend` (apps/web/app/inbox/actions.ts) now writes `approvedForAi: true` on every "Send and save for AI" upsert (both email and SMS paths). Per D-032, the operator's deliberate click IS the approval signal — no separate review UI exists.
- **Threshold trigger** — after each successful capture, count approved-for-AI rows since the last synthesis. Once the count crosses **5** AND the project has at least one enabled AI Knowledge source, enqueue the synthesis worker job with `skipIfHashUnchanged: false` and `jobKey: ai-knowledge-capture-trigger:{projectId}` (replace mode). Enqueue failures are logged but do not block the capture itself.
- **Orchestrator weighting** — `synthesizeProjectKnowledgeOrchestrator` now loads up to 50 most-recent approved canonical_reply rows and emits an `<APPROVED_REPLY_EXAMPLES>` block in the prompt, instructing the LLM to weight them MORE HEAVILY than the ordinary inbox corpus. The block is omitted when zero approved replies exist.

## Scope

PRD [#366](https://github.com/nico-kneler-as/as-comms-platform/issues/366) Phase 3 — the final PR per the three-phase plan.

| Phase | Sha | Scope |
|---|---|---|
| PR-A | `56145f6e` | Schema + data layer (sources registry, operating context, synthesis metadata) |
| PR-B-1 | `db4a9262` | Source fetcher interface + 3 implementations + Notion page helper |
| PR-B-2 | `14dba612` | Synthesis orchestrator + worker job + ops CLI |
| PR-C | `2b9a4c7d` | Wizard + project detail UI + 7 server actions |
| Phase 2 | `4687f325` | Auto-sync schedule + cron poll + skip-if-unchanged |
| **Phase 3** | this PR | Approved-reply weighting + capture-driven re-synthesis trigger |

Delivers PRD User Stories #41 (one-click approval), #42 (threshold trigger), and #43 (synthesis weighting).

## What changes for operators

A project's operators clicking "Send and save for AI" on 5 sent replies (since the last synthesis) auto-refreshes the AI Knowledge Notion page with their canonical replies as weighted examples — the AI's drafts continuously improve from the team's best work, with no manual sync click required. Existing operators can keep using the platform unchanged; the trigger first fires the next time they accumulate 5 captures for a given project.

## Test plan

- [x] `pnpm typecheck` — all 16 packages green
- [x] `pnpm lint` — no warnings
- [x] `pnpm --filter @as-comms/db test:unit` — 16 files / 100 tests
- [x] `pnpm --filter @as-comms/contracts test:unit` — 4 files / 15 tests
- [x] `pnpm --filter @as-comms/integrations test:unit` — 15 files / 145 tests
- [x] `pnpm --filter @as-comms/worker test:unit` — 48 files / 176 tests (incl. 4 new orchestrator weighting tests)
- [x] `pnpm --filter @as-comms/web test:unit` — 70 files / 506 passing (incl. 4 new threshold-trigger tests)
- [x] `node scripts/boundary-check.mjs` — passes

### New tests
- **`apps/web/tests/unit/stage3-send-action.test.ts`** — below-threshold (no enqueue), at-threshold (single enqueue with replace mode), above-threshold (re-enqueue), no-enabled-sources guard, enqueue-failure resilience (capture still succeeds, warn logged).
- **`apps/worker/test/synthesize-project-knowledge-orchestrator.test.ts`** — 3 examples → block with weighting language, 0 examples → block omitted, 60 examples → 50 cap, mixed kinds → only canonical_reply.
- Existing skip-if-unchanged orchestrator test continues to pass unchanged (approved-reply count doesn't perturb the source-hash skip path).

## Out of scope

- Approved-reply review / edit / delete UI — still deferred to a later PRD.
- Per-project configurable threshold — hardcoded at 5 for now.
- Embeddings-based retrieval of approved replies — closed in 2026-04-27 architecture collapse; replies feed synthesis as text.
- "Disapprove" / "remove from synthesis" workflow — deferred to the future review UI.
- Phase 3+ analytics (which approved replies are most influential, etc.).

## Architectural notes

- The threshold trigger fires from the inbox capture path, NOT from the cron. Auto-sync (Phase 2) handles "sources changed" recovery; the capture trigger handles "approved replies accumulated" recovery. Different signals, different paths.
- `inputHashFromSources` is unchanged — approved replies are not part of the source registry's input hash. This is correct: approved replies don't change "which sources we have," they're a separate axis of change.
- `enqueueSynthesizeProjectKnowledgeJob` and `enqueueNotionKnowledgeSyncJob` were extracted from `apps/web/app/settings/actions.ts` to a new shared module `apps/web/src/server/ai/enqueue.ts` so the inbox capture path can reuse the helper without duplicating the graphile add_job template-tag call.