### PR TITLE
feat(settings): wizard AI Knowledge step takes URL + label per row

### DIFF
--- a/apps/web/app/settings/_components/activation-wizard/index.tsx
+++ b/apps/web/app/settings/_components/activation-wizard/index.tsx
@@ -27,8 +27,8 @@ import {
   getStepOneValid,
   getStepThreeValid,
   getStepTwoValid,
-  getAiKnowledgeSourceLineErrors,
-  splitAiKnowledgeSourceLines,
+  getDraftLineErrors,
+  listEnteredDrafts,
   normalizeSignatureDraft
 } from "./shared";
 import {
@@ -122,8 +122,8 @@ export function ActivationWizard({
       return;
     }
 
-    const sourceLines = splitAiKnowledgeSourceLines(state.knowledgeSourcesText);
-    if (sourceLines.length === 0) {
+    const enteredDrafts = listEnteredDrafts(state.knowledgeSourceDrafts);
+    if (enteredDrafts.length === 0) {
       dispatch({
         type: "sync-error",
         message: "Add at least one AI Knowledge source or skip this step."
@@ -131,7 +131,7 @@ export function ActivationWizard({
       return;
     }
 
-    if (Object.keys(getAiKnowledgeSourceLineErrors(state.knowledgeSourcesText)).length > 0) {
+    if (Object.keys(getDraftLineErrors(state.knowledgeSourceDrafts)).length > 0) {
       dispatch({
         type: "sync-error",
         message: "Fix the invalid AI Knowledge source URLs before continuing."
@@ -143,7 +143,10 @@ export function ActivationWizard({
 
     const result = await submitWizardAiKnowledgeSourcesAction(
       selectedProject.projectId,
-      sourceLines
+      enteredDrafts.map((draft) => ({
+        url: draft.url.trim(),
+        label: draft.label.trim().length > 0 ? draft.label.trim() : null
+      }))
     );
     if (!result.ok) {
       dispatch({
@@ -328,14 +331,25 @@ export function ActivationWizard({
 
               {!isActivated && state.step === 3 ? (
                 <StepKnowledge
-                  knowledgeSourcesText={state.knowledgeSourcesText}
+                  knowledgeSourceDrafts={state.knowledgeSourceDrafts}
                   skipKnowledgeSetup={state.skipKnowledgeSetup}
                   knowledgeStatus={state.knowledgeStatus}
                   knowledgeMessage={state.knowledgeMessage}
-                  onKnowledgeSourcesTextChange={(nextValue) => {
+                  onAddRow={() => {
+                    dispatch({ type: "add-knowledge-source-row" });
+                  }}
+                  onRemoveRow={(index) => {
                     dispatch({
-                      type: "set-knowledge-sources-text",
-                      value: nextValue
+                      type: "remove-knowledge-source-row",
+                      index
+                    });
+                  }}
+                  onFieldChange={(index, field, value) => {
+                    dispatch({
+                      type: "set-knowledge-source-field",
+                      index,
+                      field,
+                      value
                     });
                   }}
                   onSkipKnowledgeSetupChange={(checked) => {
@@ -368,7 +382,7 @@ export function ActivationWizard({
                   selectedProject={selectedProject}
                   aliasDraft={state.aliasDraft}
                   aliases={state.aliases}
-                  knowledgeSourcesText={state.knowledgeSourcesText}
+                  knowledgeSourceDrafts={state.knowledgeSourceDrafts}
                   skipKnowledgeSetup={state.skipKnowledgeSetup}
                   signatureDraft={state.signatureDraft}
                   connectedProjectIds={state.connectedProjectIds}

--- a/apps/web/app/settings/_components/activation-wizard/shared.ts
+++ b/apps/web/app/settings/_components/activation-wizard/shared.ts
@@ -154,21 +154,28 @@ export function isBasicEmailAddress(value: string): boolean {
   return /^\S+@\S+\.\S+$/.test(value.trim());
 }
 
-export function splitAiKnowledgeSourceLines(value: string): readonly string[] {
-  return value
-    .split(/\r?\n/u)
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
+/**
+ * Drop the empty placeholder rows the wizard always renders so callers can
+ * count "real" entered sources without manually filtering each time.
+ */
+export function listEnteredDrafts(
+  drafts: readonly { readonly url: string; readonly label: string }[]
+): readonly { readonly url: string; readonly label: string }[] {
+  return drafts.filter((draft) => draft.url.trim().length > 0);
 }
 
-export function getAiKnowledgeSourceLineErrors(
-  value: string
+/**
+ * Per-row validation indexed by the operator's row position so the UI can
+ * mark the right input as invalid. Empty rows are silently skipped — they're
+ * placeholders, not errors.
+ */
+export function getDraftLineErrors(
+  drafts: readonly { readonly url: string; readonly label: string }[]
 ): Readonly<Record<number, string>> {
-  const lines = value.split(/\r?\n/u);
   const errors: Record<number, string> = {};
 
-  for (const [index, line] of lines.entries()) {
-    const trimmed = line.trim();
+  for (const [index, draft] of drafts.entries()) {
+    const trimmed = draft.url.trim();
     if (trimmed.length === 0) {
       continue;
     }

--- a/apps/web/app/settings/_components/activation-wizard/state.ts
+++ b/apps/web/app/settings/_components/activation-wizard/state.ts
@@ -11,13 +11,18 @@ import {
 export type StepIndex = 0 | 1 | 2 | 3 | 4 | 5;
 export type KnowledgeStatus = "idle" | "syncing" | "done" | "error";
 
+export interface KnowledgeSourceDraft {
+  readonly url: string;
+  readonly label: string;
+}
+
 export interface WizardState {
   readonly step: StepIndex;
   readonly pickedProjectId: string | null;
   readonly aliasDraft: string;
   readonly aliases: readonly AliasDraft[];
   readonly signatureDraft: string;
-  readonly knowledgeSourcesText: string;
+  readonly knowledgeSourceDrafts: readonly KnowledgeSourceDraft[];
   readonly skipKnowledgeSetup: boolean;
   readonly knowledgeStatus: KnowledgeStatus;
   readonly knowledgeMessage: string | null;
@@ -37,7 +42,14 @@ export type WizardAction =
   | { readonly type: "remove-alias"; readonly address: string }
   | { readonly type: "make-primary"; readonly address: string }
   | { readonly type: "set-signature"; readonly signatureDraft: string }
-  | { readonly type: "set-knowledge-sources-text"; readonly value: string }
+  | { readonly type: "add-knowledge-source-row" }
+  | { readonly type: "remove-knowledge-source-row"; readonly index: number }
+  | {
+      readonly type: "set-knowledge-source-field";
+      readonly index: number;
+      readonly field: "url" | "label";
+      readonly value: string;
+    }
   | { readonly type: "set-skip-knowledge-setup"; readonly checked: boolean }
   | { readonly type: "sync-start" }
   | { readonly type: "sync-done" }
@@ -46,6 +58,18 @@ export type WizardAction =
   | { readonly type: "activation-start" }
   | { readonly type: "activation-error"; readonly message: string }
   | { readonly type: "activation-success"; readonly project: ProjectMutationData };
+
+// Wizard always starts the AI Knowledge step with one empty row so the
+// operator sees the input shape immediately. If the project already has a
+// legacy single `ai_knowledge_url`, seed it into the first row so
+// re-activating a pre-migration project shows the existing source as
+// editable rather than dropping it.
+function buildInitialKnowledgeSourceDrafts(
+  project: ProjectRowViewModel | null
+): readonly KnowledgeSourceDraft[] {
+  const initialUrl = project?.aiKnowledgeUrl?.trim() ?? "";
+  return [{ url: initialUrl, label: "" }];
+}
 
 export function createInitialState(
   projects: readonly ProjectRowViewModel[],
@@ -60,7 +84,7 @@ export function createInitialState(
     aliasDraft: buildInitialAliasDraft(initialProject),
     aliases: buildInitialAliases(initialProject),
     signatureDraft: "",
-    knowledgeSourcesText: initialProject?.aiKnowledgeUrl ?? "",
+    knowledgeSourceDrafts: buildInitialKnowledgeSourceDrafts(initialProject),
     skipKnowledgeSetup: false,
     knowledgeStatus: "idle",
     knowledgeMessage: null,
@@ -133,7 +157,7 @@ export function activationWizardReducer(
         aliasDraft: buildInitialAliasDraft(action.project),
         aliases: buildInitialAliases(action.project),
         signatureDraft: "",
-        knowledgeSourcesText: action.project.aiKnowledgeUrl ?? "",
+        knowledgeSourceDrafts: buildInitialKnowledgeSourceDrafts(action.project),
         skipKnowledgeSetup: false,
         knowledgeStatus: "idle",
         knowledgeMessage: null,
@@ -205,18 +229,49 @@ export function activationWizardReducer(
         activationMessage: null,
         activationStatus: "idle"
       };
-    case "set-knowledge-sources-text":
-      if (state.knowledgeSourcesText === action.value) {
-        return state;
-      }
-
+    case "add-knowledge-source-row":
       return {
         ...resetKnowledgeState(state),
-        knowledgeSourcesText: action.value,
+        knowledgeSourceDrafts: [
+          ...state.knowledgeSourceDrafts,
+          { url: "", label: "" }
+        ],
         skipKnowledgeSetup: false,
         activationMessage: null,
         activationStatus: "idle"
       };
+    case "remove-knowledge-source-row": {
+      const filtered = state.knowledgeSourceDrafts.filter(
+        (_draft, index) => index !== action.index
+      );
+      // Never let the operator delete down to zero rows — keep at least one
+      // empty placeholder so they can keep typing without re-clicking "Add
+      // source." Matches the project-detail UX which always shows the Add
+      // dialog as the entry point.
+      const nextDrafts =
+        filtered.length === 0 ? [{ url: "", label: "" }] : filtered;
+      return {
+        ...resetKnowledgeState(state),
+        knowledgeSourceDrafts: nextDrafts,
+        skipKnowledgeSetup: false,
+        activationMessage: null,
+        activationStatus: "idle"
+      };
+    }
+    case "set-knowledge-source-field": {
+      const nextDrafts = state.knowledgeSourceDrafts.map((draft, index) =>
+        index === action.index
+          ? { ...draft, [action.field]: action.value }
+          : draft
+      );
+      return {
+        ...resetKnowledgeState(state),
+        knowledgeSourceDrafts: nextDrafts,
+        skipKnowledgeSetup: false,
+        activationMessage: null,
+        activationStatus: "idle"
+      };
+    }
     case "set-skip-knowledge-setup":
       return {
         ...resetKnowledgeState(state),

--- a/apps/web/app/settings/_components/activation-wizard/step-knowledge.tsx
+++ b/apps/web/app/settings/_components/activation-wizard/step-knowledge.tsx
@@ -1,43 +1,50 @@
 "use client";
 
 import * as React from "react";
-import { Check, RefreshCw } from "lucide-react";
+import { Check, Plus, RefreshCw, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 
-import {
-  getAiKnowledgeSourceLineErrors,
-  splitAiKnowledgeSourceLines
-} from "./shared";
+import { getDraftLineErrors, listEnteredDrafts } from "./shared";
+import type { KnowledgeSourceDraft } from "./state";
 
 type KnowledgeStatus = "idle" | "syncing" | "done" | "error";
 
 export function StepKnowledge({
-  knowledgeSourcesText,
+  knowledgeSourceDrafts,
   skipKnowledgeSetup,
   knowledgeStatus,
   knowledgeMessage,
-  onKnowledgeSourcesTextChange,
+  onAddRow,
+  onRemoveRow,
+  onFieldChange,
   onSkipKnowledgeSetupChange,
   onSubmit
 }: {
-  readonly knowledgeSourcesText: string;
+  readonly knowledgeSourceDrafts: readonly KnowledgeSourceDraft[];
   readonly skipKnowledgeSetup: boolean;
   readonly knowledgeStatus: KnowledgeStatus;
   readonly knowledgeMessage: string | null;
-  readonly onKnowledgeSourcesTextChange: (nextValue: string) => void;
+  readonly onAddRow: () => void;
+  readonly onRemoveRow: (index: number) => void;
+  readonly onFieldChange: (
+    index: number,
+    field: "url" | "label",
+    value: string
+  ) => void;
   readonly onSkipKnowledgeSetupChange: (checked: boolean) => void;
   readonly onSubmit: () => void;
 }) {
-  const lineErrors = getAiKnowledgeSourceLineErrors(knowledgeSourcesText);
-  const sourceLines = splitAiKnowledgeSourceLines(knowledgeSourcesText);
-  const hasInvalidLines = Object.keys(lineErrors).length > 0;
+  const draftErrors = getDraftLineErrors(knowledgeSourceDrafts);
+  const enteredDrafts = listEnteredDrafts(knowledgeSourceDrafts);
+  const hasErrors = Object.keys(draftErrors).length > 0;
   const canSubmit =
     !skipKnowledgeSetup &&
     knowledgeStatus !== "syncing" &&
-    sourceLines.length > 0 &&
-    !hasInvalidLines;
+    enteredDrafts.length > 0 &&
+    !hasErrors;
 
   return (
     <div className="flex flex-col gap-6">
@@ -46,37 +53,100 @@ export function StepKnowledge({
           AI Knowledge sources
         </p>
         <p className="mt-1 text-[12px] text-slate-500">
-          Paste links to Notion pages, public web pages, or any source the AI
-          should learn from. The system will fetch each one and synthesize them
-          into the project&apos;s AI Knowledge.
+          Add Notion pages, public web pages, or any source the AI should learn
+          from. One row per source — the label is what shows up in the project
+          detail page later (handy for Notion URLs that would otherwise read as
+          opaque IDs).
         </p>
       </div>
 
       <div className="rounded-xl border border-slate-200 bg-white p-4">
-        <label htmlFor="activation-ai-knowledge-sources" className="sr-only">
-          AI Knowledge sources
-        </label>
-        <textarea
-          id="activation-ai-knowledge-sources"
-          value={knowledgeSourcesText}
-          onChange={(event) => {
-            onKnowledgeSourcesTextChange(event.target.value);
-          }}
-          disabled={knowledgeStatus === "syncing" || skipKnowledgeSetup}
-          rows={8}
-          placeholder={"https://www.notion.so/...\nhttps://www.adventurescientists.org/..."}
-          className="w-full resize-y rounded-lg border border-slate-200 px-3 py-2.5 text-[12.5px] text-slate-800 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200 disabled:bg-slate-50"
-        />
-        {Object.entries(lineErrors).length > 0 ? (
-          <div className="mt-3 flex flex-col gap-1 text-[11.5px] text-rose-600">
-            {Object.entries(lineErrors).map(([lineIndex, message]) => (
-              <p key={lineIndex}>Line {String(Number(lineIndex) + 1)}: {message}</p>
-            ))}
-          </div>
-        ) : null}
-        {knowledgeStatus === "error" && knowledgeMessage !== null ? (
-          <p className="mt-3 text-[11.5px] text-rose-600">{knowledgeMessage}</p>
-        ) : null}
+        <div className="flex flex-col gap-3">
+          {knowledgeSourceDrafts.map((draft, index) => {
+            const urlError = draftErrors[index] ?? null;
+            const showRemove = knowledgeSourceDrafts.length > 1;
+            return (
+              <div
+                key={index}
+                className="grid grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)_auto] gap-2"
+              >
+                <div className="flex flex-col gap-1">
+                  <label
+                    htmlFor={`activation-ai-knowledge-url-${String(index)}`}
+                    className="text-[10px] font-medium uppercase tracking-wide text-slate-500"
+                  >
+                    Source URL
+                  </label>
+                  <Input
+                    id={`activation-ai-knowledge-url-${String(index)}`}
+                    value={draft.url}
+                    placeholder="https://www.notion.so/..."
+                    disabled={skipKnowledgeSetup || knowledgeStatus === "syncing"}
+                    onChange={(event) => {
+                      onFieldChange(index, "url", event.target.value);
+                    }}
+                    aria-invalid={urlError !== null}
+                  />
+                  {urlError !== null ? (
+                    <p className="text-[11.5px] text-rose-600">{urlError}</p>
+                  ) : null}
+                </div>
+                <div className="flex flex-col gap-1">
+                  <label
+                    htmlFor={`activation-ai-knowledge-label-${String(index)}`}
+                    className="text-[10px] font-medium uppercase tracking-wide text-slate-500"
+                  >
+                    Label
+                  </label>
+                  <Input
+                    id={`activation-ai-knowledge-label-${String(index)}`}
+                    value={draft.label}
+                    placeholder="Volunteer homepage"
+                    disabled={skipKnowledgeSetup || knowledgeStatus === "syncing"}
+                    onChange={(event) => {
+                      onFieldChange(index, "label", event.target.value);
+                    }}
+                  />
+                </div>
+                <div className="flex items-end pb-0.5">
+                  {showRemove ? (
+                    <button
+                      type="button"
+                      aria-label={`Remove source ${String(index + 1)}`}
+                      title="Remove source"
+                      disabled={skipKnowledgeSetup || knowledgeStatus === "syncing"}
+                      onClick={() => {
+                        onRemoveRow(index);
+                      }}
+                      className="rounded p-1 text-rose-600 hover:bg-rose-50 hover:text-rose-700 disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      <Trash2 className="size-3.5" aria-hidden="true" />
+                    </button>
+                  ) : (
+                    <div className="size-6" aria-hidden="true" />
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="mt-4 flex items-center justify-between">
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={skipKnowledgeSetup || knowledgeStatus === "syncing"}
+            onClick={onAddRow}
+          >
+            <Plus className="size-3.5" aria-hidden="true" />
+            Add source
+          </Button>
+          {knowledgeStatus === "error" && knowledgeMessage !== null ? (
+            <p className="text-[11.5px] text-rose-600">{knowledgeMessage}</p>
+          ) : null}
+        </div>
+
         <label className="mt-4 flex items-start gap-2 text-[12px] text-slate-600">
           <input
             type="checkbox"
@@ -157,15 +227,17 @@ export function StepKnowledge({
           </p>
         ) : null}
 
-        {knowledgeStatus === "idle" && !skipKnowledgeSetup && knowledgeMessage === null ? (
+        {knowledgeStatus === "idle" &&
+        !skipKnowledgeSetup &&
+        knowledgeMessage === null ? (
           <p className="text-[12px] text-slate-500">
-            Add one source per line, then save them before continuing.
+            Add at least one source, then save before continuing.
           </p>
         ) : null}
 
         {knowledgeStatus === "error" && knowledgeMessage !== null ? (
           <p className="text-[12px] text-slate-700">
-            Correct the invalid lines or try submitting again once the worker is
+            Correct the invalid rows or try submitting again once the worker is
             healthy.
           </p>
         ) : null}

--- a/apps/web/app/settings/_components/activation-wizard/step-review.tsx
+++ b/apps/web/app/settings/_components/activation-wizard/step-review.tsx
@@ -7,14 +7,16 @@ import type { ProjectRowViewModel } from "@/src/server/settings/selectors";
 import {
   type AliasDraft,
   getPrimaryAlias,
+  listEnteredDrafts,
   truncateSignatureSummary
 } from "./shared";
+import type { KnowledgeSourceDraft } from "./state";
 
 export function StepReview({
   selectedProject,
   aliasDraft,
   aliases,
-  knowledgeSourcesText,
+  knowledgeSourceDrafts,
   skipKnowledgeSetup,
   signatureDraft,
   connectedProjectIds,
@@ -24,7 +26,7 @@ export function StepReview({
   readonly selectedProject: ProjectRowViewModel | null;
   readonly aliasDraft: string;
   readonly aliases: readonly AliasDraft[];
-  readonly knowledgeSourcesText: string;
+  readonly knowledgeSourceDrafts: readonly KnowledgeSourceDraft[];
   readonly skipKnowledgeSetup: boolean;
   readonly signatureDraft: string;
   readonly connectedProjectIds: readonly string[];
@@ -32,6 +34,7 @@ export function StepReview({
   readonly activationError: string | null;
 }) {
   const primaryAlias = getPrimaryAlias(aliases);
+  const enteredKnowledgeDrafts = listEnteredDrafts(knowledgeSourceDrafts);
 
   if (selectedProject === null) {
     return null;
@@ -61,7 +64,7 @@ export function StepReview({
             ) : (
               <span className="flex items-center gap-2">
                 <span className="truncate">
-                  {`${String(knowledgeSourcesText.split(/\r?\n/u).filter((line) => line.trim().length > 0).length)} source(s) saved`}
+                  {`${String(enteredKnowledgeDrafts.length)} source(s) saved`}
                 </span>
                 <StatusBadge
                   label="Queued"

--- a/apps/web/app/settings/actions.ts
+++ b/apps/web/app/settings/actions.ts
@@ -153,10 +153,26 @@ const activationWizardInputSchema = z
     }
   });
 
+const wizardAiKnowledgeSourceDraftSchema = z.object({
+  url: z.string(),
+  label: z
+    .string()
+    .trim()
+    .max(160, "Label must be 160 characters or fewer.")
+    .nullable()
+    .optional()
+});
+
 const wizardAiKnowledgeSourcesSchema = z.object({
   projectId: z.string().trim().min(1, "Project is required."),
-  urls: z.array(z.string()).max(100, "Add no more than 100 sources.")
+  sources: z
+    .array(wizardAiKnowledgeSourceDraftSchema)
+    .max(100, "Add no more than 100 sources.")
 });
+
+export type WizardAiKnowledgeSourceDraft = z.infer<
+  typeof wizardAiKnowledgeSourceDraftSchema
+>;
 
 const addAiKnowledgeSourceSchema = z.object({
   url: z.string().trim().min(1, "Source URL is required."),
@@ -738,24 +754,20 @@ function normalizeOptionalSourceLabel(value: string | null | undefined): string 
   return trimmed.length === 0 ? null : trimmed;
 }
 
-function flattenSourceUrls(urls: readonly string[]): readonly string[] {
-  return urls.flatMap((value) =>
-    value
-      .split(/\r?\n/u)
-      .map((line) => line.trim())
-      .filter((line) => line.length > 0)
-  );
-}
-
-function buildSourceFieldErrors(urls: readonly string[]): Record<string, string> {
+// Validates each draft's URL via parseSourceUrl and reports errors keyed
+// by the operator's row index (e.g. "sources.2.url") so the wizard UI can
+// highlight exactly which row needs attention.
+function buildSourceFieldErrorsForDrafts(
+  drafts: readonly { readonly url: string; readonly originalIndex: number }[]
+): Record<string, string> {
   const fieldErrors: Record<string, string> = {};
 
-  for (const [index, url] of urls.entries()) {
+  for (const draft of drafts) {
     try {
-      parseSourceUrl(url);
+      parseSourceUrl(draft.url);
     } catch (error) {
       if (error instanceof AiKnowledgeSourceValidationError) {
-        fieldErrors[`urls.${String(index)}`] = error.message;
+        fieldErrors[`sources.${String(draft.originalIndex)}.url`] = error.message;
         continue;
       }
 
@@ -1152,7 +1164,7 @@ export async function updateProjectAiKnowledgeAction(
 
 export async function submitWizardAiKnowledgeSourcesAction(
   projectId: string,
-  urls: readonly string[]
+  sources: readonly { readonly url: string; readonly label?: string | null }[]
 ): Promise<UiResult<ProjectAiKnowledgeSourcesMutationData>> {
   const admin = await resolveSettingsAdmin({
     unauthorizedMessage:
@@ -1163,15 +1175,28 @@ export async function submitWizardAiKnowledgeSourcesAction(
     return admin.error;
   }
 
-  const parsed = wizardAiKnowledgeSourcesSchema.safeParse({ projectId, urls });
+  const parsed = wizardAiKnowledgeSourcesSchema.safeParse({
+    projectId,
+    sources
+  });
   if (!parsed.success) {
     return errorResult("validation_error", "AI knowledge sources are invalid.", {
       fieldErrors: flattenZodFieldErrors(parsed.error)
     });
   }
 
-  const normalizedUrls = flattenSourceUrls(parsed.data.urls);
-  const fieldErrors = buildSourceFieldErrors(normalizedUrls);
+  // Trim whitespace + drop blank-URL rows. The wizard UI lets operators
+  // leave empty placeholder rows; we keep the originalIndex so any error
+  // message points at the right row in the UI.
+  const normalizedDrafts = parsed.data.sources
+    .map((draft, index) => ({
+      url: draft.url.trim(),
+      label: normalizeOptionalSourceLabel(draft.label ?? null),
+      originalIndex: index
+    }))
+    .filter((draft) => draft.url.length > 0);
+
+  const fieldErrors = buildSourceFieldErrorsForDrafts(normalizedDrafts);
   if (Object.keys(fieldErrors).length > 0) {
     return errorResult(
       "validation_error",
@@ -1188,8 +1213,11 @@ export async function submitWizardAiKnowledgeSourcesAction(
 
   let nextSources: readonly AiKnowledgeSource[] = [];
   try {
-    for (const url of normalizedUrls) {
-      nextSources = addSource(nextSources, { url });
+    for (const draft of normalizedDrafts) {
+      nextSources = addSource(nextSources, {
+        url: draft.url,
+        label: draft.label
+      });
     }
   } catch (error) {
     return toAiKnowledgeValidationResult(error);

--- a/apps/web/tests/unit/settings-activation-wizard.test.tsx
+++ b/apps/web/tests/unit/settings-activation-wizard.test.tsx
@@ -9,7 +9,9 @@ Object.assign(globalThis, { React });
 
 vi.mock("lucide-react", () => ({
   Check: () => null,
-  RefreshCw: () => null
+  Plus: () => null,
+  RefreshCw: () => null,
+  Trash2: () => null
 }));
 
 vi.mock("@/components/ui/button", () => ({
@@ -19,6 +21,11 @@ vi.mock("@/components/ui/button", () => ({
   }: {
     readonly children: React.ReactNode;
   }) => React.createElement("button", props, children)
+}));
+
+vi.mock("@/components/ui/input", () => ({
+  Input: (props: Record<string, unknown>) =>
+    React.createElement("input", props)
 }));
 
 const workerRequire = createRequire(import.meta.url);
@@ -35,6 +42,7 @@ const { JSDOM } = workerRequire("jsdom") as {
 };
 
 import { StepKnowledge } from "../../app/settings/_components/activation-wizard/step-knowledge";
+import type { KnowledgeSourceDraft } from "../../app/settings/_components/activation-wizard/state";
 
 let dom: InstanceType<typeof JSDOM> | null = null;
 let root: Root | null = null;
@@ -66,7 +74,7 @@ function setupDom() {
 }
 
 function renderStep(input: {
-  readonly knowledgeSourcesText?: string;
+  readonly knowledgeSourceDrafts?: readonly KnowledgeSourceDraft[];
   readonly skipKnowledgeSetup?: boolean;
   readonly onSubmit?: () => void;
 }) {
@@ -78,11 +86,15 @@ function renderStep(input: {
   act(() => {
     activeRoot.render(
       <StepKnowledge
-        knowledgeSourcesText={input.knowledgeSourcesText ?? ""}
+        knowledgeSourceDrafts={
+          input.knowledgeSourceDrafts ?? [{ url: "", label: "" }]
+        }
         skipKnowledgeSetup={input.skipKnowledgeSetup ?? false}
         knowledgeStatus="idle"
         knowledgeMessage={null}
-        onKnowledgeSourcesTextChange={() => undefined}
+        onAddRow={() => undefined}
+        onRemoveRow={() => undefined}
+        onFieldChange={() => undefined}
         onSkipKnowledgeSetupChange={() => undefined}
         onSubmit={input.onSubmit ?? (() => undefined)}
       />
@@ -103,47 +115,64 @@ afterEach(() => {
   dom = null;
 });
 
+function getSaveButton(): HTMLButtonElement {
+  const element = Array.from(document.querySelectorAll("button")).find(
+    (button) => button.textContent.includes("Save sources")
+  );
+  if (!(element instanceof HTMLButtonElement)) {
+    throw new Error("Save sources button not found");
+  }
+  return element;
+}
+
 describe("StepKnowledge", () => {
-  it("renders the multiline textarea", () => {
-    renderStep({});
+  it("renders one row per draft with URL and Label inputs", () => {
+    renderStep({
+      knowledgeSourceDrafts: [
+        { url: "https://www.notion.so/page-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", label: "Whitebark FAQ" },
+        { url: "", label: "" }
+      ]
+    });
 
-    expect(document.querySelector("textarea")).not.toBeNull();
     expect(document.body.textContent).toContain("AI Knowledge sources");
+    expect(document.body.textContent).toContain("Source URL");
+    expect(document.body.textContent).toContain("Label");
+    // Two URL inputs + two Label inputs = 4 inputs (plus the skip checkbox).
+    const inputs = document.querySelectorAll("input");
+    // checkbox is an input too — so we have 4 row inputs + 1 checkbox.
+    expect(inputs.length).toBeGreaterThanOrEqual(5);
   });
 
-  it("validates URLs as the operator types", () => {
+  it("flags invalid URLs inline next to the offending row", () => {
     renderStep({
-      knowledgeSourcesText:
-        "https://www.notion.so/page-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\nnot-a-url"
+      knowledgeSourceDrafts: [
+        { url: "https://www.notion.so/page-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", label: "" },
+        { url: "not-a-url", label: "" }
+      ]
     });
 
-    expect(document.body.textContent).toContain("Line 2:");
+    // The error text appears in the second row.
+    const errorEls = document.querySelectorAll("p.text-rose-600");
+    const errorTexts = Array.from(errorEls).map((node) => node.textContent);
+    expect(errorTexts.length).toBeGreaterThan(0);
+    expect(errorTexts.some((text) => text.length > 0)).toBe(true);
   });
 
-  it("disables submission when the lines are empty or invalid", () => {
-    renderStep({});
-
-    const getSaveButton = () => {
-      const element = Array.from(document.querySelectorAll("button")).find(
-        (button) => button.textContent.includes("Save sources")
-      );
-      if (!(element instanceof HTMLButtonElement)) {
-        throw new Error("Save sources button not found");
-      }
-
-      return element;
-    };
-
-    expect(getSaveButton().disabled).toBe(true);
-
+  it("disables submission when every row is empty or any URL is invalid", () => {
     renderStep({
-      knowledgeSourcesText: "not-a-url"
+      knowledgeSourceDrafts: [{ url: "", label: "" }]
     });
     expect(getSaveButton().disabled).toBe(true);
 
     renderStep({
-      knowledgeSourcesText:
-        "https://www.notion.so/page-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      knowledgeSourceDrafts: [{ url: "not-a-url", label: "" }]
+    });
+    expect(getSaveButton().disabled).toBe(true);
+
+    renderStep({
+      knowledgeSourceDrafts: [
+        { url: "https://www.notion.so/page-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", label: "" }
+      ]
     });
     expect(getSaveButton().disabled).toBe(false);
   });
@@ -160,22 +189,18 @@ describe("StepKnowledge", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("submits after multiple valid URLs are entered", () => {
+  it("submits once at least one valid URL is present", () => {
     const onSubmit = vi.fn();
     renderStep({
-      knowledgeSourcesText: [
-        "https://www.notion.so/page-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "https://www.adventurescientists.org/project/whitebark-pine"
-      ].join("\n"),
+      knowledgeSourceDrafts: [
+        { url: "https://www.notion.so/page-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", label: "Notion FAQ" },
+        { url: "https://www.adventurescientists.org/project/whitebark-pine", label: "Homepage" }
+      ],
       onSubmit
     });
 
-    const saveButton = Array.from(document.querySelectorAll("button")).find(
-      (element) => element.textContent.includes("Save sources")
-    );
-    if (!(saveButton instanceof HTMLButtonElement)) {
-      throw new Error("Save sources button not found");
-    }
+    const saveButton = getSaveButton();
+    expect(saveButton.disabled).toBe(false);
 
     act(() => {
       saveButton.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));

--- a/apps/web/tests/unit/settings-project-ai-knowledge-actions.test.ts
+++ b/apps/web/tests/unit/settings-project-ai-knowledge-actions.test.ts
@@ -288,12 +288,15 @@ describe("settings project AI knowledge actions", () => {
     });
   });
 
-  it("validates wizard source submission and persists multiple sources", async () => {
+  it("validates wizard source submission and persists multiple sources with labels", async () => {
     const sqlSpy = await installSqlSpy();
 
     const invalid = await submitWizardAiKnowledgeSourcesAction("project:ai", [
-      "https://www.notion.so/page-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      "not-a-url"
+      {
+        url: "https://www.notion.so/page-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        label: "Notion FAQ"
+      },
+      { url: "not-a-url", label: "Broken" }
     ]);
 
     expect(invalid).toMatchObject({
@@ -302,8 +305,16 @@ describe("settings project AI knowledge actions", () => {
     });
 
     const valid = await submitWizardAiKnowledgeSourcesAction("project:ai", [
-      "https://www.notion.so/page-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      "https://www.adventurescientists.org/project/whitebark-pine"
+      {
+        url: "https://www.notion.so/page-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        label: "Notion FAQ"
+      },
+      {
+        url: "https://www.adventurescientists.org/project/whitebark-pine",
+        label: "Volunteer homepage"
+      },
+      // Empty row from the wizard should be silently dropped, not failed.
+      { url: "", label: "" }
     ]);
 
     expect(valid).toMatchObject({
@@ -313,6 +324,8 @@ describe("settings project AI knowledge actions", () => {
       throw new Error("expected valid wizard submission");
     }
     expect(valid.data.sources).toHaveLength(2);
+    expect(valid.data.sources[0]?.label).toBe("Notion FAQ");
+    expect(valid.data.sources[1]?.label).toBe("Volunteer homepage");
     expect(sqlSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -350,7 +363,10 @@ describe("settings project AI knowledge actions", () => {
       updateAiAutoSyncScheduleAction("project:missing", "daily"),
       updateOperatingContextAction("project:missing", "Missing"),
       submitWizardAiKnowledgeSourcesAction("project:missing", [
-        "https://www.notion.so/page-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        {
+          url: "https://www.notion.so/page-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          label: null
+        }
       ])
     ]);
 


### PR DESCRIPTION
## Summary

The wizard's old single-textarea input (paste one URL per line) traded the label concept for keystrokes. That's fine when source URLs are human-readable (`adventurescientists.org/whitebark-pine`) but useless for bare Notion page IDs like `notion.so/2158a912921180...`. The project-detail page already has an Add Source dialog with URL + Label inputs — the wizard should mirror it.

## Wizard changes

- New state shape: `knowledgeSourceDrafts: { url: string; label: string }[]` replaces `knowledgeSourcesText`. Starts with one empty row; pick-project seeds the legacy single `ai_knowledge_url` into row 0 to preserve the re-activation path. Removing the last row leaves one empty placeholder rather than collapsing to zero rows.
- New actions: `add-knowledge-source-row`, `remove-knowledge-source-row`, `set-knowledge-source-field`. Drops `set-knowledge-sources-text`.
- `step-knowledge.tsx`: row-by-row UI matching the project-detail dialog — Source URL input + Label input + per-row Trash button. URL errors render inline next to the offending row's URL input. No sync/status badges on rows (sources aren't synced yet; this step is collection-only, per the design ask).
- `step-review.tsx`: count is now `listEnteredDrafts(...).length`.
- `index.tsx`: dispatches the new row actions and submits `enteredDrafts.map(({url, label}) => ({url, label}))` — empty rows filtered out client-side as a courtesy.

## Action changes (`apps/web/app/settings/actions.ts`)

- `wizardAiKnowledgeSourcesSchema` now takes `{ sources: { url, label? }[] }` instead of `{ urls: string[] }`. Each row carries its own label. Label schema matches the existing `addAiKnowledgeSourceSchema` (trimmed, 160-char max, nullable) so the wizard and the detail-page Add-source dialog converge on one validation contract.
- `submitWizardAiKnowledgeSourcesAction` iterates drafts and calls `addSource(sources, { url, label })` instead of dropping the label.
- New `buildSourceFieldErrorsForDrafts` uses the operator's original row index so error field-paths like `sources.2.url` match the UI's row numbering. Drops legacy `flattenSourceUrls` + `buildSourceFieldErrors` (dead after the contract change; the wizard's bulk-paste path was their only caller).
- New exported type `WizardAiKnowledgeSourceDraft` for callers.

## Helpers (`shared.ts`)

- `listEnteredDrafts(drafts)` drops empty placeholder rows.
- `getDraftLineErrors(drafts)` returns errors indexed by row position.
- Drops `splitAiKnowledgeSourceLines` + `getAiKnowledgeSourceLineErrors`.

## Tests

- `settings-activation-wizard.test.tsx` rewritten for the row UI: one-row-per-draft rendering, inline error placement, submission enable/disable across empty/invalid/valid states, skip-path preservation, click-through to submit.
- `settings-project-ai-knowledge-actions.test.ts` updated to call `submitWizardAiKnowledgeSourcesAction` with `{ url, label }[]` (including an empty-row case to verify it's silently dropped). Asserts label persists on the returned source rows.

## Test plan

- [x] `pnpm -C apps/web typecheck` clean
- [x] `pnpm -C apps/web lint` clean
- [x] `pnpm -C apps/web test:unit` — 561 pass / 5 skipped
- [ ] Post-deploy: open activation wizard for an inactive project, confirm one empty row renders by default with Source URL + Label inputs side by side, add a second row, paste a Notion URL + type a label, see the source land on project-detail with the label visible (no opaque UUID rendering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)