### PR TITLE
feat(connected-projects): AI knowledge fallback + host/sub rendering on rail/row/header

### DIFF
--- a/apps/web/app/inbox/_components/inbox-contact-rail.tsx
+++ b/apps/web/app/inbox/_components/inbox-contact-rail.tsx
@@ -214,6 +214,11 @@ function ProjectsSection({ title, projects, emptyLabel }: ProjectsSectionProps) 
                   <p className="truncate text-[13px] font-medium text-slate-800 group-hover:text-slate-900">
                     {project.projectName}
                   </p>
+                  {project.subDisplayName === null ? null : (
+                    <p className="mt-0.5 truncate text-[11px] text-slate-400">
+                      via {project.subDisplayName}
+                    </p>
+                  )}
                   <p className="mt-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
                     <InboxProjectStatusBadge
                       status={project.status}
@@ -240,7 +245,7 @@ function ProjectsSection({ title, projects, emptyLabel }: ProjectsSectionProps) 
                     target="_blank"
                     rel="noreferrer"
                     className={`${rowClassName} hover:bg-white hover:ring-1 hover:ring-slate-200`}
-                    aria-label={`Open ${project.projectName} expedition member record in Salesforce`}
+                    aria-label={`Open ${project.subDisplayName ?? project.projectName} expedition member record in Salesforce`}
                   >
                     {content}
                   </a>

--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -354,10 +354,20 @@ export function InboxDetail({ detail, timelineSlot }: DetailProps) {
                         "inline-flex shrink-0 items-center rounded px-1.5 py-px text-[10px] font-medium",
                         PROJECT_STATUS_BADGE[project.status],
                       )}
+                      title={
+                        project.subDisplayName === null
+                          ? undefined
+                          : `${project.projectName} (via ${project.subDisplayName})`
+                      }
                     >
                       <span className="max-w-[160px] truncate">
                         {project.projectName}
                       </span>
+                      {project.subDisplayName === null ? null : (
+                        <span className="ml-1 max-w-[120px] truncate opacity-70">
+                          via {project.subDisplayName}
+                        </span>
+                      )}
                       <span className="mx-1 opacity-60">›</span>
                       <span className="whitespace-nowrap">
                         {project.statusLabel}
@@ -368,9 +378,18 @@ export function InboxDetail({ detail, timelineSlot }: DetailProps) {
               ) : detail.conversationProject ? (
                 <span
                   className="mt-0.5 block min-w-0 truncate text-[12px] font-medium leading-none text-slate-500"
-                  title="Via project alias"
+                  title={
+                    detail.conversationProject.subProjectName === null
+                      ? "Via project alias"
+                      : `${detail.conversationProject.projectName} (via ${detail.conversationProject.subProjectName})`
+                  }
                 >
                   {detail.conversationProject.projectName}
+                  {detail.conversationProject.subProjectName === null ? null : (
+                    <span className="ml-1 text-slate-400">
+                      via {detail.conversationProject.subProjectName}
+                    </span>
+                  )}
                 </span>
               ) : (
                 <span className="text-xs text-slate-400">

--- a/apps/web/app/inbox/_components/inbox-row.tsx
+++ b/apps/web/app/inbox/_components/inbox-row.tsx
@@ -127,8 +127,22 @@ export function InboxRow({ item, isActive }: RowProps) {
           {showBadges ? (
             <div className="mt-2 flex items-center gap-1.5">
               {item.projectLabel ? (
-                <span className="inline-flex items-center rounded bg-slate-100 px-1.5 py-0.5 text-[10px] text-slate-600">
-                  {item.projectLabel}
+                <span
+                  className={`inline-flex items-center rounded bg-slate-100 px-1.5 py-0.5 text-[10px] text-slate-600 ${
+                    item.projectSubLabel === null ? "" : "gap-1"
+                  }`}
+                  title={
+                    item.projectSubLabel === null
+                      ? undefined
+                      : `${item.projectLabel} (via ${item.projectSubLabel})`
+                  }
+                >
+                  <span>{item.projectLabel}</span>
+                  {item.projectSubLabel === null ? null : (
+                    <span className="text-slate-400">
+                      via {item.projectSubLabel}
+                    </span>
+                  )}
                 </span>
               ) : null}
               {showAsBadge ? (

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -70,6 +70,32 @@ type InboxDetailProjection = Omit<
   readonly lastEventType: CanonicalEventRecord["eventType"] | null;
 };
 
+/**
+ * Per-project metadata used by the inbox row, conversation header, and
+ * contact rail to label and route project chips. The connected-projects
+ * fields (`connectedToProjectId`, `hostProjectName`) are populated only
+ * when the project rolls up into a host (per PR #384). Standalone or host
+ * projects leave both `null` so the chip renders as a single-line label.
+ */
+type ProjectMetadataEntry = {
+  readonly projectName: string;
+  readonly isActive: boolean;
+  /**
+   * `project_dimensions.connected_to_project_id` for connected sub-projects;
+   * `null` for standalone or host rows.
+   */
+  readonly connectedToProjectId: string | null;
+  /**
+   * Display name to show as the primary chip label when the project is a
+   * connected sub. Equals the host's resolved alias-or-name (so the chip
+   * reads "Beech & Butternut" for a Beech-only volunteer). `null` for
+   * standalone or host projects.
+   */
+  readonly hostProjectName: string | null;
+};
+
+type ProjectMetadataIndex = Readonly<Record<string, ProjectMetadataEntry>>;
+
 function findNewestCanonicalEvent(
   events: readonly CanonicalEventRecord[],
 ): CanonicalEventRecord | null {
@@ -120,15 +146,7 @@ interface InboxListCacheRow {
 interface InboxListCacheData {
   readonly rows: readonly InboxListCacheRow[];
   readonly projectLabelById: Readonly<Record<string, string>>;
-  readonly projectMetadataById: Readonly<
-    Record<
-      string,
-      {
-        readonly projectName: string;
-        readonly isActive: boolean;
-      }
-    >
-  >;
+  readonly projectMetadataById: ProjectMetadataIndex;
   readonly aliasToProjectId: ReadonlyMap<string, string>;
   readonly counts: {
     readonly inbox: number;
@@ -167,15 +185,7 @@ interface InboxDetailCacheData {
     Record<string, CampaignActivitySummary>
   >;
   readonly canonicalEventById: ReadonlyMap<string, CanonicalEventRecord>;
-  readonly projectMetadataById: Readonly<
-    Record<
-      string,
-      {
-        readonly projectName: string;
-        readonly isActive: boolean;
-      }
-    >
-  >;
+  readonly projectMetadataById: ProjectMetadataIndex;
   readonly salesforceEventContextBySourceEvidenceId: ReadonlyMap<
     string,
     {
@@ -206,15 +216,7 @@ interface InboxDetailSummaryCacheData {
   } | null;
   readonly activityTimelineItems: readonly TimelineItem[];
   readonly canonicalEventById: ReadonlyMap<string, CanonicalEventRecord>;
-  readonly projectMetadataById: Readonly<
-    Record<
-      string,
-      {
-        readonly projectName: string;
-        readonly isActive: boolean;
-      }
-    >
-  >;
+  readonly projectMetadataById: ProjectMetadataIndex;
   readonly salesforceEventContextBySourceEvidenceId: ReadonlyMap<
     string,
     {
@@ -840,7 +842,20 @@ function mapVolunteerStage(
  */
 export interface ResolvedPrimaryProject {
   readonly projectId: string;
+  /**
+   * The chip's primary text. For a connected sub this is the host's display
+   * name (so the chip reads "Beech & Butternut"); for standalone or host
+   * projects it's the project's own name.
+   */
   readonly projectName: string;
+  /**
+   * Sub-project's own name when the resolved project is a connected sub,
+   * so the renderer can place "via {subProjectName}" beneath the primary
+   * label. `null` for standalone / host projects.
+   */
+  readonly subProjectName: string | null;
+  /** Mirrors {@link InboxProjectMembershipViewModel.isConnectedSub}. */
+  readonly isConnectedSub: boolean;
   /**
    * "membership" — derived from an active membership (preferred path).
    * "conversation" — fell through to the latest SF lifecycle event's project
@@ -874,15 +889,7 @@ export interface ResolvedPrimaryProject {
  */
 export function resolvePrimaryProjectForContact(input: {
   readonly memberships: readonly ContactMembershipRecord[];
-  readonly projectMetadataById: Readonly<
-    Record<
-      string,
-      {
-        readonly projectName: string;
-        readonly isActive: boolean;
-      }
-    >
-  >;
+  readonly projectMetadataById: ProjectMetadataIndex;
   readonly lastOccurredAtByProjectId: ReadonlyMap<string, string>;
   readonly conversationProjectFallback: {
     readonly projectId: string;
@@ -906,21 +913,43 @@ export function resolvePrimaryProjectForContact(input: {
   const primary = sortedActive[0] ?? null;
 
   if (primary !== null && primary.projectId !== null) {
-    const projectName =
-      input.projectMetadataById[primary.projectId]?.projectName ??
-      primary.projectId;
+    const metadata = input.projectMetadataById[primary.projectId];
+    const ownName = metadata?.projectName ?? primary.projectId;
+    const isConnectedSub =
+      metadata?.connectedToProjectId !== undefined &&
+      metadata.connectedToProjectId !== null &&
+      metadata.hostProjectName !== null;
 
     return {
       projectId: primary.projectId,
-      projectName,
+      projectName: isConnectedSub
+        ? (metadata?.hostProjectName ?? ownName)
+        : ownName,
+      subProjectName: isConnectedSub ? ownName : null,
+      isConnectedSub,
       source: "membership",
     };
   }
 
   if (input.conversationProjectFallback !== null) {
+    const fallbackId = input.conversationProjectFallback.projectId;
+    const metadata = input.projectMetadataById[fallbackId];
+    // For the conversation-fallback path the caller already resolved the
+    // sub's own name (via the metadata index → `projectName`). Reuse that
+    // as the chip's secondary line when the project is a connected sub.
+    const isConnectedSub =
+      metadata?.connectedToProjectId !== undefined &&
+      metadata.connectedToProjectId !== null &&
+      metadata.hostProjectName !== null;
+    const ownName = input.conversationProjectFallback.projectName;
+
     return {
-      projectId: input.conversationProjectFallback.projectId,
-      projectName: input.conversationProjectFallback.projectName,
+      projectId: fallbackId,
+      projectName: isConnectedSub
+        ? (metadata?.hostProjectName ?? ownName)
+        : ownName,
+      subProjectName: isConnectedSub ? ownName : null,
+      isConnectedSub,
       source: "conversation",
     };
   }
@@ -997,32 +1026,40 @@ function mapProjectStatusLabel(status: string | null): string {
 
 function buildProjectMembershipViewModel(
   membership: ContactMembershipRecord,
-  projectMetadataById: Readonly<
-    Record<
-      string,
-      {
-        readonly projectName: string;
-        readonly isActive: boolean;
-      }
-    >
-  >,
+  projectMetadataById: ProjectMetadataIndex,
 ): InboxProjectMembershipViewModel | null {
-  const projectName =
+  const metadata =
+    membership.projectId === null
+      ? undefined
+      : projectMetadataById[membership.projectId];
+  const ownName =
     membership.projectId === null
       ? null
-      : (projectMetadataById[membership.projectId]?.projectName ??
-        membership.projectId);
+      : (metadata?.projectName ?? membership.projectId);
 
-  if (projectName === null || membership.projectId === null) {
+  if (ownName === null || membership.projectId === null) {
     return null;
   }
+
+  // Connected-sub display: PR #388 keeps the sub's own row (with its own
+  // alias-or-name in `metadata.projectName`) and the host's display name in
+  // `metadata.hostProjectName`. Only flip into the two-line layout when
+  // the host's name actually resolved — otherwise fall back to the sub's
+  // own name as a single-line label so we never render an empty primary.
+  const isConnectedSub =
+    metadata?.connectedToProjectId !== undefined &&
+    metadata.connectedToProjectId !== null &&
+    metadata.hostProjectName !== null;
 
   return {
     membershipId: membership.id,
     projectId: membership.projectId,
-    projectName,
-    projectIsActive:
-      projectMetadataById[membership.projectId]?.isActive ?? false,
+    projectName: isConnectedSub
+      ? (metadata?.hostProjectName ?? ownName)
+      : ownName,
+    subDisplayName: isConnectedSub ? ownName : null,
+    isConnectedSub,
+    projectIsActive: metadata?.isActive ?? false,
     status: mapProjectStatus(membership.status),
     statusLabel: mapProjectStatusLabel(membership.status),
     crmUrl: `https://adventurescientists.lightning.force.com/lightning/r/Project__c/${encodeURIComponent(
@@ -1038,15 +1075,7 @@ function buildProjectMembershipViewModel(
 
 function isPastProject(
   membership: ContactMembershipRecord,
-  projectMetadataById: Readonly<
-    Record<
-      string,
-      {
-        readonly projectName: string;
-        readonly isActive: boolean;
-      }
-    >
-  >,
+  projectMetadataById: ProjectMetadataIndex,
 ): boolean {
   if (membership.projectId === null) {
     return true;
@@ -2877,17 +2906,7 @@ async function loadProjectMetadataById(
    * sent FROM a project alias).
    */
   extraProjectIds: readonly (string | null | undefined)[] = [],
-): Promise<
-  Readonly<
-    Record<
-      string,
-      {
-        readonly projectName: string;
-        readonly isActive: boolean;
-      }
-    >
-  >
-> {
+): Promise<ProjectMetadataIndex> {
   const projectIds = uniqueStrings([
     ...memberships.map((membership) => membership.projectId),
     ...extraProjectIds,
@@ -2901,29 +2920,53 @@ async function loadProjectMetadataById(
   const dimensions =
     await runtime.repositories.projectDimensions.listByIds(projectIds);
 
+  // Connected-projects rollup (PR #384 + #388): if any of the requested
+  // dimensions points at a host via `connected_to_project_id`, fetch that
+  // host's row in a second batch query so the renderer can label the chip
+  // with the host's display name. One extra IN(...) per page render is
+  // cheap and preserves the existing batch-loading pattern.
+  const hostIds = Array.from(
+    new Set(
+      dimensions
+        .map((dimension) => dimension.connectedToProjectId ?? null)
+        .filter((id): id is string => id !== null && !projectIds.includes(id)),
+    ),
+  );
+  const hostDimensions =
+    hostIds.length === 0
+      ? []
+      : await runtime.repositories.projectDimensions.listByIds(hostIds);
+  const hostNameById = new Map<string, string>();
+  for (const host of [...dimensions, ...hostDimensions]) {
+    hostNameById.set(
+      host.projectId,
+      host.projectAlias?.trim().length ? host.projectAlias : host.projectName,
+    );
+  }
+
   return Object.fromEntries(
-    dimensions.map((dimension) => [
-      dimension.projectId,
-      {
-        projectName: dimension.projectAlias?.trim().length
-          ? dimension.projectAlias
-          : dimension.projectName,
-        isActive: dimension.isActive ?? false,
-      },
-    ]),
+    dimensions.map((dimension) => {
+      const connectedTo = dimension.connectedToProjectId ?? null;
+      return [
+        dimension.projectId,
+        {
+          projectName: dimension.projectAlias?.trim().length
+            ? dimension.projectAlias
+            : dimension.projectName,
+          isActive: dimension.isActive ?? false,
+          connectedToProjectId: connectedTo,
+          hostProjectName:
+            connectedTo === null
+              ? null
+              : (hostNameById.get(connectedTo) ?? null),
+        } satisfies ProjectMetadataEntry,
+      ];
+    }),
   );
 }
 
 function buildProjectLabelById(
-  projectMetadataById: Readonly<
-    Record<
-      string,
-      {
-        readonly projectName: string;
-        readonly isActive: boolean;
-      }
-    >
-  >,
+  projectMetadataById: ProjectMetadataIndex,
 ): Readonly<Record<string, string>> {
   return Object.fromEntries(
     Object.entries(projectMetadataById).map(([projectId, metadata]) => [
@@ -2936,15 +2979,7 @@ function buildProjectLabelById(
 function countAdditionalActiveProjects(input: {
   readonly memberships: readonly ContactMembershipRecord[];
   readonly primaryProjectId: string | null;
-  readonly projectMetadataById: Readonly<
-    Record<
-      string,
-      {
-        readonly projectName: string;
-        readonly isActive: boolean;
-      }
-    >
-  >;
+  readonly projectMetadataById: ProjectMetadataIndex;
 }): number {
   const primaryProjectId = input.primaryProjectId;
   const additionalActiveProjectIds = new Set<string>();
@@ -4122,6 +4157,7 @@ function toListItemViewModel(
       fallbackLatestSubject(row.inboxProjection.lastEventType),
     latestChannel: mapChannel(row.inboxProjection.lastEventType),
     projectLabel: primaryProject?.projectName ?? null,
+    projectSubLabel: primaryProject?.subProjectName ?? null,
     additionalActiveProjectsCount: countAdditionalActiveProjects({
       memberships: row.memberships,
       primaryProjectId: primaryProject?.projectId ?? null,
@@ -4161,15 +4197,7 @@ function buildContactSummary(input: {
     readonly createdAt: string;
   } | null;
   readonly activityTimelineItems: readonly TimelineItem[];
-  readonly projectMetadataById: Readonly<
-    Record<
-      string,
-      {
-        readonly projectName: string;
-        readonly isActive: boolean;
-      }
-    >
-  >;
+  readonly projectMetadataById: ProjectMetadataIndex;
   readonly referenceNowIso: string;
 }): InboxContactSummaryViewModel {
   const projectActivityIndex = buildProjectActivityIndex(
@@ -4246,15 +4274,7 @@ function deriveConversationProjectFallbackFromTimeline(input: {
       readonly projectId: string | null;
     }
   >;
-  readonly projectMetadataById: Readonly<
-    Record<
-      string,
-      {
-        readonly projectName: string;
-        readonly isActive: boolean;
-      }
-    >
-  >;
+  readonly projectMetadataById: ProjectMetadataIndex;
 }): { readonly projectId: string; readonly projectName: string } | null {
   for (const item of [...input.timelineItems].sort((left, right) =>
     right.occurredAt.localeCompare(left.occurredAt),
@@ -4297,19 +4317,11 @@ function buildConversationProject(input: {
       readonly projectId: string | null;
     }
   >;
-  readonly projectMetadataById: Readonly<
-    Record<
-      string,
-      {
-        readonly projectName: string;
-        readonly isActive: boolean;
-      }
-    >
-  >;
+  readonly projectMetadataById: ProjectMetadataIndex;
 }): InboxDetailViewModel["conversationProject"] {
   // Routes through the shared helper so the header's primary project chip
   // cannot diverge from the inbox row's chip for the same contact.
-  return resolvePrimaryProjectForContact({
+  const resolved = resolvePrimaryProjectForContact({
     memberships: input.memberships,
     projectMetadataById: input.projectMetadataById,
     lastOccurredAtByProjectId: buildProjectActivityIndex(input.timelineItems)
@@ -4322,6 +4334,21 @@ function buildConversationProject(input: {
       projectMetadataById: input.projectMetadataById,
     }),
   });
+
+  if (resolved === null) {
+    return null;
+  }
+
+  // Project the wider `ResolvedPrimaryProject` shape to the narrower
+  // `conversationProject` view-model so toEqual() callers don't see the
+  // helper's `isConnectedSub` flag (which the header doesn't consume —
+  // it gates rendering on `subProjectName !== null` instead).
+  return {
+    projectId: resolved.projectId,
+    projectName: resolved.projectName,
+    subProjectName: resolved.subProjectName,
+    source: resolved.source,
+  };
 }
 
 function buildInboxDetailSummaryViewModel(input: {

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -77,7 +77,7 @@ type InboxDetailProjection = Omit<
  * when the project rolls up into a host (per PR #384). Standalone or host
  * projects leave both `null` so the chip renders as a single-line label.
  */
-type ProjectMetadataEntry = {
+interface ProjectMetadataEntry {
   readonly projectName: string;
   readonly isActive: boolean;
   /**
@@ -92,7 +92,7 @@ type ProjectMetadataEntry = {
    * standalone or host projects.
    */
   readonly hostProjectName: string | null;
-};
+}
 
 type ProjectMetadataIndex = Readonly<Record<string, ProjectMetadataEntry>>;
 
@@ -915,18 +915,16 @@ export function resolvePrimaryProjectForContact(input: {
   if (primary !== null && primary.projectId !== null) {
     const metadata = input.projectMetadataById[primary.projectId];
     const ownName = metadata?.projectName ?? primary.projectId;
-    const isConnectedSub =
-      metadata?.connectedToProjectId !== undefined &&
-      metadata.connectedToProjectId !== null &&
-      metadata.hostProjectName !== null;
+    const hostName =
+      metadata?.connectedToProjectId == null
+        ? null
+        : metadata.hostProjectName;
 
     return {
       projectId: primary.projectId,
-      projectName: isConnectedSub
-        ? (metadata?.hostProjectName ?? ownName)
-        : ownName,
-      subProjectName: isConnectedSub ? ownName : null,
-      isConnectedSub,
+      projectName: hostName ?? ownName,
+      subProjectName: hostName === null ? null : ownName,
+      isConnectedSub: hostName !== null,
       source: "membership",
     };
   }
@@ -937,19 +935,17 @@ export function resolvePrimaryProjectForContact(input: {
     // For the conversation-fallback path the caller already resolved the
     // sub's own name (via the metadata index → `projectName`). Reuse that
     // as the chip's secondary line when the project is a connected sub.
-    const isConnectedSub =
-      metadata?.connectedToProjectId !== undefined &&
-      metadata.connectedToProjectId !== null &&
-      metadata.hostProjectName !== null;
     const ownName = input.conversationProjectFallback.projectName;
+    const hostName =
+      metadata?.connectedToProjectId == null
+        ? null
+        : metadata.hostProjectName;
 
     return {
       projectId: fallbackId,
-      projectName: isConnectedSub
-        ? (metadata?.hostProjectName ?? ownName)
-        : ownName,
-      subProjectName: isConnectedSub ? ownName : null,
-      isConnectedSub,
+      projectName: hostName ?? ownName,
+      subProjectName: hostName === null ? null : ownName,
+      isConnectedSub: hostName !== null,
       source: "conversation",
     };
   }
@@ -1046,19 +1042,17 @@ function buildProjectMembershipViewModel(
   // `metadata.hostProjectName`. Only flip into the two-line layout when
   // the host's name actually resolved — otherwise fall back to the sub's
   // own name as a single-line label so we never render an empty primary.
-  const isConnectedSub =
-    metadata?.connectedToProjectId !== undefined &&
-    metadata.connectedToProjectId !== null &&
-    metadata.hostProjectName !== null;
+  const hostName =
+    metadata?.connectedToProjectId == null
+      ? null
+      : metadata.hostProjectName;
 
   return {
     membershipId: membership.id,
     projectId: membership.projectId,
-    projectName: isConnectedSub
-      ? (metadata?.hostProjectName ?? ownName)
-      : ownName,
-    subDisplayName: isConnectedSub ? ownName : null,
-    isConnectedSub,
+    projectName: hostName ?? ownName,
+    subDisplayName: hostName === null ? null : ownName,
+    isConnectedSub: hostName !== null,
     projectIsActive: metadata?.isActive ?? false,
     status: mapProjectStatus(membership.status),
     statusLabel: mapProjectStatusLabel(membership.status),

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -79,6 +79,14 @@ export interface InboxListItemViewModel {
   readonly snippet: string;
   readonly latestChannel: InboxChannel;
   readonly projectLabel: string | null;
+  /**
+   * When the row's primary project is a connected sub-project, this holds
+   * the sub-project's own name so the chip can render "via {sub}" beneath
+   * the host's name (which is in `projectLabel`). `null` when the project
+   * is standalone or a host. Mirrors the membership-level
+   * `subDisplayName` field so rail / row / header agree by construction.
+   */
+  readonly projectSubLabel: string | null;
   readonly additionalActiveProjectsCount: number;
   readonly volunteerStage: InboxVolunteerStage;
 
@@ -122,7 +130,23 @@ export type InboxProjectStatus =
 export interface InboxProjectMembershipViewModel {
   readonly membershipId: string;
   readonly projectId: string;
+  /**
+   * The label the rail / chip shows as primary text. For a standalone or
+   * host project this is just the project's own name. For a connected sub
+   * (one whose `project_dimensions.connected_to_project_id` is set) this
+   * is the **host's** name — so a Beech-only volunteer's rail entry reads
+   * "Beech & Butternut" rather than "Beech".
+   */
   readonly projectName: string;
+  /**
+   * Set when this membership's project is a connected sub. Holds the
+   * sub-project's own name (e.g. "Saving American Beech") so the rail / chip
+   * can render a small "via {subDisplayName}" line under the primary host
+   * label. `null` for standalone or host projects.
+   */
+  readonly subDisplayName: string | null;
+  /** True when this membership's project is a connected sub-project. */
+  readonly isConnectedSub: boolean;
   readonly projectIsActive: boolean;
   readonly status: InboxProjectStatus;
   readonly statusLabel: string;
@@ -403,7 +427,20 @@ export interface InboxDetailSummaryViewModel {
   readonly projectionAvailable: boolean;
   readonly conversationProject: {
     readonly projectId: string;
+    /**
+     * Same convention as
+     * {@link InboxProjectMembershipViewModel.projectName}: when the
+     * resolved project is a connected sub, this is the host's name (so the
+     * header chip says "Beech & Butternut") and the sub-project's own
+     * name lives in `subProjectName`.
+     */
     readonly projectName: string;
+    /**
+     * Sub-project's own name when the resolved project is a connected sub
+     * (so the header chip can render "via {subProjectName}"). `null` for
+     * standalone / host projects.
+     */
+    readonly subProjectName: string | null;
     readonly source: "membership" | "conversation";
   } | null;
   readonly initials: string;

--- a/apps/web/src/server/ai/retriever.ts
+++ b/apps/web/src/server/ai/retriever.ts
@@ -138,7 +138,14 @@ export async function retrieveGrounding(
       }),
       input.projectId === null
         ? Promise.resolve(null)
-        : repositories.aiKnowledge.findProjectNotionContent(input.projectId),
+        : // Connected sub-projects (per PR #388) clear their own
+          // ai_knowledge_url and inherit the host's bundle. The "effective"
+          // lookup transparently hops sub→host so the draft pipeline picks
+          // up the curated grounding even when the thread is tagged with
+          // the sub's project_id.
+          repositories.aiKnowledge.findEffectiveProjectNotionContent(
+            input.projectId,
+          ),
       repositories.canonicalEvents.listByContactId(input.contactId),
     ]);
 

--- a/apps/web/test/server/ai/retriever.test.ts
+++ b/apps/web/test/server/ai/retriever.test.ts
@@ -114,6 +114,49 @@ describe("retrieveGrounding", () => {
     expect(bundle.targetInbound?.body).toContain("current field kit list");
   });
 
+  it("falls back to the host's tier-2 entry when the project is a connected sub", async () => {
+    if (!runtime) {
+      throw new Error("Expected runtime.");
+    }
+
+    // Mark whitebark as a connected sub of host:forests. The Settings UI
+    // (PR #388) clears the sub's own ai_knowledge_url, so the AI Draft
+    // pipeline should resolve grounding via the host.
+    await runtime.context.repositories.projectDimensions.upsert({
+      projectId: "host:forests",
+      projectName: "Forests",
+      projectAlias: "Forests",
+      source: "salesforce",
+      isActive: true,
+    });
+    await runtime.context.repositories.projectDimensions.upsert({
+      projectId: "project:whitebark",
+      projectName: "Whitebark Pines",
+      projectAlias: "Whitebark",
+      source: "salesforce",
+      isActive: true,
+      connectedToProjectId: "host:forests",
+    });
+    await seedAiKnowledge(runtime, {
+      id: "ai:project:host:forests",
+      scope: "project",
+      scopeKey: "host:forests",
+      title: "Forests AI Knowledge",
+      content: "Curated host-level grounding for the connected sub.",
+    });
+
+    const bundle = await retrieveGrounding(runtime.context.repositories, {
+      contactId: "contact:maya",
+      projectId: "project:whitebark",
+      threadCursor: null,
+    });
+
+    // Even though we asked for project:whitebark, the bundle resolves
+    // through the host's curated entry — the sub itself has none.
+    expect(bundle.projectContext?.title).toBe("Forests AI Knowledge");
+    expect(bundle.grounding.some((entry) => entry.tier === 2)).toBe(true);
+  });
+
   it("handles an empty database without throwing", async () => {
     const emptyRuntime = await createStage1WebTestRuntime();
 

--- a/apps/web/tests/unit/inbox-contact-rail.test.tsx
+++ b/apps/web/tests/unit/inbox-contact-rail.test.tsx
@@ -268,6 +268,8 @@ describe("InboxContactRail", () => {
           membershipId: "membership-1",
           projectId: "project-1",
           projectName: "Alpine Stream Survey",
+          subDisplayName: null,
+          isConnectedSub: false,
           expeditionMemberUrl: null,
           crmUrl: "https://salesforce.example.com/member/1",
           projectIsActive: false,
@@ -279,5 +281,62 @@ describe("InboxContactRail", () => {
 
     expect(activeSession.container.textContent).toContain("Alpine Stream Survey");
     expect(activeSession.container.textContent).toContain("Successful");
+  });
+
+  // PR for connected-projects host/sub label: a Beech-only volunteer's
+  // active project rolls up under a "Forests" host. The rail must show
+  // the host's display name as primary, with a small "via {sub}" line
+  // beneath it so the operator can still see which Salesforce project
+  // the contact actually rolled up from.
+  it("renders the host name as primary and 'via {sub}' as secondary for a connected sub project", async () => {
+    activeSession = await renderRail({
+      ...buildContact(0),
+      activeProjects: [
+        {
+          membershipId: "membership-beech",
+          projectId: "project:beech",
+          projectName: "Beech & Butternut",
+          subDisplayName: "Saving American Beech",
+          isConnectedSub: true,
+          expeditionMemberUrl:
+            "https://salesforce.example.com/member/beech-1",
+          crmUrl: "https://salesforce.example.com/project/beech-1",
+          projectIsActive: true,
+          status: "in-field",
+          statusLabel: "In field",
+        },
+      ],
+    });
+
+    expect(activeSession.container.textContent).toContain(
+      "Beech & Butternut",
+    );
+    expect(activeSession.container.textContent).toContain(
+      "via Saving American Beech",
+    );
+  });
+
+  it("does not render 'via …' for a standalone (non-connected) active project", async () => {
+    activeSession = await renderRail({
+      ...buildContact(0),
+      activeProjects: [
+        {
+          membershipId: "membership-standalone",
+          projectId: "project:whitebark",
+          projectName: "Whitebark Pines",
+          subDisplayName: null,
+          isConnectedSub: false,
+          expeditionMemberUrl:
+            "https://salesforce.example.com/member/whitebark-1",
+          crmUrl: "https://salesforce.example.com/project/whitebark-1",
+          projectIsActive: true,
+          status: "in-field",
+          statusLabel: "In field",
+        },
+      ],
+    });
+
+    expect(activeSession.container.textContent).toContain("Whitebark Pines");
+    expect(activeSession.container.textContent).not.toContain("via ");
   });
 });

--- a/apps/web/tests/unit/inbox-detail-header.test.tsx
+++ b/apps/web/tests/unit/inbox-detail-header.test.tsx
@@ -156,6 +156,8 @@ function buildDetail(
           membershipId: "membership-1",
           projectId: "project-1",
           projectName: "Amazon Basin",
+          subDisplayName: null,
+          isConnectedSub: false,
           projectIsActive: true,
           status: "in-field",
           statusLabel: "Active",
@@ -170,6 +172,7 @@ function buildDetail(
     conversationProject: {
       projectId: "project-1",
       projectName: "Amazon Basin",
+      subProjectName: null,
       source: "membership",
     },
     initials: "RC",
@@ -375,6 +378,74 @@ describe("Inbox detail header", () => {
         '[data-tooltip-content="true"]',
       )?.textContent,
     ).toContain("Pending — click to clear");
+  });
+
+  // Connected-projects host/sub label: when the contact's primary
+  // membership is a connected sub, the header chip's primary text is the
+  // host's name and a small "via {sub}" line appears next to it.
+  it("renders the host name with 'via {sub}' for a connected sub-project membership", async () => {
+    activeSession = await renderDetail(
+      buildDetail({
+        contact: {
+          ...buildDetail().contact,
+          activeProjects: [
+            {
+              membershipId: "membership:beech",
+              projectId: "project:beech",
+              projectName: "Beech & Butternut",
+              subDisplayName: "Saving American Beech",
+              isConnectedSub: true,
+              projectIsActive: true,
+              status: "in-field",
+              statusLabel: "Active",
+              crmUrl: "/crm/project/beech",
+              expeditionMemberUrl: null,
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(activeSession.container.textContent).toContain(
+      "Beech & Butternut",
+    );
+    expect(activeSession.container.textContent).toContain(
+      "via Saving American Beech",
+    );
+  });
+
+  // When the contact has no active membership but the conversation
+  // resolved (via SF event context) to a connected sub, the fallback chip
+  // still shows the host name with the via-line.
+  it("renders the host name with 'via {sub}' when the conversation fallback is a connected sub", async () => {
+    activeSession = await renderDetail(
+      buildDetail({
+        contact: {
+          ...buildDetail().contact,
+          activeProjects: [],
+        },
+        conversationProject: {
+          projectId: "project:beech",
+          projectName: "Beech & Butternut",
+          subProjectName: "Saving American Beech",
+          source: "conversation",
+        },
+      }),
+    );
+
+    expect(activeSession.container.textContent).toContain(
+      "Beech & Butternut",
+    );
+    expect(activeSession.container.textContent).toContain(
+      "via Saving American Beech",
+    );
+  });
+
+  it("does not render 'via …' when the project is standalone", async () => {
+    activeSession = await renderDetail(buildDetail());
+
+    expect(activeSession.container.textContent).toContain("Amazon Basin");
+    expect(activeSession.container.textContent).not.toContain("via ");
   });
 
   it("keeps the follow-up toggle clickable while a request is in flight and queues the latest intent", async () => {

--- a/apps/web/tests/unit/inbox-list-shell.test.tsx
+++ b/apps/web/tests/unit/inbox-list-shell.test.tsx
@@ -219,6 +219,7 @@ function buildList(
         snippet: "Thanks for the quick update.",
         latestChannel: "email",
         projectLabel: "Amazon Basin",
+        projectSubLabel: null,
         additionalActiveProjectsCount: 0,
         volunteerStage: "active",
         bucket: "new",
@@ -746,6 +747,66 @@ describe("Inbox list shell", () => {
 
     expect(row?.textContent).toContain("Amazon Basin");
     expect(row?.textContent).not.toContain("+2");
+  });
+
+  // Connected-projects host/sub label: a Beech-only volunteer's row chip
+  // shows "Beech & Butternut · via Saving American Beech" rather than just
+  // "Beech" — same source of truth (the resolver's resolvedPrimaryProject)
+  // that the conversation header uses.
+  it("renders the host name with 'via {sub}' on the inbox row chip when the project is a connected sub", async () => {
+    fetchInboxListPageMock.mockResolvedValue(buildList());
+    const baseItem = buildList().items[0];
+
+    if (baseItem === undefined) {
+      throw new Error("Expected an inbox list fixture item");
+    }
+
+    activeSession = await mountInboxList(
+      buildList({
+        items: [
+          {
+            ...baseItem,
+            projectLabel: "Beech & Butternut",
+            projectSubLabel: "Saving American Beech",
+          },
+        ],
+      }),
+    );
+
+    const row = activeSession.container.querySelector(
+      "[data-inbox-row='true']",
+    );
+
+    expect(row?.textContent).toContain("Beech & Butternut");
+    expect(row?.textContent).toContain("via Saving American Beech");
+  });
+
+  it("renders only the project label on the inbox row chip when the project is standalone", async () => {
+    fetchInboxListPageMock.mockResolvedValue(buildList());
+    const baseItem = buildList().items[0];
+
+    if (baseItem === undefined) {
+      throw new Error("Expected an inbox list fixture item");
+    }
+
+    activeSession = await mountInboxList(
+      buildList({
+        items: [
+          {
+            ...baseItem,
+            projectLabel: "Whitebark Pines",
+            projectSubLabel: null,
+          },
+        ],
+      }),
+    );
+
+    const row = activeSession.container.querySelector(
+      "[data-inbox-row='true']",
+    );
+
+    expect(row?.textContent).toContain("Whitebark Pines");
+    expect(row?.textContent).not.toContain("via ");
   });
 
   it("renders staff-origin non-volunteer rows with an AS chip", async () => {

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -115,6 +115,7 @@ function buildItem(
     snippet: overrides.snippet ?? "Snippet",
     latestChannel: overrides.latestChannel ?? "email",
     projectLabel: overrides.projectLabel ?? null,
+    projectSubLabel: overrides.projectSubLabel ?? null,
     additionalActiveProjectsCount: overrides.additionalActiveProjectsCount ?? 0,
     volunteerStage: overrides.volunteerStage ?? "active",
     bucket: overrides.bucket ?? "opened",
@@ -693,10 +694,14 @@ describe("resolvePrimaryProjectForContact", () => {
     "project:illegal-timber": {
       projectName: "Illegal Timber",
       isActive: true,
+      connectedToProjectId: null,
+      hostProjectName: null,
     },
     "project:passive-acoustic": {
       projectName: "Passive Acoustic",
       isActive: true,
+      connectedToProjectId: null,
+      hostProjectName: null,
     },
   } as const;
 
@@ -732,6 +737,8 @@ describe("resolvePrimaryProjectForContact", () => {
       "project:beech-butternut": {
         projectName: "Beech & Butternut",
         isActive: true,
+        connectedToProjectId: null,
+        hostProjectName: null,
       },
     } as const;
     const primary = resolvePrimaryProjectForContact({
@@ -767,10 +774,14 @@ describe("resolvePrimaryProjectForContact", () => {
       "project:illegal-timber": {
         projectName: "Illegal Timber",
         isActive: false,
+        connectedToProjectId: null,
+        hostProjectName: null,
       },
       "project:passive-acoustic": {
         projectName: "Passive Acoustic",
         isActive: true,
+        connectedToProjectId: null,
+        hostProjectName: null,
       },
     } as const;
     const primary = resolvePrimaryProjectForContact({
@@ -831,6 +842,107 @@ describe("resolvePrimaryProjectForContact", () => {
     });
 
     expect(primary).toBeNull();
+  });
+
+  // Connected-projects host/sub label: a Beech-only volunteer whose only
+  // active membership is on the connected sub `project:beech` should
+  // surface "Beech & Butternut" (host) as the chip's primary text and
+  // "Saving American Beech" as the secondary `subProjectName`.
+  it("returns the host name as projectName and the sub name as subProjectName when the membership is on a connected sub", () => {
+    const primary = resolvePrimaryProjectForContact({
+      memberships: [
+        buildMembership({
+          id: "membership:beech",
+          projectId: "project:beech",
+          createdAt: "2026-04-01T10:00:00.000Z",
+          status: "active",
+        }),
+      ],
+      projectMetadataById: {
+        "project:beech": {
+          projectName: "Saving American Beech",
+          isActive: true,
+          connectedToProjectId: "host:forests",
+          hostProjectName: "Beech & Butternut",
+        },
+      },
+      lastOccurredAtByProjectId: new Map(),
+      conversationProjectFallback: null,
+    });
+
+    expect(primary).toEqual({
+      projectId: "project:beech",
+      projectName: "Beech & Butternut",
+      subProjectName: "Saving American Beech",
+      isConnectedSub: true,
+      source: "membership",
+    });
+  });
+
+  // Same logic should apply to the conversation-fallback path so the
+  // header chip stays consistent when a contact has no active memberships
+  // but the conversation resolved to a connected sub via SF event context.
+  it("applies the host/sub label to the conversation fallback path", () => {
+    const primary = resolvePrimaryProjectForContact({
+      memberships: [],
+      projectMetadataById: {
+        "project:beech": {
+          projectName: "Saving American Beech",
+          isActive: true,
+          connectedToProjectId: "host:forests",
+          hostProjectName: "Beech & Butternut",
+        },
+      },
+      lastOccurredAtByProjectId: new Map(),
+      conversationProjectFallback: {
+        projectId: "project:beech",
+        projectName: "Saving American Beech",
+      },
+    });
+
+    expect(primary).toEqual({
+      projectId: "project:beech",
+      projectName: "Beech & Butternut",
+      subProjectName: "Saving American Beech",
+      isConnectedSub: true,
+      source: "conversation",
+    });
+  });
+
+  // Defensive: when the metadata index says "connected" but the host name
+  // failed to resolve (e.g., the host row was missing from the IN(...)
+  // batch query), fall back to the sub's own name as a single-line label
+  // rather than rendering an empty chip.
+  it("falls back to the sub name when the host name is missing from the metadata", () => {
+    const primary = resolvePrimaryProjectForContact({
+      memberships: [
+        buildMembership({
+          id: "membership:beech",
+          projectId: "project:beech",
+          createdAt: "2026-04-01T10:00:00.000Z",
+          status: "active",
+        }),
+      ],
+      projectMetadataById: {
+        "project:beech": {
+          projectName: "Saving American Beech",
+          isActive: true,
+          connectedToProjectId: "host:forests",
+          // hostProjectName intentionally null — host row missing.
+          hostProjectName: null,
+        },
+      },
+      lastOccurredAtByProjectId: new Map(),
+      conversationProjectFallback: null,
+    });
+
+    expect(primary).toEqual({
+      projectId: "project:beech",
+      projectName: "Saving American Beech",
+      subProjectName: null,
+      isConnectedSub: false,
+      source: "membership",
+    });
   });
 });
 
@@ -3057,7 +3169,74 @@ describe("real inbox selectors", () => {
     expect(detail?.conversationProject).toEqual({
       projectId: "project:amazon-basin",
       projectName: "Amazon Basin Research",
+      subProjectName: null,
       source: "membership",
+    });
+  });
+
+  // Connected-projects host/sub label (PR for AI knowledge + rail): when
+  // the contact's only active membership is on a connected sub-project,
+  // both the contact rail's activeProjects entry AND the conversation
+  // header's chip resolve to the host's display name with the sub as
+  // secondary label. Same source of truth as the inbox row.
+  it("renders host name as primary with sub as secondary when the membership is on a connected sub", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    // Host project owns the alias and (in production) the AI knowledge.
+    await runtime.context.repositories.projectDimensions.upsert({
+      projectId: "host:forests",
+      projectName: "Forests",
+      projectAlias: "Beech & Butternut",
+      source: "salesforce",
+      isActive: true,
+    });
+    // Connected sub: alias and AI knowledge cleared per PR #388 invariants.
+    await runtime.context.repositories.projectDimensions.upsert({
+      projectId: "sub:beech",
+      projectName: "Saving American Beech",
+      projectAlias: null,
+      source: "salesforce",
+      isActive: true,
+      connectedToProjectId: "host:forests",
+    });
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:beech-only",
+      salesforceContactId: "sf:beech-only",
+      displayName: "Beech Only Volunteer",
+      primaryEmail: "beech-only@example.org",
+      primaryPhone: null,
+      projectId: "sub:beech",
+      projectName: "Saving American Beech",
+      projectAlias: null,
+      membershipId: "membership:beech-only",
+      membershipStatus: "active",
+    });
+    await seedInboxEmailEvent(runtime.context, {
+      id: "beech-only-thread-inbound",
+      contactId: "contact:beech-only",
+      occurredAt: "2026-05-08T10:00:00.000Z",
+      direction: "inbound",
+      subject: "Beech question",
+      snippet: "Where do I record measurements?",
+      bodyTextPreview: "Where do I record measurements?",
+    });
+
+    const detail = await getInboxDetail("contact:beech-only");
+
+    expect(detail?.conversationProject).toEqual({
+      projectId: "sub:beech",
+      projectName: "Beech & Butternut",
+      subProjectName: "Saving American Beech",
+      source: "membership",
+    });
+    expect(detail?.contact.activeProjects).toHaveLength(1);
+    expect(detail?.contact.activeProjects[0]).toMatchObject({
+      projectId: "sub:beech",
+      projectName: "Beech & Butternut",
+      subDisplayName: "Saving American Beech",
+      isConnectedSub: true,
     });
   });
 
@@ -3120,6 +3299,7 @@ describe("real inbox selectors", () => {
     expect(detail?.conversationProject).toEqual({
       projectId: "project:orcas",
       projectName: "Orcas",
+      subProjectName: null,
       source: "conversation",
     });
   });

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -1800,8 +1800,6 @@ function createStage1RepositoriesInternal(
           // the fallback observable when troubleshooting an AI Draft. The
           // synthesis worker emits stringified JSON for log scraping; mirror
           // that style here.
-          // eslint-disable-next-line no-console -- Stage1 repo layer has no
-          // injected logger; debug-level is the conventional place.
           console.debug(
             JSON.stringify({
               event: "ai_knowledge.fallback",
@@ -2659,8 +2657,6 @@ function createStage1RepositoriesInternal(
 
           if (hostRow !== undefined) {
             resolved = mapProjectDimensionRow(hostRow);
-            // eslint-disable-next-line no-console -- Stage1 repo layer has
-            // no injected logger; debug-level is the conventional place.
             console.debug(
               JSON.stringify({
                 event: "ai_knowledge.fallback",

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -17,6 +17,7 @@ import {
 import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
 
 import type {
+  EffectiveAiKnowledge,
   InboxUnifiedSearchMembership,
   InboxUnifiedSearchRow,
   InternalNoteRecord,
@@ -1779,6 +1780,56 @@ function createStage1RepositoriesInternal(
         return row === undefined ? null : mapAiKnowledgeEntryRow(row);
       },
 
+      async findEffectiveProjectNotionContent(projectId) {
+        // Hop sub→host transparently so the AI Draft retriever picks up the
+        // host's curated grounding when a thread is tagged with a connected
+        // sub-project's id (sub.ai_knowledge_url is null by Settings invariant
+        // — see PR #388).
+        const [projectRow] = await db
+          .select({
+            connectedToProjectId: projectDimensions.connectedToProjectId,
+          })
+          .from(projectDimensions)
+          .where(eq(projectDimensions.projectId, projectId))
+          .limit(1);
+        const hostProjectId = projectRow?.connectedToProjectId ?? null;
+        const effectiveScopeKey = hostProjectId ?? projectId;
+
+        if (hostProjectId !== null) {
+          // Logging at debug-level only — avoid noise on hot paths but make
+          // the fallback observable when troubleshooting an AI Draft. The
+          // synthesis worker emits stringified JSON for log scraping; mirror
+          // that style here.
+          // eslint-disable-next-line no-console -- Stage1 repo layer has no
+          // injected logger; debug-level is the conventional place.
+          console.debug(
+            JSON.stringify({
+              event: "ai_knowledge.fallback",
+              subProjectId: projectId,
+              hostProjectId,
+            }),
+          );
+        }
+
+        const [row] = await db
+          .select()
+          .from(aiKnowledgeEntries)
+          .where(
+            and(
+              eq(aiKnowledgeEntries.scope, "project"),
+              eq(aiKnowledgeEntries.scopeKey, effectiveScopeKey),
+              eq(aiKnowledgeEntries.sourceProvider, "notion"),
+            ),
+          )
+          .orderBy(
+            desc(aiKnowledgeEntries.syncedAt),
+            asc(aiKnowledgeEntries.id),
+          )
+          .limit(1);
+
+        return row === undefined ? null : mapAiKnowledgeEntryRow(row);
+      },
+
       async hasProjectNotionContent(projectId) {
         const [row] = await db
           .select({
@@ -2575,6 +2626,67 @@ function createStage1RepositoriesInternal(
           .orderBy(asc(projectDimensions.projectName));
 
         return rows.map(mapProjectDimensionRow);
+      },
+
+      async findEffectiveAiKnowledge(projectId): Promise<EffectiveAiKnowledge | null> {
+        // Resolve sub→host transparently. The AI Draft pipeline (and any
+        // future consolidated grounding loader) calls through here so a
+        // connected sub-project inherits the host's curated AI Knowledge
+        // bundle without each call site re-implementing the lookup.
+        //
+        // Settings code paths must NOT call this — they edit the raw stored
+        // value via setAiKnowledgeUrl / setAiKnowledgeSources etc.
+        const [ownRow] = await db
+          .select()
+          .from(projectDimensions)
+          .where(eq(projectDimensions.projectId, projectId))
+          .limit(1);
+
+        if (ownRow === undefined) {
+          return null;
+        }
+
+        const ownRecord = mapProjectDimensionRow(ownRow);
+        const hostProjectId = ownRecord.connectedToProjectId ?? null;
+        let resolved = ownRecord;
+
+        if (hostProjectId !== null) {
+          const [hostRow] = await db
+            .select()
+            .from(projectDimensions)
+            .where(eq(projectDimensions.projectId, hostProjectId))
+            .limit(1);
+
+          if (hostRow !== undefined) {
+            resolved = mapProjectDimensionRow(hostRow);
+            // eslint-disable-next-line no-console -- Stage1 repo layer has
+            // no injected logger; debug-level is the conventional place.
+            console.debug(
+              JSON.stringify({
+                event: "ai_knowledge.fallback",
+                subProjectId: projectId,
+                hostProjectId,
+              }),
+            );
+          }
+          // If the host row is missing (orphaned connection — shouldn't
+          // happen in practice because connected_to_project_id has
+          // ON DELETE SET NULL, but defensive), fall through to the sub's
+          // own (likely null) values rather than throwing.
+        }
+
+        return {
+          projectId,
+          resolvedFromProjectId: resolved.projectId,
+          aiKnowledgeUrl: resolved.aiKnowledgeUrl ?? null,
+          aiKnowledgeSources: aiKnowledgeSourcesSchema.parse(
+            resolved.aiKnowledgeSources ?? [],
+          ),
+          aiOperatingContext: resolved.aiOperatingContext ?? "",
+          aiAutoSyncSchedule: resolved.aiAutoSyncSchedule ?? "never",
+          aiOptimizedSynthesizedAt: resolved.aiOptimizedSynthesizedAt ?? null,
+          aiOptimizedInputHash: resolved.aiOptimizedInputHash ?? null,
+        };
       },
 
       async getAiKnowledgeSources(projectId) {

--- a/packages/db/test/effective-ai-knowledge.test.ts
+++ b/packages/db/test/effective-ai-knowledge.test.ts
@@ -1,0 +1,349 @@
+import { describe, expect, it } from "vitest";
+
+import { createTestStage1Context } from "./helpers.js";
+
+// Repository-level coverage for the consolidated AI-knowledge accessors that
+// transparently inherit from a host project when the requested project_id is
+// a connected sub. Used by the AI Draft pipeline so a thread tagged with
+// project=Beech still pulls Beech&Butternut's curated grounding.
+//
+// Settings code paths must NOT call these accessors — they edit the raw
+// stored value via setAiKnowledgeUrl / setAiKnowledgeSources etc.
+describe("effective AI knowledge accessors", () => {
+  describe("aiKnowledge.findEffectiveProjectNotionContent", () => {
+    it("returns the host's own cached Notion content when called against the host", async () => {
+      const context = await createTestStage1Context();
+      try {
+        await context.repositories.projectDimensions.upsert({
+          projectId: "host:forests",
+          projectName: "Forests",
+          projectAlias: "Forests",
+          source: "salesforce",
+          isActive: true,
+        });
+        await context.repositories.aiKnowledge.upsert({
+          id: "ai:project:host:forests",
+          scope: "project",
+          scopeKey: "host:forests",
+          sourceProvider: "notion",
+          sourceId: "notion-host-forests",
+          sourceUrl: "https://www.notion.so/forests",
+          title: "Forests AI Knowledge",
+          content: "Curated grounding for the Forests host project.",
+          contentHash: "hash:host-forests",
+          metadataJson: {},
+          sourceLastEditedAt: "2026-05-01T00:00:00.000Z",
+          syncedAt: "2026-05-01T00:00:00.000Z",
+          createdAt: "2026-05-01T00:00:00.000Z",
+          updatedAt: "2026-05-01T00:00:00.000Z",
+        });
+
+        const entry =
+          await context.repositories.aiKnowledge.findEffectiveProjectNotionContent(
+            "host:forests",
+          );
+
+        expect(entry?.title).toBe("Forests AI Knowledge");
+        expect(entry?.scopeKey).toBe("host:forests");
+      } finally {
+        await context.dispose();
+      }
+    });
+
+    it("falls back to the host's content when called against a connected sub with no own content", async () => {
+      const context = await createTestStage1Context();
+      try {
+        await context.repositories.projectDimensions.upsert({
+          projectId: "host:forests",
+          projectName: "Forests",
+          projectAlias: "Forests",
+          source: "salesforce",
+          isActive: true,
+        });
+        await context.repositories.projectDimensions.upsert({
+          projectId: "sub:beech",
+          projectName: "Saving American Beech",
+          projectAlias: null,
+          source: "salesforce",
+          isActive: true,
+          connectedToProjectId: "host:forests",
+        });
+        await context.repositories.aiKnowledge.upsert({
+          id: "ai:project:host:forests",
+          scope: "project",
+          scopeKey: "host:forests",
+          sourceProvider: "notion",
+          sourceId: "notion-host-forests",
+          sourceUrl: "https://www.notion.so/forests",
+          title: "Forests AI Knowledge",
+          content: "Curated grounding for the Forests host project.",
+          contentHash: "hash:host-forests",
+          metadataJson: {},
+          sourceLastEditedAt: "2026-05-01T00:00:00.000Z",
+          syncedAt: "2026-05-01T00:00:00.000Z",
+          createdAt: "2026-05-01T00:00:00.000Z",
+          updatedAt: "2026-05-01T00:00:00.000Z",
+        });
+
+        const entry =
+          await context.repositories.aiKnowledge.findEffectiveProjectNotionContent(
+            "sub:beech",
+          );
+
+        expect(entry?.title).toBe("Forests AI Knowledge");
+        // The cached row's scopeKey is the host's id — confirms the lookup
+        // walked the connection rather than returning null because the sub's
+        // own scope_key has no row.
+        expect(entry?.scopeKey).toBe("host:forests");
+      } finally {
+        await context.dispose();
+      }
+    });
+
+    it("returns null when the sub is no longer connected (host deactivated and cascade ran)", async () => {
+      const context = await createTestStage1Context();
+      try {
+        // Sub was previously connected; the host was deactivated and PR #388's
+        // cascade set connected_to_project_id to null on the sub. The sub now
+        // stands alone (still active) and has no content of its own — the
+        // accessor returns null instead of resolving the prior host.
+        await context.repositories.projectDimensions.upsert({
+          projectId: "host:forests",
+          projectName: "Forests",
+          projectAlias: "Forests",
+          source: "salesforce",
+          isActive: false,
+        });
+        await context.repositories.projectDimensions.upsert({
+          projectId: "sub:beech",
+          projectName: "Saving American Beech",
+          projectAlias: "Beech",
+          source: "salesforce",
+          isActive: true,
+        });
+        // Host's own content still cached but the sub is no longer connected.
+        await context.repositories.aiKnowledge.upsert({
+          id: "ai:project:host:forests",
+          scope: "project",
+          scopeKey: "host:forests",
+          sourceProvider: "notion",
+          sourceId: "notion-host-forests",
+          sourceUrl: "https://www.notion.so/forests",
+          title: "Forests AI Knowledge",
+          content: "Curated grounding for the Forests host project.",
+          contentHash: "hash:host-forests",
+          metadataJson: {},
+          sourceLastEditedAt: "2026-05-01T00:00:00.000Z",
+          syncedAt: "2026-05-01T00:00:00.000Z",
+          createdAt: "2026-05-01T00:00:00.000Z",
+          updatedAt: "2026-05-01T00:00:00.000Z",
+        });
+
+        const entry =
+          await context.repositories.aiKnowledge.findEffectiveProjectNotionContent(
+            "sub:beech",
+          );
+
+        expect(entry).toBeNull();
+      } finally {
+        await context.dispose();
+      }
+    });
+
+    it("returns the project's own content when not connected (standalone)", async () => {
+      const context = await createTestStage1Context();
+      try {
+        await context.repositories.projectDimensions.upsert({
+          projectId: "standalone:whitebark",
+          projectName: "Whitebark Pines",
+          projectAlias: "Whitebark",
+          source: "salesforce",
+          isActive: true,
+        });
+        await context.repositories.aiKnowledge.upsert({
+          id: "ai:project:whitebark",
+          scope: "project",
+          scopeKey: "standalone:whitebark",
+          sourceProvider: "notion",
+          sourceId: "notion-whitebark",
+          sourceUrl: "https://www.notion.so/whitebark",
+          title: "Whitebark Pines",
+          content: "Whitebark grounding.",
+          contentHash: "hash:whitebark",
+          metadataJson: {},
+          sourceLastEditedAt: "2026-05-01T00:00:00.000Z",
+          syncedAt: "2026-05-01T00:00:00.000Z",
+          createdAt: "2026-05-01T00:00:00.000Z",
+          updatedAt: "2026-05-01T00:00:00.000Z",
+        });
+
+        const entry =
+          await context.repositories.aiKnowledge.findEffectiveProjectNotionContent(
+            "standalone:whitebark",
+          );
+
+        expect(entry?.scopeKey).toBe("standalone:whitebark");
+      } finally {
+        await context.dispose();
+      }
+    });
+  });
+
+  describe("projectDimensions.findEffectiveAiKnowledge", () => {
+    const baseHostFixture = {
+      projectId: "host:forests",
+      projectName: "Forests",
+      projectAlias: "Forests",
+      source: "salesforce" as const,
+      isActive: true,
+      aiKnowledgeUrl: "https://www.notion.so/host-forests",
+      aiOperatingContext: "Forests host operating context.",
+      aiAutoSyncSchedule: "weekly" as const,
+      aiOptimizedSynthesizedAt: "2026-05-01T00:00:00.000Z",
+      aiOptimizedInputHash: "hash:host-input",
+    };
+
+    const sampleSource = {
+      id: "00000000-0000-0000-0000-000000000001",
+      url: "https://www.notion.so/forests-source",
+      kind: "notion" as const,
+      label: "Forests source",
+      enabled: true,
+      last_synced_at: "2026-05-01T00:00:00.000Z",
+      last_sync_status: "healthy" as const,
+      last_sync_error: null,
+      source_id: "src-forests",
+      source_content_hash: "src-hash",
+      created_at: "2026-05-01T00:00:00.000Z",
+      updated_at: "2026-05-01T00:00:00.000Z",
+    };
+
+    it("returns the host's own bundle when called against a host project", async () => {
+      const context = await createTestStage1Context();
+      try {
+        await context.repositories.projectDimensions.upsert({
+          ...baseHostFixture,
+          aiKnowledgeSources: [sampleSource],
+        });
+
+        const effective =
+          await context.repositories.projectDimensions.findEffectiveAiKnowledge(
+            "host:forests",
+          );
+
+        expect(effective).not.toBeNull();
+        expect(effective?.projectId).toBe("host:forests");
+        expect(effective?.resolvedFromProjectId).toBe("host:forests");
+        expect(effective?.aiKnowledgeUrl).toBe(
+          "https://www.notion.so/host-forests",
+        );
+        expect(effective?.aiOperatingContext).toBe(
+          "Forests host operating context.",
+        );
+        expect(effective?.aiAutoSyncSchedule).toBe("weekly");
+        expect(effective?.aiOptimizedSynthesizedAt).toBe(
+          "2026-05-01T00:00:00.000Z",
+        );
+        expect(effective?.aiOptimizedInputHash).toBe("hash:host-input");
+        expect(effective?.aiKnowledgeSources).toHaveLength(1);
+        expect(effective?.aiKnowledgeSources[0]?.id).toBe(sampleSource.id);
+      } finally {
+        await context.dispose();
+      }
+    });
+
+    it("falls back to the host bundle when called against a connected sub with null fields", async () => {
+      const context = await createTestStage1Context();
+      try {
+        await context.repositories.projectDimensions.upsert({
+          ...baseHostFixture,
+          aiKnowledgeSources: [sampleSource],
+        });
+        await context.repositories.projectDimensions.upsert({
+          projectId: "sub:beech",
+          projectName: "Saving American Beech",
+          projectAlias: null,
+          source: "salesforce",
+          isActive: true,
+          connectedToProjectId: "host:forests",
+          // Connected subs land here with all AI fields null/empty per
+          // PR #388's connect cascade.
+        });
+
+        const effective =
+          await context.repositories.projectDimensions.findEffectiveAiKnowledge(
+            "sub:beech",
+          );
+
+        expect(effective).not.toBeNull();
+        expect(effective?.projectId).toBe("sub:beech");
+        expect(effective?.resolvedFromProjectId).toBe("host:forests");
+        expect(effective?.aiKnowledgeUrl).toBe(
+          "https://www.notion.so/host-forests",
+        );
+        expect(effective?.aiKnowledgeSources).toHaveLength(1);
+        expect(effective?.aiOperatingContext).toBe(
+          "Forests host operating context.",
+        );
+        expect(effective?.aiAutoSyncSchedule).toBe("weekly");
+        expect(effective?.aiOptimizedSynthesizedAt).toBe(
+          "2026-05-01T00:00:00.000Z",
+        );
+        expect(effective?.aiOptimizedInputHash).toBe("hash:host-input");
+      } finally {
+        await context.dispose();
+      }
+    });
+
+    it("returns the sub's own (likely null) values when the sub is no longer connected", async () => {
+      const context = await createTestStage1Context();
+      try {
+        // Host deactivated; PR #388's cascade clears connectedToProjectId on
+        // the sub. The sub stands alone — no fallback fires.
+        await context.repositories.projectDimensions.upsert({
+          ...baseHostFixture,
+          isActive: false,
+          aiKnowledgeSources: [sampleSource],
+        });
+        await context.repositories.projectDimensions.upsert({
+          projectId: "sub:beech",
+          projectName: "Saving American Beech",
+          projectAlias: "Beech",
+          source: "salesforce",
+          isActive: true,
+        });
+
+        const effective =
+          await context.repositories.projectDimensions.findEffectiveAiKnowledge(
+            "sub:beech",
+          );
+
+        expect(effective).not.toBeNull();
+        expect(effective?.projectId).toBe("sub:beech");
+        expect(effective?.resolvedFromProjectId).toBe("sub:beech");
+        expect(effective?.aiKnowledgeUrl).toBeNull();
+        expect(effective?.aiKnowledgeSources).toEqual([]);
+        expect(effective?.aiOperatingContext).toBe("");
+        expect(effective?.aiAutoSyncSchedule).toBe("never");
+        expect(effective?.aiOptimizedSynthesizedAt).toBeNull();
+        expect(effective?.aiOptimizedInputHash).toBeNull();
+      } finally {
+        await context.dispose();
+      }
+    });
+
+    it("returns null when the requested project_id does not exist", async () => {
+      const context = await createTestStage1Context();
+      try {
+        const effective =
+          await context.repositories.projectDimensions.findEffectiveAiKnowledge(
+            "missing:project",
+          );
+
+        expect(effective).toBeNull();
+      } finally {
+        await context.dispose();
+      }
+    });
+  });
+});

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -147,6 +147,19 @@ export interface AiKnowledgeRepository {
   findProjectNotionContent(
     projectId: string,
   ): Promise<AiKnowledgeEntryRecord | null>;
+  /**
+   * Like {@link findProjectNotionContent}, but transparently falls back to
+   * the host project's cached Notion content when `projectId` refers to a
+   * connected sub-project (one with `project_dimensions.connected_to_project_id`
+   * set). Used by the AI Draft retriever so a thread tagged with the sub's
+   * project_id still gets the host-curated grounding.
+   *
+   * Settings + sync code paths must NOT call this — they need the raw
+   * project's content keyed by its own id.
+   */
+  findEffectiveProjectNotionContent(
+    projectId: string,
+  ): Promise<AiKnowledgeEntryRecord | null>;
   hasProjectNotionContent(projectId: string): Promise<boolean>;
   findProjectIdsWithNotionContent(
     projectIds: readonly string[],
@@ -347,6 +360,28 @@ export interface SmsSenderRepository {
   } | null>;
 }
 
+/**
+ * Effective (i.e. resolved-after-fallback) AI knowledge bundle for a project.
+ *
+ * - `projectId` is the project the caller asked about.
+ * - `resolvedFromProjectId` is the project the values were actually read from.
+ *   Equal to `projectId` when the project is a host or standalone; equal to
+ *   the host's id when the project is a connected sub.
+ * - The remaining fields mirror the AI-knowledge columns on
+ *   {@link ProjectDimensionRecord} so the AI Draft pipeline can use them
+ *   without caring whether the project is a sub or a host.
+ */
+export interface EffectiveAiKnowledge {
+  readonly projectId: string;
+  readonly resolvedFromProjectId: string;
+  readonly aiKnowledgeUrl: string | null;
+  readonly aiKnowledgeSources: readonly AiKnowledgeSource[];
+  readonly aiOperatingContext: string;
+  readonly aiAutoSyncSchedule: "never" | "daily" | "weekly";
+  readonly aiOptimizedSynthesizedAt: string | null;
+  readonly aiOptimizedInputHash: string | null;
+}
+
 export interface ProjectDimensionRepository {
   findById(projectId: string): Promise<ProjectDimensionRecord | null>;
   listAll(): Promise<readonly ProjectDimensionRecord[]>;
@@ -368,6 +403,18 @@ export interface ProjectDimensionRepository {
   listAvailableConnectionCandidates(): Promise<
     readonly ProjectDimensionRecord[]
   >;
+  /**
+   * Returns the AI-knowledge bundle the synthesis + draft pipelines should
+   * use for `projectId`, transparently inheriting from the host when the
+   * row is a connected sub-project.
+   *
+   * Settings code paths must NOT call this — they need the raw stored value
+   * (see {@link findById}). Use this only when you want the inherited /
+   * "effective" value.
+   */
+  findEffectiveAiKnowledge(
+    projectId: string,
+  ): Promise<EffectiveAiKnowledge | null>;
   getAiKnowledgeSources(
     projectId: string,
   ): Promise<readonly AiKnowledgeSource[]>;

--- a/packages/domain/test/normalization.test.ts
+++ b/packages/domain/test/normalization.test.ts
@@ -418,6 +418,7 @@ function buildContext(input: {
     aiKnowledge: {
       findByScope: () => Promise.resolve(null),
       findProjectNotionContent: () => Promise.resolve(null),
+      findEffectiveProjectNotionContent: () => Promise.resolve(null),
       hasProjectNotionContent: () => Promise.resolve(false),
       findProjectIdsWithNotionContent: () => Promise.resolve([]),
       upsert: (record) => Promise.resolve(record),
@@ -510,6 +511,7 @@ function buildContext(input: {
       listByIds: () => Promise.resolve([]),
       listConnectedProjects: () => Promise.resolve([]),
       listAvailableConnectionCandidates: () => Promise.resolve([]),
+      findEffectiveAiKnowledge: () => Promise.resolve(null),
       getAiKnowledgeSources: () => Promise.resolve([]),
       setAiKnowledgeSources: () => Promise.resolve(),
       setAiAutoSyncSchedule: () => Promise.resolve(),

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -56,6 +56,7 @@ describe("defineStage1RepositoryBundle", () => {
       aiKnowledge: {
         findByScope: () => Promise.resolve(null),
         findProjectNotionContent: () => Promise.resolve(null),
+        findEffectiveProjectNotionContent: () => Promise.resolve(null),
         hasProjectNotionContent: () => Promise.resolve(false),
         findProjectIdsWithNotionContent: () => Promise.resolve([]),
         upsert: (record) => Promise.resolve(record),
@@ -120,6 +121,7 @@ describe("defineStage1RepositoryBundle", () => {
         listByIds: () => Promise.resolve([]),
         listConnectedProjects: () => Promise.resolve([]),
         listAvailableConnectionCandidates: () => Promise.resolve([]),
+        findEffectiveAiKnowledge: () => Promise.resolve(null),
         getAiKnowledgeSources: () => Promise.resolve([]),
         setAiKnowledgeSources: () => Promise.resolve(),
         setAiAutoSyncSchedule: () => Promise.resolve(),

--- a/packages/domain/test/stage3-last-inbound-alias.test.ts
+++ b/packages/domain/test/stage3-last-inbound-alias.test.ts
@@ -75,6 +75,7 @@ function buildRepositoryBundle(input: {
     aiKnowledge: {
       findByScope: () => Promise.resolve(null),
       findProjectNotionContent: () => Promise.resolve(null),
+      findEffectiveProjectNotionContent: () => Promise.resolve(null),
       hasProjectNotionContent: () => Promise.resolve(false),
       findProjectIdsWithNotionContent: () => Promise.resolve([]),
       upsert: (record) => Promise.resolve(record),
@@ -139,6 +140,7 @@ function buildRepositoryBundle(input: {
       listByIds: () => Promise.resolve([]),
       listConnectedProjects: () => Promise.resolve([]),
       listAvailableConnectionCandidates: () => Promise.resolve([]),
+      findEffectiveAiKnowledge: () => Promise.resolve(null),
       getAiKnowledgeSources: () => Promise.resolve([]),
       setAiKnowledgeSources: () => Promise.resolve(),
       setAiAutoSyncSchedule: () => Promise.resolve(),

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -152,6 +152,7 @@ function createRepositoryBundle(input: {
     aiKnowledge: {
       findByScope: () => Promise.resolve(null),
       findProjectNotionContent: () => Promise.resolve(null),
+      findEffectiveProjectNotionContent: () => Promise.resolve(null),
       hasProjectNotionContent: () => Promise.resolve(false),
       findProjectIdsWithNotionContent: () => Promise.resolve([]),
       upsert: (record) => Promise.resolve(record),
@@ -216,6 +217,7 @@ function createRepositoryBundle(input: {
       listByIds: () => Promise.resolve([]),
       listConnectedProjects: () => Promise.resolve([]),
       listAvailableConnectionCandidates: () => Promise.resolve([]),
+      findEffectiveAiKnowledge: () => Promise.resolve(null),
       getAiKnowledgeSources: () => Promise.resolve([]),
       setAiKnowledgeSources: () => Promise.resolve(),
       setAiAutoSyncSchedule: () => Promise.resolve(),


### PR DESCRIPTION
## Summary

Closes the last two gaps in the Connected Projects feature shipped in #384 + #388:

1. **AI Knowledge fallback**: when AI Draft runs on a thread whose project is a connected sub, the consolidated AI-knowledge accessor now returns the host's bundle (URL, sources, operating context, auto-sync schedule, optimized synthesis fields). Settings UI continues to read raw stored values (no inheritance leak there).
2. **Host/sub label**: contact rail "Active Projects", inbox row's project chip, and conversation header chip now render \`{host name}\` as the primary label with \`via {sub name}\` as a muted secondary line when the resolved project is a connected sub. All three surfaces flow through the same shared helper, so they agree by construction (preserves PR #375's invariant).

## What changed

- New consolidated effective-AI-knowledge accessor in \`packages/db/src/repositories.ts\` (+108) with a 349-line test in \`packages/db/test/effective-ai-knowledge.test.ts\`.
- AI retriever (\`apps/web/src/server/ai/retriever.ts\`) routes through the new accessor.
- View-model gains \`subDisplayName\` and \`isConnectedSub\` fields populated from a batched host-name lookup.
- Rail (\`inbox-contact-rail.tsx\`), row (\`inbox-row.tsx\`), and header (\`inbox-detail.tsx\`) render the two-line \`Host\` / \`via Sub\` chip when applicable; standalone projects render unchanged.

## Closes the loop on issue #383

This is PR3 of the Connected Projects feature. PR1 (#384) shipped the data foundation, PR2 (#388) shipped the Settings UX, this PR closes AI knowledge and rail rendering.

## Test plan

- [x] 11 test files updated/added: PGlite repo tests, AI retriever tests, contact-rail tests, inbox-row chip tests, conversation-header tests, view-model selector tests.
- [x] Inherited fields tested for: \`aiKnowledgeUrl\`, \`aiKnowledgeSources\`, \`aiOperatingContext\`, \`aiAutoSyncSchedule\`, \`aiOptimizedSynthesizedAt\`, \`aiOptimizedInputHash\`.
- [x] Edge cases: orphaned connection (\`ON DELETE SET NULL\` cleared the host), disconnected sub no longer falls back.
- [x] Three surfaces (rail/row/header) tested for both connected-sub and standalone-project cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)