### PR TITLE
fix(connected-projects): nest subs in Settings list, hide from inbox filter

### DIFF
--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -3215,20 +3215,29 @@ async function readInboxListCacheData(input: {
     ...primaryProjectionPage.rows,
     ...attentionScanProjectionPage.rows,
   ]);
+  // Connected sub-projects roll up into their host (see PR #384's
+  // host-aware predicate). The host is the only entry point — exclude subs
+  // so the dropdown doesn't list them as their own filter option.
   const activeProjects: readonly InboxActiveProjectOption[] =
-    activeProjectRecords.map((record) => ({
-      id: record.projectId,
-      name:
-        record.projectAlias?.trim().length &&
-        record.projectAlias.trim().length > 0
-          ? record.projectAlias.trim()
-          : record.projectName,
-      alias:
-        record.projectAlias?.trim().length &&
-        record.projectAlias.trim().length > 0
-          ? record.projectAlias.trim()
-          : null,
-    }));
+    activeProjectRecords
+      .filter(
+        (record) =>
+          record.connectedToProjectId === null ||
+          record.connectedToProjectId === undefined,
+      )
+      .map((record) => ({
+        id: record.projectId,
+        name:
+          record.projectAlias?.trim().length &&
+          record.projectAlias.trim().length > 0
+            ? record.projectAlias.trim()
+            : record.projectName,
+        alias:
+          record.projectAlias?.trim().length &&
+          record.projectAlias.trim().length > 0
+            ? record.projectAlias.trim()
+            : null,
+      }));
   const candidateContactIds = uniqueStrings(
     matchedProjections.map((projection) => projection.contactId),
   );

--- a/apps/web/app/settings/_components/projects-section.tsx
+++ b/apps/web/app/settings/_components/projects-section.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { FolderOpen, Plus } from "lucide-react";
+import { CornerDownRight, FolderOpen, Plus } from "lucide-react";
 
 import {
   FOCUS_RING,
@@ -17,6 +17,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type {
+  ProjectListEntryViewModel,
   ProjectRowViewModel,
   ProjectsSettingsViewModel
 } from "@/src/server/settings/selectors";
@@ -45,6 +46,11 @@ export function ProjectsSection({
     router.refresh();
   }
 
+  // The wizard's pick-project list is a flat row list of inactive +
+  // unconnected candidates, not the nested envelope the Settings list uses.
+  // Flatten host + sub rows back into a single array for that surface.
+  const inactiveFlatProjects = flattenEntries(viewModel.inactive);
+
   return (
     <>
       <SettingsSection
@@ -66,7 +72,7 @@ export function ProjectsSection({
         }
       >
         <ProjectList
-          projects={viewModel.active}
+          entries={viewModel.active}
           emptyMessage="No active projects yet."
           renderLeading={() => (
             <span className="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-lg bg-emerald-50 text-emerald-700 ring-1 ring-inset ring-emerald-200/60">
@@ -80,7 +86,7 @@ export function ProjectsSection({
         <ActivationWizard
           open
           onClose={closeWizard}
-          inactiveProjects={viewModel.inactive}
+          inactiveProjects={inactiveFlatProjects}
           {...(wizardRequest.initialProjectId === undefined
             ? {}
             : { initialProjectId: wizardRequest.initialProjectId })}
@@ -90,18 +96,29 @@ export function ProjectsSection({
   );
 }
 
+function flattenEntries(
+  entries: readonly ProjectListEntryViewModel[]
+): readonly ProjectRowViewModel[] {
+  const out: ProjectRowViewModel[] = [];
+
+  for (const entry of entries) {
+    out.push(entry.host);
+    for (const sub of entry.connectedSubProjects) {
+      out.push(sub);
+    }
+  }
+
+  return out;
+}
+
 function ProjectList({
-  projects,
+  entries,
   emptyMessage,
-  renderLeading,
-  renderMeta,
-  renderAction
+  renderLeading
 }: {
-  readonly projects: readonly ProjectRowViewModel[];
+  readonly entries: readonly ProjectListEntryViewModel[];
   readonly emptyMessage: string;
-  readonly renderLeading?: (project: ProjectRowViewModel) => ReactNode;
-  readonly renderMeta?: (project: ProjectRowViewModel) => ReactNode;
-  readonly renderAction?: (project: ProjectRowViewModel) => ReactNode;
+  readonly renderLeading?: ((project: ProjectRowViewModel) => ReactNode) | undefined;
 }) {
   return (
     <ul
@@ -111,66 +128,132 @@ function ProjectList({
         "border border-slate-200 bg-white",
         SHADOW.sm
       )}
+      data-testid="settings-projects-list"
     >
-      {projects.map((project) => (
-        <li
-          key={project.projectId}
-          className={cn(
-            "group flex items-center gap-3",
-            SPACING.listItem,
-            TRANSITION.fast,
-            "hover:bg-slate-50/80"
-          )}
-        >
-          <Link
-            href={`/settings/projects/${encodeURIComponent(project.projectId)}`}
-            className={cn(
-              renderLeading
-                ? "flex min-w-0 flex-1 items-start gap-4"
-                : "flex min-w-0 flex-1 flex-col gap-1",
-              FOCUS_RING,
-              RADIUS.sm
-            )}
-            aria-label={`Open ${project.projectName}`}
-          >
-            {renderLeading ? renderLeading(project) : null}
-            <div className="min-w-0 flex-1">
-              <div className="flex min-w-0 items-center gap-2">
-                <p
-                  className={
-                    renderLeading
-                      ? "truncate text-[14.5px] font-semibold text-slate-900"
-                      : "truncate text-sm font-medium text-slate-900"
-                  }
-                >
-                  {project.projectName}
-                </p>
-                {renderMeta ? renderMeta(project) : null}
-              </div>
-              {renderLeading ? (
-                <p className={cn("mt-1 truncate text-slate-500", TYPE.caption)}>
-                  {getProjectSecondaryLabel(project)}
-                </p>
-              ) : (
-                <>
-                  <p className={cn(TYPE.caption, "truncate text-slate-500")}>
-                    {getProjectSecondaryLabel(project)}
-                  </p>
-                </>
-              )}
-            </div>
-          </Link>
-
-          {renderAction ? renderAction(project) : null}
-        </li>
+      {entries.map((entry) => (
+        <ProjectListEntry
+          key={entry.host.projectId}
+          entry={entry}
+          renderLeading={renderLeading}
+        />
       ))}
 
-      {projects.length === 0 ? (
+      {entries.length === 0 ? (
         <li className="px-5 py-10 text-center">
           <p className={TYPE.caption}>{emptyMessage}</p>
         </li>
       ) : null}
     </ul>
+  );
+}
+
+function ProjectListEntry({
+  entry,
+  renderLeading
+}: {
+  readonly entry: ProjectListEntryViewModel;
+  readonly renderLeading: ((project: ProjectRowViewModel) => ReactNode) | undefined;
+}) {
+  const { host, connectedSubProjects } = entry;
+
+  return (
+    <li
+      className="flex flex-col"
+      data-testid="settings-projects-entry"
+      data-project-id={host.projectId}
+    >
+      <ProjectRow project={host} renderLeading={renderLeading} />
+
+      {connectedSubProjects.length > 0 ? (
+        <ul
+          className="flex flex-col divide-y divide-slate-100 border-t border-slate-100 bg-slate-50/40"
+          data-testid="settings-projects-connected-subs"
+        >
+          {connectedSubProjects.map((sub) => (
+            <ProjectRow
+              key={sub.projectId}
+              project={sub}
+              renderLeading={renderLeading}
+              hostName={host.projectName}
+              isConnectedSub
+            />
+          ))}
+        </ul>
+      ) : null}
+    </li>
+  );
+}
+
+function ProjectRow({
+  project,
+  renderLeading,
+  hostName,
+  isConnectedSub = false
+}: {
+  readonly project: ProjectRowViewModel;
+  readonly renderLeading: ((project: ProjectRowViewModel) => ReactNode) | undefined;
+  readonly hostName?: string;
+  readonly isConnectedSub?: boolean;
+}) {
+  const secondaryLabel = isConnectedSub
+    ? `Connected to ${hostName ?? ""}`.trim()
+    : getProjectSecondaryLabel(project);
+
+  return (
+    <li
+      className={cn(
+        "group flex items-center gap-3",
+        SPACING.listItem,
+        TRANSITION.fast,
+        "hover:bg-slate-50/80",
+        isConnectedSub ? "pl-8" : ""
+      )}
+      data-testid={
+        isConnectedSub
+          ? "settings-projects-connected-sub-row"
+          : "settings-projects-row"
+      }
+      data-project-id={project.projectId}
+    >
+      {isConnectedSub ? (
+        <span
+          className="flex size-5 shrink-0 items-center justify-center text-slate-400"
+          aria-hidden="true"
+        >
+          <CornerDownRight className="size-3.5" />
+        </span>
+      ) : null}
+
+      <Link
+        href={`/settings/projects/${encodeURIComponent(project.projectId)}`}
+        className={cn(
+          renderLeading
+            ? "flex min-w-0 flex-1 items-start gap-4"
+            : "flex min-w-0 flex-1 flex-col gap-1",
+          FOCUS_RING,
+          RADIUS.sm
+        )}
+        aria-label={`Open ${project.projectName}`}
+      >
+        {renderLeading && !isConnectedSub ? renderLeading(project) : null}
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-2">
+            <p
+              className={
+                renderLeading && !isConnectedSub
+                  ? "truncate text-[14.5px] font-semibold text-slate-900"
+                  : "truncate text-sm font-medium text-slate-900"
+              }
+            >
+              {project.projectName}
+            </p>
+          </div>
+          <p className={cn("mt-1 truncate text-slate-500", TYPE.caption)}>
+            {secondaryLabel}
+          </p>
+        </div>
+      </Link>
+    </li>
   );
 }
 

--- a/apps/web/src/server/settings/selectors.ts
+++ b/apps/web/src/server/settings/selectors.ts
@@ -38,6 +38,19 @@ export interface ProjectRowViewModel {
   readonly activationRequirementsMet: boolean;
 }
 
+/**
+ * Top-level row in the Settings → Projects list. Connected sub-projects do
+ * not appear at this level; they are nested under their host's
+ * `connectedSubProjects` and inherit "Connected to {host}" copy in the
+ * renderer. `host` carries the host's own row exactly as it would render
+ * standalone, so `connectedSubProjects` is the only sub-aware field on the
+ * envelope.
+ */
+export interface ProjectListEntryViewModel {
+  readonly host: ProjectRowViewModel;
+  readonly connectedSubProjects: readonly ProjectRowViewModel[];
+}
+
 export interface ConnectedProjectSummaryViewModel {
   readonly projectId: string;
   readonly projectName: string;
@@ -52,8 +65,8 @@ export interface ConnectedHostSummaryViewModel {
 
 export interface ProjectsSettingsViewModel {
   readonly isAdmin: boolean;
-  readonly active: readonly ProjectRowViewModel[];
-  readonly inactive: readonly ProjectRowViewModel[];
+  readonly active: readonly ProjectListEntryViewModel[];
+  readonly inactive: readonly ProjectListEntryViewModel[];
   readonly counts: {
     readonly active: number;
     readonly inactive: number;
@@ -547,7 +560,7 @@ async function readProjectsSettings(input: {
     return input.filter === "active" ? project.isActive : !project.isActive;
   });
 
-  const active = filteredProjects
+  const activeRows = filteredProjects
     .filter((project) => project.isActive)
     .sort(
       (left, right) =>
@@ -555,7 +568,7 @@ async function readProjectsSettings(input: {
         left.projectName.localeCompare(right.projectName)
     )
     .map(toProjectRowViewModel);
-  const inactive = filteredProjects
+  const inactiveRows = filteredProjects
     .filter((project) => !project.isActive)
     .sort(
       (left, right) =>
@@ -564,15 +577,63 @@ async function readProjectsSettings(input: {
     )
     .map(toProjectRowViewModel);
 
+  const active = nestConnectedSubProjects(activeRows);
+  const inactive = nestConnectedSubProjects(inactiveRows);
+
   return {
     active,
     inactive,
     counts: {
-      active: active.length,
-      inactive: inactive.length,
-      total: active.length + inactive.length
+      active: activeRows.length,
+      inactive: inactiveRows.length,
+      total: activeRows.length + inactiveRows.length
     }
   };
+}
+
+/**
+ * Folds a flat row list into `{ host, connectedSubProjects }` entries.
+ * Connected sub-projects are removed from the top level and nested under
+ * their host. Sub-projects whose host isn't in this bucket (e.g. host is
+ * inactive while sub remains active) stay as their own top-level entry —
+ * data integrity should prevent this, but the fallback keeps the row
+ * visible rather than silently dropping it. Sub-projects under each host
+ * are sorted by project name.
+ */
+function nestConnectedSubProjects(
+  rows: readonly ProjectRowViewModel[]
+): readonly ProjectListEntryViewModel[] {
+  const subsByHostId = new Map<string, ProjectRowViewModel[]>();
+  const hostIds = new Set(rows.map((row) => row.projectId));
+
+  for (const row of rows) {
+    if (
+      row.connectedToProjectId !== null &&
+      hostIds.has(row.connectedToProjectId)
+    ) {
+      const existing = subsByHostId.get(row.connectedToProjectId) ?? [];
+      existing.push(row);
+      subsByHostId.set(row.connectedToProjectId, existing);
+    }
+  }
+
+  return rows
+    .filter(
+      (row) =>
+        row.connectedToProjectId === null ||
+        !hostIds.has(row.connectedToProjectId)
+    )
+    .map((host) => {
+      const subs = subsByHostId.get(host.projectId) ?? [];
+      return {
+        host,
+        connectedSubProjects: subs
+          .slice()
+          .sort((left, right) =>
+            left.projectName.localeCompare(right.projectName)
+          )
+      };
+    });
 }
 
 async function readProjectSettingsDetail(

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -894,6 +894,34 @@ describe("real inbox selectors", () => {
     });
   });
 
+  it("excludes connected sub-projects from the inbox project filter options", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await runtime.context.repositories.projectDimensions.upsert({
+      projectId: "project:butternut",
+      projectName: "Restoring Butternut Tree Health",
+      projectAlias: "forests",
+      source: "salesforce",
+      isActive: true,
+    });
+    await runtime.context.repositories.projectDimensions.upsert({
+      projectId: "project:beech",
+      projectName: "Saving American Beech",
+      projectAlias: null,
+      connectedToProjectId: "project:butternut",
+      source: "salesforce",
+      isActive: true,
+    });
+
+    const list = await getInboxList();
+    const ids = list.activeProjects.map((option) => option.id);
+
+    expect(ids).toContain("project:butternut");
+    expect(ids).not.toContain("project:beech");
+  });
+
   it("keeps one-to-one SMS visible in the timeline regardless of SMS compose availability", async () => {
     const originalSmsEnabled = process.env.SMS_ENABLED;
     process.env.SMS_ENABLED = "false";

--- a/apps/web/tests/unit/settings-projects-section.test.tsx
+++ b/apps/web/tests/unit/settings-projects-section.test.tsx
@@ -23,6 +23,7 @@ vi.mock("next/link", () => ({
 }));
 
 vi.mock("lucide-react", () => ({
+  CornerDownRight: () => null,
   FolderOpen: () => null,
   Plus: () => null,
 }));
@@ -46,7 +47,31 @@ vi.mock("../../app/settings/_components/activation-wizard", () => ({
 }));
 
 import { ProjectsSection } from "../../app/settings/_components/projects-section";
-import type { ProjectsSettingsViewModel } from "../../src/server/settings/selectors";
+import type {
+  ProjectRowViewModel,
+  ProjectsSettingsViewModel,
+} from "../../src/server/settings/selectors";
+
+function buildRow(
+  override: Partial<ProjectRowViewModel> & { readonly projectId: string },
+): ProjectRowViewModel {
+  return {
+    projectName: "Project",
+    suggestedAlias: "Project",
+    projectAlias: null,
+    connectedToProjectId: null,
+    isActive: true,
+    primaryEmail: null,
+    emailAliases: [],
+    additionalEmailCount: 0,
+    aiKnowledgeUrl: null,
+    aiKnowledgeSyncedAt: null,
+    hasCachedAiKnowledge: false,
+    memberCount: 0,
+    activationRequirementsMet: false,
+    ...override,
+  };
+}
 
 describe("ProjectsSection accessibility", () => {
   it("renders one project-detail link per active project", () => {
@@ -54,20 +79,17 @@ describe("ProjectsSection accessibility", () => {
       isAdmin: true,
       active: [
         {
-          projectId: "project:one",
-          projectName: "Orca Soundwatch",
-          suggestedAlias: "Orca Soundwatch",
-          projectAlias: "orca",
-          connectedToProjectId: null,
-          isActive: true,
-          primaryEmail: "orca@example.org",
-          emailAliases: ["orca@example.org"],
-          additionalEmailCount: 0,
-          aiKnowledgeUrl: null,
-          aiKnowledgeSyncedAt: null,
-          hasCachedAiKnowledge: false,
-          memberCount: 3,
-          activationRequirementsMet: true,
+          host: buildRow({
+            projectId: "project:one",
+            projectName: "Orca Soundwatch",
+            suggestedAlias: "Orca Soundwatch",
+            projectAlias: "orca",
+            primaryEmail: "orca@example.org",
+            emailAliases: ["orca@example.org"],
+            memberCount: 3,
+            activationRequirementsMet: true,
+          }),
+          connectedSubProjects: [],
         },
       ],
       inactive: [],
@@ -86,5 +108,69 @@ describe("ProjectsSection accessibility", () => {
       html.match(/href="\/settings\/projects\/project%3Aone"/g),
     ).toHaveLength(1);
     expect(html.match(/aria-label="Open Orca Soundwatch"/g)).toHaveLength(1);
+  });
+
+  it("nests connected sub-projects under their host with the connected-to subtitle", () => {
+    const viewModel: ProjectsSettingsViewModel = {
+      isAdmin: true,
+      active: [
+        {
+          host: buildRow({
+            projectId: "project:butternut",
+            projectName: "Restoring Butternut Tree Health",
+            suggestedAlias: "Restoring Butternut Tree Health",
+            projectAlias: "forests",
+            primaryEmail: "forests@example.org",
+            emailAliases: ["forests@example.org"],
+            memberCount: 12,
+            activationRequirementsMet: true,
+          }),
+          connectedSubProjects: [
+            buildRow({
+              projectId: "project:beech",
+              projectName: "Saving American Beech",
+              suggestedAlias: "Saving American Beech",
+              projectAlias: null,
+              connectedToProjectId: "project:butternut",
+              memberCount: 4,
+            }),
+          ],
+        },
+      ],
+      inactive: [],
+      counts: {
+        active: 2,
+        inactive: 0,
+        total: 2,
+      },
+    };
+
+    const html = renderToStaticMarkup(
+      createElement(ProjectsSection, { viewModel }),
+    );
+
+    // Sub renders nested with the sub's link under the host's entry.
+    const entryStart = html.indexOf(
+      'data-testid="settings-projects-entry"',
+    );
+    expect(entryStart).toBeGreaterThanOrEqual(0);
+    const hostStart = html.indexOf(
+      'data-testid="settings-projects-row"',
+      entryStart,
+    );
+    const subStart = html.indexOf(
+      'data-testid="settings-projects-connected-sub-row"',
+      entryStart,
+    );
+    expect(hostStart).toBeGreaterThan(entryStart);
+    expect(subStart).toBeGreaterThan(hostStart);
+
+    expect(
+      html.match(/Connected to Restoring Butternut Tree Health/g),
+    ).toHaveLength(1);
+    expect(html.includes("No project inbox aliases configured")).toBe(false);
+    expect(
+      html.match(/href="\/settings\/projects\/project%3Abeech"/g),
+    ).toHaveLength(1);
   });
 });

--- a/apps/web/tests/unit/settings-selectors.test.ts
+++ b/apps/web/tests/unit/settings-selectors.test.ts
@@ -61,6 +61,7 @@ async function seedProject(
     readonly projectId: string;
     readonly projectName: string;
     readonly projectAlias?: string | null;
+    readonly connectedToProjectId?: string | null;
     readonly isActive: boolean;
     readonly aiKnowledgeUrl: string | null;
     readonly aiKnowledgeSyncedAt?: string | null;
@@ -73,6 +74,7 @@ async function seedProject(
     projectName: input.projectName,
     projectAlias:
       input.projectAlias === undefined ? input.projectName : input.projectAlias,
+    connectedToProjectId: input.connectedToProjectId ?? null,
     source: "salesforce",
     isActive: input.isActive,
     aiKnowledgeUrl: input.aiKnowledgeUrl,
@@ -316,7 +318,7 @@ describe("settings selectors", () => {
     });
 
     expect(viewModel.active).toHaveLength(2);
-    expect(viewModel.active.every((project) => project.isActive)).toBe(true);
+    expect(viewModel.active.every((entry) => entry.host.isActive)).toBe(true);
     expect(viewModel.inactive).toHaveLength(0);
     expect(viewModel.counts).toEqual({
       active: 2,
@@ -361,7 +363,10 @@ describe("settings selectors", () => {
     const viewModel = await loadProjectsSettings({
       filter: "all",
     });
-    const projects = [...viewModel.active, ...viewModel.inactive];
+    const projects = [
+      ...viewModel.active.map((entry) => entry.host),
+      ...viewModel.inactive.map((entry) => entry.host),
+    ];
 
     expect(
       projects.find((project) => project.projectId === "project:ready")
@@ -406,7 +411,7 @@ describe("settings selectors", () => {
       search: "sfkw",
     });
 
-    expect(byAlias.active.map((project) => project.projectId)).toEqual([
+    expect(byAlias.active.map((entry) => entry.host.projectId)).toEqual([
       "project:alias-search",
     ]);
   });
@@ -439,14 +444,86 @@ describe("settings selectors", () => {
     });
 
     expect(
-      viewModel.active.find((project) => project.projectId === "project:colon")
-        ?.suggestedAlias,
+      viewModel.active.find(
+        (entry) => entry.host.projectId === "project:colon",
+      )?.host.suggestedAlias,
     ).toBe("White Oak Savanna");
     expect(
       viewModel.inactive.find(
-        (project) => project.projectId === "project:prefix",
-      )?.suggestedAlias,
+        (entry) => entry.host.projectId === "project:prefix",
+      )?.host.suggestedAlias,
     ).toBe("Killer Whales 2025/2026");
+  });
+
+  it("nests connected sub-projects under their host in the active list", async () => {
+    if (!runtime) {
+      throw new Error("runtime not initialized");
+    }
+
+    await seedProject(runtime, {
+      projectId: "project:butternut",
+      projectName: "Restoring Butternut Tree Health",
+      projectAlias: "forests",
+      isActive: true,
+      aiKnowledgeUrl: "https://www.notion.so/forests",
+      aiKnowledgeSyncedAt: "2026-04-20T15:00:00.000Z",
+      emails: ["forests@asc.internal"],
+      memberCount: 5,
+    });
+    await seedProject(runtime, {
+      projectId: "project:beech",
+      projectName: "Saving American Beech",
+      projectAlias: null,
+      connectedToProjectId: "project:butternut",
+      isActive: true,
+      aiKnowledgeUrl: null,
+      emails: [],
+      memberCount: 3,
+    });
+    await seedProject(runtime, {
+      projectId: "project:standalone",
+      projectName: "Pollinator Gardens",
+      projectAlias: "pollinator",
+      isActive: true,
+      aiKnowledgeUrl: "https://www.notion.so/pollinator",
+      aiKnowledgeSyncedAt: "2026-04-20T15:00:00.000Z",
+      emails: ["pollinator@asc.internal"],
+      memberCount: 2,
+    });
+
+    const viewModel = await loadProjectsSettings({ filter: "active" });
+
+    // Connected sub does not appear at top level.
+    expect(viewModel.active.map((entry) => entry.host.projectId)).not.toContain(
+      "project:beech",
+    );
+
+    const butternutEntry = viewModel.active.find(
+      (entry) => entry.host.projectId === "project:butternut",
+    );
+    expect(butternutEntry).toBeDefined();
+    expect(
+      butternutEntry?.connectedSubProjects.map((sub) => sub.projectId),
+    ).toEqual(["project:beech"]);
+    expect(butternutEntry?.connectedSubProjects[0]?.projectName).toBe(
+      "Saving American Beech",
+    );
+    expect(
+      butternutEntry?.connectedSubProjects[0]?.connectedToProjectId,
+    ).toBe("project:butternut");
+
+    // Counts include all rows (host + sub + standalone).
+    expect(viewModel.counts).toEqual({
+      active: 3,
+      inactive: 0,
+      total: 3,
+    });
+
+    // Standalone projects keep their own top-level entry with no subs.
+    const standalone = viewModel.active.find(
+      (entry) => entry.host.projectId === "project:standalone",
+    );
+    expect(standalone?.connectedSubProjects).toHaveLength(0);
   });
 
   it("returns null when project detail is requested for an unknown id", async () => {


### PR DESCRIPTION
## Why

Connected sub-projects (rows with `connected_to_project_id IS NOT NULL`) were leaking into two surfaces where the host should be the only entry point:

1. **Settings -> Projects** rendered each connected sub as a peer card with the misleading subtitle `No project inbox aliases configured` — the sub *intentionally* has no alias because it inherits the host's.
2. **Inbox project filter dropdown** listed every connected sub as a standalone filter option, even though selecting the sub returns only its own rows while the host's filter already rolls up both per PR #384's predicate.

## What

- **Settings list**: selector now returns nested `{ host, connectedSubProjects }` envelopes; renderer indents subs underneath their host with a `Connected to {host name}` subtitle and a `CornerDownRight` glyph. Activation wizard still receives a flat row array (re-flattened in the section component).
- **Inbox filter**: the data-layer `activeProjects` builder filters out rows with `connected_to_project_id IS NOT NULL` before the dropdown is built. Hosts remain the single entry point.

## Reference

Builds on PR #384 (host-aware predicate rollup) and PR #388 (Settings UX scaffolding).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm build` clean
- [x] New selector test asserts host nests sub with `connectedSubProjects: ["project:beech"]`
- [x] New selector test asserts inbox `activeProjects` excludes connected sub ids
- [x] New component test asserts nested DOM hierarchy + `Connected to` subtitle, no leak of "No project inbox aliases configured"
- [x] Existing tests updated to read via `entry.host` envelope

## Out of scope (per brief)

- AI Knowledge fallback (separate in-flight PR3)
- Contact rail / inbox row / conversation header rendering for connected subs (separate PR3)
- Welcome workload tile rendering (separate PR3)
- `project_dimensions` schema, SF capture path, or activation wizard internals