### PR TITLE
fix(ai-draft): net-new compose no longer drafts as a reply

### DIFF
--- a/apps/web/src/server/ai/prompt-builder.ts
+++ b/apps/web/src/server/ai/prompt-builder.ts
@@ -58,9 +58,19 @@ function renderTier3Entries(bundle: GroundingBundle): string {
     .join("\n\n");
 }
 
-function renderChannelInstructionBlock(channel: AiDraftRequest["channel"]): string {
-  if (channel === "sms") {
+function renderChannelInstructionBlock(input: {
+  readonly channel: AiDraftRequest["channel"];
+  readonly isNewConversation: boolean;
+}): string {
+  if (input.channel === "sms") {
+    if (input.isNewConversation) {
+      return "Write a brand-new outbound SMS. The operator is starting a new conversation, not replying to anything — do NOT phrase this as a reply. Be concise, plaintext, one thought, target ~140 characters and never exceed 320 (two segments). No markdown. Open with the volunteer's first name when natural. No signature unless the operator asked. Don't include 'Reply STOP to opt out' — Twilio appends compliance language automatically.";
+    }
     return "Write SMS replies. Be concise, plaintext, one thought, target ~140 characters and never exceed 320 (two segments). No markdown, no greetings if the volunteer is mid-thread, no signature unless the operator asked. Match the tone of prior thread messages if any. Use the volunteer's first name when natural; default to no salutation. Don't include 'Reply STOP to opt out' — Twilio appends compliance language automatically.";
+  }
+
+  if (input.isNewConversation) {
+    return "You are drafting a brand-new outbound email to a volunteer. The operator is starting a new conversation — do NOT phrase this as a reply, do NOT begin with 'Thanks for reaching out' or any reply-style opener, and do NOT reference any inbound message as if it triggered this. The thread history below is background context only. Use only the information above and the operator's directive (if any). Never invent facts.";
   }
 
   return "You are drafting a reply to a volunteer. Use only the information above and the inbound message. Never invent facts.";
@@ -70,6 +80,7 @@ function buildSystemPrompt(
   bundle: GroundingBundle,
   request: Pick<AiDraftRequest, "channel">,
 ): string {
+  const isNewConversation = bundle.targetInbound === null;
   return [
     renderContextSection(
       "Tier 1 Voice Instructions",
@@ -91,14 +102,29 @@ function buildSystemPrompt(
     "",
     "The examples above are pattern support, not templates. Never copy any example verbatim. Adapt the style and structure to the current volunteer and project context.",
     "",
-    renderChannelInstructionBlock(request.channel),
+    renderChannelInstructionBlock({
+      channel: request.channel,
+      isNewConversation,
+    }),
   ].join("\n");
 }
 
 function buildContextPayload(bundle: GroundingBundle): string {
+  if (bundle.targetInbound === null) {
+    return [
+      "This is a brand-new outbound conversation. The operator picked this contact",
+      "from the new-draft pane and has not been triggered by any specific inbound.",
+      "Do not respond as if replying to a message.",
+      "",
+      "Recent thread history with this contact (background context only — do NOT",
+      "treat any of these as the message you are replying to):",
+      renderRecentEvents(bundle),
+    ].join("\n");
+  }
+
   return [
     "Inbound message:",
-    bundle.targetInbound?.body ?? "[No inbound message was captured.]",
+    bundle.targetInbound.body,
     "",
     "Recent thread context:",
     renderRecentEvents(bundle),
@@ -133,6 +159,11 @@ export function buildFillPrompt(
   bundle: GroundingBundle,
   input: Extract<AiDraftRequest, { mode: "fill" }>,
 ): BuiltPrompt {
+  const isNewConversation = bundle.targetInbound === null;
+  const expansionInstruction = isNewConversation
+    ? "Expand the operator's directive into a complete outbound message in the voice and context above. This is a new conversation, not a reply. If the directive contradicts the project context, produce the draft as directed AND emit a clear marker that the operator should reconfirm. Example marker: [NOTE: directive may conflict with project context, please verify X]."
+    : "Expand the operator's directive into a complete reply in the voice and context above. If the directive contradicts the project context, produce the draft as directed AND emit a clear marker that the operator should reconfirm. Example marker: [NOTE: directive may conflict with project context, please verify X].";
+
   return {
     system: buildSystemPrompt(bundle, input),
     messages: [
@@ -144,7 +175,7 @@ export function buildFillPrompt(
           "Operator directive:",
           input.operatorPrompt,
           "",
-          "Expand the operator's directive into a complete reply in the voice and context above. If the directive contradicts the project context, produce the draft as directed AND emit a clear marker that the operator should reconfirm. Example marker: [NOTE: directive may conflict with project context — please verify X].",
+          expansionInstruction,
         ]),
       },
     ],

--- a/apps/web/src/server/ai/retriever.ts
+++ b/apps/web/src/server/ai/retriever.ts
@@ -242,18 +242,33 @@ export async function retrieveGrounding(
   );
 
   const inboundEvents = threadEvents.filter((event) => event.direction === "inbound");
+  // When the operator passes an explicit threadCursor, the AI is replying to
+  // that specific inbound and we anchor to it. When threadCursor is null,
+  // the operator is composing a brand new outbound from the new-draft pane
+  // (the pencil button) — they are NOT replying to anything. Treating the
+  // most-recent inbound as the implicit target made every net-new compose
+  // come out as a reply (operator-reported 2026-05-12). Leave targetInbound
+  // null in that case; the prompt-builder switches to a new-conversation
+  // framing.
   const targetInbound =
-    (input.threadCursor === null
+    input.threadCursor === null
       ? null
       : inboundEvents.find(
           (event) => event.canonicalEventId === input.threadCursor,
-        )) ??
-    inboundEvents.at(-1) ??
-    null;
+        ) ?? null;
 
+  // Recent thread events still travel into the prompt for either case so
+  // the AI knows the contact's history. For a reply, we cap at events at-
+  // or-before the target inbound. For a new conversation we include the
+  // last 10 events overall (gives Claude full context to mention recent
+  // submissions, milestones, etc. without treating any one as the message
+  // being replied to).
   const recentEvents =
     targetInbound === null
-      ? []
+      ? threadEvents.slice(-10).map((event) => ({
+          ...event,
+          body: truncate(event.body, 500),
+        }))
       : threadEvents
           .filter(
             (event) =>

--- a/apps/web/test/server/ai/prompt-builder.test.ts
+++ b/apps/web/test/server/ai/prompt-builder.test.ts
@@ -135,7 +135,7 @@ describe("prompt builder", () => {
       Operator directive:
       Tell her the revised field kit will ship tomorrow.
       
-      Expand the operator's directive into a complete reply in the voice and context above. If the directive contradicts the project context, produce the draft as directed AND emit a clear marker that the operator should reconfirm. Example marker: [NOTE: directive may conflict with project context — please verify X].
+      Expand the operator's directive into a complete reply in the voice and context above. If the directive contradicts the project context, produce the draft as directed AND emit a clear marker that the operator should reconfirm. Example marker: [NOTE: directive may conflict with project context, please verify X].
       
       Output ONLY the final reply text. Do not include any preamble, sign-off commentary, or marker text OTHER than the contradiction marker if triggered.",
             "role": "user",

--- a/apps/web/test/server/ai/retriever.test.ts
+++ b/apps/web/test/server/ai/retriever.test.ts
@@ -14,11 +14,13 @@ import {
 
 describe("retrieveGrounding", () => {
   let runtime: Stage1WebTestRuntime | null = null;
+  let seededInboundId: string | null = null;
 
   beforeEach(async () => {
     runtime = await createStage1WebTestRuntime();
     await seedAiContact(runtime);
-    await seedAiThread(runtime);
+    const { latestInboundId } = await seedAiThread(runtime);
+    seededInboundId = latestInboundId;
   });
 
   afterEach(async () => {
@@ -72,7 +74,7 @@ describe("retrieveGrounding", () => {
     expect(bundle.grounding.some((entry) => entry.tier === 2)).toBe(true);
   });
 
-  it("retrieves approved tier-3 project knowledge", async () => {
+  it("retrieves approved tier-3 project knowledge when replying to a specific inbound", async () => {
     if (!runtime) {
       throw new Error("Expected runtime.");
     }
@@ -87,10 +89,17 @@ describe("retrieveGrounding", () => {
       approvedForAi: false,
     });
 
+    // Tier-3 retrieval is keyword-matched against the target inbound, only
+    // applies when the operator is actually replying (threadCursor set).
+    // Net-new compose (threadCursor=null) intentionally skips tier-3.
+    if (seededInboundId === null) {
+      throw new Error("Expected seededInboundId.");
+    }
+
     const bundle = await retrieveGrounding(runtime.context.repositories, {
       contactId: "contact:maya",
       projectId: "project:whitebark",
-      threadCursor: null,
+      threadCursor: seededInboundId,
     });
 
     expect(bundle.tier3Entries.map((entry) => entry.id)).toEqual([
@@ -111,7 +120,28 @@ describe("retrieveGrounding", () => {
     });
 
     expect(bundle.projectContext).toBeNull();
-    expect(bundle.targetInbound?.body).toContain("current field kit list");
+    // threadCursor=null is the new-conversation signal; the retriever no
+    // longer fabricates a target inbound from the most recent thread event.
+    expect(bundle.targetInbound).toBeNull();
+  });
+
+  it("leaves targetInbound null on net-new compose but still surfaces thread history as context", async () => {
+    if (!runtime) {
+      throw new Error("Expected runtime.");
+    }
+
+    const bundle = await retrieveGrounding(runtime.context.repositories, {
+      contactId: "contact:maya",
+      projectId: "project:whitebark",
+      threadCursor: null,
+    });
+
+    // Operator started a new conversation from the pencil button: no message
+    // is being replied to, even though this contact has thread history.
+    expect(bundle.targetInbound).toBeNull();
+    // The history still travels as background context so the AI knows
+    // recent activity (submissions, milestones, etc.).
+    expect(bundle.recentEvents.length).toBeGreaterThan(0);
   });
 
   it("falls back to the host's tier-2 entry when the project is a connected sub", async () => {


### PR DESCRIPTION
## Summary

Operator-reported 2026-05-12: clicking **Draft With AI** from the pencil new-email button always produced a reply to the contact's most recent inbound, even when the operator was explicitly starting a brand-new conversation.

## Root cause

In `apps/web/src/server/ai/retriever.ts`, when `threadCursor === null` (the signal from the new-draft pane), the retriever fell back to `inboundEvents.at(-1)` and set that as `targetInbound`. Downstream, the prompt builder rendered:

```
Inbound message:
<that body>
```

…and the system prompt said `"You are drafting a reply to a volunteer."` — so Claude faithfully wrote a reply to a message the operator wasn't responding to.

## Fix

**`retriever.ts`** — drop the `at(-1)` fallback. `threadCursor=null` now resolves `targetInbound=null`, which is the correct semantic for net-new compose. Recent thread events are still surfaced (last 10 overall) so the AI knows the contact's recent activity for context, but no single event gets cast as "the message being replied to."

**`prompt-builder.ts`** — branch on `bundle.targetInbound`:
- **null (net-new compose):** user prompt opens with *"This is a brand-new outbound conversation. ... Do not respond as if replying to a message."* The thread history block is labeled *"Recent thread history with this contact (background context only — do NOT treat any of these as the message you are replying to)."*
- System instruction switches to *"drafting a brand-new outbound email/SMS"* with explicit *"do NOT phrase this as a reply, do NOT begin with 'Thanks for reaching out'"* rules.
- Fill-mode (operator directive) expansion line also switches to *"complete outbound message ... new conversation, not a reply"* when targetInbound is null.

**Bonus:** the fill prompt's marker example switched from em-dash to comma form (`,`), matching the new *"avoid em-dashes"* rule that just landed in Tier 1.

## Tests

- `retriever.test.ts`: tier-3 test now passes `threadCursor` explicitly (it asserts pattern matching against an inbound, which only applies in reply context). The null-safe-bundle test asserts `targetInbound === null` instead of "echo of the latest inbound." New test confirms net-new leaves `targetInbound` null while preserving `recentEvents`.
- `prompt-builder.test.ts`: fill snapshot updated for the new comma-form marker example.

## Test plan

- [x] `pnpm -C apps/web typecheck` clean
- [x] `pnpm -C apps/web lint` clean
- [x] `pnpm -C apps/web test:unit -- retriever prompt-builder draft-generator` — all green
- [x] Full unit suite — 563 pass / 5 skipped
- [ ] Post-deploy: click the pencil "new email" button, pick a contact who has prior inbound history, click Draft With AI without typing a directive. Verify the draft opens with the volunteer's first name + a new-conversation framing, NOT "Thanks for reaching out about <subject of their last inbound>".

🤖 Generated with [Claude Code](https://claude.com/claude-code)