### PR TITLE
feat(composer): forward action + hover Reply/Forward + alias-default for connected subs + KB indicator host hop

### DIFF
--- a/apps/web/app/inbox/_components/composer-detail-surfaces.tsx
+++ b/apps/web/app/inbox/_components/composer-detail-surfaces.tsx
@@ -250,6 +250,8 @@ export function ComposerEmailSurface({
   showCc,
   showBcc,
   isReplying,
+  recipientAutoFocus = false,
+  recipientPlaceholder = "Search contacts",
   recipientError,
   ccError,
   bccError,
@@ -307,6 +309,8 @@ export function ComposerEmailSurface({
   readonly showCc: boolean;
   readonly showBcc: boolean;
   readonly isReplying: boolean;
+  readonly recipientAutoFocus?: boolean;
+  readonly recipientPlaceholder?: string;
   readonly recipientError?: ComposerValidationError;
   readonly ccError?: ComposerValidationError;
   readonly bccError?: ComposerValidationError;
@@ -394,6 +398,8 @@ export function ComposerEmailSurface({
             recipients={recipient === null ? [] : [recipient]}
             locked={isReplying}
             single
+            autoFocusInput={recipientAutoFocus}
+            placeholder={recipientPlaceholder}
             rightSlot={
               !showCc || !showBcc ? (
                 <div className="flex items-center gap-1 pt-0.5 text-[11.5px]">

--- a/apps/web/app/inbox/_components/composer-floating-pill.tsx
+++ b/apps/web/app/inbox/_components/composer-floating-pill.tsx
@@ -32,6 +32,15 @@ export function resolveFloatingComposerLabel(
     return /^re:/iu.test(base) ? base : `Re: ${base}`;
   }
 
+  if (composerPane.mode === "forwarding") {
+    const subject = composerPane.forwardContext.originalSubject.trim();
+    return subject.length > 0
+      ? /^fwd:/iu.test(subject)
+        ? subject
+        : `Fwd: ${subject}`
+      : "Forward message";
+  }
+
   return "Composer";
 }
 

--- a/apps/web/app/inbox/_components/composer-recipient-picker.tsx
+++ b/apps/web/app/inbox/_components/composer-recipient-picker.tsx
@@ -87,6 +87,7 @@ export function ComposerRecipientPicker({
   recipients,
   locked = false,
   single = false,
+  autoFocusInput = false,
   placeholder = "Search contacts",
   rightSlot,
   onRecipientsChange,
@@ -94,6 +95,7 @@ export function ComposerRecipientPicker({
   readonly recipients: readonly ComposerRecipientValue[];
   readonly locked?: boolean;
   readonly single?: boolean;
+  readonly autoFocusInput?: boolean;
   readonly placeholder?: string;
   readonly rightSlot?: ReactNode;
   readonly onRecipientsChange: (
@@ -229,6 +231,8 @@ export function ComposerRecipientPicker({
               <SearchIcon className="pointer-events-none mr-2 size-3.5 shrink-0 text-slate-400" />
             ) : null}
             <Input
+              autoFocus={autoFocusInput}
+              data-composer-recipient-input={single ? "" : undefined}
               value={query}
               onChange={(event) => {
                 setQuery(event.currentTarget.value);

--- a/apps/web/app/inbox/_components/icons.tsx
+++ b/apps/web/app/inbox/_components/icons.tsx
@@ -33,6 +33,7 @@ export {
   PanelRightClose as PanelRightCloseIcon,
   UserRound as UserRoundIcon,
   CornerUpLeft as CornerUpLeftIcon,
+  CornerUpRight as CornerUpRightIcon,
   ArrowRight as ArrowRightIcon,
   X as XIcon,
   LogOut as LogOutIcon,

--- a/apps/web/app/inbox/_components/inbox-client-provider.tsx
+++ b/apps/web/app/inbox/_components/inbox-client-provider.tsx
@@ -12,6 +12,7 @@ import {
 import type { AiDraftRequestPayload, AiDraftResponseVm } from "../actions";
 import type {
   InboxComposerAliasOption,
+  InboxComposerForwardContext,
   InboxComposerReplyContext,
   OptimisticOutbound,
 } from "../_lib/view-models";
@@ -158,6 +159,10 @@ interface InboxClientState {
   readonly openReplyDraft: (
     replyContext: InboxComposerReplyContext,
     initialTab?: "email" | "note",
+  ) => void;
+  readonly openForwardDraft: (
+    forwardContext: InboxComposerForwardContext,
+    initialTab?: "email",
   ) => void;
   readonly closeComposer: () => void;
   readonly minimizeComposer: () => void;
@@ -346,6 +351,25 @@ export function InboxClientProvider({
         reduceComposerPane(previous, {
           type: "open-reply",
           replyContext,
+          initialTab,
+        }),
+      );
+      setComposerView("modal");
+      setComposerStatus("idle");
+      setComposerErrors([]);
+    },
+    [],
+  );
+
+  const openForwardDraft = useCallback(
+    (
+      forwardContext: InboxComposerForwardContext,
+      initialTab: "email" = "email",
+    ) => {
+      setComposerPane((previous) =>
+        reduceComposerPane(previous, {
+          type: "open-forward",
+          forwardContext,
           initialTab,
         }),
       );
@@ -601,6 +625,7 @@ export function InboxClientProvider({
       composerView,
       openNewDraft,
       openReplyDraft,
+      openForwardDraft,
       closeComposer,
       minimizeComposer,
       expandComposer,
@@ -649,6 +674,7 @@ export function InboxClientProvider({
       composerView,
       openNewDraft,
       openReplyDraft,
+      openForwardDraft,
       closeComposer,
       minimizeComposer,
       expandComposer,

--- a/apps/web/app/inbox/_components/inbox-composer.tsx
+++ b/apps/web/app/inbox/_components/inbox-composer.tsx
@@ -9,7 +9,12 @@ import {
   FOCUS_RING,
   TRANSITION,
 } from "@/app/_lib/design-tokens-v2";
-import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 
 import {
@@ -62,6 +67,18 @@ function resolveReplyTitle(input: {
   }
 
   return /^re:/iu.test(subject) ? subject : `Re: ${subject}`;
+}
+
+function resolveForwardTitle(subject: string | null | undefined): string {
+  const normalizedSubject = subject?.trim() ?? "";
+
+  if (normalizedSubject.length === 0) {
+    return "Forward message";
+  }
+
+  return /^fwd:/iu.test(normalizedSubject)
+    ? normalizedSubject
+    : `Fwd: ${normalizedSubject}`;
 }
 
 function ComposerModeTabs({
@@ -306,11 +323,17 @@ export function InboxComposerDetailPane({
     (error) => error.field === "attachments",
   );
   const modalTitle =
-    isReplying && replyContext !== null
-      ? resolveReplyTitle({
-          subject: replyContext.subject,
-          fallbackName: replyContext.contactDisplayName,
-        })
+    composerPane.mode === "forwarding"
+      ? resolveForwardTitle(composerPane.forwardContext.originalSubject)
+      : isReplying && replyContext !== null
+        ? resolveReplyTitle({
+            subject: replyContext.subject,
+            fallbackName: replyContext.contactDisplayName,
+          })
+        : null;
+  const modalDescription =
+    composerPane.mode === "forwarding"
+      ? "Pick a contact or type an email"
       : null;
   const handleFilesSelected = useAttachmentIntake({
     attachmentBytes,
@@ -430,6 +453,11 @@ export function InboxComposerDetailPane({
         <DialogTitle className="sr-only">
           {modalTitle ?? "Message composer"}
         </DialogTitle>
+        {modalDescription === null ? null : (
+          <DialogDescription className="sr-only">
+            {modalDescription}
+          </DialogDescription>
+        )}
         <header className="flex items-center justify-between gap-3 border-b border-slate-200 bg-white px-4 py-2.5">
           <ComposerModeTabs
             activeTab={state.activeTab}
@@ -475,6 +503,12 @@ export function InboxComposerDetailPane({
               showCc={state.showCc}
               showBcc={state.showBcc}
               isReplying={isReplying}
+              recipientAutoFocus={composerPane.mode === "forwarding"}
+              recipientPlaceholder={
+                composerPane.mode === "forwarding"
+                  ? "Pick a contact or type an email"
+                  : "Search contacts"
+              }
               subject={state.subject}
               body={state.body}
               attachments={state.attachments}

--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -32,6 +32,8 @@ import {
 } from "../actions";
 import { plaintextToComposerHtml } from "@/src/lib/html-sanitizer";
 import { fetchInboxTimelinePage } from "../_lib/client-api";
+import { buildForwardContextFromEntry } from "../_lib/composer-forward";
+import { resolveProjectAliasOverride } from "../_lib/composer-ui";
 import type {
   InboxComposerReplyContext,
   InboxDetailSummaryViewModel,
@@ -306,16 +308,17 @@ export function InboxDetail({ detail, timelineSlot }: DetailProps) {
   // Default the reply alias to the alias belonging to the conversation tag's
   // project (first active-project chip, falling back to conversationProject)
   // so a forests@ thread opens with forests@ selected — not whatever alias
-  // the volunteer last replied to.
-  const tagProjectId =
-    contact.activeProjects[0]?.projectId ??
-    detail.conversationProject?.projectId ??
-    null;
-  const projectAliasOverride =
-    tagProjectId === null
-      ? null
-      : (composerAliases.find((option) => option.projectId === tagProjectId)
-          ?.alias ?? null);
+  // the volunteer last replied to. Connected-sub volunteers must hop through
+  // the host project id too because the alias is owned by the host.
+  const tagProject = contact.activeProjects[0] ?? null;
+  const projectAliasOverride = resolveProjectAliasOverride({
+    projectIds: [
+      tagProject?.projectId ?? null,
+      tagProject?.hostProjectId ?? null,
+      detail.conversationProject?.projectId ?? null,
+    ],
+    aliases: composerAliases,
+  });
   const resolvedReplyContext =
     composerReplyContext === null
       ? null
@@ -549,6 +552,7 @@ export function InboxDetailTimelinePanel({
     optimisticOutbounds,
     clearOptimisticForContact,
     removeOptimisticOutbound,
+    openForwardDraft,
     openReplyDraft,
     showToast,
   } = useInboxClient();
@@ -717,6 +721,26 @@ export function InboxDetailTimelinePanel({
     ],
   );
 
+  const handleForward = useCallback(
+    (entryId: string) => {
+      const entry = mergedTimelineEntries.find((item) => item.id === entryId);
+
+      if (entry === undefined) {
+        return;
+      }
+
+      const forwardContext = buildForwardContextFromEntry({
+        entry,
+        defaultAlias: composerReplyContext?.defaultAlias ?? null,
+      });
+
+      if (forwardContext !== null) {
+        openForwardDraft(forwardContext);
+      }
+    },
+    [composerReplyContext?.defaultAlias, mergedTimelineEntries, openForwardDraft],
+  );
+
   const handleRetryPending = useCallback(
     (entryId: string) => {
       const entry = mergedTimelineEntries.find((item) => item.id === entryId);
@@ -800,6 +824,7 @@ export function InboxDetailTimelinePanel({
           isLoadingOlder={isTimelineLoading}
           retryingEntryId={isRetryPending ? retryingEntryId : null}
           onRetryPending={handleRetryPending}
+          onForward={handleForward}
           onReply={handleReply}
           onLoadOlder={() => {
             void loadOlderTimeline();

--- a/apps/web/app/inbox/_components/inbox-timeline-bubble.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-bubble.tsx
@@ -27,6 +27,7 @@ import {
   AdventureScientistsLogo,
   ArrowUpRightIcon,
   CornerUpLeftIcon,
+  CornerUpRightIcon,
   FileDocIcon,
   LoaderIcon,
   MailIcon,
@@ -219,31 +220,59 @@ function MessageAttachments({
 
 function ReplyFooter({
   entryId,
+  onForward,
   onReply,
 }: {
   readonly entryId: string;
+  readonly onForward?: (entryId: string) => void;
   readonly onReply?: (entryId: string) => void;
 }) {
-  if (onReply === undefined) {
+  if (onForward === undefined && onReply === undefined) {
     return null;
   }
 
   return (
-    <div className="flex items-center justify-end border-t border-slate-100 px-4 py-1.5">
-      <button
-        type="button"
-        onClick={() => {
-          onReply(entryId);
-        }}
-        className={cn(
-          "inline-flex items-center gap-1 text-[11px] text-slate-500 hover:text-slate-800",
-          TRANSITION.fast,
-          TRANSITION.reduceMotion,
+    <div
+      className={cn(
+        "border-t border-slate-100 px-4 py-1.5 opacity-0 group-hover:opacity-100",
+        TRANSITION.fast,
+        TRANSITION.reduceMotion,
+      )}
+    >
+      <div className="flex items-center justify-end gap-3">
+        {onForward === undefined ? null : (
+          <button
+            type="button"
+            onClick={() => {
+              onForward(entryId);
+            }}
+            className={cn(
+              "inline-flex items-center gap-1 text-[11px] text-slate-500 hover:text-slate-800",
+              TRANSITION.fast,
+              TRANSITION.reduceMotion,
+            )}
+          >
+            <CornerUpRightIcon className="size-3" />
+            <span>Forward</span>
+          </button>
         )}
-      >
-        <CornerUpLeftIcon className="size-3" />
-        <span>Reply</span>
-      </button>
+        {onReply === undefined ? null : (
+          <button
+            type="button"
+            onClick={() => {
+              onReply(entryId);
+            }}
+            className={cn(
+              "inline-flex items-center gap-1 text-[11px] text-slate-500 hover:text-slate-800",
+              TRANSITION.fast,
+              TRANSITION.reduceMotion,
+            )}
+          >
+            <CornerUpLeftIcon className="size-3" />
+            <span>Reply</span>
+          </button>
+        )}
+      </div>
     </div>
   );
 }
@@ -381,12 +410,14 @@ function OutboundBrandAvatar() {
 export function MessageBubble({
   entry,
   direction,
+  onForward,
   onReply,
   isRetrying = false,
   onRetryPending,
 }: {
   readonly entry: InboxTimelineEntryViewModel;
   readonly direction: "inbound" | "outbound";
+  readonly onForward?: (entryId: string) => void;
   readonly onReply?: (entryId: string) => void;
   readonly isRetrying?: boolean;
   readonly onRetryPending?: (entryId: string) => void;
@@ -427,7 +458,7 @@ export function MessageBubble({
   const bubble = (
     <div
       className={cn(
-        "min-w-0 overflow-hidden rounded-xl",
+        "group min-w-0 overflow-hidden rounded-xl",
         bubbleWidthClassName,
         SHADOW.sm,
         bubbleClassName,
@@ -486,6 +517,7 @@ export function MessageBubble({
 
       <ReplyFooter
         entryId={entry.id}
+        {...(onForward === undefined ? {} : { onForward })}
         {...(onReply === undefined ? {} : { onReply })}
       />
     </div>

--- a/apps/web/app/inbox/_components/inbox-timeline.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline.tsx
@@ -52,6 +52,7 @@ interface TimelineProps {
   readonly onLoadOlder?: () => void;
   readonly retryingEntryId?: string | null;
   readonly onRetryPending?: (entryId: string) => void;
+  readonly onForward?: (entryId: string) => void;
   readonly onReply?: (entryId: string) => void;
 }
 
@@ -65,6 +66,7 @@ export function InboxTimeline({
   onLoadOlder,
   retryingEntryId = null,
   onRetryPending,
+  onForward,
   onReply,
 }: TimelineProps) {
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(
@@ -148,6 +150,7 @@ export function InboxTimeline({
                   isExpanded={expanded.has(item.id)}
                   retryingEntryId={retryingEntryId}
                   onRetryPending={onRetryPending}
+                  {...(onForward === undefined ? {} : { onForward })}
                   {...(onReply === undefined ? {} : { onReply })}
                   onToggle={() => {
                     toggle(item.id);
@@ -181,6 +184,7 @@ export function InboxTimeline({
                   isExpanded={expanded.has(entry.id)}
                   retryingEntryId={retryingEntryId}
                   onRetryPending={onRetryPending}
+                  {...(onForward === undefined ? {} : { onForward })}
                   {...(onReply === undefined ? {} : { onReply })}
                   onToggle={() => {
                     toggle(entry.id);
@@ -256,6 +260,7 @@ interface EntryProps {
   readonly isExpanded: boolean;
   readonly retryingEntryId: string | null;
   readonly onRetryPending: ((entryId: string) => void) | undefined;
+  readonly onForward?: (entryId: string) => void;
   readonly onReply?: (entryId: string) => void;
   readonly onToggle: () => void;
 }
@@ -267,6 +272,7 @@ function TimelineEntry({
   isExpanded,
   retryingEntryId,
   onRetryPending,
+  onForward,
   onReply,
   onToggle,
 }: EntryProps) {
@@ -288,6 +294,7 @@ function TimelineEntry({
         <MessageBubble
           entry={entry}
           direction="inbound"
+          {...(onForward === undefined ? {} : { onForward })}
           {...(onReply === undefined ? {} : { onReply })}
         />
       );
@@ -309,6 +316,7 @@ function TimelineEntry({
           entry={entry}
           direction="outbound"
           isRetrying={retryingEntryId === entry.id}
+          {...(onForward === undefined ? {} : { onForward })}
           {...(onReply === undefined ? {} : { onReply })}
           {...(onRetryPending === undefined ? {} : { onRetryPending })}
         />

--- a/apps/web/app/inbox/_hooks/composer-draft-reducer.ts
+++ b/apps/web/app/inbox/_hooks/composer-draft-reducer.ts
@@ -1,9 +1,15 @@
 import {
+  buildForwardBodyHtml,
+  buildForwardBodyPlaintext,
+  buildForwardSubject,
+} from "../_lib/composer-forward";
+import {
   resolveDefaultAlias,
   type ComposerPaneState,
 } from "../_lib/composer-ui";
 import type {
   InboxComposerAliasOption,
+  InboxComposerForwardContext,
   InboxComposerReplyContext,
 } from "../_lib/view-models";
 import type {
@@ -59,6 +65,7 @@ export type ComposerDraftAction =
       readonly type: "RESET_TO_PANE_MODE";
       readonly composerPane: ComposerPaneState;
       readonly replyContext: InboxComposerReplyContext | null;
+      readonly forwardContext: InboxComposerForwardContext | null;
     }
   | {
       readonly type: "HYDRATE_FROM_STORED_DRAFT";
@@ -158,6 +165,7 @@ export function reduceComposerDraft(
       }
 
       const replyContext = action.replyContext;
+      const forwardContext = action.forwardContext;
       const replyRecipient: ComposerRecipientValue | null =
         replyContext === null
           ? null
@@ -176,6 +184,10 @@ export function reduceComposerDraft(
 
         return candidate.emailAddress !== replyContext?.defaultAlias;
       });
+      const bodyHtml =
+        forwardContext?.originalBodyHtml === null || forwardContext === null
+          ? ""
+          : buildForwardBodyHtml(forwardContext);
 
       return {
         ...INITIAL_COMPOSER_DRAFT_STATE,
@@ -197,11 +209,24 @@ export function reduceComposerDraft(
           action.composerPane.initialTab === "note"
             ? "note"
             : "email",
-        recipient: replyRecipient,
-        cc,
-        showCc: cc.length > 0,
-        selectedAlias: replyContext?.defaultAlias ?? null,
-        subject: replyContext?.subject ?? "",
+        recipient:
+          action.composerPane.mode === "forwarding" ? null : replyRecipient,
+        cc: action.composerPane.mode === "forwarding" ? [] : cc,
+        showCc:
+          action.composerPane.mode === "forwarding" ? false : cc.length > 0,
+        selectedAlias:
+          action.composerPane.mode === "forwarding"
+            ? (forwardContext?.defaultAlias ?? null)
+            : (replyContext?.defaultAlias ?? null),
+        subject:
+          action.composerPane.mode === "forwarding"
+            ? buildForwardSubject(forwardContext?.originalSubject ?? "")
+            : (replyContext?.subject ?? ""),
+        body:
+          action.composerPane.mode === "forwarding" && forwardContext !== null
+            ? buildForwardBodyPlaintext(forwardContext)
+            : "",
+        bodyHtml,
       };
     }
     case "HYDRATE_FROM_STORED_DRAFT": {

--- a/apps/web/app/inbox/_hooks/use-composer-draft-state.ts
+++ b/apps/web/app/inbox/_hooks/use-composer-draft-state.ts
@@ -1,14 +1,16 @@
 import { useEffect, useReducer, useRef } from "react";
 
 import {
+  buildForwardBodyHtml,
+  buildForwardBodyPlaintext,
+  buildForwardSubject,
+} from "../_lib/composer-forward";
+import {
   clearDraft,
   loadDraft,
   saveDraft,
 } from "../_lib/composer-draft-storage";
-import {
-  resolveDefaultAlias,
-  type ComposerPaneState,
-} from "../_lib/composer-ui";
+import { resolveDefaultAlias, type ComposerPaneState } from "../_lib/composer-ui";
 import type { InboxComposerAliasOption } from "../_lib/view-models";
 import {
   resolveComposerDraftKey,
@@ -41,14 +43,32 @@ export function useComposerDraftState({
   const hydratedDraftKeyRef = useRef<string | null>(null);
   const replyContext =
     composerPane.mode === "replying" ? composerPane.replyContext : null;
+  const forwardContext =
+    composerPane.mode === "forwarding" ? composerPane.forwardContext : null;
   const isReplying = composerPane.mode === "replying";
-  const baselineSubject = replyContext?.subject ?? "";
-  const baselineAlias = isReplying
-    ? (replyContext?.defaultAlias ?? null)
-    : resolveDefaultAlias({
-        recipient: state.recipient,
-        aliases: composerAliases,
-      });
+  const baselineSubject =
+    composerPane.mode === "forwarding" && forwardContext !== null
+      ? buildForwardSubject(forwardContext.originalSubject)
+      : (replyContext?.subject ?? "");
+  const baselineBody =
+    composerPane.mode === "forwarding" && forwardContext !== null
+      ? buildForwardBodyPlaintext(forwardContext)
+      : "";
+  const baselineBodyHtml =
+    composerPane.mode === "forwarding" &&
+    forwardContext?.originalBodyHtml !== null &&
+    forwardContext !== null
+      ? buildForwardBodyHtml(forwardContext)
+      : "";
+  const baselineAlias =
+    composerPane.mode === "forwarding"
+      ? (forwardContext?.defaultAlias ?? null)
+      : isReplying
+        ? (replyContext?.defaultAlias ?? null)
+        : resolveDefaultAlias({
+            recipient: state.recipient,
+            aliases: composerAliases,
+          });
   const draftKey = resolveComposerDraftKey({
     actorId,
     recipient: state.recipient,
@@ -63,12 +83,14 @@ export function useComposerDraftState({
       type: "RESET_TO_PANE_MODE",
       composerPane,
       replyContext,
+      forwardContext,
     });
     setComposerStatus("idle");
     setComposerErrors([]);
     resetAiDraft();
   }, [
     composerPane,
+    forwardContext,
     replyContext,
     resetAiDraft,
     setComposerErrors,
@@ -87,8 +109,8 @@ export function useComposerDraftState({
 
     const isUntouchedComposer =
       state.subject.trim() === baselineSubject.trim() &&
-      state.body.trim().length === 0 &&
-      state.bodyHtml.trim().length === 0 &&
+      state.body.trim() === baselineBody.trim() &&
+      state.bodyHtml.trim() === baselineBodyHtml.trim() &&
       state.cc.length === 0 &&
       state.bcc.length === 0 &&
       state.attachments.length === 0 &&
@@ -110,6 +132,8 @@ export function useComposerDraftState({
     }
   }, [
     baselineAlias,
+    baselineBody,
+    baselineBodyHtml,
     baselineSubject,
     composerPane.mode,
     draftKey,
@@ -134,8 +158,8 @@ export function useComposerDraftState({
 
     const hasPersistableContent =
       state.subject.trim() !== baselineSubject.trim() ||
-      state.body.trim().length > 0 ||
-      state.bodyHtml.trim().length > 0 ||
+      state.body.trim() !== baselineBody.trim() ||
+      state.bodyHtml.trim() !== baselineBodyHtml.trim() ||
       state.cc.length > 0 ||
       state.bcc.length > 0 ||
       state.selectedAlias !== baselineAlias ||
@@ -173,6 +197,8 @@ export function useComposerDraftState({
     };
   }, [
     baselineAlias,
+    baselineBody,
+    baselineBodyHtml,
     baselineSubject,
     composerPane.mode,
     draftKey,

--- a/apps/web/app/inbox/_lib/composer-forward.ts
+++ b/apps/web/app/inbox/_lib/composer-forward.ts
@@ -1,0 +1,144 @@
+import { sanitizeComposerHtml } from "@/src/lib/html-sanitizer";
+
+import type {
+  InboxComposerForwardContext,
+  InboxTimelineEntryViewModel,
+} from "./view-models";
+
+const FORWARD_SUBJECT_PREFIX_PATTERN = /^\s*fwd:\s*/iu;
+const HTML_TAG_PATTERN = /<\/?[a-zA-Z][^>]*>/u;
+const HTML_BREAK_PATTERN = /<(?:br|\/p|\/div|\/li)\b[^>]*>/giu;
+const HTML_BLOCK_CLOSE_PATTERN = /<\/(?:p|div|li|blockquote|ul|ol|table|tr|h[1-6])>/giu;
+const HTML_TAG_STRIP_PATTERN = /<[^>]+>/gu;
+const HTML_ENTITY_REPLACEMENTS = new Map<string, string>([
+  ["&nbsp;", " "],
+  ["&amp;", "&"],
+  ["&lt;", "<"],
+  ["&gt;", ">"],
+  ["&quot;", '"'],
+  ["&#39;", "'"],
+]);
+
+function bodyContainsHtml(body: string): boolean {
+  return HTML_TAG_PATTERN.test(body);
+}
+
+function formatForwardedDate(occurredAtIso: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/Denver",
+    dateStyle: "long",
+    timeStyle: "short",
+  })
+    .format(new Date(occurredAtIso))
+    .replace(/, (?=\d{1,2}:\d{2}\s)/u, " at ");
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function htmlToPlaintext(bodyHtml: string): string {
+  const withLineBreaks = bodyHtml
+    .replace(HTML_BREAK_PATTERN, "\n")
+    .replace(HTML_BLOCK_CLOSE_PATTERN, "\n");
+  const withoutTags = withLineBreaks.replace(HTML_TAG_STRIP_PATTERN, "");
+
+  let decoded = withoutTags;
+  for (const [entity, replacement] of HTML_ENTITY_REPLACEMENTS) {
+    decoded = decoded.replaceAll(entity, replacement);
+  }
+
+  return decoded.replace(/\n{3,}/gu, "\n\n").trim();
+}
+
+export function buildForwardSubject(originalSubject: string): string {
+  return FORWARD_SUBJECT_PREFIX_PATTERN.test(originalSubject)
+    ? originalSubject
+    : `Fwd: ${originalSubject}`;
+}
+
+export function buildForwardBodyPlaintext(
+  context: InboxComposerForwardContext,
+): string {
+  const headerLines = [
+    "---------- Forwarded message ----------",
+    `From: ${context.originalFromLabel}`,
+    `Date: ${formatForwardedDate(context.originalOccurredAtIso)}`,
+    `Subject: ${context.originalSubject}`,
+    `To: ${context.originalToLabel}`,
+    ...(context.originalCcLabel === null
+      ? []
+      : [`Cc: ${context.originalCcLabel}`]),
+    "",
+    context.originalBodyPlaintext,
+  ];
+
+  return `\n\n${headerLines.join("\n")}`;
+}
+
+export function buildForwardBodyHtml(
+  context: InboxComposerForwardContext,
+): string {
+  const ccLine =
+    context.originalCcLabel === null
+      ? ""
+      : `<div>Cc: ${escapeHtml(context.originalCcLabel)}</div>`;
+
+  return [
+    "<p><br/></p>",
+    "<p><br/></p>",
+    "<div>---------- Forwarded message ----------</div>",
+    `<div>From: ${escapeHtml(context.originalFromLabel)}</div>`,
+    `<div>Date: ${escapeHtml(formatForwardedDate(context.originalOccurredAtIso))}</div>`,
+    `<div>Subject: ${escapeHtml(context.originalSubject)}</div>`,
+    `<div>To: ${escapeHtml(context.originalToLabel)}</div>`,
+    ccLine,
+    '<blockquote style="border-left:2px solid #cbd5e1; margin:0; padding-left:12px; color:#475569;">',
+    context.originalBodyHtml ?? "",
+    "</blockquote>",
+  ]
+    .filter((line) => line.length > 0)
+    .join("");
+}
+
+export function buildForwardContextFromEntry(input: {
+  readonly entry: InboxTimelineEntryViewModel;
+  readonly defaultAlias: string | null;
+}): InboxComposerForwardContext | null {
+  if (input.entry.channel !== "email") {
+    return null;
+  }
+
+  const originalBody = input.entry.body.trim();
+  const originalBodyHtml =
+    originalBody.length > 0 && bodyContainsHtml(originalBody)
+      ? sanitizeComposerHtml(originalBody)
+      : null;
+  const originalFromLabel = input.entry.fromHeader?.trim();
+  const originalToLabel = input.entry.toHeader?.trim();
+
+  return {
+    originalEntryId: input.entry.id,
+    originalSubject: input.entry.subject ?? "",
+    originalFromLabel:
+      originalFromLabel && originalFromLabel.length > 0
+        ? originalFromLabel
+        : "Unknown sender",
+    originalToLabel:
+      originalToLabel && originalToLabel.length > 0
+        ? originalToLabel
+        : "Unknown recipient",
+    originalCcLabel:
+      input.entry.ccHeader?.trim().length ? input.entry.ccHeader.trim() : null,
+    originalOccurredAtIso: input.entry.occurredAt,
+    originalBodyPlaintext:
+      originalBodyHtml === null ? originalBody : htmlToPlaintext(originalBodyHtml),
+    originalBodyHtml,
+    defaultAlias: input.defaultAlias,
+  };
+}

--- a/apps/web/app/inbox/_lib/composer-ui.ts
+++ b/apps/web/app/inbox/_lib/composer-ui.ts
@@ -2,7 +2,8 @@ import { z } from "zod";
 
 import type {
   InboxComposerAliasOption,
-  InboxComposerReplyContext
+  InboxComposerForwardContext,
+  InboxComposerReplyContext,
 } from "./view-models";
 
 const emailSchema = z.string().email();
@@ -19,6 +20,11 @@ export type ComposerPaneState =
       readonly mode: "replying";
       readonly replyContext: InboxComposerReplyContext;
       readonly initialTab?: "email" | "note";
+    }
+  | {
+      readonly mode: "forwarding";
+      readonly forwardContext: InboxComposerForwardContext;
+      readonly initialTab?: "email";
     };
 
 export type ComposerSendKind = "send" | "send-and-save";
@@ -31,6 +37,11 @@ export type ComposerPaneAction =
       readonly type: "open-reply";
       readonly replyContext: InboxComposerReplyContext;
       readonly initialTab?: "email" | "note";
+    }
+  | {
+      readonly type: "open-forward";
+      readonly forwardContext: InboxComposerForwardContext;
+      readonly initialTab?: "email";
     }
   | {
       readonly type: "close";
@@ -50,6 +61,12 @@ export function reduceComposerPane(
       return {
         mode: "replying",
         replyContext: action.replyContext,
+        initialTab: action.initialTab ?? "email",
+      };
+    case "open-forward":
+      return {
+        mode: "forwarding",
+        forwardContext: action.forwardContext,
         initialTab: action.initialTab ?? "email",
       };
     case "close":
@@ -138,6 +155,25 @@ export function resolveDefaultAlias(input: {
   return (
     input.aliases.find((alias) => alias.projectName === primaryProjectName)
       ?.alias ?? null
+  );
+}
+
+export function resolveProjectAliasOverride(input: {
+  readonly projectIds: readonly (string | null | undefined)[];
+  readonly aliases: readonly InboxComposerAliasOption[];
+}): string | null {
+  const projectIds = input.projectIds.filter(
+    (projectId): projectId is string =>
+      typeof projectId === "string" && projectId.length > 0,
+  );
+
+  if (projectIds.length === 0) {
+    return null;
+  }
+
+  return (
+    input.aliases.find((alias) => projectIds.includes(alias.projectId))?.alias ??
+    null
   );
 }
 

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -1053,6 +1053,7 @@ function buildProjectMembershipViewModel(
     projectName: hostName ?? ownName,
     subDisplayName: hostName === null ? null : ownName,
     isConnectedSub: hostName !== null,
+    hostProjectId: metadata?.connectedToProjectId ?? null,
     projectIsActive: metadata?.isActive ?? false,
     status: mapProjectStatus(membership.status),
     statusLabel: mapProjectStatusLabel(membership.status),

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -147,6 +147,7 @@ export interface InboxProjectMembershipViewModel {
   readonly subDisplayName: string | null;
   /** True when this membership's project is a connected sub-project. */
   readonly isConnectedSub: boolean;
+  readonly hostProjectId: string | null;
   readonly projectIsActive: boolean;
   readonly status: InboxProjectStatus;
   readonly statusLabel: string;
@@ -407,6 +408,18 @@ export interface InboxComposerReplyContext {
   readonly inReplyToRfc822: string | null;
   readonly defaultAlias: string | null;
   readonly cc?: readonly string[];
+}
+
+export interface InboxComposerForwardContext {
+  readonly originalEntryId: string;
+  readonly originalSubject: string;
+  readonly originalFromLabel: string;
+  readonly originalToLabel: string;
+  readonly originalCcLabel: string | null;
+  readonly originalOccurredAtIso: string;
+  readonly originalBodyPlaintext: string;
+  readonly originalBodyHtml: string | null;
+  readonly defaultAlias: string | null;
 }
 
 export interface InboxDetailTimelinePageViewModel {

--- a/apps/web/tests/unit/composer-canonical-modal.test.tsx
+++ b/apps/web/tests/unit/composer-canonical-modal.test.tsx
@@ -158,6 +158,13 @@ vi.mock("@/components/ui/dialog", () => ({
     readonly children: ReactNode;
     readonly className?: string;
   }) => createElement("h2", { className }, children),
+  DialogDescription: ({
+    children,
+    className,
+  }: {
+    readonly children: ReactNode;
+    readonly className?: string;
+  }) => createElement("p", { className }, children),
 }));
 
 vi.mock("../../app/inbox/actions", () => ({

--- a/apps/web/tests/unit/composer-draft-reducer.test.ts
+++ b/apps/web/tests/unit/composer-draft-reducer.test.ts
@@ -49,6 +49,7 @@ describe("composer draft reducer", () => {
         inReplyToRfc822: "<message@example.org>",
         cc: ["forest@adventuresci.org", "partner@example.org"],
       },
+      forwardContext: null,
     });
 
     expect(state).toMatchObject({
@@ -129,6 +130,48 @@ describe("composer draft reducer", () => {
     ]);
   });
 
+  it("seeds forwarding mode with a subject, quoted body, and editable recipient", () => {
+    const state = reduceComposerDraft(INITIAL_COMPOSER_DRAFT_STATE, {
+      type: "RESET_TO_PANE_MODE",
+      composerPane: {
+        mode: "forwarding",
+        initialTab: "email",
+        forwardContext: {
+          originalEntryId: "entry-1",
+          originalSubject: "Field update",
+          originalFromLabel: "Jim Warren <jim@example.com>",
+          originalToLabel: "field@adventuresci.org",
+          originalCcLabel: "cc@example.com",
+          originalOccurredAtIso: "2026-05-09T20:42:00.000Z",
+          originalBodyPlaintext: "Original message body.",
+          originalBodyHtml: "<p>Original message body.</p>",
+          defaultAlias: "forest@adventuresci.org",
+        },
+      },
+      replyContext: null,
+      forwardContext: {
+        originalEntryId: "entry-1",
+        originalSubject: "Field update",
+        originalFromLabel: "Jim Warren <jim@example.com>",
+        originalToLabel: "field@adventuresci.org",
+        originalCcLabel: "cc@example.com",
+        originalOccurredAtIso: "2026-05-09T20:42:00.000Z",
+        originalBodyPlaintext: "Original message body.",
+        originalBodyHtml: "<p>Original message body.</p>",
+        defaultAlias: "forest@adventuresci.org",
+      },
+    });
+
+    expect(state.recipient).toBeNull();
+    expect(state.cc).toEqual([]);
+    expect(state.showCc).toBe(false);
+    expect(state.selectedAlias).toBe("forest@adventuresci.org");
+    expect(state.subject).toBe("Fwd: Field update");
+    expect(state.body).toContain("---------- Forwarded message ----------");
+    expect(state.body).toContain("Original message body.");
+    expect(state.bodyHtml).toContain("<blockquote");
+  });
+
   it("applies AI approval and clears tab-scoped errors on tab switch", () => {
     const approved = reduceComposerDraft(INITIAL_COMPOSER_DRAFT_STATE, {
       type: "APPLY_AI_APPROVAL",
@@ -185,6 +228,7 @@ describe("composer draft reducer", () => {
           type: "RESET_TO_PANE_MODE",
           composerPane: closedPane,
           replyContext: null,
+          forwardContext: null,
         },
       ),
     ).toEqual(INITIAL_COMPOSER_DRAFT_STATE);

--- a/apps/web/tests/unit/inbox-contact-rail.test.tsx
+++ b/apps/web/tests/unit/inbox-contact-rail.test.tsx
@@ -270,6 +270,7 @@ describe("InboxContactRail", () => {
           projectName: "Alpine Stream Survey",
           subDisplayName: null,
           isConnectedSub: false,
+          hostProjectId: null,
           expeditionMemberUrl: null,
           crmUrl: "https://salesforce.example.com/member/1",
           projectIsActive: false,
@@ -298,6 +299,7 @@ describe("InboxContactRail", () => {
           projectName: "Beech & Butternut",
           subDisplayName: "Saving American Beech",
           isConnectedSub: true,
+          hostProjectId: "host:forests",
           expeditionMemberUrl:
             "https://salesforce.example.com/member/beech-1",
           crmUrl: "https://salesforce.example.com/project/beech-1",
@@ -326,6 +328,7 @@ describe("InboxContactRail", () => {
           projectName: "Whitebark Pines",
           subDisplayName: null,
           isConnectedSub: false,
+          hostProjectId: null,
           expeditionMemberUrl:
             "https://salesforce.example.com/member/whitebark-1",
           crmUrl: "https://salesforce.example.com/project/whitebark-1",

--- a/apps/web/tests/unit/inbox-detail-default-alias.test.ts
+++ b/apps/web/tests/unit/inbox-detail-default-alias.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveProjectAliasOverride } from "../../app/inbox/_lib/composer-ui";
+
+describe("resolveProjectAliasOverride", () => {
+  it("falls through to the host project alias for connected subs", () => {
+    expect(
+      resolveProjectAliasOverride({
+        projectIds: ["sub:beech", "host:forests", null],
+        aliases: [
+          {
+            id: "alias-1",
+            alias: "forests@adventurescientists.org",
+            projectId: "host:forests",
+            projectName: "Beech & Butternut",
+            signature: "Best,\nForests",
+            isAiReady: true,
+            isAiConfigured: true,
+            hasCachedContent: true,
+          },
+        ],
+      }),
+    ).toBe("forests@adventurescientists.org");
+  });
+
+  it("returns null when none of the candidate projects own an alias", () => {
+    expect(
+      resolveProjectAliasOverride({
+        projectIds: ["sub:beech", "host:forests"],
+        aliases: [],
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/inbox-detail-header.test.tsx
+++ b/apps/web/tests/unit/inbox-detail-header.test.tsx
@@ -13,6 +13,7 @@ const routerRefreshMock = vi.hoisted(() => vi.fn());
 const setTimelineLoadingMock = vi.hoisted(() => vi.fn());
 const clearOptimisticForContactMock = vi.hoisted(() => vi.fn());
 const removeOptimisticOutboundMock = vi.hoisted(() => vi.fn());
+const openForwardDraftMock = vi.hoisted(() => vi.fn());
 const openReplyDraftMock = vi.hoisted(() => vi.fn());
 const showToastMock = vi.hoisted(() => vi.fn());
 const markInboxNeedsFollowUpActionMock = vi.hoisted(() => vi.fn());
@@ -52,6 +53,7 @@ vi.mock("../../app/inbox/_components/inbox-client-provider", () => ({
     optimisticOutbounds: [],
     clearOptimisticForContact: clearOptimisticForContactMock,
     removeOptimisticOutbound: removeOptimisticOutboundMock,
+    openForwardDraft: openForwardDraftMock,
     openReplyDraft: openReplyDraftMock,
     showToast: showToastMock,
     composerAliases: [],
@@ -158,6 +160,7 @@ function buildDetail(
           projectName: "Amazon Basin",
           subDisplayName: null,
           isConnectedSub: false,
+          hostProjectId: null,
           projectIsActive: true,
           status: "in-field",
           statusLabel: "Active",
@@ -395,6 +398,7 @@ describe("Inbox detail header", () => {
               projectName: "Beech & Butternut",
               subDisplayName: "Saving American Beech",
               isConnectedSub: true,
+              hostProjectId: "host:forests",
               projectIsActive: true,
               status: "in-field",
               statusLabel: "Active",

--- a/apps/web/tests/unit/inbox-timeline-bubble.test.tsx
+++ b/apps/web/tests/unit/inbox-timeline-bubble.test.tsx
@@ -15,6 +15,11 @@ vi.mock("@/components/ui/dialog", () => ({
     createElement("div", { "data-dialog-content": true }, children),
   DialogTitle: ({ children }: { readonly children?: React.ReactNode }) =>
     createElement("div", { "data-dialog-title": true }, children),
+  DialogDescription: ({
+    children,
+  }: {
+    readonly children?: React.ReactNode;
+  }) => createElement("div", { "data-dialog-description": true }, children),
 }));
 
 vi.mock("@/components/ui/tooltip", () => ({
@@ -54,6 +59,7 @@ vi.mock("../../app/inbox/_components/icons", () => ({
   AdventureScientistsLogo: () => createElement("svg"),
   ArrowUpRightIcon: () => createElement("svg"),
   CornerUpLeftIcon: () => createElement("svg"),
+  CornerUpRightIcon: () => createElement("svg"),
   FileDocIcon: () => createElement("svg"),
   LoaderIcon: () => createElement("svg"),
   MailIcon: () => createElement("svg"),
@@ -345,6 +351,21 @@ describe("MessageBubble metadata and polish", () => {
 
     expect(markup).toContain("Sarah Martinez");
     expect(markup).toContain("SMS body");
+  });
+
+  it("renders forward and reply footer actions when both callbacks are provided", () => {
+    const markup = renderToStaticMarkup(
+      createElement(MessageBubble, {
+        entry: buildEntry(),
+        direction: "inbound",
+        onForward: vi.fn(),
+        onReply: vi.fn(),
+      }),
+    );
+
+    expect(markup).toContain("Forward");
+    expect(markup).toContain("Reply");
+    expect(markup).toContain("group-hover:opacity-100");
   });
 
   it("renders the outbound brand avatar as dark-on-light without a ring", () => {

--- a/apps/web/tests/unit/stage3-composer-ui.test.tsx
+++ b/apps/web/tests/unit/stage3-composer-ui.test.tsx
@@ -10,6 +10,7 @@ import {
   isComposerSendDisabled,
   resolveComposerSendActionFlags,
   resolveDefaultAlias,
+  resolveProjectAliasOverride,
   resolveSendAndSaveForAiAvailability,
   type ComposerPaneState,
 } from "../../app/inbox/_lib/composer-ui";
@@ -62,6 +63,34 @@ describe("stage3 composer ui helpers", () => {
     } satisfies ComposerPaneState);
   });
 
+  it("stores forward context when opening a forward draft", () => {
+    const forwardContext = {
+      originalEntryId: "entry-1",
+      originalSubject: "Trip logistics",
+      originalFromLabel: "Alice Smith <alice@example.com>",
+      originalToLabel: "field@adventuresci.org",
+      originalCcLabel: null,
+      originalOccurredAtIso: "2026-05-09T20:42:00.000Z",
+      originalBodyPlaintext: "Forward this along.",
+      originalBodyHtml: null,
+      defaultAlias: "field@adventuresci.org",
+    } as const;
+
+    const forwarding = reduceComposerPane(
+      { mode: "closed" },
+      {
+        type: "open-forward",
+        forwardContext,
+      },
+    );
+
+    expect(forwarding).toEqual({
+      mode: "forwarding",
+      forwardContext,
+      initialTab: "email",
+    } satisfies ComposerPaneState);
+  });
+
   it("derives minimized composer labels from the active composer pane", () => {
     expect(
       resolveFloatingComposerLabel({
@@ -85,6 +114,24 @@ describe("stage3 composer ui helpers", () => {
         initialTab: "note",
       }),
     ).toBe("Note about Alice Smith");
+
+    expect(
+      resolveFloatingComposerLabel({
+        mode: "forwarding",
+        forwardContext: {
+          originalEntryId: "entry-1",
+          originalSubject: "Trip logistics",
+          originalFromLabel: "Alice Smith <alice@example.com>",
+          originalToLabel: "field@adventuresci.org",
+          originalCcLabel: null,
+          originalOccurredAtIso: "2026-05-09T20:42:00.000Z",
+          originalBodyPlaintext: "Forward this along.",
+          originalBodyHtml: null,
+          defaultAlias: "field@adventuresci.org",
+        },
+        initialTab: "email",
+      }),
+    ).toBe("Fwd: Trip logistics");
   });
 
   it("accepts an unmatched valid email as an external recipient", () => {
@@ -247,5 +294,24 @@ describe("stage3 composer ui helpers", () => {
     ).toBe(
       "<p>Hi Lily,</p><p>Thanks for reaching out.<br>Second line</p><p>&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;</p>",
     );
+  });
+
+  it("resolves the project alias across direct and host project ids", () => {
+    expect(
+      resolveProjectAliasOverride({
+        projectIds: ["project:beech", "host:forests", null],
+        aliases: [
+          {
+            id: "alias-1",
+            alias: "forests@adventuresci.org",
+            projectId: "host:forests",
+            projectName: "Beech & Butternut",
+            signature: "Best,\nForests",
+            isAiReady: true,
+            hasCachedContent: true,
+          },
+        ],
+      }),
+    ).toBe("forests@adventuresci.org");
   });
 });

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -1851,6 +1851,28 @@ function createStage1RepositoriesInternal(
         if (projectIds.length === 0) {
           return [];
         }
+
+        const projectRows = await db
+          .select({
+            projectId: projectDimensions.projectId,
+            connectedToProjectId: projectDimensions.connectedToProjectId,
+          })
+          .from(projectDimensions)
+          .where(inArray(projectDimensions.projectId, projectIds as string[]));
+
+        const effectiveScopeKeyByInputId = new Map(
+          projectIds.map((projectId) => [projectId, projectId]),
+        );
+        for (const row of projectRows) {
+          effectiveScopeKeyByInputId.set(
+            row.projectId,
+            row.connectedToProjectId ?? row.projectId,
+          );
+        }
+
+        const effectiveScopeKeys = Array.from(
+          new Set(effectiveScopeKeyByInputId.values()),
+        );
         const rows = await db
           .selectDistinct({ scopeKey: aiKnowledgeEntries.scopeKey })
           .from(aiKnowledgeEntries)
@@ -1858,14 +1880,21 @@ function createStage1RepositoriesInternal(
             and(
               eq(aiKnowledgeEntries.scope, "project"),
               eq(aiKnowledgeEntries.sourceProvider, "notion"),
-              inArray(aiKnowledgeEntries.scopeKey, projectIds as string[]),
+              inArray(aiKnowledgeEntries.scopeKey, effectiveScopeKeys),
               sql`length(btrim(${aiKnowledgeEntries.content})) > 0`,
             ),
           );
+        const matchedScopeKeys = new Set(
+          rows
+            .map((row) => row.scopeKey)
+            .filter((scopeKey): scopeKey is string => scopeKey !== null),
+        );
 
-        return rows
-          .map((row) => row.scopeKey)
-          .filter((key): key is string => key !== null);
+        return projectIds.filter((projectId) =>
+          matchedScopeKeys.has(
+            effectiveScopeKeyByInputId.get(projectId) ?? projectId,
+          ),
+        );
       },
 
       async upsert(record) {

--- a/packages/db/test/ai-knowledge-host-hop.test.ts
+++ b/packages/db/test/ai-knowledge-host-hop.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import { createTestStage1Context } from "./helpers.js";
+
+describe("aiKnowledge.findProjectIdsWithNotionContent", () => {
+  it("returns standalone projects with content, skips empty hosts, and hops connected subs to their host", async () => {
+    const context = await createTestStage1Context();
+
+    try {
+      await context.repositories.projectDimensions.upsert({
+        projectId: "standalone:ready",
+        projectName: "Standalone Ready",
+        projectAlias: "Standalone Ready",
+        source: "salesforce",
+        isActive: true,
+      });
+      await context.repositories.projectDimensions.upsert({
+        projectId: "standalone:empty",
+        projectName: "Standalone Empty",
+        projectAlias: "Standalone Empty",
+        source: "salesforce",
+        isActive: true,
+      });
+      await context.repositories.projectDimensions.upsert({
+        projectId: "host:ready",
+        projectName: "Host Ready",
+        projectAlias: "Host Ready",
+        source: "salesforce",
+        isActive: true,
+      });
+      await context.repositories.projectDimensions.upsert({
+        projectId: "host:empty",
+        projectName: "Host Empty",
+        projectAlias: "Host Empty",
+        source: "salesforce",
+        isActive: true,
+      });
+      await context.repositories.projectDimensions.upsert({
+        projectId: "sub:beech",
+        projectName: "Saving American Beech",
+        projectAlias: null,
+        source: "salesforce",
+        isActive: true,
+        connectedToProjectId: "host:ready",
+      });
+      await context.repositories.projectDimensions.upsert({
+        projectId: "sub:butternut",
+        projectName: "Butternut",
+        projectAlias: null,
+        source: "salesforce",
+        isActive: true,
+        connectedToProjectId: "host:empty",
+      });
+
+      await context.repositories.aiKnowledge.upsert({
+        id: "ai:standalone:ready",
+        scope: "project",
+        scopeKey: "standalone:ready",
+        sourceProvider: "notion",
+        sourceId: "notion-standalone-ready",
+        sourceUrl: "https://www.notion.so/standalone-ready",
+        title: "Standalone Ready",
+        content: "Standalone content",
+        contentHash: "hash:standalone-ready",
+        metadataJson: {},
+        sourceLastEditedAt: "2026-05-01T00:00:00.000Z",
+        syncedAt: "2026-05-01T00:00:00.000Z",
+        createdAt: "2026-05-01T00:00:00.000Z",
+        updatedAt: "2026-05-01T00:00:00.000Z",
+      });
+      await context.repositories.aiKnowledge.upsert({
+        id: "ai:host:ready",
+        scope: "project",
+        scopeKey: "host:ready",
+        sourceProvider: "notion",
+        sourceId: "notion-host-ready",
+        sourceUrl: "https://www.notion.so/host-ready",
+        title: "Host Ready",
+        content: "Host content",
+        contentHash: "hash:host-ready",
+        metadataJson: {},
+        sourceLastEditedAt: "2026-05-01T00:00:00.000Z",
+        syncedAt: "2026-05-01T00:00:00.000Z",
+        createdAt: "2026-05-01T00:00:00.000Z",
+        updatedAt: "2026-05-01T00:00:00.000Z",
+      });
+
+      const result =
+        await context.repositories.aiKnowledge.findProjectIdsWithNotionContent([
+          "standalone:ready",
+          "standalone:empty",
+          "sub:beech",
+          "sub:butternut",
+        ]);
+
+      expect(result).toEqual(["standalone:ready", "sub:beech"]);
+    } finally {
+      await context.dispose();
+    }
+  });
+});

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -161,6 +161,13 @@ export interface AiKnowledgeRepository {
     projectId: string,
   ): Promise<AiKnowledgeEntryRecord | null>;
   hasProjectNotionContent(projectId: string): Promise<boolean>;
+  /**
+   * Returns the subset of input project IDs whose effective Notion
+   * knowledge bundle has non-empty content. Connected sub-projects
+   * (`project_dimensions.connected_to_project_id IS NOT NULL`)
+   * transparently hop to their host before checking content — mirrors
+   * `findEffectiveProjectNotionContent` for the bulk path.
+   */
   findProjectIdsWithNotionContent(
     projectIds: readonly string[],
   ): Promise<readonly string[]>;


### PR DESCRIPTION
## Summary

- **Forward action** on every email message bubble (hover-reveal alongside Reply, with outgoing-arrow icon). Composer opens in a new `forwarding` mode that prefills Subject (`Fwd: ...`) and Body (standard forwarded-message block with original headers + quoted content), leaves recipient empty, and focuses the picker.
- **Default reply alias is now host-aware**: a Beech (sub) volunteer thread now defaults to `forests@adventurescientists.org` (owned by Beech & Butternut host). Implemented by extending `InboxProjectMembershipViewModel` with `hostProjectId` and matching against both sub + host IDs in `inbox-detail.tsx`.
- **Knowledge Base footer chip now hops sub→host** in the bulk lookup (`findProjectIdsWithNotionContent`), mirroring PR #392's AI Draft path. Fixes "Without Knowledge Base" appearing on connected-sub conversations even when the host has cached content.
- Reply behavior unchanged.

## Test plan

- [ ] Compose forward from an inbound email → recipient empty, subject prefixed `Fwd:`, body contains forwarded-message block + original content
- [ ] Compose forward from an outbound email → same
- [ ] Open a Beech volunteer thread → From defaults to `forests@adventurescientists.org`
- [ ] KB chip on a Beech-tagged conversation with `forests@` selected → reads "Beech and Butternut Knowledge Base" (emerald)
- [ ] Existing Reply behavior unchanged
- [x] `pnpm typecheck` and `pnpm lint` clean
- [x] Targeted unit tests added (default-alias, forward seed, hover actions, DB host-hop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)