### PR TITLE
fix(settings): tab panel content leak + AI Knowledge table polish

### DIFF
--- a/apps/web/app/settings/_components/project-ai-knowledge-section.tsx
+++ b/apps/web/app/settings/_components/project-ai-knowledge-section.tsx
@@ -520,7 +520,7 @@ export function ProjectAiKnowledgeSection({
                     className={cn(!source.enabled && "opacity-70", isRowPending && "opacity-60")}
                   >
                     <td className="px-3 py-3">
-                      <div className="flex flex-col gap-1">
+                      <div className="flex flex-col items-start gap-1">
                         <StatusBadge
                           label={badge.label}
                           colorClasses={badge.classes}

--- a/apps/web/app/settings/_components/project-ai-knowledge-section.tsx
+++ b/apps/web/app/settings/_components/project-ai-knowledge-section.tsx
@@ -77,6 +77,19 @@ function buildSourceLabel(source: AiKnowledgeSource): string {
   }
 }
 
+function formatKindLabel(kind: AiKnowledgeSource["kind"]): string {
+  switch (kind) {
+    case "notion":
+      return "Notion";
+    case "web_page":
+      return "Web page";
+    case "inline_text":
+      return "Inline text";
+    default:
+      return kind;
+  }
+}
+
 type DerivedStatus =
   | "disabled"
   | "pending"
@@ -511,7 +524,8 @@ export function ProjectAiKnowledgeSection({
                         <StatusBadge
                           label={badge.label}
                           colorClasses={badge.classes}
-                          variant="soft"
+                          variant="subtle"
+                          className="ring-1 ring-inset"
                         />
                         {showError ? (
                           <p
@@ -527,12 +541,8 @@ export function ProjectAiKnowledgeSection({
                         ) : null}
                       </div>
                     </td>
-                    <td className="px-3 py-3 align-top">
-                      <StatusBadge
-                        label={source.kind}
-                        colorClasses="bg-slate-100 text-slate-700 ring-slate-200"
-                        variant="soft"
-                      />
+                    <td className="px-3 py-3 align-top text-slate-600">
+                      {formatKindLabel(source.kind)}
                     </td>
                     <td
                       className="px-3 py-3 align-top font-medium text-slate-900"

--- a/apps/web/app/settings/_components/project-detail.tsx
+++ b/apps/web/app/settings/_components/project-detail.tsx
@@ -705,13 +705,12 @@ export function ProjectDetail({
                 setActiveTab(tab.id);
               }}
               className={cn(
-                "-mb-px border-b-2 pb-2.5 pt-1 text-sm font-medium",
+                "-mb-px inline-flex items-center border-b-2 px-0.5 pb-3 pt-2 text-sm",
                 TRANSITION.fast,
-                FOCUS_RING,
-                RADIUS.sm,
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2",
                 isActive
-                  ? "border-slate-900 text-slate-900"
-                  : "border-transparent text-slate-500 hover:text-slate-800"
+                  ? "border-slate-900 font-semibold text-slate-900"
+                  : "border-transparent font-medium text-slate-500 hover:text-slate-800"
               )}
             >
               {tab.label}
@@ -725,7 +724,7 @@ export function ProjectDetail({
         id="project-tabpanel-overview"
         aria-labelledby="project-tab-overview"
         hidden={activeTab !== "overview"}
-        className="flex flex-col gap-5"
+        className={cn(activeTab === "overview" && "flex flex-col gap-5")}
       >
         <SettingsCard
           title="Project basics"
@@ -1016,7 +1015,7 @@ export function ProjectDetail({
         id="project-tabpanel-ai-knowledge"
         aria-labelledby="project-tab-ai-knowledge"
         hidden={activeTab !== "ai-knowledge"}
-        className="flex flex-col gap-5"
+        className={cn(activeTab === "ai-knowledge" && "flex flex-col gap-5")}
       >
         {isConnectedSub && connectedHost ? (
           <SettingsCard
@@ -1058,7 +1057,7 @@ export function ProjectDetail({
         id="project-tabpanel-danger-zone"
         aria-labelledby="project-tab-danger-zone"
         hidden={activeTab !== "danger-zone"}
-        className="flex flex-col gap-5"
+        className={cn(activeTab === "danger-zone" && "flex flex-col gap-5")}
       >
         {project.isAdmin && optimisticProject.isActive && !isConnectedSub ? (
           <Dialog open={deactivateOpen} onOpenChange={setDeactivateOpen}>


### PR DESCRIPTION
## Summary
- **Tab content leak (P0):** every tabpanel had `className=\"flex flex-col gap-5\"` alongside HTML `hidden` attribute; the `flex` class won the cascade vs UA `display: none`, so all three panels rendered at once. Apply flex layout only on the active tab; inactive panels fall back to `hidden`'s `display: none`.
- **Tab buttons:** drop the stray `rounded-md`, balance padding (`pb-3 pt-2`), bold the active label, plain text otherwise — matches v2 design reference.
- **Status pill (AI Knowledge table):** switched `soft` → `subtle` variant, added `items-start` to wrapper so the badge no longer stretches to ~310px column width. Now sized to content (~50px).
- **Kind column:** dropped the always-grey pill (color never varied) and switched to plain slate text. Added `formatKindLabel` helper so `notion`, `web_page`, `inline_text` render as `Notion`, `Web page`, `Inline text`.

## Verification
- Typecheck + lint clean
- 561 unit tests pass
- Visually verified in dev server on Whitebark Pine project (active host, has sources, has linked volunteers):
  - Overview tab: shows only Project basics + Inbox aliases & signatures + Connected projects
  - AI knowledge tab: shows only AI Knowledge table + Operating context + side-by-side Synthesis status / Auto-sync schedule
  - Danger zone tab: shows only the Deactivate card with linked-volunteer count

## Test plan
- [ ] Confirm tabs isolate content on prod for an active host, sub-project (AI knowledge inheritance message), and inactive project
- [ ] Confirm Status column pills are compact and Kind column reads as plain text

🤖 Generated with [Claude Code](https://claude.com/claude-code)