### PR TITLE
fix(security): trust order for getClientIp (Railway x-forwarded-for is spoofable)

### DIFF
--- a/apps/web/src/server/security/rate-limit.ts
+++ b/apps/web/src/server/security/rate-limit.ts
@@ -127,24 +127,58 @@ export function resetSecurityRateLimiterForTests(): void {
   rateLimiterOverride = null;
 }
 
+/**
+ * Resolve the request's client IP for rate-limit bucketing.
+ *
+ * Trust order matters: an attacker can spoof headers they fully control.
+ * Per Railway's edge-proxy documented behavior (verified 2026-05-02, see
+ * `.STATE-2026-05-02-security-review-pass-2.md` H5 and the Railway
+ * forum post on x-forwarded-for trust):
+ *
+ *   - `x-real-ip` is set by Railway's edge AND any client-supplied value
+ *     is stripped before forwarding. Trustworthy.
+ *   - `cf-connecting-ip` is set by Cloudflare's edge AND any client-supplied
+ *     value is stripped. Trustworthy when Cloudflare fronts the deploy.
+ *   - `x-forwarded-for` is APPENDED to by Railway with the actual client IP,
+ *     but client-supplied entries are preserved at the LEFTMOST positions.
+ *     The rightmost value is Railway's view of the client; the leftmost is
+ *     attacker-controlled. Naive "take the first" implementations are
+ *     spoofable for rate-limit evasion.
+ *
+ * Prefer the trustworthy headers; fall back to the rightmost X-Forwarded-For
+ * value (Railway's edge entry) only when nothing else is available — this
+ * is the right default for non-Railway dev environments where there's no
+ * edge proxy adding a trusted header.
+ *
+ * In tests and local dev with no proxy headers, returns "127.0.0.1".
+ */
 export function getClientIp(request: Request): string {
+  const cfConnectingIp = request.headers.get("cf-connecting-ip");
+  if (cfConnectingIp && cfConnectingIp.trim().length > 0) {
+    return cfConnectingIp.trim();
+  }
+
+  const xRealIp = request.headers.get("x-real-ip");
+  if (xRealIp && xRealIp.trim().length > 0) {
+    return xRealIp.trim();
+  }
+
   const forwardedFor = request.headers.get("x-forwarded-for");
   if (forwardedFor) {
-    const firstForwardedIp = forwardedFor
+    const chain = forwardedFor
       .split(",")
       .map((value) => value.trim())
-      .find((value) => value.length > 0);
+      .filter((value) => value.length > 0);
 
-    if (firstForwardedIp) {
-      return firstForwardedIp;
+    // Take the rightmost entry — the trusted edge's view of the client.
+    // The leftmost entries are client-controlled and can be spoofed.
+    const trustedEdgeEntry = chain[chain.length - 1];
+    if (trustedEdgeEntry !== undefined) {
+      return trustedEdgeEntry;
     }
   }
 
-  return (
-    request.headers.get("cf-connecting-ip") ??
-    request.headers.get("x-real-ip") ??
-    "127.0.0.1"
-  );
+  return "127.0.0.1";
 }
 
 export async function enforceRateLimit(input: {

--- a/apps/web/test/server/security/rate-limit.test.ts
+++ b/apps/web/test/server/security/rate-limit.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { getClientIp } from "@/src/server/security/rate-limit";
+
+function makeRequest(headers: Record<string, string>): Request {
+  return new Request("https://example.test/", { headers });
+}
+
+describe("getClientIp — Railway / Cloudflare trust order", () => {
+  it("prefers cf-connecting-ip over everything else", () => {
+    const request = makeRequest({
+      "cf-connecting-ip": "1.1.1.1",
+      "x-real-ip": "2.2.2.2",
+      "x-forwarded-for": "3.3.3.3, 4.4.4.4",
+    });
+    expect(getClientIp(request)).toBe("1.1.1.1");
+  });
+
+  it("prefers x-real-ip when cf-connecting-ip is absent", () => {
+    // Railway's edge strips client-supplied X-Real-IP and sets its own
+    // trusted value. Use this in preference to X-Forwarded-For chains.
+    const request = makeRequest({
+      "x-real-ip": "2.2.2.2",
+      "x-forwarded-for": "spoofed.value, 4.4.4.4",
+    });
+    expect(getClientIp(request)).toBe("2.2.2.2");
+  });
+
+  it("falls back to the rightmost x-forwarded-for value (trusted edge entry)", () => {
+    // The leftmost x-forwarded-for entries are client-controllable on
+    // Railway and can be spoofed. The rightmost entry is the trusted edge's
+    // view of the real client IP — that's what we use.
+    const request = makeRequest({
+      "x-forwarded-for": "8.8.8.8, 4.4.4.4, 192.0.2.5",
+    });
+    expect(getClientIp(request)).toBe("192.0.2.5");
+  });
+
+  it("does not return a spoofed leftmost x-forwarded-for value", () => {
+    // Regression: prior implementation took the FIRST x-forwarded-for entry,
+    // which is the value an attacker can set with curl -H. The fix returns
+    // the rightmost entry instead.
+    const request = makeRequest({
+      "x-forwarded-for": "9.9.9.9, 198.51.100.7",
+    });
+    const ip = getClientIp(request);
+    expect(ip).not.toBe("9.9.9.9");
+    expect(ip).toBe("198.51.100.7");
+  });
+
+  it("handles a single x-forwarded-for value", () => {
+    const request = makeRequest({
+      "x-forwarded-for": "203.0.113.1",
+    });
+    expect(getClientIp(request)).toBe("203.0.113.1");
+  });
+
+  it("trims whitespace around x-forwarded-for entries", () => {
+    const request = makeRequest({
+      "x-forwarded-for": "  10.0.0.1  ,   203.0.113.1   ",
+    });
+    expect(getClientIp(request)).toBe("203.0.113.1");
+  });
+
+  it("ignores empty x-forwarded-for entries from malformed chains", () => {
+    const request = makeRequest({
+      "x-forwarded-for": ",, ,  203.0.113.42 ,",
+    });
+    expect(getClientIp(request)).toBe("203.0.113.42");
+  });
+
+  it("returns 127.0.0.1 when no proxy headers are present (local dev)", () => {
+    const request = makeRequest({});
+    expect(getClientIp(request)).toBe("127.0.0.1");
+  });
+
+  it("ignores empty header values", () => {
+    const request = makeRequest({
+      "cf-connecting-ip": "",
+      "x-real-ip": "",
+      "x-forwarded-for": "",
+    });
+    expect(getClientIp(request)).toBe("127.0.0.1");
+  });
+});


### PR DESCRIPTION
## Summary

**H5 from the 2026-05-02 pre-launch security review** (was M5 "verify Railway proxy behavior" — verifying turned up a real bug).

Per Railway's documented edge-proxy behavior ([staff post on station.railway.com](https://station.railway.com/questions/edge-proxy-x-forwarded-for-and-x-real-ip-c5a50049)):

- `cf-connecting-ip` and `x-real-ip` are set by the edge AND client-supplied values are stripped before forwarding. Trustworthy.
- `x-forwarded-for` is appended-to by Railway with the real client IP, but client-supplied entries are preserved at the LEFTMOST positions. The rightmost value is the trusted edge view; the leftmost is attacker-controlled.

The prior `getClientIp` took the FIRST x-forwarded-for entry — the spoofable one. An attacker setting `X-Forwarded-For: <fake-ip>` appeared as a unique IP per request, bypassing:

- **`/api/auth/[...nextauth]` sign-in rate limit (10 req/min/IP)** — production-facing
- `/api/dev-auth` rate limit (5 req/min/IP) — non-prod only (route 404s in production)

## Fix

Explicit trust order in `getClientIp`:
1. `cf-connecting-ip` (Cloudflare trusted)
2. `x-real-ip` (Railway trusted)
3. RIGHTMOST `x-forwarded-for` entry (Railway's edge view, never leftmost)
4. `127.0.0.1` (local dev)

## New test

`apps/web/test/server/security/rate-limit.test.ts` — 9 cases covering:
- Preference order (cf > x-real > x-forwarded)
- **Spoofed-leftmost regression** (`9.9.9.9, 198.51.100.7` must return `198.51.100.7`, not `9.9.9.9`)
- Single-value, whitespace, empty-entry handling
- Local-dev fallback to `127.0.0.1`

## Test plan

- [x] `pnpm typecheck` — 16/16 ✓
- [x] `pnpm lint` — 16/16 ✓
- [x] `pnpm boundaries` — green
- [x] `pnpm security` — green
- [x] `pnpm --filter @as-comms/web exec vitest run test/server/security/rate-limit.test.ts` — 9/9 new tests pass
- [x] Full `apps/web` test:unit suite — 561/561 still green
- [ ] CI runs full `pnpm test:unit`

## Refs

- `.STATE-2026-05-02-security-review-pass-2.md` H5
- Original M5 finding upgraded to H5 after verifying Railway's actual proxy behavior
- Railway forum post (verified 2026-05-02): https://station.railway.com/questions/edge-proxy-x-forwarded-for-and-x-real-ip-c5a50049

🤖 Generated with [Claude Code](https://claude.com/claude-code)