### PR TITLE
fix(composer): KB chip uses ai_optimized_synthesized_at + toolbar pinned to modal bottom

### DIFF
--- a/apps/web/app/inbox/_components/composer-detail-surfaces.tsx
+++ b/apps/web/app/inbox/_components/composer-detail-surfaces.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { RefObject } from "react";
+import { useState, type RefObject } from "react";
 
 import { smsMetrics, type SmsMetrics } from "@as-comms/domain/sms-segments";
 
@@ -32,8 +32,12 @@ import {
   ComposerField,
   InlineErrorBanner,
   RichTextComposerEditor,
+  type RichTextComposerCommandState,
 } from "./composer-editor-surface";
-import { ComposerToolbar } from "./composer-toolbar";
+import {
+  ComposerToolbar,
+  type ComposerToolbarCommand,
+} from "./composer-toolbar";
 import {
   BookOpenIcon,
   ChevronDownIcon,
@@ -60,6 +64,10 @@ import type {
 } from "./inbox-client-provider";
 import { ComposerSmsRecipientPicker } from "./composer-sms-recipient-picker";
 import { SendFromPhoneChip } from "./composer-send-from-phone-chip";
+
+const EMPTY_ACTIVE_COMMANDS = new Set<ComposerToolbarCommand>();
+const NOOP_COMPOSER_COMMAND: (command: ComposerToolbarCommand) => void = () =>
+  undefined;
 
 function KnowledgeBaseIndicator({
   hasKnowledge,
@@ -381,205 +389,222 @@ export function ComposerEmailSurface({
       projectName={selectedAliasProjectName}
     />
   ) : null;
+  const [editorCommandState, setEditorCommandState] =
+    useState<RichTextComposerCommandState | null>(null);
+  const activeCommands =
+    editorCommandState?.activeCommands ?? EMPTY_ACTIVE_COMMANDS;
+  const onToolbarCommand =
+    editorCommandState?.onCommand ?? NOOP_COMPOSER_COMMAND;
 
   return (
     <TooltipProvider delayDuration={200}>
-      <div className="flex min-h-full flex-col">
-        <ComposerField label="FROM">
-          <ComposerSendFromChip
-            value={selectedAlias}
-            aliases={composerAliases}
-            onChange={onAliasChange}
-            {...(aliasError?.message ? { errorMessage: aliasError.message } : {})}
-          />
-        </ComposerField>
-
-      <ComposerField label="TO">
-        <div className="rounded-md bg-white">
-          <ComposerRecipientPicker
-            recipients={recipient === null ? [] : [recipient]}
-            locked={isReplying}
-            single
-            autoFocusInput={recipientAutoFocus}
-            placeholder={recipientPlaceholder}
-            rightSlot={
-              !showCc || !showBcc ? (
-                <div className="flex items-center gap-1 pt-0.5 text-[11.5px]">
-                  {!showCc ? (
-                    <button
-                      type="button"
-                      onClick={() => {
-                        onToggleCc(true);
-                      }}
-                      className="rounded px-1.5 py-0.5 text-slate-500 hover:bg-slate-100 hover:text-slate-700"
-                    >
-                      Cc
-                    </button>
-                  ) : null}
-                  {!showBcc ? (
-                    <button
-                      type="button"
-                      onClick={() => {
-                        onToggleBcc(true);
-                      }}
-                      className="rounded px-1.5 py-0.5 text-slate-500 hover:bg-slate-100 hover:text-slate-700"
-                    >
-                      Bcc
-                    </button>
-                  ) : null}
-                </div>
-              ) : null
-            }
-            onRecipientsChange={(nextRecipients) => {
-              onRecipientChange(nextRecipients[0] ?? null);
-            }}
-          />
-        </div>
-        {recipientError ? (
-          <p className="mt-1 text-xs text-rose-700">{recipientError.message}</p>
-        ) : null}
-      </ComposerField>
-
-      {showCc ? (
-        <ComposerField label="CC">
-          <ComposerRecipientPicker
-            recipients={ccRecipients}
-            rightSlot={
-              <button
-                type="button"
-                aria-label="Hide Cc field"
-                onClick={() => {
-                  onToggleCc(false);
-                }}
-                className="text-slate-400 hover:text-slate-700"
-              >
-                <XIcon className="size-3.5" />
-              </button>
-            }
-            onRecipientsChange={onCcChange}
-          />
-          {ccError ? (
-            <p className="mt-1 text-xs text-rose-700">{ccError.message}</p>
-          ) : null}
-        </ComposerField>
-      ) : null}
-
-      {showBcc ? (
-        <ComposerField label="BCC">
-          <ComposerRecipientPicker
-            recipients={bccRecipients}
-            rightSlot={
-              <button
-                type="button"
-                aria-label="Hide Bcc field"
-                onClick={() => {
-                  onToggleBcc(false);
-                }}
-                className="text-slate-400 hover:text-slate-700"
-              >
-                <XIcon className="size-3.5" />
-              </button>
-            }
-            onRecipientsChange={onBccChange}
-          />
-          {bccError ? (
-            <p className="mt-1 text-xs text-rose-700">{bccError.message}</p>
-          ) : null}
-        </ComposerField>
-      ) : null}
-
-      <ComposerField label="SUBJ">
-        <Input
-          value={subject}
-          onChange={(event) => {
-            onSubjectChange(event.currentTarget.value);
-          }}
-          placeholder="Subject"
-          className={cn(
-            "h-8 border-0 px-0 text-[13px] font-medium shadow-none focus-visible:ring-0",
-            subjectError ? "text-rose-900" : "",
-          )}
-        />
-        {subjectError ? (
-          <p className="mt-1 text-xs text-rose-700">{subjectError.message}</p>
-        ) : null}
-      </ComposerField>
-
-      <RichTextComposerEditor
-        className="flex min-h-0 flex-1 flex-col"
-        frameClassName="flex min-h-0 flex-1 flex-col border-x-0 border-b-0 shadow-none"
-        contentClassName="min-h-0 flex-1"
-        bodyPlaintext={body}
-        errorMessage={bodyError?.message}
-        onChange={(nextBody) => {
-          onBodyChange(nextBody);
-          if (aiDraft.status === "inserted") {
-            onAiEdited();
-          }
-        }}
-        onClearErrors={onClearErrors}
-        topSlot={
-          showAiDraftAffordances ? (
-            <ComposerAiDraftWindow
-              tone="email"
-              aiDraft={aiDraft}
-              directiveText={aiDirective}
-              repromptText={repromptText}
-              isGeneratingAi={isGeneratingAi}
-              runDraftDisabled={runAiDraftDisabled}
-              runDraftDisabledReason={runAiDraftDisabledReason}
-              onDirectiveTextChange={onAiDirectiveChange}
-              onRepromptTextChange={onRepromptTextChange}
-              onRunDraft={onRunAiDraft}
-              onOpenReprompt={onOpenReprompt}
-              onSubmitReprompt={onReprompt}
-              onCancelReprompt={onCancelReprompt}
-              onDiscard={onDiscardAi}
-              onApprove={onApproveAi}
+      <div className="flex h-full flex-col">
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+          <ComposerField label="FROM">
+            <ComposerSendFromChip
+              value={selectedAlias}
+              aliases={composerAliases}
+              onChange={onAliasChange}
+              {...(aliasError?.message
+                ? { errorMessage: aliasError.message }
+                : {})}
             />
-          ) : undefined
-        }
-        bottomSlot={
-          selectedAliasSignature.length > 0 ? (
-            <div className="px-4 pb-3 pt-2 whitespace-pre-line text-[13px] leading-relaxed text-slate-500">
-              {selectedAliasSignature}
-            </div>
-          ) : undefined
-        }
-        toolbarFooter={({ activeCommands, onCommand }) => (
-          <div className="border-t border-slate-100 bg-slate-50/40 px-3 py-2">
-            <AttachmentRow
-              attachments={attachments}
-              onRemove={onAttachmentRemove}
-            />
-            {attachmentError ? (
-              <div className="px-1 pb-3 text-xs text-rose-700">
-                {attachmentError.message}
-              </div>
-            ) : null}
+          </ComposerField>
 
-            {inlineError || recipientError || ccError || bccError || attachmentError ? (
-              <InlineErrorBanner
-                message={
-                  inlineError?.message ??
-                  recipientError?.message ??
-                  ccError?.message ??
-                  bccError?.message ??
-                  attachmentError?.message ??
-                  "Something went wrong."
+          <ComposerField label="TO">
+            <div className="rounded-md bg-white">
+              <ComposerRecipientPicker
+                recipients={recipient === null ? [] : [recipient]}
+                locked={isReplying}
+                single
+                autoFocusInput={recipientAutoFocus}
+                placeholder={recipientPlaceholder}
+                rightSlot={
+                  !showCc || !showBcc ? (
+                    <div className="flex items-center gap-1 pt-0.5 text-[11.5px]">
+                      {!showCc ? (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            onToggleCc(true);
+                          }}
+                          className="rounded px-1.5 py-0.5 text-slate-500 hover:bg-slate-100 hover:text-slate-700"
+                        >
+                          Cc
+                        </button>
+                      ) : null}
+                      {!showBcc ? (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            onToggleBcc(true);
+                          }}
+                          className="rounded px-1.5 py-0.5 text-slate-500 hover:bg-slate-100 hover:text-slate-700"
+                        >
+                          Bcc
+                        </button>
+                      ) : null}
+                    </div>
+                  ) : null
                 }
-                retryable={inlineError?.retryable === true}
-                onRetry={() => {
-                  onSend("send");
+                onRecipientsChange={(nextRecipients) => {
+                  onRecipientChange(nextRecipients[0] ?? null);
                 }}
               />
+            </div>
+            {recipientError ? (
+              <p className="mt-1 text-xs text-rose-700">
+                {recipientError.message}
+              </p>
             ) : null}
+          </ComposerField>
 
+          {showCc ? (
+            <ComposerField label="CC">
+              <ComposerRecipientPicker
+                recipients={ccRecipients}
+                rightSlot={
+                  <button
+                    type="button"
+                    aria-label="Hide Cc field"
+                    onClick={() => {
+                      onToggleCc(false);
+                    }}
+                    className="text-slate-400 hover:text-slate-700"
+                  >
+                    <XIcon className="size-3.5" />
+                  </button>
+                }
+                onRecipientsChange={onCcChange}
+              />
+              {ccError ? (
+                <p className="mt-1 text-xs text-rose-700">{ccError.message}</p>
+              ) : null}
+            </ComposerField>
+          ) : null}
+
+          {showBcc ? (
+            <ComposerField label="BCC">
+              <ComposerRecipientPicker
+                recipients={bccRecipients}
+                rightSlot={
+                  <button
+                    type="button"
+                    aria-label="Hide Bcc field"
+                    onClick={() => {
+                      onToggleBcc(false);
+                    }}
+                    className="text-slate-400 hover:text-slate-700"
+                  >
+                    <XIcon className="size-3.5" />
+                  </button>
+                }
+                onRecipientsChange={onBccChange}
+              />
+              {bccError ? (
+                <p className="mt-1 text-xs text-rose-700">{bccError.message}</p>
+              ) : null}
+            </ComposerField>
+          ) : null}
+
+          <ComposerField label="SUBJ">
+            <Input
+              value={subject}
+              onChange={(event) => {
+                onSubjectChange(event.currentTarget.value);
+              }}
+              placeholder="Subject"
+              className={cn(
+                "h-8 border-0 px-0 text-[13px] font-medium shadow-none focus-visible:ring-0",
+                subjectError ? "text-rose-900" : "",
+              )}
+            />
+            {subjectError ? (
+              <p className="mt-1 text-xs text-rose-700">{subjectError.message}</p>
+            ) : null}
+          </ComposerField>
+
+          <RichTextComposerEditor
+            bodyPlaintext={body}
+            className="flex min-h-0 flex-1 flex-col"
+            contentClassName="min-h-0 flex-1"
+            errorMessage={bodyError?.message}
+            frameClassName="flex min-h-0 flex-1 flex-col border-x-0 border-b-0 shadow-none"
+            onChange={(nextBody) => {
+              onBodyChange(nextBody);
+              if (aiDraft.status === "inserted") {
+                onAiEdited();
+              }
+            }}
+            onClearErrors={onClearErrors}
+            onCommandStateChange={setEditorCommandState}
+            showToolbar={false}
+            topSlot={
+              showAiDraftAffordances ? (
+                <ComposerAiDraftWindow
+                  tone="email"
+                  aiDraft={aiDraft}
+                  directiveText={aiDirective}
+                  repromptText={repromptText}
+                  isGeneratingAi={isGeneratingAi}
+                  runDraftDisabled={runAiDraftDisabled}
+                  runDraftDisabledReason={runAiDraftDisabledReason}
+                  onDirectiveTextChange={onAiDirectiveChange}
+                  onRepromptTextChange={onRepromptTextChange}
+                  onRunDraft={onRunAiDraft}
+                  onOpenReprompt={onOpenReprompt}
+                  onSubmitReprompt={onReprompt}
+                  onCancelReprompt={onCancelReprompt}
+                  onDiscard={onDiscardAi}
+                  onApprove={onApproveAi}
+                />
+              ) : undefined
+            }
+            bottomSlot={
+              selectedAliasSignature.length > 0 ? (
+                <div className="px-4 pb-3 pt-2 whitespace-pre-line text-[13px] leading-relaxed text-slate-500">
+                  {selectedAliasSignature}
+                </div>
+              ) : undefined
+            }
+          />
+        </div>
+
+        <div className="shrink-0 border-t border-slate-100 bg-slate-50/40">
+          <AttachmentRow attachments={attachments} onRemove={onAttachmentRemove} />
+          {attachmentError ? (
+            <div className="px-1 pb-3 text-xs text-rose-700">
+              {attachmentError.message}
+            </div>
+          ) : null}
+
+          {inlineError ||
+          recipientError ||
+          ccError ||
+          bccError ||
+          attachmentError ? (
+            <InlineErrorBanner
+              message={
+                inlineError?.message ??
+                recipientError?.message ??
+                ccError?.message ??
+                bccError?.message ??
+                attachmentError?.message ??
+                "Something went wrong."
+              }
+              retryable={inlineError?.retryable === true}
+              onRetry={() => {
+                onSend("send");
+              }}
+            />
+          ) : null}
+
+          <div className="px-3 py-2">
             <div className="flex min-w-0 items-center gap-2">
               <div className="shrink-0">
                 <ComposerToolbar
                   activeCommands={activeCommands}
-                  onCommand={onCommand}
+                  onCommand={onToolbarCommand}
                 />
               </div>
 
@@ -664,7 +689,8 @@ export function ComposerEmailSurface({
                             Save draft
                           </span>
                           <span className={TYPE.caption}>
-                            Collapse this draft to the floating pill without sending
+                            Collapse this draft to the floating pill without
+                            sending
                           </span>
                         </div>
                       </DropdownMenuItem>
@@ -678,19 +704,18 @@ export function ComposerEmailSurface({
               <div className="mt-2 md:hidden">{knowledgeIndicator}</div>
             ) : null}
           </div>
-        )}
-      />
 
-      {aiWarningMessage ? (
-        <div className="border-t border-amber-200 bg-amber-50 px-4 py-2 text-sm text-amber-900">
-          {aiWarningMessage}
+          {aiWarningMessage ? (
+            <div className="border-t border-amber-200 bg-amber-50 px-4 py-2 text-sm text-amber-900">
+              {aiWarningMessage}
+            </div>
+          ) : null}
+          {bodyError ? (
+            <div className="px-4 py-2 text-xs text-rose-700">
+              {bodyError.message}
+            </div>
+          ) : null}
         </div>
-      ) : null}
-        {bodyError ? (
-          <div className="px-4 py-2 text-xs text-rose-700">
-            {bodyError.message}
-          </div>
-        ) : null}
       </div>
     </TooltipProvider>
   );

--- a/apps/web/app/inbox/_components/composer-editor-surface.tsx
+++ b/apps/web/app/inbox/_components/composer-editor-surface.tsx
@@ -141,12 +141,19 @@ export function InlineErrorBanner({
   );
 }
 
+export interface RichTextComposerCommandState {
+  readonly activeCommands: ReadonlySet<ComposerToolbarCommand>;
+  readonly onCommand: (command: ComposerToolbarCommand) => void;
+}
+
 export function RichTextComposerEditor({
   bodyPlaintext,
   errorMessage,
   topSlot,
   bottomSlot,
   toolbarFooter,
+  onCommandStateChange,
+  showToolbar = true,
   className,
   frameClassName,
   contentClassName,
@@ -157,6 +164,10 @@ export function RichTextComposerEditor({
   readonly errorMessage: string | undefined;
   readonly topSlot?: React.ReactNode;
   readonly bottomSlot?: React.ReactNode;
+  readonly onCommandStateChange?: (
+    state: RichTextComposerCommandState,
+  ) => void;
+  readonly showToolbar?: boolean;
   readonly toolbarFooter?: (input: {
     readonly activeCommands: ReadonlySet<ComposerToolbarCommand>;
     readonly onCommand: (command: ComposerToolbarCommand) => void;
@@ -218,6 +229,8 @@ export function RichTextComposerEditor({
     activeCommands.add("orderedList");
   if (editor?.isActive("link") === true) activeCommands.add("link");
   if (editor?.isActive("blockquote") === true) activeCommands.add("blockquote");
+  const activeCommandsSnapshot = Array.from(activeCommands).sort();
+  const activeCommandsKey = activeCommandsSnapshot.join(",");
 
   const runCommand = useCallback(
     (command: ComposerToolbarCommand) => {
@@ -280,6 +293,22 @@ export function RichTextComposerEditor({
     }
   }, [bodyPlaintext, editor]);
 
+  useEffect(() => {
+    if (onCommandStateChange === undefined) {
+      return;
+    }
+
+    onCommandStateChange({
+      activeCommands:
+        activeCommandsKey.length === 0
+          ? new Set<ComposerToolbarCommand>()
+          : new Set(
+              activeCommandsKey.split(",") as readonly ComposerToolbarCommand[],
+            ),
+      onCommand: runCommand,
+    });
+  }, [activeCommandsKey, onCommandStateChange, runCommand]);
+
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
       event.preventDefault();
@@ -297,9 +326,9 @@ export function RichTextComposerEditor({
           frameClassName,
         )}
       >
-        {toolbarFooter ? null : (
+        {showToolbar && !toolbarFooter ? (
           <ComposerToolbar activeCommands={activeCommands} onCommand={runCommand} />
-        )}
+        ) : null}
         {topSlot}
         <div
           className={cn("relative min-h-44", contentClassName)}

--- a/apps/web/app/inbox/_components/inbox-composer.tsx
+++ b/apps/web/app/inbox/_components/inbox-composer.tsx
@@ -497,7 +497,7 @@ export function InboxComposerDetailPane({
           </div>
         </header>
 
-        <div className="min-h-0 flex-1 overflow-y-auto bg-white">
+        <div className="flex min-h-0 flex-1 flex-col bg-white">
           {state.activeTab === "email" ? (
             <ComposerEmailSurface
               composerAliases={composerAliases}

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -386,9 +386,9 @@ export interface InboxComposerAliasOption {
   readonly isAiReady: boolean;
   readonly isAiConfigured?: boolean;
   /**
-   * Whether the effective project (host or own) is configured for AI
-   * knowledge — i.e. `ai_knowledge_synced_at IS NOT NULL`. This drives the
-   * composer's "Knowledge Base" footer chip.
+   * Whether the effective project (host or own) has had AI Knowledge
+   * synthesis run at least once (`ai_optimized_synthesized_at IS NOT NULL`).
+   * This is the signal for the composer's "Knowledge Base" footer chip.
    */
   readonly hasCachedContent?: boolean;
 }

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -1856,7 +1856,8 @@ function createStage1RepositoriesInternal(
           .select({
             projectId: projectDimensions.projectId,
             connectedToProjectId: projectDimensions.connectedToProjectId,
-            aiKnowledgeSyncedAt: projectDimensions.aiKnowledgeSyncedAt,
+            aiOptimizedSynthesizedAt:
+              projectDimensions.aiOptimizedSynthesizedAt,
           })
           .from(projectDimensions)
           .where(inArray(projectDimensions.projectId, projectIds as string[]));
@@ -1886,7 +1887,8 @@ function createStage1RepositoriesInternal(
           const hostRows = await db
             .select({
               projectId: projectDimensions.projectId,
-              aiKnowledgeSyncedAt: projectDimensions.aiKnowledgeSyncedAt,
+              aiOptimizedSynthesizedAt:
+                projectDimensions.aiOptimizedSynthesizedAt,
             })
             .from(projectDimensions)
             .where(inArray(projectDimensions.projectId, hostIdsToFetch));
@@ -1895,14 +1897,14 @@ function createStage1RepositoriesInternal(
             knownProjectsById.set(row.projectId, {
               projectId: row.projectId,
               connectedToProjectId: null,
-              aiKnowledgeSyncedAt: row.aiKnowledgeSyncedAt,
+              aiOptimizedSynthesizedAt: row.aiOptimizedSynthesizedAt,
             });
           }
         }
 
         const configuredEffectiveIds = new Set(
           Array.from(knownProjectsById.values())
-            .filter((row) => row.aiKnowledgeSyncedAt !== null)
+            .filter((row) => row.aiOptimizedSynthesizedAt !== null)
             .map((row) => row.projectId),
         );
 

--- a/packages/db/test/ai-knowledge-host-hop.test.ts
+++ b/packages/db/test/ai-knowledge-host-hop.test.ts
@@ -13,7 +13,7 @@ describe("aiKnowledge.findProjectIdsWithAiKnowledgeConfigured", () => {
         projectAlias: "Standalone Ready",
         source: "salesforce",
         isActive: true,
-        aiKnowledgeSyncedAt: "2026-05-01T00:00:00.000Z",
+        aiOptimizedSynthesizedAt: "2026-05-01T00:00:00.000Z",
       });
       await context.repositories.projectDimensions.upsert({
         projectId: "standalone:empty",
@@ -21,7 +21,7 @@ describe("aiKnowledge.findProjectIdsWithAiKnowledgeConfigured", () => {
         projectAlias: "Standalone Empty",
         source: "salesforce",
         isActive: true,
-        aiKnowledgeSyncedAt: null,
+        aiOptimizedSynthesizedAt: null,
       });
       await context.repositories.projectDimensions.upsert({
         projectId: "host:ready",
@@ -29,7 +29,7 @@ describe("aiKnowledge.findProjectIdsWithAiKnowledgeConfigured", () => {
         projectAlias: "Host Ready",
         source: "salesforce",
         isActive: true,
-        aiKnowledgeSyncedAt: "2026-05-01T00:00:00.000Z",
+        aiOptimizedSynthesizedAt: "2026-05-01T00:00:00.000Z",
       });
       await context.repositories.projectDimensions.upsert({
         projectId: "host:empty",
@@ -37,7 +37,7 @@ describe("aiKnowledge.findProjectIdsWithAiKnowledgeConfigured", () => {
         projectAlias: "Host Empty",
         source: "salesforce",
         isActive: true,
-        aiKnowledgeSyncedAt: null,
+        aiOptimizedSynthesizedAt: null,
       });
       await context.repositories.projectDimensions.upsert({
         projectId: "sub:beech",

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -162,16 +162,16 @@ export interface AiKnowledgeRepository {
   ): Promise<AiKnowledgeEntryRecord | null>;
   hasProjectNotionContent(projectId: string): Promise<boolean>;
   /**
-   * Returns the subset of input project IDs whose effective project is
-   * configured for AI knowledge — i.e. has
-   * `ai_knowledge_synced_at IS NOT NULL`. Connected sub-projects
-   * transparently hop to their host's synced timestamp (same semantics as
+   * Returns the subset of input project IDs whose effective project has had
+   * AI Knowledge synthesis run at least once — i.e.
+   * `ai_optimized_synthesized_at IS NOT NULL`. Connected sub-projects
+   * transparently hop to their host's synthesis timestamp (same semantics as
    * {@link findEffectiveProjectNotionContent} for the bulk path).
    *
    * This is the chip-facing signal (composer "Knowledge Base" indicator).
-   * It does NOT inspect `ai_knowledge_entries` cache content — a project
-   * may be configured before its cache row is populated by the next sync,
-   * and we still want the chip to show as configured.
+   * It reflects whether synthesis has produced a published AI Knowledge
+   * document, not whether the Notion -> cache sync has populated
+   * `ai_knowledge_entries`.
    */
   findProjectIdsWithAiKnowledgeConfigured(
     projectIds: readonly string[],


### PR DESCRIPTION
## Summary

- **KB chip signal** switched from `ai_knowledge_synced_at` to `ai_optimized_synthesized_at` on the effective project (with sub→host hop). The synthesis worker (PR #372) sets `ai_optimized_synthesized_at` when it publishes the synthesized AI Knowledge Notion page; `ai_knowledge_synced_at` tracks the optional Notion→cache sync, which defaults to "never" and was the wrong signal. All 4 active projects with synthesis dated 2026-05-10 now correctly show "<Project> Knowledge Base".
- **Composer toolbar pinning**: refactored `ComposerEmailSurface` so the toolbar + Send row is a sibling of the scrollable content (extracted from the editor's `toolbarFooter` slot via a new exposed command-state API on `RichTextComposerEditor`). The middle region (FROM/TO/CC/BCC/SUBJ + AI Draft + body + signature) scrolls behind the toolbar; adding CC/BCC or a long signature no longer pushes Send off-screen.

## Test plan

- [ ] Open the composer on any active project → KB chip reads "<Project Alias> Knowledge Base"
- [ ] Open the composer on a Beech volunteer thread with `forests@` selected → KB chip reads "Beech & Butternut Knowledge Base"
- [ ] Open the composer, click Cc → CC line appears, Send button still visible at modal bottom
- [ ] Add multiple CC + BCC recipients → toolbar stays pinned
- [ ] Long signature → signature scrolls behind the toolbar, toolbar always visible
- [x] `pnpm typecheck` and `pnpm lint` clean
- [x] Targeted unit tests pass (ai-knowledge-host-hop, composer-canonical-modal, stage3-composer-ui, inbox-composer-send-menu)

🤖 Generated with [Claude Code](https://claude.com/claude-code)