### PR TITLE
fix(inbox): hide inline-signature images by filename heuristic

### DIFF
--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -2394,6 +2394,46 @@ function buildTimelineEntry(input: {
   };
 }
 
+/**
+ * Filename patterns that email clients use as defaults when the sender
+ * embeds an inline image without an explicit filename — typically the
+ * sender's signature graphic. Used as a belt-and-suspenders alongside
+ * `message_attachments.is_inline`: capture-side detection requires both
+ * a Content-ID header AND a `cid:` reference in the live HTML body, but
+ * reply chains often strip the reference even though the image is still
+ * dragged along as a quoted-signature artifact. Those slip through the
+ * primary filter and end up showing as map-sized thumbnails.
+ *
+ * Patterns covered (case-insensitive):
+ *   - "noname"                   (Outlook default, no extension)
+ *   - "image001.png"             (Outlook embedded-image convention)
+ *   - "image.png" / "image.jpg"  (mobile mail clients, generic)
+ *   - "ATT00001.png"             (legacy Lotus Notes / similar)
+ *
+ * Conservative: only image MIME types, only when the filename matches
+ * one of these placeholder shapes. Real photos with descriptive names
+ * are unaffected, and the API endpoint still serves the bytes — we
+ * just don't surface them as visible thumbnails in the bubble.
+ */
+const INLINE_SIGNATURE_FILENAME_PATTERN =
+  /^(noname|image\d*\.(?:png|jpe?g|gif|webp)|ATT\d+\.(?:png|jpe?g|gif|webp))$/iu;
+
+function looksLikeInlineSignatureImage(attachment: {
+  readonly mimeType: string;
+  readonly filename: string | null;
+}): boolean {
+  if (!attachment.mimeType.toLowerCase().startsWith("image/")) {
+    return false;
+  }
+
+  const trimmed = attachment.filename?.trim();
+  if (trimmed === undefined || trimmed.length === 0) {
+    return true;
+  }
+
+  return INLINE_SIGNATURE_FILENAME_PATTERN.test(trimmed);
+}
+
 function buildEmailAttachmentsForEntry(input: {
   readonly canonical: readonly MessageAttachmentRecord[];
   readonly pending: readonly {
@@ -2403,7 +2443,10 @@ function buildEmailAttachmentsForEntry(input: {
   }[];
 }): InboxTimelineEntryViewModel["attachments"] {
   const canonicalAttachments = input.canonical
-    .filter((attachment) => !attachment.isInline)
+    .filter(
+      (attachment) =>
+        !attachment.isInline && !looksLikeInlineSignatureImage(attachment),
+    )
     .map((attachment) => ({
       id: attachment.id,
       mimeType: attachment.mimeType,


### PR DESCRIPTION
## Why

[#262](https://github.com/nico-kneler-as/as-comms-platform/pull/262) added `is_inline` and a capture-side detector. It correctly flags inline images that satisfy ALL of:
1. Content-ID header present
2. Content-ID referenced via `cid:` in the *current* HTML body
3. Content-Disposition is not "attachment"

The strict definition misses signature images that survived through reply chains. Production data:

```
filename            size    is_inline   created_at
noname              114642  f           2026-05-08
ATT00001.png        114642  f           2026-05-08
image.png           114642  t           2026-05-07
noname              114642  t           2026-05-07
```

Same Mountain Madness logo, same byte count, captured days apart. Email clients strip the `cid:` reference when quoting prior bodies, so the *next* capture on the same thread no longer satisfies (2). The signature image still rides along as a regular attachment and shows up as a bubble thumbnail.

## What

Belt-and-suspenders heuristic in `buildEmailAttachmentsForEntry`. Hides image attachments whose filename matches the placeholder shapes email clients use when embedding inline images without a real name:

- `noname` (Outlook)
- `image001.png` / `image.png` (Outlook + mobile clients)
- `ATT00001.png` (legacy Lotus Notes / similar)
- empty / null filename on an `image/*` MIME type

Conservative: only image MIME types, only the placeholder regex shape. Real photos with descriptive names stay visible. The proxy endpoint still serves the bytes — we're only filtering the bubble-thumbnail surface.

## Out of scope, follow-up

Broaden the capture-side detector (e.g. trust `Content-Disposition: inline` even without a body cid: reference, or write the inline flag based on Content-ID presence alone). That would re-flag historic and future captures correctly at the source. This PR is the immediate UX fix without requiring re-capture.

## Test plan
- [ ] CI green
- [ ] Mountain Madness signature on Mark Gunlogson's thread no longer renders as a thumbnail
- [ ] Real screenshots in the same email (descriptive filenames) still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)