### PR TITLE
feat(composer): forward refinements — email-only, default-from-original-recipient, focus-to-input, redesigned bubble footer

### DIFF
--- a/apps/web/app/inbox/_components/composer-detail-surfaces.tsx
+++ b/apps/web/app/inbox/_components/composer-detail-surfaces.tsx
@@ -251,6 +251,7 @@ export function ComposerEmailSurface({
   showBcc,
   isReplying,
   recipientAutoFocus = false,
+  showAiDraftAffordances = true,
   recipientPlaceholder = "Search contacts",
   recipientError,
   ccError,
@@ -310,6 +311,7 @@ export function ComposerEmailSurface({
   readonly showBcc: boolean;
   readonly isReplying: boolean;
   readonly recipientAutoFocus?: boolean;
+  readonly showAiDraftAffordances?: boolean;
   readonly recipientPlaceholder?: string;
   readonly recipientError?: ComposerValidationError;
   readonly ccError?: ComposerValidationError;
@@ -373,12 +375,12 @@ export function ComposerEmailSurface({
     canSendAndSaveForAi || sendAndSaveDisabledReason === null
       ? null
       : sendAndSaveDisabledReason;
-  const knowledgeIndicator = (
+  const knowledgeIndicator = showAiDraftAffordances ? (
     <KnowledgeBaseIndicator
       hasKnowledge={selectedAliasHasCachedContent}
       projectName={selectedAliasProjectName}
     />
-  );
+  ) : null;
 
   return (
     <TooltipProvider delayDuration={200}>
@@ -517,23 +519,25 @@ export function ComposerEmailSurface({
         }}
         onClearErrors={onClearErrors}
         topSlot={
-          <ComposerAiDraftWindow
-            tone="email"
-            aiDraft={aiDraft}
-            directiveText={aiDirective}
-            repromptText={repromptText}
-            isGeneratingAi={isGeneratingAi}
-            runDraftDisabled={runAiDraftDisabled}
-            runDraftDisabledReason={runAiDraftDisabledReason}
-            onDirectiveTextChange={onAiDirectiveChange}
-            onRepromptTextChange={onRepromptTextChange}
-            onRunDraft={onRunAiDraft}
-            onOpenReprompt={onOpenReprompt}
-            onSubmitReprompt={onReprompt}
-            onCancelReprompt={onCancelReprompt}
-            onDiscard={onDiscardAi}
-            onApprove={onApproveAi}
-          />
+          showAiDraftAffordances ? (
+            <ComposerAiDraftWindow
+              tone="email"
+              aiDraft={aiDraft}
+              directiveText={aiDirective}
+              repromptText={repromptText}
+              isGeneratingAi={isGeneratingAi}
+              runDraftDisabled={runAiDraftDisabled}
+              runDraftDisabledReason={runAiDraftDisabledReason}
+              onDirectiveTextChange={onAiDirectiveChange}
+              onRepromptTextChange={onRepromptTextChange}
+              onRunDraft={onRunAiDraft}
+              onOpenReprompt={onOpenReprompt}
+              onSubmitReprompt={onReprompt}
+              onCancelReprompt={onCancelReprompt}
+              onDiscard={onDiscardAi}
+              onApprove={onApproveAi}
+            />
+          ) : undefined
         }
         bottomSlot={
           selectedAliasSignature.length > 0 ? (
@@ -589,9 +593,11 @@ export function ComposerEmailSurface({
                 Attach
               </Button>
 
-              <div className="hidden min-w-0 max-w-[18rem] items-center border-l border-slate-200 pl-3 md:flex">
-                {knowledgeIndicator}
-              </div>
+              {knowledgeIndicator ? (
+                <div className="hidden min-w-0 max-w-[18rem] items-center border-l border-slate-200 pl-3 md:flex">
+                  {knowledgeIndicator}
+                </div>
+              ) : null}
 
               <div className="min-w-0 flex-1" />
 
@@ -668,7 +674,9 @@ export function ComposerEmailSurface({
               </div>
             </div>
 
-            <div className="mt-2 md:hidden">{knowledgeIndicator}</div>
+            {knowledgeIndicator ? (
+              <div className="mt-2 md:hidden">{knowledgeIndicator}</div>
+            ) : null}
           </div>
         )}
       />

--- a/apps/web/app/inbox/_components/composer-recipient-picker.tsx
+++ b/apps/web/app/inbox/_components/composer-recipient-picker.tsx
@@ -108,6 +108,7 @@ export function ComposerRecipientPicker({
   const [isResultsOpen, setIsResultsOpen] = useState(false);
   const activeSearchIdRef = useRef(0);
   const rootRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const listboxId = useId();
 
   useEffect(() => {
@@ -183,6 +184,20 @@ export function ComposerRecipientPicker({
     shouldShowInput &&
     (isSearching || results.length > 0 || query.trim().length >= 2);
 
+  useEffect(() => {
+    if (!autoFocusInput || !shouldShowInput || inputRef.current === null) {
+      return undefined;
+    }
+
+    const handle = window.setTimeout(() => {
+      inputRef.current?.focus();
+    }, 0);
+
+    return () => {
+      window.clearTimeout(handle);
+    };
+  }, [autoFocusInput, shouldShowInput]);
+
   const commitRecipient = (recipient: ComposerRecipientValue) => {
     if (single) {
       onRecipientsChange([recipient]);
@@ -231,7 +246,7 @@ export function ComposerRecipientPicker({
               <SearchIcon className="pointer-events-none mr-2 size-3.5 shrink-0 text-slate-400" />
             ) : null}
             <Input
-              autoFocus={autoFocusInput}
+              ref={inputRef}
               data-composer-recipient-input={single ? "" : undefined}
               value={query}
               onChange={(event) => {

--- a/apps/web/app/inbox/_components/inbox-composer.tsx
+++ b/apps/web/app/inbox/_components/inbox-composer.tsx
@@ -459,15 +459,19 @@ export function InboxComposerDetailPane({
           </DialogDescription>
         )}
         <header className="flex items-center justify-between gap-3 border-b border-slate-200 bg-white px-4 py-2.5">
-          <ComposerModeTabs
-            activeTab={state.activeTab}
-            onEmail={() => {
-              dispatch({ type: "SET_ACTIVE_TAB", tab: "email" });
-            }}
-            onSms={() => {
-              dispatch({ type: "SET_ACTIVE_TAB", tab: "sms" });
-            }}
-          />
+          {composerPane.mode === "forwarding" ? (
+            <div className="text-sm font-medium text-slate-600">Forward</div>
+          ) : (
+            <ComposerModeTabs
+              activeTab={state.activeTab}
+              onEmail={() => {
+                dispatch({ type: "SET_ACTIVE_TAB", tab: "email" });
+              }}
+              onSms={() => {
+                dispatch({ type: "SET_ACTIVE_TAB", tab: "sms" });
+              }}
+            />
+          )}
           <div className="flex items-center gap-1">
             <button
               type="button"
@@ -504,6 +508,7 @@ export function InboxComposerDetailPane({
               showBcc={state.showBcc}
               isReplying={isReplying}
               recipientAutoFocus={composerPane.mode === "forwarding"}
+              showAiDraftAffordances={composerPane.mode !== "forwarding"}
               recipientPlaceholder={
                 composerPane.mode === "forwarding"
                   ? "Pick a contact or type an email"

--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -551,6 +551,7 @@ export function InboxDetailTimelinePanel({
     setTimelineLoading,
     optimisticOutbounds,
     clearOptimisticForContact,
+    composerAliases,
     removeOptimisticOutbound,
     openForwardDraft,
     openReplyDraft,
@@ -731,6 +732,7 @@ export function InboxDetailTimelinePanel({
 
       const forwardContext = buildForwardContextFromEntry({
         entry,
+        composerAliases,
         defaultAlias: composerReplyContext?.defaultAlias ?? null,
       });
 

--- a/apps/web/app/inbox/_components/inbox-timeline-bubble.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-bubble.tsx
@@ -234,45 +234,49 @@ function ReplyFooter({
   return (
     <div
       className={cn(
-        "border-t border-slate-100 px-4 py-1.5 opacity-0 group-hover:opacity-100",
+        "grid grid-cols-2 border-t border-slate-100 opacity-0 group-hover:opacity-100",
         TRANSITION.fast,
         TRANSITION.reduceMotion,
       )}
     >
-      <div className="flex items-center justify-end gap-3">
-        {onForward === undefined ? null : (
-          <button
-            type="button"
-            onClick={() => {
-              onForward(entryId);
-            }}
-            className={cn(
-              "inline-flex items-center gap-1 text-[11px] text-slate-500 hover:text-slate-800",
-              TRANSITION.fast,
-              TRANSITION.reduceMotion,
-            )}
-          >
-            <CornerUpRightIcon className="size-3" />
-            <span>Forward</span>
-          </button>
-        )}
-        {onReply === undefined ? null : (
-          <button
-            type="button"
-            onClick={() => {
-              onReply(entryId);
-            }}
-            className={cn(
-              "inline-flex items-center gap-1 text-[11px] text-slate-500 hover:text-slate-800",
-              TRANSITION.fast,
-              TRANSITION.reduceMotion,
-            )}
-          >
-            <CornerUpLeftIcon className="size-3" />
-            <span>Reply</span>
-          </button>
-        )}
-      </div>
+      {onReply === undefined ? (
+        <div aria-hidden="true" />
+      ) : (
+        <button
+          type="button"
+          onClick={() => {
+            onReply(entryId);
+          }}
+          className={cn(
+            "inline-flex items-center justify-center gap-1.5 py-2 text-[12px] text-slate-500 transition-colors",
+            "hover:bg-sky-50 hover:text-sky-700",
+            TRANSITION.fast,
+            TRANSITION.reduceMotion,
+          )}
+        >
+          <CornerUpLeftIcon className="size-3.5" />
+          <span>Reply</span>
+        </button>
+      )}
+      {onForward === undefined ? (
+        <div aria-hidden="true" />
+      ) : (
+        <button
+          type="button"
+          onClick={() => {
+            onForward(entryId);
+          }}
+          className={cn(
+            "inline-flex items-center justify-center gap-1.5 border-l border-slate-100 py-2 text-[12px] text-slate-500 transition-colors",
+            "hover:bg-slate-100 hover:text-slate-700",
+            TRANSITION.fast,
+            TRANSITION.reduceMotion,
+          )}
+        >
+          <CornerUpRightIcon className="size-3.5" />
+          <span>Forward</span>
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/web/app/inbox/_lib/composer-forward.ts
+++ b/apps/web/app/inbox/_lib/composer-forward.ts
@@ -1,6 +1,8 @@
 import { sanitizeComposerHtml } from "@/src/lib/html-sanitizer";
 
+import { extractEmailAddresses } from "./message-formatting";
 import type {
+  InboxComposerAliasOption,
   InboxComposerForwardContext,
   InboxTimelineEntryViewModel,
 } from "./view-models";
@@ -56,6 +58,23 @@ function htmlToPlaintext(bodyHtml: string): string {
   return decoded.replace(/\n{3,}/gu, "\n\n").trim();
 }
 
+function findMatchingAlias(
+  header: string | null,
+  composerAliases: readonly InboxComposerAliasOption[],
+): string | null {
+  for (const emailAddress of extractEmailAddresses(header)) {
+    const match = composerAliases.find(
+      (option) => option.alias.toLowerCase() === emailAddress,
+    );
+
+    if (match !== undefined) {
+      return match.alias;
+    }
+  }
+
+  return null;
+}
+
 export function buildForwardSubject(originalSubject: string): string {
   return FORWARD_SUBJECT_PREFIX_PATTERN.test(originalSubject)
     ? originalSubject
@@ -108,6 +127,7 @@ export function buildForwardBodyHtml(
 
 export function buildForwardContextFromEntry(input: {
   readonly entry: InboxTimelineEntryViewModel;
+  readonly composerAliases: readonly InboxComposerAliasOption[];
   readonly defaultAlias: string | null;
 }): InboxComposerForwardContext | null {
   if (input.entry.channel !== "email") {
@@ -121,6 +141,11 @@ export function buildForwardContextFromEntry(input: {
       : null;
   const originalFromLabel = input.entry.fromHeader?.trim();
   const originalToLabel = input.entry.toHeader?.trim();
+  const defaultAlias =
+    findMatchingAlias(input.entry.toHeader, input.composerAliases) ??
+    findMatchingAlias(input.entry.ccHeader, input.composerAliases) ??
+    input.defaultAlias ??
+    null;
 
   return {
     originalEntryId: input.entry.id,
@@ -139,6 +164,6 @@ export function buildForwardContextFromEntry(input: {
     originalBodyPlaintext:
       originalBodyHtml === null ? originalBody : htmlToPlaintext(originalBodyHtml),
     originalBodyHtml,
-    defaultAlias: input.defaultAlias,
+    defaultAlias,
   };
 }

--- a/apps/web/tests/unit/composer-canonical-modal.test.tsx
+++ b/apps/web/tests/unit/composer-canonical-modal.test.tsx
@@ -2,6 +2,8 @@ import { createRequire } from "node:module";
 import React, {
   act,
   createElement,
+  useEffect,
+  useRef,
   type ButtonHTMLAttributes,
   type ChangeEvent,
   type InputEvent as ReactInputEvent,
@@ -213,8 +215,10 @@ vi.mock("../../app/inbox/_components/composer-detail-surfaces", () => ({
     onToggleBcc,
     onToggleCc,
     recipient,
+    recipientAutoFocus,
     runAiDraftDisabled,
     runAiDraftDisabledReason,
+    showAiDraftAffordances,
     showBcc,
     showCc,
     subject,
@@ -261,180 +265,203 @@ vi.mock("../../app/inbox/_components/composer-detail-surfaces", () => ({
       | { readonly kind: "email"; readonly emailAddress: string }
       | { readonly kind: "contact"; readonly displayName: string }
       | null;
+    readonly recipientAutoFocus?: boolean;
     readonly runAiDraftDisabled: boolean;
     readonly runAiDraftDisabledReason: string | null;
+    readonly showAiDraftAffordances?: boolean;
     readonly showBcc: boolean;
     readonly showCc: boolean;
     readonly subject: string;
   }) =>
-    createElement(
-      "div",
-      { "data-testid": "email-surface" },
-      createElement("input", {
-        "aria-label": "Recipient",
-        onChange: (event: ChangeEvent<HTMLInputElement>) => {
-          const value = event.currentTarget.value.trim();
-          onRecipientChange(
-            value.length > 0 ? { kind: "email", emailAddress: value } : null,
-          );
-        },
-        onInput: (event: ReactInputEvent<HTMLInputElement>) => {
-          const value = event.currentTarget.value.trim();
-          onRecipientChange(
-            value.length > 0 ? { kind: "email", emailAddress: value } : null,
-          );
-        },
-        value:
-          recipient?.kind === "email"
-            ? recipient.emailAddress
-            : recipient?.kind === "contact"
-              ? recipient.displayName
-              : "",
-      } satisfies InputHTMLAttributes<HTMLInputElement>),
-      createElement("input", {
-        "aria-label": "Subject",
-        onChange: (event: ChangeEvent<HTMLInputElement>) => {
-          onSubjectChange(event.currentTarget.value);
-        },
-        onInput: (event: ReactInputEvent<HTMLInputElement>) => {
-          onSubjectChange(event.currentTarget.value);
-        },
-        value: subject,
-      } satisfies InputHTMLAttributes<HTMLInputElement>),
-      createElement("textarea", {
-        "aria-label": "Message body",
-        onChange: (event: ChangeEvent<HTMLTextAreaElement>) => {
-          const value = event.currentTarget.value;
-          onBodyChange({
-            bodyPlaintext: value,
-            bodyHtml: `<p>${value}</p>`,
-          });
-        },
-        onInput: (event: ReactInputEvent<HTMLTextAreaElement>) => {
-          const value = event.currentTarget.value;
-          onBodyChange({
-            bodyPlaintext: value,
-            bodyHtml: `<p>${value}</p>`,
-          });
-        },
-        value: body,
-      } satisfies TextareaHTMLAttributes<HTMLTextAreaElement>),
-      createElement("textarea", {
-        "aria-label": "AI directive",
-        onChange: (event: ChangeEvent<HTMLTextAreaElement>) => {
-          onAiDirectiveChange(event.currentTarget.value);
-        },
-        onInput: (event: ReactInputEvent<HTMLTextAreaElement>) => {
-          onAiDirectiveChange(event.currentTarget.value);
-        },
-        value: aiDirective,
-      } satisfies TextareaHTMLAttributes<HTMLTextAreaElement>),
-      createElement(
-        "button",
-        {
-          type: "button",
-          disabled: runAiDraftDisabled,
-          title: runAiDraftDisabledReason ?? undefined,
-        },
-        "Draft with AI",
-      ),
-      !showCc
-        ? createElement(
-            "button",
-            {
-              type: "button",
-              onClick: () => {
-                onToggleCc(true);
+    createElement(function MockComposerEmailSurface() {
+      const recipientRef = useRef<HTMLInputElement>(null);
+
+      useEffect(() => {
+        if (!recipientAutoFocus || recipientRef.current === null) {
+          return;
+        }
+
+        recipientRef.current.focus();
+      }, [recipientAutoFocus]);
+
+      return createElement(
+        "div",
+        { "data-testid": "email-surface" },
+        createElement("input", {
+          ref: recipientRef,
+          "aria-label": "Recipient",
+          onChange: (event: ChangeEvent<HTMLInputElement>) => {
+            const value = event.currentTarget.value.trim();
+            onRecipientChange(
+              value.length > 0 ? { kind: "email", emailAddress: value } : null,
+            );
+          },
+          onInput: (event: ReactInputEvent<HTMLInputElement>) => {
+            const value = event.currentTarget.value.trim();
+            onRecipientChange(
+              value.length > 0 ? { kind: "email", emailAddress: value } : null,
+            );
+          },
+          value:
+            recipient?.kind === "email"
+              ? recipient.emailAddress
+              : recipient?.kind === "contact"
+                ? recipient.displayName
+                : "",
+        }),
+        createElement("input", {
+          "aria-label": "Subject",
+          onChange: (event: ChangeEvent<HTMLInputElement>) => {
+            onSubjectChange(event.currentTarget.value);
+          },
+          onInput: (event: ReactInputEvent<HTMLInputElement>) => {
+            onSubjectChange(event.currentTarget.value);
+          },
+          value: subject,
+        } satisfies InputHTMLAttributes<HTMLInputElement>),
+        createElement("textarea", {
+          "aria-label": "Message body",
+          onChange: (event: ChangeEvent<HTMLTextAreaElement>) => {
+            const value = event.currentTarget.value;
+            onBodyChange({
+              bodyPlaintext: value,
+              bodyHtml: `<p>${value}</p>`,
+            });
+          },
+          onInput: (event: ReactInputEvent<HTMLTextAreaElement>) => {
+            const value = event.currentTarget.value;
+            onBodyChange({
+              bodyPlaintext: value,
+              bodyHtml: `<p>${value}</p>`,
+            });
+          },
+          value: body,
+        } satisfies TextareaHTMLAttributes<HTMLTextAreaElement>),
+        showAiDraftAffordances !== false
+          ? createElement("textarea", {
+              "aria-label": "AI directive",
+              onChange: (event: ChangeEvent<HTMLTextAreaElement>) => {
+                onAiDirectiveChange(event.currentTarget.value);
               },
-            },
-            "Show Cc",
-          )
-        : null,
-      showCc
-        ? createElement("input", {
-            "aria-label": "Cc",
-            onChange: (event: ChangeEvent<HTMLInputElement>) => {
-              onCcChange(
-                event.currentTarget.value
-                  .split(",")
-                  .map((value) => value.trim())
-                  .filter((value) => value.length > 0)
-                  .map((emailAddress) => ({
-                    kind: "email" as const,
-                    emailAddress,
-                  })),
-              );
-            },
-            onInput: (event: ReactInputEvent<HTMLInputElement>) => {
-              onCcChange(
-                event.currentTarget.value
-                  .split(",")
-                  .map((value) => value.trim())
-                  .filter((value) => value.length > 0)
-                  .map((emailAddress) => ({
-                    kind: "email" as const,
-                    emailAddress,
-                  })),
-              );
-            },
-            value: ccRecipients.map((recipient) => recipient.emailAddress).join(", "),
-          } satisfies InputHTMLAttributes<HTMLInputElement>)
-        : null,
-      !showBcc
-        ? createElement(
-            "button",
-            {
-              type: "button",
-              onClick: () => {
-                onToggleBcc(true);
+              onInput: (event: ReactInputEvent<HTMLTextAreaElement>) => {
+                onAiDirectiveChange(event.currentTarget.value);
               },
-            },
-            "Show Bcc",
-          )
-        : null,
-      showBcc
-        ? createElement("input", {
-            "aria-label": "Bcc",
-            onChange: (event: ChangeEvent<HTMLInputElement>) => {
-              onBccChange(
-                event.currentTarget.value
-                  .split(",")
-                  .map((value) => value.trim())
-                  .filter((value) => value.length > 0)
-                  .map((emailAddress) => ({
-                    kind: "email" as const,
-                    emailAddress,
-                  })),
-              );
-            },
-            onInput: (event: ReactInputEvent<HTMLInputElement>) => {
-              onBccChange(
-                event.currentTarget.value
-                  .split(",")
-                  .map((value) => value.trim())
-                  .filter((value) => value.length > 0)
-                  .map((emailAddress) => ({
-                    kind: "email" as const,
-                    emailAddress,
-                  })),
-              );
-            },
-            value: bccRecipients.map((recipient) => recipient.emailAddress).join(", "),
-          } satisfies InputHTMLAttributes<HTMLInputElement>)
-        : null,
-      createElement(
-        "ul",
-        { "aria-label": "Attachments" },
-        attachments.map((attachment) =>
-          createElement(
-            "li",
-            { key: attachment.filename },
-            attachment.filename,
+              value: aiDirective,
+            } satisfies TextareaHTMLAttributes<HTMLTextAreaElement>)
+          : null,
+        showAiDraftAffordances !== false
+          ? createElement(
+              "button",
+              {
+                type: "button",
+                disabled: runAiDraftDisabled,
+                title: runAiDraftDisabledReason ?? undefined,
+              },
+              "Draft with AI",
+            )
+          : null,
+        !showCc
+          ? createElement(
+              "button",
+              {
+                type: "button",
+                onClick: () => {
+                  onToggleCc(true);
+                },
+              },
+              "Show Cc",
+            )
+          : null,
+        showCc
+          ? createElement("input", {
+              "aria-label": "Cc",
+              onChange: (event: ChangeEvent<HTMLInputElement>) => {
+                onCcChange(
+                  event.currentTarget.value
+                    .split(",")
+                    .map((value) => value.trim())
+                    .filter((value) => value.length > 0)
+                    .map((emailAddress) => ({
+                      kind: "email" as const,
+                      emailAddress,
+                    })),
+                );
+              },
+              onInput: (event: ReactInputEvent<HTMLInputElement>) => {
+                onCcChange(
+                  event.currentTarget.value
+                    .split(",")
+                    .map((value) => value.trim())
+                    .filter((value) => value.length > 0)
+                    .map((emailAddress) => ({
+                      kind: "email" as const,
+                      emailAddress,
+                    })),
+                );
+              },
+              value: ccRecipients
+                .map((recipient) => recipient.emailAddress)
+                .join(", "),
+            } satisfies InputHTMLAttributes<HTMLInputElement>)
+          : null,
+        !showBcc
+          ? createElement(
+              "button",
+              {
+                type: "button",
+                onClick: () => {
+                  onToggleBcc(true);
+                },
+              },
+              "Show Bcc",
+            )
+          : null,
+        showBcc
+          ? createElement("input", {
+              "aria-label": "Bcc",
+              onChange: (event: ChangeEvent<HTMLInputElement>) => {
+                onBccChange(
+                  event.currentTarget.value
+                    .split(",")
+                    .map((value) => value.trim())
+                    .filter((value) => value.length > 0)
+                    .map((emailAddress) => ({
+                      kind: "email" as const,
+                      emailAddress,
+                    })),
+                );
+              },
+              onInput: (event: ReactInputEvent<HTMLInputElement>) => {
+                onBccChange(
+                  event.currentTarget.value
+                    .split(",")
+                    .map((value) => value.trim())
+                    .filter((value) => value.length > 0)
+                    .map((emailAddress) => ({
+                      kind: "email" as const,
+                      emailAddress,
+                    })),
+                );
+              },
+              value: bccRecipients
+                .map((recipient) => recipient.emailAddress)
+                .join(", "),
+            } satisfies InputHTMLAttributes<HTMLInputElement>)
+          : null,
+        createElement(
+          "ul",
+          { "aria-label": "Attachments" },
+          attachments.map((attachment) =>
+            createElement(
+              "li",
+              { key: attachment.filename },
+              attachment.filename,
+            ),
           ),
         ),
-      ),
-      createElement("button", { onClick: onCancel, type: "button" }, "Cancel"),
-    ),
+        createElement("button", { onClick: onCancel, type: "button" }, "Cancel"),
+      );
+    }),
   ComposerNoteSurface: ({
     body,
     onBodyChange,
@@ -526,6 +553,18 @@ const replyContext = {
   defaultAlias: "whitebark@adventurescientists.org",
 };
 
+const forwardContext = {
+  originalEntryId: "entry:forward-1",
+  originalSubject: "Trip logistics",
+  originalFromLabel: "Maya Lee <maya@example.org>",
+  originalToLabel: "whitebark@adventurescientists.org",
+  originalCcLabel: null,
+  originalOccurredAtIso: "2026-05-11T16:00:00.000Z",
+  originalBodyPlaintext: "Forward this update.",
+  originalBodyHtml: "<p>Forward this update.</p>",
+  defaultAlias: "whitebark@adventurescientists.org",
+} as const;
+
 interface RenderSession {
   readonly cleanup: () => Promise<void>;
   readonly container: HTMLDivElement;
@@ -586,6 +625,22 @@ function setDomGlobals(window: Window & typeof globalThis) {
     writable: true,
   });
 
+  if (!("attachEvent" in window.HTMLElement.prototype)) {
+    Object.defineProperty(window.HTMLElement.prototype, "attachEvent", {
+      configurable: true,
+      value: () => undefined,
+      writable: true,
+    });
+  }
+
+  if (!("detachEvent" in window.HTMLElement.prototype)) {
+    Object.defineProperty(window.HTMLElement.prototype, "detachEvent", {
+      configurable: true,
+      value: () => undefined,
+      writable: true,
+    });
+  }
+
   window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
     return globalThis.setTimeout(() => {
       callback(Date.now());
@@ -618,6 +673,7 @@ function ComposerControls() {
     composerView,
     expandComposer,
     minimizeComposer,
+    openForwardDraft,
     openNewDraft,
     openReplyDraft,
   } = useInboxClient();
@@ -642,6 +698,14 @@ function ComposerControls() {
         }}
       >
         Open note draft
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          openForwardDraft(forwardContext);
+        }}
+      >
+        Open forward draft
       </button>
       <button type="button" onClick={minimizeComposer}>
         Minimize from context
@@ -957,6 +1021,20 @@ describe("composer canonical modal", () => {
 
     expect(getInput("Cc").value).toBe("partner@example.org");
     expect(getInput("Bcc").value).toBe("archive@example.org");
+  });
+
+  it("opens forwarding mode without tabs or AI draft affordances and focuses the recipient input", async () => {
+    await mount(<TestApp />);
+
+    await click(getByText("Open forward draft"));
+
+    expect(getStateText()).toBe("forwarding:modal");
+    expect(document.querySelector("[role='tablist']")).toBeNull();
+    expect(document.body.textContent).toContain("Forward");
+    expect(document.body.textContent).not.toContain("SMS");
+    expect(document.body.textContent).not.toContain("Draft with AI");
+    expect(document.querySelector("textarea[aria-label='AI directive']")).toBeNull();
+    expect(document.activeElement).toBe(getInput("Recipient"));
   });
 
   it("closes from the modal header and from the minimized pill", async () => {

--- a/apps/web/tests/unit/composer-forward.test.ts
+++ b/apps/web/tests/unit/composer-forward.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { buildForwardContextFromEntry } from "../../app/inbox/_lib/composer-forward";
+import type {
+  InboxComposerAliasOption,
+  InboxTimelineEntryViewModel,
+} from "../../app/inbox/_lib/view-models";
+
+const composerAliases: readonly InboxComposerAliasOption[] = [
+  {
+    id: "alias-forests",
+    alias: "forests@adventurescientists.org",
+    projectId: "project-forests",
+    projectName: "Forests",
+    signature: "Thanks,\nForests",
+    isAiReady: true,
+    isAiConfigured: true,
+    hasCachedContent: true,
+  },
+  {
+    id: "alias-volunteers",
+    alias: "volunteers@adventurescientists.org",
+    projectId: "project-volunteers",
+    projectName: "Volunteers",
+    signature: "Thanks,\nVolunteers",
+    isAiReady: true,
+    isAiConfigured: true,
+    hasCachedContent: true,
+  },
+];
+
+function buildEntry(
+  overrides: Partial<InboxTimelineEntryViewModel> = {},
+): InboxTimelineEntryViewModel {
+  return {
+    id: "entry-1",
+    kind: "inbound-email",
+    occurredAt: "2026-05-12T12:00:00.000Z",
+    occurredAtLabel: "1m ago",
+    actorLabel: "Original Sender",
+    subject: "Forward me",
+    body: "Body",
+    channel: "email",
+    isUnread: false,
+    isPreview: true,
+    fromHeader: "Original Sender <sender@example.org>",
+    toHeader: "forests@adventurescientists.org",
+    recipientLabel: null,
+    ccHeader: null,
+    mailbox: "forests@adventurescientists.org",
+    threadId: "thread-1",
+    rfc822MessageId: "<message-1@example.org>",
+    inReplyToRfc822: null,
+    sendStatus: null,
+    failedReason: null,
+    failedDetail: null,
+    attachmentCount: 0,
+    attachments: [],
+    campaignActivity: [],
+    ...overrides,
+  };
+}
+
+describe("buildForwardContextFromEntry", () => {
+  it("defaults the alias from the original recipient header before the host-aware fallback", () => {
+    const context = buildForwardContextFromEntry({
+      entry: buildEntry({
+        toHeader: "forests@adventurescientists.org",
+      }),
+      composerAliases,
+      defaultAlias: "volunteers@adventurescientists.org",
+    });
+
+    expect(context?.defaultAlias).toBe("forests@adventurescientists.org");
+  });
+});

--- a/apps/web/tests/unit/inbox-timeline-bubble.test.tsx
+++ b/apps/web/tests/unit/inbox-timeline-bubble.test.tsx
@@ -365,7 +365,10 @@ describe("MessageBubble metadata and polish", () => {
 
     expect(markup).toContain("Forward");
     expect(markup).toContain("Reply");
+    expect(markup).toContain("grid grid-cols-2 border-t border-slate-100 opacity-0");
     expect(markup).toContain("group-hover:opacity-100");
+    expect(markup).toContain("hover:bg-sky-50 hover:text-sky-700");
+    expect(markup).toContain("hover:bg-slate-100 hover:text-slate-700");
   });
 
   it("renders the outbound brand avatar as dark-on-light without a ring", () => {


### PR DESCRIPTION
## Summary

- In forwarding mode, hide the AI Draft window, the KB footer chip, and the Email/SMS tab toggle. Forward is email-only.
- Default From alias to the alias matching the original message's recipient header (e.g. forwarding a message originally sent to `forests@` now defaults From to `forests@`). Falls back to the existing host-aware reply default if no alias matches.
- Recipient picker now imperatively focuses the underlying `<input>` element via ref + effect (React's `autoFocus` prop didn't reliably win focus against the Dialog mount sequence).
- Redesigned the bubble Reply/Forward footer: hover-revealed, full-width 50/50 split, top border + vertical divider, per-button hover backgrounds (Reply → sky, Forward → light-grey).

## Test plan

- [ ] Click Forward on any inbound or outbound email → composer opens in forwarding mode with the AI Draft window, KB chip, and SMS tab hidden; cursor lands in the To: field; From defaults to the original message's recipient
- [ ] Open the inbox, hover an email bubble → footer reveals with Reply (left) and Forward (right) split 50/50
- [ ] Hover Reply → sky-tinted bg
- [ ] Hover Forward → light-grey bg
- [ ] Reply behavior unchanged
- [x] pnpm typecheck and pnpm lint clean
- [x] Targeted unit tests added (forward-default-from-original-recipient, hover footer states, focus-on-mount)

🤖 Generated with [Claude Code](https://claude.com/claude-code)