### PR TITLE
fix(settings): suppress stale banner pre-first-synthesis + show synthesis-in-progress

### DIFF
--- a/apps/web/app/settings/_components/project-ai-knowledge-section.tsx
+++ b/apps/web/app/settings/_components/project-ai-knowledge-section.tsx
@@ -41,7 +41,11 @@ interface FeedbackState {
   readonly message: string;
 }
 
-const POLL_WINDOW_MS = 30_000;
+// Source fetches finish in seconds, but the synthesis tail (Claude call +
+// Notion publish + setSynthesisMetadata) can take 60-90s. Window is sized so
+// the operator sees "Last synthesized" tick forward on a normal run without
+// having to refresh the page.
+const POLL_WINDOW_MS = 120_000;
 const POLL_INTERVAL_MS = 3_000;
 
 function formatTimestamp(value: string | null): string {
@@ -212,13 +216,16 @@ export function ProjectAiKnowledgeSection({
     };
   }, [enqueuedAt, router]);
 
-  // If every enabled source has now caught up past the enqueue mark, lift the
-  // optimistic pending overlay early — no need to keep polling for 30s.
+  // Lift the optimistic pending overlay early once both legs of the run have
+  // caught up past the enqueue mark: every enabled source has been re-synced
+  // AND the synthesis tail has written aiOptimizedSynthesizedAt. Otherwise the
+  // 120s window keeps polling so the operator sees the synthesis timestamp
+  // appear without a manual refresh.
   useEffect(() => {
     if (enqueuedAt === null) {
       return;
     }
-    const stillPending = sources.some((source) => {
+    const sourcesPending = sources.some((source) => {
       if (!source.enabled) {
         return false;
       }
@@ -228,10 +235,17 @@ export function ProjectAiKnowledgeSection({
           : Date.parse(source.last_synced_at);
       return lastSyncedMs === null || lastSyncedMs < enqueuedAt;
     });
-    if (!stillPending) {
+    const synthesizedAtMs =
+      aiOptimizedSynthesizedAt === null
+        ? null
+        : Date.parse(aiOptimizedSynthesizedAt);
+    const synthesisPending =
+      synthesizedAtMs === null || synthesizedAtMs < enqueuedAt;
+
+    if (!sourcesPending && !synthesisPending) {
       setEnqueuedAt(null);
     }
-  }, [sources, enqueuedAt]);
+  }, [sources, enqueuedAt, aiOptimizedSynthesizedAt]);
 
   function announce(message: string, kind: FeedbackState["kind"] = "success") {
     setFeedback({ kind, message });
@@ -645,12 +659,30 @@ export function ProjectAiKnowledgeSection({
 
       <div className="rounded-xl border border-slate-200 bg-white p-4">
         <p className="text-sm font-medium text-slate-900">Synthesis status</p>
-        <p className={cn(TYPE.caption, "mt-1 text-slate-600")}>
-          {aiOptimizedSynthesizedAt === null
-            ? "Not yet synthesized."
-            : `Last synthesized: ${formatTimestamp(aiOptimizedSynthesizedAt)} (${String(enabledHealthySources.length)} healthy enabled sources, model metadata unavailable).`}
+        <p
+          className={cn(
+            TYPE.caption,
+            "mt-1 flex items-center gap-1.5 text-slate-600"
+          )}
+        >
+          {enqueuedAt !== null ? (
+            <>
+              <RefreshCw
+                className="size-3 animate-spin text-sky-600"
+                aria-hidden="true"
+              />
+              <span>
+                Synthesizing now — Claude call + Notion publish typically
+                takes 30–90s.
+              </span>
+            </>
+          ) : aiOptimizedSynthesizedAt === null ? (
+            <span>Not yet synthesized.</span>
+          ) : (
+            <span>{`Last synthesized: ${formatTimestamp(aiOptimizedSynthesizedAt)} (${String(enabledHealthySources.length)} healthy enabled sources, model metadata unavailable).`}</span>
+          )}
         </p>
-        {aiKnowledgeSynthesisStale ? (
+        {aiKnowledgeSynthesisStale && enqueuedAt === null ? (
           <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[12px] text-amber-900">
             Synthesis is stale. One or more source hashes no longer match the
             last synthesized input. Re-sync recommended.

--- a/apps/web/src/server/settings/selectors.ts
+++ b/apps/web/src/server/settings/selectors.ts
@@ -560,7 +560,13 @@ async function readProjectSettingsDetail(
     aiAutoSyncSchedule: dimension?.aiAutoSyncSchedule ?? "never",
     aiOptimizedSynthesizedAt: dimension?.aiOptimizedSynthesizedAt ?? null,
     aiOptimizedInputHash,
+    // Only consider synthesis "stale" when a prior synthesis exists to
+    // compare against. Otherwise (never-synthesized), the project is in a
+    // "needs first synthesis" state, which the Synthesis status copy already
+    // conveys via "Not yet synthesized." Showing the stale banner alongside
+    // that copy is contradictory — the input never matched anything yet.
     aiKnowledgeSynthesisStale:
+      aiOptimizedInputHash !== null &&
       inputHashFromSources(aiKnowledgeSources) !== aiOptimizedInputHash,
     emails: project.emails,
     salesforceProjectId: project.salesforceProjectId


### PR DESCRIPTION
## Summary

Two follow-up bugs from #382 that operators hit immediately after the access fix landed:

### 1. Stale banner showing for projects that have never been synthesized

`selectors.ts:563-564` computed:
\`\`\`ts
aiKnowledgeSynthesisStale:
  inputHashFromSources(aiKnowledgeSources) !== aiOptimizedInputHash,
\`\`\`

For a project with healthy sources but no prior synthesis (`aiOptimizedInputHash === null`), the current hash is non-null so they're never equal → the amber **"Synthesis is stale. One or more source hashes no longer match the last synthesized input. Re-sync recommended."** banner lit up under **"Not yet synthesized."** — contradictory copy.

Fix: only treat as stale when there's a prior synthesis to drift from.

### 2. Polling window was too short for the synthesis tail

Source fetches finish in seconds (Notion API + http GET), but the rest of the run — Claude call → `createNotionMarkdownPage` → `setSynthesisMetadata` — typically takes 30–90s. The previous 30s polling window stopped well before the synthesis timestamp landed, so operators never saw `Last synthesized` tick forward without a manual refresh.

Fix:
- Bump `POLL_WINDOW_MS` to 120s.
- Keep polling until **both** legs of the run catch up past `enqueuedAt`: sources AND synthesis (`aiOptimizedSynthesizedAt`).
- Replace the static `Not yet synthesized.` with a spinner + `Synthesizing now — Claude call + Notion publish typically takes 30–90s.` while the window is open.
- Suppress the (now-correctly-gated) stale banner while a re-sync is mid-flight to avoid flashing it during the gap between source-sync completion and synthesis completion.

## Test plan

- [x] `pnpm -C apps/web typecheck`
- [x] `pnpm -C apps/web lint`
- [x] `pnpm -C apps/web test:unit` — 513 pass / 5 skipped
- [ ] Manual: click Re-sync all on a project, confirm the spinner appears in the Synthesis status row, persists past the source-sync rows turning Healthy, and resolves to a fresh `Last synthesized: ...` timestamp without manual refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)