### PR TITLE
feat(ai-knowledge): EMAIL_CORPUS bulk-history backfill + PII masking fixes

### DIFF
--- a/apps/web/app/inbox/actions.ts
+++ b/apps/web/app/inbox/actions.ts
@@ -10,6 +10,7 @@ import {
   CanonicalContactAmbiguityError,
   canSendTo,
   computePendingComposerOutboundFingerprint,
+  maskKnowledgeExample,
   smsMetrics,
   toE164,
 } from "@as-comms/domain";
@@ -294,13 +295,6 @@ function mapProjectMetricContactRow(
   };
 }
 
-function maskKnowledgeExample(value: string): string {
-  return value
-    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/giu, "{EMAIL}")
-    .replace(/\+?1?[\s.-]?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}/gu, "{PHONE}")
-    .replace(/\b[A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,3}\b/gu, "{NAME}");
-}
-
 async function captureKnowledgeFromSend(input: {
   readonly runtime: Awaited<ReturnType<typeof getStage1WebRuntime>>;
   readonly projectId: string;
@@ -368,7 +362,10 @@ async function captureKnowledgeFromSend(input: {
     volunteerStage: null,
     questionSummary,
     replyStrategy: null,
-    maskedExample: input.bodyPlaintext,
+    // The column is named masked_example for a reason; the synthesis path
+    // and prompt builder both read from it expecting masked PII. Storing
+    // the raw body here was a long-standing miss — fixed 2026-05-10.
+    maskedExample: maskKnowledgeExample(input.bodyPlaintext),
     sourceKind: "captured_from_send",
     approvedForAi: true,
     sourceEventId: null,

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -11,6 +11,7 @@
     "start": "node dist/index.js",
     "ops": "tsx src/ops/cli.ts",
     "ops:backfill-content-fingerprint": "tsx src/ops/backfill-content-fingerprint.ts",
+    "ops:backfill-project-corpus": "tsx src/ops/backfill-project-corpus.ts",
     "ops:backfill-garbled-message-bodies": "tsx src/ops/cli.ts backfill-garbled-message-bodies",
     "ops:re-extract-signed-envelope-bodies": "tsx src/ops/cli.ts re-extract-signed-envelope-bodies",
     "ops:check-config": "tsx src/ops/cli.ts check-config",

--- a/apps/worker/src/jobs/synthesize-project-knowledge/orchestrator.ts
+++ b/apps/worker/src/jobs/synthesize-project-knowledge/orchestrator.ts
@@ -18,6 +18,11 @@ const DEFAULT_MODEL = "claude-sonnet-4-6";
 const DEFAULT_MAX_TOKENS = 16_000;
 const DEFAULT_TEMPERATURE = 0.3;
 const APPROVED_REPLY_PROMPT_LIMIT = 50;
+// Cap on backfilled / accumulated bulk corpus examples sent into the
+// EMAIL_CORPUS prompt block. Lower-weighted than approved canonical
+// replies; volume matters here for tone/pattern distillation, but going
+// past ~100 inflates input tokens without proportional signal gain.
+const CORPUS_PROMPT_LIMIT = 100;
 // Synthesis bundles every healthy source document into one prompt and asks
 // for up to DEFAULT_MAX_TOKENS back. The default Anthropic timeout (25s)
 // fits inbox AI drafts but kills synthesis runs that span 30-90s. Confirmed
@@ -221,9 +226,36 @@ ${renderedExamples}
 </APPROVED_REPLY_EXAMPLES>`;
 }
 
+function buildEmailCorpusBlock(
+  corpusEntries: readonly ProjectKnowledgeEntryRecord[],
+): string {
+  if (corpusEntries.length === 0) {
+    return `Here is the corpus of 0 past sent replies from this project's volunteer alias(es), most recent first:
+
+<EMAIL_CORPUS>
+</EMAIL_CORPUS>`;
+  }
+
+  const renderedExamples = corpusEntries
+    .map((entry, index) => {
+      const capturedAt = entry.createdAt.slice(0, 10);
+      const example = entry.maskedExample?.trim() ?? "";
+      return `--- Reply ${String(index + 1)} (sent ${capturedAt}) ---
+${example}`;
+    })
+    .join("\n\n");
+
+  return `Here is the corpus of ${String(corpusEntries.length)} past sent replies from this project's volunteer alias(es), most recent first. Use it to distill tone signals, common volunteer questions, and recurring approved-answer patterns. Volume here is for pattern extraction; do NOT treat any single message as authoritative the way an APPROVED_REPLY_EXAMPLE entry would be — corpus messages are unreviewed historical sends.
+
+<EMAIL_CORPUS>
+${renderedExamples}
+</EMAIL_CORPUS>`;
+}
+
 function buildUserContent(input: {
   readonly healthySources: readonly HealthySourceContent[];
   readonly approvedReplies: readonly ProjectKnowledgeEntryRecord[];
+  readonly corpusEntries: readonly ProjectKnowledgeEntryRecord[];
 }): string {
   const inlineDocs = input.healthySources
     .filter((source) => source.source.kind === "inline_text")
@@ -249,6 +281,7 @@ ${additionalSourcesBlock}`;
   const approvedRepliesNote = buildApprovedReplyExamplesBlock(
     input.approvedReplies,
   );
+  const emailCorpusBlock = buildEmailCorpusBlock(input.corpusEntries);
 
   return `Here is the existing AI Knowledge document for the project:
 
@@ -256,10 +289,7 @@ ${additionalSourcesBlock}`;
 ${existingDoc}
 </EXISTING_DOC>${additionalSourcesNote}
 
-Here is the corpus of 0 past sent replies from this project's volunteer alias(es), most recent first:
-
-<EMAIL_CORPUS>
-</EMAIL_CORPUS>${approvedRepliesNote}
+${emailCorpusBlock}${approvedRepliesNote}
 
 Produce the updated AI Knowledge document per the system instructions. Output ONLY the markdown.`;
 }
@@ -429,6 +459,14 @@ export async function synthesizeProjectKnowledgeOrchestrator(
   const approvedReplies = allApprovedKnowledge
     .filter((entry) => entry.kind === "canonical_reply")
     .slice(0, APPROVED_REPLY_PROMPT_LIMIT);
+  // 2026-05-10: bulk corpus from historical outbounds, backfilled per
+  // project via apps/worker/src/ops/backfill-project-corpus.ts. Lower
+  // training weight than canonical_reply (see system prompt + corpus
+  // block copy) but provides the volume needed for the prompt's
+  // "Common volunteer questions and approved answer patterns" section.
+  const corpusEntries = allApprovedKnowledge
+    .filter((entry) => entry.kind === "corpus_example")
+    .slice(0, CORPUS_PROMPT_LIMIT);
 
   try {
     const model = deps.model ?? DEFAULT_MODEL;
@@ -441,6 +479,7 @@ export async function synthesizeProjectKnowledgeOrchestrator(
           content: buildUserContent({
             healthySources: syncPass.healthySources,
             approvedReplies,
+            corpusEntries,
           }),
         },
       ],

--- a/apps/worker/src/ops/backfill-project-corpus.ts
+++ b/apps/worker/src/ops/backfill-project-corpus.ts
@@ -1,0 +1,275 @@
+#!/usr/bin/env tsx
+/**
+ * backfill-project-corpus
+ *
+ * Seeds the bulk EMAIL_CORPUS training signal for a project by sweeping
+ * historical outbound Gmail replies and writing them as
+ * `project_knowledge_entries` rows with `kind = 'corpus_example'`.
+ *
+ * Why this exists: PRD #366 Phase 3 made canonical_reply (operator-marked
+ * "Send and save for AI") the primary tone-control surface, leaving the
+ * EMAIL_CORPUS block of the synthesis prompt empty by default. With zero
+ * approved canonical replies in any active project (platform pre-launch),
+ * synthesis runs with no tone signal at all — the prompt's section 5
+ * ("Common volunteer questions and approved answer patterns") collapses
+ * to nothing useful. This script bootstraps that signal from history.
+ *
+ * Quality filters (keep them tight; bad backfills poison the AI):
+ *   - direction = outbound, sent from the project's volunteer alias
+ *   - body length 200..3000 chars (excludes one-liners and forwarded threads)
+ *   - last 18 months (recent enough to reflect current voice)
+ *   - PII masked through the shared maskKnowledgeExample primitive
+ *
+ * Idempotent: row id derived from source_evidence_id, so repeat runs upsert
+ * the same id and overwrite (which catches mask-rule changes and drift).
+ *
+ * Usage:
+ *   pnpm --filter @as-comms/worker ops:backfill-project-corpus -- \
+ *     --project=<salesforce_project_id> --alias=<alias_email> [--limit=200] [--execute]
+ *
+ * Dry-run by default. Pass --execute to actually upsert.
+ */
+import process from "node:process";
+
+import { and, desc, eq, gte, sql } from "drizzle-orm";
+
+import {
+  canonicalEventLedger,
+  closeDatabaseConnection,
+  createDatabaseConnection,
+  createStage1RepositoryBundleFromConnection,
+  gmailMessageDetails,
+} from "@as-comms/db";
+import { maskKnowledgeExample } from "@as-comms/domain";
+
+import {
+  parseCliFlags,
+  readOptionalBooleanFlag,
+  readOptionalIntegerFlag,
+  readRequiredFlag,
+} from "./helpers.js";
+
+const DEFAULT_LIMIT = 200;
+const MIN_BODY_LENGTH = 200;
+const MAX_BODY_LENGTH = 3_000;
+const RECENCY_MONTHS = 18;
+
+interface OutboundCandidate {
+  readonly sourceEvidenceId: string;
+  readonly canonicalEventId: string;
+  readonly occurredAt: Date;
+  readonly subject: string | null;
+  readonly bodyText: string;
+}
+
+function readConnectionString(env: NodeJS.ProcessEnv): string {
+  const connectionString = env.WORKER_DATABASE_URL ?? env.DATABASE_URL;
+
+  if (connectionString === undefined || connectionString.trim().length === 0) {
+    throw new Error(
+      "DATABASE_URL or WORKER_DATABASE_URL is required for this ops command.",
+    );
+  }
+
+  return connectionString;
+}
+
+function deriveEntryId(sourceEvidenceId: string): string {
+  // Stable id keyed on source_evidence_id so repeat runs upsert in place.
+  // Shape mirrors the capture path's `project_knowledge:captured:<...>`
+  // namespace but uses a `corpus:` discriminator to make audit/cleanup easy.
+  return `project_knowledge:corpus:${sourceEvidenceId}`;
+}
+
+function buildQuestionSummary(subject: string | null, bodyText: string): string {
+  const trimmedSubject = subject?.trim() ?? "";
+  if (trimmedSubject.length > 0) {
+    return trimmedSubject.slice(0, 200);
+  }
+  // Fall back to first line of body when the subject is empty/missing —
+  // some Gmail captures lose the subject header on threading.
+  const firstLine = bodyText.trim().split("\n").find((line) => line.trim().length > 0);
+  return (firstLine ?? "(historical outbound reply)").slice(0, 200);
+}
+
+async function fetchOutboundCandidates(input: {
+  readonly db: { readonly db: ReturnType<typeof createDatabaseConnection>["db"] };
+  readonly alias: string;
+  readonly limit: number;
+}): Promise<readonly OutboundCandidate[]> {
+  const sinceDate = new Date();
+  sinceDate.setMonth(sinceDate.getMonth() - RECENCY_MONTHS);
+
+  const rows = await input.db.db
+    .select({
+      sourceEvidenceId: gmailMessageDetails.sourceEvidenceId,
+      canonicalEventId: canonicalEventLedger.id,
+      occurredAt: canonicalEventLedger.occurredAt,
+      subject: gmailMessageDetails.subject,
+      bodyText: gmailMessageDetails.bodyTextPreview,
+    })
+    .from(gmailMessageDetails)
+    .innerJoin(
+      canonicalEventLedger,
+      eq(canonicalEventLedger.sourceEvidenceId, gmailMessageDetails.sourceEvidenceId),
+    )
+    .where(
+      and(
+        eq(gmailMessageDetails.direction, "outbound"),
+        eq(gmailMessageDetails.projectInboxAlias, input.alias),
+        gte(canonicalEventLedger.occurredAt, sinceDate),
+        sql`length(${gmailMessageDetails.bodyTextPreview}) BETWEEN ${MIN_BODY_LENGTH} AND ${MAX_BODY_LENGTH}`,
+      ),
+    )
+    .orderBy(desc(canonicalEventLedger.occurredAt))
+    .limit(input.limit);
+
+  return rows.map((row) => ({
+    sourceEvidenceId: row.sourceEvidenceId,
+    canonicalEventId: row.canonicalEventId,
+    occurredAt:
+      row.occurredAt instanceof Date ? row.occurredAt : new Date(row.occurredAt),
+    subject: row.subject,
+    bodyText: row.bodyText,
+  }));
+}
+
+export interface BackfillProjectCorpusResult {
+  readonly projectId: string;
+  readonly alias: string;
+  readonly dryRun: boolean;
+  readonly candidatesScanned: number;
+  readonly upserted: number;
+  readonly skippedEmptyBody: number;
+  readonly runtimeMs: number;
+}
+
+interface RunOptions {
+  readonly projectId: string;
+  readonly alias: string;
+  readonly limit: number;
+  readonly dryRun: boolean;
+  readonly logger?: Pick<Console, "info" | "warn" | "error">;
+}
+
+export async function runBackfillProjectCorpus(
+  options: RunOptions,
+): Promise<BackfillProjectCorpusResult> {
+  const startedAt = Date.now();
+  const logger = options.logger ?? console;
+  const connectionString = readConnectionString(process.env);
+  const connection = createDatabaseConnection({ connectionString });
+  const repositories = createStage1RepositoryBundleFromConnection(connection);
+
+  try {
+    const candidates = await fetchOutboundCandidates({
+      db: connection,
+      alias: options.alias,
+      limit: options.limit,
+    });
+
+    logger.info(
+      `[backfill-project-corpus] project=${options.projectId} alias=${options.alias} ` +
+        `scanned=${String(candidates.length)} dry-run=${String(options.dryRun)}`,
+    );
+
+    let upserted = 0;
+    let skippedEmptyBody = 0;
+
+    for (const candidate of candidates) {
+      const trimmed = candidate.bodyText.trim();
+      if (trimmed.length === 0) {
+        skippedEmptyBody += 1;
+        continue;
+      }
+
+      const masked = maskKnowledgeExample(trimmed);
+      const occurredIso = candidate.occurredAt.toISOString();
+
+      if (options.dryRun) {
+        upserted += 1;
+        continue;
+      }
+
+      await repositories.projectKnowledge.upsert({
+        id: deriveEntryId(candidate.sourceEvidenceId),
+        projectId: options.projectId,
+        kind: "corpus_example",
+        issueType: null,
+        volunteerStage: null,
+        questionSummary: buildQuestionSummary(candidate.subject, trimmed),
+        replyStrategy: null,
+        maskedExample: masked,
+        sourceKind: "captured_from_send",
+        approvedForAi: true,
+        sourceEventId: candidate.canonicalEventId,
+        metadataJson: {
+          backfilledAt: new Date().toISOString(),
+          backfillSource: "backfill-project-corpus",
+          alias: options.alias,
+          subject: candidate.subject,
+          originalBodyLength: trimmed.length,
+        },
+        lastReviewedAt: null,
+        createdAt: occurredIso,
+        updatedAt: new Date().toISOString(),
+      });
+      upserted += 1;
+    }
+
+    return {
+      projectId: options.projectId,
+      alias: options.alias,
+      dryRun: options.dryRun,
+      candidatesScanned: candidates.length,
+      upserted,
+      skippedEmptyBody,
+      runtimeMs: Date.now() - startedAt,
+    };
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}
+
+async function main(): Promise<void> {
+  const flags = parseCliFlags(process.argv.slice(2));
+  const projectId = readRequiredFlag(flags, "project");
+  const alias = readRequiredFlag(flags, "alias");
+  const limit = readOptionalIntegerFlag(flags, "limit", DEFAULT_LIMIT);
+  const execute = readOptionalBooleanFlag(flags, "execute", false);
+
+  if (limit <= 0 || limit > 1_000) {
+    console.error("--limit must be between 1 and 1000.");
+    process.exit(2);
+  }
+
+  const result = await runBackfillProjectCorpus({
+    projectId,
+    alias,
+    limit,
+    dryRun: !execute,
+  });
+
+  console.error(
+    `[backfill-project-corpus] done project=${result.projectId} ` +
+      `alias=${result.alias} ` +
+      `scanned=${String(result.candidatesScanned)} ` +
+      `upserted=${String(result.upserted)} ` +
+      `skipped_empty=${String(result.skippedEmptyBody)} ` +
+      `dry_run=${String(result.dryRun)} ` +
+      `runtime_ms=${String(result.runtimeMs)}`,
+  );
+
+  if (result.dryRun) {
+    console.error(
+      "[backfill-project-corpus] dry-run: no rows written. Re-run with --execute to persist.",
+    );
+  }
+}
+
+if (process.argv[1]?.endsWith("backfill-project-corpus.ts")) {
+  void main().catch((error: unknown) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/apps/worker/test/synthesize-project-knowledge-orchestrator.test.ts
+++ b/apps/worker/test/synthesize-project-knowledge-orchestrator.test.ts
@@ -690,4 +690,162 @@ describe("synthesizeProjectKnowledgeOrchestrator", () => {
     expect(prompt).not.toContain("SNIPPET_BODY");
     expect(prompt).not.toContain("PATTERN_BODY");
   });
+
+  it("renders corpus_example entries into the EMAIL_CORPUS block separately from canonical replies", async () => {
+    const project = buildProject();
+    const sources = [
+      buildSource({
+        id: "11111111-1111-4111-8111-111111111111",
+        kind: "inline_text",
+        url: "https://example.test/inline-1",
+      }),
+    ];
+    const approvedEntries = [
+      buildApprovedReply({
+        id: "approved:1",
+        maskedExample: "CANONICAL_REPLY_TONE",
+        createdAt: "2026-05-08T12:00:00.000Z",
+        kind: "canonical_reply",
+      }),
+      buildApprovedReply({
+        id: "corpus:1",
+        maskedExample: "Hi {NAME}, thanks for the field-data submission.",
+        createdAt: "2026-04-22T08:30:00.000Z",
+        kind: "corpus_example",
+      }),
+      buildApprovedReply({
+        id: "corpus:2",
+        maskedExample: "Welcome aboard {NAME}! Kit ships next week.",
+        createdAt: "2026-04-21T08:30:00.000Z",
+        kind: "corpus_example",
+      }),
+    ];
+    const invokeModel = vi.fn().mockResolvedValue(buildDraftResult("# Synthesized"));
+
+    await synthesizeProjectKnowledgeOrchestrator(
+      {
+        repositories: {
+          projectDimensions: {
+            findById: vi.fn().mockResolvedValue(project),
+            getAiKnowledgeSources: vi.fn().mockResolvedValue(sources),
+            setAiKnowledgeSources: vi.fn().mockResolvedValue(undefined),
+          },
+          projectKnowledge: { list: vi.fn().mockResolvedValue(approvedEntries) },
+        },
+        fetchers: {
+          inline_text: { fetch: vi.fn().mockResolvedValue(healthyContent("Inline operator context")) },
+          notion: { fetch: vi.fn() },
+          web_page: { fetch: vi.fn() },
+        },
+        invokeModel,
+      },
+      {
+        projectId: project.projectId,
+      },
+    );
+
+    const prompt = readPromptFromInvokeModelMock(invokeModel);
+    // EMAIL_CORPUS block is now populated with corpus_example rows
+    expect(prompt).toContain("<EMAIL_CORPUS>");
+    expect(prompt).toContain("</EMAIL_CORPUS>");
+    expect(prompt).toContain("2 past sent replies");
+    expect(prompt).toContain(
+      "Hi {NAME}, thanks for the field-data submission.",
+    );
+    expect(prompt).toContain("Welcome aboard {NAME}! Kit ships next week.");
+    expect(prompt).toContain("--- Reply 1 (sent 2026-04-22) ---");
+    // Canonical reply still goes in its own dedicated higher-weight block
+    expect(prompt).toContain("<APPROVED_REPLY_EXAMPLES>");
+    expect(prompt).toContain("CANONICAL_REPLY_TONE");
+    // Anti-leak: corpus_example bodies should not appear in the canonical
+    // block's authoritative weighting copy
+    expect(prompt).toContain("1 canonical reply examples");
+  });
+
+  it("renders an empty EMAIL_CORPUS block when no corpus_example rows exist", async () => {
+    const project = buildProject();
+    const sources = [
+      buildSource({
+        id: "11111111-1111-4111-8111-111111111111",
+        kind: "inline_text",
+        url: "https://example.test/inline-1",
+      }),
+    ];
+    const invokeModel = vi.fn().mockResolvedValue(buildDraftResult("# Synthesized"));
+
+    await synthesizeProjectKnowledgeOrchestrator(
+      {
+        repositories: {
+          projectDimensions: {
+            findById: vi.fn().mockResolvedValue(project),
+            getAiKnowledgeSources: vi.fn().mockResolvedValue(sources),
+            setAiKnowledgeSources: vi.fn().mockResolvedValue(undefined),
+          },
+          projectKnowledge: { list: vi.fn().mockResolvedValue([]) },
+        },
+        fetchers: {
+          inline_text: { fetch: vi.fn().mockResolvedValue(healthyContent("Inline operator context")) },
+          notion: { fetch: vi.fn() },
+          web_page: { fetch: vi.fn() },
+        },
+        invokeModel,
+      },
+      {
+        projectId: project.projectId,
+      },
+    );
+
+    const prompt = readPromptFromInvokeModelMock(invokeModel);
+    expect(prompt).toContain("0 past sent replies");
+    expect(prompt).toContain("<EMAIL_CORPUS>\n</EMAIL_CORPUS>");
+  });
+
+  it("caps the EMAIL_CORPUS block at the 100 most recently returned corpus_example rows", async () => {
+    const project = buildProject();
+    const sources = [
+      buildSource({
+        id: "11111111-1111-4111-8111-111111111111",
+        kind: "inline_text",
+        url: "https://example.test/inline-1",
+      }),
+    ];
+    const corpusEntries = Array.from({ length: 120 }, (_, index) =>
+      buildApprovedReply({
+        id: `corpus:${String(index)}`,
+        maskedExample: `CORPUS_BODY_${String(index)}`,
+        createdAt: "2026-04-22T08:30:00.000Z",
+        kind: "corpus_example",
+      }),
+    );
+    const invokeModel = vi.fn().mockResolvedValue(buildDraftResult("# Synthesized"));
+
+    await synthesizeProjectKnowledgeOrchestrator(
+      {
+        repositories: {
+          projectDimensions: {
+            findById: vi.fn().mockResolvedValue(project),
+            getAiKnowledgeSources: vi.fn().mockResolvedValue(sources),
+            setAiKnowledgeSources: vi.fn().mockResolvedValue(undefined),
+          },
+          projectKnowledge: { list: vi.fn().mockResolvedValue(corpusEntries) },
+        },
+        fetchers: {
+          inline_text: { fetch: vi.fn().mockResolvedValue(healthyContent("Inline operator context")) },
+          notion: { fetch: vi.fn() },
+          web_page: { fetch: vi.fn() },
+        },
+        invokeModel,
+      },
+      {
+        projectId: project.projectId,
+      },
+    );
+
+    const prompt = readPromptFromInvokeModelMock(invokeModel);
+    expect(prompt).toContain("100 past sent replies");
+    expect(prompt).toContain("CORPUS_BODY_0");
+    expect(prompt).toContain("CORPUS_BODY_99");
+    expect(prompt).not.toContain("CORPUS_BODY_100");
+    expect(prompt).not.toContain("CORPUS_BODY_119");
+  });
 });

--- a/packages/contracts/src/stage1-records.ts
+++ b/packages/contracts/src/stage1-records.ts
@@ -227,7 +227,12 @@ export type AiKnowledgeEntryRecord = z.infer<typeof aiKnowledgeEntrySchema>;
 export const projectKnowledgeEntrySchema = z.object({
   id: idSchema,
   projectId: z.string().min(1),
-  kind: z.enum(["canonical_reply", "snippet", "pattern"]),
+  // corpus_example added 2026-05-10: bulk historical outbound replies
+  // backfilled per project to populate the EMAIL_CORPUS block in the
+  // synthesis prompt. Lower training weight than canonical_reply
+  // (which represents operator-endorsed exemplars). See PRD #366 +
+  // backfill-project-corpus ops script.
+  kind: z.enum(["canonical_reply", "snippet", "pattern", "corpus_example"]),
   issueType: nullableStringSchema.default(null),
   volunteerStage: nullableStringSchema.default(null),
   questionSummary: z.string().min(1),

--- a/packages/db/src/schema/tables.ts
+++ b/packages/db/src/schema/tables.ts
@@ -1121,7 +1121,7 @@ export const projectKnowledgeEntries = pgTable(
     id: text("id").primaryKey(),
     projectId: text("project_id").notNull(),
     kind: text("kind")
-      .$type<"canonical_reply" | "snippet" | "pattern">()
+      .$type<"canonical_reply" | "snippet" | "pattern" | "corpus_example">()
       .notNull(),
     issueType: text("issue_type"),
     volunteerStage: text("volunteer_stage"),

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -5,6 +5,7 @@ export * from "./notes.js";
 export * from "./normalization.js";
 export * from "./outbound-email-dedup.js";
 export * from "./pending-outbounds.js";
+export * from "./pii-mask.js";
 export * from "./phone.js";
 export * from "./readiness.js";
 export * from "./persistence.js";

--- a/packages/domain/src/pii-mask.ts
+++ b/packages/domain/src/pii-mask.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared PII masker for replies stored as AI training data
+ * (canonical_reply and corpus_example rows in project_knowledge_entries).
+ *
+ * Rules match the canonical-reply capture path that has been live since
+ * Phase 3 of PRD #366 (apps/web/app/inbox/actions.ts maskKnowledgeExample).
+ * Extracted 2026-05-10 so the backfill ops script that builds the bulk
+ * email corpus can reuse the exact same masking surface — anything stored
+ * as project knowledge passes through this single function.
+ *
+ * Kept deliberately conservative:
+ *   - Email addresses → `{EMAIL}`
+ *   - Phone numbers (US-style 10-digit) → `{PHONE}`
+ *   - Probable person names (sequences of capitalised tokens, 2-4 words) → `{NAME}`
+ *
+ * Intentionally NOT masked:
+ *   - Project terminology (species names, geography, app names, dates,
+ *     elevations) — these are project-specific signal, not PII.
+ *   - Single capitalised words (would over-mask common English: "Monday",
+ *     "Pacific", project names that legitimately appear in tone signal).
+ *   - Greetings and sign-offs — Claude needs these to learn voice.
+ */
+export function maskKnowledgeExample(value: string): string {
+  return value
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/giu, "{EMAIL}")
+    .replace(/\+?1?[\s.-]?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}/gu, "{PHONE}")
+    .replace(/\b[A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,3}\b/gu, "{NAME}");
+}

--- a/packages/domain/test/pii-mask.test.ts
+++ b/packages/domain/test/pii-mask.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { maskKnowledgeExample } from "../src/pii-mask.js";
+
+describe("maskKnowledgeExample", () => {
+  it("replaces email addresses with {EMAIL}", () => {
+    expect(maskKnowledgeExample("Reach out to volunteer.lead@example.com")).toBe(
+      "Reach out to {EMAIL}",
+    );
+    expect(
+      maskKnowledgeExample("Cc: support@adventurescientists.org and ops@asc.io"),
+    ).toBe("Cc: {EMAIL} and {EMAIL}");
+  });
+
+  it("replaces US-format phone numbers with {PHONE}", () => {
+    // The phone regex's leading [\s.-]? consumes the separator before the
+    // area code, so "Call (415) 555-0123" collapses to "Call{PHONE}". That's
+    // intentional — PII removal is the priority, spacing is cosmetic.
+    expect(maskKnowledgeExample("Call (415) 555-0123 or 415.555.0124")).toBe(
+      "Call{PHONE} or{PHONE}",
+    );
+    expect(maskKnowledgeExample("Reach me at 4155550125")).toBe(
+      "Reach me at{PHONE}",
+    );
+    // When the match starts on `+1` the leading space stays put because
+    // the regex's [\s.-]? is between the country code and the area code,
+    // not at the head of the match.
+    expect(maskKnowledgeExample("Try +1 415-555-0126 anytime")).toBe(
+      "Try {PHONE} anytime",
+    );
+  });
+
+  it("replaces probable person names (2-4 capitalised tokens in a row)", () => {
+    // Note: "Hi Anna Schmidt" is itself a sequence of 3 capitalised tokens,
+    // so the regex matches it as a single {NAME}. This is conservative
+    // over-masking by design — better to lose the greeting word than to
+    // leak a real name. Operator copy that wants to preserve "Hi" should
+    // be authored without the trailing capitalised name (rare).
+    expect(maskKnowledgeExample("Hi Anna Schmidt, thanks for joining")).toBe(
+      "{NAME}, thanks for joining",
+    );
+    expect(maskKnowledgeExample("Best, Cooper Smith Jr")).toBe("Best, {NAME}");
+    // When the leading lowercase word breaks the capitalised run, the
+    // greeting survives.
+    expect(maskKnowledgeExample("hi Anna Schmidt, glad you joined")).toBe(
+      "hi {NAME}, glad you joined",
+    );
+  });
+
+  it("preserves single capitalised words so it doesn't over-mask common nouns", () => {
+    // Single-token capitalised words like Monday, Pacific, Whitebark should
+    // pass through unchanged — they're project signal, not PII.
+    const sample =
+      "Monday is the deadline. Pacific Northwest crews report on Whitebark.";
+    const masked = maskKnowledgeExample(sample);
+    expect(masked).toContain("Monday");
+    expect(masked).toContain("Whitebark");
+    // "Pacific Northwest" is two capitalised tokens in a row and DOES get
+    // caught by the {NAME} regex — that's a known and acceptable limitation;
+    // the project signal still survives via the rest of the sentence and the
+    // operator-curated source documents.
+    expect(masked).toContain("{NAME}");
+  });
+
+  it("is composable — leaves project terminology like dates and elevations alone", () => {
+    const sample =
+      "On 2026-05-13 we deploy ARUs at 2400m elevation. Send to acoustic-pacific@example.com.";
+    const masked = maskKnowledgeExample(sample);
+    expect(masked).toContain("2026-05-13");
+    expect(masked).toContain("2400m");
+    expect(masked).toContain("ARUs");
+    expect(masked).toContain("{EMAIL}");
+    expect(masked).not.toContain("acoustic-pacific@example.com");
+  });
+
+  it("returns the input unchanged when there is nothing to mask", () => {
+    const sample = "the deadline is Monday at 2400m elevation";
+    expect(maskKnowledgeExample(sample)).toBe(sample);
+  });
+});


### PR DESCRIPTION
## Summary

Pre-launch the platform has **zero approved `canonical_reply` rows** across every active project (verified via prod read 2026-05-10). Synthesis therefore runs with two empty signals: the `APPROVED_REPLY_EXAMPLES` block has nothing to weight, and the `EMAIL_CORPUS` block was hardcoded to `0 past sent replies` + an empty `<EMAIL_CORPUS></EMAIL_CORPUS>`. The synthesis prompt's section 5 ("Common volunteer questions and approved answer patterns. 8–15 clusters ordered by frequency") had nothing to extract from.

This adds a bulk-corpus path that bootstraps tone signal from historical operator-sent outbounds while keeping `canonical_reply` as the curated higher-weight surface operators steer going forward via "Send and save for AI."

## What's available to backfill (verified)

| Project | Alias | Outbound total | Sweet spot 200–3000 chars |
|---|---|---:|---:|
| PNW Biodiversity | pnwbio@ | 1,115 | 976 |
| Whitebark Pine | whitebarkpine@ | 220 | 185 |
| Killer Whales | orcas@ | 171 | 155 |
| Beech & Butternut | (forests@, pre-launch) | 0 | 0 |

## Changes

### Schema
- New `project_knowledge_entries.kind` value `corpus_example`, added to the contracts Zod enum and the drizzle column type union. No DB migration: `kind` is plain text, only TypeScript/Zod surfaces learned the value.

### Synthesis orchestrator (`apps/worker/src/jobs/synthesize-project-knowledge/orchestrator.ts`)
- New `buildEmailCorpusBlock` renders `corpus_example` rows into the `EMAIL_CORPUS` block with a "do NOT treat any single message as authoritative" weighting note.
- `CORPUS_PROMPT_LIMIT = 100` caps prompt rendering. Pulled from the same `allApprovedKnowledge.list` call already used for canonical replies, filtered separately by `kind`.
- Three new orchestrator tests cover: corpus block populates, empty block when no rows, 100-row cap.

### Backfill ops script (`apps/worker/src/ops/backfill-project-corpus.ts`)
- Pulls outbound `gmail_message_details` rows for a given project alias, last 18 months, body length 200–3000 chars (excludes one-liners and forwarded threads), upserts as `corpus_example` with `approved_for_ai=true` and a stable id keyed on `source_evidence_id` for idempotent re-runs.
- PII masked through the shared masker.
- Dry-run by default; `--execute` persists.
- pnpm script: `pnpm --filter @as-comms/worker ops:backfill-project-corpus`

### Shared PII masker (`packages/domain/src/pii-mask.ts`)
- Extracted `maskKnowledgeExample` from `apps/web/app/inbox/actions.ts` so the backfill script reuses the exact same masking primitives the live capture path uses.
- New test file documents the regex's known over-mask cases (leading whitespace eaten by phone separators; "Hi <Name>" folded into `{NAME}`) — privacy-favoring behavior, intentional.

### Bonus bug fix (capture path, `apps/web/app/inbox/actions.ts`)
- Discovered while wiring this PR: the live capture path was upserting `canonical_reply` with `maskedExample = input.bodyPlaintext` — **raw body**, not masked. The column is named `masked_example` for a reason; synthesis reads it expecting masked PII. Now applies the masker before upsert. Existing rows have raw PII in that column; not fixing retroactively because there are 0 such rows in prod.

## Cost

With 3 active projects on the recommended **weekly** auto-sync schedule:
- ~25k extra input tokens per run × 12 runs/month ≈ **+$2.70/month**
- Total synthesis ≈ **$3.60/month** with corpus uplift
- Well within the $10 test-budget cap.

## Operator action after merge

Run the backfill once per project from architect machine:

```
pnpm --filter @as-comms/worker ops:backfill-project-corpus -- \
  --project=a0tVK00000AeJqzYAF --alias=pnwbio@adventurescientists.org --execute

pnpm --filter @as-comms/worker ops:backfill-project-corpus -- \
  --project=a0tVK00000BV3GDYA1 --alias=whitebarkpine@adventurescientists.org --execute

pnpm --filter @as-comms/worker ops:backfill-project-corpus -- \
  --project=a0tVK00000EG0jyYAD --alias=orcas@adventurescientists.org --execute
```

Then click **Re-sync all** on each project's AI Knowledge section to fold the new corpus into the synthesized document.

## Test plan

- [x] `pnpm -C packages/contracts typecheck` + lint
- [x] `pnpm -C packages/domain typecheck` + lint + `test:unit` (103 pass, including new 6 masker tests)
- [x] `pnpm -C packages/db typecheck` + lint + `test:unit` (117 pass)
- [x] `pnpm -C packages/integrations typecheck` + lint + `test:unit` (151 pass)
- [x] `pnpm -C apps/worker typecheck` + lint + `test:unit` (179 pass, including 3 new orchestrator tests)
- [x] `pnpm -C apps/web typecheck` + lint + `test:unit` (535 pass / 5 skipped)
- [x] `node scripts/boundary-check.mjs`
- [ ] Post-merge: run backfill ops script per project, then trigger Re-sync all, confirm `Last synthesized` advances and the synthesized doc's section 5 is populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)