### PR TITLE
UI polish: composer reply alias, Pin Note, settings lists, Access→Team

### DIFF
--- a/apps/web/app/inbox/_components/composer-ai-draft-window.tsx
+++ b/apps/web/app/inbox/_components/composer-ai-draft-window.tsx
@@ -232,6 +232,7 @@ export function ComposerAiDraftWindow({
         {showsEmptyState ? (
           <div className="flex min-w-0 items-start gap-2">
             <textarea
+              autoFocus
               value={directiveText}
               onChange={(event) => {
                 onDirectiveTextChange(event.currentTarget.value);

--- a/apps/web/app/inbox/_components/composer-detail-surfaces.tsx
+++ b/apps/web/app/inbox/_components/composer-detail-surfaces.tsx
@@ -43,6 +43,7 @@ import {
   MailIcon,
   NoteIcon,
   PaperclipIcon,
+  PinIcon,
   SendIcon,
   XIcon,
 } from "./icons";
@@ -1075,6 +1076,7 @@ export function ComposerNoteSurface({
         ) : null}
         <textarea
           ref={textareaRef}
+          autoFocus
           rows={6}
           value={body}
           onChange={(event) => {
@@ -1112,12 +1114,12 @@ export function ComposerNoteSurface({
           {isSavingNote ? (
             <>
               <LoaderIcon className="size-4 animate-spin" />
-              Saving...
+              Pinning...
             </>
           ) : (
             <>
-              <NoteIcon className="size-4" />
-              Save note
+              <PinIcon className="size-4" />
+              Pin Note
             </>
           )}
         </Button>

--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -218,7 +218,7 @@ function realEntryMatchesOptimistic(
 
 export function InboxDetail({ detail, timelineSlot }: DetailProps) {
   const { contact } = detail;
-  const { openReplyDraft } = useInboxClient();
+  const { openReplyDraft, composerAliases } = useInboxClient();
 
   const [railOpen, setRailOpen] = useState(false);
   const followUpToggle = useOptimisticBooleanToggle({
@@ -302,6 +302,26 @@ export function InboxDetail({ detail, timelineSlot }: DetailProps) {
 
   const isFollowUp = followUpToggle.value;
   const composerReplyContext = detail.composerReplyContext;
+
+  // Default the reply alias to the alias belonging to the conversation tag's
+  // project (first active-project chip, falling back to conversationProject)
+  // so a forests@ thread opens with forests@ selected — not whatever alias
+  // the volunteer last replied to.
+  const tagProjectId =
+    contact.activeProjects[0]?.projectId ??
+    detail.conversationProject?.projectId ??
+    null;
+  const projectAliasOverride =
+    tagProjectId === null
+      ? null
+      : (composerAliases.find((option) => option.projectId === tagProjectId)
+          ?.alias ?? null);
+  const resolvedReplyContext =
+    composerReplyContext === null
+      ? null
+      : projectAliasOverride === null
+        ? composerReplyContext
+        : { ...composerReplyContext, defaultAlias: projectAliasOverride };
 
   return (
     <div className="flex min-h-0 flex-1">
@@ -460,13 +480,13 @@ export function InboxDetail({ detail, timelineSlot }: DetailProps) {
         {timelineSlot ?? <InboxDetailTimelineFallback />}
 
         <div className="shrink-0">
-          {composerReplyContext ? (
+          {resolvedReplyContext ? (
             <InboxComposerReplyBar
               onReply={() => {
-                openReplyDraft(composerReplyContext);
+                openReplyDraft(resolvedReplyContext);
               }}
               onNote={() => {
-                openReplyDraft(composerReplyContext, "note");
+                openReplyDraft(resolvedReplyContext, "note");
               }}
             />
           ) : null}

--- a/apps/web/app/settings/_components/access-section.tsx
+++ b/apps/web/app/settings/_components/access-section.tsx
@@ -203,8 +203,8 @@ export function AccessSection({
 
   return (
     <SettingsSection
-      id="settings-access"
-      title="Access"
+      id="settings-team"
+      title="Team"
       description="Teammates, roles, and deactivated accounts"
       feedback={feedback}
       action={

--- a/apps/web/app/settings/_components/integrations-section.tsx
+++ b/apps/web/app/settings/_components/integrations-section.tsx
@@ -14,10 +14,6 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import {
-  formatSmsEstimatedCostUsd,
-  formatUsdAmount,
-} from "@/src/lib/sms-pricing";
 import type {
   IntegrationHealthViewModel,
   IntegrationsSettingsViewModel,
@@ -88,11 +84,6 @@ function formatRelative(iso: string | null): string {
   return `${String(years)}y ago`;
 }
 
-function formatMailchimpCount(value: number | null): string {
-  if (value === null) return "—";
-  return new Intl.NumberFormat("en-US").format(value);
-}
-
 function formatMailchimpStatus(
   integration: Extract<IntegrationHealthViewModel, { mailchimp: unknown }>,
 ): { readonly label: string; readonly colorClasses: string } {
@@ -114,34 +105,6 @@ function formatMailchimpStatus(
         colorClasses: "bg-amber-50 text-amber-800 ring-amber-200",
       };
   }
-}
-
-function buildTwilioUsageState(input: {
-  readonly spendUsd: number | null;
-  readonly capUsd: number | null;
-}): null | {
-  readonly label: string;
-  readonly className: string;
-} {
-  if (input.spendUsd === null || input.capUsd === null || input.capUsd <= 0) {
-    return null;
-  }
-
-  if (input.spendUsd >= input.capUsd) {
-    return {
-      label: "Cap exceeded — sends still allowed in v1, no hard enforcement",
-      className: "bg-rose-50 text-rose-700 ring-rose-200",
-    };
-  }
-
-  if (input.spendUsd >= input.capUsd * 0.8) {
-    return {
-      label: "Approaching cap",
-      className: "bg-amber-50 text-amber-800 ring-amber-200",
-    };
-  }
-
-  return null;
 }
 
 export function IntegrationsSection({ viewModel }: IntegrationsSectionProps) {
@@ -191,136 +154,91 @@ export function IntegrationsSection({ viewModel }: IntegrationsSectionProps) {
       <SettingsSection
         id="settings-integrations"
         title="Integrations"
+        description="Providers this workspace depends on"
         feedback={feedback}
       >
-        <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-          {items.map((integration) => {
-            const statusMeta =
-              integration.serviceName === "mailchimp" &&
-              integration.mailchimp !== null
-                ? formatMailchimpStatus(integration)
-                : STATUS_META[integration.status];
-            const isRowPending =
-              pending && pendingId === integration.serviceName;
-            const isSyncDisabled = !integration.supportsRefresh || isRowPending;
-            const descriptionTerminator = /[.!?]$/.test(integration.description)
-              ? ""
-              : ".";
-            const summary = integration.detail
-              ? `${integration.description}${descriptionTerminator} ${integration.detail}`
-              : integration.description;
+        <div
+          className={cn(
+            "overflow-hidden",
+            RADIUS.lg,
+            "border border-slate-200 bg-white",
+            SHADOW.sm,
+          )}
+        >
+          <ul className="divide-y divide-slate-100">
+            {items.map((integration) => {
+              const statusMeta =
+                integration.serviceName === "mailchimp" &&
+                integration.mailchimp !== null
+                  ? formatMailchimpStatus(integration)
+                  : STATUS_META[integration.status];
+              const isRowPending =
+                pending && pendingId === integration.serviceName;
+              const isSyncDisabled =
+                !integration.supportsRefresh || isRowPending;
+              const descriptionTerminator = /[.!?]$/.test(
+                integration.description,
+              )
+                ? ""
+                : ".";
+              const summary = integration.detail
+                ? `${integration.description}${descriptionTerminator} ${integration.detail}`
+                : integration.description;
 
-            return (
-              <li
-                key={integration.serviceName}
-                className={cn(
-                  "flex min-h-full flex-col gap-3 border border-slate-200 bg-white p-4",
-                  RADIUS.lg,
-                  SHADOW.sm,
-                  isRowPending && "opacity-60",
-                )}
-              >
-                <div className="flex items-start gap-3">
-                  <div className="flex min-w-0 flex-1 items-start gap-3">
-                    <IntegrationLogoMark integration={integration} />
-                    <div className="min-w-0 flex-1">
-                      <div className="flex flex-wrap items-center gap-1.5">
-                        <span className="truncate text-[13.5px] font-semibold text-slate-900">
-                          {integration.displayName}
-                        </span>
-                        <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-400">
-                          {CATEGORY_LABEL[integration.category]}
-                        </span>
-                      </div>
-                      <p className="mt-1 line-clamp-2 text-[12px] text-slate-500">
-                        {summary}
-                      </p>
+              return (
+                <li
+                  key={integration.serviceName}
+                  className={cn(
+                    "flex items-center gap-3 px-5 py-3",
+                    isRowPending && "opacity-60",
+                  )}
+                >
+                  <IntegrationLogoMark integration={integration} />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-1.5">
+                      <span className="truncate text-[13.5px] font-semibold text-slate-900">
+                        {integration.displayName}
+                      </span>
+                      <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-400">
+                        {CATEGORY_LABEL[integration.category]}
+                      </span>
                     </div>
+                    <p className="mt-0.5 truncate text-[12px] text-slate-500">
+                      {summary}
+                    </p>
+                    <p className="mt-0.5 truncate text-[11.5px] text-slate-400 tabular-nums">
+                      Last checked · {formatRelative(integration.lastCheckedAt)}
+                    </p>
                   </div>
-
                   <StatusBadge
                     label={statusMeta.label}
                     colorClasses={statusMeta.colorClasses}
                     variant="soft"
                     className="shrink-0"
                   />
-                </div>
-
-                {integration.mailchimp !== null ? (
-                  <MailchimpTileDetails integration={integration} />
-                ) : (
-                  <div className="flex items-center justify-between gap-3 text-[11.5px] text-slate-500">
-                    <span className="min-w-0 truncate tabular-nums">
-                      Last checked · {formatRelative(integration.lastCheckedAt)}
-                    </span>
-
-                    {viewModel.isAdmin && (
-                      <SyncButton
-                        disabled={isSyncDisabled}
-                        supportsRefresh={integration.supportsRefresh}
-                        pending={isRowPending}
-                        integrationName={integration.displayName}
-                        onSync={() => {
-                          handleRefresh(integration);
-                        }}
-                      />
-                    )}
-                  </div>
-                )}
-              </li>
-            );
-          })}
-          {/* Twilio is rendered inside the same grid so all 6 cards share equal column widths */}
-          <TwilioConnectorCard viewModel={viewModel.twilioCard} />
-        </ul>
+                  {viewModel.isAdmin ? (
+                    <SyncButton
+                      disabled={isSyncDisabled}
+                      supportsRefresh={integration.supportsRefresh}
+                      pending={isRowPending}
+                      integrationName={integration.displayName}
+                      onSync={() => {
+                        handleRefresh(integration);
+                      }}
+                    />
+                  ) : null}
+                </li>
+              );
+            })}
+            <TwilioConnectorRow viewModel={viewModel.twilioCard} />
+          </ul>
+        </div>
       </SettingsSection>
     </TooltipProvider>
   );
 }
 
-function MailchimpTileDetails({
-  integration,
-}: {
-  readonly integration: IntegrationHealthViewModel;
-}) {
-  if (integration.mailchimp === null) {
-    return null;
-  }
-
-  return (
-    <div className="border-t border-slate-200 pt-3">
-      <dl className="grid gap-2 text-[12px] text-slate-600">
-        <div className="flex items-start justify-between gap-3">
-          <dt className="font-medium text-slate-900">Last sync</dt>
-          <dd className="text-right tabular-nums">
-            {formatRelative(integration.mailchimp.lastSuccessfulSyncAt)}
-          </dd>
-        </div>
-        <div className="flex items-start justify-between gap-3">
-          <dt className="font-medium text-slate-900">Last campaign</dt>
-          <dd className="max-w-[60%] text-right">
-            {integration.mailchimp.lastCampaignName === null
-              ? "—"
-              : `${integration.mailchimp.lastCampaignName} · ${formatRelative(
-                  integration.mailchimp.lastCampaignSentAt,
-                )}`}
-          </dd>
-        </div>
-        <div className="flex items-start justify-between gap-3">
-          <dt className="font-medium text-slate-900">Last batch</dt>
-          <dd className="text-right tabular-nums">
-            {formatMailchimpCount(
-              integration.mailchimp.lastBatchRecipientCount,
-            )}{" "}
-            recipients
-          </dd>
-        </div>
-      </dl>
-    </div>
-  );
-}
-
-function TwilioConnectorCard({
+function TwilioConnectorRow({
   viewModel,
 }: {
   readonly viewModel: IntegrationsSettingsViewModel["twilioCard"];
@@ -339,101 +257,36 @@ function TwilioConnectorCard({
       colorClasses: "bg-amber-50 text-amber-800 ring-amber-200",
     },
   }[viewModel.status];
-  const usageState = buildTwilioUsageState({
-    spendUsd: viewModel.monthToDateSpendUsd,
-    capUsd: viewModel.monthlyCapUsd,
-  });
-  const showUsageRows =
-    viewModel.smsEnabled &&
-    viewModel.monthToDateSpendUsd !== null &&
-    viewModel.monthToDateSegments !== null;
 
   return (
-    <li
-      className={cn(
-        "flex min-h-full flex-col gap-3 border border-slate-200 bg-white p-4",
-        RADIUS.lg,
-        SHADOW.sm,
-      )}
-    >
-      <div className="flex items-start gap-3">
-        <div className="flex min-w-0 flex-1 items-start gap-3">
-          <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-white text-slate-700 ring-1 ring-inset ring-slate-200/70">
-            <span className="text-[10px] font-semibold uppercase">TW</span>
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="flex flex-wrap items-center gap-1.5">
-              <span className="truncate text-[13.5px] font-semibold text-slate-900">
-                Twilio
-              </span>
-              <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-400">
-                Messaging
-              </span>
-            </div>
-            <p className="mt-1 text-[12px] text-slate-500">
-              Outbound SMS connector. Read-only in this phase.
-            </p>
-          </div>
-        </div>
-        <StatusBadge
-          label={statusMeta.label}
-          colorClasses={statusMeta.colorClasses}
-          variant="soft"
-          className="shrink-0"
-        />
+    <li className="flex items-center gap-3 px-5 py-3">
+      <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-white text-slate-700 ring-1 ring-inset ring-slate-200/70">
+        <span className="text-[10px] font-semibold uppercase">TW</span>
       </div>
-
-      <dl className="grid gap-2 text-[12px] text-slate-600 sm:grid-cols-3">
-        <div>
-          <dt className="font-medium text-slate-900">SMS enabled</dt>
-          <dd>{viewModel.smsEnabled ? "On" : "Off"}</dd>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="truncate text-[13.5px] font-semibold text-slate-900">
+            Twilio
+          </span>
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-400">
+            Messaging
+          </span>
         </div>
-        <div>
-          <dt className="font-medium text-slate-900">Active sender</dt>
-          <dd>{viewModel.hasActiveSender ? "Configured" : "Missing"}</dd>
-        </div>
-        <div>
-          <dt className="font-medium text-slate-900">Last status callback</dt>
-          <dd>{formatRelative(viewModel.lastStatusCallbackAt)}</dd>
-        </div>
-      </dl>
-
-      {showUsageRows ? (
-        <div className="border-t border-slate-200 pt-3">
-          <dl className="grid gap-2 text-[12px] text-slate-600">
-            <div className="flex items-start justify-between gap-3">
-              <dt className="font-medium text-slate-900">Spend MTD</dt>
-              <dd className="text-right">
-                <span className="font-medium tabular-nums text-slate-900">
-                  ${formatUsdAmount(viewModel.monthToDateSpendUsd)}
-                </span>
-              </dd>
-            </div>
-            <div className="-mt-1 text-right text-[11.5px] text-slate-500 tabular-nums">
-              (${formatSmsEstimatedCostUsd(viewModel.outboundRateUsdPerSegment)}{" "}
-              / segment, {String(viewModel.monthToDateSegments)} segments)
-            </div>
-            <div className="flex items-start justify-between gap-3">
-              <dt className="font-medium text-slate-900">Monthly cap</dt>
-              <dd className="font-medium tabular-nums text-slate-900">
-                {viewModel.monthlyCapUsd === null
-                  ? "—"
-                  : `$${formatUsdAmount(viewModel.monthlyCapUsd)}`}
-              </dd>
-            </div>
-          </dl>
-
-          {usageState ? (
-            <div className="mt-3">
-              <StatusBadge
-                label={usageState.label}
-                colorClasses={usageState.className}
-                variant="soft"
-              />
-            </div>
-          ) : null}
-        </div>
-      ) : null}
+        <p className="mt-0.5 truncate text-[12px] text-slate-500">
+          Outbound SMS connector. Read-only in this phase.
+        </p>
+        <p className="mt-0.5 truncate text-[11.5px] text-slate-400 tabular-nums">
+          SMS · {viewModel.smsEnabled ? "On" : "Off"} · Sender ·{" "}
+          {viewModel.hasActiveSender ? "Configured" : "Missing"} · Last callback ·{" "}
+          {formatRelative(viewModel.lastStatusCallbackAt)}
+        </p>
+      </div>
+      <StatusBadge
+        label={statusMeta.label}
+        colorClasses={statusMeta.colorClasses}
+        variant="soft"
+        className="shrink-0"
+      />
     </li>
   );
 }

--- a/apps/web/app/settings/_components/projects-section.tsx
+++ b/apps/web/app/settings/_components/projects-section.tsx
@@ -15,7 +15,6 @@ import {
   TRANSITION
 } from "@/app/_lib/design-tokens-v2";
 import { Button } from "@/components/ui/button";
-import { StatusBadge } from "@/components/ui/status-badge";
 import { cn } from "@/lib/utils";
 import type {
   ProjectRowViewModel,
@@ -48,49 +47,33 @@ export function ProjectsSection({
 
   return (
     <>
-      <SettingsSection id="settings-projects" title="Projects">
-        <div className="flex flex-col gap-6">
-          <div className="flex flex-col gap-3">
-            <div className="flex items-center justify-between gap-3">
-              <h3 className="text-sm font-semibold text-slate-900">
-                Currently active
-              </h3>
-              <div className="flex items-center gap-2">
-                <span className={cn(TYPE.caption, "tabular-nums")}>
-                  {String(viewModel.counts.active)} active
-                </span>
-                {viewModel.isAdmin ? (
-                  <Button
-                    type="button"
-                    size="sm"
-                    onClick={() => {
-                      openWizard();
-                    }}
-                  >
-                    <Plus className="size-3.5" aria-hidden="true" />
-                    Activate a project
-                  </Button>
-                ) : null}
-              </div>
-            </div>
-            <ProjectList
-              projects={viewModel.active}
-              emptyMessage="No active projects yet."
-              renderLeading={() => (
-                <span className="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-lg bg-emerald-50 text-emerald-700 ring-1 ring-inset ring-emerald-200/60">
-                  <FolderOpen className="size-4" aria-hidden="true" />
-                </span>
-              )}
-              renderMeta={() => (
-                <StatusBadge
-                  label="Active"
-                  colorClasses="bg-emerald-50 text-emerald-700 ring-emerald-200"
-                  variant="soft"
-                />
-              )}
-            />
-          </div>
-        </div>
+      <SettingsSection
+        id="settings-projects"
+        title="Projects"
+        description="Projects currently receiving inbound mail"
+        action={
+          viewModel.isAdmin ? (
+            <Button
+              type="button"
+              onClick={() => {
+                openWizard();
+              }}
+            >
+              <Plus className="size-3.5" aria-hidden="true" />
+              Activate a project
+            </Button>
+          ) : null
+        }
+      >
+        <ProjectList
+          projects={viewModel.active}
+          emptyMessage="No active projects yet."
+          renderLeading={() => (
+            <span className="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-lg bg-emerald-50 text-emerald-700 ring-1 ring-inset ring-emerald-200/60">
+              <FolderOpen className="size-4" aria-hidden="true" />
+            </span>
+          )}
+        />
       </SettingsSection>
 
       {wizardRequest !== null ? (

--- a/apps/web/app/settings/_components/settings-section-nav.tsx
+++ b/apps/web/app/settings/_components/settings-section-nav.tsx
@@ -32,10 +32,10 @@ const ITEMS: readonly SectionItem[] = [
     Icon: FolderOpen
   },
   {
-    id: "access",
-    label: "Access",
+    id: "team",
+    label: "Team",
     description: "Teammates, roles, and deactivated accounts.",
-    href: "/settings/access",
+    href: "/settings/team",
     Icon: Users
   },
   {

--- a/apps/web/app/settings/layout.tsx
+++ b/apps/web/app/settings/layout.tsx
@@ -19,7 +19,7 @@ export const metadata = {
  * same platform:
  *   1. Shared {@link PrimaryIconRail} (`w-14`) — gear is active on any
  *      `/settings/*` route.
- *   2. {@link SettingsSectionNav} (`w-[22rem]`) — Active Projects / Access /
+ *   2. {@link SettingsSectionNav} (`w-[22rem]`) — Active Projects / Team /
  *      Integrations rows styled like the inbox list column.
  *   3. `<main>` (flex-1) — renders the active section's page, or the
  *      project detail view.

--- a/apps/web/app/settings/team/page.tsx
+++ b/apps/web/app/settings/team/page.tsx
@@ -9,11 +9,11 @@ import { SettingsContent } from "../_components/settings-content";
 export const dynamic = "force-dynamic";
 
 /**
- * Access section — teammates, roles, last sign-in. This is the only settings
+ * Team section — teammates, roles, last sign-in. This is the only settings
  * sub-route that exposes user PII, so the `settings.users.read` sensitive-read
  * audit fires from here (moved off the previous single-page `/settings`).
  */
-export default async function SettingsAccessPage() {
+export default async function SettingsTeamPage() {
   try {
     await requireSession();
   } catch (error) {

--- a/apps/web/src/server/settings/revalidate.ts
+++ b/apps/web/src/server/settings/revalidate.ts
@@ -13,8 +13,8 @@ export function revalidateProjectSettings(projectId: string): void {
 }
 
 export function revalidateAccessSettings(): void {
-  revalidateTag("settings:access");
-  revalidatePath("/settings/access");
+  revalidateTag("settings:team");
+  revalidatePath("/settings/team");
 }
 
 export function revalidateIntegrationHealth(): void {

--- a/apps/web/src/server/settings/selectors.ts
+++ b/apps/web/src/server/settings/selectors.ts
@@ -875,8 +875,8 @@ function loadAccessSettingsCacheData() {
     return readAccessSettings();
   }
 
-  return unstable_cache(() => readAccessSettings(), ["settings:access"], {
-    tags: ["settings:access"]
+  return unstable_cache(() => readAccessSettings(), ["settings:team"], {
+    tags: ["settings:team"]
   })();
 }
 

--- a/apps/web/tests/smoke/settings.spec.ts
+++ b/apps/web/tests/smoke/settings.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-test("settings access page loads for authenticated user", async ({ page }) => {
+test("settings team page loads for authenticated user", async ({ page }) => {
   // Seed a dev session via the dev-auth cookie endpoint
   const devAuthResponse = await page.request.get(
     "/api/dev-auth?email=nico@adventurescientists.org"
@@ -18,7 +18,7 @@ test("settings access page loads for authenticated user", async ({ page }) => {
   expect(devAuthResponse.ok()).toBeTruthy();
 
   // /settings redirects to /settings/projects — exercise the redirect
-  // and then walk the section nav over to Access, which is where the
+  // and then walk the section nav over to Team, which is where the
   // `settings.users.read` audit fires now that the users table is scoped to
   // that sub-route.
   await page.goto("/settings");
@@ -28,12 +28,12 @@ test("settings access page loads for authenticated user", async ({ page }) => {
     page.getByRole("heading", { name: "Active Projects" })
   ).toBeVisible();
 
-  // Section nav row routes to Access. The heading on that page is rendered
+  // Section nav row routes to Team. The heading on that page is rendered
   // by `SettingsContent` (h1) AND by the inner `SettingsSection` (h2), so
   // lock to the column-header h1 via level.
-  await page.getByRole("link", { name: /Access/ }).first().click();
-  await expect(page).toHaveURL(/\/settings\/access$/);
-  await expect(page.getByRole("heading", { name: "Access" })).toBeVisible();
+  await page.getByRole("link", { name: /Team/ }).first().click();
+  await expect(page).toHaveURL(/\/settings\/team$/);
+  await expect(page.getByRole("heading", { name: "Team" })).toBeVisible();
 
   // Integrations is the third row; verify routing + heading.
   await page.getByRole("link", { name: /Integrations/ }).first().click();

--- a/apps/web/tests/unit/inbox-detail-header.test.tsx
+++ b/apps/web/tests/unit/inbox-detail-header.test.tsx
@@ -54,6 +54,7 @@ vi.mock("../../app/inbox/_components/inbox-client-provider", () => ({
     removeOptimisticOutbound: removeOptimisticOutboundMock,
     openReplyDraft: openReplyDraftMock,
     showToast: showToastMock,
+    composerAliases: [],
   }),
 }));
 

--- a/apps/web/tests/unit/settings-users-read-audit.test.ts
+++ b/apps/web/tests/unit/settings-users-read-audit.test.ts
@@ -22,7 +22,7 @@ vi.mock("@/src/server/auth/session", () => ({
   getCurrentUser,
 }));
 
-import SettingsAccessPage from "../../app/settings/access/page";
+import SettingsTeamPage from "../../app/settings/team/page";
 import { waitForPendingSecurityAuditTasksForTests } from "../../src/server/security/audit";
 import {
   createStage1WebTestRuntime,
@@ -94,8 +94,8 @@ describe("settings users read audit", () => {
     runtime = null;
   });
 
-  it("records who opened the settings Access page", async () => {
-    const page = await SettingsAccessPage();
+  it("records who opened the settings Team page", async () => {
+    const page = await SettingsTeamPage();
     if (!runtime) {
       throw new Error("runtime not initialized");
     }
@@ -141,7 +141,7 @@ describe("settings users read audit", () => {
       throw new Error("NEXT_REDIRECT_SETTINGS");
     });
 
-    await expect(SettingsAccessPage()).rejects.toThrow("NEXT_REDIRECT_SETTINGS");
+    await expect(SettingsTeamPage()).rejects.toThrow("NEXT_REDIRECT_SETTINGS");
     expect(redirect).toHaveBeenCalledWith("/settings");
   });
 });


### PR DESCRIPTION
## Summary

- **Composer reply** — sender alias now defaults to the project shown in the conversation tag (forests@ thread → forests@ alias), with fallbacks through `conversationProject` and the existing last-inbound default. AI Draft directive textarea autofocuses on open so the operator can type the intent immediately.
- **Pin Note** — clicking Pin Note from the reply bar autofocuses the note textarea (one click, not two). The active "Save note" button now matches the passive/hover Pin Note button: pin icon + "Pin Note" label (and "Pinning..." while saving). Amber colors unchanged.
- **Settings list consistency** — Projects + Integrations adopt the Access-style bordered list. Description + section action button move to the `SettingsSection` header. Mailchimp sync sub-rows and the Twilio usage card details are dropped to fit row format. Logs description trailing-period normalized.
- **"Active" badge** removed from active-projects rows (redundant on the active list).
- **Access → Team** — `/settings/access` route + visible label renamed to `/settings/team`. Page title, section ID, page comment + function name (`SettingsTeamPage`), revalidate tag/path (`settings:team`), unstable_cache key/tag, smoke + unit tests all updated. The `AccessSection` symbol is left as-is — rename was scoped to user-visible label + URL.

## Test plan

- [ ] Open a `forests@` thread → click Reply → sender chip defaults to `forests@`
- [ ] Open a `volunteers@` thread → click Reply → sender chip defaults to `volunteers@`
- [ ] Open Reply → cursor is in the AI Draft directive textarea
- [ ] Click Pin Note in the reply bar → cursor is in the note textarea immediately
- [ ] In note write mode, the active "Pin Note" button shows pin icon + "Pin Note" (and amber "Pinning..." while saving)
- [ ] `/settings/team` loads, heading reads "Team", side-nav row says "Team"
- [ ] `/settings/access` returns 404 (route is gone)
- [ ] `/settings/projects` — "Activate a project" button is top-right of section header, no "Active" badge on rows, no "Currently active" sub-heading
- [ ] `/settings/integrations` — single bordered list, Mailchimp row has no sub-rows, Twilio row matches the others
- [ ] `pnpm typecheck` clean, `pnpm lint` clean, CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)