### PR TITLE
fix(composer): reconcile pending outbounds via rfc822 Message-ID first (+ backfill script)

### DIFF
--- a/apps/worker/src/ops/backfill-rfc822-reconcile.ts
+++ b/apps/worker/src/ops/backfill-rfc822-reconcile.ts
@@ -1,0 +1,147 @@
+#!/usr/bin/env tsx
+/**
+ * backfill-rfc822-reconcile
+ *
+ * Retroactive reconcile pass for pending_composer_outbounds rows that were
+ * orphaned by the pre-rfc822 fingerprint-only reconcile path. Finds rows
+ * where:
+ *   - sentRfc822MessageId IS NOT NULL
+ *   - reconciledEventId IS NULL
+ *   - status IN ('pending', 'confirmed', 'orphaned')
+ *
+ * For each, looks up gmail_message_details by rfc822MessageId, finds the
+ * matching canonical_event_ledger row, and calls markConfirmed.
+ *
+ * Usage:
+ *   pnpm --filter @as-comms/worker exec tsx src/ops/backfill-rfc822-reconcile.ts [--dry-run]
+ */
+import process from "node:process";
+
+import { type CanonicalEventRecord } from "@as-comms/contracts";
+import {
+  closeDatabaseConnection,
+  createDatabaseConnection,
+  createStage1RepositoryBundleFromConnection,
+} from "@as-comms/db";
+import type { PendingComposerOutboundRecord } from "@as-comms/domain";
+
+import { parseCliFlags, readOptionalBooleanFlag } from "./helpers.js";
+
+interface BackfillSummary {
+  readonly processed: number;
+  readonly reconciled: number;
+  readonly skipped: number;
+}
+
+function readConnectionString(env: NodeJS.ProcessEnv): string {
+  const connectionString = env.WORKER_DATABASE_URL ?? env.DATABASE_URL;
+
+  if (connectionString === undefined || connectionString.trim().length === 0) {
+    throw new Error(
+      "DATABASE_URL or WORKER_DATABASE_URL is required for this ops command.",
+    );
+  }
+
+  return connectionString;
+}
+
+async function findCanonicalOutboundEvent(input: {
+  readonly pending: PendingComposerOutboundRecord;
+  readonly repositories: ReturnType<typeof createStage1RepositoryBundleFromConnection>;
+}): Promise<CanonicalEventRecord | null> {
+  const rfc822MessageId = input.pending.sentRfc822MessageId;
+
+  if (rfc822MessageId === null) {
+    return null;
+  }
+
+  const gmailDetail =
+    await input.repositories.gmailMessageDetails.findByRfc822MessageId(
+      rfc822MessageId,
+    );
+
+  if (gmailDetail === null) {
+    return null;
+  }
+
+  return input.repositories.canonicalEvents.findBySourceEvidenceId(
+    gmailDetail.sourceEvidenceId,
+    "communication.email.outbound",
+  );
+}
+
+async function backfillRfc822Reconcile(input: {
+  readonly dryRun: boolean;
+  readonly repositories: ReturnType<typeof createStage1RepositoryBundleFromConnection>;
+}): Promise<BackfillSummary> {
+  const candidates =
+    await input.repositories.pendingOutbounds.listUnreconciledWithRfc822();
+  let reconciled = 0;
+  let skipped = 0;
+
+  for (const pending of candidates) {
+    const canonicalEvent = await findCanonicalOutboundEvent({
+      pending,
+      repositories: input.repositories,
+    });
+
+    if (canonicalEvent === null) {
+      skipped += 1;
+      console.info(
+        `[skip] pending=${pending.id} rfc822=${pending.sentRfc822MessageId ?? "null"} reason=no_match`,
+      );
+      continue;
+    }
+
+    if (input.dryRun) {
+      console.info(
+        `[dry-run] pending=${pending.id} rfc822=${pending.sentRfc822MessageId ?? "null"} canonicalEvent=${canonicalEvent.id}`,
+      );
+    } else {
+      await input.repositories.pendingOutbounds.markConfirmed(pending.id, {
+        reconciledEventId: canonicalEvent.id,
+      });
+      console.info(
+        `[reconciled] pending=${pending.id} rfc822=${pending.sentRfc822MessageId ?? "null"} canonicalEvent=${canonicalEvent.id}`,
+      );
+    }
+
+    reconciled += 1;
+  }
+
+  return {
+    processed: candidates.length,
+    reconciled,
+    skipped,
+  };
+}
+
+export async function main(
+  args: readonly string[] = process.argv.slice(2),
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  const flags = parseCliFlags(args);
+  const dryRun = readOptionalBooleanFlag(flags, "dry-run", false);
+  const connection = createDatabaseConnection({
+    connectionString: readConnectionString(env),
+  });
+
+  try {
+    const repositories = createStage1RepositoryBundleFromConnection(connection);
+    const summary = await backfillRfc822Reconcile({
+      dryRun,
+      repositories,
+    });
+
+    console.info(
+      `Processed ${String(summary.processed)} candidates, reconciled ${String(summary.reconciled)}, skipped ${String(summary.skipped)} (no match).`,
+    );
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}
+
+void main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -1591,6 +1591,21 @@ function createStage1RepositoriesInternal(
         return row === undefined ? null : mapCanonicalEventRow(row);
       },
 
+      async findBySourceEvidenceId(sourceEvidenceId, eventType) {
+        const [row] = await db
+          .select()
+          .from(canonicalEventLedger)
+          .where(
+            and(
+              eq(canonicalEventLedger.sourceEvidenceId, sourceEvidenceId),
+              eq(canonicalEventLedger.eventType, eventType),
+            ),
+          )
+          .limit(1);
+
+        return row === undefined ? null : mapCanonicalEventRow(row);
+      },
+
       async listByContentFingerprintWindow(input) {
         const occurredAt = new Date(input.occurredAt);
 
@@ -2823,6 +2838,17 @@ function createStage1RepositoriesInternal(
     },
 
     gmailMessageDetails: {
+      async findByRfc822MessageId(rfc822MessageId) {
+        const [row] = await db
+          .select()
+          .from(gmailMessageDetails)
+          .where(eq(gmailMessageDetails.rfc822MessageId, rfc822MessageId))
+          .orderBy(desc(gmailMessageDetails.createdAt))
+          .limit(1);
+
+        return row === undefined ? null : mapGmailMessageDetailRow(row);
+      },
+
       async listBySourceEvidenceIds(sourceEvidenceIds) {
         if (sourceEvidenceIds.length === 0) {
           return [];
@@ -3506,6 +3532,29 @@ function createStage1RepositoriesInternal(
         return row === undefined ? null : mapPendingComposerOutboundRow(row);
       },
 
+      async listUnreconciledWithRfc822() {
+        const rows = (await db
+          .select()
+          .from(pendingComposerOutbounds)
+          .where(
+            and(
+              isNotNull(pendingComposerOutbounds.sentRfc822MessageId),
+              isNull(pendingComposerOutbounds.reconciledEventId),
+              inArray(pendingComposerOutbounds.status, [
+                "pending",
+                "confirmed",
+                "orphaned",
+              ]),
+            ),
+          )
+          .orderBy(
+            desc(pendingComposerOutbounds.attemptedAt),
+            desc(pendingComposerOutbounds.createdAt),
+          )) as PendingComposerOutboundRow[];
+
+        return rows.map(mapPendingComposerOutboundRow);
+      },
+
       async markConfirmed(id, input) {
         await db
           .update(pendingComposerOutbounds)
@@ -3523,6 +3572,7 @@ function createStage1RepositoriesInternal(
               eq(pendingComposerOutbounds.id, id),
               or(
                 eq(pendingComposerOutbounds.status, "pending"),
+                eq(pendingComposerOutbounds.status, "orphaned"),
                 and(
                   eq(pendingComposerOutbounds.status, "confirmed"),
                   isNull(pendingComposerOutbounds.reconciledEventId),

--- a/packages/domain/src/normalization.ts
+++ b/packages/domain/src/normalization.ts
@@ -552,6 +552,42 @@ async function reconcilePendingComposerOutbound(
     return;
   }
 
+  const [gmailDetails] =
+    await persistence.repositories.gmailMessageDetails.listBySourceEvidenceIds([
+      input.sourceEvidence.id,
+    ]);
+  const rfc822MessageId = gmailDetails?.rfc822MessageId ?? null;
+
+  if (rfc822MessageId !== null) {
+    const pending =
+      await persistence.repositories.pendingOutbounds.findBySentRfc822MessageId(
+        rfc822MessageId,
+      );
+
+    if (
+      pending !== null &&
+      (pending.status === "pending" ||
+        pending.status === "orphaned" ||
+        (pending.status === "confirmed" && pending.reconciledEventId === null))
+    ) {
+      await persistence.repositories.pendingOutbounds.markConfirmed(pending.id, {
+        reconciledEventId: input.canonicalEvent.id,
+      });
+      logStructuredEvent({
+        event: "composer.reconciliation.matched",
+        metadata: {
+          pendingOutboundId: pending.id,
+          rfc822MessageId,
+          canonicalEventId: input.canonicalEvent.id,
+          sourceEvidenceId: input.sourceEvidence.id,
+          providerRecordId: input.sourceEvidence.providerRecordId,
+          via: "rfc822",
+        },
+      });
+      return;
+    }
+  }
+
   const fingerprint = input.canonicalEvent.contentFingerprint;
 
   if (fingerprint === null) {
@@ -559,6 +595,7 @@ async function reconcilePendingComposerOutbound(
       event: "composer.reconciliation.unmatched",
       metadata: {
         reason: "missing_fingerprint",
+        rfc822MessageId,
         canonicalEventId: input.canonicalEvent.id,
         sourceEvidenceId: input.sourceEvidence.id,
         providerRecordId: input.sourceEvidence.providerRecordId,
@@ -599,6 +636,7 @@ async function reconcilePendingComposerOutbound(
     event: "composer.reconciliation.unmatched",
     metadata: {
       fingerprint,
+      rfc822MessageId,
       canonicalEventId: input.canonicalEvent.id,
       sourceEvidenceId: input.sourceEvidence.id,
       providerRecordId: input.sourceEvidence.providerRecordId,

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -121,6 +121,10 @@ export interface CanonicalEventRepository {
   findByIdempotencyKey(
     idempotencyKey: string,
   ): Promise<CanonicalEventRecord | null>;
+  findBySourceEvidenceId(
+    sourceEvidenceId: string,
+    eventType: CanonicalEventRecord["eventType"],
+  ): Promise<CanonicalEventRecord | null>;
   listByContentFingerprintWindow(input: {
     readonly contactId: string;
     readonly channel: CanonicalEventRecord["channel"];
@@ -472,6 +476,9 @@ export interface ExpeditionDimensionRepository {
 }
 
 export interface GmailMessageDetailRepository {
+  findByRfc822MessageId(
+    rfc822MessageId: string,
+  ): Promise<GmailMessageDetailRecord | null>;
   listBySourceEvidenceIds(
     sourceEvidenceIds: readonly string[],
   ): Promise<readonly GmailMessageDetailRecord[]>;
@@ -618,6 +625,9 @@ export interface PendingComposerOutboundRepository {
   findBySentRfc822MessageId(
     messageId: string,
   ): Promise<PendingComposerOutboundRecord | null>;
+  listUnreconciledWithRfc822(): Promise<
+    readonly PendingComposerOutboundRecord[]
+  >;
   markConfirmed(
     id: string,
     input: { readonly reconciledEventId: string | null },

--- a/packages/domain/test/normalization.test.ts
+++ b/packages/domain/test/normalization.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type {
   AuditEvidenceRecord,
@@ -24,6 +24,7 @@ import type {
 } from "@as-comms/contracts";
 
 import {
+  computePendingComposerOutboundFingerprint,
   createStage1NormalizationService,
   createStage1PersistenceService,
   defineStage1RepositoryBundle,
@@ -56,6 +57,9 @@ interface TestContext {
   readonly normalization: ReturnType<typeof createStage1NormalizationService>;
   readonly getInboxProjection: () => InboxProjectionRow | null;
   readonly getInboxSaveCount: () => number;
+  readonly getPendingOutbound: (
+    id: string,
+  ) => PendingComposerOutboundRecord | null;
 }
 
 function sortEvents(
@@ -175,6 +179,74 @@ function buildExistingProjection(input: {
   };
 }
 
+function buildGmailDetail(input: {
+  readonly key: string;
+  readonly direction: GmailMessageDetailRecord["direction"];
+  readonly rfc822MessageId?: string | null;
+  readonly subject?: string | null;
+  readonly bodyTextPreview?: string;
+}): GmailMessageDetailRecord {
+  return {
+    sourceEvidenceId: `source:${input.key}`,
+    providerRecordId: `gmail:${input.key}`,
+    gmailThreadId: `thread:${input.key}`,
+    rfc822MessageId: input.rfc822MessageId ?? `<${input.key}@example.org>`,
+    direction: input.direction,
+    subject: input.subject ?? `Subject ${input.key}`,
+    fromHeader:
+      input.direction === "outbound"
+        ? "Forests <forests@adventurescientists.org>"
+        : "Volunteer <volunteer@example.org>",
+    toHeader:
+      input.direction === "outbound"
+        ? "Volunteer <volunteer@example.org>"
+        : "Forests <forests@adventurescientists.org>",
+    ccHeader: null,
+    snippetClean: input.bodyTextPreview ?? `Snippet ${input.key}`,
+    bodyTextPreview: input.bodyTextPreview ?? `Body ${input.key}`,
+    capturedMailbox: "volunteers@adventurescientists.org",
+    projectInboxAlias: "forests@adventurescientists.org",
+  };
+}
+
+function buildPendingOutbound(input: {
+  readonly id: string;
+  readonly fingerprint: string;
+  readonly status: PendingComposerOutboundRecord["status"];
+  readonly sentRfc822MessageId?: string | null;
+  readonly reconciledEventId?: string | null;
+}): PendingComposerOutboundRecord {
+  return {
+    id: input.id,
+    fingerprint: input.fingerprint,
+    status: input.status,
+    actorId: "user:operator",
+    canonicalContactId: contact.id,
+    projectId: null,
+    fromAlias: "forests@adventurescientists.org",
+    toEmailNormalized: "volunteer@example.org",
+    subject: "Pending subject",
+    bodyPlaintext: "Pending body",
+    bodyHtml: null,
+    bodySha256: "sha256:pending",
+    attachmentMetadata: [],
+    gmailThreadId: null,
+    inReplyToRfc822: null,
+    attemptedAt: "2026-04-24T10:00:00.000Z",
+    reconciledEventId: input.reconciledEventId ?? null,
+    reconciledAt:
+      input.reconciledEventId === undefined || input.reconciledEventId === null
+        ? null
+        : "2026-04-24T10:01:00.000Z",
+    failedReason: null,
+    sentRfc822MessageId: input.sentRfc822MessageId ?? null,
+    failedDetail: null,
+    orphanedAt: input.status === "orphaned" ? "2026-04-24T10:05:00.000Z" : null,
+    createdAt: "2026-04-24T10:00:00.000Z",
+    updatedAt: "2026-04-24T10:00:00.000Z",
+  };
+}
+
 function buildReplayInput(
   event: CanonicalEventRecord,
 ): NormalizedCanonicalEventIntake {
@@ -232,6 +304,8 @@ function buildContext(input: {
   readonly existingProjection?: InboxProjectionRow | null;
   readonly contacts?: readonly ContactRecord[];
   readonly contactIdentities?: readonly ContactIdentityRecord[];
+  readonly gmailMessageDetails?: readonly GmailMessageDetailRecord[];
+  readonly pendingOutbounds?: readonly PendingComposerOutboundRecord[];
   readonly sourceProvider?: SourceEvidenceRecord["provider"];
   readonly onContactIdentityUpsert?: (record: ContactIdentityRecord) => void;
   readonly onContactMembershipUpsert?: (
@@ -243,6 +317,7 @@ function buildContext(input: {
       Stage1RepositoryBundle["expeditionDimensions"]["upsert"]
     >[0],
   ) => void;
+  readonly onPendingOutboundConfirmed?: (record: PendingComposerOutboundRecord) => void;
 }): TestContext {
   const contacts = input.contacts ?? [contact];
   const contactIdentities = input.contactIdentities ?? [emailIdentity];
@@ -288,7 +363,15 @@ function buildContext(input: {
   const gmailDetailsBySourceEvidenceId = new Map<
     string,
     GmailMessageDetailRecord
-  >();
+  >(
+    (input.gmailMessageDetails ?? []).map((record) => [
+      record.sourceEvidenceId,
+      record,
+    ]),
+  );
+  const pendingOutboundsById = new Map(
+    (input.pendingOutbounds ?? []).map((record) => [record.id, record]),
+  );
   const sourceEvidenceQuarantineEntries = new Array<{
     id: string;
     provider: SourceEvidenceRecord["provider"];
@@ -383,9 +466,17 @@ function buildContext(input: {
         Promise.resolve(
           canonicalEventsByIdempotencyKey.get(idempotencyKey) ?? null,
         ),
+      findBySourceEvidenceId: (sourceEvidenceId, eventType) =>
+        Promise.resolve(
+          [...canonicalEventsById.values()].find(
+            (event) =>
+              event.sourceEvidenceId === sourceEvidenceId &&
+              event.eventType === eventType,
+          ) ?? null,
+        ),
       listByContentFingerprintWindow: () => Promise.resolve([]),
-      countAll: () => Promise.resolve(input.events.length),
-      countByPrimaryProvider: () => Promise.resolve(input.events.length),
+      countAll: () => Promise.resolve(canonicalEventsById.size),
+      countByPrimaryProvider: () => Promise.resolve(canonicalEventsById.size),
       countDistinctInboxContacts: () => Promise.resolve(1),
       listByIds: (ids) =>
         Promise.resolve(
@@ -398,13 +489,15 @@ function buildContext(input: {
       listByContactId: (contactId) =>
         Promise.resolve(
           sortEvents(
-            input.events.filter((event) => event.contactId === contactId),
+            [...canonicalEventsById.values()].filter(
+              (event) => event.contactId === contactId,
+            ),
           ),
         ),
       listByContactIds: (contactIds) =>
         Promise.resolve(
           sortEvents(
-            input.events.filter((event) =>
+            [...canonicalEventsById.values()].filter((event) =>
               contactIds.includes(event.contactId),
             ),
           ),
@@ -530,6 +623,12 @@ function buildContext(input: {
       },
     },
     gmailMessageDetails: {
+      findByRfc822MessageId: (rfc822MessageId) =>
+        Promise.resolve(
+          [...gmailDetailsBySourceEvidenceId.values()].find(
+            (record) => record.rfc822MessageId === rfc822MessageId,
+          ) ?? null,
+        ),
       listBySourceEvidenceIds: (ids) =>
         Promise.resolve(
           ids
@@ -600,16 +699,61 @@ function buildContext(input: {
     },
     pendingOutbounds: {
       insert: ({ id }) => Promise.resolve(id),
-      findByFingerprint: () =>
-        Promise.resolve<PendingComposerOutboundRecord | null>(null),
+      findByFingerprint: (fingerprint) =>
+        Promise.resolve(
+          [...pendingOutboundsById.values()].find(
+            (record) => record.fingerprint === fingerprint,
+          ) ?? null,
+        ),
       markSentRfc822: () => Promise.resolve(),
-      findBySentRfc822MessageId: () =>
-        Promise.resolve<PendingComposerOutboundRecord | null>(null),
-      markConfirmed: () => Promise.resolve(),
+      findBySentRfc822MessageId: (messageId) =>
+        Promise.resolve(
+          [...pendingOutboundsById.values()].find(
+            (record) => record.sentRfc822MessageId === messageId,
+          ) ?? null,
+        ),
+      listUnreconciledWithRfc822: () =>
+        Promise.resolve(
+          [...pendingOutboundsById.values()].filter(
+            (record) =>
+              record.sentRfc822MessageId !== null &&
+              record.reconciledEventId === null &&
+              ["pending", "confirmed", "orphaned"].includes(record.status),
+          ),
+        ),
+      markConfirmed: (id, confirmedInput) => {
+        const existing = pendingOutboundsById.get(id);
+
+        if (
+          existing === undefined ||
+          !(
+            existing.status === "pending" ||
+            existing.status === "orphaned" ||
+            (existing.status === "confirmed" &&
+              existing.reconciledEventId === null)
+          )
+        ) {
+          return Promise.resolve();
+        }
+
+        const updated: PendingComposerOutboundRecord = {
+          ...existing,
+          status: "confirmed",
+          reconciledEventId: confirmedInput.reconciledEventId,
+          reconciledAt: "2026-04-24T10:02:00.000Z",
+          failedReason: null,
+          failedDetail: null,
+          orphanedAt: null,
+          updatedAt: "2026-04-24T10:02:00.000Z",
+        };
+        pendingOutboundsById.set(id, updated);
+        input.onPendingOutboundConfirmed?.(updated);
+        return Promise.resolve();
+      },
       markFailed: () => Promise.resolve(),
       markSuperseded: () => Promise.resolve(),
       sweepOrphans: () => Promise.resolve(0),
-      findForContact: () => Promise.resolve([]),
+      findForContact: () => Promise.resolve([...pendingOutboundsById.values()]),
     },
     identityResolutionQueue: {
       findById: () => Promise.resolve(null),
@@ -738,6 +882,7 @@ function buildContext(input: {
     normalization: createStage1NormalizationService(persistence),
     getInboxProjection: () => inboxProjection,
     getInboxSaveCount: () => inboxSaveCount,
+    getPendingOutbound: (id) => pendingOutboundsById.get(id) ?? null,
   };
 }
 
@@ -1308,5 +1453,258 @@ describe("identity resolution hardening", () => {
         [contact.id, duplicateContact.id].sort(),
       );
     }
+  });
+});
+
+describe("pending composer outbound reconciliation", () => {
+  it("reconciles via rfc822 Message-ID before fingerprint matching", async () => {
+    const consoleLog = vi
+      .spyOn(console, "log")
+      .mockImplementation((entry) => void entry);
+    const event = buildEvent({
+      key: "rfc822-primary",
+      occurredAt: "2026-04-24T15:05:02.000Z",
+      direction: "outbound",
+    });
+    const context = buildContext({
+      events: [],
+      pendingOutbounds: [
+        buildPendingOutbound({
+          id: "pending:rfc822-primary",
+          fingerprint: "fp:deliberately-different",
+          status: "pending",
+          sentRfc822MessageId: "<matched-rfc822@example.org>",
+        }),
+      ],
+    });
+
+    const result = await context.normalization.applyNormalizedCanonicalEvent({
+      ...buildReplayInput(event),
+      gmailMessageDetail: buildGmailDetail({
+        key: "rfc822-primary",
+        direction: "outbound",
+        rfc822MessageId: "<matched-rfc822@example.org>",
+        subject: "Project Inquiry",
+        bodyTextPreview: "Thanks for reaching out about the project.",
+      }),
+    });
+
+    expect(result.outcome).toBe("applied");
+    if (result.outcome !== "applied") {
+      throw new Error("Expected applied result.");
+    }
+
+    expect(context.getPendingOutbound("pending:rfc822-primary")).toMatchObject({
+      status: "confirmed",
+      reconciledEventId: result.canonicalEvent.id,
+    });
+
+    const matchedLog = consoleLog.mock.calls
+      .map(([entry]) => JSON.parse(String(entry)) as Record<string, unknown>)
+      .find((entry) => entry.event === "composer.reconciliation.matched");
+
+    expect(matchedLog).toMatchObject({
+      pendingOutboundId: "pending:rfc822-primary",
+      rfc822MessageId: "<matched-rfc822@example.org>",
+      via: "rfc822",
+    });
+
+    consoleLog.mockRestore();
+  });
+
+  it("falls back to fingerprint matching when the Gmail detail has no rfc822 Message-ID", async () => {
+    const consoleLog = vi
+      .spyOn(console, "log")
+      .mockImplementation((entry) => void entry);
+    const subject = "Fallback subject";
+    const body = "Fallback body";
+    const occurredAt = "2026-04-24T15:04:00.000Z";
+    const event = buildEvent({
+      key: "fingerprint-fallback-missing-rfc822",
+      occurredAt,
+      direction: "outbound",
+    });
+    const fingerprint = computePendingComposerOutboundFingerprint({
+      contactId: contact.id,
+      subject,
+      bodyPlaintext: body,
+      sentAt: occurredAt,
+    });
+
+    if (fingerprint === null) {
+      throw new Error("Expected fingerprint to be computed for pending outbound.");
+    }
+
+    const context = buildContext({
+      events: [],
+      pendingOutbounds: [
+        buildPendingOutbound({
+          id: "pending:fingerprint-fallback-missing-rfc822",
+          fingerprint,
+          status: "pending",
+        }),
+      ],
+    });
+
+    const result = await context.normalization.applyNormalizedCanonicalEvent({
+      ...buildReplayInput(event),
+      gmailMessageDetail: buildGmailDetail({
+        key: "fingerprint-fallback-missing-rfc822",
+        direction: "outbound",
+        rfc822MessageId: null,
+        subject,
+        bodyTextPreview: body,
+      }),
+    });
+
+    expect(result.outcome).toBe("applied");
+    if (result.outcome !== "applied") {
+      throw new Error("Expected applied result.");
+    }
+
+    expect(
+      context.getPendingOutbound("pending:fingerprint-fallback-missing-rfc822"),
+    ).toMatchObject({
+      status: "confirmed",
+      reconciledEventId: result.canonicalEvent.id,
+    });
+
+    const matchedLog = consoleLog.mock.calls
+      .map(([entry]) => JSON.parse(String(entry)) as Record<string, unknown>)
+      .find((entry) => entry.event === "composer.reconciliation.matched");
+
+    expect(matchedLog).toMatchObject({
+      pendingOutboundId: "pending:fingerprint-fallback-missing-rfc822",
+      fingerprint,
+      via: "fingerprint",
+    });
+
+    consoleLog.mockRestore();
+  });
+
+  it("falls back to fingerprint matching when rfc822 is present but no pending row matches it", async () => {
+    const consoleLog = vi
+      .spyOn(console, "log")
+      .mockImplementation((entry) => void entry);
+    const subject = "Fingerprint fallback despite rfc822";
+    const body = "Body that should still fingerprint-match.";
+    const occurredAt = "2026-04-24T15:06:00.000Z";
+    const event = buildEvent({
+      key: "fingerprint-fallback-rfc822-miss",
+      occurredAt,
+      direction: "outbound",
+    });
+    const fingerprint = computePendingComposerOutboundFingerprint({
+      contactId: contact.id,
+      subject,
+      bodyPlaintext: body,
+      sentAt: occurredAt,
+    });
+
+    if (fingerprint === null) {
+      throw new Error("Expected fingerprint to be computed for pending outbound.");
+    }
+
+    const context = buildContext({
+      events: [],
+      pendingOutbounds: [
+        buildPendingOutbound({
+          id: "pending:fingerprint-fallback-rfc822-miss",
+          fingerprint,
+          status: "pending",
+          sentRfc822MessageId: "<different-rfc822@example.org>",
+        }),
+      ],
+    });
+
+    const result = await context.normalization.applyNormalizedCanonicalEvent({
+      ...buildReplayInput(event),
+      gmailMessageDetail: buildGmailDetail({
+        key: "fingerprint-fallback-rfc822-miss",
+        direction: "outbound",
+        rfc822MessageId: "<unmatched-rfc822@example.org>",
+        subject,
+        bodyTextPreview: body,
+      }),
+    });
+
+    expect(result.outcome).toBe("applied");
+    if (result.outcome !== "applied") {
+      throw new Error("Expected applied result.");
+    }
+
+    expect(
+      context.getPendingOutbound("pending:fingerprint-fallback-rfc822-miss"),
+    ).toMatchObject({
+      status: "confirmed",
+      reconciledEventId: result.canonicalEvent.id,
+    });
+
+    const matchedLog = consoleLog.mock.calls
+      .map(([entry]) => JSON.parse(String(entry)) as Record<string, unknown>)
+      .find((entry) => entry.event === "composer.reconciliation.matched");
+
+    expect(matchedLog).toMatchObject({
+      pendingOutboundId: "pending:fingerprint-fallback-rfc822-miss",
+      fingerprint,
+      via: "fingerprint",
+    });
+
+    consoleLog.mockRestore();
+  });
+
+  it("does not reconfirm a pending row that is already linked to another canonical event", async () => {
+    const consoleLog = vi
+      .spyOn(console, "log")
+      .mockImplementation((entry) => void entry);
+    const confirmedRows: PendingComposerOutboundRecord[] = [];
+    const event = buildEvent({
+      key: "already-linked-rfc822",
+      occurredAt: "2026-04-24T15:07:00.000Z",
+      direction: "outbound",
+    });
+    const context = buildContext({
+      events: [],
+      pendingOutbounds: [
+        buildPendingOutbound({
+          id: "pending:already-linked-rfc822",
+          fingerprint: "fp:already-linked",
+          status: "confirmed",
+          sentRfc822MessageId: "<already-linked@example.org>",
+          reconciledEventId: "event:existing-link",
+        }),
+      ],
+      onPendingOutboundConfirmed: (record) => {
+        confirmedRows.push(record);
+      },
+    });
+
+    const result = await context.normalization.applyNormalizedCanonicalEvent({
+      ...buildReplayInput(event),
+      gmailMessageDetail: buildGmailDetail({
+        key: "already-linked-rfc822",
+        direction: "outbound",
+        rfc822MessageId: "<already-linked@example.org>",
+        subject: "Already linked subject",
+        bodyTextPreview: "Already linked body",
+      }),
+    });
+
+    expect(result.outcome).toBe("applied");
+    expect(confirmedRows).toHaveLength(0);
+    expect(context.getPendingOutbound("pending:already-linked-rfc822")).toMatchObject(
+      {
+        status: "confirmed",
+        reconciledEventId: "event:existing-link",
+      },
+    );
+
+    const matchedLog = consoleLog.mock.calls
+      .map(([entry]) => JSON.parse(String(entry)) as Record<string, unknown>)
+      .find((entry) => entry.event === "composer.reconciliation.matched");
+
+    expect(matchedLog).toBeUndefined();
+
+    consoleLog.mockRestore();
   });
 });

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -44,6 +44,7 @@ describe("defineStage1RepositoryBundle", () => {
       canonicalEvents: {
         findById: () => Promise.resolve(null),
         findByIdempotencyKey: () => Promise.resolve(null),
+        findBySourceEvidenceId: () => Promise.resolve(null),
         listByContentFingerprintWindow: () => Promise.resolve([]),
         countAll: () => Promise.resolve(0),
         countByPrimaryProvider: () => Promise.resolve(0),
@@ -134,6 +135,7 @@ describe("defineStage1RepositoryBundle", () => {
         upsert: (record) => Promise.resolve(record),
       },
       gmailMessageDetails: {
+        findByRfc822MessageId: () => Promise.resolve(null),
         listBySourceEvidenceIds: () => Promise.resolve([]),
         listLastInboundAliasByContactIds: () => Promise.resolve(new Map()),
         upsert: (record) => Promise.resolve(record),
@@ -195,6 +197,7 @@ describe("defineStage1RepositoryBundle", () => {
         markSentRfc822: () => Promise.resolve(),
         findBySentRfc822MessageId: () =>
           Promise.resolve<PendingComposerOutboundRecord | null>(null),
+        listUnreconciledWithRfc822: () => Promise.resolve([]),
         markConfirmed: () => Promise.resolve(),
         markFailed: () => Promise.resolve(),
         markSuperseded: () => Promise.resolve(),

--- a/packages/domain/test/stage3-last-inbound-alias.test.ts
+++ b/packages/domain/test/stage3-last-inbound-alias.test.ts
@@ -53,6 +53,7 @@ function buildRepositoryBundle(input: {
     canonicalEvents: {
       findById: () => Promise.resolve(null),
       findByIdempotencyKey: () => Promise.resolve(null),
+      findBySourceEvidenceId: () => Promise.resolve(null),
       listByContentFingerprintWindow: () => Promise.resolve([]),
       countAll: () => Promise.resolve(input.canonicalEvents.length),
       countByPrimaryProvider: () => Promise.resolve(0),
@@ -153,6 +154,7 @@ function buildRepositoryBundle(input: {
       upsert: (record) => Promise.resolve(record),
     },
     gmailMessageDetails: {
+      findByRfc822MessageId: () => Promise.resolve(null),
       listBySourceEvidenceIds: (sourceEvidenceIds) =>
         Promise.resolve(
           input.gmailDetails.filter((detail) =>
@@ -219,6 +221,7 @@ function buildRepositoryBundle(input: {
       markSentRfc822: () => Promise.resolve(),
       findBySentRfc822MessageId: () =>
         Promise.resolve<PendingComposerOutboundRecord | null>(null),
+      listUnreconciledWithRfc822: () => Promise.resolve([]),
       markConfirmed: () => Promise.resolve(),
       markFailed: () => Promise.resolve(),
       markSuperseded: () => Promise.resolve(),

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -124,6 +124,7 @@ function createRepositoryBundle(input: {
     canonicalEvents: {
       findById: (id) => Promise.resolve(canonicalEventsById.get(id) ?? null),
       findByIdempotencyKey: () => Promise.resolve(null),
+      findBySourceEvidenceId: () => Promise.resolve(null),
       listByContentFingerprintWindow: () => Promise.resolve([]),
       countAll: () => Promise.resolve(input.canonicalEvents.length),
       countByPrimaryProvider: () => Promise.resolve(0),
@@ -230,6 +231,7 @@ function createRepositoryBundle(input: {
       upsert: (record) => Promise.resolve(record),
     },
     gmailMessageDetails: {
+      findByRfc822MessageId: () => Promise.resolve(null),
       listBySourceEvidenceIds: (sourceEvidenceIds) =>
         Promise.resolve(
           sourceEvidenceIds.flatMap((sourceEvidenceId) => {
@@ -334,6 +336,7 @@ function createRepositoryBundle(input: {
       findByFingerprint: () => Promise.resolve(null),
       markSentRfc822: () => Promise.resolve(),
       findBySentRfc822MessageId: () => Promise.resolve(null),
+      listUnreconciledWithRfc822: () => Promise.resolve([]),
       markConfirmed: () => Promise.resolve(),
       markFailed: () => Promise.resolve(),
       markSuperseded: () => Promise.resolve(),


### PR DESCRIPTION
## Summary

- `reconcilePendingComposerOutbound` now attempts an **rfc822 Message-ID lookup** (`gmail_message_details.rfc822_message_id` ↔ `pending_composer_outbounds.sent_rfc822_message_id`) BEFORE falling back to content-fingerprint matching. Closes the dedup gap flagged in memory `project_dedup_architecture_debt`. Fixes the operator-reported case where a single Gmail send produces two timeline bubbles (one real, one stuck pending) because the composer's `attemptedAt` and Gmail's `Date:` header cross a minute boundary.
- One-time backfill ops script at `apps/worker/src/ops/backfill-rfc822-reconcile.ts` retroactively reconciles existing stuck pending rows that have `sentRfc822MessageId` set but `reconciledEventId === null`. Supports `--dry-run`.

## Test plan

- [ ] After deploy, send a fresh composer email → verify the timeline shows ONE bubble (not two)
- [ ] Dry-run the backfill against production to count stuck pendings: `pnpm --filter @as-comms/worker exec tsx src/ops/backfill-rfc822-reconcile.ts --dry-run`
- [ ] Run backfill for real → existing stuck duplicates (e.g. Tiffany Lirones "Project Inquiry" from 2026-05-13) collapse to one bubble
- [x] `pnpm typecheck` and `pnpm lint` clean
- [x] Targeted reconcile tests cover rfc822-match, fallback-to-fingerprint, double-confirm prevention

🤖 Generated with [Claude Code](https://claude.com/claude-code)