### PR TITLE
fix(inbox): display timestamps in America/Denver (org timezone), not UTC

### DIFF
--- a/apps/web/app/_lib/org-timezone.ts
+++ b/apps/web/app/_lib/org-timezone.ts
@@ -1,0 +1,10 @@
+/**
+ * Locked organization timezone (Adventure Scientists is HQ'd in Bozeman, MT;
+ * America/Denver covers all of Mountain Time including Bozeman). Source of
+ * truth: docs/01-core/product-core.md.
+ *
+ * Use this in every operator-facing timestamp formatter. Do NOT hardcode
+ * `timeZone: "UTC"` for display — that displays the UTC clock and confuses
+ * operators reading their local inbox.
+ */
+export const ORG_TIMEZONE = "America/Denver";

--- a/apps/web/app/inbox/_components/email-participant-header.tsx
+++ b/apps/web/app/inbox/_components/email-participant-header.tsx
@@ -7,6 +7,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import { ORG_TIMEZONE } from "@/app/_lib/org-timezone";
 import { cn } from "@/lib/utils";
 import { FOCUS_RING, TRANSITION, TYPE } from "@/app/_lib/design-tokens-v2";
 
@@ -23,7 +24,7 @@ const EXACT_TIMESTAMP_FORMATTER = new Intl.DateTimeFormat("en-US", {
   year: "numeric",
   hour: "numeric",
   minute: "2-digit",
-  timeZone: "UTC",
+  timeZone: ORG_TIMEZONE,
   timeZoneName: "short",
 });
 

--- a/apps/web/app/inbox/_components/inbox-timeline-automated-row.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-automated-row.tsx
@@ -7,6 +7,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { ORG_TIMEZONE } from "@/app/_lib/org-timezone";
 import { cn } from "@/lib/utils";
 import { TRANSITION } from "@/app/_lib/design-tokens-v2";
 
@@ -39,7 +40,7 @@ const EXACT_TIMESTAMP_FORMATTER = new Intl.DateTimeFormat("en-US", {
   year: "numeric",
   hour: "numeric",
   minute: "2-digit",
-  timeZone: "UTC",
+  timeZone: ORG_TIMEZONE,
   timeZoneName: "short",
 });
 

--- a/apps/web/app/inbox/_components/inbox-timeline-note-entry.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-note-entry.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 
+import { ORG_TIMEZONE } from "@/app/_lib/org-timezone";
 import { Button } from "@/components/ui/button";
 import {
   Popover,
@@ -28,7 +29,7 @@ const EXACT_TIMESTAMP_FORMATTER = new Intl.DateTimeFormat("en-US", {
   year: "numeric",
   hour: "numeric",
   minute: "2-digit",
-  timeZone: "UTC",
+  timeZone: ORG_TIMEZONE,
   timeZoneName: "short",
 });
 

--- a/apps/web/app/inbox/_components/inbox-timeline-system-divider.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-system-divider.tsx
@@ -1,5 +1,6 @@
 import type { ComponentType } from "react";
 
+import { ORG_TIMEZONE } from "@/app/_lib/org-timezone";
 import { cn } from "@/lib/utils";
 import { SHADOW, TONE_CLASSES, type ToneNameV2 } from "@/app/_lib/design-tokens-v2";
 
@@ -20,7 +21,7 @@ const EXACT_TIMESTAMP_FORMATTER = new Intl.DateTimeFormat("en-US", {
   year: "numeric",
   hour: "numeric",
   minute: "2-digit",
-  timeZone: "UTC",
+  timeZone: ORG_TIMEZONE,
   timeZoneName: "short",
 });
 

--- a/apps/web/app/inbox/_components/inbox-timeline.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline.tsx
@@ -18,6 +18,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { ORG_TIMEZONE } from "@/app/_lib/org-timezone";
 import { cn } from "@/lib/utils";
 import { TONE_CLASSES, TRANSITION } from "@/app/_lib/design-tokens-v2";
 import { TimelineAutomatedRow } from "./inbox-timeline-automated-row";
@@ -38,7 +39,7 @@ const EXACT_TIMESTAMP_FORMATTER = new Intl.DateTimeFormat("en-US", {
   year: "numeric",
   hour: "numeric",
   minute: "2-digit",
-  timeZone: "UTC",
+  timeZone: ORG_TIMEZONE,
   timeZoneName: "short",
 });
 

--- a/apps/web/app/inbox/_lib/format-date.ts
+++ b/apps/web/app/inbox/_lib/format-date.ts
@@ -1,4 +1,6 @@
-const RAIL_EVENT_TIME_ZONE = "America/Denver";
+import { ORG_TIMEZONE } from "@/app/_lib/org-timezone";
+
+const RAIL_EVENT_TIME_ZONE = ORG_TIMEZONE;
 
 function buildRailEventFormatters(timeZone: string) {
   return {

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -17,6 +17,7 @@ import {
   occurredAtIsBeforePlatformFullCaptureCutover,
   filterItemsAtOrAfterPlatformFullCaptureCutover,
 } from "@/app/_lib/cutover";
+import { ORG_TIMEZONE } from "@/app/_lib/org-timezone";
 
 import { INBOX_FILTERS } from "./filters";
 import { formatUtcRailEventDate } from "./format-date";
@@ -1083,7 +1084,7 @@ function formatJoinedAtLabel(createdAt: string): string {
   const formatter = new Intl.DateTimeFormat("en-US", {
     month: "short",
     year: "numeric",
-    timeZone: "UTC",
+    timeZone: ORG_TIMEZONE,
   });
 
   return `Joined ${formatter.format(new Date(createdAt))}`;
@@ -1136,13 +1137,13 @@ const BUBBLE_TIME_FORMATTER_CACHE = new Map<string, Intl.DateTimeFormat>();
 const BUBBLE_MONTH_DAY_FORMATTER = new Intl.DateTimeFormat("en-US", {
   month: "short",
   day: "numeric",
-  timeZone: "UTC",
+  timeZone: ORG_TIMEZONE,
 });
 const BUBBLE_MONTH_DAY_YEAR_FORMATTER = new Intl.DateTimeFormat("en-US", {
   month: "short",
   day: "numeric",
   year: "numeric",
-  timeZone: "UTC",
+  timeZone: ORG_TIMEZONE,
 });
 
 function bubbleDayKey(timestamp: string, timeZone: string): string {
@@ -1184,7 +1185,7 @@ function bubbleYear(timestamp: string, timeZone: string): number {
 export function formatBubbleTimestamp(
   timestamp: string,
   referenceNowIso: string,
-  timeZone: string = Intl.DateTimeFormat().resolvedOptions().timeZone,
+  timeZone: string = ORG_TIMEZONE,
 ): string {
   const targetDayKey = bubbleDayKey(timestamp, timeZone);
   const referenceDayKey = bubbleDayKey(referenceNowIso, timeZone);

--- a/apps/web/tests/unit/inbox-timeline.test.ts
+++ b/apps/web/tests/unit/inbox-timeline.test.ts
@@ -697,7 +697,7 @@ describe("InboxTimeline", () => {
     );
 
     expect(markup).toContain(">2h ago<");
-    expect(markup).toContain('title="Apr 16, 2026, 12:30 PM UTC"');
+    expect(markup).toContain('title="Apr 16, 2026, 6:30 AM MDT"');
   });
 
   it("adds wrap-anywhere behavior to expanded timeline copy", () => {


### PR DESCRIPTION
## Summary

- Extracted a shared `ORG_TIMEZONE = "America/Denver"` constant in `apps/web/app/_lib/org-timezone.ts`.
- Replaced every hardcoded `timeZone: "UTC"` in inbox display formatters (bubble header, day dividers, AUTOMATED row, note entries, system divider, bubble day/time/year formatters, Joined label) with `ORG_TIMEZONE`. Operators in Bozeman (or anywhere in Mountain Time) now see real local clock times.
- Storage and machine-readable payloads remain UTC; only operator-facing display formatters changed.

## Test plan

- [ ] Open any inbox conversation → email bubble timestamps match the local Mountain Time clock
- [ ] Day dividers, AUTOMATED rows, system event rows, and note entries all render Mountain Time
- [ ] Contact rail event timestamps continue to render correctly
- [x] `pnpm typecheck` and `pnpm lint` clean
- [x] Updated test snapshots/assertions for the new formatted time strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)