### PR TITLE
feat(wizard): strict mode-conditional Step 3 + alias-scoped search + Continue gated at audience=0

### DIFF
--- a/apps/web/app/broadcasts/_lib/audience-data-source.ts
+++ b/apps/web/app/broadcasts/_lib/audience-data-source.ts
@@ -824,18 +824,18 @@ export async function loadComposePreviewAction(input: {
 }
 
 export async function searchProjectVolunteersAction(input: {
-  readonly projectIds: readonly string[];
+  readonly aliasProjectIds: readonly string[];
   readonly query: string;
 }): Promise<UiResult<readonly AudienceVolunteerSearchRow[]>> {
   await requireSession();
 
-  const projectIds = input.projectIds
+  const aliasProjectIds = input.aliasProjectIds
     .map((projectId) => projectId.trim())
     .filter((projectId, index, values) => {
       return projectId.length > 0 && values.indexOf(projectId) === index;
     });
   const query = input.query.trim();
-  if (projectIds.length === 0 || query.length < 2) {
+  if (aliasProjectIds.length === 0 || query.length < 2) {
     return successResult([]);
   }
 
@@ -855,12 +855,12 @@ export async function searchProjectVolunteersAction(input: {
         contacts.map((contact) => contact.id),
       );
     const projects = await runtime.repositories.projectDimensions.listByIds(
-      projectIds,
+      aliasProjectIds,
     );
     const projectsById = new Map(
       projects.map((project) => [project.projectId, project] as const),
     );
-    const selectedProjectIds = new Set(projectIds);
+    const selectedProjectIds = new Set(aliasProjectIds);
     const membershipsByContact = new Map<
       string,
       (typeof memberships)[number][]

--- a/apps/web/app/broadcasts/new/_components/audience-builder-step.tsx
+++ b/apps/web/app/broadcasts/new/_components/audience-builder-step.tsx
@@ -25,7 +25,7 @@ import type {
   AudiencePreviewRow,
   AudienceStatusCounts,
   AudienceVolunteerSearchRow,
-  CampaignProjectGroup,
+  CampaignProjectOption,
 } from "../../_lib/audience-data-source";
 import { AudienceFilterPanel } from "./audience-filter-panel";
 import { AudiencePreviewList } from "./audience-preview-list";
@@ -72,7 +72,7 @@ interface AudienceBuilderStepProps {
   readonly volunteerSearchRows: readonly AudienceVolunteerSearchRow[];
   readonly volunteerSearchLoading: boolean;
   readonly volunteerSearchErrorMessage: string | null;
-  readonly projectGroups: readonly CampaignProjectGroup[];
+  readonly projectOptions: readonly CampaignProjectOption[];
   readonly statusOptions: readonly ExpeditionMemberStatus[];
   readonly statusCounts: AudienceStatusCounts;
   readonly statusCountsErrorMessage: string | null;
@@ -98,7 +98,7 @@ export function AudienceBuilderStep({
   volunteerSearchRows,
   volunteerSearchLoading,
   volunteerSearchErrorMessage,
-  projectGroups,
+  projectOptions,
   statusOptions,
   statusCounts,
   statusCountsErrorMessage,
@@ -112,6 +112,18 @@ export function AudienceBuilderStep({
   onContinue,
 }: AudienceBuilderStepProps) {
   const initialFilter = criteria.initialFilter ?? "project_status";
+  const canContinue =
+    initialFilter === "project_status"
+      ? [
+          ...(criteria.projectId == null ? [] : [criteria.projectId]),
+          ...criteria.projectIds,
+        ].filter((projectId, index, values) => values.indexOf(projectId) === index)
+          .length > 0 &&
+        criteria.statuses.length > 0 &&
+        countState.count > 0
+      : initialFilter === "specific"
+        ? (criteria.contactIds?.length ?? 0) > 0 && countState.count > 0
+        : countState.count > 0;
 
   return (
     <section className="flex h-full flex-col">
@@ -141,7 +153,7 @@ export function AudienceBuilderStep({
           <>
             <AudienceFilterPanel
               criteria={criteria}
-              projectGroups={projectGroups}
+              projectOptions={projectOptions}
               statusOptions={statusOptions}
               statusCounts={statusCounts}
               statusCountsErrorMessage={statusCountsErrorMessage}
@@ -155,28 +167,11 @@ export function AudienceBuilderStep({
               loading={previewLoading}
               errorMessage={previewErrorMessage}
             />
-
-            <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2.5 text-[11.5px] text-slate-600">
-              Always auto-excluded: unsubscribed contacts, hard-bounced
-              addresses, and anyone without an email on file.
-            </div>
           </>
         ) : null}
 
         {initialFilter === "specific" ? (
           <>
-            <AudienceFilterPanel
-              criteria={criteria}
-              projectGroups={projectGroups}
-              statusOptions={statusOptions}
-              statusCounts={statusCounts}
-              statusCountsErrorMessage={statusCountsErrorMessage}
-              showStatusSection={false}
-              onProjectChange={onProjectChange}
-              onSelectAllStatuses={onSelectAllStatuses}
-              onStatusToggle={onStatusToggle}
-            />
-
             <SpecificVolunteerSelector
               criteria={criteria}
               query={volunteerSearchQuery}
@@ -192,11 +187,6 @@ export function AudienceBuilderStep({
               loading={previewLoading}
               errorMessage={previewErrorMessage}
             />
-
-            <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2.5 text-[11.5px] text-slate-600">
-              Always auto-excluded: unsubscribed contacts, hard-bounced
-              addresses, and anyone without an email on file.
-            </div>
           </>
         ) : null}
 
@@ -222,7 +212,17 @@ export function AudienceBuilderStep({
         <Button variant="outline" onClick={onBack}>
           Back
         </Button>
-        <Button onClick={onContinue}>Continue to compose</Button>
+        <Button
+          onClick={() => {
+            if (canContinue) {
+              onContinue();
+            }
+          }}
+          aria-disabled={!canContinue}
+          disabled={!canContinue}
+        >
+          Continue to compose
+        </Button>
       </div>
     </section>
   );
@@ -386,7 +386,7 @@ function SpecificVolunteerSelector({
   if (selectedProjectIds.length === 0) {
     return (
       <section className="rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-4 text-[12.5px] text-slate-600">
-        Select at least one project above to find volunteers.
+        No sender-scoped projects are available for volunteer search.
       </section>
     );
   }
@@ -425,11 +425,11 @@ function SpecificVolunteerSelector({
           </div>
         ) : query.trim().length < 2 ? (
           <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-4 text-[12px] text-slate-500">
-            Type at least 2 characters to search within the selected projects.
+            Type at least 2 characters to search within this sender alias.
           </div>
         ) : rows.length === 0 ? (
           <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-4 text-[12px] text-slate-500">
-            No matching volunteers found in the selected projects.
+            No matching volunteers found for this sender alias.
           </div>
         ) : (
           <div

--- a/apps/web/app/broadcasts/new/_components/audience-filter-panel.tsx
+++ b/apps/web/app/broadcasts/new/_components/audience-filter-panel.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { Check } from "lucide-react";
+import { Check, Lock } from "lucide-react";
 
 import {
   FOCUS_RING,
   RADIUS,
-  SHADOW,
   TONE_CLASSES,
   TRANSITION,
   type ToneNameV2,
@@ -16,7 +15,7 @@ import { cn } from "@/lib/utils";
 
 import type {
   AudienceStatusCounts,
-  CampaignProjectGroup,
+  CampaignProjectOption,
 } from "../../_lib/audience-data-source";
 import type { CampaignAudienceCriteria } from "./audience-builder-step";
 
@@ -71,7 +70,7 @@ const SELECTED_RING_CLASSES: Record<ToneNameV2, string> = {
 
 interface AudienceFilterPanelProps {
   readonly criteria: CampaignAudienceCriteria;
-  readonly projectGroups: readonly CampaignProjectGroup[];
+  readonly projectOptions: readonly CampaignProjectOption[];
   readonly statusOptions: readonly ExpeditionMemberStatus[];
   readonly statusCounts: AudienceStatusCounts;
   readonly statusCountsErrorMessage: string | null;
@@ -84,7 +83,7 @@ interface AudienceFilterPanelProps {
 
 export function AudienceFilterPanel({
   criteria,
-  projectGroups,
+  projectOptions,
   statusOptions,
   statusCounts,
   statusCountsErrorMessage,
@@ -106,6 +105,8 @@ export function AudienceFilterPanel({
     populatedStatuses.length > 0 &&
     populatedStatuses.every((status) => criteria.statuses.includes(status));
   const knownStatuses = new Set(statusOptions);
+  const projectAliasHint = projectOptions[0]?.aliasHint ?? null;
+  const hasSingleLockedProject = projectOptions.length === 1;
   const stageSections = Object.values(STAGE_GROUPS)
     .map((group) => {
       const statuses = group.statuses.filter(
@@ -136,32 +137,33 @@ export function AudienceFilterPanel({
         {showProjectSection ? (
           <FilterSection
             title="Project"
-            description="Connected sub-projects stay separate choices even when they share the same alias."
+            {...(projectAliasHint === null
+              ? {}
+              : {
+                  description: hasSingleLockedProject
+                    ? `Inherited from ${projectAliasHint}`
+                    : `Inherited from ${projectAliasHint} · pick one or more sub-projects`,
+                })}
           >
-            <div className="space-y-2">
-              {projectGroups.map((group) => (
-                <div key={group.host.id} className="space-y-2">
-                  <ProjectOptionRow
-                    id={group.host.id}
-                    name={group.host.name}
-                    aliasHint={group.host.aliasHint}
-                    selected={selectedProjectIdSet.has(group.host.id)}
+            <div className="flex flex-wrap gap-2">
+              {projectOptions.map((project) =>
+                hasSingleLockedProject ? (
+                  <LockedProjectPill
+                    key={project.id}
+                    name={project.name}
+                    aliasHint={project.aliasHint}
+                  />
+                ) : (
+                  <ProjectOptionPill
+                    key={project.id}
+                    id={project.id}
+                    name={project.name}
+                    aliasHint={project.aliasHint}
+                    selected={selectedProjectIdSet.has(project.id)}
                     onSelect={onProjectChange}
                   />
-                  {group.connectedSubs.map((subProject) => (
-                    <div key={subProject.id} className="pl-5">
-                      <ProjectOptionRow
-                        id={subProject.id}
-                        name={subProject.name}
-                        aliasHint={subProject.aliasHint}
-                        selected={selectedProjectIdSet.has(subProject.id)}
-                        onSelect={onProjectChange}
-                        isSubProject
-                      />
-                    </div>
-                  ))}
-                </div>
-              ))}
+                ),
+              )}
             </div>
           </FilterSection>
         ) : null}
@@ -254,20 +256,18 @@ function FilterSection({
   );
 }
 
-function ProjectOptionRow({
+function ProjectOptionPill({
   id,
   name,
   aliasHint,
   selected,
   onSelect,
-  isSubProject = false,
 }: {
   readonly id: string;
   readonly name: string;
   readonly aliasHint: string | null;
   readonly selected: boolean;
   readonly onSelect: (projectId: string) => void;
-  readonly isSubProject?: boolean;
 }) {
   return (
     <button
@@ -278,37 +278,52 @@ function ProjectOptionRow({
         onSelect(id);
       }}
       className={cn(
-        `flex w-full items-start gap-3 border px-3 py-3 text-left ${RADIUS.lg} ${SHADOW.sm} ${TRANSITION.fast} ${FOCUS_RING}`,
+        `inline-flex items-center gap-2.5 px-3 py-2 text-left text-[12px] font-semibold ${RADIUS.full} ${TRANSITION.fast} ${FOCUS_RING}`,
         selected
-          ? "border-slate-950 bg-slate-50 ring-1 ring-slate-950/10"
-          : "border-slate-200 bg-white hover:border-slate-300 hover:bg-slate-50",
+          ? "bg-slate-900 text-white ring-1 ring-slate-900"
+          : "bg-slate-50 text-slate-700 ring-1 ring-slate-200 hover:bg-slate-100 hover:text-slate-900",
       )}
     >
-      <span
-        className={cn(
-          "mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full border",
-          selected ? "border-slate-950" : "border-slate-300",
-        )}
-        aria-hidden="true"
-      >
-        {selected ? <Check className="size-3 text-slate-950" /> : null}
-      </span>
-      <span className="min-w-0">
+      {selected ? <Check className="size-3.5 shrink-0" aria-hidden="true" /> : null}
+      <span className="min-w-0 truncate">{name}</span>
+      {aliasHint ? (
         <span
           className={cn(
-            "block text-[12.5px] text-slate-900",
-            isSubProject ? "font-medium" : "font-semibold",
+            "shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
+            selected
+              ? "bg-white/15 text-white"
+              : "bg-white text-slate-500 ring-1 ring-slate-200",
           )}
         >
-          {name}
+          {aliasHint}
         </span>
-        {aliasHint ? (
-          <span className="mt-0.5 block text-[11px] text-slate-500">
-            {aliasHint}
-          </span>
-        ) : null}
-      </span>
+      ) : null}
     </button>
+  );
+}
+
+function LockedProjectPill({
+  name,
+  aliasHint,
+}: {
+  readonly name: string;
+  readonly aliasHint: string | null;
+}) {
+  return (
+    <div
+      className={cn(
+        `inline-flex items-center gap-2.5 bg-slate-100 px-3 py-2 text-[12px] font-semibold text-slate-700 ring-1 ring-slate-200 ${RADIUS.full}`,
+      )}
+      aria-label={`Project ${name} is locked to this sender alias`}
+    >
+      <Lock className="size-3.5 shrink-0 text-slate-500" aria-hidden="true" />
+      <span className="min-w-0 truncate">{name}</span>
+      {aliasHint ? (
+        <span className="shrink-0 rounded-full bg-white px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-slate-500 ring-1 ring-slate-200">
+          {aliasHint}
+        </span>
+      ) : null}
+    </div>
   );
 }
 

--- a/apps/web/app/broadcasts/new/_components/new-campaign-wizard.tsx
+++ b/apps/web/app/broadcasts/new/_components/new-campaign-wizard.tsx
@@ -457,6 +457,10 @@ export function NewCampaignWizard({
     () => readAliasProjectsForSender(bootstrap, selectedSenderOption),
     [bootstrap, selectedSenderOption],
   );
+  const aliasProjectIds = useMemo(
+    () => normalizeProjectIds(aliasProjects.map((project) => project.id)),
+    [aliasProjects],
+  );
   const kind = kindForAudienceMode(criteria.initialFilter ?? "project_status");
   const fingerprint = useMemo(
     () =>
@@ -715,7 +719,7 @@ export function NewCampaignWizard({
       return;
     }
 
-    if (selectedProjectIds.length === 0 || volunteerSearchQuery.trim().length < 2) {
+    if (aliasProjectIds.length === 0 || volunteerSearchQuery.trim().length < 2) {
       setVolunteerSearchRows([]);
       setVolunteerSearchErrorMessage(null);
       return;
@@ -725,7 +729,7 @@ export function NewCampaignWizard({
     const timer = setTimeout(() => {
       startVolunteerSearchTransition(async () => {
         const result = await searchProjectVolunteersAction({
-          projectIds: selectedProjectIds,
+          aliasProjectIds,
           query: volunteerSearchQuery,
         });
         if (requestId !== volunteerSearchRequestRef.current) {
@@ -746,9 +750,9 @@ export function NewCampaignWizard({
       clearTimeout(timer);
     };
   }, [
+    aliasProjectIds,
     criteria.initialFilter,
     currentStep,
-    selectedProjectIds,
     volunteerSearchQuery,
   ]);
 
@@ -1145,7 +1149,7 @@ export function NewCampaignWizard({
                 volunteerSearchRows={volunteerSearchRows}
                 volunteerSearchLoading={volunteerSearchPending}
                 volunteerSearchErrorMessage={volunteerSearchErrorMessage}
-                projectGroups={bootstrap.projects}
+                projectOptions={aliasProjects}
                 statusOptions={bootstrap.statuses}
                 statusCounts={statusCounts}
                 statusCountsErrorMessage={statusCountsErrorMessage}

--- a/apps/web/tests/unit/campaign-audience-filter-panel.test.tsx
+++ b/apps/web/tests/unit/campaign-audience-filter-panel.test.tsx
@@ -9,6 +9,7 @@ Object.assign(globalThis, { React });
 
 vi.mock("lucide-react", () => ({
   Check: () => null,
+  Lock: () => null,
 }));
 
 import { AudienceFilterPanel } from "../../app/broadcasts/new/_components/audience-filter-panel";
@@ -60,8 +61,8 @@ function renderPanel(overrides: Partial<React.ComponentProps<typeof AudienceFilt
 
   const props: React.ComponentProps<typeof AudienceFilterPanel> = {
     criteria: {
-      projectId: "host-project",
-      projectIds: ["host-project"],
+      projectId: "project-a",
+      projectIds: ["project-a", "project-b"],
       statuses: [],
       contactIds: [],
       expeditionIds: [],
@@ -69,26 +70,22 @@ function renderPanel(overrides: Partial<React.ComponentProps<typeof AudienceFilt
       hasReplied: "either",
       hasClicked: "either",
     },
-    projectGroups: [
+    projectOptions: [
       {
-        host: {
-          id: "host-project",
-          name: "Forests",
-          alias: "forests",
-          aliasHint: "forests@",
-          connectedToProjectId: null,
-          isSubProject: false,
-        },
-        connectedSubs: [
-          {
-            id: "sub-project",
-            name: "Butternut Canker",
-            alias: null,
-            aliasHint: "forests@",
-            connectedToProjectId: "host-project",
-            isSubProject: true,
-          },
-        ],
+        id: "project-a",
+        name: "Restoring Butternut Forest Health",
+        alias: null,
+        aliasHint: "forests@",
+        connectedToProjectId: "host-project",
+        isSubProject: true,
+      },
+      {
+        id: "project-b",
+        name: "Saving American Beech",
+        alias: null,
+        aliasHint: "forests@",
+        connectedToProjectId: "host-project",
+        isSubProject: true,
       },
     ],
     statusOptions: ["Waitlist", "In Progress", "Denied"],
@@ -127,17 +124,20 @@ describe("AudienceFilterPanel", () => {
 
     expect(
       Array.from(document.querySelectorAll("button")).some(
-        (button) => button.getAttribute("aria-label") === "Choose project Forests",
+        (button) =>
+          button.getAttribute("aria-label") ===
+          "Choose project Restoring Butternut Forest Health",
       ),
     ).toBe(true);
     expect(
       Array.from(document.querySelectorAll("button")).some(
         (button) =>
           button.getAttribute("aria-label") ===
-          "Choose project Butternut Canker",
+          "Choose project Saving American Beech",
       ),
     ).toBe(true);
     expect(document.body.textContent).toContain("forests@");
+    expect(document.body.textContent).toContain("pick one or more sub-projects");
     expect(
       Array.from(document.querySelectorAll("button")).some((button) =>
         button.getAttribute("aria-label") ===
@@ -161,7 +161,9 @@ describe("AudienceFilterPanel", () => {
     });
 
     const hostButton = Array.from(document.querySelectorAll("button")).find(
-      (button) => button.getAttribute("aria-label") === "Choose project Forests",
+      (button) =>
+        button.getAttribute("aria-label") ===
+        "Choose project Restoring Butternut Forest Health",
     );
     if (!(hostButton instanceof HTMLButtonElement)) {
       throw new Error("Host project button not found");
@@ -195,7 +197,7 @@ describe("AudienceFilterPanel", () => {
       selectAllButton.click();
     });
 
-    expect(projectChange).toHaveBeenCalledWith("host-project");
+    expect(projectChange).toHaveBeenCalledWith("project-a");
     expect(statusToggle).toHaveBeenCalledWith("Waitlist");
     expect(selectAllStatuses).toHaveBeenCalled();
   });
@@ -203,8 +205,8 @@ describe("AudienceFilterPanel", () => {
   it("applies the stage tone classes and hides empty stages", () => {
     renderPanel({
       criteria: {
-        projectId: "host-project",
-        projectIds: ["host-project"],
+        projectId: "project-a",
+        projectIds: ["project-a", "project-b"],
         statuses: ["Waitlist"],
         contactIds: [],
         expeditionIds: [],
@@ -236,5 +238,38 @@ describe("AudienceFilterPanel", () => {
     expect(waitlistButton.className).toContain("bg-emerald-600");
     expect(deniedButton.className).toContain("bg-rose-50");
     expect(document.body.textContent).not.toContain("Mid-funnel");
+  });
+
+  it("renders a locked pill for single-project aliases", () => {
+    renderPanel({
+      criteria: {
+        projectId: "project-a",
+        projectIds: ["project-a"],
+        statuses: [],
+        contactIds: [],
+        expeditionIds: [],
+        lastActivityWindow: "all_time",
+        hasReplied: "either",
+        hasClicked: "either",
+      },
+      projectOptions: [
+        {
+          id: "project-a",
+          name: "CA Biodiversity",
+          alias: "cabio",
+          aliasHint: "cabio@",
+          connectedToProjectId: null,
+          isSubProject: false,
+        },
+      ],
+    });
+
+    expect(document.body.textContent).toContain("Inherited from cabio@");
+    expect(document.body.textContent).toContain("CA Biodiversity");
+    expect(
+      Array.from(document.querySelectorAll("button")).some((button) =>
+        button.getAttribute("aria-label")?.startsWith("Choose project "),
+      ),
+    ).toBe(false);
   });
 });

--- a/apps/web/tests/unit/campaign-audience-step.test.tsx
+++ b/apps/web/tests/unit/campaign-audience-step.test.tsx
@@ -6,7 +6,9 @@ Object.assign(globalThis, { React });
 
 vi.mock("lucide-react", () => ({
   AlertTriangle: () => null,
+  Check: () => null,
   CheckCircle2: () => null,
+  Lock: () => null,
   Search: () => null,
   Sparkles: () => null,
   X: () => null,
@@ -49,7 +51,7 @@ const baseProps: React.ComponentProps<typeof AudienceBuilderStep> = {
   volunteerSearchRows: [],
   volunteerSearchLoading: false,
   volunteerSearchErrorMessage: null,
-  projectGroups: [],
+  projectOptions: [],
   statusOptions: ["Waitlist"],
   statusCounts: {},
   statusCountsErrorMessage: null,
@@ -86,6 +88,99 @@ describe("AudienceBuilderStep initial filter gate", () => {
     expect(markup).toContain("All approved contacts");
     expect(markup).toContain(
       "This broadcast goes to every approved contact across all projects, minus auto-exclusions.",
+    );
+  });
+
+  it("renders only the project and status surface in project mode", () => {
+    const markup = renderToStaticMarkup(
+      <AudienceBuilderStep
+        {...baseProps}
+        projectOptions={[
+          {
+            id: "project-1",
+            name: "Restoring Butternut Forest Health",
+            alias: null,
+            aliasHint: "forests@",
+            connectedToProjectId: "host-project",
+            isSubProject: true,
+          },
+          {
+            id: "project-2",
+            name: "Saving American Beech",
+            alias: null,
+            aliasHint: "forests@",
+            connectedToProjectId: "host-project",
+            isSubProject: true,
+          },
+        ]}
+        criteria={{
+          ...baseProps.criteria,
+          projectId: "project-1",
+          projectIds: ["project-1", "project-2"],
+          statuses: ["Waitlist"],
+          initialFilter: "project_status",
+        }}
+        countState={{
+          count: 42,
+          hasAppliedFilters: true,
+        }}
+        statusCounts={{
+          Waitlist: 42,
+        }}
+      />,
+    );
+
+    expect(markup).toContain("Audience filters");
+    expect(markup).toContain("Inherited from forests@");
+    expect(markup).toContain("Member status");
+    expect(markup).not.toContain("Search by name or email");
+    expect(markup).not.toContain("Find volunteers");
+  });
+
+  it("renders only the volunteer search surface in individual mode", () => {
+    const markup = renderToStaticMarkup(
+      <AudienceBuilderStep
+        {...baseProps}
+        criteria={{
+          ...baseProps.criteria,
+          projectId: "project-1",
+          projectIds: ["project-1", "project-2"],
+          contactIds: [],
+          initialFilter: "specific",
+        }}
+      />,
+    );
+
+    expect(markup).toContain("Find volunteers");
+    expect(markup).toContain("Search by name or email");
+    expect(markup).not.toContain("Audience filters");
+    expect(markup).not.toContain("Member status");
+    expect(markup).not.toContain("Toggle expedition-member status");
+  });
+
+  it("disables continue when the live audience is zero", () => {
+    const invalidMarkup = renderToStaticMarkup(<AudienceBuilderStep {...baseProps} />);
+    const validMarkup = renderToStaticMarkup(
+      <AudienceBuilderStep
+        {...baseProps}
+        criteria={{
+          ...baseProps.criteria,
+          projectId: "project-1",
+          projectIds: ["project-1"],
+          statuses: ["Waitlist"],
+        }}
+        countState={{
+          count: 12,
+          hasAppliedFilters: true,
+        }}
+      />,
+    );
+
+    expect(invalidMarkup).toMatch(
+      /<button[^>]*aria-disabled="true"[^>]*>Continue to compose<\/button>/,
+    );
+    expect(validMarkup).not.toMatch(
+      /<button[^>]*aria-disabled="true"[^>]*>Continue to compose<\/button>/,
     );
   });
 });


### PR DESCRIPTION
## Summary

Tightens Step 3 of the broadcasts wizard so the two audience modes are strictly separated. The audience counter (top) and audience preview (bottom) are the only persistent UI across both modes; everything else is mode-specific.

## What changes

### 1. Strict mode-conditional rendering

**Project / Status mode** shows:
- Mode selector
- Alias-scoped PROJECT section (locked pill or horizontal selectable pills)
- MEMBER STATUS section (stage-grouped pills)
- Audience preview

**Individual Volunteers mode** shows:
- Mode selector
- Volunteer search bar with typeahead
- Audience preview

The shared auto-exclusion panel that previously rendered in both modes has been removed from the per-mode surfaces; only the counter + preview persist across mode switches.

### 2. Alias-scoped project picker

- **Single-project alias** (e.g., `cabio@` → CA Biodiversity): locked pill display, no picker, no other options visible.
- **Multi-project alias** (only `forests@` today, owns **Beech** + **Butternut**): horizontal selectable pills (current codebase style, not the designer's vertical card layout), default-all-selected, deselect-all allowed.
- Wizard shell now passes only the sender alias's resolved projects into Step 3, so scoping is enforced at the UI boundary.

### 3. Alias-scoped Individual search

The Individual Volunteers typeahead now takes `aliasProjectIds` and constrains results to contacts whose memberships include at least one of the alias's projects. For `forests@`, search hits only Beech/Butternut members.

### 4. Continue button disabled at audience = 0

`aria-disabled="true"` + `disabled` attribute + click guard whenever the effective audience count is zero. Applies across both modes (e.g., all projects deselected in multi-project alias, or all status pills off, or no volunteers added).

### 5. Tests updated

- `campaign-audience-filter-panel.test.tsx` — locked vs multi-project pill rendering, alias scoping
- `campaign-audience-step.test.tsx` — mode-conditional surfaces, Continue disabled at zero (new test)

## Out of scope (deferred per architect — separate dispatch)

The designer mockup includes several copy + layout polish touches that are NOT in this PR:
- "STEP 3" small label above the heading
- Heading rename `Audience` → `Build the audience`
- Helper copy refresh
- "Live audience" green check-badge above the count
- `AUDIENCE TYPE` → `AUDIENCE MODE` rename
- "Audience filters" sub-section heading
- Mode-card description copy refresh
- "All changes saved" indicator (vs "Auto-saved · 12s ago")

These land in a follow-up.

## Validation

- ``pnpm typecheck`` — passed
- ``pnpm lint`` — passed
- ``pnpm boundaries`` — passed
- ``pnpm --filter @as-comms/web build`` — passed
- Targeted vitest (4 wizard test files) — all pass

## Test plan

- [ ] CI green
- [ ] Visual check on staging: enter Step 3 with `cabio@` alias → locked CA Biodiversity pill + status pills only, no volunteer search
- [ ] Switch to Individual Volunteers → search bar appears, project + status sections disappear
- [ ] With `forests@` alias → Beech + Butternut horizontal pills, deselecting both yields count 0 + Continue disabled
- [ ] Individual search for "forests@" only returns Beech/Butternut members
- [ ] Continue button greyed at audience=0, re-enables once count > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code) via Codex