### PR TITLE
fix(inbox): structured fetch-error log + status in refresh banner

### DIFF
--- a/apps/web/app/inbox/_components/inbox-list.tsx
+++ b/apps/web/app/inbox/_components/inbox-list.tsx
@@ -60,6 +60,45 @@ const STATE_HEADER_LABEL: Partial<Record<InboxFilterId, string>> = {
   archived: "Archived",
 };
 
+/**
+ * Pull a numeric HTTP status off an unknown caught error, when one is
+ * available. We don't know the exact thrown shape (could be `InboxFetchError`,
+ * a plain `Error`, a `TypeError` for network failures, etc.), so we duck-type
+ * for `.status` instead of relying on `instanceof`.
+ */
+function extractFetchErrorStatus(error: unknown): number | null {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    typeof (error as { status: unknown }).status === "number"
+  ) {
+    return (error as { status: number }).status;
+  }
+
+  return null;
+}
+
+/**
+ * Build the banner string for a failed inbox refresh. Surfacing the HTTP
+ * status (when available) gives operators something concrete to report when a
+ * refresh fails, without leaking request bodies, headers, or query params.
+ */
+function resolveInboxRefreshErrorMessage(input: {
+  readonly status: number | null;
+  readonly errorName: string | null;
+}): string {
+  if (input.status !== null) {
+    return `Inbox refresh failed (HTTP ${input.status.toString()}). Keeping the last loaded rows.`;
+  }
+
+  if (input.errorName === "TypeError") {
+    return "Inbox refresh failed (network error). Keeping the last loaded rows.";
+  }
+
+  return "Inbox refresh failed. Keeping the last loaded rows.";
+}
+
 function resolveInboxHeaderTitle(input: {
   readonly searchQuery: string;
   readonly activeFilter: InboxFilterId;
@@ -324,12 +363,36 @@ export function InboxList({
               }
             : nextList,
         );
-      } catch {
+      } catch (error) {
         if (activeRequestIdRef.current !== requestId) {
           return;
         }
 
-        setQueueError("Inbox refresh failed. Keeping the last loaded rows.");
+        // AbortError fires when the user navigates away or the freshness
+        // poller cancels a stale fetch — neither is a failure we should
+        // surface to the operator.
+        if (error instanceof Error && error.name === "AbortError") {
+          return;
+        }
+
+        const status = extractFetchErrorStatus(error);
+        const errorName = error instanceof Error ? error.name : null;
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+
+        // Structured log only — never include request bodies, tokens,
+        // headers, or query params. We rely on `Error.message` as
+        // emitted by `InboxFetchError`/native fetch, which doesn't carry
+        // those fields.
+        console.warn("inbox.refresh.failed", {
+          status,
+          name: errorName ?? "unknown",
+          message: errorMessage,
+        });
+
+        setQueueError(
+          resolveInboxRefreshErrorMessage({ status, errorName }),
+        );
       } finally {
         if (
           appendCursor !== null &&

--- a/apps/web/app/inbox/_lib/client-api.ts
+++ b/apps/web/app/inbox/_lib/client-api.ts
@@ -19,14 +19,32 @@ export interface InboxFreshnessResponse {
   readonly detail: InboxDetailFreshnessViewModel | null;
 }
 
+/**
+ * Typed error thrown by inbox client fetchers when an HTTP request returns a
+ * non-OK status. Surfacing `status` lets callers distinguish HTTP failures
+ * (where we have a status) from network/parse failures (where we don't), and
+ * lets the UI display a meaningful error label without leaking request
+ * payloads, headers, or URLs.
+ */
+export class InboxFetchError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "InboxFetchError";
+    this.status = status;
+  }
+}
+
 async function readJson<T>(input: RequestInfo | URL): Promise<T> {
   const response = await fetch(input, {
     cache: "no-store",
   });
 
   if (!response.ok) {
-    throw new Error(
+    throw new InboxFetchError(
       `Request failed with status ${response.status.toString()}.`,
+      response.status,
     );
   }
 

--- a/apps/web/tests/unit/inbox-list-shell.test.tsx
+++ b/apps/web/tests/unit/inbox-list-shell.test.tsx
@@ -927,4 +927,77 @@ describe("Inbox list shell", () => {
     expect(activeSession.container.textContent).not.toContain("Eliza Tate");
     expect(activeSession.container.textContent).toContain("Riley Carter");
   });
+
+  it("surfaces the HTTP status in the refresh-failed banner", async () => {
+    const fetchError = Object.assign(new Error("Request failed with status 502."), {
+      name: "InboxFetchError",
+      status: 502,
+    });
+    fetchInboxListPageMock.mockRejectedValue(fetchError);
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+
+    activeSession = await mountInboxList(buildPnwProjectList());
+    await flushReact();
+
+    expect(activeSession.container.textContent).toContain("HTTP 502");
+    expect(activeSession.container.textContent).toContain(
+      "Keeping the last loaded rows.",
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      "inbox.refresh.failed",
+      expect.objectContaining({
+        status: 502,
+        name: "InboxFetchError",
+      }),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it("labels TypeError network failures in the refresh-failed banner", async () => {
+    const networkError = new TypeError("Failed to fetch");
+    fetchInboxListPageMock.mockRejectedValue(networkError);
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+
+    activeSession = await mountInboxList(buildPnwProjectList());
+    await flushReact();
+
+    expect(activeSession.container.textContent).toContain("network error");
+    expect(activeSession.container.textContent).toContain(
+      "Keeping the last loaded rows.",
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      "inbox.refresh.failed",
+      expect.objectContaining({
+        status: null,
+        name: "TypeError",
+      }),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it("suppresses AbortError silently — no banner, no console warn", async () => {
+    const abortError = new Error("The user aborted a request.");
+    abortError.name = "AbortError";
+    fetchInboxListPageMock.mockRejectedValue(abortError);
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+
+    activeSession = await mountInboxList(buildPnwProjectList());
+    await flushReact();
+
+    expect(activeSession.container.textContent).not.toContain(
+      "Inbox refresh failed",
+    );
+    expect(activeSession.container.textContent).not.toContain("HTTP");
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Why

Today the inbox list fetcher's catch block is bare:

```ts
} catch {
  setQueueError("Inbox refresh failed. Keeping the last loaded rows.");
}
```

This swallows the actual error type entirely — we can't distinguish HTTP 500 from a network failure, an abort, or a parse error. Combined with the web service having no request logging configured, we have **zero observability** when the inbox refresh fails.

Mid-2026-05-09 a user reported the "Inbox refresh failed" banner after applying a project filter post-deploy. We had no diagnosable signal — no status, no error name, nothing. This PR makes the next occurrence actionable.

## What

- New `InboxFetchError` class in `apps/web/app/inbox/_lib/client-api.ts` carries the HTTP `status` so `readJson` callers can branch on it.
- `loadFilterPage` catch block in `apps/web/app/inbox/_components/inbox-list.tsx` now:
  - **Suppresses `AbortError`** silently (no banner, no log) — these fire on navigation away or stale-fetch cancellation.
  - **Logs a structured `console.warn("inbox.refresh.failed", { status, name, message })`** on real failures.
  - **Sets the banner text** based on context: `Inbox refresh failed (HTTP 502). Keeping the last loaded rows.` when status is known, `(network error)` for `TypeError`, original string as fallback.
- Three unit tests in `apps/web/tests/unit/inbox-list-shell.test.tsx` cover all three paths.

## Privacy / data hygiene

- No request bodies, tokens, headers, or query params are logged.
- Only `status` (number), `name` (error name like `InboxFetchError` / `TypeError` / `AbortError`), and `message` (the canned `"Request failed with status N."` string emitted by `InboxFetchError`, never derived from server response body).

## Why this matters

Previous "Inbox refresh failed" report had no diagnosable signal. The next occurrence will tell us whether the request is hitting an HTTP error, a network failure, or being aborted — which routes the diagnosis (server vs. client vs. expected lifecycle) immediately.

## Out of scope

- Server-side request logging on the API route (separate concern).
- Retry logic for failed fetches.
- External error reporting (Sentry, etc.).
- Observability on other surfaces (composer, settings, search). Search path's catch block is unchanged.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm build` clean
- [x] `vitest run tests/unit/inbox-list-shell.test.tsx` — 23/23 pass (3 new + 20 existing)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)