### PR TITLE
fix(ai-draft, composer): reply intent honors Reply-button regardless of inbound presence + KB chip reflects synced_at

### DIFF
--- a/apps/web/app/inbox/_components/inbox-composer.tsx
+++ b/apps/web/app/inbox/_components/inbox-composer.tsx
@@ -354,6 +354,7 @@ export function InboxComposerDetailPane({
     selectedAliasRecord,
     selectedAliasAiConfigured,
     replyContext,
+    composerPaneMode: composerPane.mode,
     startAiGeneration,
     markAiDraftReviewable,
     approveAiDraft,

--- a/apps/web/app/inbox/_hooks/use-ai-draft-run.ts
+++ b/apps/web/app/inbox/_hooks/use-ai-draft-run.ts
@@ -11,6 +11,7 @@ import type {
   ComposerDraftAction,
   ComposerDraftState,
 } from "./composer-draft-reducer";
+import type { ComposerPaneState } from "../_lib/composer-ui";
 import type { InboxComposerReplyContext } from "../_lib/view-models";
 
 export function useAiDraftRun({
@@ -20,6 +21,7 @@ export function useAiDraftRun({
   selectedAliasRecord,
   selectedAliasAiConfigured,
   replyContext,
+  composerPaneMode,
   startAiGeneration,
   markAiDraftReviewable,
   approveAiDraft,
@@ -37,6 +39,7 @@ export function useAiDraftRun({
   readonly selectedAliasRecord: InboxComposerAliasOption | null;
   readonly selectedAliasAiConfigured: boolean;
   readonly replyContext: InboxComposerReplyContext | null;
+  readonly composerPaneMode: ComposerPaneState["mode"];
   readonly startAiGeneration: (input: {
     readonly request: AiDraftRequestPayload;
     readonly prompt: string;
@@ -103,6 +106,10 @@ export function useAiDraftRun({
     const baseRequest = {
       contactId,
       projectId: selectedAliasRecord?.projectId ?? null,
+      intent:
+        composerPaneMode === "new-draft"
+          ? ("new" as const)
+          : ("reply" as const),
       threadCursor: replyContext?.threadCursor ?? null,
       channel: isSms ? ("sms" as const) : ("email" as const),
     } as const;

--- a/apps/web/app/inbox/_lib/composer-data.ts
+++ b/apps/web/app/inbox/_lib/composer-data.ts
@@ -19,14 +19,18 @@ export async function getInboxComposerAliases(): Promise<
         .filter((projectId): projectId is string => projectId !== null)
     )
   );
-  const [projectDimensions, projectIdsWithCachedContent] = await Promise.all([
+  const [projectDimensions, projectIdsWithKnowledgeConfigured] = await Promise.all([
     runtime.repositories.projectDimensions.listByIds(projectIds),
-    runtime.repositories.aiKnowledge.findProjectIdsWithNotionContent(projectIds),
+    runtime.repositories.aiKnowledge.findProjectIdsWithAiKnowledgeConfigured(
+      projectIds,
+    ),
   ]);
   const projectById = new Map(
     projectDimensions.map((project) => [project.projectId, project])
   );
-  const hasCachedContentByProjectId = new Set(projectIdsWithCachedContent);
+  const hasKnowledgeConfiguredByProjectId = new Set(
+    projectIdsWithKnowledgeConfigured,
+  );
 
   return aliases.flatMap((alias): readonly InboxComposerAliasOption[] => {
     if (alias.projectId === null) {
@@ -55,7 +59,7 @@ export async function getInboxComposerAliases(): Promise<
         projectName: projectDisplayName,
         signature: alias.signature,
         isAiConfigured,
-        hasCachedContent: hasCachedContentByProjectId.has(alias.projectId),
+        hasCachedContent: hasKnowledgeConfiguredByProjectId.has(alias.projectId),
         isAiReady: project.isActive === true && isAiConfigured,
       },
     ];

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -386,8 +386,9 @@ export interface InboxComposerAliasOption {
   readonly isAiReady: boolean;
   readonly isAiConfigured?: boolean;
   /**
-   * Canonical project-knowledge signal: whether this alias's project has
-   * cached Notion-backed context available for grounding.
+   * Whether the effective project (host or own) is configured for AI
+   * knowledge — i.e. `ai_knowledge_synced_at IS NOT NULL`. This drives the
+   * composer's "Knowledge Base" footer chip.
    */
   readonly hasCachedContent?: boolean;
 }

--- a/apps/web/src/server/ai/prompt-builder.ts
+++ b/apps/web/src/server/ai/prompt-builder.ts
@@ -60,27 +60,26 @@ function renderTier3Entries(bundle: GroundingBundle): string {
 
 function renderChannelInstructionBlock(input: {
   readonly channel: AiDraftRequest["channel"];
-  readonly isNewConversation: boolean;
+  readonly intent: GroundingBundle["intent"];
 }): string {
   if (input.channel === "sms") {
-    if (input.isNewConversation) {
+    if (input.intent === "new") {
       return "Write a brand-new outbound SMS. The operator is starting a new conversation, not replying to anything — do NOT phrase this as a reply. Be concise, plaintext, one thought, target ~140 characters and never exceed 320 (two segments). No markdown. Open with the volunteer's first name when natural. No signature unless the operator asked. Don't include 'Reply STOP to opt out' — Twilio appends compliance language automatically.";
     }
     return "Write SMS replies. Be concise, plaintext, one thought, target ~140 characters and never exceed 320 (two segments). No markdown, no greetings if the volunteer is mid-thread, no signature unless the operator asked. Match the tone of prior thread messages if any. Use the volunteer's first name when natural; default to no salutation. Don't include 'Reply STOP to opt out' — Twilio appends compliance language automatically.";
   }
 
-  if (input.isNewConversation) {
+  if (input.intent === "new") {
     return "You are drafting a brand-new outbound email to a volunteer. The operator is starting a new conversation — do NOT phrase this as a reply, do NOT begin with 'Thanks for reaching out' or any reply-style opener, and do NOT reference any inbound message as if it triggered this. The thread history below is background context only. Use only the information above and the operator's directive (if any). Never invent facts.";
   }
 
-  return "You are drafting a reply to a volunteer. Use only the information above and the inbound message. Never invent facts.";
+  return "You are drafting a reply to a volunteer. Use only the information above and the inbound message (if present). Never invent facts.";
 }
 
 function buildSystemPrompt(
   bundle: GroundingBundle,
   request: Pick<AiDraftRequest, "channel">,
 ): string {
-  const isNewConversation = bundle.targetInbound === null;
   return [
     renderContextSection(
       "Tier 1 Voice Instructions",
@@ -104,13 +103,13 @@ function buildSystemPrompt(
     "",
     renderChannelInstructionBlock({
       channel: request.channel,
-      isNewConversation,
+      intent: bundle.intent,
     }),
   ].join("\n");
 }
 
 function buildContextPayload(bundle: GroundingBundle): string {
-  if (bundle.targetInbound === null) {
+  if (bundle.intent === "new") {
     return [
       "This is a brand-new outbound conversation. The operator picked this contact",
       "from the new-draft pane and has not been triggered by any specific inbound.",
@@ -118,6 +117,18 @@ function buildContextPayload(bundle: GroundingBundle): string {
       "",
       "Recent thread history with this contact (background context only — do NOT",
       "treat any of these as the message you are replying to):",
+      renderRecentEvents(bundle),
+    ].join("\n");
+  }
+
+  if (bundle.targetInbound === null) {
+    return [
+      "Reply framing: the operator is composing a reply, but the thread has no",
+      "specific inbound message to anchor on (the thread may be automated-only,",
+      "or the operator is following up without a specific message in mind).",
+      "",
+      "Recent thread context (use as background to inform the reply, not as the",
+      "message you are replying to):",
       renderRecentEvents(bundle),
     ].join("\n");
   }
@@ -159,8 +170,8 @@ export function buildFillPrompt(
   bundle: GroundingBundle,
   input: Extract<AiDraftRequest, { mode: "fill" }>,
 ): BuiltPrompt {
-  const isNewConversation = bundle.targetInbound === null;
-  const expansionInstruction = isNewConversation
+  const expansionInstruction =
+    bundle.intent === "new"
     ? "Expand the operator's directive into a complete outbound message in the voice and context above. This is a new conversation, not a reply. If the directive contradicts the project context, produce the draft as directed AND emit a clear marker that the operator should reconfirm. Example marker: [NOTE: directive may conflict with project context, please verify X]."
     : "Expand the operator's directive into a complete reply in the voice and context above. If the directive contradicts the project context, produce the draft as directed AND emit a clear marker that the operator should reconfirm. Example marker: [NOTE: directive may conflict with project context, please verify X].";
 

--- a/apps/web/src/server/ai/retriever.ts
+++ b/apps/web/src/server/ai/retriever.ts
@@ -126,7 +126,10 @@ function buildTierFourGrounding(
 
 export async function retrieveGrounding(
   repositories: AiRetrieverRepositories,
-  input: Pick<AiDraftRequest, "contactId" | "projectId" | "threadCursor">,
+  input: Pick<
+    AiDraftRequest,
+    "contactId" | "projectId" | "intent" | "threadCursor"
+  >,
   logger: Pick<Console, "warn"> = console,
 ): Promise<GroundingBundle> {
   const [contact, generalTraining, projectContext, canonicalEvents] =
@@ -242,20 +245,20 @@ export async function retrieveGrounding(
   );
 
   const inboundEvents = threadEvents.filter((event) => event.direction === "inbound");
-  // When the operator passes an explicit threadCursor, the AI is replying to
-  // that specific inbound and we anchor to it. When threadCursor is null,
-  // the operator is composing a brand new outbound from the new-draft pane
-  // (the pencil button) — they are NOT replying to anything. Treating the
-  // most-recent inbound as the implicit target made every net-new compose
-  // come out as a reply (operator-reported 2026-05-12). Leave targetInbound
-  // null in that case; the prompt-builder switches to a new-conversation
-  // framing.
+  // The framing decision uses `intent` (not threadCursor). Intent "new"
+  // comes from the pencil-button "new draft" pane and means: do NOT
+  // anchor on any prior inbound, frame as brand-new outbound. Intent
+  // "reply" comes from any Reply trigger (bubble footer or bottom bar)
+  // and means: anchor on the explicit threadCursor inbound if provided,
+  // else the most-recent inbound, else null with reply framing still on.
   const targetInbound =
-    input.threadCursor === null
+    input.intent === "new"
       ? null
-      : inboundEvents.find(
-          (event) => event.canonicalEventId === input.threadCursor,
-        ) ?? null;
+      : input.threadCursor !== null
+        ? inboundEvents.find(
+            (event) => event.canonicalEventId === input.threadCursor,
+          ) ?? null
+        : inboundEvents.at(-1) ?? null;
 
   // Recent thread events still travel into the prompt for either case so
   // the AI knows the contact's history. For a reply, we cap at events at-
@@ -335,6 +338,7 @@ export async function retrieveGrounding(
     generalTraining,
     projectContext,
     tier3Entries: [...tier3Entries],
+    intent: input.intent,
     targetInbound:
       targetInbound === null
         ? null

--- a/apps/web/src/server/ai/types.ts
+++ b/apps/web/src/server/ai/types.ts
@@ -65,6 +65,7 @@ export type AiDraftModelParams = z.infer<typeof aiDraftModelParamsSchema>;
 const aiDraftBaseRequestSchema = z.object({
   contactId: z.string().min(1),
   projectId: z.string().min(1).nullable().optional().default(null),
+  intent: z.enum(["reply", "new"]).optional().default("reply"),
   threadCursor: z.string().min(1).nullable().optional().default(null),
   repromptIndex: z.number().int().nonnegative().optional().default(0),
   channel: z.enum(["email", "sms"]).default("email"),
@@ -104,6 +105,7 @@ export const groundingBundleSchema = z.object({
   generalTraining: aiKnowledgeEntrySchema.nullable(),
   projectContext: aiKnowledgeEntrySchema.nullable(),
   tier3Entries: z.array(projectKnowledgeEntrySchema),
+  intent: z.enum(["reply", "new"]),
   targetInbound: aiThreadContextEventSchema.nullable(),
   recentEvents: z.array(aiThreadContextEventSchema),
   grounding: z.array(aiDraftGroundingSchema),

--- a/apps/web/test/server/ai/draft-generator.test.ts
+++ b/apps/web/test/server/ai/draft-generator.test.ts
@@ -73,6 +73,7 @@ describe("generateAiDraft", () => {
     const result = await generateAiDraft(createDeps(runtime), {
       contactId: "contact:maya",
       projectId: "project:whitebark",
+      intent: "reply",
       threadCursor: "event:thread-1-inbound",
       repromptIndex: 0,
       channel: "email",
@@ -95,6 +96,7 @@ describe("generateAiDraft", () => {
     const result = await generateAiDraft(createDeps(runtime), {
       contactId: "contact:maya",
       projectId: "project:whitebark",
+      intent: "reply",
       threadCursor: "event:thread-1-inbound",
       repromptIndex: 0,
       channel: "email",
@@ -114,6 +116,7 @@ describe("generateAiDraft", () => {
     const result = await generateAiDraft(createDeps(runtime), {
       contactId: "contact:maya",
       projectId: "project:whitebark",
+      intent: "reply",
       threadCursor: "event:thread-1-inbound",
       repromptIndex: 1,
       channel: "email",
@@ -138,6 +141,7 @@ describe("generateAiDraft", () => {
       {
         contactId: "contact:maya",
         projectId: "project:whitebark",
+        intent: "reply",
         threadCursor: "event:thread-1-inbound",
         repromptIndex: 0,
         channel: "email",
@@ -167,6 +171,7 @@ describe("generateAiDraft", () => {
       {
         contactId: "contact:maya",
         projectId: "project:whitebark",
+        intent: "reply",
         threadCursor: "event:thread-1-inbound",
         repromptIndex: 0,
         channel: "email",
@@ -189,6 +194,7 @@ describe("generateAiDraft", () => {
     const result = await generateAiDraft(createDeps(runtime), {
       contactId: "contact:maya",
       projectId: "project:missing",
+      intent: "reply",
       threadCursor: "event:thread-1-inbound",
       repromptIndex: 0,
       channel: "email",
@@ -213,6 +219,7 @@ describe("generateAiDraft", () => {
       {
         contactId: "contact:maya",
         projectId: "project:whitebark",
+        intent: "reply",
         threadCursor: "event:thread-1-inbound",
         repromptIndex: 0,
         channel: "email",
@@ -246,6 +253,7 @@ describe("generateAiDraft", () => {
       {
         contactId: "contact:maya",
         projectId: "project:whitebark",
+        intent: "reply",
         threadCursor: "event:thread-1-inbound",
         repromptIndex: 0,
         channel: "email",

--- a/apps/web/test/server/ai/prompt-builder.test.ts
+++ b/apps/web/test/server/ai/prompt-builder.test.ts
@@ -38,6 +38,7 @@ const baseBundle: GroundingBundle = {
     updatedAt: "2026-04-24T12:00:00.000Z",
   },
   tier3Entries: [],
+  intent: "reply",
   targetInbound: {
     canonicalEventId: "event:inbound-1",
     occurredAt: "2026-04-24T09:15:00.000Z",
@@ -68,6 +69,7 @@ describe("prompt builder", () => {
     const prompt = buildDraftPrompt(baseBundle, {
       contactId: "contact:maya",
       projectId: "project:whitebark",
+      intent: "reply",
       threadCursor: "event:inbound-1",
       repromptIndex: 0,
       channel: "email",
@@ -101,11 +103,11 @@ describe("prompt builder", () => {
       
       The examples above are pattern support, not templates. Never copy any example verbatim. Adapt the style and structure to the current volunteer and project context.
       
-      You are drafting a reply to a volunteer. Use only the information above and the inbound message. Never invent facts.",
+      You are drafting a reply to a volunteer. Use only the information above and the inbound message (if present). Never invent facts.",
       }
     `);
     expect(prompt.system).toContain(
-      "You are drafting a reply to a volunteer. Use only the information above and the inbound message. Never invent facts.",
+      "You are drafting a reply to a volunteer. Use only the information above and the inbound message (if present). Never invent facts.",
     );
   });
 
@@ -114,6 +116,7 @@ describe("prompt builder", () => {
       buildFillPrompt(baseBundle, {
         contactId: "contact:maya",
         projectId: "project:whitebark",
+        intent: "reply",
         threadCursor: "event:inbound-1",
         repromptIndex: 0,
         channel: "email",
@@ -152,7 +155,7 @@ describe("prompt builder", () => {
       
       The examples above are pattern support, not templates. Never copy any example verbatim. Adapt the style and structure to the current volunteer and project context.
       
-      You are drafting a reply to a volunteer. Use only the information above and the inbound message. Never invent facts.",
+      You are drafting a reply to a volunteer. Use only the information above and the inbound message (if present). Never invent facts.",
       }
     `);
   });
@@ -162,6 +165,7 @@ describe("prompt builder", () => {
       buildRepromptPrompt(baseBundle, {
         contactId: "contact:maya",
         projectId: "project:whitebark",
+        intent: "reply",
         threadCursor: "event:inbound-1",
         repromptIndex: 1,
         channel: "email",
@@ -204,7 +208,7 @@ describe("prompt builder", () => {
       
       The examples above are pattern support, not templates. Never copy any example verbatim. Adapt the style and structure to the current volunteer and project context.
       
-      You are drafting a reply to a volunteer. Use only the information above and the inbound message. Never invent facts.",
+      You are drafting a reply to a volunteer. Use only the information above and the inbound message (if present). Never invent facts.",
       }
     `);
   });
@@ -220,6 +224,7 @@ describe("prompt builder", () => {
         {
           contactId: "contact:maya",
           projectId: null,
+          intent: "reply",
           threadCursor: null,
           repromptIndex: 0,
           channel: "email",
@@ -253,7 +258,7 @@ describe("prompt builder", () => {
       
       The examples above are pattern support, not templates. Never copy any example verbatim. Adapt the style and structure to the current volunteer and project context.
       
-      You are drafting a reply to a volunteer. Use only the information above and the inbound message. Never invent facts.",
+      You are drafting a reply to a volunteer. Use only the information above and the inbound message (if present). Never invent facts.",
       }
     `);
   });
@@ -287,6 +292,7 @@ describe("prompt builder", () => {
         {
           contactId: "contact:maya",
           projectId: "project:whitebark",
+          intent: "reply",
           threadCursor: "event:inbound-1",
           repromptIndex: 0,
           channel: "email",
@@ -298,10 +304,59 @@ describe("prompt builder", () => {
     );
   });
 
+  it("uses brand-new outbound framing when intent is new", () => {
+    const prompt = buildDraftPrompt(
+      {
+        ...baseBundle,
+        intent: "new",
+        targetInbound: null,
+      },
+      {
+        contactId: "contact:maya",
+        projectId: "project:whitebark",
+        intent: "new",
+        threadCursor: null,
+        repromptIndex: 0,
+        channel: "email",
+        mode: "draft",
+      },
+    );
+
+    expect(prompt.system).toContain("brand-new outbound email");
+    expect(prompt.messages[0]?.content).toContain(
+      "This is a brand-new outbound conversation.",
+    );
+  });
+
+  it("keeps reply framing when intent is reply but there is no specific inbound", () => {
+    const prompt = buildDraftPrompt(
+      {
+        ...baseBundle,
+        intent: "reply",
+        targetInbound: null,
+      },
+      {
+        contactId: "contact:maya",
+        projectId: "project:whitebark",
+        intent: "reply",
+        threadCursor: null,
+        repromptIndex: 0,
+        channel: "email",
+        mode: "draft",
+      },
+    );
+
+    expect(prompt.system).toContain("drafting a reply to a volunteer");
+    expect(prompt.messages[0]?.content).toContain(
+      "Reply framing: the operator is composing a reply, but the thread has no",
+    );
+  });
+
   it("builds the sms system prompt variant", () => {
     const prompt = buildDraftPrompt(baseBundle, {
       contactId: "contact:maya",
       projectId: "project:whitebark",
+      intent: "reply",
       threadCursor: "event:inbound-1",
       repromptIndex: 0,
       channel: "sms",

--- a/apps/web/test/server/ai/retriever.test.ts
+++ b/apps/web/test/server/ai/retriever.test.ts
@@ -44,6 +44,7 @@ describe("retrieveGrounding", () => {
     const bundle = await retrieveGrounding(runtime.context.repositories, {
       contactId: "contact:maya",
       projectId: "project:whitebark",
+      intent: "reply",
       threadCursor: null,
     });
 
@@ -67,6 +68,7 @@ describe("retrieveGrounding", () => {
     const bundle = await retrieveGrounding(runtime.context.repositories, {
       contactId: "contact:maya",
       projectId: "project:whitebark",
+      intent: "reply",
       threadCursor: null,
     });
 
@@ -99,6 +101,7 @@ describe("retrieveGrounding", () => {
     const bundle = await retrieveGrounding(runtime.context.repositories, {
       contactId: "contact:maya",
       projectId: "project:whitebark",
+      intent: "reply",
       threadCursor: seededInboundId,
     });
 
@@ -116,16 +119,35 @@ describe("retrieveGrounding", () => {
     const bundle = await retrieveGrounding(runtime.context.repositories, {
       contactId: "contact:maya",
       projectId: "project:missing",
+      intent: "reply",
       threadCursor: null,
     });
 
     expect(bundle.projectContext).toBeNull();
-    // threadCursor=null is the new-conversation signal; the retriever no
-    // longer fabricates a target inbound from the most recent thread event.
-    expect(bundle.targetInbound).toBeNull();
+    expect(bundle.targetInbound).not.toBeNull();
   });
 
-  it("leaves targetInbound null on net-new compose but still surfaces thread history as context", async () => {
+  it("leaves targetInbound null on new intent even when threadCursor is set", async () => {
+    if (!runtime) {
+      throw new Error("Expected runtime.");
+    }
+
+    if (seededInboundId === null) {
+      throw new Error("Expected seededInboundId.");
+    }
+
+    const bundle = await retrieveGrounding(runtime.context.repositories, {
+      contactId: "contact:maya",
+      projectId: "project:whitebark",
+      intent: "new",
+      threadCursor: seededInboundId,
+    });
+
+    expect(bundle.targetInbound).toBeNull();
+    expect(bundle.recentEvents.length).toBeGreaterThan(0);
+  });
+
+  it("falls back to the most recent inbound on reply intent when threadCursor is null", async () => {
     if (!runtime) {
       throw new Error("Expected runtime.");
     }
@@ -133,15 +155,30 @@ describe("retrieveGrounding", () => {
     const bundle = await retrieveGrounding(runtime.context.repositories, {
       contactId: "contact:maya",
       projectId: "project:whitebark",
+      intent: "reply",
       threadCursor: null,
     });
 
-    // Operator started a new conversation from the pencil button: no message
-    // is being replied to, even though this contact has thread history.
-    expect(bundle.targetInbound).toBeNull();
-    // The history still travels as background context so the AI knows
-    // recent activity (submissions, milestones, etc.).
-    expect(bundle.recentEvents.length).toBeGreaterThan(0);
+    expect(bundle.targetInbound?.canonicalEventId).toBe(seededInboundId);
+  });
+
+  it("leaves targetInbound null on reply intent when no inbound exists", async () => {
+    const emptyRuntime = await createStage1WebTestRuntime();
+
+    try {
+      await seedAiContact(emptyRuntime);
+
+      const bundle = await retrieveGrounding(emptyRuntime.context.repositories, {
+        contactId: "contact:maya",
+        projectId: "project:whitebark",
+        intent: "reply",
+        threadCursor: null,
+      });
+
+      expect(bundle.targetInbound).toBeNull();
+    } finally {
+      await emptyRuntime.dispose();
+    }
   });
 
   it("falls back to the host's tier-2 entry when the project is a connected sub", async () => {
@@ -178,6 +215,7 @@ describe("retrieveGrounding", () => {
     const bundle = await retrieveGrounding(runtime.context.repositories, {
       contactId: "contact:maya",
       projectId: "project:whitebark",
+      intent: "reply",
       threadCursor: null,
     });
 
@@ -194,6 +232,7 @@ describe("retrieveGrounding", () => {
       const bundle = await retrieveGrounding(emptyRuntime.context.repositories, {
         contactId: "contact:missing",
         projectId: "project:missing",
+        intent: "reply",
         threadCursor: null,
       });
 
@@ -202,6 +241,7 @@ describe("retrieveGrounding", () => {
         generalTraining: null,
         projectContext: null,
         tier3Entries: [],
+        intent: "reply",
         targetInbound: null,
         recentEvents: [],
         grounding: [],

--- a/apps/web/test/server/ai/validator.test.ts
+++ b/apps/web/test/server/ai/validator.test.ts
@@ -24,6 +24,7 @@ const bundle: GroundingBundle = {
   },
   projectContext: null,
   tier3Entries: [],
+  intent: "reply",
   targetInbound: null,
   recentEvents: [],
   grounding: [],

--- a/apps/web/tests/unit/use-ai-draft-run.test.ts
+++ b/apps/web/tests/unit/use-ai-draft-run.test.ts
@@ -33,6 +33,7 @@ function setup(input?: {
   readonly body?: string;
   readonly smsBody?: string;
   readonly activeTab?: "email" | "sms" | "note";
+  readonly composerPaneMode?: "new-draft" | "replying" | "forwarding";
   readonly recipient?: (typeof INITIAL_COMPOSER_DRAFT_STATE)["recipient"];
   readonly smsRecipient?: (typeof INITIAL_COMPOSER_DRAFT_STATE)["smsRecipient"];
   readonly selectedAliasAiConfigured?: boolean;
@@ -91,6 +92,7 @@ function setup(input?: {
       defaultAlias: "forest@adventuresci.org",
       cc: [],
     },
+    composerPaneMode: input?.composerPaneMode ?? "replying",
     startAiGeneration,
     markAiDraftReviewable: vi.fn(),
     approveAiDraft,
@@ -223,6 +225,7 @@ describe("useAiDraftRun", () => {
       request: {
         contactId: "contact-sms-42",
         projectId: "project-1",
+        intent: "reply",
         threadCursor: "thread-cursor-1",
         channel: "sms",
         mode: "draft",

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -1847,7 +1847,7 @@ function createStage1RepositoriesInternal(
         return row !== undefined;
       },
 
-      async findProjectIdsWithNotionContent(projectIds) {
+      async findProjectIdsWithAiKnowledgeConfigured(projectIds) {
         if (projectIds.length === 0) {
           return [];
         }
@@ -1856,43 +1856,59 @@ function createStage1RepositoriesInternal(
           .select({
             projectId: projectDimensions.projectId,
             connectedToProjectId: projectDimensions.connectedToProjectId,
+            aiKnowledgeSyncedAt: projectDimensions.aiKnowledgeSyncedAt,
           })
           .from(projectDimensions)
           .where(inArray(projectDimensions.projectId, projectIds as string[]));
 
-        const effectiveScopeKeyByInputId = new Map(
+        const knownProjectsById = new Map(
+          projectRows.map((row) => [row.projectId, row]),
+        );
+        const effectiveProjectIdByInput = new Map(
           projectIds.map((projectId) => [projectId, projectId]),
         );
         for (const row of projectRows) {
-          effectiveScopeKeyByInputId.set(
+          effectiveProjectIdByInput.set(
             row.projectId,
             row.connectedToProjectId ?? row.projectId,
           );
         }
 
-        const effectiveScopeKeys = Array.from(
-          new Set(effectiveScopeKeyByInputId.values()),
-        );
-        const rows = await db
-          .selectDistinct({ scopeKey: aiKnowledgeEntries.scopeKey })
-          .from(aiKnowledgeEntries)
-          .where(
-            and(
-              eq(aiKnowledgeEntries.scope, "project"),
-              eq(aiKnowledgeEntries.sourceProvider, "notion"),
-              inArray(aiKnowledgeEntries.scopeKey, effectiveScopeKeys),
-              sql`length(btrim(${aiKnowledgeEntries.content})) > 0`,
+        const hostIdsToFetch = Array.from(
+          new Set(
+            Array.from(effectiveProjectIdByInput.values()).filter(
+              (projectId) => !knownProjectsById.has(projectId),
             ),
-          );
-        const matchedScopeKeys = new Set(
-          rows
-            .map((row) => row.scopeKey)
-            .filter((scopeKey): scopeKey is string => scopeKey !== null),
+          ),
+        );
+
+        if (hostIdsToFetch.length > 0) {
+          const hostRows = await db
+            .select({
+              projectId: projectDimensions.projectId,
+              aiKnowledgeSyncedAt: projectDimensions.aiKnowledgeSyncedAt,
+            })
+            .from(projectDimensions)
+            .where(inArray(projectDimensions.projectId, hostIdsToFetch));
+
+          for (const row of hostRows) {
+            knownProjectsById.set(row.projectId, {
+              projectId: row.projectId,
+              connectedToProjectId: null,
+              aiKnowledgeSyncedAt: row.aiKnowledgeSyncedAt,
+            });
+          }
+        }
+
+        const configuredEffectiveIds = new Set(
+          Array.from(knownProjectsById.values())
+            .filter((row) => row.aiKnowledgeSyncedAt !== null)
+            .map((row) => row.projectId),
         );
 
         return projectIds.filter((projectId) =>
-          matchedScopeKeys.has(
-            effectiveScopeKeyByInputId.get(projectId) ?? projectId,
+          configuredEffectiveIds.has(
+            effectiveProjectIdByInput.get(projectId) ?? projectId,
           ),
         );
       },

--- a/packages/db/test/ai-knowledge-host-hop.test.ts
+++ b/packages/db/test/ai-knowledge-host-hop.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import { createTestStage1Context } from "./helpers.js";
 
-describe("aiKnowledge.findProjectIdsWithNotionContent", () => {
-  it("returns standalone projects with content, skips empty hosts, and hops connected subs to their host", async () => {
+describe("aiKnowledge.findProjectIdsWithAiKnowledgeConfigured", () => {
+  it("returns the configured subset across standalone and connected projects", async () => {
     const context = await createTestStage1Context();
 
     try {
@@ -13,6 +13,7 @@ describe("aiKnowledge.findProjectIdsWithNotionContent", () => {
         projectAlias: "Standalone Ready",
         source: "salesforce",
         isActive: true,
+        aiKnowledgeSyncedAt: "2026-05-01T00:00:00.000Z",
       });
       await context.repositories.projectDimensions.upsert({
         projectId: "standalone:empty",
@@ -20,6 +21,7 @@ describe("aiKnowledge.findProjectIdsWithNotionContent", () => {
         projectAlias: "Standalone Empty",
         source: "salesforce",
         isActive: true,
+        aiKnowledgeSyncedAt: null,
       });
       await context.repositories.projectDimensions.upsert({
         projectId: "host:ready",
@@ -27,6 +29,7 @@ describe("aiKnowledge.findProjectIdsWithNotionContent", () => {
         projectAlias: "Host Ready",
         source: "salesforce",
         isActive: true,
+        aiKnowledgeSyncedAt: "2026-05-01T00:00:00.000Z",
       });
       await context.repositories.projectDimensions.upsert({
         projectId: "host:empty",
@@ -34,6 +37,7 @@ describe("aiKnowledge.findProjectIdsWithNotionContent", () => {
         projectAlias: "Host Empty",
         source: "salesforce",
         isActive: true,
+        aiKnowledgeSyncedAt: null,
       });
       await context.repositories.projectDimensions.upsert({
         projectId: "sub:beech",
@@ -52,46 +56,15 @@ describe("aiKnowledge.findProjectIdsWithNotionContent", () => {
         connectedToProjectId: "host:empty",
       });
 
-      await context.repositories.aiKnowledge.upsert({
-        id: "ai:standalone:ready",
-        scope: "project",
-        scopeKey: "standalone:ready",
-        sourceProvider: "notion",
-        sourceId: "notion-standalone-ready",
-        sourceUrl: "https://www.notion.so/standalone-ready",
-        title: "Standalone Ready",
-        content: "Standalone content",
-        contentHash: "hash:standalone-ready",
-        metadataJson: {},
-        sourceLastEditedAt: "2026-05-01T00:00:00.000Z",
-        syncedAt: "2026-05-01T00:00:00.000Z",
-        createdAt: "2026-05-01T00:00:00.000Z",
-        updatedAt: "2026-05-01T00:00:00.000Z",
-      });
-      await context.repositories.aiKnowledge.upsert({
-        id: "ai:host:ready",
-        scope: "project",
-        scopeKey: "host:ready",
-        sourceProvider: "notion",
-        sourceId: "notion-host-ready",
-        sourceUrl: "https://www.notion.so/host-ready",
-        title: "Host Ready",
-        content: "Host content",
-        contentHash: "hash:host-ready",
-        metadataJson: {},
-        sourceLastEditedAt: "2026-05-01T00:00:00.000Z",
-        syncedAt: "2026-05-01T00:00:00.000Z",
-        createdAt: "2026-05-01T00:00:00.000Z",
-        updatedAt: "2026-05-01T00:00:00.000Z",
-      });
-
       const result =
-        await context.repositories.aiKnowledge.findProjectIdsWithNotionContent([
-          "standalone:ready",
-          "standalone:empty",
-          "sub:beech",
-          "sub:butternut",
-        ]);
+        await context.repositories.aiKnowledge.findProjectIdsWithAiKnowledgeConfigured(
+          [
+            "standalone:ready",
+            "standalone:empty",
+            "sub:beech",
+            "sub:butternut",
+          ],
+        );
 
       expect(result).toEqual(["standalone:ready", "sub:beech"]);
     } finally {

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -162,13 +162,18 @@ export interface AiKnowledgeRepository {
   ): Promise<AiKnowledgeEntryRecord | null>;
   hasProjectNotionContent(projectId: string): Promise<boolean>;
   /**
-   * Returns the subset of input project IDs whose effective Notion
-   * knowledge bundle has non-empty content. Connected sub-projects
-   * (`project_dimensions.connected_to_project_id IS NOT NULL`)
-   * transparently hop to their host before checking content — mirrors
-   * `findEffectiveProjectNotionContent` for the bulk path.
+   * Returns the subset of input project IDs whose effective project is
+   * configured for AI knowledge — i.e. has
+   * `ai_knowledge_synced_at IS NOT NULL`. Connected sub-projects
+   * transparently hop to their host's synced timestamp (same semantics as
+   * {@link findEffectiveProjectNotionContent} for the bulk path).
+   *
+   * This is the chip-facing signal (composer "Knowledge Base" indicator).
+   * It does NOT inspect `ai_knowledge_entries` cache content — a project
+   * may be configured before its cache row is populated by the next sync,
+   * and we still want the chip to show as configured.
    */
-  findProjectIdsWithNotionContent(
+  findProjectIdsWithAiKnowledgeConfigured(
     projectIds: readonly string[],
   ): Promise<readonly string[]>;
   upsert(record: AiKnowledgeEntryRecord): Promise<AiKnowledgeEntryRecord>;

--- a/packages/domain/test/normalization.test.ts
+++ b/packages/domain/test/normalization.test.ts
@@ -420,7 +420,7 @@ function buildContext(input: {
       findProjectNotionContent: () => Promise.resolve(null),
       findEffectiveProjectNotionContent: () => Promise.resolve(null),
       hasProjectNotionContent: () => Promise.resolve(false),
-      findProjectIdsWithNotionContent: () => Promise.resolve([]),
+      findProjectIdsWithAiKnowledgeConfigured: () => Promise.resolve([]),
       upsert: (record) => Promise.resolve(record),
     },
     projectKnowledge: {

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -58,7 +58,7 @@ describe("defineStage1RepositoryBundle", () => {
         findProjectNotionContent: () => Promise.resolve(null),
         findEffectiveProjectNotionContent: () => Promise.resolve(null),
         hasProjectNotionContent: () => Promise.resolve(false),
-        findProjectIdsWithNotionContent: () => Promise.resolve([]),
+        findProjectIdsWithAiKnowledgeConfigured: () => Promise.resolve([]),
         upsert: (record) => Promise.resolve(record),
       },
       projectKnowledge: {

--- a/packages/domain/test/stage3-last-inbound-alias.test.ts
+++ b/packages/domain/test/stage3-last-inbound-alias.test.ts
@@ -77,7 +77,7 @@ function buildRepositoryBundle(input: {
       findProjectNotionContent: () => Promise.resolve(null),
       findEffectiveProjectNotionContent: () => Promise.resolve(null),
       hasProjectNotionContent: () => Promise.resolve(false),
-      findProjectIdsWithNotionContent: () => Promise.resolve([]),
+      findProjectIdsWithAiKnowledgeConfigured: () => Promise.resolve([]),
       upsert: (record) => Promise.resolve(record),
     },
     projectKnowledge: {

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -154,7 +154,7 @@ function createRepositoryBundle(input: {
       findProjectNotionContent: () => Promise.resolve(null),
       findEffectiveProjectNotionContent: () => Promise.resolve(null),
       hasProjectNotionContent: () => Promise.resolve(false),
-      findProjectIdsWithNotionContent: () => Promise.resolve([]),
+      findProjectIdsWithAiKnowledgeConfigured: () => Promise.resolve([]),
       upsert: (record) => Promise.resolve(record),
     },
     projectKnowledge: {


### PR DESCRIPTION
## Summary

- AI Draft now uses an explicit `intent: "new" | "reply"` field (defaulting to `"reply"`) instead of the implicit `threadCursor === null` signal from PR #403. The pencil "new draft" button sets `intent: "new"`; all Reply triggers set `intent: "reply"`. Fixes the regression where replies on conversations without inbound messages (or replies on outbound messages) drafted as new emails.
- KB footer chip in the composer now reflects "project is configured for AI knowledge" (`ai_knowledge_synced_at IS NOT NULL` on the effective project, with the same sub→host hop as the AI Draft retriever), instead of the narrower "cache row has non-empty content". Operators see "Without Knowledge Base" only when the project genuinely isn't configured. Per `D-037`.

## Test plan

- [ ] Click Reply on an outbound message in a thread with no inbound → AI Draft frames it as a reply, not a new email
- [ ] Click Reply on a thread that only has AUTOMATED outbounds → AI Draft frames it as a reply
- [ ] Click the pencil "new draft" button → AI Draft frames it as new-conversation
- [ ] Open the composer on a project configured for AI knowledge (e.g. PNW Biodiversity with `pnwbio@`) → KB chip reads "<Project> Knowledge Base"
- [ ] Open the composer on a Beech volunteer thread with `forests@` selected → KB chip reads "Beech and Butternut Knowledge Base"
- [x] pnpm typecheck and pnpm lint clean
- [x] Targeted unit tests added/updated (retriever intent branches, prompt-builder framing branches, chip signal host-hop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)