### PR TITLE
fix(security): pre-launch hardening (timingSafeEqual + attachment audit + secret patterns)

### DIFF
--- a/apps/web/app/api/attachments/[id]/route.ts
+++ b/apps/web/app/api/attachments/[id]/route.ts
@@ -1,6 +1,7 @@
 import { getStage1WebRuntime } from "@/src/server/stage1-runtime";
 import { requireApiSession } from "@/src/server/auth/api";
 import { fetchAttachmentUpstream } from "@/src/server/attachments/upstream";
+import { appendSecurityAudit } from "@/src/server/security/audit";
 
 export const dynamic = "force-dynamic";
 
@@ -60,6 +61,23 @@ export async function GET(
   const attachment = await runtime.repositories.messageAttachments.findById(id);
 
   if (attachment === null) {
+    // Defense-in-depth observability: log every cross-attachment access
+    // attempt so a future cross-project IDOR pattern is detectable in the
+    // audit log without requiring a structural project-scope filter.
+    // See `.STATE-2026-05-02-security-review.md` H2.
+    await appendSecurityAudit({
+      actorType: "user",
+      actorId: session.user.id,
+      action: "attachment.fetch",
+      entityType: "message_attachment",
+      entityId: id,
+      result: "denied",
+      policyCode: "attachment.fetch.not_found",
+      metadataJson: {},
+    }).catch((error: unknown) => {
+      console.error("Failed to append attachment audit.", error);
+    });
+
     return new Response("Attachment not found", { status: 404 });
   }
 
@@ -93,6 +111,24 @@ export async function GET(
   if (!upstreamResponse.ok) {
     return new Response("Attachment upstream unavailable.", { status: 502 });
   }
+
+  // Successful fetch — log who fetched what for the cross-attachment access
+  // audit trail (see `.STATE-2026-05-02-security-review.md` H2).
+  await appendSecurityAudit({
+    actorType: "user",
+    actorId: session.user.id,
+    action: "attachment.fetch",
+    entityType: "message_attachment",
+    entityId: id,
+    result: "allowed",
+    policyCode: "attachment.fetch",
+    metadataJson: {
+      mimeType: attachment.mimeType,
+      sizeBytes: attachment.sizeBytes,
+    },
+  }).catch((error: unknown) => {
+    console.error("Failed to append attachment audit.", error);
+  });
 
   return new Response(upstreamResponse.body, {
     status: 200,

--- a/apps/web/app/api/internal/inbox-rebuild/route.ts
+++ b/apps/web/app/api/internal/inbox-rebuild/route.ts
@@ -1,3 +1,5 @@
+import { timingSafeEqual } from "node:crypto";
+
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
@@ -26,7 +28,18 @@ function isAuthorized(request: Request): boolean {
     return false;
   }
 
-  return request.headers.get("authorization") === `Bearer ${expectedToken}`;
+  const received = request.headers.get("authorization") ?? "";
+  const expectedHeader = `Bearer ${expectedToken}`;
+  // Length check first — `timingSafeEqual` throws on length mismatch, and
+  // the throw itself would leak a length signal via timing. Short-circuit
+  // cleanly so equal-length comparisons run in constant time.
+  if (received.length !== expectedHeader.length) {
+    return false;
+  }
+  return timingSafeEqual(
+    Buffer.from(received, "utf8"),
+    Buffer.from(expectedHeader, "utf8"),
+  );
 }
 
 function compareCanonicalEventOrder(

--- a/apps/web/app/api/internal/revalidate/route.ts
+++ b/apps/web/app/api/internal/revalidate/route.ts
@@ -1,3 +1,5 @@
+import { timingSafeEqual } from "node:crypto";
+
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
@@ -16,7 +18,18 @@ function isAuthorized(request: Request): boolean {
     return false;
   }
 
-  return request.headers.get("authorization") === `Bearer ${expectedToken}`;
+  const received = request.headers.get("authorization") ?? "";
+  const expectedHeader = `Bearer ${expectedToken}`;
+  // Length check first — `timingSafeEqual` throws on length mismatch, and
+  // the throw itself would leak a length signal via timing. Short-circuit
+  // cleanly so equal-length comparisons run in constant time.
+  if (received.length !== expectedHeader.length) {
+    return false;
+  }
+  return timingSafeEqual(
+    Buffer.from(received, "utf8"),
+    Buffer.from(expectedHeader, "utf8"),
+  );
 }
 
 export async function POST(request: Request) {

--- a/apps/web/src/server/ai/cost-counter.ts
+++ b/apps/web/src/server/ai/cost-counter.ts
@@ -4,6 +4,21 @@ interface DailyCostState {
 }
 
 declare global {
+  /**
+   * Process-local daily cost accumulator for the AI draft surface. Lives on
+   * `globalThis` so module reloads in dev (HMR) and shared module instances
+   * across Next route boundaries observe the same accumulator within a
+   * single Node process.
+   *
+   * Intentional: pattern flagged as "hidden_state_mutation" by static
+   * analysis but is a real cross-module cache, not a hidden side-effect.
+   *
+   * Limitation: if the web service ever scales to multiple Railway
+   * instances, each instance has its own counter, so the effective cap
+   * becomes N × `AI_DAILY_CAP_USD`. Current deploy is single-instance;
+   * if that changes, move this counter to a Redis or DB row. See
+   * `.STATE-2026-05-02-security-review.md` M2.
+   */
   var __AS_COMMS_AI_DAILY_COST_STATE__: DailyCostState | undefined;
 }
 

--- a/apps/web/src/server/security/rate-limit.ts
+++ b/apps/web/src/server/security/rate-limit.ts
@@ -31,6 +31,22 @@ export interface IRateLimiter {
 }
 
 declare global {
+  /**
+   * Process-local in-memory rate-limit buckets keyed by `${scope}:${identifier}`.
+   * Lives on `globalThis` so the bucket map survives Next route module
+   * reloads within a single Node process (HMR in dev; warm Lambda-style
+   * reuse in prod). Scoped per-process: with horizontal scaling, each
+   * Railway instance has its own bucket map and clients can shop limits
+   * by hitting different instances.
+   *
+   * Intentional: pattern flagged as "hidden_state_mutation" by static
+   * analysis but is a real cross-module cache, not a hidden side-effect.
+   *
+   * For per-IP/per-user limits this is acceptable on single-instance deploy.
+   * If the web service ever scales horizontally, swap the InMemoryRateLimiter
+   * for a Redis-backed implementation. The IRateLimiter interface below
+   * exists so the swap is a one-line change in `getSecurityRateLimiter`.
+   */
   var __AS_COMMS_RATE_LIMIT_STATE__: GlobalRateLimitState | undefined;
 }
 

--- a/packages/domain/src/pii-mask.ts
+++ b/packages/domain/src/pii-mask.ts
@@ -19,6 +19,26 @@
  *   - Single capitalised words (would over-mask common English: "Monday",
  *     "Pacific", project names that legitimately appear in tone signal).
  *   - Greetings and sign-offs — Claude needs these to learn voice.
+ *
+ * Compliance boundary (security review 2026-05-02 M4):
+ *
+ * This masker is **heuristic, not regulatory-grade.** Specifically:
+ *   - Phone regex matches US-style 10-digit numbers only. International
+ *     formats (e.g. `+44 207 123 4567`, `+33 1 ...`) will NOT be masked.
+ *   - Name regex requires 2+ consecutive capitalised words. Single first
+ *     names in greetings (e.g. "Hi Sarah,") will NOT be masked.
+ *   - The following PII categories are NOT masked at all and would leak
+ *     to Anthropic if present in a corpus example: physical addresses,
+ *     dates of birth, member/donor IDs, social-security-style numbers,
+ *     payment card numbers, donation amounts.
+ *
+ * Acceptable for the current data class — Adventure Scientists volunteer
+ * communications are non-regulated PII and Anthropic's DPA covers the
+ * processing. If this masker is ever reused for HIPAA-regulated content
+ * (e.g. citizen-science health-research volunteers), GDPR-resident data
+ * beyond what Anthropic's DPA covers, or financial reconciliation data,
+ * **revisit and tighten before extending the corpus surface.** Consider
+ * a policy-driven masking library (e.g. presidio) at that point.
  */
 export function maskKnowledgeExample(value: string): string {
   return value

--- a/packages/integrations/src/ai-knowledge-fetchers.ts
+++ b/packages/integrations/src/ai-knowledge-fetchers.ts
@@ -226,6 +226,100 @@ function isTextContentType(contentType: string | null): boolean {
   );
 }
 
+// SSRF guards. The fetcher is reachable from `addAiKnowledgeSourceAction`,
+// which is admin-only but still operator-supplied. Without these guards an
+// admin could point a `web_page` source at `http://localhost`, a private
+// RFC1918 IP, the cloud-metadata link-local IP, or `*.railway.internal`,
+// and the response body would be fed into the AI Knowledge synthesis
+// prompt and ultimately surfaced in operator-visible AI Knowledge content.
+// Practical risk is low (admin-only, 1-3 trusted operators) but we
+// still close the obvious vectors here at the choke point.
+//
+// Hostname-string matching only — does NOT defend against DNS rebinding or
+// DNS-based bypasses (an attacker-controlled public hostname that resolves
+// to a private IP at fetch time). Documented as a future hardening item;
+// belt-and-suspenders DNS resolution would require either a custom
+// `lookup` Agent or a userspace IP-resolution + range check, neither of
+// which is justified for the current trust model.
+const DISALLOWED_FETCH_HOSTNAMES = new Set([
+  "localhost",
+  "0.0.0.0",
+  "::",
+  "::1",
+  "[::1]",
+]);
+
+const DISALLOWED_FETCH_HOSTNAME_SUFFIXES = [
+  ".localhost",
+  ".railway.internal",
+  ".internal",
+] as const;
+
+const PRIVATE_OR_LINK_LOCAL_IPV4_PATTERN =
+  /^(?:127\.|10\.|172\.(?:1[6-9]|2\d|3[0-1])\.|192\.168\.|169\.254\.)/u;
+
+function isAllowedFetchUrl(
+  urlString: string,
+):
+  | { readonly allowed: true }
+  | { readonly allowed: false; readonly reason: string } {
+  let parsed: URL;
+  try {
+    parsed = new URL(urlString);
+  } catch {
+    return { allowed: false, reason: "URL is not parseable." };
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return {
+      allowed: false,
+      reason: `Scheme "${parsed.protocol}" is not allowed; web sources must use http(s).`,
+    };
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  if (hostname.length === 0) {
+    return { allowed: false, reason: "URL host is empty." };
+  }
+
+  if (DISALLOWED_FETCH_HOSTNAMES.has(hostname)) {
+    return {
+      allowed: false,
+      reason: `URL host "${hostname}" is not allowed (loopback or unspecified address).`,
+    };
+  }
+
+  if (
+    DISALLOWED_FETCH_HOSTNAME_SUFFIXES.some((suffix) =>
+      hostname.endsWith(suffix),
+    )
+  ) {
+    return {
+      allowed: false,
+      reason: `URL host "${hostname}" is not allowed (internal mesh suffix).`,
+    };
+  }
+
+  if (PRIVATE_OR_LINK_LOCAL_IPV4_PATTERN.test(hostname)) {
+    return {
+      allowed: false,
+      reason: `URL host "${hostname}" is not allowed (private or link-local IP range).`,
+    };
+  }
+
+  // IPv6 literal in URL form: hostname comes back wrapped in brackets per
+  // WHATWG URL but with brackets stripped via .hostname; check the raw form
+  // for unique-local (fc00::/7) and link-local (fe80::/10) prefixes.
+  if (hostname.startsWith("fc") || hostname.startsWith("fd") || hostname.startsWith("fe8") || hostname.startsWith("fe9") || hostname.startsWith("fea") || hostname.startsWith("feb")) {
+    return {
+      allowed: false,
+      reason: `URL host "${hostname}" is not allowed (IPv6 unique-local or link-local).`,
+    };
+  }
+
+  return { allowed: true };
+}
+
 export class WebPageFetcher implements SourceFetcher {
   readonly kind = "web_page" as const;
 
@@ -249,6 +343,15 @@ export class WebPageFetcher implements SourceFetcher {
         ok: false,
         status: "broken",
         error: "Global fetch is unavailable.",
+      };
+    }
+
+    const urlValidation = isAllowedFetchUrl(input.url);
+    if (!urlValidation.allowed) {
+      return {
+        ok: false,
+        status: "broken",
+        error: urlValidation.reason,
       };
     }
 

--- a/packages/integrations/test/ai-knowledge-fetchers.test.ts
+++ b/packages/integrations/test/ai-knowledge-fetchers.test.ts
@@ -404,6 +404,46 @@ describe("AI knowledge fetchers", () => {
     }
   });
 
+  it("rejects loopback, private, internal-mesh, and non-http(s) URLs without invoking fetch (SSRF guard)", async () => {
+    // Each of these would, if allowed, give an admin-supplied AI Knowledge
+    // source the ability to exfiltrate internal HTTP responses through the
+    // synthesis prompt. See `.STATE-2026-05-02-security-review-pass-2.md` H4.
+    const disallowedUrls = [
+      "http://localhost/",
+      "http://127.0.0.1:8080/admin",
+      "http://0.0.0.0:9000/",
+      "http://10.0.0.1/health",
+      "http://172.16.5.5/",
+      "http://192.168.1.1/router",
+      "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+      "http://web.railway.internal/",
+      "http://example.localhost/",
+      "file:///etc/passwd",
+      "ftp://example.com/",
+      "gopher://example.com/",
+    ];
+
+    for (const url of disallowedUrls) {
+      const fetchImpl = vi.fn();
+      const fetcher = new WebPageFetcher({
+        fetchImplementation: fetchImpl as unknown as typeof fetch,
+      });
+      const result = await fetcher.fetch({
+        url,
+        sourceId: "source:web",
+        lastContentHash: null,
+      });
+      expect(result).toMatchObject({ ok: false, status: "broken" });
+      if (!result.ok) {
+        expect(result.error.toLowerCase()).toMatch(
+          /not allowed|not parseable|empty/u,
+        );
+      }
+      // The SSRF guard MUST short-circuit before the network call.
+      expect(fetchImpl).not.toHaveBeenCalled();
+    }
+  });
+
   it("returns inline text verbatim with a content hash", async () => {
     const fetcher = new InlineTextFetcher();
 

--- a/scripts/security-check.mjs
+++ b/scripts/security-check.mjs
@@ -25,6 +25,27 @@ const secretPatterns = [
     name: "hard-coded database URL",
     regex:
       /\b(?:DATABASE_URL|WORKER_DATABASE_URL|SUPABASE_SERVICE_ROLE_KEY)\s*[:=]\s*["'`][^"'`\s]{8,}/g
+  },
+  // Vendors we actually use — added 2026-05-02 after the pre-launch
+  // security review (.STATE-2026-05-02-security-review.md H3) noted the
+  // existing pattern list missed Anthropic / Notion / Google / OpenAI keys.
+  {
+    name: "Anthropic API key",
+    regex: /\bsk-ant-(?:api03|admin01)-[A-Za-z0-9_-]{80,}\b/g
+  },
+  {
+    name: "OpenAI API key",
+    // Negative lookahead excludes Anthropic keys (which also start with
+    // `sk-ant-` and would otherwise match this generic OpenAI shape).
+    regex: /\bsk-(?!ant-)(?:proj-)?[A-Za-z0-9_-]{40,}\b/g
+  },
+  {
+    name: "Notion integration token",
+    regex: /\b(?:secret_|ntn_)[A-Za-z0-9]{40,}\b/g
+  },
+  {
+    name: "Google OAuth client secret",
+    regex: /\bGOCSPX-[A-Za-z0-9_-]{20,}\b/g
   }
 ];
 


### PR DESCRIPTION
## Summary

Pre-launch security hardening: 4 fixes from the 2026-05-02 vibecoder-review pass-1 + pass-2. None are critical. All mechanical, shippable before Monday's launch with 1–3 operators.

### Pass 1 (3 fixes — first commit)

- **H1 — `crypto.timingSafeEqual` for internal API bearer tokens.** Two internal-only routes (`/api/internal/inbox-rebuild`, `/api/internal/revalidate`) compared the bearer token using `===`. Replaced with length-equal short-circuit + `timingSafeEqual` over equal-length Buffers. Behavior identical for valid/invalid tokens; only the timing characteristic changed. Fail-closed default preserved.
- **H2 — Attachment fetches now emit `appendSecurityAudit` entries.** The route is auth-gated but unscoped. With 1–3 trusted operators in one Workspace this is acceptable for v1; to detect a future cross-project access pattern without the structural project-scope filter, every fetch now logs `result="allowed"` on success and `result="denied"` on findById misses. Audit failures are swallowed so they never break the user request — same pattern as rate-limit audits.
- **H3 — Secret-pattern scanner now catches the keys we actually use.** `scripts/security-check.mjs` covered AWS / GitHub / Slack / Stripe but missed Anthropic, Notion, Google OAuth client secrets, and OpenAI keys. Added four entries. The OpenAI pattern uses `(?!ant-)` negative lookahead to avoid double-flagging Anthropic keys.

### Pass 2 (3 fixes — second commit)

- **H4 (NEW) — SSRF guard in WebPageFetcher.** PR #394 hardened content-type and body size, but URLs were still trusted. An admin could point a `web_page` AI Knowledge source at `http://localhost`, `http://127.0.0.1`, `http://10.0.0.1`, the cloud-metadata IP `169.254.169.254`, or `*.railway.internal` — fetched response goes into the synthesis prompt. Added a hostname-string deny list at the fetcher choke point: non-http(s) schemes, loopback, RFC1918 + link-local IPv4, IPv6 unique-local + link-local, and internal-mesh suffixes. Hostname-string only — does NOT defend against DNS rebinding (documented as a future hardening item). New test covers 12 disallowed URL classes.
- **M3 — JSDoc on `globalThis` patterns.** Patterns analyzer flagged `cost-counter.ts` and `rate-limit.ts` `globalThis` caches as `hidden_state_mutation`. They're intentional cross-module caches, not hidden side-effects. Added `declare global` JSDoc explaining rationale + horizontal-scaling limitations.
- **M4 — PII masker compliance boundary.** `pii-mask.ts` is heuristic-only: international phones, single-name greetings, addresses, DOBs, member IDs, SSNs, payment cards, donation amounts are NOT masked. Added a "Compliance boundary" section to the JSDoc documenting v1 scope (Adventure Scientists volunteer comms, non-regulated PII) and trigger conditions for tightening (HIPAA, GDPR-beyond-DPA, financial reconciliation).

## Test plan

- [x] `pnpm typecheck` — 16/16 ✓
- [x] `pnpm lint` — 16/16 ✓
- [x] `pnpm boundaries` — green
- [x] `pnpm security` — green (clean diff)
- [x] `pnpm --filter @as-comms/integrations test:unit` — 155/155 ✓ (was 154; +1 SSRF case)
- [ ] CI runs full `pnpm test:unit` (skipped locally per macOS rollup memory)

## H3 regression check (verified during pass 1)

Temporarily inlined a fake `sk-ant-api03-` + 80-char alphanumeric key in `apps/web/middleware.ts`. `pnpm security` failed with:

```
Security check failed.
- apps/web/middleware.ts:4 potential Anthropic API key
```

Reverted; passes clean. Confirms the new patterns catch the format without the OpenAI pattern (post `(?!ant-)` tightening) double-flagging.

## H4 SSRF test cases

The new test in `ai-knowledge-fetchers.test.ts` exercises 12 URL classes:
`http://localhost/`, `http://127.0.0.1:8080/admin`, `http://0.0.0.0:9000/`,
`http://10.0.0.1/health`, `http://172.16.5.5/`, `http://192.168.1.1/router`,
`http://169.254.169.254/latest/meta-data/...`, `http://web.railway.internal/`,
`http://example.localhost/`, `file:///etc/passwd`, `ftp://example.com/`,
`gopher://example.com/`. Each must short-circuit before `fetchImplementation` is invoked.

## Refs

- `.STATE-2026-05-02-security-review.md` H1, H2, H3
- `.STATE-2026-05-02-security-review-pass-2.md` H4, M3, M4
- M1 (Gmail OAuth token encryption), M2 (Anthropic cap multi-instance), M5 (`x-forwarded-for` trust) remain on post-launch backlog — they need design decisions, not mechanical fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)