### PR TITLE
feat(connected-projects): data foundation for shared-alias rollup

### DIFF
--- a/apps/web/app/inbox/_lib/home-dashboard.ts
+++ b/apps/web/app/inbox/_lib/home-dashboard.ts
@@ -126,31 +126,58 @@ async function readLifecycleEvents(
     );
 }
 
-async function readLifecycleProjects(): Promise<readonly ProjectRow[]> {
+interface LifecycleProjectsData {
+  readonly tiles: readonly ProjectRow[];
+  // Sub-project id -> host id, used to fold connected-sub-project memberships
+  // and lifecycle events into the host's tile. See migration 0056.
+  readonly hostByConnectedProjectId: ReadonlyMap<string, string>;
+}
+
+async function readLifecycleProjects(): Promise<LifecycleProjectsData> {
   const runtime = await getStage1WebRuntime();
   const activeProjects = await runtime.repositories.projectDimensions.listActive();
+
+  // Connected sub-projects fold into their host's tile (one merged tile per
+  // host) instead of getting their own tile. Build the redirect map first so
+  // it stays consistent with the tile list below.
+  const hostByConnectedProjectId = new Map<string, string>();
+  const hostProjects = activeProjects.filter((project) => {
+    const connectedTo = project.connectedToProjectId ?? null;
+    if (connectedTo !== null && connectedTo.length > 0) {
+      hostByConnectedProjectId.set(project.projectId, connectedTo);
+      return false;
+    }
+    return true;
+  });
+
   const projectCounts = await Promise.all(
-    activeProjects.map((project) =>
+    hostProjects.map((project) =>
       runtime.repositories.inboxProjection.countByFilters({
         projectId: project.projectId,
       }),
     ),
   );
 
-  return activeProjects.map((project, index) => {
+  const tiles = hostProjects.map((project, index) => {
     const projectName = readProjectDisplayName(project);
     return {
       projectId: project.projectId,
       projectName,
       projectTone: projectToneFromName(projectName),
       isActive: project.isActive ?? true,
+      // countByFilters already counts connected-sub-project memberships under
+      // the host (buildInboxProjectPredicate's third branch), so this is the
+      // rolled-up unread count.
       unreadCount: projectCounts[index]?.unread ?? 0,
     };
   });
+
+  return { tiles, hostByConnectedProjectId };
 }
 
 async function readLifecycleMemberships(
   contactIds: readonly string[],
+  hostByConnectedProjectId: ReadonlyMap<string, string>,
 ): Promise<readonly MembershipRow[]> {
   const runtime = await getStage1WebRuntime();
   const memberships =
@@ -165,7 +192,10 @@ async function readLifecycleMemberships(
     )
     .map((membership) => ({
       contactId: membership.contactId,
-      projectId: membership.projectId,
+      // Memberships in a connected sub-project roll up to the host so the
+      // lifecycle metric aggregator credits the host's tile.
+      projectId:
+        hostByConnectedProjectId.get(membership.projectId) ?? membership.projectId,
     }));
 }
 
@@ -202,20 +232,21 @@ export async function getInboxWelcomeSalesforceLifecycle(
   },
 ): Promise<InboxWelcomeSalesforceLifecycleData> {
   const now = input?.now ?? new Date();
-  const [events, projects, lastSuccessAt] = await Promise.all([
+  const [events, projectsData, lastSuccessAt] = await Promise.all([
     readLifecycleEvents(now),
     readLifecycleProjects(),
     readSalesforceCaptureLastSuccessAt(),
   ]);
   const memberships = await readLifecycleMemberships(
     Array.from(new Set(events.map((event) => event.contactId))),
+    projectsData.hostByConnectedProjectId,
   );
 
   return {
     tiles: buildProjectLifecycleMetrics({
       events,
       memberships,
-      projects,
+      projects: projectsData.tiles,
       now,
     }),
     freshness: classifySyncFreshness({

--- a/apps/web/tests/unit/inbox-home-dashboard.test.ts
+++ b/apps/web/tests/unit/inbox-home-dashboard.test.ts
@@ -151,4 +151,152 @@ describe("getInboxWelcomeSalesforceLifecycle", () => {
       },
     ]);
   });
+
+  it("rolls connected sub-project signups into the host's tile and hides the sub from the tile list", async () => {
+    // Migration 0056 lets two Salesforce projects share an inbox alias: one
+    // is the host, the other is a connected sub-project. The dashboard must
+    // present them as a single tile (the host's), with the sub's signups,
+    // training completions, and unread counts folded in.
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    // Host project + a contact + signup directly on the host. (Existing path.)
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:host-volunteer",
+      salesforceContactId: "003-host-volunteer",
+      displayName: "Host Volunteer",
+      primaryEmail: "host-volunteer@example.org",
+      primaryPhone: null,
+      projectId: "project:beech",
+      projectName: "Beech",
+      projectAlias: "Beech",
+      membershipId: "membership:host",
+      membershipStatus: "active",
+      membershipCreatedAt: "2026-04-20T12:00:00.000Z",
+    });
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "lifecycle-host-signup",
+      contactId: "contact:host-volunteer",
+      occurredAt: "2026-05-07T10:00:00.000Z",
+      eventType: "lifecycle.signed_up",
+      summary: "Host signed up",
+      projectId: "project:beech",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:host-volunteer",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-05-07T11:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-05-07T11:00:00.000Z",
+      snippet: "Host inbound",
+      lastCanonicalEventId: "event:lifecycle-host-signup",
+      lastEventType: "communication.email.inbound",
+    });
+
+    // Connected sub-project + a contact + signup. This contact has no host
+    // membership; only a sub-project membership.
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:sub-volunteer",
+      salesforceContactId: "003-sub-volunteer",
+      displayName: "Sub Volunteer",
+      primaryEmail: "sub-volunteer@example.org",
+      primaryPhone: null,
+      projectId: "project:butternut",
+      projectName: "Butternut",
+      // Connected sub-projects don't need their own alias under 0056. The
+      // helper's default would set one; pass null explicitly to mirror the
+      // production shape.
+      projectAlias: null,
+      membershipId: "membership:sub",
+      membershipStatus: "active",
+      membershipCreatedAt: "2026-04-20T12:30:00.000Z",
+    });
+    // Mark the sub-project as connected to the host AFTER the project row
+    // exists. The seed helper doesn't accept connectedToProjectId; do the
+    // upsert directly.
+    await runtime.context.repositories.projectDimensions.upsert({
+      projectId: "project:butternut",
+      projectName: "Butternut",
+      projectAlias: null,
+      source: "salesforce",
+      isActive: true,
+      connectedToProjectId: "project:beech",
+    });
+    await seedInboxLifecycleEvent(runtime.context, {
+      id: "lifecycle-sub-signup",
+      contactId: "contact:sub-volunteer",
+      occurredAt: "2026-05-07T10:30:00.000Z",
+      eventType: "lifecycle.signed_up",
+      summary: "Sub signed up",
+      projectId: "project:butternut",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:sub-volunteer",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-05-07T11:30:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-05-07T11:30:00.000Z",
+      snippet: "Sub inbound",
+      lastCanonicalEventId: "event:lifecycle-sub-signup",
+      lastEventType: "communication.email.inbound",
+    });
+
+    await runtime.context.settings.integrationHealth.seedDefaults();
+    const salesforceHealth =
+      await runtime.context.settings.integrationHealth.findById("salesforce");
+    if (salesforceHealth === null) {
+      throw new Error("Expected seeded Salesforce integration health row");
+    }
+    await runtime.context.settings.integrationHealth.upsert({
+      ...salesforceHealth,
+      status: "healthy",
+      lastCheckedAt: "2026-05-07T11:55:00.000Z",
+      updatedAt: "2026-05-07T11:55:00.000Z",
+    });
+    await runtime.context.repositories.syncState.upsert({
+      id: "sync:salesforce:live:latest",
+      scope: "provider",
+      provider: "salesforce",
+      jobType: "live_ingest",
+      cursor: "cursor:salesforce",
+      windowStart: "2026-05-07T11:45:00.000Z",
+      windowEnd: "2026-05-07T11:50:00.000Z",
+      status: "succeeded",
+      parityPercent: null,
+      freshnessP95Seconds: null,
+      freshnessP99Seconds: null,
+      lastSuccessfulAt: "2026-05-07T11:50:00.000Z",
+      consecutiveFailureCount: 0,
+      leaseOwner: null,
+      heartbeatAt: null,
+      deadLetterCount: 0,
+    });
+
+    const result = await getInboxWelcomeSalesforceLifecycle({
+      now: new Date("2026-05-07T12:00:00.000Z"),
+    });
+
+    // Only the host appears as a tile.
+    expect(result.tiles.map((tile) => tile.projectId)).toEqual([
+      "project:beech",
+    ]);
+    const beech = result.tiles[0];
+    expect(beech).toBeDefined();
+    if (beech === undefined) {
+      throw new Error("Expected beech tile");
+    }
+    // Both signups (host + sub) credited to the host.
+    expect(beech.totals.signups).toBe(2);
+    expect(beech.today.signups).toBe(2);
+    expect(beech.sparkline.signups).toEqual([0, 0, 0, 0, 0, 0, 2]);
+    // Both unread inbound contacts (host + sub) counted under the host's tile,
+    // because buildInboxProjectPredicate's connected-projects branch makes
+    // countByFilters include sub-project members.
+    expect(beech.unreadCount).toBe(2);
+  });
 });

--- a/apps/worker/test/stage1-orchestration.test.ts
+++ b/apps/worker/test/stage1-orchestration.test.ts
@@ -497,6 +497,7 @@ Alias drift outbound message.
           projectAlias: null,
           source: "salesforce",
           isActive: false,
+          connectedToProjectId: null,
           aiKnowledgeUrl: null,
           aiKnowledgeSyncedAt: null,
           aiKnowledgeSources: [],

--- a/packages/contracts/src/stage1-records.ts
+++ b/packages/contracts/src/stage1-records.ts
@@ -153,6 +153,11 @@ export const projectDimensionSchema = z.object({
   projectId: idSchema,
   projectName: z.string().min(1),
   projectAlias: nullableStringSchema.optional(),
+  // Pointer to the host project this row rolls up into (NULL = host or
+  // standalone). See migration 0056. The platform supports two Salesforce
+  // projects sharing one inbox alias / AI knowledge by marking one as the
+  // host and the other(s) connected to it.
+  connectedToProjectId: nullableStringSchema.optional(),
   source: recordSourceSchema,
   isActive: z.boolean().optional(),
   aiKnowledgeUrl: nullableStringSchema.optional(),

--- a/packages/db/drizzle/0056_project_dimensions_connected_to.sql
+++ b/packages/db/drizzle/0056_project_dimensions_connected_to.sql
@@ -1,0 +1,122 @@
+-- Connected sub-project relationship for the shared-alias / shared-AI-knowledge
+-- pattern (e.g. Beech & Butternut both running under forests@adventurescientists.org).
+--
+-- One project (host) owns the alias and AI knowledge; one or more "connected
+-- sub-projects" point at that host via connected_to_project_id and get rolled
+-- up into the host's inbox/dashboard views without owning their own alias.
+--
+-- This is data-foundation only. UX (Settings wizard, project detail page,
+-- contact rail) and AI Knowledge fallback land in follow-up PRs. After this
+-- migration applies, an operator can manually:
+--   UPDATE project_dimensions SET connected_to_project_id = '<host>'
+--     WHERE project_id = '<sub>';
+-- to test the rollup.
+
+-- Step 1: new column with FK + ON DELETE SET NULL.
+-- Disconnect-on-host-delete is the safe default; the trigger below also
+-- prevents chains so a connected sub-project can't itself become a host.
+ALTER TABLE "project_dimensions"
+  ADD COLUMN "connected_to_project_id" text;
+
+ALTER TABLE "project_dimensions"
+  ADD CONSTRAINT "project_dimensions_connected_to_project_id_fkey"
+  FOREIGN KEY ("connected_to_project_id")
+    REFERENCES "project_dimensions" ("project_id")
+    ON DELETE SET NULL;
+
+-- Step 2: index for the rollup queries that fan out from a host id.
+CREATE INDEX "project_dimensions_connected_to_idx"
+  ON "project_dimensions" ("connected_to_project_id");
+
+-- Step 3: relax the active-alias CHECK so connected sub-projects can be active
+-- without owning their own alias. The original constraint (added in 0045)
+-- required is_active=false OR alias-non-empty; the new constraint adds an OR
+-- branch for "has a connection".
+ALTER TABLE "project_dimensions"
+  DROP CONSTRAINT "project_dimensions_active_alias_required";
+
+ALTER TABLE "project_dimensions"
+  ADD CONSTRAINT "project_dimensions_active_alias_required"
+  CHECK (
+    "is_active" = false
+    OR ("project_alias" IS NOT NULL AND BTRIM("project_alias") <> '')
+    OR "connected_to_project_id" IS NOT NULL
+  );
+
+-- Step 4: chain prevention. A connected sub-project's connected_to_project_id
+-- must point at a HOST — i.e. a project whose own connected_to_project_id is
+-- NULL. Postgres CHECK constraints can't run sub-queries, so this lives in a
+-- BEFORE INSERT OR UPDATE trigger.
+CREATE OR REPLACE FUNCTION "project_dimensions_no_chained_connections"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  parent_connected_to text;
+BEGIN
+  IF NEW."connected_to_project_id" IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW."connected_to_project_id" = NEW."project_id" THEN
+    RAISE EXCEPTION 'Connected projects cannot point at themselves: %.', NEW."project_id"
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  SELECT "connected_to_project_id"
+    INTO parent_connected_to
+    FROM "project_dimensions"
+    WHERE "project_id" = NEW."connected_to_project_id";
+
+  IF parent_connected_to IS NOT NULL THEN
+    RAISE EXCEPTION 'Connected projects cannot be chained: % already has a connection.',
+      NEW."connected_to_project_id"
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER "project_dimensions_no_chained_connections_trigger"
+  BEFORE INSERT OR UPDATE OF "connected_to_project_id"
+  ON "project_dimensions"
+  FOR EACH ROW
+  WHEN (NEW."connected_to_project_id" IS NOT NULL)
+  EXECUTE FUNCTION "project_dimensions_no_chained_connections"();
+
+-- Step 5: also prevent a host from acquiring a connection while it still has
+-- connected sub-projects (would create a chain in the other direction). This
+-- runs as a separate trigger so the WHEN clause stays simple.
+CREATE OR REPLACE FUNCTION "project_dimensions_no_host_with_connection"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  child_count int;
+BEGIN
+  IF NEW."connected_to_project_id" IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT count(*)
+    INTO child_count
+    FROM "project_dimensions"
+    WHERE "connected_to_project_id" = NEW."project_id";
+
+  IF child_count > 0 THEN
+    RAISE EXCEPTION 'Connected projects cannot be chained: % already has a connection.',
+      NEW."project_id"
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER "project_dimensions_no_host_with_connection_trigger"
+  BEFORE INSERT OR UPDATE OF "connected_to_project_id"
+  ON "project_dimensions"
+  FOR EACH ROW
+  WHEN (NEW."connected_to_project_id" IS NOT NULL)
+  EXECUTE FUNCTION "project_dimensions_no_host_with_connection"();

--- a/packages/db/src/mappers.ts
+++ b/packages/db/src/mappers.ts
@@ -537,6 +537,7 @@ export function mapProjectDimensionRow(
     projectId: row.projectId,
     projectName: row.projectName,
     projectAlias: row.projectAlias,
+    connectedToProjectId: row.connectedToProjectId,
     source: row.source,
     isActive: row.isActive,
     aiKnowledgeUrl: row.aiKnowledgeUrl,
@@ -558,6 +559,10 @@ export function mapProjectDimensionToInsert(
     projectId: parsed.projectId,
     projectName: parsed.projectName,
     projectAlias: parsed.projectAlias ?? null,
+    // connectedToProjectId is operator-managed; absent in incoming records
+    // means "don't set it" (mirrors projectAlias behaviour). Salesforce
+    // capture never sets this — only Settings/admin actions should.
+    connectedToProjectId: parsed.connectedToProjectId ?? null,
     isActive: parsed.isActive ?? false,
     aiKnowledgeUrl: parsed.aiKnowledgeUrl ?? null,
     aiKnowledgeSyncedAt:

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -1014,6 +1014,17 @@ function buildInboxProjectPredicate(
     return undefined;
   }
 
+  // Three-way OR predicate (membership + alias + connected sub-project),
+  // expressed as a single EXISTS over a UNION ALL so the planner can stop at
+  // the first match. Branches:
+  //   1. The contact has an active membership in the requested project.
+  //   2. The contact has an inbound Gmail event captured at the requested
+  //      project's alias (covers volunteers who haven't been backfilled to a
+  //      membership yet — see PR #333).
+  //   3. The contact has an active membership in a project that is connected
+  //      to the requested project (host rollup — see migration 0056). The
+  //      target project must itself be active; connected sub-projects are
+  //      defined as is_active=true with connected_to_project_id set.
   return sql`exists (
     select 1
     from (
@@ -1038,6 +1049,16 @@ function buildInboxProjectPredicate(
       where ${canonicalEventLedger.contactId} = ${contactInboxProjection.contactId}
         and ${gmailMessageDetails.direction} = 'inbound'
         and ${projectAliases.projectId} = ${projectId}
+        and ${projectDimensions.isActive} = true
+
+      union all
+
+      select 1
+      from ${contactMemberships}
+      inner join ${projectDimensions}
+        on ${contactMemberships.projectId} = ${projectDimensions.projectId}
+      where ${contactMemberships.contactId} = ${contactInboxProjection.contactId}
+        and ${projectDimensions.connectedToProjectId} = ${projectId}
         and ${projectDimensions.isActive} = true
     ) inbox_project_match
   )`;
@@ -2552,6 +2573,11 @@ function createStage1RepositoriesInternal(
               projectAlias: sql`COALESCE(EXCLUDED.${sql.identifier(
                 "project_alias",
               )}, ${projectDimensions.projectAlias})`,
+              // connectedToProjectId follows the same rule as projectAlias:
+              // operator-managed, must not be clobbered by Salesforce capture.
+              connectedToProjectId: sql`COALESCE(EXCLUDED.${sql.identifier(
+                "connected_to_project_id",
+              )}, ${projectDimensions.connectedToProjectId})`,
               // isActive intentionally NOT updated: admins manage it in Settings,
               // and Salesforce capture must not overwrite that app-owned state.
               aiKnowledgeUrl: values.aiKnowledgeUrl,

--- a/packages/db/src/schema/tables.ts
+++ b/packages/db/src/schema/tables.ts
@@ -223,6 +223,14 @@ export const projectDimensions = pgTable(
     projectName: text("project_name").notNull(),
     projectAlias: text("project_alias"),
     isActive: boolean("is_active").notNull().default(false),
+    // Connected-sub-project pointer. NULL = host (or standalone) project.
+    // Non-NULL = this project rolls up into the referenced host's inbox and
+    // dashboard views; it does not own its own alias or AI knowledge.
+    // Chain prevention is enforced by a BEFORE-INSERT/UPDATE trigger added
+    // in migration 0056 (drizzle-kit can't model triggers, so it lives in
+    // raw SQL). FK with ON DELETE SET NULL: deleting a host disconnects
+    // its sub-projects safely.
+    connectedToProjectId: text("connected_to_project_id"),
     aiKnowledgeUrl: text("ai_knowledge_url"),
     aiKnowledgeSyncedAt: timestamp("ai_knowledge_synced_at", {
       mode: "date",
@@ -249,12 +257,13 @@ export const projectDimensions = pgTable(
   (table) => [
     check(
       "project_dimensions_active_alias_required",
-      sql`${table.isActive} = false OR (${table.projectAlias} IS NOT NULL AND BTRIM(${table.projectAlias}) <> '')`,
+      sql`${table.isActive} = false OR (${table.projectAlias} IS NOT NULL AND BTRIM(${table.projectAlias}) <> '') OR ${table.connectedToProjectId} IS NOT NULL`,
     ),
     check(
       "project_dimensions_ai_auto_sync_schedule_valid",
       sql`${table.aiAutoSyncSchedule} IN ('never', 'daily', 'weekly')`,
     ),
+    index("project_dimensions_connected_to_idx").on(table.connectedToProjectId),
   ],
 );
 

--- a/packages/db/test/ai-knowledge-sources.test.ts
+++ b/packages/db/test/ai-knowledge-sources.test.ts
@@ -350,6 +350,12 @@ describe("0055_ai_knowledge_auto_sync_schedule migration", () => {
         client,
         "0055_ai_knowledge_auto_sync_schedule.sql",
       );
+      // Apply later migrations so the table schema matches the Drizzle table
+      // definition (which includes connected_to_project_id from 0056).
+      await applySingleMigration(
+        client,
+        "0056_project_dimensions_connected_to.sql",
+      );
 
       const db = drizzle(client) as Stage1Database;
       await client.exec(`
@@ -451,10 +457,14 @@ describe("0054_ai_knowledge_source_registry migration", () => {
       await applySingleMigration(client, "0054_ai_knowledge_source_registry.sql");
       // Apply later migrations so the table schema matches the Drizzle table
       // definition (which includes columns added after 0054, e.g.,
-      // ai_auto_sync_schedule from 0055).
+      // ai_auto_sync_schedule from 0055 and connected_to_project_id from 0056).
       await applySingleMigration(
         client,
         "0055_ai_knowledge_auto_sync_schedule.sql",
+      );
+      await applySingleMigration(
+        client,
+        "0056_project_dimensions_connected_to.sql",
       );
 
       const db = drizzle(client) as Stage1Database;

--- a/packages/db/test/projects-repository-connected-projects.test.ts
+++ b/packages/db/test/projects-repository-connected-projects.test.ts
@@ -1,0 +1,252 @@
+import { sql } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+
+import { createTestStage1Context } from "./helpers.js";
+
+// drizzle-orm wraps Postgres errors in a generic "Failed query: ..." Error.
+// The original Postgres error (with our raise message) lives in `cause`.
+// Walk the cause chain to find a message we can assert against.
+function readNestedErrorMessage(error: unknown): string {
+  let current: unknown = error;
+  let message = error instanceof Error ? error.message : String(error);
+  for (let depth = 0; depth < 8; depth += 1) {
+    if (current instanceof Error && typeof current.cause !== "undefined") {
+      current = current.cause;
+      if (current instanceof Error) {
+        message = `${message}\n${current.message}`;
+      } else if (typeof current === "string") {
+        message = `${message}\n${current}`;
+      } else if (current && typeof current === "object" && "message" in current) {
+        const nested = (current as { message?: unknown }).message;
+        if (typeof nested === "string") {
+          message = `${message}\n${nested}`;
+        }
+      }
+      continue;
+    }
+    break;
+  }
+  return message;
+}
+
+async function captureError(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error("Expected promise to reject");
+}
+
+// Schema-level guarantees added by migration 0056. The data foundation needs
+// to enforce four invariants:
+//   1. Active connected sub-projects don't need their own alias (relaxed
+//      project_dimensions_active_alias_required CHECK).
+//   2. Active stand-alone projects with no alias and no host are still
+//      rejected (the relaxed constraint must not turn into "anything goes").
+//   3. Connected sub-projects can't chain (a sub can't itself be a host).
+//   4. Deleting a host disconnects its sub-projects via ON DELETE SET NULL.
+describe("project_dimensions connected-sub-project schema", () => {
+  it("allows an active connected sub-project with no alias", async () => {
+    const context = await createTestStage1Context();
+    try {
+      await context.repositories.projectDimensions.upsert({
+        projectId: "host:beech",
+        projectName: "Beech",
+        projectAlias: "Beech",
+        source: "salesforce",
+        isActive: true,
+      });
+
+      const sub = await context.repositories.projectDimensions.upsert({
+        projectId: "sub:butternut",
+        projectName: "Butternut",
+        projectAlias: null,
+        source: "salesforce",
+        isActive: true,
+        connectedToProjectId: "host:beech",
+      });
+
+      expect(sub.isActive).toBe(true);
+      expect(sub.projectAlias).toBeNull();
+      expect(sub.connectedToProjectId).toBe("host:beech");
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("also allows an active connected sub-project with an alias set", async () => {
+    // We don't FORBID a connected sub-project from having an alias; the
+    // constraint only says "active rows must have alias OR connection".
+    // Operators may still want a friendly short name for display purposes
+    // even though sends go through the host's alias.
+    const context = await createTestStage1Context();
+    try {
+      await context.repositories.projectDimensions.upsert({
+        projectId: "host:forests",
+        projectName: "Forests",
+        projectAlias: "Forests",
+        source: "salesforce",
+        isActive: true,
+      });
+
+      const sub = await context.repositories.projectDimensions.upsert({
+        projectId: "sub:beech",
+        projectName: "Beech",
+        projectAlias: "Beech",
+        source: "salesforce",
+        isActive: true,
+        connectedToProjectId: "host:forests",
+      });
+
+      expect(sub.isActive).toBe(true);
+      expect(sub.projectAlias).toBe("Beech");
+      expect(sub.connectedToProjectId).toBe("host:forests");
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("rejects an active row with no alias AND no connection", async () => {
+    const context = await createTestStage1Context();
+    try {
+      // Direct INSERT bypasses the upsert protection (which preserves
+      // operator-set alias/active state) so we hit the relaxed CHECK head-on.
+      const error = await captureError(
+        context.db.execute(sql`
+          insert into "project_dimensions"
+            ("project_id", "project_name", "project_alias",
+             "is_active", "connected_to_project_id", "source")
+          values
+            ('orphan', 'Orphan', null, true, null, 'salesforce')
+        `),
+      );
+      expect(readNestedErrorMessage(error)).toMatch(
+        /project_dimensions_active_alias_required/u,
+      );
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("rejects setting connected_to_project_id when the target already has its own connection (chain)", async () => {
+    const context = await createTestStage1Context();
+    try {
+      await context.repositories.projectDimensions.upsert({
+        projectId: "host:x",
+        projectName: "X",
+        projectAlias: "X",
+        source: "salesforce",
+        isActive: true,
+      });
+      await context.repositories.projectDimensions.upsert({
+        projectId: "sub:y",
+        projectName: "Y",
+        projectAlias: null,
+        source: "salesforce",
+        isActive: true,
+        connectedToProjectId: "host:x",
+      });
+
+      // Z trying to connect to Y (which already has a connection) -> chain.
+      await context.repositories.projectDimensions.upsert({
+        projectId: "candidate:z",
+        projectName: "Z",
+        projectAlias: "Z",
+        source: "salesforce",
+        isActive: true,
+      });
+
+      const error = await captureError(
+        context.db.execute(sql`
+          update "project_dimensions"
+             set "connected_to_project_id" = 'sub:y'
+           where "project_id" = 'candidate:z'
+        `),
+      );
+      expect(readNestedErrorMessage(error)).toMatch(/cannot be chained/u);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("rejects giving an existing host its own connection while it has sub-projects", async () => {
+    // The other chain direction: a host that already has children can't itself
+    // be turned into a sub-project.
+    const context = await createTestStage1Context();
+    try {
+      await context.repositories.projectDimensions.upsert({
+        projectId: "host:m",
+        projectName: "M",
+        projectAlias: "M",
+        source: "salesforce",
+        isActive: true,
+      });
+      await context.repositories.projectDimensions.upsert({
+        projectId: "sub:n",
+        projectName: "N",
+        projectAlias: null,
+        source: "salesforce",
+        isActive: true,
+        connectedToProjectId: "host:m",
+      });
+      await context.repositories.projectDimensions.upsert({
+        projectId: "candidate:p",
+        projectName: "P",
+        projectAlias: "P",
+        source: "salesforce",
+        isActive: true,
+      });
+
+      const error = await captureError(
+        context.db.execute(sql`
+          update "project_dimensions"
+             set "connected_to_project_id" = 'candidate:p'
+           where "project_id" = 'host:m'
+        `),
+      );
+      expect(readNestedErrorMessage(error)).toMatch(/cannot be chained/u);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("disconnects sub-projects when the host is deleted (ON DELETE SET NULL)", async () => {
+    const context = await createTestStage1Context();
+    try {
+      await context.repositories.projectDimensions.upsert({
+        projectId: "host:to-delete",
+        projectName: "Deleted Host",
+        projectAlias: "Deleted Host",
+        source: "salesforce",
+        isActive: true,
+      });
+      await context.repositories.projectDimensions.upsert({
+        projectId: "sub:orphaned",
+        projectName: "Orphaned Sub",
+        // Alias set so the CHECK still holds after the connection disappears.
+        projectAlias: "Orphaned Sub",
+        source: "salesforce",
+        isActive: true,
+        connectedToProjectId: "host:to-delete",
+      });
+
+      await context.db.execute(sql`
+        delete from "project_dimensions" where "project_id" = 'host:to-delete'
+      `);
+
+      const sub = await context.repositories.projectDimensions.findById(
+        "sub:orphaned",
+      );
+
+      expect(sub).not.toBeNull();
+      expect(sub?.connectedToProjectId).toBeNull();
+      // The disconnected row should still satisfy the relaxed CHECK because
+      // it has its own alias set.
+      expect(sub?.isActive).toBe(true);
+      expect(sub?.projectAlias).toBe("Orphaned Sub");
+    } finally {
+      await context.dispose();
+    }
+  });
+});

--- a/packages/db/test/stage1-repositories.test.ts
+++ b/packages/db/test/stage1-repositories.test.ts
@@ -1688,4 +1688,281 @@ describe("Stage 1 DB repositories", () => {
     expect(forestsACounts.all).toBe(3);
     expect(forestsBCounts.all).toBe(1);
   });
+
+  it("rolls connected sub-project memberships into the host's inbox filter", async () => {
+    // Migration 0056 adds connected_to_project_id, letting two Salesforce
+    // projects share one inbox alias. Filtering by the host should now
+    // include volunteers whose only membership is in a connected sub-project.
+    // Filtering by the sub-project's own id is intentionally NOT supported —
+    // operators look at the host tile.
+    const { repositories, settings } = await createTestStage1Context();
+    const now = "2026-04-21T00:00:00.000Z";
+
+    // Two host/sub pairs, modelled on the Beech & Butternut shared-alias case.
+    await repositories.projectDimensions.upsert({
+      projectId: "project:host-a",
+      projectName: "Host A",
+      projectAlias: "Host A",
+      source: "salesforce",
+      isActive: true,
+    });
+    await repositories.projectDimensions.upsert({
+      projectId: "project:sub-b",
+      projectName: "Sub B",
+      // Connected sub-projects don't need their own alias — that's the whole
+      // point of the relaxed CHECK in 0056.
+      projectAlias: null,
+      source: "salesforce",
+      isActive: true,
+      connectedToProjectId: "project:host-a",
+    });
+    await repositories.projectDimensions.upsert({
+      projectId: "project:host-d",
+      projectName: "Host D",
+      projectAlias: "Host D",
+      source: "salesforce",
+      isActive: true,
+    });
+    await repositories.projectDimensions.upsert({
+      projectId: "project:sub-c",
+      projectName: "Sub C",
+      projectAlias: null,
+      source: "salesforce",
+      isActive: true,
+      connectedToProjectId: "project:host-d",
+    });
+
+    // Sanity-check the column landed and the trigger isn't refusing the
+    // connected sub-project insert.
+    const subB = await repositories.projectDimensions.findById("project:sub-b");
+    expect(subB?.connectedToProjectId).toBe("project:host-a");
+
+    const seedContact = async (input: {
+      readonly contactId: string;
+      readonly projectId: string;
+      readonly membershipId: string;
+    }) => {
+      const sourceEvidenceId = `source:${input.contactId}-inbound`;
+      const canonicalEventId = `event:${input.contactId}-inbound`;
+      await repositories.contacts.upsert({
+        id: input.contactId,
+        salesforceContactId: `003-${input.contactId}`,
+        displayName: input.contactId,
+        primaryEmail: `${input.contactId}@example.org`,
+        primaryPhone: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      });
+      await repositories.contactMemberships.upsert({
+        id: input.membershipId,
+        contactId: input.contactId,
+        projectId: input.projectId,
+        expeditionId: null,
+        salesforceMembershipId: `sf-${input.membershipId}`,
+        role: "volunteer",
+        status: "lead",
+        source: "salesforce",
+        createdAt: "2026-04-01T10:00:00.000Z",
+      });
+      await repositories.sourceEvidence.append({
+        id: sourceEvidenceId,
+        provider: "salesforce",
+        providerRecordType: "task",
+        providerRecordId: `${input.contactId}-msg`,
+        receivedAt: now,
+        occurredAt: now,
+        payloadRef: `payloads/salesforce/${input.contactId}.json`,
+        idempotencyKey: `salesforce:${input.contactId}-inbound`,
+        checksum: `checksum:${input.contactId}`,
+      });
+      await repositories.canonicalEvents.upsert({
+        id: canonicalEventId,
+        contactId: input.contactId,
+        eventType: "communication.email.inbound",
+        channel: "email",
+        occurredAt: now,
+        contentFingerprint: null,
+        sourceEvidenceId,
+        idempotencyKey: `canonical:${input.contactId}-inbound`,
+        provenance: {
+          primaryProvider: "salesforce",
+          primarySourceEvidenceId: sourceEvidenceId,
+          supportingSourceEvidenceIds: [],
+          winnerReason: "single_source",
+          sourceRecordType: "task",
+          sourceRecordId: `${input.contactId}-msg`,
+          messageKind: "one_to_one",
+          campaignRef: null,
+          threadRef: null,
+          direction: "inbound",
+          notes: null,
+        },
+        reviewState: "clear",
+      });
+      await repositories.inboxProjection.upsert({
+        contactId: input.contactId,
+        bucket: "New",
+        needsFollowUp: false,
+        hasUnresolved: false,
+        lastInboundAt: now,
+        lastOutboundAt: null,
+        lastActivityAt: now,
+        snippet: `signal for ${input.contactId}`,
+        archivedAt: null,
+        lastCanonicalEventId: canonicalEventId,
+        lastEventType: "communication.email.inbound",
+      });
+    };
+
+    // Three contacts, each in a different project:
+    //   contact:in-host-a    — direct membership in the host (existing case 1)
+    //   contact:in-sub-b     — membership in the connected sub-project (NEW)
+    //   contact:in-sub-c     — membership in a sub-project of a DIFFERENT host
+    await seedContact({
+      contactId: "contact:in-host-a",
+      projectId: "project:host-a",
+      membershipId: "membership:host-a",
+    });
+    await seedContact({
+      contactId: "contact:in-sub-b",
+      projectId: "project:sub-b",
+      membershipId: "membership:sub-b",
+    });
+    await seedContact({
+      contactId: "contact:in-sub-c",
+      projectId: "project:sub-c",
+      membershipId: "membership:sub-c",
+    });
+
+    // Existing alias case: contact emails the host's alias with no membership.
+    await settings.aliases.create({
+      id: "alias:host-a",
+      alias: "host-a@example.org",
+      signature: "",
+      projectId: "project:host-a",
+      createdAt: new Date(now),
+      updatedAt: new Date(now),
+      createdBy: null,
+      updatedBy: null,
+    });
+    await repositories.contacts.upsert({
+      id: "contact:alias-only",
+      salesforceContactId: "003-alias-only",
+      displayName: "Alias Only",
+      primaryEmail: "alias-only@example.org",
+      primaryPhone: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    await repositories.sourceEvidence.append({
+      id: "source:alias-only",
+      provider: "gmail",
+      providerRecordType: "message",
+      providerRecordId: "alias-only-msg",
+      receivedAt: now,
+      occurredAt: now,
+      payloadRef: "payloads/gmail/alias-only.json",
+      idempotencyKey: "gmail:alias-only",
+      checksum: "checksum:alias-only",
+    });
+    await repositories.canonicalEvents.upsert({
+      id: "event:alias-only",
+      contactId: "contact:alias-only",
+      eventType: "communication.email.inbound",
+      channel: "email",
+      occurredAt: now,
+      contentFingerprint: null,
+      sourceEvidenceId: "source:alias-only",
+      idempotencyKey: "canonical:alias-only",
+      provenance: {
+        primaryProvider: "gmail",
+        primarySourceEvidenceId: "source:alias-only",
+        supportingSourceEvidenceIds: [],
+        winnerReason: "single_source",
+        sourceRecordType: "message",
+        sourceRecordId: "alias-only-msg",
+        messageKind: "one_to_one",
+        campaignRef: null,
+        threadRef: null,
+        direction: "inbound",
+        notes: null,
+      },
+      reviewState: "clear",
+    });
+    await repositories.gmailMessageDetails.upsert({
+      sourceEvidenceId: "source:alias-only",
+      providerRecordId: "alias-only-msg",
+      gmailThreadId: "thread:alias-only",
+      rfc822MessageId: "<alias-only@example.org>",
+      direction: "inbound",
+      subject: "alias-only inbound",
+      fromHeader: "Alias Only <alias-only@example.org>",
+      toHeader: "host-a@example.org",
+      ccHeader: null,
+      labelIds: ["INBOX"],
+      snippetClean: "alias-only signal",
+      bodyTextPreview: "alias-only signal",
+      capturedMailbox: "host-a@example.org",
+      projectInboxAlias: "host-a@example.org",
+    });
+    await repositories.inboxProjection.upsert({
+      contactId: "contact:alias-only",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: now,
+      lastOutboundAt: null,
+      lastActivityAt: now,
+      snippet: "alias-only signal",
+      archivedAt: null,
+      lastCanonicalEventId: "event:alias-only",
+      lastEventType: "communication.email.inbound",
+    });
+
+    const hostARows = await repositories.inboxProjection.listPageOrderedByRecency({
+      filter: "visible",
+      order: "last-inbound",
+      limit: 10,
+      cursor: null,
+      projectId: "project:host-a",
+    });
+    const subBRows = await repositories.inboxProjection.listPageOrderedByRecency(
+      {
+        filter: "visible",
+        order: "last-inbound",
+        limit: 10,
+        cursor: null,
+        projectId: "project:sub-b",
+      },
+    );
+    const hostDRows = await repositories.inboxProjection.listPageOrderedByRecency(
+      {
+        filter: "visible",
+        order: "last-inbound",
+        limit: 10,
+        cursor: null,
+        projectId: "project:host-d",
+      },
+    );
+
+    // Filtering by host A returns: direct member, sub-project member, alias-only.
+    expect(new Set(hostARows.map((row) => row.contactId))).toEqual(
+      new Set([
+        "contact:in-host-a",
+        "contact:in-sub-b",
+        "contact:alias-only",
+      ]),
+    );
+    // Filtering by the sub-project's own id is not the operator-facing path —
+    // it should match only the contact whose membership is on that exact id
+    // (existing case 1) and NOT the host or other host's contacts. The sub
+    // does not have a host of its own, so no rollup happens here.
+    expect(subBRows.map((row) => row.contactId)).toEqual([
+      "contact:in-sub-b",
+    ]);
+    // Cross-host isolation: host D's filter must not include host A's family.
+    expect(hostDRows.map((row) => row.contactId)).toEqual([
+      "contact:in-sub-c",
+    ]);
+  });
 });


### PR DESCRIPTION
## Why

Enable two Salesforce projects (e.g. Beech & Butternut) to operate as one in the platform — shared inbox alias, shared AI knowledge — without redesigning routing, threading, or storage. This generalizes the Beech & Butternut shared-inbox case (`forests@adventurescientists.org`).

Today, only one of a pair can be active in `project_dimensions` (the alias-owning host); the other stays inactive and its volunteers' threads are stranded. With this change, one project owns the alias (host) and one or more others (connected sub-projects) get rolled up into the host's inbox and dashboard views.

## What's in this PR (data foundation only)

- **Migration `0056`** on `project_dimensions`:
  - New column `connected_to_project_id text` with FK back to `project_id`, `ON DELETE SET NULL`.
  - Relaxed `project_dimensions_active_alias_required` CHECK: an active row is now valid if it has a non-empty alias OR a connection.
  - Two `BEFORE INSERT OR UPDATE` triggers preventing chains: a sub can't itself be a host, and a host with children can't become a sub.
  - Index on `connected_to_project_id` for the rollup queries.
- **`buildInboxProjectPredicate`**: adds a third UNION ALL branch — contacts whose only membership is in a connected sub-project of the requested project also match.
- **Dashboard tile rollup** (`apps/web/app/inbox/_lib/home-dashboard.ts`):
  - Connected sub-projects are filtered out of the active-tile list (one tile per host).
  - Memberships in connected sub-projects are remapped to the host's id so lifecycle metrics (signups, training, submissions) credit the host's tile.
  - The host's `unreadCount` already rolls up via the extended inbox predicate.
- **Drizzle schema** (`tables.ts`) and **contracts schema** (`stage1-records.ts`) get the new optional field; mappers preserve it on read and on upsert (operator-managed, never overwritten by Salesforce capture).

## What's NOT in this PR (follow-ups)

- Settings UI to manage connections (PR2).
- Contact rail "connected to host" display (PR3).
- AI Knowledge URL fallback for connected sub-projects in the AI Draft pipeline (PR3).
- Composer alias chip (no change needed — connected sub-projects have no alias).

## Manual operator path until UI ships

```sql
UPDATE project_dimensions
   SET connected_to_project_id = '<host project_id>'
 WHERE project_id = '<sub project_id>';
```

The relaxed CHECK and the chain-prevention trigger keep this safe; `ON DELETE SET NULL` cleans up if the host is deleted, and the connection can always be undone with `SET connected_to_project_id = NULL`.

## Reversibility

- `ON DELETE SET NULL` on the FK.
- Triggers fire only when `NEW.connected_to_project_id IS NOT NULL`, so disconnecting (and the FK cascade itself) bypasses them cleanly.
- No data is mutated by the migration beyond schema/constraint changes.

## Tests

Repository tests (PGlite, `packages/db/test/stage1-repositories.test.ts`):
- Connected-membership match: filtering by host returns sub-project members.
- Filtering by the sub's own id returns only direct members of that sub (no rollup, intentional).
- Cross-host isolation: two host/sub pairs don't bleed into each other.
- Existing membership case still returns under the host.
- Existing alias case still returns under the host.

Schema tests (`packages/db/test/projects-repository-connected-projects.test.ts`, new file):
- Active connected sub-project with no alias is valid.
- Active connected sub-project with alias is also valid (we don't forbid it).
- Active without alias and without connection is rejected by the relaxed CHECK.
- Chain rejected from the sub-end (Z connecting to Y where Y already has a connection).
- Chain rejected from the host-end (host M with sub N can't itself acquire a connection).
- Disconnect cascade: deleting the host nulls the sub's `connected_to_project_id` and the sub remains valid (because it has its own alias in this fixture).

Dashboard rollup test (`apps/web/tests/unit/inbox-home-dashboard.test.ts`):
- Connected sub-project's signups roll into host's tile; sub does not appear as its own tile; unread count includes both.

## Validation

- `pnpm typecheck` clean.
- `pnpm lint` clean.
- `pnpm build` clean.
- New tests pass; existing repository / schema / domain / contracts / web unit suites unaffected (513 web tests still green).

## Test plan

- [ ] Apply migration to staging DB.
- [ ] Manually `UPDATE project_dimensions SET connected_to_project_id = '<host>' WHERE project_id = '<sub>';` for a real host/sub pair.
- [ ] Verify the host's tile on the inbox welcome screen counts both projects' signups.
- [ ] Verify volunteers from the sub-project show up when filtering inbox by the host.
- [ ] Verify the sub-project disappears as its own tile.
- [ ] Verify the sub still shows as an active row in Settings projects list (no UI change yet — separate PR).
- [ ] Verify `DELETE FROM project_dimensions WHERE project_id = '<host>'` cascades the sub's `connected_to_project_id` to NULL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)