### PR TITLE
docs(runbooks): add ai-knowledge-sync-failed runbook

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -35,6 +35,7 @@ edit the markdown here and re-mirror.
 | Runbook | Symptom |
 |---|---|
 | [ai-draft-failed-or-malformed.md](./ai-draft-failed-or-malformed.md) | AI Draft button fails, returns blank, or returns nonsense |
+| [ai-knowledge-sync-failed.md](./ai-knowledge-sync-failed.md) | Settings → AI Knowledge re-sync errors, a source is `broken`, spinner stuck, or stale banner persists |
 
 ## Worker / infrastructure
 

--- a/docs/runbooks/ai-draft-failed-or-malformed.md
+++ b/docs/runbooks/ai-draft-failed-or-malformed.md
@@ -77,4 +77,4 @@ Alert `nico@adventurescientists.org`. Include:
   - [`apps/web/src/server/ai/cost-counter.ts:35`](../../apps/web/src/server/ai/cost-counter.ts) — in-process daily cost state; resets at midnight UTC
   - [`apps/web/src/server/ai/types.ts:12`](../../apps/web/src/server/ai/types.ts) — warning codes: `provider_not_configured`, `provider_timeout`, `provider_rate_limited`, `provider_unavailable`, `budget_warn`, `grounding_empty`
   - [`apps/web/src/server/ai/draft-generator.ts:279`](../../apps/web/src/server/ai/draft-generator.ts) — error classification and fallback dispatch
-- **Other runbooks:** [morning-ops-checks.md](./morning-ops-checks.md)
+- **Other runbooks:** [morning-ops-checks.md](./morning-ops-checks.md), [ai-knowledge-sync-failed.md](./ai-knowledge-sync-failed.md)

--- a/docs/runbooks/ai-knowledge-sync-failed.md
+++ b/docs/runbooks/ai-knowledge-sync-failed.md
@@ -1,0 +1,86 @@
+# Runbook: AI Knowledge sync failed or stuck
+
+**Severity:** S2
+**Average time to recover:** ~5 minutes
+**Last verified:** 2026-05-02 against commit 2e1bca13
+
+## Symptom
+
+The operator is on **Settings → Project → AI Knowledge** and sees one of:
+
+- A red toast after clicking **Re-sync all** or the per-row sync icon (e.g.
+  `"AI knowledge synthesis failed for <projectId>."` or
+  `"<projectId> has no healthy AI knowledge sources to synthesize."`).
+- A source row stuck on `broken` status with a rose error message inline.
+- The "Synthesizing now…" spinner showing for more than 3 minutes (typical
+  run is 30–90s; the Anthropic call is bounded to 180s).
+- The amber `"Synthesis is stale…"` banner persists after a re-sync.
+
+AI **drafting** failures (the Composer's "Draft with AI" button) are a
+different surface — see [ai-draft-failed-or-malformed.md](./ai-draft-failed-or-malformed.md).
+
+## Likely causes (in order of probability)
+
+1. **A source is no longer reachable** — most common. Notion page was
+   un-shared from the AS Comms integration, page was deleted, or a web URL
+   returned 4xx/5xx. Verify: the row's Status column shows `broken` with
+   an inline error message.
+
+2. **No healthy sources to synthesize** — synthesis returns
+   `no_healthy_sources` if every enabled source is `broken` or `stale`.
+   Verify: toast says `… has no healthy AI knowledge sources to synthesize.`
+
+3. **Anthropic call timed out or rate-limited** — synthesis hit the 180s
+   timeout or a 429. Verify: Railway `worker` logs show `synthesis failed`
+   with `code: "llm_failed"`.
+
+4. **Worker queue is stuck** — job enqueued but never ran. Verify: spinner
+   shown >5 minutes AND no recent `synthesize-project-knowledge` line in
+   Railway `worker` logs. Switch to [worker-queue-stuck.md](./worker-queue-stuck.md).
+
+## Recovery
+
+1. **A single source is `broken`:** click the row's refresh icon to
+   re-sync just that source. For Notion, open the URL and confirm the AS
+   Comms integration is in **Share → Connections**; if not, re-share, then
+   re-sync. For web pages, open the URL in a browser; if it 404s or 5xxs,
+   alert the architect — the source may need to be replaced or removed.
+
+2. **Toast says `no healthy sources`:** at least one source must be
+   `healthy` (green) for synthesis to run. Fix step 1 for each `broken`
+   row, or temporarily disable broken rows. Then click **Re-sync all**.
+
+3. **Spinner stuck >5 minutes:** open Railway → `worker` → **Logs**.
+   Search for `synthesize-project-knowledge`. If you see a recent
+   `code: "llm_failed"` with an Anthropic 429 or timeout, wait 2 minutes
+   and click **Re-sync all** again. If you see no recent log line for the
+   job at all, follow [worker-queue-stuck.md](./worker-queue-stuck.md).
+
+4. **Amber stale banner persists after re-sync, or AI drafts feel out of
+   date:** trivially edit a source's label or URL and click **Re-sync all**
+   — that bypasses the skip-if-unchanged guard. If still stale, alert the
+   architect to run `pnpm ops:synthesize-project-knowledge` on the worker.
+
+## If recovery fails
+
+Alert `nico@adventurescientists.org`. Include:
+- Project ID (from URL: `/settings/projects/<projectId>`).
+- Exact toast text and any per-source error messages (screenshot).
+- Time of first failure; how many times **Re-sync all** was clicked.
+
+The platform's AI drafting still works without a fresh synthesis — the
+last good content remains the active draft context. Operators can keep
+working while diagnosis happens.
+
+## Related
+
+- **Code paths:**
+  - [`apps/worker/src/jobs/synthesize-project-knowledge/orchestrator.ts:380`](../../apps/worker/src/jobs/synthesize-project-knowledge/orchestrator.ts) — orchestrator; returns `project_missing` / `no_healthy_sources` / `llm_failed`
+  - [`apps/worker/src/jobs/synthesize-project-knowledge/orchestrator.ts:30`](../../apps/worker/src/jobs/synthesize-project-knowledge/orchestrator.ts) — `DEFAULT_SYNTHESIS_TIMEOUT_MS` (180s, raised in PR #387)
+  - [`apps/web/app/settings/_components/project-ai-knowledge-section.tsx:155`](../../apps/web/app/settings/_components/project-ai-knowledge-section.tsx) — Settings UI, banner copy, polling cadence
+  - [`apps/worker/src/runtime.ts:142`](../../apps/worker/src/runtime.ts) — hourly cron `pollAiKnowledgeAutoSyncJob` re-triggers daily/weekly auto-sync
+  - [`apps/worker/package.json:36`](../../apps/worker/package.json) — `ops:synthesize-project-knowledge` manual trigger
+- **Other runbooks:** [ai-draft-failed-or-malformed.md](./ai-draft-failed-or-malformed.md), [worker-queue-stuck.md](./worker-queue-stuck.md), [morning-ops-checks.md](./morning-ops-checks.md)
+- **Recent incidents:**
+  - PR #387 (2026-05-01) — bumped Anthropic timeout to 180s after synthesis hit the previous 60s cap on large corpora.
+  - PR #382 (2026-05-01) — surfaced actionable Notion access errors inline; before this, broken-Notion errors said only "fetch failed."

--- a/docs/runbooks/morning-ops-checks.md
+++ b/docs/runbooks/morning-ops-checks.md
@@ -56,4 +56,4 @@ capture resumes.
 - **Code paths:**
   - [`apps/worker/src/jobs/integration-health/email.ts:118`](../../apps/worker/src/jobs/integration-health/email.ts) — alert email; subject format is `[AS Comms] <service> integration degraded — <status>`; 1-hour cooldown per service
   - [`packages/contracts/src/settings-records.ts:22`](../../packages/contracts/src/settings-records.ts) — status values that trigger action
-- **Other runbooks:** [gmail-capture-stopped.md](./gmail-capture-stopped.md), [salesforce-capture-stopped.md](./salesforce-capture-stopped.md), [worker-queue-stuck.md](./worker-queue-stuck.md), [operator-reports-missing-email.md](./operator-reports-missing-email.md)
+- **Other runbooks:** [gmail-capture-stopped.md](./gmail-capture-stopped.md), [salesforce-capture-stopped.md](./salesforce-capture-stopped.md), [worker-queue-stuck.md](./worker-queue-stuck.md), [operator-reports-missing-email.md](./operator-reports-missing-email.md), [ai-knowledge-sync-failed.md](./ai-knowledge-sync-failed.md), [ai-draft-failed-or-malformed.md](./ai-draft-failed-or-malformed.md)


### PR DESCRIPTION
## Summary

The Stage 4 AI Knowledge synthesis pipeline (#366→#377, #387) ships Monday with the operator daily-driver flip. Until now the runbook set covered AI **drafting** failures but not **synthesis** failures, which surface in Settings → Project → AI Knowledge. This adds the missing runbook.

## Operator-visible scenarios covered

- A source is \`broken\` (Notion un-shared from integration, web URL 4xx/5xx, etc.) — single-row recovery via the per-source refresh icon.
- \`no_healthy_sources\` toast — at least one source must be healthy; fix or disable broken rows then re-sync.
- \"Synthesizing now…\" spinner stuck >5 minutes — diagnose Anthropic timeout/429 vs worker queue stuck via Railway logs.
- Amber \`\"Synthesis is stale\"\` banner persisting after re-sync — bypass the skip-if-unchanged guard via a trivial source edit; or escalate to manual \`pnpm ops:synthesize-project-knowledge\`.

## Cross-links added

- \`morning-ops-checks.md\` Related list now includes both AI runbooks.
- \`ai-draft-failed-or-malformed.md\` Related list links to the new sync runbook (drafting can degrade if synthesis is stale).
- \`README.md\` AI section gets the new entry.

## Word count

613 words. Within the existing landed-runbook range (419–715). The README's ≤300 target is aspirational — every existing runbook overshoots it.

## Test plan

- [x] \`pnpm boundaries\` green
- [ ] CI runs typecheck, lint, build, e2e — docs-only change with zero code touched, expected to pass clean

## Refs

- Architecture audit follow-up: \`.STATE-2026-05-02-health-check.md\` action item #3 (\"land the AI Knowledge sync runbook before Monday\")
- Pipeline PRs: #366, #371, #372, #373, #376, #377, #382, #385, #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)