### PR TITLE
feat(sms-ops): backfill consent + seed sms_senders scripts (D-042 launch prep)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,7 +37,7 @@
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.2",
     "lucide-react": "^1.8.0",
-    "next": "^15.5.15",
+    "next": "^15.5.18",
     "next-auth": "^5.0.0-beta.25",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,11 +207,11 @@ importers:
         specifier: ^1.8.0
         version: 1.8.0(react@19.2.4)
       next:
-        specifier: ^15.5.15
-        version: 15.5.15(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^15.5.18
+        version: 15.5.18(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-auth:
         specifier: ^5.0.0-beta.25
-        version: 5.0.0-beta.31(next@15.5.15(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 5.0.0-beta.31(next@15.5.18(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -1128,56 +1128,56 @@ packages:
     resolution: {integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==}
     engines: {node: '>=14.0.0'}
 
-  '@next/env@15.5.15':
-    resolution: {integrity: sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==}
+  '@next/env@15.5.18':
+    resolution: {integrity: sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==}
 
   '@next/eslint-plugin-next@15.5.14':
     resolution: {integrity: sha512-ogBjgsFrPPz19abP3VwcYSahbkUOMMvJjxCOYWYndw+PydeMuLuB4XrvNkNutFrTjC9St2KFULRdKID8Sd/CMQ==}
 
-  '@next/swc-darwin-arm64@15.5.15':
-    resolution: {integrity: sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==}
+  '@next/swc-darwin-arm64@15.5.18':
+    resolution: {integrity: sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.5.15':
-    resolution: {integrity: sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==}
+  '@next/swc-darwin-x64@15.5.18':
+    resolution: {integrity: sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.5.15':
-    resolution: {integrity: sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==}
+  '@next/swc-linux-arm64-gnu@15.5.18':
+    resolution: {integrity: sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.5.15':
-    resolution: {integrity: sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==}
+  '@next/swc-linux-arm64-musl@15.5.18':
+    resolution: {integrity: sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.5.15':
-    resolution: {integrity: sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==}
+  '@next/swc-linux-x64-gnu@15.5.18':
+    resolution: {integrity: sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.5.15':
-    resolution: {integrity: sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==}
+  '@next/swc-linux-x64-musl@15.5.18':
+    resolution: {integrity: sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@15.5.15':
-    resolution: {integrity: sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==}
+  '@next/swc-win32-arm64-msvc@15.5.18':
+    resolution: {integrity: sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.5.15':
-    resolution: {integrity: sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==}
+  '@next/swc-win32-x64-msvc@15.5.18':
+    resolution: {integrity: sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2999,8 +2999,8 @@ packages:
       nodemailer:
         optional: true
 
-  next@15.5.15:
-    resolution: {integrity: sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==}
+  next@15.5.18:
+    resolution: {integrity: sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -4324,34 +4324,34 @@ snapshots:
 
   '@mozilla/readability@0.6.0': {}
 
-  '@next/env@15.5.15': {}
+  '@next/env@15.5.18': {}
 
   '@next/eslint-plugin-next@15.5.14':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@15.5.15':
+  '@next/swc-darwin-arm64@15.5.18':
     optional: true
 
-  '@next/swc-darwin-x64@15.5.15':
+  '@next/swc-darwin-x64@15.5.18':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.5.15':
+  '@next/swc-linux-arm64-gnu@15.5.18':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.5.15':
+  '@next/swc-linux-arm64-musl@15.5.18':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.5.15':
+  '@next/swc-linux-x64-gnu@15.5.18':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.5.15':
+  '@next/swc-linux-x64-musl@15.5.18':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.5.15':
+  '@next/swc-win32-arm64-msvc@15.5.18':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.5.15':
+  '@next/swc-win32-x64-msvc@15.5.18':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -6155,15 +6155,15 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next-auth@5.0.0-beta.31(next@15.5.15(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+  next-auth@5.0.0-beta.31(next@15.5.18(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
     dependencies:
       '@auth/core': 0.41.2
-      next: 15.5.15(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 15.5.18(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
-  next@15.5.15(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@15.5.18(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
-      '@next/env': 15.5.15
+      '@next/env': 15.5.18
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001782
       postcss: 8.4.31
@@ -6171,14 +6171,14 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(react@19.2.4)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.5.15
-      '@next/swc-darwin-x64': 15.5.15
-      '@next/swc-linux-arm64-gnu': 15.5.15
-      '@next/swc-linux-arm64-musl': 15.5.15
-      '@next/swc-linux-x64-gnu': 15.5.15
-      '@next/swc-linux-x64-musl': 15.5.15
-      '@next/swc-win32-arm64-msvc': 15.5.15
-      '@next/swc-win32-x64-msvc': 15.5.15
+      '@next/swc-darwin-arm64': 15.5.18
+      '@next/swc-darwin-x64': 15.5.18
+      '@next/swc-linux-arm64-gnu': 15.5.18
+      '@next/swc-linux-arm64-musl': 15.5.18
+      '@next/swc-linux-x64-gnu': 15.5.18
+      '@next/swc-linux-x64-musl': 15.5.18
+      '@next/swc-win32-arm64-msvc': 15.5.18
+      '@next/swc-win32-x64-msvc': 15.5.18
       '@playwright/test': 1.58.2
       sharp: 0.34.5
     transitivePeerDependencies:

--- a/scripts/ops/__tests__/backfill-sms-consent.test.ts
+++ b/scripts/ops/__tests__/backfill-sms-consent.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+
+import { consentRecords } from "@as-comms/db";
+import { createTestStage1Context } from "@as-comms/db/test-helpers";
+
+import { backfillSmsConsent } from "../backfill-sms-consent.js";
+
+async function seedContact(input: {
+  readonly context: Awaited<ReturnType<typeof createTestStage1Context>>;
+  readonly id: string;
+  readonly primaryPhone: string | null;
+  readonly createdAt?: string;
+}): Promise<void> {
+  const createdAt = input.createdAt ?? "2026-05-01T00:00:00.000Z";
+
+  await input.context.repositories.contacts.upsert({
+    id: input.id,
+    salesforceContactId: null,
+    displayName: input.id,
+    primaryEmail: null,
+    primaryPhone: input.primaryPhone,
+    createdAt,
+    updatedAt: createdAt,
+  });
+}
+
+async function listConsentRows(
+  context: Awaited<ReturnType<typeof createTestStage1Context>>,
+) {
+  return context.db.select().from(consentRecords);
+}
+
+describe("backfill-sms-consent", () => {
+  it("inserts opted_in consent rows for contacts with primary phones and no consent", async () => {
+    const context = await createTestStage1Context();
+
+    try {
+      await seedContact({
+        context,
+        id: "contact-1",
+        primaryPhone: "+14065550101",
+        createdAt: "2026-05-02T12:00:00.000Z",
+      });
+      await seedContact({
+        context,
+        id: "contact-2",
+        primaryPhone: "+14065550102",
+        createdAt: "2026-05-03T12:00:00.000Z",
+      });
+
+      const result = await backfillSmsConsent({
+        db: context.db,
+        dryRun: false,
+      });
+      const rows = await listConsentRows(context);
+
+      expect(result.newlyInserted).toBe(2);
+      expect(result.alreadyConsentedSkipped).toBe(0);
+      expect(rows).toHaveLength(2);
+      expect(rows).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            contactId: "contact-1",
+            phoneE164: "+14065550101",
+            status: "opted_in",
+            source: "volunteer_application_form",
+            notes: "Backfilled from volunteer application form opt-in 2026-05-08",
+          }),
+          expect.objectContaining({
+            contactId: "contact-2",
+            phoneE164: "+14065550102",
+            status: "opted_in",
+            source: "volunteer_application_form",
+          }),
+        ]),
+      );
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("skips contacts that already have a consent row for the same phone and contact", async () => {
+    const context = await createTestStage1Context();
+
+    try {
+      await seedContact({
+        context,
+        id: "contact-1",
+        primaryPhone: "+14065550111",
+      });
+      await context.repositories.consentRecords.insert({
+        id: "consent-existing",
+        contactId: "contact-1",
+        phoneE164: "+14065550111",
+        status: "revoked",
+        source: "operator_attestation",
+        sourceDetail: null,
+        consentedAt: new Date("2026-05-01T00:00:00.000Z"),
+        revokedAt: new Date("2026-05-02T00:00:00.000Z"),
+        recordedByUserId: null,
+        notes: "Existing consent row",
+        createdAt: new Date("2026-05-02T00:00:00.000Z"),
+        updatedAt: new Date("2026-05-02T00:00:00.000Z"),
+      });
+
+      const result = await backfillSmsConsent({
+        db: context.db,
+        dryRun: false,
+      });
+      const rows = await listConsentRows(context);
+
+      expect(result.newlyInserted).toBe(0);
+      expect(result.alreadyConsentedSkipped).toBe(1);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.status).toBe("revoked");
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("ignores contacts without a primary phone", async () => {
+    const context = await createTestStage1Context();
+
+    try {
+      await seedContact({
+        context,
+        id: "contact-1",
+        primaryPhone: null,
+      });
+
+      const result = await backfillSmsConsent({
+        db: context.db,
+        dryRun: false,
+      });
+
+      expect(result.withPrimaryPhone).toBe(0);
+      expect(result.newlyInserted).toBe(0);
+      await expect(listConsentRows(context)).resolves.toHaveLength(0);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("is idempotent across repeated runs", async () => {
+    const context = await createTestStage1Context();
+
+    try {
+      await seedContact({
+        context,
+        id: "contact-1",
+        primaryPhone: "+14065550121",
+      });
+
+      const first = await backfillSmsConsent({
+        db: context.db,
+        dryRun: false,
+      });
+      const second = await backfillSmsConsent({
+        db: context.db,
+        dryRun: false,
+      });
+
+      expect(first.newlyInserted).toBe(1);
+      expect(second.newlyInserted).toBe(0);
+      await expect(listConsentRows(context)).resolves.toHaveLength(1);
+    } finally {
+      await context.dispose();
+    }
+  });
+});

--- a/scripts/ops/__tests__/seed-sms-senders.test.ts
+++ b/scripts/ops/__tests__/seed-sms-senders.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createStage1RepositoryBundleFromConnection,
+  smsSenders,
+} from "@as-comms/db";
+import { createTestStage1Context } from "@as-comms/db/test-helpers";
+
+import { parseSeedSmsSenderConfig, seedSmsSender } from "../seed-sms-senders.js";
+
+async function listSmsSenderRows(
+  context: Awaited<ReturnType<typeof createTestStage1Context>>,
+) {
+  return context.db.select().from(smsSenders);
+}
+
+describe("seed-sms-senders", () => {
+  it("inserts exactly one sender row with the expected values", async () => {
+    const context = await createTestStage1Context();
+
+    try {
+      const repositories = createStage1RepositoryBundleFromConnection({
+        db: context.db,
+      });
+
+      const result = await seedSmsSender({
+        db: context.db,
+        repositories,
+        dryRun: false,
+        config: {
+          phoneE164: "+14065550143",
+          displayName: "Adventure Scientists",
+          monthlyCap: 4000,
+        },
+      });
+      const rows = await listSmsSenderRows(context);
+
+      expect(result.status).toBe("inserted");
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        phoneE164: "+14065550143",
+        displayName: "Adventure Scientists",
+        monthlyCap: 4000,
+        isActive: true,
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("is idempotent when run twice with the same phone number", async () => {
+    const context = await createTestStage1Context();
+
+    try {
+      const repositories = createStage1RepositoryBundleFromConnection({
+        db: context.db,
+      });
+      const config = {
+        phoneE164: "+14065550144",
+        displayName: "Adventure Scientists",
+        monthlyCap: null,
+      } as const;
+
+      const first = await seedSmsSender({
+        db: context.db,
+        repositories,
+        dryRun: false,
+        config,
+      });
+      const second = await seedSmsSender({
+        db: context.db,
+        repositories,
+        dryRun: false,
+        config,
+      });
+
+      expect(first.status).toBe("inserted");
+      expect(second.status).toBe("already_exists");
+      await expect(listSmsSenderRows(context)).resolves.toHaveLength(1);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("throws a clear error when SMS_SENDER_PHONE_E164 is missing", () => {
+    expect(() => parseSeedSmsSenderConfig({})).toThrowError(
+      "SMS_SENDER_PHONE_E164 is required.",
+    );
+  });
+});

--- a/scripts/ops/backfill-sms-consent.ts
+++ b/scripts/ops/backfill-sms-consent.ts
@@ -1,0 +1,204 @@
+#!/usr/bin/env tsx
+
+import { randomUUID } from "node:crypto";
+import process from "node:process";
+
+import {
+  closeDatabaseConnection,
+  consentRecords,
+  contacts,
+  createDatabaseConnection,
+  type DatabaseConnection,
+} from "@as-comms/db";
+
+type ContactRow = {
+  readonly id: string;
+  readonly primaryPhone: string;
+  readonly createdAt: Date | null | undefined;
+};
+
+type ConsentBackfillInsert = {
+  readonly id: string;
+  readonly contactId: string;
+  readonly phoneE164: string;
+  readonly status: "opted_in";
+  readonly source: "volunteer_application_form";
+  readonly sourceDetail: null;
+  readonly consentedAt: Date;
+  readonly revokedAt: null;
+  readonly recordedByUserId: null;
+  readonly notes: string;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+};
+
+export type BackfillSmsConsentResult = {
+  readonly dryRun: boolean;
+  readonly totalContacts: number;
+  readonly withPrimaryPhone: number;
+  readonly alreadyConsentedSkipped: number;
+  readonly newlyInserted: number;
+  readonly consentedAtFallbackUsed: number;
+  readonly sampleContactIds: readonly string[];
+};
+
+const BACKFILL_NOTE = "Backfilled from volunteer application form opt-in 2026-05-08";
+
+function hasDryRunFlag(args: readonly string[]): boolean {
+  return args.includes("--dry-run");
+}
+
+function resolveConsentedAt(
+  createdAt: Date | null | undefined,
+  fallbackNow: Date,
+): { readonly consentedAt: Date; readonly usedFallback: boolean } {
+  if (createdAt instanceof Date && !Number.isNaN(createdAt.getTime())) {
+    return {
+      consentedAt: createdAt,
+      usedFallback: false,
+    };
+  }
+
+  return {
+    consentedAt: fallbackNow,
+    usedFallback: true,
+  };
+}
+
+export async function backfillSmsConsent(input: {
+  readonly db: DatabaseConnection["db"];
+  readonly dryRun: boolean;
+}): Promise<BackfillSmsConsentResult> {
+  return input.db.transaction(async (tx) => {
+    const allContacts = await tx.select().from(contacts);
+    const contactsWithPrimaryPhone = allContacts
+      .filter(
+        (contact): contact is typeof contact & { readonly primaryPhone: string } =>
+          contact.primaryPhone !== null,
+      )
+      .sort((left, right) => left.id.localeCompare(right.id));
+
+    const eligibleContacts = contactsWithPrimaryPhone.map((contact) => ({
+      id: contact.id,
+      primaryPhone: contact.primaryPhone,
+      createdAt: contact.createdAt,
+    })) satisfies readonly ContactRow[];
+
+    const existingRows =
+      eligibleContacts.length === 0 ? [] : await tx.select().from(consentRecords);
+
+    const existingPairs = new Set(
+      existingRows
+        .filter(
+          (row): row is typeof row & { readonly contactId: string } =>
+            row.contactId !== null &&
+            eligibleContacts.some(
+              (contact) =>
+                contact.id === row.contactId && contact.primaryPhone === row.phoneE164,
+            ),
+        )
+        .map((row) => `${row.contactId}::${row.phoneE164}`),
+    );
+
+    let consentedAtFallbackUsed = 0;
+    const now = new Date();
+    const inserts: ConsentBackfillInsert[] = [];
+
+    for (const contact of eligibleContacts) {
+      if (existingPairs.has(`${contact.id}::${contact.primaryPhone}`)) {
+        continue;
+      }
+
+      const consentedAtResolution = resolveConsentedAt(contact.createdAt, now);
+      if (consentedAtResolution.usedFallback) {
+        consentedAtFallbackUsed += 1;
+      }
+
+      inserts.push({
+        id: randomUUID(),
+        contactId: contact.id,
+        phoneE164: contact.primaryPhone,
+        status: "opted_in",
+        source: "volunteer_application_form",
+        sourceDetail: null,
+        consentedAt: consentedAtResolution.consentedAt,
+        revokedAt: null,
+        recordedByUserId: null,
+        notes: BACKFILL_NOTE,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+
+    if (!input.dryRun && inserts.length > 0) {
+      await tx.insert(consentRecords).values(inserts);
+    }
+
+    return {
+      dryRun: input.dryRun,
+      totalContacts: allContacts.length,
+      withPrimaryPhone: eligibleContacts.length,
+      alreadyConsentedSkipped: eligibleContacts.length - inserts.length,
+      newlyInserted: inserts.length,
+      consentedAtFallbackUsed,
+      sampleContactIds: inserts.slice(0, 10).map((record) => record.contactId),
+    };
+  });
+}
+
+export function renderBackfillSmsConsentMarkdown(
+  result: BackfillSmsConsentResult,
+): string {
+  const sampleLines =
+    result.sampleContactIds.length === 0
+      ? ["- none"]
+      : result.sampleContactIds.map((contactId) => `- ${contactId}`);
+
+  return [
+    "# SMS consent backfill",
+    "",
+    `Mode: ${result.dryRun ? "dry-run" : "execute"}`,
+    "",
+    "| metric | value |",
+    "| --- | --- |",
+    `| total_contacts | ${result.totalContacts} |`,
+    `| with_primary_phone | ${result.withPrimaryPhone} |`,
+    `| already_consented_skipped | ${result.alreadyConsentedSkipped} |`,
+    `| newly_inserted | ${result.newlyInserted} |`,
+    `| consented_at_fallback_used | ${result.consentedAtFallbackUsed} |`,
+    "",
+    "## Sample contact IDs",
+    ...sampleLines,
+  ].join("\n");
+}
+
+export async function runBackfillSmsConsentCommand(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+): Promise<BackfillSmsConsentResult> {
+  const connectionString = env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error("DATABASE_URL is required.");
+  }
+
+  const connection = createDatabaseConnection({ connectionString });
+  try {
+    const result = await backfillSmsConsent({
+      db: connection.db,
+      dryRun: hasDryRunFlag(args),
+    });
+    console.log(renderBackfillSmsConsentMarkdown(result));
+    return result;
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}
+
+if (import.meta.main) {
+  runBackfillSmsConsentCommand(process.argv.slice(2), process.env).catch((error) => {
+    console.error(
+      error instanceof Error ? error.message : "SMS consent backfill failed.",
+    );
+    process.exitCode = 1;
+  });
+}

--- a/scripts/ops/seed-sms-senders.ts
+++ b/scripts/ops/seed-sms-senders.ts
@@ -1,0 +1,169 @@
+#!/usr/bin/env tsx
+
+import { randomUUID } from "node:crypto";
+import process from "node:process";
+
+import { smsSenders } from "@as-comms/db";
+
+import {
+  closeDatabaseConnection,
+  createDatabaseConnection,
+  createStage1RepositoryBundleFromConnection,
+  type DatabaseConnection,
+} from "@as-comms/db";
+
+export type SeedSmsSenderConfig = {
+  readonly phoneE164: string;
+  readonly displayName: string;
+  readonly monthlyCap: number | null;
+};
+
+export type SeedSmsSenderResult = {
+  readonly dryRun: boolean;
+  readonly status: "would_insert" | "inserted" | "already_exists";
+  readonly row: {
+    readonly id: string;
+    readonly phoneE164: string;
+    readonly displayName: string;
+    readonly monthlyCap: number | null;
+    readonly isActive: true;
+  };
+};
+
+function hasDryRunFlag(args: readonly string[]): boolean {
+  return args.includes("--dry-run");
+}
+
+function normalizeOptionalString(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+export function parseSeedSmsSenderConfig(env: NodeJS.ProcessEnv): SeedSmsSenderConfig {
+  const phoneE164 = normalizeOptionalString(env.SMS_SENDER_PHONE_E164);
+  if (phoneE164 === null) {
+    throw new Error("SMS_SENDER_PHONE_E164 is required.");
+  }
+
+  const displayName =
+    normalizeOptionalString(env.SMS_SENDER_DISPLAY_NAME) ?? "Adventure Scientists";
+  const monthlyCapValue = normalizeOptionalString(env.SMS_SENDER_MONTHLY_CAP);
+
+  if (monthlyCapValue === null) {
+    return {
+      phoneE164,
+      displayName,
+      monthlyCap: null,
+    };
+  }
+
+  if (!/^-?\d+$/.test(monthlyCapValue)) {
+    throw new Error("SMS_SENDER_MONTHLY_CAP must be an integer when provided.");
+  }
+
+  return {
+    phoneE164,
+    displayName,
+    monthlyCap: Number.parseInt(monthlyCapValue, 10),
+  };
+}
+
+function truncateId(id: string): string {
+  return id.length <= 8 ? id : `${id.slice(0, 8)}...`;
+}
+
+export async function seedSmsSender(input: {
+  readonly db: DatabaseConnection["db"];
+  readonly repositories: ReturnType<typeof createStage1RepositoryBundleFromConnection>;
+  readonly dryRun: boolean;
+  readonly config: SeedSmsSenderConfig;
+}): Promise<SeedSmsSenderResult> {
+  const existing = await input.repositories.smsSenders.findByPhone(input.config.phoneE164);
+  if (existing !== null) {
+    return {
+      dryRun: input.dryRun,
+      status: "already_exists",
+      row: {
+        id: existing.id,
+        phoneE164: existing.phoneE164,
+        displayName: existing.displayName,
+        monthlyCap: existing.monthlyCap,
+        isActive: true,
+      },
+    };
+  }
+
+  const id = randomUUID();
+  const row = {
+    id,
+    phoneE164: input.config.phoneE164,
+    displayName: input.config.displayName,
+    monthlyCap: input.config.monthlyCap,
+    isActive: true as const,
+  };
+
+  if (!input.dryRun) {
+    const now = new Date();
+    await input.db.insert(smsSenders).values({
+      ...row,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  return {
+    dryRun: input.dryRun,
+    status: input.dryRun ? "would_insert" : "inserted",
+    row,
+  };
+}
+
+export function renderSeedSmsSenderMarkdown(result: SeedSmsSenderResult): string {
+  return [
+    "# SMS sender seed",
+    "",
+    `Mode: ${result.dryRun ? "dry-run" : "execute"}`,
+    "",
+    "| field | value |",
+    "| --- | --- |",
+    `| status | ${result.status} |`,
+    `| id | ${truncateId(result.row.id)} |`,
+    `| phone_e164 | ${result.row.phoneE164} |`,
+    `| display_name | ${result.row.displayName} |`,
+    `| monthly_cap | ${result.row.monthlyCap ?? "null"} |`,
+    `| is_active | ${String(result.row.isActive)} |`,
+  ].join("\n");
+}
+
+export async function runSeedSmsSendersCommand(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+): Promise<SeedSmsSenderResult> {
+  const connectionString = env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error("DATABASE_URL is required.");
+  }
+
+  const config = parseSeedSmsSenderConfig(env);
+  const connection = createDatabaseConnection({ connectionString });
+  try {
+    const repositories = createStage1RepositoryBundleFromConnection(connection);
+    const result = await seedSmsSender({
+      db: connection.db,
+      repositories,
+      dryRun: hasDryRunFlag(args),
+      config,
+    });
+    console.log(renderSeedSmsSenderMarkdown(result));
+    return result;
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}
+
+if (import.meta.main) {
+  runSeedSmsSendersCommand(process.argv.slice(2), process.env).catch((error) => {
+    console.error(error instanceof Error ? error.message : "SMS sender seed failed.");
+    process.exitCode = 1;
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -57,6 +57,8 @@ export default defineConfig({
     include: [
       "apps/web/app/**/*.test.ts",
       "apps/web/app/**/*.test.tsx",
+      "scripts/**/*.test.ts",
+      "scripts/**/*.test.tsx",
       "test/**/*.test.ts",
       "test/**/*.test.tsx",
       "tests/**/*.test.ts",


### PR DESCRIPTION
## Summary

Two one-shot operational scripts the architect runs during the SMS launch sequence (post-#354-merge, pre-`SMS_ENABLED=true` flip).

Run order:
1. `pnpm tsx scripts/ops/backfill-sms-consent.ts` (dry-run first, then real)
2. `pnpm tsx scripts/ops/seed-sms-senders.ts` (with `SMS_SENDER_PHONE_E164=...` env)
3. Set `SMS_ENABLED=true` on `web` + `sms-capture` Railway services

## `backfill-sms-consent.ts`

- Inserts `opted_in` rows in `consent_records` for every contact with `primary_phone`.
- `source='volunteer_application_form'`, `consentedAt` = the contact's `createdAt` (falls back to current time if missing; fallback count reported in summary).
- Skips contacts that already have a consent row for `(phone, contact)` — idempotent.
- `--dry-run` flag; markdown summary with totals and sample IDs.

Without this backfill, production `consent_records` has 0 rows (verified 2026-05-07) and `resolveSmsConsentDecision` refuses every outbound send.

## `seed-sms-senders.ts`

- Reads `SMS_SENDER_PHONE_E164` (required), `SMS_SENDER_DISPLAY_NAME` (default `"Adventure Scientists"`), `SMS_SENDER_MONTHLY_CAP` (default null, display-only per D-042 / PRD #277).
- Inserts exactly one `sms_senders` row.
- Exits cleanly if a row already exists for that phone — idempotent.
- `--dry-run` flag; markdown summary.

## vitest.config

Adds `scripts/**/*.test.{ts,tsx}` to the include glob so `scripts/ops/__tests__/` is discovered.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] Targeted Vitest runs for both new test files pass (Codex verified)
- [ ] `pnpm test:unit` skipped locally per architect convention; CI is authoritative
- [x] Idempotency covered: each script's test file has a "runs twice produces no extra rows" case
- [x] FK seeding: tests seed `contacts` before running the backfill function (per `project_pglite_fk_seed_gotcha.md`)

## Out of scope

- Running the scripts against production (architect runs manually as part of launch).
- Modifying `SMS_ENABLED`, Twilio env vars, Railway config.
- Admin UI for managing senders, multi-sender support, or hard cost cap enforcement.