### PR TITLE
feat(inbox): show unread count in list header title

### DIFF
--- a/apps/web/app/inbox/_components/inbox-list.tsx
+++ b/apps/web/app/inbox/_components/inbox-list.tsx
@@ -154,6 +154,45 @@ function resolveInboxHeaderTitle(input: {
   return projectLabel ?? activeStateLabel ?? "Inbox";
 }
 
+/**
+ * Format the inbox header title with an unread count suffix, e.g.
+ * `Inbox (22)` or `PNW Biodiversity (20)`.
+ *
+ * The count is `totals.unread` which is already scoped to the active project
+ * filter server-side (see `countByFilters({ projectId })`), so the same value
+ * reads correctly across no-filter and project-filtered views.
+ *
+ * Skipped when:
+ *  - a search is active (the title is "Results" and the count concept doesn't
+ *    apply to the unified search response)
+ *  - the unread count is zero (cleaner empty state)
+ *  - the active filter is one of `sent` / `archived` / `follow-up` where
+ *    "unread" isn't the dominant metric
+ */
+function formatInboxHeaderTitleWithUnreadCount(input: {
+  readonly title: string;
+  readonly unreadCount: number;
+  readonly activeFilter: InboxFilterId;
+  readonly isSearchActive: boolean;
+}): string {
+  if (input.isSearchActive) {
+    return input.title;
+  }
+
+  if (input.unreadCount <= 0) {
+    return input.title;
+  }
+
+  const filterId = input.activeFilter;
+  const showsUnreadAsHeadline =
+    filterId === "inbox" || filterId === "unread";
+  if (!showsUnreadAsHeadline) {
+    return input.title;
+  }
+
+  return `${input.title} (${String(input.unreadCount)})`;
+}
+
 export function InboxList({
   initialList,
   initialFilterId = "inbox",
@@ -559,16 +598,30 @@ export function InboxList({
   const hasActiveFilters =
     activeFilter !== "inbox" || selectedProjectId !== null;
   const shouldShowSearchSummary = search.isActive && isSearchThresholdMet;
+  const unreadCount = currentList.totals.unread;
   const headerTitle = useMemo(
     () =>
-      resolveInboxHeaderTitle({
-        searchQuery: search.query,
+      formatInboxHeaderTitleWithUnreadCount({
+        title: resolveInboxHeaderTitle({
+          searchQuery: search.query,
+          activeFilter,
+          selectedProjectId,
+          urlProjectIds,
+          activeProjects,
+        }),
+        unreadCount,
         activeFilter,
-        selectedProjectId,
-        urlProjectIds,
-        activeProjects,
+        isSearchActive: search.isActive,
       }),
-    [activeFilter, activeProjects, search.query, selectedProjectId, urlProjectIds],
+    [
+      activeFilter,
+      activeProjects,
+      search.isActive,
+      search.query,
+      selectedProjectId,
+      unreadCount,
+      urlProjectIds,
+    ],
   );
 
   const handleFilterChange = useCallback(

--- a/apps/web/tests/unit/inbox-list-shell.test.tsx
+++ b/apps/web/tests/unit/inbox-list-shell.test.tsx
@@ -388,21 +388,21 @@ describe("Inbox list shell", () => {
     searchParamsMock.current = "";
   });
 
-  it("renders Inbox when no filter is active", async () => {
+  it("renders Inbox with the unread count when no filter is active", async () => {
     fetchInboxListPageMock.mockResolvedValue(buildList());
     activeSession = await mountInboxList();
 
     const heading = activeSession.container.querySelector("h1");
-    expect(heading?.textContent).toBe("Inbox");
+    expect(heading?.textContent).toBe("Inbox (3)");
   });
 
-  it("renders the selected project alias in the header", async () => {
+  it("renders the selected project alias in the header with the unread count", async () => {
     const projectList = buildPnwProjectList();
     fetchInboxListPageMock.mockResolvedValue(projectList);
     activeSession = await mountInboxList(projectList);
 
     const heading = activeSession.container.querySelector("h1");
-    expect(heading?.textContent).toBe("PNW Biodiversity");
+    expect(heading?.textContent).toBe("PNW Biodiversity (3)");
   });
 
   it("falls back old filter=all URLs to inbox", async () => {
@@ -415,7 +415,7 @@ describe("Inbox list shell", () => {
       scroll: false,
     });
     expect(activeSession.container.querySelector("h1")?.textContent).toBe(
-      "Inbox",
+      "Inbox (3)",
     );
   });
 
@@ -437,7 +437,7 @@ describe("Inbox list shell", () => {
     await flushReact();
 
     const heading = session.container.querySelector("h1");
-    expect(heading?.textContent).toBe("PNW Biodiversity · Unread");
+    expect(heading?.textContent).toBe("PNW Biodiversity · Unread (3)");
   });
 
   it("renders the active state label when only a state filter is active", async () => {
@@ -494,7 +494,7 @@ describe("Inbox list shell", () => {
     );
 
     const heading = activeSession.container.querySelector("h1");
-    expect(heading?.textContent).toBe("2 projects");
+    expect(heading?.textContent).toBe("2 projects (3)");
   });
 
   it("renders Filtered when more than two facets are active", async () => {
@@ -531,7 +531,24 @@ describe("Inbox list shell", () => {
     await flushReact();
 
     const heading = session.container.querySelector("h1");
-    expect(heading?.textContent).toBe("Filtered");
+    expect(heading?.textContent).toBe("Filtered (3)");
+  });
+
+  it("omits the unread count from the title when no unread emails remain", async () => {
+    const listWithZeroUnread = buildList({
+      totals: {
+        inbox: 1289,
+        unread: 0,
+        followUp: 2,
+        sent: 7,
+        archived: 1,
+      },
+    });
+    fetchInboxListPageMock.mockResolvedValue(listWithZeroUnread);
+    activeSession = await mountInboxList(listWithZeroUnread);
+
+    const heading = activeSession.container.querySelector("h1");
+    expect(heading?.textContent).toBe("Inbox");
   });
 
   it("keeps filters hidden by default and exposes open and active button states", async () => {


### PR DESCRIPTION
## Summary
- Inbox header title now shows the unread count next to the label: `Inbox (22)`, `PNW Biodiversity (20)`, `PNW Biodiversity · Unread (3)`
- Uses `totals.unread`, which is already scoped to the active project filter server-side (`countByFilters({ projectId })`) — no new query
- New helper `formatInboxHeaderTitleWithUnreadCount` keeps the resolver pure and the suffix isolated

## Skipped cases
- Search active: title is \"Results\"; result count lives in the search summary
- Unread count is zero: cleaner empty state
- Active filter is `sent` / `archived` / `follow-up`: unread isn't the headline metric there

## Verification
- Typecheck + lint clean
- 562 unit tests pass (added one for the zero-unread case; updated six existing assertions for the new behavior)
- Visually verified in dev server:
  - `/inbox` → \`Inbox (20)\`
  - `/inbox?projectId=a0tVK00000AeJqzYAF` (PNW Biodiversity) → \`PNW Biodiversity (18)\`

## Test plan
- [ ] Spot-check counts move correctly when emails are marked read or new ones land
- [ ] Confirm Sent / Archived / Follow-up filters show their bare label (no count) and that the search overlay still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)