### PR TITLE
docs(auth): codify Stage 5 trusted-admin model in requireAdmin JSDoc

### DIFF
--- a/apps/web/src/server/auth/session.ts
+++ b/apps/web/src/server/auth/session.ts
@@ -86,6 +86,27 @@ export async function requireSession(): Promise<UserRecord> {
   return user;
 }
 
+/**
+ * Returns the current user if they have the `admin` role; throws `FORBIDDEN` otherwise.
+ *
+ * Trust model (Stage 5+): admins are **globally trusted across all projects**.
+ * Campaign actions, audience reads, run mutations, and Stage 5A wizard server actions
+ * rely on this helper for authorization and DO NOT perform per-project membership
+ * checks against `project_id`. This is intentional — the operator pool is 1–3 internal
+ * staff who all need access to every project for triage and broadcast review (see
+ * `project_operator_scale.md` in the architect's auto-memory).
+ *
+ * The overnight broadcasts security review (2026-05-19,
+ * `.codex-worktrees/broadcasts-overnight-review/REVIEW-FINDINGS-2026-05-19.md`)
+ * flagged the absence of resource-level project authorization as a P0 — the architect
+ * reviewed and accepted that risk because the trust model above makes per-project
+ * gating cost without benefit at current scale.
+ *
+ * If the trust model changes (operator pool grows past ~5, or a project needs
+ * isolation from other admins), this is the choke point: add a project-membership
+ * check here or at every campaign action entry. `git grep requireAdmin` enumerates
+ * the callers.
+ */
 export async function requireAdmin(): Promise<UserRecord> {
   const user = await requireSession();
   if (user.role !== "admin") {


### PR DESCRIPTION
## Summary

Pure documentation change. No behavior modified.

The overnight broadcasts security review (`.codex-worktrees/broadcasts-overnight-review/REVIEW-FINDINGS-2026-05-19.md`) flagged the absence of resource-level project authorization across campaign actions as a P0 security finding. After reviewing, the architect accepted that risk because the operator pool is 1–3 internal staff who all need access to every project — per-project gating costs operational friction without buying real isolation at current scale.

This PR codifies that decision at the auth choke point so future reviewers (human or LLM) don't keep flagging it as an unsupervised gap.

## What changes

- `apps/web/src/server/auth/session.ts`: JSDoc on `requireAdmin()` explaining the trust model, citing `project_operator_scale.md` and the review file, and naming `requireAdmin` itself as the future choke point to retrofit per-project membership checks if the operator pool grows past ~5 or a project needs isolation.

## What does NOT change

- Behavior of `requireAdmin` / `requireSession` / `getCurrentUser`
- Any call site of these helpers
- Anywhere downstream of them

## Validation

- `pnpm --filter @as-comms/web typecheck` — passed
- `pnpm --filter @as-comms/web lint` — passed

## Why this matters

Without this note, the next pass of a security tool (Codex, vibecoder-review, ultrareview, even Claude's own review skill) will re-flag the missing per-project authz as a P0. Writing the decision down once means we don't pay that triage tax repeatedly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)