### PR TITLE
feat(inbox): split search into Volunteers/Contacts; drop body matches

### DIFF
--- a/apps/web/app/api/inbox/search/route.ts
+++ b/apps/web/app/api/inbox/search/route.ts
@@ -16,17 +16,19 @@ const querySchema = z.object({
 /**
  * GET /api/inbox/search
  *
- * Unified search for the existing inbox search bar. Returns two sections:
+ * Unified search for the existing inbox search bar. Returns two sections,
+ * partitioned by membership-existence on the matched contacts:
  *
- * - `contactMatches` — contacts matching name / primary email / primary phone
- *   (includes contacts who have only lifecycle/campaign events, or none).
- * - `bodyMatches` — projection-backed contacts whose snippet or latest
- *   message subject ILIKE the query (excluding contacts already in
- *   `contactMatches`).
+ * - `volunteers` — contacts matching name / primary email / primary phone
+ *   that have at least one `contact_memberships` row (active OR past).
+ * - `contacts` — contacts matching the same attributes that have zero
+ *   membership rows.
  *
  * Below the min query length (3 characters) the route returns empty arrays
  * without hitting the DB. Each section is capped at 25 in v1; `totals`
- * exposes pre-truncation counts for the UX.
+ * exposes pre-truncation counts for the UX. Sort key per section is
+ * volunteer-side last activity desc — outbound 1:1 sends and campaign
+ * events are excluded so an operator's reply doesn't bump a contact up.
  *
  * Distinct from `/api/inbox/list` which returns the folder-filtered queue
  * shape. We picked a dedicated endpoint over overloading `/list` because
@@ -59,9 +61,9 @@ export async function GET(request: Request) {
   if (trimmed.length < INBOX_UNIFIED_SEARCH_MIN_QUERY_LENGTH) {
     return NextResponse.json({
       query: trimmed,
-      contactMatches: [],
-      bodyMatches: [],
-      totals: { contactMatches: 0, bodyMatches: 0 },
+      volunteers: [],
+      contacts: [],
+      totals: { volunteers: 0, contacts: 0 },
     });
   }
 

--- a/apps/web/app/inbox/_components/inbox-list.tsx
+++ b/apps/web/app/inbox/_components/inbox-list.tsx
@@ -554,7 +554,7 @@ export function InboxList({
   const searchResultCount =
     searchResult === null
       ? 0
-      : searchResult.contactMatches.length + searchResult.bodyMatches.length;
+      : searchResult.volunteers.length + searchResult.contacts.length;
   const activeProjects = currentList.activeProjects;
   const hasActiveFilters =
     activeFilter !== "inbox" || selectedProjectId !== null;
@@ -960,7 +960,7 @@ function SearchEmptyState({
       description={
         <>
           Nothing matches &ldquo;{query}&rdquo;. Try a different name, email,
-          phone number, or message snippet.
+          or phone number.
         </>
       }
       action={
@@ -979,11 +979,12 @@ function SearchEmptyState({
 
 /**
  * Two-section result list rendered when the inbox search bar is in unified
- * search mode. Section A — `contactMatches` — shows attribute matches first;
- * Section B — `bodyMatches` — shows projection snippet/subject matches with
- * the matched substring highlighted via `<mark>`. Both sections share the
- * same row format so the divider is the only visual separator. Section
- * labels are omitted when only one section is non-empty.
+ * search mode. Top section — `volunteers` — shows matched contacts with at
+ * least one membership in the existing full-row format. Bottom section —
+ * `contacts` — shows matched contacts with zero memberships in a compact
+ * single-line format. Section labels render only when both sections have
+ * results; if only one is populated we render that section's rows without
+ * a header.
  */
 function UnifiedSearchResultList({
   result,
@@ -993,25 +994,20 @@ function UnifiedSearchResultList({
   readonly activeContactId: string | null;
 }) {
   const showSectionLabels =
-    result.contactMatches.length > 0 && result.bodyMatches.length > 0;
+    result.volunteers.length > 0 && result.contacts.length > 0;
 
   return (
     <div>
-      {result.contactMatches.length > 0 ? (
-        <section aria-label="Contact matches">
+      {result.volunteers.length > 0 ? (
+        <section aria-label="Volunteers">
           {showSectionLabels ? (
-            <UnifiedSearchSectionHeader
-              label="Contacts"
-              count={result.totals.contactMatches}
-              shown={result.contactMatches.length}
-            />
+            <UnifiedSearchSectionHeader label="Volunteers" />
           ) : null}
           <ul className="divide-y divide-slate-100">
-            {result.contactMatches.map((row) => (
+            {result.volunteers.map((row) => (
               <InboxUnifiedSearchRow
                 key={row.contactId}
                 row={row}
-                query={result.query}
                 isActive={row.contactId === activeContactId}
               />
             ))}
@@ -1019,21 +1015,18 @@ function UnifiedSearchResultList({
         </section>
       ) : null}
 
-      {result.bodyMatches.length > 0 ? (
-        <section aria-label="Message matches">
-          <UnifiedSearchSectionHeader
-            label={showSectionLabels ? "Message matches" : "Results"}
-            count={result.totals.bodyMatches}
-            shown={result.bodyMatches.length}
-          />
+      {result.contacts.length > 0 ? (
+        <section aria-label="Contacts">
+          {showSectionLabels ? (
+            <UnifiedSearchSectionHeader label="Contacts" />
+          ) : null}
           <ul className="divide-y divide-slate-100">
-            {result.bodyMatches.map((row) => (
+            {result.contacts.map((row) => (
               <InboxUnifiedSearchRow
                 key={row.contactId}
                 row={row}
-                query={result.query}
                 isActive={row.contactId === activeContactId}
-                highlightSnippet
+                compact
               />
             ))}
           </ul>
@@ -1043,22 +1036,11 @@ function UnifiedSearchResultList({
   );
 }
 
-function UnifiedSearchSectionHeader({
-  label,
-  count,
-  shown,
-}: {
-  readonly label: string;
-  readonly count: number;
-  readonly shown: number;
-}) {
+function UnifiedSearchSectionHeader({ label }: { readonly label: string }) {
   return (
     <div className="border-y border-slate-100 bg-slate-50 px-4 py-1.5">
-      <div className="flex items-center justify-between gap-2 text-[10.5px] font-semibold uppercase tracking-[0.08em] text-slate-500">
-        <span>{label}</span>
-        <span className="text-slate-400">
-          {count > shown ? `${shown.toString()} of ${count.toString()}` : count.toString()}
-        </span>
+      <div className="text-[10.5px] font-semibold uppercase tracking-[0.08em] text-slate-500">
+        {label}
       </div>
     </div>
   );

--- a/apps/web/app/inbox/_components/inbox-unified-search-row.tsx
+++ b/apps/web/app/inbox/_components/inbox-unified-search-row.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Fragment, useCallback, useMemo, useRef } from "react";
+import { useCallback, useMemo, useRef } from "react";
 
 import type { InboxUnifiedSearchRowViewModel } from "../_lib/view-models";
 import { InboxAvatar } from "./inbox-avatar";
@@ -10,29 +10,29 @@ import { MailIcon, PhoneIcon } from "./icons";
 import { FOCUS_RING, TRANSITION } from "@/app/_lib/design-tokens-v2";
 
 /**
- * Single result row inside the unified search list. Shares layout primitives
- * with `InboxRow` so projection-backed and contact-only matches feel
- * identical. The two row formats:
+ * Single result row inside the unified search list. Two visual modes:
  *
- * - `hasProjection === true`: renders subject + snippet (with `<mark>` over
- *   the matched substring when `highlightSnippet` is set).
- * - `hasProjection === false`: renders email/phone (or "No conversation
- *   yet") on the secondary line; no subject/snippet.
+ * - Default (Volunteers section): full-row format — avatar + name +
+ *   time-ago + snippet + project chip. `hasProjection === true` rows show
+ *   subject/snippet from the inbox projection; `hasProjection === false`
+ *   rows fall back to email/phone with a muted "No conversation yet" line.
+ * - Compact (Contacts section, `compact = true`): single-line format with
+ *   no avatar, no time-ago, no snippet, no project chip. If `displayName`
+ *   contains "@" we render just the email; otherwise we render
+ *   "Name · email".
  *
- * Click target is `/inbox/[contactId]` regardless of section, preserving
+ * Click target is `/inbox/[contactId]` regardless of mode, preserving
  * existing `q` / `filter` / `projectId` URL params so the search input
  * stays populated when navigating back.
  */
 export function InboxUnifiedSearchRow({
   row,
-  query,
   isActive,
-  highlightSnippet = false,
+  compact = false,
 }: {
   readonly row: InboxUnifiedSearchRowViewModel;
-  readonly query: string;
   readonly isActive: boolean;
-  readonly highlightSnippet?: boolean;
+  readonly compact?: boolean;
 }) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -58,27 +58,23 @@ export function InboxUnifiedSearchRow({
     return null;
   }, [row.latestChannel]);
 
+  if (compact) {
+    return (
+      <CompactContactRow
+        row={row}
+        href={href}
+        isActive={isActive}
+        prefetchDetail={prefetchDetail}
+      />
+    );
+  }
+
   const showSubject =
     row.hasProjection &&
     row.latestSubject !== null &&
     row.latestSubject.length > 0;
 
-  // Body-match snippet: slice ±60 chars around the first match position so
-  // the matched substring is visible even for long snippets, then highlight
-  // the matched substring with <mark>.
-  const snippetContent = useMemo(() => {
-    const snippet = row.snippet ?? "";
-
-    if (snippet.length === 0) {
-      return null;
-    }
-
-    if (!highlightSnippet || query.trim().length === 0) {
-      return <span>{snippet}</span>;
-    }
-
-    return renderHighlightedSnippet(snippet, query);
-  }, [row.snippet, query, highlightSnippet]);
+  const snippet = row.snippet ?? "";
 
   return (
     <li>
@@ -127,9 +123,9 @@ export function InboxUnifiedSearchRow({
                   <p className="truncate text-slate-700">{row.latestSubject}</p>
                 </div>
               ) : null}
-              {snippetContent !== null ? (
+              {snippet.length > 0 ? (
                 <p className="mt-0.5 truncate text-[11px] text-slate-400">
-                  {snippetContent}
+                  {snippet}
                 </p>
               ) : null}
             </>
@@ -179,77 +175,58 @@ export function InboxUnifiedSearchRow({
 }
 
 /**
- * Slice ±60 chars around the first occurrence of the query (case-insensitive)
- * and wrap every match with <mark>. When the snippet is shorter than ~140
- * chars, return it unsliced.
+ * Compact single-line row for the Contacts section. Visually lightest row
+ * format we render: no avatar, no time-ago, no snippet, no project chip.
+ * Email-only contacts (the dominant case — ~3,304 of ~3,467) collapse to
+ * just the email; SF-anchored named contacts render `Name · email`.
  */
-function renderHighlightedSnippet(
-  snippet: string,
-  query: string,
-): React.ReactNode {
-  const trimmed = query.trim();
-  if (trimmed.length === 0) {
-    return <span>{snippet}</span>;
-  }
-
-  const lower = snippet.toLowerCase();
-  const needle = trimmed.toLowerCase();
-  const firstIdx = lower.indexOf(needle);
-
-  let workingSnippet = snippet;
-  let leadEllipsis = false;
-  let trailEllipsis = false;
-
-  // Slice around the first match if the snippet is long enough to need it.
-  if (firstIdx >= 0 && snippet.length > 140) {
-    const start = Math.max(0, firstIdx - 60);
-    const end = Math.min(snippet.length, firstIdx + needle.length + 60);
-    workingSnippet = snippet.slice(start, end);
-    leadEllipsis = start > 0;
-    trailEllipsis = end < snippet.length;
-  }
-
-  // Walk the working snippet, splitting on case-insensitive matches.
-  const workingLower = workingSnippet.toLowerCase();
-  const parts: React.ReactNode[] = [];
-  let cursor = 0;
-  let key = 0;
-  while (cursor < workingSnippet.length) {
-    const idx = workingLower.indexOf(needle, cursor);
-    if (idx === -1) {
-      parts.push(
-        <Fragment key={`t-${key.toString()}`}>
-          {workingSnippet.slice(cursor)}
-        </Fragment>,
-      );
-      key += 1;
-      break;
-    }
-    if (idx > cursor) {
-      parts.push(
-        <Fragment key={`t-${key.toString()}`}>
-          {workingSnippet.slice(cursor, idx)}
-        </Fragment>,
-      );
-      key += 1;
-    }
-    parts.push(
-      <mark
-        key={`m-${key.toString()}`}
-        className="rounded bg-amber-100 px-0.5 text-slate-900"
-      >
-        {workingSnippet.slice(idx, idx + needle.length)}
-      </mark>,
-    );
-    key += 1;
-    cursor = idx + needle.length;
-  }
+function CompactContactRow({
+  row,
+  href,
+  isActive,
+  prefetchDetail,
+}: {
+  readonly row: InboxUnifiedSearchRowViewModel;
+  readonly href: string;
+  readonly isActive: boolean;
+  readonly prefetchDetail: () => void;
+}) {
+  const isDisplayNameAnEmail = row.displayName.includes("@");
+  const hasSecondaryEmail =
+    !isDisplayNameAnEmail &&
+    row.primaryEmail !== null &&
+    row.primaryEmail.length > 0;
 
   return (
-    <span>
-      {leadEllipsis ? "… " : null}
-      {parts}
-      {trailEllipsis ? " …" : null}
-    </span>
+    <li>
+      <Link
+        href={href}
+        prefetch={false}
+        data-inbox-row="true"
+        data-inbox-search-row="true"
+        data-inbox-search-row-compact="true"
+        data-contact-id={row.contactId}
+        data-active={isActive ? "true" : "false"}
+        aria-current={isActive ? "page" : undefined}
+        onMouseEnter={prefetchDetail}
+        onFocus={prefetchDetail}
+        className={`flex w-full items-center gap-2 border-b border-slate-100 px-4 py-2 text-left text-[12px] ${TRANSITION.fast} ${FOCUS_RING} ${TRANSITION.reduceMotion} ${
+          isActive ? "bg-sky-50/50" : "hover:bg-slate-50"
+        }`}
+      >
+        {isDisplayNameAnEmail ? (
+          <span className="truncate text-slate-700">{row.displayName}</span>
+        ) : (
+          <span className="truncate">
+            <span className="font-semibold text-slate-900">
+              {row.displayName}
+            </span>
+            {hasSecondaryEmail ? (
+              <span className="text-slate-400"> · {row.primaryEmail}</span>
+            ) : null}
+          </span>
+        )}
+      </Link>
+    </li>
   );
 }

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -4591,9 +4591,10 @@ export const INBOX_UNIFIED_SEARCH_SECTION_LIMIT = 25;
 /**
  * Server selector for the unified inbox search bar. Replaces the dedicated
  * `/inbox/all-contacts` surface and the projection-only inbox-list search:
- * the input now searches the broad set of contacts (Section A — contact
- * attribute matches) plus projection snippet/subject matches (Section B),
- * with each section sorted by last activity desc and capped per section.
+ * the input searches contact attributes (name / primary email / primary
+ * phone) and partitions matches into Volunteers (≥1 membership) and Contacts
+ * (zero memberships). Each section is sorted by volunteer-side last
+ * activity desc and capped at 25.
  *
  * Below the min-query length the selector short-circuits without hitting
  * the DB, so the API route can rely on this for cheap empty responses.
@@ -4606,14 +4607,14 @@ export async function getInboxUnifiedSearch(input: {
   if (trimmedQuery.length < INBOX_UNIFIED_SEARCH_MIN_QUERY_LENGTH) {
     return {
       query: trimmedQuery,
-      contactMatches: [],
-      bodyMatches: [],
-      totals: { contactMatches: 0, bodyMatches: 0 },
+      volunteers: [],
+      contacts: [],
+      totals: { volunteers: 0, contacts: 0 },
     };
   }
 
   const runtime = await getStage1WebRuntime();
-  const { contactMatches, bodyMatches, totals } =
+  const { volunteers, contacts, totals } =
     await runtime.repositories.contacts.searchInboxUnified({
       query: trimmedQuery,
       limit: INBOX_UNIFIED_SEARCH_SECTION_LIMIT,
@@ -4624,7 +4625,7 @@ export async function getInboxUnifiedSearch(input: {
   const toRow = (
     row: Awaited<
       ReturnType<typeof runtime.repositories.contacts.searchInboxUnified>
-    >["contactMatches"][number],
+    >["volunteers"][number],
   ): InboxUnifiedSearchRowViewModel => {
     const projectLabel =
       row.memberships.length === 0
@@ -4651,6 +4652,7 @@ export async function getInboxUnifiedSearch(input: {
       primaryEmail: row.contact.primaryEmail,
       primaryPhone: row.contact.primaryPhone,
       projectLabel,
+      hasMembership: row.hasMembership,
       hasProjection: row.hasProjection,
       lastActivityAt: row.lastActivityAt,
       lastActivityLabel,
@@ -4663,8 +4665,8 @@ export async function getInboxUnifiedSearch(input: {
 
   return {
     query: trimmedQuery,
-    contactMatches: contactMatches.map(toRow),
-    bodyMatches: bodyMatches.map(toRow),
+    volunteers: volunteers.map(toRow),
+    contacts: contacts.map(toRow),
     totals,
   };
 }

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -519,8 +519,17 @@ export interface InboxUnifiedSearchRowViewModel {
   readonly primaryEmail: string | null;
   readonly primaryPhone: string | null;
   readonly projectLabel: string | null;
+  /**
+   * True when the contact has at least one row in `contact_memberships`
+   * (active OR past). Drives the Volunteers / Contacts partition.
+   */
+  readonly hasMembership: boolean;
   readonly hasProjection: boolean;
-  /** Last activity across ALL canonical event types (lifecycle, comm, etc.). */
+  /**
+   * Last volunteer-side activity (lifecycle.* + inbound 1:1 + sms.opt_*).
+   * Outbound 1:1 sends and campaign events are excluded so an operator's
+   * reply doesn't move a contact up.
+   */
   readonly lastActivityAt: string | null;
   readonly lastActivityLabel: string;
   /** Latest message subject, when projection-backed. Null otherwise. */
@@ -533,16 +542,23 @@ export interface InboxUnifiedSearchRowViewModel {
 }
 
 /**
- * Two-section unified search response. Both sections capped at 25 in v1.
- * `totals` reports the count BEFORE truncation.
+ * Two-section unified search response, partitioned by membership-existence:
+ *
+ * - `volunteers`: matched contacts with at least one `contact_memberships`
+ *   row (active OR past), rendered in the existing full-row format.
+ * - `contacts`: matched contacts with zero memberships, rendered in the
+ *   compact single-line format.
+ *
+ * Each section capped at 25 in v1. `totals` reports the count BEFORE
+ * truncation.
  */
 export interface InboxUnifiedSearchViewModel {
   readonly query: string;
-  readonly contactMatches: readonly InboxUnifiedSearchRowViewModel[];
-  readonly bodyMatches: readonly InboxUnifiedSearchRowViewModel[];
+  readonly volunteers: readonly InboxUnifiedSearchRowViewModel[];
+  readonly contacts: readonly InboxUnifiedSearchRowViewModel[];
   readonly totals: {
-    readonly contactMatches: number;
-    readonly bodyMatches: number;
+    readonly volunteers: number;
+    readonly contacts: number;
   };
 }
 

--- a/apps/web/tests/unit/inbox-list-shell.test.tsx
+++ b/apps/web/tests/unit/inbox-list-shell.test.tsx
@@ -981,11 +981,11 @@ describe("Inbox list shell", () => {
     ).toBeNull();
   });
 
-  it("renders the two-section unified search result with contact and body matches", async () => {
+  it("renders the Volunteers and Contacts section labels when both sections have results", async () => {
     fetchInboxListPageMock.mockResolvedValue(buildList());
     fetchInboxUnifiedSearchMock.mockResolvedValue({
       query: "Eli",
-      contactMatches: [
+      volunteers: [
         {
           contactId: "contact:eliza",
           displayName: "Eliza Tate",
@@ -993,7 +993,8 @@ describe("Inbox list shell", () => {
           avatarTone: "violet",
           primaryEmail: "eliza.tate@example.org",
           primaryPhone: null,
-          projectLabel: null,
+          projectLabel: "Pollinator Watch",
+          hasMembership: true,
           hasProjection: false,
           lastActivityAt: "2026-04-22T12:00:00.000Z",
           lastActivityLabel: "1d ago",
@@ -1003,25 +1004,26 @@ describe("Inbox list shell", () => {
           lastEventType: null,
         },
       ],
-      bodyMatches: [
+      contacts: [
         {
-          contactId: "contact:bm",
-          displayName: "Quincy Adams",
-          initials: "QA",
+          contactId: "contact:elias",
+          displayName: "elias.partner@example.org",
+          initials: "EP",
           avatarTone: "amber",
-          primaryEmail: "quincy@example.org",
+          primaryEmail: "elias.partner@example.org",
           primaryPhone: null,
-          projectLabel: "Amazon Basin",
-          hasProjection: true,
-          lastActivityAt: "2026-04-21T09:00:00.000Z",
-          lastActivityLabel: "2d ago",
-          latestSubject: "Re: thanks",
-          snippet: "Thanks Eli for the helpful update.",
-          latestChannel: "email",
-          lastEventType: "communication.email.inbound",
+          projectLabel: null,
+          hasMembership: false,
+          hasProjection: false,
+          lastActivityAt: null,
+          lastActivityLabel: "",
+          latestSubject: null,
+          snippet: null,
+          latestChannel: null,
+          lastEventType: null,
         },
       ],
-      totals: { contactMatches: 1, bodyMatches: 1 },
+      totals: { volunteers: 1, contacts: 1 },
     });
 
     activeSession = await mountInboxList(buildList(), {
@@ -1031,21 +1033,166 @@ describe("Inbox list shell", () => {
     await flushReact();
 
     expect(activeSession.container.textContent).toContain("Eliza Tate");
-    expect(activeSession.container.textContent).toContain("Quincy Adams");
+    expect(activeSession.container.textContent).toContain(
+      "elias.partner@example.org",
+    );
     // Section labels render when both sections are non-empty.
-    expect(activeSession.container.textContent).toContain("Contacts");
-    expect(activeSession.container.textContent).toContain("Message matches");
-    // Body-match snippet should highlight the substring with <mark>.
-    const mark = activeSession.container.querySelector("mark");
-    expect(mark).not.toBeNull();
-    expect((mark?.textContent ?? "").toLowerCase()).toBe("eli");
+    const volunteersSection = activeSession.container.querySelector(
+      'section[aria-label="Volunteers"]',
+    );
+    const contactsSection = activeSession.container.querySelector(
+      'section[aria-label="Contacts"]',
+    );
+    expect(volunteersSection).not.toBeNull();
+    expect(contactsSection).not.toBeNull();
+    expect(volunteersSection?.textContent).toContain("Volunteers");
+    expect(contactsSection?.textContent).toContain("Contacts");
+  });
+
+  it("renders volunteer rows in full-row format and contact rows in compact single-line format", async () => {
+    fetchInboxListPageMock.mockResolvedValue(buildList());
+    fetchInboxUnifiedSearchMock.mockResolvedValue({
+      query: "Eli",
+      volunteers: [
+        {
+          contactId: "contact:eliza",
+          displayName: "Eliza Tate",
+          initials: "ET",
+          avatarTone: "violet",
+          primaryEmail: "eliza.tate@example.org",
+          primaryPhone: null,
+          projectLabel: "Pollinator Watch",
+          hasMembership: true,
+          hasProjection: true,
+          lastActivityAt: "2026-04-22T12:00:00.000Z",
+          lastActivityLabel: "1d ago",
+          latestSubject: "Re: question",
+          snippet: "Thanks for the update.",
+          latestChannel: "email",
+          lastEventType: "communication.email.inbound",
+        },
+      ],
+      contacts: [
+        {
+          contactId: "contact:emailonly",
+          displayName: "elias.partner@example.org",
+          initials: "EP",
+          avatarTone: "amber",
+          primaryEmail: "elias.partner@example.org",
+          primaryPhone: null,
+          projectLabel: null,
+          hasMembership: false,
+          hasProjection: false,
+          lastActivityAt: null,
+          lastActivityLabel: "",
+          latestSubject: null,
+          snippet: null,
+          latestChannel: null,
+          lastEventType: null,
+        },
+        {
+          contactId: "contact:named",
+          displayName: "Maya Patel",
+          initials: "MP",
+          avatarTone: "sky",
+          primaryEmail: "maya.patel@example.org",
+          primaryPhone: null,
+          projectLabel: null,
+          hasMembership: false,
+          hasProjection: false,
+          lastActivityAt: null,
+          lastActivityLabel: "",
+          latestSubject: null,
+          snippet: null,
+          latestChannel: null,
+          lastEventType: null,
+        },
+      ],
+      totals: { volunteers: 1, contacts: 2 },
+    });
+
+    activeSession = await mountInboxList(buildList(), {
+      query: "Eli",
+      isQueueLoading: false,
+    });
+    await flushReact();
+
+    // Volunteer row uses the full-row format — the snippet line should be
+    // rendered (snippet text appears).
+    expect(activeSession.container.textContent).toContain("Thanks for the update.");
+    // Volunteer row shows a time-ago label.
+    expect(activeSession.container.textContent).toContain("1d ago");
+
+    // Contact rows use the compact format — both must carry the compact
+    // attribute marker we exposed on the row.
+    const compactRows = activeSession.container.querySelectorAll(
+      "[data-inbox-search-row-compact='true']",
+    );
+    expect(compactRows.length).toBe(2);
+
+    // Email-only contact: rendered text is just the email (no separator).
+    const emailOnlyRow = activeSession.container.querySelector(
+      "[data-contact-id='contact:emailonly']",
+    );
+    expect((emailOnlyRow?.textContent ?? "").trim()).toBe(
+      "elias.partner@example.org",
+    );
+    expect(emailOnlyRow?.textContent ?? "").not.toContain(" · ");
+
+    // Named contact: rendered text is "Name · email".
+    const namedRow = activeSession.container.querySelector(
+      "[data-contact-id='contact:named']",
+    );
+    expect(namedRow?.textContent ?? "").toContain("Maya Patel");
+    expect(namedRow?.textContent ?? "").toContain(" · ");
+    expect(namedRow?.textContent ?? "").toContain("maya.patel@example.org");
+  });
+
+  it("does not render a body-match section or any <mark> highlights", async () => {
+    fetchInboxListPageMock.mockResolvedValue(buildList());
+    fetchInboxUnifiedSearchMock.mockResolvedValue({
+      query: "Eli",
+      volunteers: [
+        {
+          contactId: "contact:eliza",
+          displayName: "Eliza Tate",
+          initials: "ET",
+          avatarTone: "violet",
+          primaryEmail: "eliza.tate@example.org",
+          primaryPhone: null,
+          projectLabel: "Pollinator Watch",
+          hasMembership: true,
+          hasProjection: true,
+          lastActivityAt: "2026-04-22T12:00:00.000Z",
+          lastActivityLabel: "1d ago",
+          latestSubject: "Re: question",
+          snippet: "Thanks Eli for the update.",
+          latestChannel: "email",
+          lastEventType: "communication.email.inbound",
+        },
+      ],
+      contacts: [],
+      totals: { volunteers: 1, contacts: 0 },
+    });
+
+    activeSession = await mountInboxList(buildList(), {
+      query: "Eli",
+      isQueueLoading: false,
+    });
+    await flushReact();
+
+    // The body-match section was named "Message matches" — should not
+    // appear at all.
+    expect(activeSession.container.textContent).not.toContain("Message matches");
+    // No <mark> element should be rendered (we dropped highlighting).
+    expect(activeSession.container.querySelector("mark")).toBeNull();
   });
 
   it("returns to the folder-filtered list when the search is cleared", async () => {
     fetchInboxListPageMock.mockResolvedValue(buildList());
     fetchInboxUnifiedSearchMock.mockResolvedValue({
       query: "Eli",
-      contactMatches: [
+      volunteers: [
         {
           contactId: "contact:eliza",
           displayName: "Eliza Tate",
@@ -1054,6 +1201,7 @@ describe("Inbox list shell", () => {
           primaryEmail: "eliza.tate@example.org",
           primaryPhone: null,
           projectLabel: null,
+          hasMembership: true,
           hasProjection: false,
           lastActivityAt: "2026-04-22T12:00:00.000Z",
           lastActivityLabel: "1d ago",
@@ -1063,8 +1211,8 @@ describe("Inbox list shell", () => {
           lastEventType: null,
         },
       ],
-      bodyMatches: [],
-      totals: { contactMatches: 1, bodyMatches: 0 },
+      contacts: [],
+      totals: { volunteers: 1, contacts: 0 },
     });
 
     activeSession = await mountInboxList(buildList(), {

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -2116,15 +2116,20 @@ function createStage1RepositoriesInternal(
       },
 
       async searchInboxUnified(input) {
-        // Unified search backing the inbox search bar. Returns two sections:
-        //   A. contactMatches — name / primary email / primary phone ILIKE
-        //   B. bodyMatches    — projection snippet / latest message subject
-        //                       ILIKE, EXCLUDING contactMatches
+        // Unified search backing the inbox search bar. Returns the same
+        // contact-attribute query partitioned by membership-existence:
         //
-        // Both sections are sorted by lastActivityAt desc (across ALL
-        // canonical events, not just inbox-driving comm types) and capped at
-        // `limit`. `totals` reports the count BEFORE truncation so the UI
-        // can render "X+ results".
+        //   - volunteers: matched contacts with at least one row in
+        //     `contact_memberships` (active OR past).
+        //   - contacts:   matched contacts with zero membership rows.
+        //
+        // Sort key is `lastActivityAt` desc — restricted to
+        // volunteer-initiated events (lifecycle.* + inbound 1:1 comm +
+        // sms.opt_*) so an operator's outbound reply or a campaign send
+        // doesn't bump a contact to the top. NULL `lastActivityAt` sorts
+        // last with `contacts.created_at` desc as the tiebreaker. Each
+        // section is independently capped at `limit`. `totals` reports the
+        // pre-truncation count per section.
         const trimmedQuery = input.query.trim();
 
         if (trimmedQuery.length === 0) {
@@ -2132,86 +2137,58 @@ function createStage1RepositoriesInternal(
           // length the route should short-circuit before reaching this; this
           // is a defence-in-depth empty-result shortcut.
           return {
-            contactMatches: [],
-            bodyMatches: [],
-            totals: { contactMatches: 0, bodyMatches: 0 },
+            volunteers: [],
+            contacts: [],
+            totals: { volunteers: 0, contacts: 0 },
           };
         }
 
         const limit = Math.max(1, Math.min(input.limit, 200));
         const pattern = `%${escapeIlikePattern(trimmedQuery)}%`;
 
-        // Per-contact lastActivityAt CTE used by both sections so we don't
-        // recompute it twice. Anchored on canonical_event_ledger so any
-        // event type (comm, lifecycle, campaign) qualifies.
+        // Volunteer-initiated event types that count toward `lastActivityAt`.
+        // Excludes outbound sends, all campaign events, and internal notes
+        // so an operator's reply or a Mailchimp blast doesn't move a contact
+        // up the search-result list. See
+        // packages/contracts/src/stage1-taxonomy.ts:36-51 for the canonical
+        // event-type list.
+        const VOLUNTEER_SIDE_EVENT_TYPES = [
+          "lifecycle.signed_up",
+          "lifecycle.received_training",
+          "lifecycle.completed_training",
+          "lifecycle.submitted_first_data",
+          "communication.email.inbound",
+          "communication.sms.inbound",
+          "communication.sms.opt_in",
+          "communication.sms.opt_out",
+        ] as const;
+
+        // Per-contact lastActivityAt CTE filtered to volunteer-side events.
         const lastActivityCte = sql`(
           select
             ${canonicalEventLedger.contactId} as contact_id,
             max(${canonicalEventLedger.occurredAt}) as last_activity_at
           from ${canonicalEventLedger}
+          where ${canonicalEventLedger.eventType} in ${VOLUNTEER_SIDE_EVENT_TYPES}
           group by ${canonicalEventLedger.contactId}
         )`;
 
-        // Section A: contact-attribute matches. LEFT JOIN inbox projection
-        // so projection-backed contacts return their thread metadata for the
-        // hybrid row format; non-projection contacts get nulls and render as
-        // contact-only rows on the client.
-        //
-        // Section B: body matches with the same projection join, filtered to
-        // contacts NOT already in section A and with snippet/subject ILIKE.
-        // We run both as raw SQL so the lastActivityAt sort uses the CTE
-        // value uniformly even when the projection is absent.
+        // Per-contact membership-existence CTE. Either an active OR past
+        // membership qualifies — any row in `contact_memberships` for the
+        // contact flips them into the Volunteers section.
+        const membershipFlagCte = sql`(
+          select distinct ${contactMemberships.contactId} as contact_id
+          from ${contactMemberships}
+        )`;
 
-        const totalsResult = await db.execute(sql`
-          with last_activity as ${lastActivityCte},
-          contact_matches as (
-            select ${contacts.id} as id
-            from ${contacts}
-            where (
-              ${contacts.displayName} ilike ${pattern} escape '\\'
-              or coalesce(${contacts.primaryEmail}, '') ilike ${pattern} escape '\\'
-              or coalesce(${contacts.primaryPhone}, '') ilike ${pattern} escape '\\'
-            )
-          ),
-          body_matches as (
-            select ${contactInboxProjection.contactId} as id
-            from ${contactInboxProjection}
-            left join ${canonicalEventLedger}
-              on ${canonicalEventLedger.id} = ${contactInboxProjection.lastCanonicalEventId}
-            left join ${gmailMessageDetails}
-              on ${gmailMessageDetails.sourceEvidenceId} = ${canonicalEventLedger.sourceEvidenceId}
-            left join ${salesforceCommunicationDetailsTable}
-              on ${salesforceCommunicationDetailsTable.sourceEvidenceId} = ${canonicalEventLedger.sourceEvidenceId}
-            where (
-              ${contactInboxProjection.snippet} ilike ${pattern} escape '\\'
-              or coalesce(${gmailMessageDetails.subject}, '') ilike ${pattern} escape '\\'
-              or coalesce(${salesforceCommunicationDetailsTable.subject}, '') ilike ${pattern} escape '\\'
-            )
-          )
-          select
-            (select count(*)::int from contact_matches) as contact_total,
-            (select count(*)::int from body_matches
-              where id not in (select id from contact_matches)
-            ) as body_total
-        `);
-
-        interface TotalsRow {
-          readonly contact_total: number | string | null;
-          readonly body_total: number | string | null;
-        }
-        const totalsRowSource = (
-          (totalsResult as { rows?: readonly TotalsRow[] }).rows ??
-          (totalsResult as readonly TotalsRow[])
-        );
-        const totalsRow = totalsRowSource[0] ?? {
-          contact_total: 0,
-          body_total: 0,
-        };
-        const contactTotal = Number(totalsRow.contact_total ?? 0);
-        const bodyTotal = Number(totalsRow.body_total ?? 0);
-
+        // Single contact-attribute query, partitioned in TS after we read
+        // the `has_membership` flag. We LEFT JOIN inbox projection so
+        // projection-backed contacts return their thread metadata for the
+        // hybrid row format; non-projection contacts get nulls and render
+        // as contact-only rows on the client.
         const contactMatchesResult = await db.execute(sql`
-          with last_activity as ${lastActivityCte}
+          with last_activity as ${lastActivityCte},
+          memberships_flag as ${membershipFlagCte}
           select
             ${contacts.id} as id,
             ${contacts.salesforceContactId} as salesforce_contact_id,
@@ -2221,6 +2198,7 @@ function createStage1RepositoriesInternal(
             ${contacts.createdAt} as created_at,
             ${contacts.updatedAt} as updated_at,
             la.last_activity_at as last_activity_at,
+            (mf.contact_id is not null) as has_membership,
             ${contactInboxProjection.snippet} as snippet,
             ${contactInboxProjection.lastEventType} as last_event_type,
             ${contactInboxProjection.lastCanonicalEventId} as last_canonical_event_id,
@@ -2229,6 +2207,8 @@ function createStage1RepositoriesInternal(
           from ${contacts}
           left join last_activity la
             on la.contact_id = ${contacts.id}
+          left join memberships_flag mf
+            on mf.contact_id = ${contacts.id}
           left join ${contactInboxProjection}
             on ${contactInboxProjection.contactId} = ${contacts.id}
           left join ${canonicalEventLedger}
@@ -2242,54 +2222,7 @@ function createStage1RepositoriesInternal(
             or coalesce(${contacts.primaryEmail}, '') ilike ${pattern} escape '\\'
             or coalesce(${contacts.primaryPhone}, '') ilike ${pattern} escape '\\'
           )
-          order by la.last_activity_at desc nulls last, ${contacts.displayName} asc, ${contacts.id} asc
-          limit ${limit}
-        `);
-
-        const bodyMatchesResult = await db.execute(sql`
-          with last_activity as ${lastActivityCte},
-          contact_matches as (
-            select ${contacts.id} as id
-            from ${contacts}
-            where (
-              ${contacts.displayName} ilike ${pattern} escape '\\'
-              or coalesce(${contacts.primaryEmail}, '') ilike ${pattern} escape '\\'
-              or coalesce(${contacts.primaryPhone}, '') ilike ${pattern} escape '\\'
-            )
-          )
-          select
-            ${contacts.id} as id,
-            ${contacts.salesforceContactId} as salesforce_contact_id,
-            ${contacts.displayName} as display_name,
-            ${contacts.primaryEmail} as primary_email,
-            ${contacts.primaryPhone} as primary_phone,
-            ${contacts.createdAt} as created_at,
-            ${contacts.updatedAt} as updated_at,
-            la.last_activity_at as last_activity_at,
-            ${contactInboxProjection.snippet} as snippet,
-            ${contactInboxProjection.lastEventType} as last_event_type,
-            ${contactInboxProjection.lastCanonicalEventId} as last_canonical_event_id,
-            coalesce(${gmailMessageDetails.subject}, ${salesforceCommunicationDetailsTable.subject}) as latest_subject,
-            true as has_projection
-          from ${contactInboxProjection}
-          inner join ${contacts}
-            on ${contacts.id} = ${contactInboxProjection.contactId}
-          left join last_activity la
-            on la.contact_id = ${contacts.id}
-          left join ${canonicalEventLedger}
-            on ${canonicalEventLedger.id} = ${contactInboxProjection.lastCanonicalEventId}
-          left join ${gmailMessageDetails}
-            on ${gmailMessageDetails.sourceEvidenceId} = ${canonicalEventLedger.sourceEvidenceId}
-          left join ${salesforceCommunicationDetailsTable}
-            on ${salesforceCommunicationDetailsTable.sourceEvidenceId} = ${canonicalEventLedger.sourceEvidenceId}
-          where (
-            ${contactInboxProjection.snippet} ilike ${pattern} escape '\\'
-            or coalesce(${gmailMessageDetails.subject}, '') ilike ${pattern} escape '\\'
-            or coalesce(${salesforceCommunicationDetailsTable.subject}, '') ilike ${pattern} escape '\\'
-          )
-          and ${contacts.id} not in (select id from contact_matches)
-          order by la.last_activity_at desc nulls last, ${contacts.displayName} asc, ${contacts.id} asc
-          limit ${limit}
+          order by la.last_activity_at desc nulls last, ${contacts.createdAt} desc, ${contacts.id} asc
         `);
 
         interface SearchRowResult {
@@ -2301,6 +2234,7 @@ function createStage1RepositoriesInternal(
           readonly created_at: Date | string;
           readonly updated_at: Date | string;
           readonly last_activity_at: Date | string | null;
+          readonly has_membership: boolean | string | number | null;
           readonly snippet: string | null;
           readonly last_event_type: string | null;
           readonly last_canonical_event_id: string | null;
@@ -2308,19 +2242,23 @@ function createStage1RepositoriesInternal(
           readonly has_projection: boolean | string | number | null;
         }
 
-        const contactRowsRaw =
+        const allRowsRaw =
           (contactMatchesResult as { rows?: readonly SearchRowResult[] }).rows ??
           (contactMatchesResult as readonly SearchRowResult[]);
-        const bodyRowsRaw =
-          (bodyMatchesResult as { rows?: readonly SearchRowResult[] }).rows ??
-          (bodyMatchesResult as readonly SearchRowResult[]);
 
-        const allMatchedIds = new Set<string>();
-        for (const row of contactRowsRaw) allMatchedIds.add(row.id);
-        for (const row of bodyRowsRaw) allMatchedIds.add(row.id);
-        const matchedContactIds = [...allMatchedIds];
+        // Postgres can return booleans as boolean | "t"/"f" | 1/0 depending
+        // on the driver layer; normalise once.
+        const isTruthyBool = (
+          value: boolean | string | number | null | undefined,
+        ): boolean =>
+          value === true || value === "t" || value === 1 || value === "1";
 
-        // Active project memberships for chip rendering.
+        const matchedContactIds = allRowsRaw.map((row) => row.id);
+
+        // Active project memberships for chip rendering. Same join as before:
+        // `contact_memberships` filtered by active project. (Membership-flag
+        // CTE above considers any membership row; this query is for the chip
+        // payload, which only renders active projects.)
         const membershipRows =
           matchedContactIds.length === 0
             ? []
@@ -2384,11 +2322,9 @@ function createStage1RepositoriesInternal(
             updatedAt: toDate(raw.updated_at),
           }),
           memberships: membershipsByContactId.get(raw.id) ?? [],
+          hasMembership: isTruthyBool(raw.has_membership),
           lastActivityAt: toIso(raw.last_activity_at),
-          hasProjection:
-            raw.has_projection === true ||
-            raw.has_projection === "t" ||
-            raw.has_projection === 1,
+          hasProjection: isTruthyBool(raw.has_projection),
           snippet: raw.snippet,
           latestMessageSubject:
             raw.latest_subject !== null && raw.latest_subject.length > 0
@@ -2400,12 +2336,23 @@ function createStage1RepositoriesInternal(
               : (raw.last_event_type as InboxUnifiedSearchRow["lastEventType"]),
         });
 
+        const volunteerRowsAll: InboxUnifiedSearchRow[] = [];
+        const contactRowsAll: InboxUnifiedSearchRow[] = [];
+        for (const raw of allRowsRaw) {
+          const mapped = toRow(raw);
+          if (mapped.hasMembership) {
+            volunteerRowsAll.push(mapped);
+          } else {
+            contactRowsAll.push(mapped);
+          }
+        }
+
         return {
-          contactMatches: contactRowsRaw.map(toRow),
-          bodyMatches: bodyRowsRaw.map(toRow),
+          volunteers: volunteerRowsAll.slice(0, limit),
+          contacts: contactRowsAll.slice(0, limit),
           totals: {
-            contactMatches: contactTotal,
-            bodyMatches: bodyTotal,
+            volunteers: volunteerRowsAll.length,
+            contacts: contactRowsAll.length,
           },
         };
       },

--- a/packages/db/test/inbox-unified-search.test.ts
+++ b/packages/db/test/inbox-unified-search.test.ts
@@ -15,6 +15,17 @@ async function seedFixture() {
     source: "salesforce",
   });
 
+  // Inactive project used to validate that PAST memberships still flip a
+  // contact into the Volunteers section even when the project is no longer
+  // active.
+  await context.repositories.projectDimensions.upsert({
+    projectId: "project-archived",
+    projectName: "Archived Watch",
+    projectAlias: null,
+    isActive: false,
+    source: "salesforce",
+  });
+
   return context;
 }
 
@@ -155,144 +166,466 @@ async function seedInboundEmail(
   return { sourceEvidenceId, canonicalEventId };
 }
 
+async function seedOutboundEmail(
+  context: Awaited<ReturnType<typeof seedFixture>>,
+  input: {
+    readonly contactId: string;
+    readonly occurredAt: string;
+    readonly idSuffix: string;
+  },
+) {
+  const sourceEvidenceId = `sev-${input.idSuffix}`;
+  await context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "gmail",
+    providerRecordType: "message",
+    providerRecordId: `gm-${input.idSuffix}`,
+    receivedAt: input.occurredAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `payloads/gmail/${input.idSuffix}.json`,
+    idempotencyKey: `gmail:${input.idSuffix}`,
+    checksum: `checksum:${input.idSuffix}`,
+  });
+  await context.repositories.canonicalEvents.upsert({
+    id: `evt-${input.idSuffix}`,
+    contactId: input.contactId,
+    eventType: "communication.email.outbound",
+    channel: "email",
+    occurredAt: input.occurredAt,
+    contentFingerprint: null,
+    sourceEvidenceId,
+    idempotencyKey: `canonical:evt-${input.idSuffix}`,
+    provenance: {
+      primaryProvider: "gmail",
+      primarySourceEvidenceId: sourceEvidenceId,
+      supportingSourceEvidenceIds: [],
+      winnerReason: "single_source",
+      sourceRecordType: "message",
+      sourceRecordId: `gm-${input.idSuffix}`,
+      messageKind: "one_to_one",
+      campaignRef: null,
+      threadRef: null,
+      direction: "outbound",
+      notes: null,
+    },
+    reviewState: "clear",
+  });
+}
+
+async function seedCampaignSentEvent(
+  context: Awaited<ReturnType<typeof seedFixture>>,
+  input: {
+    readonly contactId: string;
+    readonly occurredAt: string;
+    readonly idSuffix: string;
+  },
+) {
+  const sourceEvidenceId = `sev-${input.idSuffix}`;
+  await context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "mailchimp",
+    providerRecordType: "campaign-activity",
+    providerRecordId: `mc-${input.idSuffix}`,
+    receivedAt: input.occurredAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `payloads/mailchimp/${input.idSuffix}.json`,
+    idempotencyKey: `mailchimp:${input.idSuffix}`,
+    checksum: `checksum:${input.idSuffix}`,
+  });
+  await context.repositories.canonicalEvents.upsert({
+    id: `evt-${input.idSuffix}`,
+    contactId: input.contactId,
+    eventType: "campaign.email.sent",
+    channel: "campaign_email",
+    occurredAt: input.occurredAt,
+    contentFingerprint: null,
+    sourceEvidenceId,
+    idempotencyKey: `canonical:evt-${input.idSuffix}`,
+    provenance: {
+      primaryProvider: "mailchimp",
+      primarySourceEvidenceId: sourceEvidenceId,
+      supportingSourceEvidenceIds: [],
+      winnerReason: "single_source",
+      sourceRecordType: "campaign-activity",
+      sourceRecordId: `mc-${input.idSuffix}`,
+      messageKind: null,
+      campaignRef: {
+        providerCampaignId: `camp-${input.idSuffix}`,
+        providerAudienceId: null,
+        providerMessageName: null,
+      },
+      threadRef: null,
+      direction: null,
+      notes: null,
+    },
+    reviewState: "clear",
+  });
+}
+
 describe("contact repository searchInboxUnified", () => {
-  it("finds a signup-only contact by name in section A; section B is empty for that query", async () => {
+  it("places a contact with one PAST membership in volunteers (any-membership-ever rule)", async () => {
     const context = await seedFixture();
 
     try {
-      const contactId = "contact:eliza";
+      const contactId = "contact:past-member";
       await context.repositories.contacts.upsert({
         id: contactId,
-        salesforceContactId: "003-eliza",
-        displayName: "Eliza Tate",
-        primaryEmail: "eliza.tate@example.org",
+        salesforceContactId: "003-pm",
+        displayName: "Past Member Pat",
+        primaryEmail: "pat@example.org",
         primaryPhone: null,
         createdAt: BASE_TIMESTAMP,
         updatedAt: BASE_TIMESTAMP,
+      });
+      // Past membership on an inactive project — still counts.
+      await context.repositories.contactMemberships.upsert({
+        id: "membership-pat-past",
+        contactId,
+        projectId: "project-archived",
+        expeditionId: null,
+        salesforceMembershipId: "sf-pat-past",
+        role: "volunteer",
+        status: "inactive",
+        source: "salesforce",
+        createdAt: BASE_TIMESTAMP,
+      });
+
+      const result = await context.repositories.contacts.searchInboxUnified({
+        query: "Past",
+        limit: 25,
+      });
+
+      expect(result.volunteers).toHaveLength(1);
+      expect(result.volunteers[0]?.contact.id).toBe(contactId);
+      expect(result.volunteers[0]?.hasMembership).toBe(true);
+      expect(result.contacts).toHaveLength(0);
+      expect(result.totals.volunteers).toBe(1);
+      expect(result.totals.contacts).toBe(0);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("places a contact with zero memberships in contacts", async () => {
+    const context = await seedFixture();
+
+    try {
+      const contactId = "contact:no-membership";
+      await context.repositories.contacts.upsert({
+        id: contactId,
+        salesforceContactId: null,
+        displayName: "Solo Walker",
+        primaryEmail: "solo@example.org",
+        primaryPhone: null,
+        createdAt: BASE_TIMESTAMP,
+        updatedAt: BASE_TIMESTAMP,
+      });
+
+      const result = await context.repositories.contacts.searchInboxUnified({
+        query: "Solo",
+        limit: 25,
+      });
+
+      expect(result.volunteers).toHaveLength(0);
+      expect(result.contacts).toHaveLength(1);
+      expect(result.contacts[0]?.contact.id).toBe(contactId);
+      expect(result.contacts[0]?.hasMembership).toBe(false);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("sorts each section by last volunteer-side activity desc — outbound 1:1 sends do NOT influence the sort", async () => {
+    const context = await seedFixture();
+
+    try {
+      // Volunteer A: inbound email at 2026-01-01
+      const aId = "contact:vol-a";
+      await context.repositories.contacts.upsert({
+        id: aId,
+        salesforceContactId: "003-a",
+        displayName: "Sortable Alpha",
+        primaryEmail: "alpha@example.org",
+        primaryPhone: null,
+        createdAt: BASE_TIMESTAMP,
+        updatedAt: BASE_TIMESTAMP,
+      });
+      await context.repositories.contactMemberships.upsert({
+        id: "membership-a",
+        contactId: aId,
+        projectId: "project-pollinators",
+        expeditionId: null,
+        salesforceMembershipId: "sf-a",
+        role: "volunteer",
+        status: "active",
+        source: "salesforce",
+        createdAt: BASE_TIMESTAMP,
+      });
+      await seedInboundEmail(context, {
+        contactId: aId,
+        occurredAt: "2026-01-01T00:00:00.000Z",
+        idSuffix: "a-inb",
+        subject: "alpha inbound",
+      });
+
+      // Volunteer B: inbound email at 2025-01-01, but outbound send at
+      // 2026-04-01 (later than A's inbound). Sort key must IGNORE the
+      // outbound — B should still rank below A.
+      const bId = "contact:vol-b";
+      await context.repositories.contacts.upsert({
+        id: bId,
+        salesforceContactId: "003-b",
+        displayName: "Sortable Beta",
+        primaryEmail: "beta@example.org",
+        primaryPhone: null,
+        createdAt: BASE_TIMESTAMP,
+        updatedAt: BASE_TIMESTAMP,
+      });
+      await context.repositories.contactMemberships.upsert({
+        id: "membership-b",
+        contactId: bId,
+        projectId: "project-pollinators",
+        expeditionId: null,
+        salesforceMembershipId: "sf-b",
+        role: "volunteer",
+        status: "active",
+        source: "salesforce",
+        createdAt: BASE_TIMESTAMP,
+      });
+      await seedInboundEmail(context, {
+        contactId: bId,
+        occurredAt: "2025-01-01T00:00:00.000Z",
+        idSuffix: "b-inb",
+        subject: "beta inbound",
+      });
+      await seedOutboundEmail(context, {
+        contactId: bId,
+        occurredAt: "2026-04-01T00:00:00.000Z",
+        idSuffix: "b-out",
+      });
+
+      const result = await context.repositories.contacts.searchInboxUnified({
+        query: "Sortable",
+        limit: 25,
+      });
+
+      expect(result.volunteers.map((row) => row.contact.id)).toEqual([
+        aId,
+        bId,
+      ]);
+      // B's lastActivityAt should be its inbound (2025), not its outbound.
+      expect(result.volunteers[1]?.lastActivityAt).toBe(
+        "2025-01-01T00:00:00.000Z",
+      );
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("campaign events do NOT influence the sort", async () => {
+    const context = await seedFixture();
+
+    try {
+      // Volunteer A: lifecycle signup at 2026-01-01
+      const aId = "contact:camp-a";
+      await context.repositories.contacts.upsert({
+        id: aId,
+        salesforceContactId: "003-ca",
+        displayName: "Camp Alpha",
+        primaryEmail: "ca@example.org",
+        primaryPhone: null,
+        createdAt: BASE_TIMESTAMP,
+        updatedAt: BASE_TIMESTAMP,
+      });
+      await context.repositories.contactMemberships.upsert({
+        id: "membership-camp-a",
+        contactId: aId,
+        projectId: "project-pollinators",
+        expeditionId: null,
+        salesforceMembershipId: "sf-ca",
+        role: "volunteer",
+        status: "active",
+        source: "salesforce",
+        createdAt: BASE_TIMESTAMP,
       });
       await seedSignedUpEvent(context, {
-        contactId,
-        occurredAt: "2026-03-15T09:30:00.000Z",
-        idSuffix: "eliza",
+        contactId: aId,
+        occurredAt: "2026-01-01T00:00:00.000Z",
+        idSuffix: "ca-signup",
       });
 
-      const result = await context.repositories.contacts.searchInboxUnified({
-        query: "Eli",
-        limit: 25,
-      });
-
-      expect(result.contactMatches).toHaveLength(1);
-      expect(result.contactMatches[0]?.contact.id).toBe(contactId);
-      expect(result.contactMatches[0]?.hasProjection).toBe(false);
-      expect(result.contactMatches[0]?.lastActivityAt).toBe(
-        "2026-03-15T09:30:00.000Z",
-      );
-      expect(result.bodyMatches).toHaveLength(0);
-      expect(result.totals.contactMatches).toBe(1);
-      expect(result.totals.bodyMatches).toBe(0);
-    } finally {
-      await context.dispose();
-    }
-  });
-
-  it("finds a contact in section B when the snippet matches but the name does not", async () => {
-    const context = await seedFixture();
-
-    try {
-      const contactId = "contact:body-match";
-      const occurredAt = "2026-04-20T16:00:00.000Z";
+      // Volunteer B: signup at 2024-01-01, campaign sent at 2026-05-01.
+      // Campaign event should NOT bump B above A.
+      const bId = "contact:camp-b";
       await context.repositories.contacts.upsert({
-        id: contactId,
-        salesforceContactId: "003-bm",
-        displayName: "Quincy Adams",
-        primaryEmail: "quincy@example.org",
+        id: bId,
+        salesforceContactId: "003-cb",
+        displayName: "Camp Beta",
+        primaryEmail: "cb@example.org",
         primaryPhone: null,
         createdAt: BASE_TIMESTAMP,
         updatedAt: BASE_TIMESTAMP,
       });
-      const { canonicalEventId } = await seedInboundEmail(context, {
-        contactId,
-        occurredAt,
-        idSuffix: "qa-body",
-        subject: "Hello there",
-      });
-      await seedInboxProjection(context, {
-        contactId,
-        snippet: "thanks for the helpful biodiversity update",
-        occurredAt,
-        canonicalEventId,
-      });
-
-      const result = await context.repositories.contacts.searchInboxUnified({
-        query: "biodiversity",
-        limit: 25,
-      });
-
-      expect(result.contactMatches).toHaveLength(0);
-      expect(result.bodyMatches).toHaveLength(1);
-      expect(result.bodyMatches[0]?.contact.id).toBe(contactId);
-      expect(result.bodyMatches[0]?.hasProjection).toBe(true);
-      expect(result.bodyMatches[0]?.snippet).toContain("biodiversity");
-      expect(result.totals.bodyMatches).toBe(1);
-    } finally {
-      await context.dispose();
-    }
-  });
-
-  it("dedupes a contact appearing in both sections — only Section A is returned", async () => {
-    const context = await seedFixture();
-
-    try {
-      const contactId = "contact:dual-match";
-      const occurredAt = "2026-04-15T08:00:00.000Z";
-      await context.repositories.contacts.upsert({
-        id: contactId,
-        salesforceContactId: "003-dm",
-        displayName: "Hannah Hawthorne",
-        primaryEmail: "hannah@example.org",
-        primaryPhone: null,
+      await context.repositories.contactMemberships.upsert({
+        id: "membership-camp-b",
+        contactId: bId,
+        projectId: "project-pollinators",
+        expeditionId: null,
+        salesforceMembershipId: "sf-cb",
+        role: "volunteer",
+        status: "active",
+        source: "salesforce",
         createdAt: BASE_TIMESTAMP,
-        updatedAt: BASE_TIMESTAMP,
       });
-      const { canonicalEventId } = await seedInboundEmail(context, {
-        contactId,
-        occurredAt,
-        idSuffix: "hannah-dual",
-        subject: "About hannah",
+      await seedSignedUpEvent(context, {
+        contactId: bId,
+        occurredAt: "2024-01-01T00:00:00.000Z",
+        idSuffix: "cb-signup",
       });
-      await seedInboxProjection(context, {
-        contactId,
-        snippet: "this body also mentions hannah",
-        occurredAt,
-        canonicalEventId,
+      await seedCampaignSentEvent(context, {
+        contactId: bId,
+        occurredAt: "2026-05-01T00:00:00.000Z",
+        idSuffix: "cb-camp",
       });
 
       const result = await context.repositories.contacts.searchInboxUnified({
-        query: "hannah",
+        query: "Camp",
         limit: 25,
       });
 
-      expect(result.contactMatches.map((row) => row.contact.id)).toEqual([
-        contactId,
+      expect(result.volunteers.map((row) => row.contact.id)).toEqual([
+        aId,
+        bId,
       ]);
-      expect(result.bodyMatches.map((row) => row.contact.id)).toEqual([]);
+      expect(result.volunteers[1]?.lastActivityAt).toBe(
+        "2024-01-01T00:00:00.000Z",
+      );
     } finally {
       await context.dispose();
     }
   });
 
-  it("caps each section at 25 and reports the pre-truncation total", async () => {
+  it("a contact with only outbound + campaign events sorts to the bottom of its section (NULL lastActivityAt)", async () => {
     const context = await seedFixture();
 
     try {
-      // 30 distinct name-matching contacts.
+      // Volunteer with only outbound + campaign events. No volunteer-side
+      // events → lastActivityAt is null and sorts last.
+      const aId = "contact:bottom-a";
+      await context.repositories.contacts.upsert({
+        id: aId,
+        salesforceContactId: "003-ba",
+        displayName: "Bottom Alpha",
+        primaryEmail: "ba@example.org",
+        primaryPhone: null,
+        createdAt: "2026-04-01T00:00:00.000Z",
+        updatedAt: BASE_TIMESTAMP,
+      });
+      await context.repositories.contactMemberships.upsert({
+        id: "membership-ba",
+        contactId: aId,
+        projectId: "project-pollinators",
+        expeditionId: null,
+        salesforceMembershipId: "sf-ba",
+        role: "volunteer",
+        status: "active",
+        source: "salesforce",
+        createdAt: BASE_TIMESTAMP,
+      });
+      await seedOutboundEmail(context, {
+        contactId: aId,
+        occurredAt: "2026-05-01T00:00:00.000Z",
+        idSuffix: "ba-out",
+      });
+      await seedCampaignSentEvent(context, {
+        contactId: aId,
+        occurredAt: "2026-05-02T00:00:00.000Z",
+        idSuffix: "ba-camp",
+      });
+
+      // Volunteer with one inbound — should sort first.
+      const bId = "contact:bottom-b";
+      await context.repositories.contacts.upsert({
+        id: bId,
+        salesforceContactId: "003-bb",
+        displayName: "Bottom Beta",
+        primaryEmail: "bb@example.org",
+        primaryPhone: null,
+        createdAt: BASE_TIMESTAMP,
+        updatedAt: BASE_TIMESTAMP,
+      });
+      await context.repositories.contactMemberships.upsert({
+        id: "membership-bb",
+        contactId: bId,
+        projectId: "project-pollinators",
+        expeditionId: null,
+        salesforceMembershipId: "sf-bb",
+        role: "volunteer",
+        status: "active",
+        source: "salesforce",
+        createdAt: BASE_TIMESTAMP,
+      });
+      await seedInboundEmail(context, {
+        contactId: bId,
+        occurredAt: "2026-02-01T00:00:00.000Z",
+        idSuffix: "bb-inb",
+        subject: "beta hello",
+      });
+
+      const result = await context.repositories.contacts.searchInboxUnified({
+        query: "Bottom",
+        limit: 25,
+      });
+
+      // Beta (with inbound) ranks first; Alpha (only outbound + campaign)
+      // ranks last with null lastActivityAt.
+      expect(result.volunteers.map((row) => row.contact.id)).toEqual([
+        bId,
+        aId,
+      ]);
+      expect(result.volunteers[1]?.lastActivityAt).toBeNull();
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("caps each section at the limit and reports pre-truncation totals", async () => {
+    const context = await seedFixture();
+
+    try {
+      // 30 volunteers all matching "Bulky".
       for (let i = 0; i < 30; i += 1) {
-        const id = `contact:bulk-${String(i).padStart(2, "0")}`;
+        const id = `contact:vol-${String(i).padStart(2, "0")}`;
         await context.repositories.contacts.upsert({
           id,
           salesforceContactId: null,
-          displayName: `Bulky Bulk ${String(i).padStart(2, "0")}`,
-          primaryEmail: `bulk-${String(i).padStart(2, "0")}@example.org`,
+          displayName: `Bulky Vol ${String(i).padStart(2, "0")}`,
+          primaryEmail: `vol-${String(i).padStart(2, "0")}@example.org`,
+          primaryPhone: null,
+          createdAt: BASE_TIMESTAMP,
+          updatedAt: BASE_TIMESTAMP,
+        });
+        await context.repositories.contactMemberships.upsert({
+          id: `mem-vol-${String(i).padStart(2, "0")}`,
+          contactId: id,
+          projectId: "project-pollinators",
+          expeditionId: null,
+          salesforceMembershipId: `sf-vol-${String(i).padStart(2, "0")}`,
+          role: "volunteer",
+          status: "active",
+          source: "salesforce",
+          createdAt: BASE_TIMESTAMP,
+        });
+      }
+
+      // 28 plain contacts (no membership) all matching "Bulky".
+      for (let i = 0; i < 28; i += 1) {
+        const id = `contact:plain-${String(i).padStart(2, "0")}`;
+        await context.repositories.contacts.upsert({
+          id,
+          salesforceContactId: null,
+          displayName: `Bulky Plain ${String(i).padStart(2, "0")}`,
+          primaryEmail: `plain-${String(i).padStart(2, "0")}@example.org`,
           primaryPhone: null,
           createdAt: BASE_TIMESTAMP,
           updatedAt: BASE_TIMESTAMP,
@@ -304,68 +637,10 @@ describe("contact repository searchInboxUnified", () => {
         limit: 25,
       });
 
-      expect(result.contactMatches).toHaveLength(25);
-      expect(result.totals.contactMatches).toBe(30);
-    } finally {
-      await context.dispose();
-    }
-  });
-
-  it("orders by last activity desc across all event types (lifecycle event newer than older comm event)", async () => {
-    const context = await seedFixture();
-
-    try {
-      const oldCommContactId = "contact:older-comm";
-      const newerLifecycleContactId = "contact:newer-lifecycle";
-
-      await context.repositories.contacts.upsert({
-        id: oldCommContactId,
-        salesforceContactId: "003-oc",
-        displayName: "Order Test Older",
-        primaryEmail: "older@example.org",
-        primaryPhone: null,
-        createdAt: BASE_TIMESTAMP,
-        updatedAt: BASE_TIMESTAMP,
-      });
-      const { canonicalEventId: oldEventId } = await seedInboundEmail(context, {
-        contactId: oldCommContactId,
-        occurredAt: "2026-01-01T00:00:00.000Z",
-        idSuffix: "older",
-        subject: "old subject",
-      });
-      await seedInboxProjection(context, {
-        contactId: oldCommContactId,
-        snippet: "old snippet",
-        occurredAt: "2026-01-01T00:00:00.000Z",
-        canonicalEventId: oldEventId,
-      });
-
-      await context.repositories.contacts.upsert({
-        id: newerLifecycleContactId,
-        salesforceContactId: "003-nl",
-        displayName: "Order Test Newer",
-        primaryEmail: "newer@example.org",
-        primaryPhone: null,
-        createdAt: BASE_TIMESTAMP,
-        updatedAt: BASE_TIMESTAMP,
-      });
-      await seedSignedUpEvent(context, {
-        contactId: newerLifecycleContactId,
-        occurredAt: "2026-04-01T00:00:00.000Z",
-        idSuffix: "newer",
-      });
-
-      const result = await context.repositories.contacts.searchInboxUnified({
-        query: "Order Test",
-        limit: 25,
-      });
-
-      // Both match section A; the newer lifecycle event must beat the older
-      // comm event's lastActivityAt.
-      expect(result.contactMatches.map((row) => row.contact.id)).toEqual([
-        newerLifecycleContactId,
-        oldCommContactId,
-      ]);
+      expect(result.volunteers).toHaveLength(25);
+      expect(result.contacts).toHaveLength(25);
+      expect(result.totals.volunteers).toBe(30);
+      expect(result.totals.contacts).toBe(28);
     } finally {
       await context.dispose();
     }
@@ -390,21 +665,21 @@ describe("contact repository searchInboxUnified", () => {
         query: "",
         limit: 25,
       });
-      expect(empty.contactMatches).toEqual([]);
-      expect(empty.bodyMatches).toEqual([]);
-      expect(empty.totals).toEqual({ contactMatches: 0, bodyMatches: 0 });
+      expect(empty.volunteers).toEqual([]);
+      expect(empty.contacts).toEqual([]);
+      expect(empty.totals).toEqual({ volunteers: 0, contacts: 0 });
 
       const whitespace = await context.repositories.contacts.searchInboxUnified(
         { query: "   ", limit: 25 },
       );
-      expect(whitespace.contactMatches).toEqual([]);
-      expect(whitespace.bodyMatches).toEqual([]);
+      expect(whitespace.volunteers).toEqual([]);
+      expect(whitespace.contacts).toEqual([]);
     } finally {
       await context.dispose();
     }
   });
 
-  it("returns active project memberships alongside matching contacts", async () => {
+  it("returns active project memberships alongside matching volunteers", async () => {
     const context = await seedFixture();
 
     try {
@@ -435,13 +710,61 @@ describe("contact repository searchInboxUnified", () => {
         limit: 25,
       });
 
-      expect(result.contactMatches[0]?.memberships).toEqual([
+      expect(result.volunteers).toHaveLength(1);
+      expect(result.volunteers[0]?.memberships).toEqual([
         {
           projectId: "project-pollinators",
           projectName: "Pollinator Watch",
           projectAlias: "pollinators",
         },
       ]);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("does NOT return a `bodyMatches` field — body-match search has been removed", async () => {
+    const context = await seedFixture();
+
+    try {
+      const contactId = "contact:body-only";
+      const occurredAt = "2026-04-20T16:00:00.000Z";
+      await context.repositories.contacts.upsert({
+        id: contactId,
+        salesforceContactId: "003-bo",
+        displayName: "Quincy Adams",
+        primaryEmail: "quincy@example.org",
+        primaryPhone: null,
+        createdAt: BASE_TIMESTAMP,
+        updatedAt: BASE_TIMESTAMP,
+      });
+      const { canonicalEventId } = await seedInboundEmail(context, {
+        contactId,
+        occurredAt,
+        idSuffix: "qa-body",
+        subject: "Hello there",
+      });
+      await seedInboxProjection(context, {
+        contactId,
+        snippet: "thanks for the helpful biodiversity update",
+        occurredAt,
+        canonicalEventId,
+      });
+
+      // Searching for a body-only term ("biodiversity") that doesn't appear
+      // in name/email/phone should now return zero results — body matching
+      // was dropped.
+      const result = await context.repositories.contacts.searchInboxUnified({
+        query: "biodiversity",
+        limit: 25,
+      });
+
+      expect(result.volunteers).toEqual([]);
+      expect(result.contacts).toEqual([]);
+      expect(result.totals).toEqual({ volunteers: 0, contacts: 0 });
+
+      // Sanity-check that the function shape doesn't include bodyMatches.
+      expect("bodyMatches" in result).toBe(false);
     } finally {
       await context.dispose();
     }

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -217,9 +217,18 @@ export interface InboxUnifiedSearchRow {
   readonly contact: ContactRecord;
   readonly memberships: readonly InboxUnifiedSearchMembership[];
   /**
-   * MAX(canonicalEventLedger.occurredAt) across ALL event types — not just
-   * inbox-driving comm events. Drives the "last activity" sort key and
-   * timestamp label. Null when the contact has no events at all.
+   * True when the contact has at least one row in `contact_memberships`,
+   * regardless of whether the membership is active or past. Drives the
+   * Volunteers / Contacts partition on the client.
+   */
+  readonly hasMembership: boolean;
+  /**
+   * MAX(canonicalEventLedger.occurredAt) WHERE event_type is
+   * volunteer-initiated (lifecycle.* + inbound 1:1 comm + sms.opt_*).
+   * Excludes outbound 1:1 sends, all campaign events, and internal notes
+   * so an operator's reply doesn't bump a contact to the top. Drives the
+   * "last activity" sort key and timestamp label. Null when the contact has
+   * no qualifying events at all.
    */
   readonly lastActivityAt: string | null;
   /**
@@ -248,20 +257,26 @@ export interface InboxUnifiedSearchRow {
 }
 
 /**
- * Two-section unified search result. Section A (`contactMatches`) matches on
- * contact attributes (display name, primary email, primary phone). Section B
- * (`bodyMatches`) matches on inbox-projection snippet or latest message
- * subject and EXCLUDES contacts already in `contactMatches`. Each section is
- * sorted by lastActivityAt desc internally and capped at the `limit` passed
- * in. `totals` exposes the count BEFORE truncation so the UI can show
- * "X+ results".
+ * Two-section unified search result. Both sections match on contact
+ * attributes (display name, primary email, primary phone) and partition the
+ * matched contacts by membership-existence:
+ *
+ * - `volunteers`: contacts with at least one `contact_memberships` row
+ *   (active OR past).
+ * - `contacts`: contacts with zero membership rows.
+ *
+ * Each section is sorted by `lastActivityAt` desc (volunteer-initiated
+ * events only — see {@link InboxUnifiedSearchRow.lastActivityAt}) with NULL
+ * last and `contacts.created_at` desc as the tiebreaker, then capped at the
+ * `limit` passed in. `totals` exposes the count BEFORE truncation so the UI
+ * can show "X+ results".
  */
 export interface InboxUnifiedSearchResult {
-  readonly contactMatches: readonly InboxUnifiedSearchRow[];
-  readonly bodyMatches: readonly InboxUnifiedSearchRow[];
+  readonly volunteers: readonly InboxUnifiedSearchRow[];
+  readonly contacts: readonly InboxUnifiedSearchRow[];
   readonly totals: {
-    readonly contactMatches: number;
-    readonly bodyMatches: number;
+    readonly volunteers: number;
+    readonly contacts: number;
   };
 }
 
@@ -278,17 +293,17 @@ export interface ContactRepository {
     readonly limit: number;
   }): Promise<readonly ContactRecord[]>;
   /**
-   * Unified inbox search. Bypasses the projection-only filter so the result
-   * includes contacts who have lifecycle/campaign events (or no events at
-   * all) alongside contacts with conversation history. Returns two sections:
+   * Unified inbox search. Returns contacts matching name / primary email /
+   * primary phone (ILIKE), partitioned by whether the contact has any
+   * `contact_memberships` row (active OR past):
    *
-   * - `contactMatches`: matches on `contacts.displayName`, `primaryEmail`,
-   *   `primaryPhone`. Includes contacts without inbox projection.
-   * - `bodyMatches`: matches on `contact_inbox_projection.snippet` or the
-   *   latest message subject (joined via `last_canonical_event_id`). Excludes
-   *   contacts already returned in `contactMatches`.
+   * - `volunteers`: matched contacts with at least one membership.
+   * - `contacts`: matched contacts with zero memberships.
    *
-   * Both sections are sorted by `lastActivityAt` desc and capped at `limit`.
+   * Both sections are sorted by `lastActivityAt` desc — restricted to
+   * volunteer-initiated events (lifecycle.* + inbound 1:1 communication +
+   * sms.opt_*) so outbound sends and campaign events don't bump a contact
+   * to the top — and capped at `limit`.
    */
   searchInboxUnified(input: {
     readonly query: string;

--- a/packages/domain/test/normalization.test.ts
+++ b/packages/domain/test/normalization.test.ts
@@ -452,9 +452,9 @@ function buildContext(input: {
       searchByQuery: () => Promise.resolve([...contacts]),
       searchInboxUnified: () =>
         Promise.resolve({
-          contactMatches: [],
-          bodyMatches: [],
-          totals: { contactMatches: 0, bodyMatches: 0 },
+          volunteers: [],
+          contacts: [],
+          totals: { volunteers: 0, contacts: 0 },
         }),
       upsert: (record) => Promise.resolve(record),
     },

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -78,9 +78,9 @@ describe("defineStage1RepositoryBundle", () => {
         searchByQuery: () => Promise.resolve([contact]),
         searchInboxUnified: () =>
           Promise.resolve({
-            contactMatches: [],
-            bodyMatches: [],
-            totals: { contactMatches: 0, bodyMatches: 0 },
+            volunteers: [],
+            contacts: [],
+            totals: { volunteers: 0, contacts: 0 },
           }),
         upsert: (record) => Promise.resolve(record),
       },

--- a/packages/domain/test/stage3-last-inbound-alias.test.ts
+++ b/packages/domain/test/stage3-last-inbound-alias.test.ts
@@ -97,9 +97,9 @@ function buildRepositoryBundle(input: {
       searchByQuery: () => Promise.resolve([contact]),
       searchInboxUnified: () =>
         Promise.resolve({
-          contactMatches: [],
-          bodyMatches: [],
-          totals: { contactMatches: 0, bodyMatches: 0 },
+          volunteers: [],
+          contacts: [],
+          totals: { volunteers: 0, contacts: 0 },
         }),
       upsert: (record) => Promise.resolve(record),
     },

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -174,9 +174,9 @@ function createRepositoryBundle(input: {
       searchByQuery: () => Promise.resolve([contact]),
       searchInboxUnified: () =>
         Promise.resolve({
-          contactMatches: [],
-          bodyMatches: [],
-          totals: { contactMatches: 0, bodyMatches: 0 },
+          volunteers: [],
+          contacts: [],
+          totals: { volunteers: 0, contacts: 0 },
         }),
       upsert: (record) => Promise.resolve(record),
     },


### PR DESCRIPTION
## Why

Section B body matches from PR #379 were noisy — they ILIKE the
`contact_inbox_projection.snippet` (last-message body only) plus the
latest message subject, which surfaced random partial-word hits without
much signal. The architect wants Section A split into Volunteers vs
Contacts instead, with the sort filtered to volunteer-initiated activity
only so an operator's outbound reply or a Mailchimp campaign doesn't bump
a contact to the top of the search list.

## What changed

- **Body-match section removed.** Dropped the second SQL query, the
  `bodyMatches` field from the response shape, the `<mark>` highlight
  wrapper, and `matchPositions` plumbing. The `Message matches` section
  no longer renders.
- **Volunteers / Contacts partition.** `searchInboxUnified` now runs the
  contact-attribute query once and computes a `hasMembership` flag per
  row via a CTE on `contact_memberships` (active OR past). Returns
  `{ volunteers, contacts, totals }`.
- **Last-activity sort filtered to volunteer-side events.**
  `MAX(occurred_at)` is now restricted to:
  - `lifecycle.signed_up`, `lifecycle.received_training`,
    `lifecycle.completed_training`, `lifecycle.submitted_first_data`
  - `communication.email.inbound`, `communication.sms.inbound`
  - `communication.sms.opt_in`, `communication.sms.opt_out`

  Excluded: `communication.email.outbound`, `communication.sms.outbound`,
  `note.internal.created`, all `campaign.*`. Contacts with no qualifying
  events sort last (NULL last) with `contacts.created_at desc` as the
  tiebreaker.
- **Compact single-line row format for Contacts section.**
  - Email-only contact (`displayName` contains `@`): renders just the
    email, full-width single line.
  - Named contact: renders `<bold>Name</bold> · <muted>email</muted>`.
  - No avatar, no time-ago, no snippet, no project chip. Click target
    is `/inbox/[contactId]` same as Volunteer rows.
- **25 + 25 caps preserved**; `totals.volunteers` / `totals.contacts`
  report pre-cap counts.
- **Min length 3, debounce 400 ms preserved.**

## Files touched

- `packages/domain/src/repositories.ts` — type updates (new shape, new
  `hasMembership` field on the row, doc comments).
- `packages/db/src/repositories.ts` — single contact-attribute query
  with two CTEs (`last_activity` filtered to volunteer-side event types,
  `memberships_flag`); TS-side partition + per-section cap.
- `packages/db/test/inbox-unified-search.test.ts` — full rewrite. 9
  tests: any-membership-ever rule, zero-membership rule, outbound-no-
  influence sort, campaign-no-influence sort, NULL-sort-last, 25+25
  caps, min-query, memberships chip, no-bodyMatches-shape.
- `apps/web/app/inbox/_lib/view-models.ts` — view-model shape change.
- `apps/web/app/inbox/_lib/selectors.ts` — selector returns new shape.
- `apps/web/app/api/inbox/search/route.ts` — empty-result short-circuit
  shape updated.
- `apps/web/app/inbox/_components/inbox-unified-search-row.tsx` — new
  compact mode; dropped `<mark>` highlight code.
- `apps/web/app/inbox/_components/inbox-list.tsx` — `UnifiedSearchResultList`
  rewritten to the two new sections.
- `apps/web/tests/unit/inbox-list-shell.test.tsx` — replaced the
  body-match test with three new tests covering section labels, full-row
  vs compact-row formatting, and absence of `<mark>` / `Message matches`.
- `packages/domain/test/{repositories,normalization,stage3-last-inbound-alias,timeline}.test.ts`
  — mock shape updates.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm build` clean
- [x] `vitest run` for `packages/db/test/inbox-unified-search.test.ts` — 9/9 pass
- [x] `vitest run` for `apps/web/tests/unit/inbox-list-shell.test.tsx` — 30/30 pass
- [x] `vitest run` for `packages/domain/test` — 103/103 pass
- [ ] CI green
- [ ] Manual: search "Eli" → Eliza Tate appears in Volunteers (she has a
      membership); email-only contacts with `eli` in the email appear in
      Contacts in compact format
- [ ] Manual: an outbound reply does not bump the recipient to the top
      of the search list
- [ ] Manual: a Mailchimp campaign event does not bump a recipient to
      the top either

## Acceptance criteria

- Searching "Eli" with ≥3 chars returns Eliza Tate in the Volunteers
  section if she has any membership; otherwise in the Contacts section.
- Searching for an email-only contact (no membership) returns them in
  the Contacts section in compact format.
- Last-activity sort treats only volunteer-side events — outbound 1:1
  sends and campaign events don't move a contact up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)