### PR TITLE
feat(wizard): pixel-perfect Step 3 layout + async loading + default-unselected statuses

### DIFF
--- a/apps/web/app/broadcasts/new/_components/audience-builder-step.tsx
+++ b/apps/web/app/broadcasts/new/_components/audience-builder-step.tsx
@@ -3,6 +3,7 @@
 import {
   AlertTriangle,
   CheckCircle2,
+  LoaderCircle,
   Search,
   Sparkles,
   X,
@@ -75,10 +76,11 @@ interface AudienceBuilderStepProps {
   readonly projectOptions: readonly CampaignProjectOption[];
   readonly statusOptions: readonly ExpeditionMemberStatus[];
   readonly statusCounts: AudienceStatusCounts;
+  readonly statusCountsLoading: boolean;
   readonly statusCountsErrorMessage: string | null;
   readonly onInitialFilterChange: (value: AudienceInitialFilter) => void;
   readonly onProjectChange: (projectId: string) => void;
-  readonly onSelectAllStatuses: () => void;
+  readonly onToggleAllStatuses: (selectAll: boolean) => void;
   readonly onStatusToggle: (status: ExpeditionMemberStatus) => void;
   readonly onVolunteerSearchQueryChange: (value: string) => void;
   readonly onVolunteerToggle: (contactId: string) => void;
@@ -101,10 +103,11 @@ export function AudienceBuilderStep({
   projectOptions,
   statusOptions,
   statusCounts,
+  statusCountsLoading,
   statusCountsErrorMessage,
   onInitialFilterChange,
   onProjectChange,
-  onSelectAllStatuses,
+  onToggleAllStatuses,
   onStatusToggle,
   onVolunteerSearchQueryChange,
   onVolunteerToggle,
@@ -113,7 +116,8 @@ export function AudienceBuilderStep({
 }: AudienceBuilderStepProps) {
   const initialFilter = criteria.initialFilter ?? "project_status";
   const canContinue =
-    initialFilter === "project_status"
+    !countLoading &&
+    (initialFilter === "project_status"
       ? [
           ...(criteria.projectId == null ? [] : [criteria.projectId]),
           ...criteria.projectIds,
@@ -123,7 +127,7 @@ export function AudienceBuilderStep({
         countState.count > 0
       : initialFilter === "specific"
         ? (criteria.contactIds?.length ?? 0) > 0 && countState.count > 0
-        : countState.count > 0;
+        : countState.count > 0);
 
   return (
     <section className="flex h-full flex-col">
@@ -156,9 +160,10 @@ export function AudienceBuilderStep({
               projectOptions={projectOptions}
               statusOptions={statusOptions}
               statusCounts={statusCounts}
+              statusCountsLoading={statusCountsLoading}
               statusCountsErrorMessage={statusCountsErrorMessage}
               onProjectChange={onProjectChange}
-              onSelectAllStatuses={onSelectAllStatuses}
+              onToggleAllStatuses={onToggleAllStatuses}
               onStatusToggle={onStatusToggle}
             />
 
@@ -323,21 +328,30 @@ export function AudienceCountPanel({
                 : "bg-amber-50 text-amber-800 ring-1 ring-amber-200",
           )}
         >
-          {tone === "neutral" ? (
+          {loading ? (
+            <LoaderCircle className="size-3.5 animate-spin" aria-hidden="true" />
+          ) : tone === "neutral" ? (
             <Sparkles className="size-3.5" aria-hidden="true" />
           ) : tone === "positive" ? (
             <CheckCircle2 className="size-3.5" aria-hidden="true" />
           ) : (
             <AlertTriangle className="size-3.5" aria-hidden="true" />
           )}
-          {loading ? "Updating live count…" : "Live audience"}
+          {loading ? "Calculating audience…" : "Live audience"}
         </div>
         <div className="mt-3 flex items-end gap-3">
-          <span className="text-[32px] font-semibold leading-none tabular-nums text-slate-900">
-            {countState.hasAppliedFilters
-              ? countState.count.toLocaleString()
-              : "—"}
-          </span>
+          {loading ? (
+            <span
+              aria-hidden="true"
+              className="skeleton-pulse block h-8 w-20 rounded-md"
+            />
+          ) : (
+            <span className="text-[32px] font-semibold leading-none tabular-nums text-slate-900">
+              {countState.hasAppliedFilters
+                ? countState.count.toLocaleString()
+                : "—"}
+            </span>
+          )}
           <span className="pb-1 text-[12px] text-slate-500">
             recipients match · live as you change filters
           </span>
@@ -351,7 +365,7 @@ export function AudienceCountPanel({
         </p>
       </div>
 
-      {countState.count > 5000 ? (
+      {!loading && countState.count > 5000 ? (
         <div className="mt-4 rounded-md border border-amber-200 bg-white px-3 py-2.5 text-[12.5px] text-amber-800">
           This is a large send. Double-check the filters before continuing.
         </div>

--- a/apps/web/app/broadcasts/new/_components/audience-filter-panel.tsx
+++ b/apps/web/app/broadcasts/new/_components/audience-filter-panel.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { Check, Lock } from "lucide-react";
+import { Check, LoaderCircle, Lock } from "lucide-react";
 
 import {
   FOCUS_RING,
-  RADIUS,
   TONE_CLASSES,
   TRANSITION,
   type ToneNameV2,
@@ -21,7 +20,7 @@ import type { CampaignAudienceCriteria } from "./audience-builder-step";
 
 const STAGE_GROUPS = {
   top: {
-    label: "Top-funnel",
+    label: "TOP-FUNNEL",
     color: "emerald",
     statuses: [
       "Waitlist",
@@ -34,17 +33,17 @@ const STAGE_GROUPS = {
     ],
   },
   mid: {
-    label: "Mid-funnel",
+    label: "MID-FUNNEL",
     color: "sky",
     statuses: ["In Progress", "Trip Planning", "In the Field"],
   },
   bottom: {
-    label: "Bottom-funnel",
+    label: "BOTTOM-FUNNEL",
     color: "violet",
     statuses: ["Successful", "Completed", "Returning Gear"],
   },
   off: {
-    label: "Off-funnel",
+    label: "OFF-FUNNEL",
     color: "rose",
     statuses: ["Denied", "Aborted", "Soft Denied", "Failed"],
   },
@@ -73,11 +72,12 @@ interface AudienceFilterPanelProps {
   readonly projectOptions: readonly CampaignProjectOption[];
   readonly statusOptions: readonly ExpeditionMemberStatus[];
   readonly statusCounts: AudienceStatusCounts;
+  readonly statusCountsLoading: boolean;
   readonly statusCountsErrorMessage: string | null;
   readonly showProjectSection?: boolean;
   readonly showStatusSection?: boolean;
   readonly onProjectChange: (projectId: string) => void;
-  readonly onSelectAllStatuses: () => void;
+  readonly onToggleAllStatuses: (selectAll: boolean) => void;
   readonly onStatusToggle: (status: ExpeditionMemberStatus) => void;
 }
 
@@ -86,11 +86,12 @@ export function AudienceFilterPanel({
   projectOptions,
   statusOptions,
   statusCounts,
+  statusCountsLoading,
   statusCountsErrorMessage,
   showProjectSection = true,
   showStatusSection = true,
   onProjectChange,
-  onSelectAllStatuses,
+  onToggleAllStatuses,
   onStatusToggle,
 }: AudienceFilterPanelProps) {
   const selectedProjectIds = [
@@ -98,21 +99,21 @@ export function AudienceFilterPanel({
     ...criteria.projectIds,
   ].filter((projectId, index, values) => values.indexOf(projectId) === index);
   const selectedProjectIdSet = new Set(selectedProjectIds);
-  const populatedStatuses = statusOptions.filter((status) => {
-    return selectedProjectIds.length > 0 && (statusCounts[status] ?? 0) > 0;
-  });
-  const allPopulatedStatusesSelected =
-    populatedStatuses.length > 0 &&
-    populatedStatuses.every((status) => criteria.statuses.includes(status));
   const knownStatuses = new Set(statusOptions);
   const projectAliasHint = projectOptions[0]?.aliasHint ?? null;
   const hasSingleLockedProject = projectOptions.length === 1;
+  const shouldRenderStatusShell =
+    selectedProjectIds.length > 0 && statusCountsLoading;
+
   const stageSections = Object.values(STAGE_GROUPS)
     .map((group) => {
-      const statuses = group.statuses.filter(
-        (status) =>
-          knownStatuses.has(status) && (statusCounts[status] ?? 0) > 0,
-      );
+      const statuses = group.statuses.filter((status) => {
+        return (
+          knownStatuses.has(status) &&
+          (shouldRenderStatusShell || (statusCounts[status] ?? 0) > 0)
+        );
+      });
+
       return {
         ...group,
         statuses,
@@ -124,6 +125,11 @@ export function AudienceFilterPanel({
     })
     .filter((group) => group.statuses.length > 0);
 
+  const visibleStatuses = stageSections.flatMap((group) => group.statuses);
+  const allVisibleStatusesSelected =
+    visibleStatuses.length > 0 &&
+    visibleStatuses.every((status) => criteria.statuses.includes(status));
+
   return (
     <div className="rounded-lg border border-slate-200 bg-white">
       <div className="border-b border-slate-200 px-4 py-3">
@@ -133,32 +139,26 @@ export function AudienceFilterPanel({
         </p>
       </div>
 
-      <div className="space-y-6 px-4 py-4">
+      <div className="space-y-7 px-4 py-4">
         {showProjectSection ? (
           <FilterSection
             title="Project"
-            {...(projectAliasHint === null
-              ? {}
-              : {
-                  description: hasSingleLockedProject
-                    ? `Inherited from ${projectAliasHint}`
-                    : `Inherited from ${projectAliasHint} · pick one or more sub-projects`,
-                })}
+            aside={
+              projectAliasHint === null ? null : hasSingleLockedProject ? (
+                `Inherited from ${projectAliasHint}`
+              ) : (
+                `Inherited from ${projectAliasHint} · pick one or more sub-projects`
+              )
+            }
           >
-            <div className="flex flex-wrap gap-2">
+            <div className="space-y-2.5">
               {projectOptions.map((project) =>
                 hasSingleLockedProject ? (
-                  <LockedProjectPill
-                    key={project.id}
-                    name={project.name}
-                    aliasHint={project.aliasHint}
-                  />
+                  <LockedProjectRow key={project.id} project={project} />
                 ) : (
-                  <ProjectOptionPill
+                  <ProjectOptionRow
                     key={project.id}
-                    id={project.id}
-                    name={project.name}
-                    aliasHint={project.aliasHint}
+                    project={project}
                     selected={selectedProjectIdSet.has(project.id)}
                     onSelect={onProjectChange}
                   />
@@ -175,16 +175,15 @@ export function AudienceFilterPanel({
               selectedProjectIds.length > 0 ? (
                 <button
                   type="button"
-                  onClick={onSelectAllStatuses}
-                  disabled={allPopulatedStatusesSelected}
+                  onClick={() => {
+                    onToggleAllStatuses(!allVisibleStatusesSelected);
+                  }}
                   className={cn(
                     `text-[11.5px] font-medium text-slate-500 ${TRANSITION.fast} ${FOCUS_RING}`,
-                    allPopulatedStatusesSelected
-                      ? "cursor-not-allowed opacity-50"
-                      : "hover:text-slate-900",
+                    "hover:text-slate-900",
                   )}
                 >
-                  Select all
+                  {allVisibleStatusesSelected ? "Unselect all" : "Select all"}
                 </button>
               ) : null
             }
@@ -199,19 +198,20 @@ export function AudienceFilterPanel({
               <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-3 text-[12px] italic text-slate-500">
                 Select at least one project above to see member statuses.
               </div>
-            ) : stageSections.length === 0 ? (
+            ) : !statusCountsLoading && stageSections.length === 0 ? (
               <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-3 text-[12px] text-slate-500">
                 No populated member statuses were found for the selected
                 projects.
               </div>
             ) : (
-              <div className="space-y-4">
+              <div className="space-y-5">
                 {stageSections.map((group) => (
                   <StageStatusSection
                     key={group.label}
                     count={group.count}
-                    label={group.label}
                     color={group.color}
+                    label={group.label}
+                    loading={statusCountsLoading}
                     selectedStatuses={criteria.statuses}
                     statusCounts={statusCounts}
                     statuses={group.statuses}
@@ -229,100 +229,113 @@ export function AudienceFilterPanel({
 
 function FilterSection({
   title,
-  description,
+  aside,
   action,
   children,
 }: {
   readonly title: string;
-  readonly description?: string;
+  readonly aside?: string | null;
   readonly action?: React.ReactNode;
   readonly children: React.ReactNode;
 }) {
   return (
     <section>
-      <div className="flex items-center justify-between gap-3">
-        <h4 className="text-[10.5px] font-semibold uppercase tracking-wider text-slate-500">
+      <div className="flex items-start justify-between gap-4">
+        <h4 className="pt-0.5 text-[10.5px] font-semibold uppercase tracking-wider text-slate-500">
           {title}
         </h4>
-        {action}
+        {action ?? aside ? (
+          <div className="min-w-0 text-right">
+            {action ?? (
+              <p className="text-pretty text-[11px] leading-5 text-slate-500">
+                {aside}
+              </p>
+            )}
+          </div>
+        ) : null}
       </div>
-      {description ? (
-        <p className="mt-1 text-pretty text-[11px] leading-5 text-slate-500">
-          {description}
-        </p>
-      ) : null}
       <div className="mt-3">{children}</div>
     </section>
   );
 }
 
-function ProjectOptionPill({
-  id,
-  name,
-  aliasHint,
+function ProjectOptionRow({
+  project,
   selected,
   onSelect,
 }: {
-  readonly id: string;
-  readonly name: string;
-  readonly aliasHint: string | null;
+  readonly project: CampaignProjectOption;
   readonly selected: boolean;
   readonly onSelect: (projectId: string) => void;
 }) {
+  const aliasAddress = readAliasAddress(project);
+
   return (
     <button
       type="button"
-      aria-label={`Choose project ${name}`}
+      aria-label={`Choose project ${project.name}`}
       aria-pressed={selected}
       onClick={() => {
-        onSelect(id);
+        onSelect(project.id);
       }}
       className={cn(
-        `inline-flex items-center gap-2.5 px-3 py-2 text-left text-[12px] font-semibold ${RADIUS.full} ${TRANSITION.fast} ${FOCUS_RING}`,
+        `flex w-full items-center justify-between gap-3 rounded-xl border px-4 py-3 text-left ${TRANSITION.fast} ${FOCUS_RING}`,
         selected
-          ? "bg-slate-900 text-white ring-1 ring-slate-900"
-          : "bg-slate-50 text-slate-700 ring-1 ring-slate-200 hover:bg-slate-100 hover:text-slate-900",
+          ? "border-slate-900 bg-slate-900 text-white shadow-sm"
+          : "border-slate-200 bg-slate-50/70 text-slate-700 hover:border-slate-300 hover:bg-white hover:text-slate-900",
       )}
     >
-      {selected ? <Check className="size-3.5 shrink-0" aria-hidden="true" /> : null}
-      <span className="min-w-0 truncate">{name}</span>
-      {aliasHint ? (
+      <div className="flex min-w-0 items-center gap-3">
+        <ProjectSelectionIndicator selected={selected} />
         <span
           className={cn(
-            "shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
-            selected
-              ? "bg-white/15 text-white"
-              : "bg-white text-slate-500 ring-1 ring-slate-200",
+            "size-1.5 shrink-0 rounded-full",
+            selected ? "bg-white/70" : "bg-slate-300",
           )}
-        >
-          {aliasHint}
-        </span>
-      ) : null}
+          aria-hidden="true"
+        />
+        <div className="min-w-0">
+          <p className="truncate text-[13px] font-semibold">{project.name}</p>
+          {aliasAddress ? (
+            <p
+              className={cn(
+                "truncate text-[11.5px]",
+                selected ? "text-white/70" : "text-slate-500",
+              )}
+            >
+              {aliasAddress}
+            </p>
+          ) : null}
+        </div>
+      </div>
     </button>
   );
 }
 
-function LockedProjectPill({
-  name,
-  aliasHint,
+function LockedProjectRow({
+  project,
 }: {
-  readonly name: string;
-  readonly aliasHint: string | null;
+  readonly project: CampaignProjectOption;
 }) {
+  const aliasAddress = readAliasAddress(project);
+
   return (
     <div
-      className={cn(
-        `inline-flex items-center gap-2.5 bg-slate-100 px-3 py-2 text-[12px] font-semibold text-slate-700 ring-1 ring-slate-200 ${RADIUS.full}`,
-      )}
-      aria-label={`Project ${name} is locked to this sender alias`}
+      className="flex w-full items-center gap-3 rounded-xl border border-slate-200 bg-slate-50/80 px-4 py-3 text-left"
+      aria-label={`Project ${project.name} is locked to this sender alias`}
     >
-      <Lock className="size-3.5 shrink-0 text-slate-500" aria-hidden="true" />
-      <span className="min-w-0 truncate">{name}</span>
-      {aliasHint ? (
-        <span className="shrink-0 rounded-full bg-white px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-slate-500 ring-1 ring-slate-200">
-          {aliasHint}
-        </span>
-      ) : null}
+      <span className="flex size-9 shrink-0 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-500">
+        <Lock className="size-4" aria-hidden="true" />
+      </span>
+      <span className="size-1.5 shrink-0 rounded-full bg-slate-300" aria-hidden="true" />
+      <div className="min-w-0">
+        <p className="truncate text-[13px] font-semibold text-slate-900">
+          {project.name}
+        </p>
+        {aliasAddress ? (
+          <p className="truncate text-[11.5px] text-slate-500">{aliasAddress}</p>
+        ) : null}
+      </div>
     </div>
   );
 }
@@ -334,6 +347,7 @@ function StageStatusSection({
   statusCounts,
   selectedStatuses,
   count,
+  loading,
   onStatusToggle,
 }: {
   readonly label: string;
@@ -342,21 +356,30 @@ function StageStatusSection({
   readonly statusCounts: AudienceStatusCounts;
   readonly selectedStatuses: readonly ExpeditionMemberStatus[];
   readonly count: number;
+  readonly loading: boolean;
   readonly onStatusToggle: (status: ExpeditionMemberStatus) => void;
 }) {
   const tone = TONE_CLASSES[color];
 
   return (
-    <section className="space-y-2">
-      <div className="flex items-center justify-between gap-3">
-        <p className="text-[10.5px] font-semibold uppercase tracking-wider text-slate-500">
+    <section className="space-y-3">
+      <div className="flex items-center justify-between gap-3 border-b border-slate-200/80 pb-2">
+        <p className="text-[10.5px] font-semibold tracking-wider text-slate-500">
           {label}
         </p>
-        <span className="text-[11.5px] font-medium tabular-nums text-slate-500">
-          {count.toLocaleString()}
-        </span>
+        {loading ? (
+          <LoaderCircle
+            className={cn(`size-3.5 animate-spin ${tone.text}`)}
+            aria-label={`Loading ${label} total`}
+          />
+        ) : (
+          <span className="text-[12px] font-medium tabular-nums text-slate-500">
+            {count.toLocaleString()}
+          </span>
+        )}
       </div>
-      <div className="flex flex-wrap gap-2">
+
+      <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
         {statuses.map((status) => {
           const selected = selectedStatuses.includes(status);
           const countForStatus = statusCounts[status] ?? 0;
@@ -372,28 +395,89 @@ function StageStatusSection({
                 onStatusToggle(status);
               }}
               className={cn(
-                `inline-flex items-center gap-2 px-3 py-1.5 text-[12px] font-semibold ${RADIUS.full} ${TRANSITION.fast} ${FOCUS_RING}`,
+                `flex min-h-[48px] items-center justify-between gap-3 rounded-xl border px-3.5 py-3 text-left text-[12.5px] font-semibold ${TRANSITION.fast} ${FOCUS_RING}`,
                 selected
                   ? `${tone.bg} text-white ring-1 ${SELECTED_RING_CLASSES[color]}`
-                  : `${tone.subtle} ${tone.subtleText} ring-1 ${tone.ring} hover:opacity-90`,
+                  : `${tone.subtle} ${tone.subtleText} border-transparent ring-1 ${tone.ring} hover:opacity-90`,
               )}
             >
-              {selected ? (
-                <Check className="size-3.5 shrink-0" aria-hidden="true" />
+              <span className="flex min-w-0 items-center gap-3">
+                <StatusSelectionIndicator color={color} selected={selected} />
+                <span className="truncate">{status}</span>
+              </span>
+              {loading ? (
+                <span
+                  aria-hidden="true"
+                  className="skeleton-pulse block h-3.5 w-5 shrink-0 rounded"
+                />
               ) : (
                 <span
-                  className={cn("size-2 shrink-0 rounded-full", tone.dot)}
-                  aria-hidden="true"
-                />
+                  className={cn(
+                    "shrink-0 tabular-nums",
+                    selected ? "text-white" : tone.text,
+                  )}
+                >
+                  {countForStatus.toLocaleString()}
+                </span>
               )}
-              <span className="flex items-center gap-2">
-                <span>{status}</span>
-                <span className="tabular-nums">{countForStatus}</span>
-              </span>
             </button>
           );
         })}
       </div>
     </section>
   );
+}
+
+function ProjectSelectionIndicator({
+  selected,
+}: {
+  readonly selected: boolean;
+}) {
+  return (
+    <span
+      className={cn(
+        "flex size-5 shrink-0 items-center justify-center rounded-full border",
+        selected
+          ? "border-white/20 bg-white/15 text-white"
+          : "border-slate-300 bg-white text-transparent",
+      )}
+      aria-hidden="true"
+    >
+      {selected ? <Check className="size-3" aria-hidden="true" /> : null}
+    </span>
+  );
+}
+
+function StatusSelectionIndicator({
+  color,
+  selected,
+}: {
+  readonly color: ToneNameV2;
+  readonly selected: boolean;
+}) {
+  const tone = TONE_CLASSES[color];
+
+  return (
+    <span
+      className={cn(
+        "flex size-5 shrink-0 items-center justify-center rounded-full border",
+        selected
+          ? "border-white/30 bg-white/15 text-white"
+          : `bg-white/70 ${tone.text} ${tone.ring}`,
+      )}
+      aria-hidden="true"
+    >
+      {selected ? (
+        <Check className="size-3" aria-hidden="true" />
+      ) : null}
+    </span>
+  );
+}
+
+function readAliasAddress(project: CampaignProjectOption): string | null {
+  if (project.aliasHint === null) {
+    return null;
+  }
+
+  return `${project.aliasHint}adventurescientists.org`;
 }

--- a/apps/web/app/broadcasts/new/_components/audience-preview-list.tsx
+++ b/apps/web/app/broadcasts/new/_components/audience-preview-list.tsx
@@ -2,6 +2,7 @@
 
 import { Eye } from "lucide-react";
 
+import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 
 import type { AudiencePreviewRow } from "../../_lib/audience-data-source";
@@ -19,8 +20,28 @@ export function AudiencePreviewList({
 }: AudiencePreviewListProps) {
   if (loading) {
     return (
-      <div className="rounded-2xl border border-slate-200 bg-white px-4 py-4 text-sm text-slate-500">
-        Loading the first 50 matching recipients…
+      <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white">
+        <div className="flex items-center gap-2 border-b border-slate-200 px-4 py-3 text-xs font-semibold uppercase text-slate-500">
+          <Eye className="size-3.5" aria-hidden="true" />
+          Audience preview
+        </div>
+        <div className="space-y-3 px-4 py-4">
+          {Array.from({ length: 4 }, (_, index) => (
+            <div
+              key={`audience-preview-skeleton-${String(index)}`}
+              className="flex items-center gap-3"
+            >
+              <Skeleton className="size-10 shrink-0 rounded-full bg-slate-200/70" />
+              <div className="min-w-0 flex-1 space-y-2">
+                <div className="flex items-center justify-between gap-3">
+                  <Skeleton className="h-3.5 w-32 bg-slate-200/80" />
+                  <Skeleton className="h-5 w-20 rounded-full bg-slate-200/70" />
+                </div>
+                <Skeleton className="h-3 w-44 bg-slate-100" />
+              </div>
+            </div>
+          ))}
+        </div>
       </div>
     );
   }

--- a/apps/web/app/broadcasts/new/_components/new-campaign-wizard.tsx
+++ b/apps/web/app/broadcasts/new/_components/new-campaign-wizard.tsx
@@ -382,7 +382,11 @@ export function NewCampaignWizard({
   const [previewRows, setPreviewRows] = useState<readonly AudiencePreviewRow[]>(
     [],
   );
+  const [previewErrorMessage, setPreviewErrorMessage] = useState<string | null>(
+    null,
+  );
   const [statusCounts, setStatusCounts] = useState<AudienceStatusCounts>({});
+  const [statusCountsLoading, setStatusCountsLoading] = useState(false);
   const [statusCountsErrorMessage, setStatusCountsErrorMessage] = useState<
     string | null
   >(null);
@@ -414,8 +418,10 @@ export function NewCampaignWizard({
   const [runState, setRunState] = useState(draft.state);
   const [scheduledAt, setScheduledAt] = useState(draft.scheduledAt);
   const [toast, setToast] = useState<ToastState>(null);
-  const [countPending, startCountTransition] = useTransition();
-  const [previewPending, startPreviewTransition] = useTransition();
+  const [countLoading, setCountLoading] = useState(false);
+  const [audiencePreviewLoading, setAudiencePreviewLoading] = useState(false);
+  const [, startCountTransition] = useTransition();
+  const [composePreviewPending, startComposePreviewTransition] = useTransition();
   const [, startStatusCountsTransition] = useTransition();
   const [volunteerSearchPending, startVolunteerSearchTransition] =
     useTransition();
@@ -431,9 +437,6 @@ export function NewCampaignWizard({
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const previousLaunchTypeRef = useRef(draft.launchType);
   const previousFromEmailRef = useRef(draft.fromEmail);
-  const shouldAutoSelectStatusesRef = useRef(
-    (criteria.initialFilter ?? "project_status") === "project_status",
-  );
 
   const frozen = runState !== "draft";
   const previewFingerprint = useMemo(
@@ -556,7 +559,6 @@ export function NewCampaignWizard({
       return;
     }
 
-    shouldAutoSelectStatusesRef.current = currentMode === "project_status";
     setCriteria((current) =>
       buildCriteriaForMode({
         current,
@@ -572,7 +574,6 @@ export function NewCampaignWizard({
     }
 
     previousLaunchTypeRef.current = launchType;
-    shouldAutoSelectStatusesRef.current = true;
     setCriteria((current) =>
       buildCriteriaForMode({
         current,
@@ -591,8 +592,6 @@ export function NewCampaignWizard({
     }
 
     previousFromEmailRef.current = fromEmail;
-    shouldAutoSelectStatusesRef.current =
-      (criteria.initialFilter ?? "project_status") === "project_status";
     setCriteria((current) =>
       buildCriteriaForMode({
         current,
@@ -612,11 +611,21 @@ export function NewCampaignWizard({
   useEffect(() => {
     if ((criteria.initialFilter ?? "project_status") !== "project_status") {
       setStatusCounts({});
+      setStatusCountsLoading(false);
+      setStatusCountsErrorMessage(null);
+      return;
+    }
+
+    if (selectedProjectIds.length === 0) {
+      setStatusCounts({});
+      setStatusCountsLoading(false);
       setStatusCountsErrorMessage(null);
       return;
     }
 
     const requestId = ++statusCountsRequestRef.current;
+    setStatusCountsLoading(true);
+    setStatusCountsErrorMessage(null);
     startStatusCountsTransition(async () => {
       const result = await loadMemberStatusCountsForProjects(selectedProjectIds);
       if (requestId !== statusCountsRequestRef.current) {
@@ -624,11 +633,14 @@ export function NewCampaignWizard({
       }
 
       if (!result.ok) {
+        setStatusCounts({});
+        setStatusCountsLoading(false);
         setStatusCountsErrorMessage(result.message);
         return;
       }
 
       setStatusCounts(result.data);
+      setStatusCountsLoading(false);
       setStatusCountsErrorMessage(null);
       setCriteria((current) => {
         const availableStatuses = bootstrap.statuses.filter(
@@ -638,20 +650,12 @@ export function NewCampaignWizard({
           availableStatuses.includes(status),
         );
 
-        if (!shouldAutoSelectStatusesRef.current) {
-          return selectedStatuses.length === current.statuses.length
-            ? current
-            : {
-                ...current,
-                statuses: selectedStatuses,
-              };
-        }
-
-        shouldAutoSelectStatusesRef.current = false;
-        return {
-          ...current,
-          statuses: availableStatuses,
-        };
+        return selectedStatuses.length === current.statuses.length
+          ? current
+          : {
+              ...current,
+              statuses: selectedStatuses,
+            };
       });
     });
   }, [bootstrap.statuses, criteria.initialFilter, selectedProjectIds]);
@@ -668,48 +672,52 @@ export function NewCampaignWizard({
 
   useEffect(() => {
     if (frozen) {
+      setCountLoading(false);
       return;
     }
 
     const requestId = ++countRequestRef.current;
-    const timer = setTimeout(() => {
-      startCountTransition(async () => {
-        const result = await resolveAudienceCountAction({ kind, criteria });
-        if (requestId !== countRequestRef.current || !result.ok) {
-          if (!result.ok && requestId === countRequestRef.current) {
-            setSaveMessage(result.message);
-          }
-          return;
-        }
-
-        setCountState(result.data);
-      });
-    }, 300);
-
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [criteria, frozen, kind]);
-
-  useEffect(() => {
-    if (currentStep !== 2) {
-      return;
-    }
-
-    const requestId = ++audiencePreviewRequestRef.current;
-    startPreviewTransition(async () => {
-      const result = await previewAudienceAction({ kind, criteria });
-      if (requestId !== audiencePreviewRequestRef.current) {
+    setCountLoading(true);
+    startCountTransition(async () => {
+      const result = await resolveAudienceCountAction({ kind, criteria });
+      if (requestId !== countRequestRef.current) {
         return;
       }
 
+      setCountLoading(false);
       if (!result.ok) {
         setSaveMessage(result.message);
         return;
       }
 
-      setPreviewRows(result.data);
+      setCountState(result.data);
     });
+  }, [criteria, frozen, kind]);
+
+  useEffect(() => {
+    if (currentStep !== 2) {
+      setAudiencePreviewLoading(false);
+      return;
+    }
+
+    const requestId = ++audiencePreviewRequestRef.current;
+    setAudiencePreviewLoading(true);
+    setPreviewErrorMessage(null);
+    void (async () => {
+      const result = await previewAudienceAction({ kind, criteria });
+      if (requestId !== audiencePreviewRequestRef.current) {
+        return;
+      }
+
+      setAudiencePreviewLoading(false);
+      if (!result.ok) {
+        setPreviewErrorMessage(result.message);
+        return;
+      }
+
+      setPreviewRows(result.data);
+      setPreviewErrorMessage(null);
+    })();
   }, [criteria, currentStep, kind]);
 
   useEffect(() => {
@@ -763,7 +771,7 @@ export function NewCampaignWizard({
 
     const requestId = ++composePreviewRequestRef.current;
     const timer = setTimeout(() => {
-      startPreviewTransition(async () => {
+      startComposePreviewTransition(async () => {
         const result = await loadComposePreviewAction({
           kind,
           criteria,
@@ -928,7 +936,6 @@ export function NewCampaignWizard({
   }
 
   function changeInitialFilter(value: AudienceInitialFilter) {
-    shouldAutoSelectStatusesRef.current = value === "project_status";
     updateCriteria((current) =>
       buildCriteriaForMode({
         current,
@@ -958,16 +965,19 @@ export function NewCampaignWizard({
       contactIds: [],
       statuses: [],
     }));
-    shouldAutoSelectStatusesRef.current = true;
     setVolunteerSearchQuery("");
     setVolunteerSearchRows([]);
     setVolunteerSearchErrorMessage(null);
   }
 
-  function selectAllStatuses() {
+  function toggleAllStatuses(selectAll: boolean) {
     updateCriteria((current) => ({
       ...current,
-      statuses: bootstrap.statuses.filter((status) => (statusCounts[status] ?? 0) > 0),
+      statuses: !selectAll
+        ? []
+        : bootstrap.statuses.filter((status) => {
+            return statusCountsLoading || (statusCounts[status] ?? 0) > 0;
+          }),
     }));
   }
 
@@ -1142,9 +1152,9 @@ export function NewCampaignWizard({
                 criteria={criteria}
                 countState={countState}
                 previewRows={previewRows}
-                countLoading={countPending}
-                previewLoading={previewPending}
-                previewErrorMessage={saveState === "error" ? saveMessage : null}
+                countLoading={countLoading}
+                previewLoading={audiencePreviewLoading}
+                previewErrorMessage={previewErrorMessage}
                 volunteerSearchQuery={volunteerSearchQuery}
                 volunteerSearchRows={volunteerSearchRows}
                 volunteerSearchLoading={volunteerSearchPending}
@@ -1152,10 +1162,11 @@ export function NewCampaignWizard({
                 projectOptions={aliasProjects}
                 statusOptions={bootstrap.statuses}
                 statusCounts={statusCounts}
+                statusCountsLoading={statusCountsLoading}
                 statusCountsErrorMessage={statusCountsErrorMessage}
                 onInitialFilterChange={changeInitialFilter}
                 onProjectChange={toggleProject}
-                onSelectAllStatuses={selectAllStatuses}
+                onToggleAllStatuses={toggleAllStatuses}
                 onStatusToggle={toggleStatus}
                 onVolunteerSearchQueryChange={setVolunteerSearchQuery}
                 onVolunteerToggle={toggleVolunteer}
@@ -1195,7 +1206,7 @@ export function NewCampaignWizard({
                 subject={subject}
                 preheader={preheader}
                 previewData={composePreview}
-                previewLoading={previewPending}
+                previewLoading={composePreviewPending}
                 warningDismissed={warningDismissed}
                 affectedContactsOpen={affectedContactsOpen}
                 testSendOpen={testSendOpen}

--- a/apps/web/tests/unit/campaign-audience-count-panel.test.tsx
+++ b/apps/web/tests/unit/campaign-audience-count-panel.test.tsx
@@ -7,6 +7,7 @@ Object.assign(globalThis, { React });
 vi.mock("lucide-react", () => ({
   AlertTriangle: () => null,
   CheckCircle2: () => null,
+  LoaderCircle: () => null,
   Search: () => null,
   Sparkles: () => null,
   X: () => null,

--- a/apps/web/tests/unit/campaign-audience-filter-panel.test.tsx
+++ b/apps/web/tests/unit/campaign-audience-filter-panel.test.tsx
@@ -9,6 +9,7 @@ Object.assign(globalThis, { React });
 
 vi.mock("lucide-react", () => ({
   Check: () => null,
+  LoaderCircle: () => null,
   Lock: () => null,
 }));
 
@@ -94,8 +95,9 @@ function renderPanel(overrides: Partial<React.ComponentProps<typeof AudienceFilt
       "In Progress": 0,
       Denied: 3,
     },
+    statusCountsLoading: false,
     statusCountsErrorMessage: null,
-    onSelectAllStatuses: () => undefined,
+    onToggleAllStatuses: () => undefined,
     onProjectChange: () => undefined,
     onStatusToggle: () => undefined,
     ...overrides,
@@ -144,19 +146,19 @@ describe("AudienceFilterPanel", () => {
         "Toggle expedition-member status Waitlist",
       ),
     ).toBe(true);
-    expect(document.body.textContent).toContain("Top-funnel");
-    expect(document.body.textContent).toContain("Off-funnel");
-    expect(document.body.textContent).not.toContain("Mid-funnel");
+    expect(document.body.textContent).toContain("TOP-FUNNEL");
+    expect(document.body.textContent).toContain("OFF-FUNNEL");
+    expect(document.body.textContent).not.toContain("MID-FUNNEL");
   });
 
   it("fires project, select-all, and status callbacks when those controls change", () => {
     const projectChange = vi.fn();
-    const selectAllStatuses = vi.fn();
+    const toggleAllStatuses = vi.fn();
     const statusToggle = vi.fn();
 
     renderPanel({
       onProjectChange: projectChange,
-      onSelectAllStatuses: selectAllStatuses,
+      onToggleAllStatuses: toggleAllStatuses,
       onStatusToggle: statusToggle,
     });
 
@@ -199,7 +201,7 @@ describe("AudienceFilterPanel", () => {
 
     expect(projectChange).toHaveBeenCalledWith("project-a");
     expect(statusToggle).toHaveBeenCalledWith("Waitlist");
-    expect(selectAllStatuses).toHaveBeenCalled();
+    expect(toggleAllStatuses).toHaveBeenCalledWith(true);
   });
 
   it("applies the stage tone classes and hides empty stages", () => {
@@ -237,7 +239,7 @@ describe("AudienceFilterPanel", () => {
     expect(waitlistButton.getAttribute("aria-checked")).toBe("true");
     expect(waitlistButton.className).toContain("bg-emerald-600");
     expect(deniedButton.className).toContain("bg-rose-50");
-    expect(document.body.textContent).not.toContain("Mid-funnel");
+    expect(document.body.textContent).not.toContain("MID-FUNNEL");
   });
 
   it("renders a locked pill for single-project aliases", () => {

--- a/apps/web/tests/unit/campaign-audience-step.test.tsx
+++ b/apps/web/tests/unit/campaign-audience-step.test.tsx
@@ -8,6 +8,7 @@ vi.mock("lucide-react", () => ({
   AlertTriangle: () => null,
   Check: () => null,
   CheckCircle2: () => null,
+  LoaderCircle: () => null,
   Lock: () => null,
   Search: () => null,
   Sparkles: () => null,
@@ -54,10 +55,11 @@ const baseProps: React.ComponentProps<typeof AudienceBuilderStep> = {
   projectOptions: [],
   statusOptions: ["Waitlist"],
   statusCounts: {},
+  statusCountsLoading: false,
   statusCountsErrorMessage: null,
   onInitialFilterChange: () => undefined,
   onProjectChange: () => undefined,
-  onSelectAllStatuses: () => undefined,
+  onToggleAllStatuses: () => undefined,
   onStatusToggle: () => undefined,
   onVolunteerSearchQueryChange: () => undefined,
   onVolunteerToggle: () => undefined,
@@ -133,6 +135,7 @@ describe("AudienceBuilderStep initial filter gate", () => {
     expect(markup).toContain("Audience filters");
     expect(markup).toContain("Inherited from forests@");
     expect(markup).toContain("Member status");
+    expect(markup).toContain("TOP-FUNNEL");
     expect(markup).not.toContain("Search by name or email");
     expect(markup).not.toContain("Find volunteers");
   });


### PR DESCRIPTION
## Summary

Three related changes to Step 3 (Audience):

1. **Pixel-perfect project + status layout** — wide row-style project picker, wide button-row status pills, per-stage sub-headers with totals, `Select all` / `Unselect all` toggle. Replicates the designer's mockup.
2. **Async loading states** — Step 3 shell renders immediately and stays interactive while counts resolve. Spinner + `Calculating audience…` for numbers; skeleton rows for the audience preview list.
3. **Default state = all statuses unselected** — operator deliberately builds the audience. Combined with the existing Continue-disabled-at-zero rule (PR #442), the wizard requires an explicit pick before advancing.

## Project section

- **Single-project alias** (e.g., `cabio@`): wide locked row with lock icon + tone bullet + project name + alias address on one line, tinted background
- **Multi-project alias** (`forests@` → Beech + Butternut): stacked full-width selectable rows with leading circular check indicator. No more horizontal pills.

## Member status section

- Section header: `MEMBER STATUS` on the left, **`Select all` / `Unselect all` toggle** on the right (replaces the prior `Clear all` link). Label flips based on current state.
- Per-stage sub-headers (`TOP-FUNNEL`, `MID-FUNNEL`, `BOTTOM-FUNNEL`, `OFF-FUNNEL`) show the stage's recipient total right-aligned (e.g., `TOP-FUNNEL ... 26`).
- Pills are now **wide button-rows**: leading circular check + status name + right-aligned count. 2–3 per row.
- **Per-stage color rule unchanged** from PR #440: `emerald TF / sky MF / violet BF / rose OffF`. Within a stage, all statuses share the same color.
- Selected: solid stage-color fill + white text + filled check
- Unselected: pale tint + colored text + outline check

## Default selection state

Statuses default to **all unselected** on first entry to Step 3. Continue is disabled at audience=0 (per the existing rule), so the operator must explicitly pick at least one status to advance.

## Async loading states

- Audience counter (top): inline spinner + `Calculating audience…` during fetch
- Stage totals + per-pill counts: inline spinner / shimmer placeholder
- During initial load, the full 17-status grid renders (no layout shift when counts arrive); trims to populated statuses once data returns
- Audience preview list: 3–5 skeleton rows during load
- Mode selector, project picker, and status pill clicks are all **immediately responsive** during load
- Continue no longer holds an enabled state on a stale positive count while a fresh count is pending — recomputes per filter change

## Files changed

- `apps/web/app/broadcasts/new/_components/audience-builder-step.tsx`
- `apps/web/app/broadcasts/new/_components/audience-filter-panel.tsx` (largest diff — project + status section restructure)
- `apps/web/app/broadcasts/new/_components/audience-preview-list.tsx` (skeleton rows)
- `apps/web/app/broadcasts/new/_components/new-campaign-wizard.tsx` (loading-state plumbing + default-unselected)
- `apps/web/tests/unit/campaign-audience-step.test.tsx`
- `apps/web/tests/unit/campaign-audience-filter-panel.test.tsx`
- `apps/web/tests/unit/campaign-audience-count-panel.test.tsx`

## Out of scope (deferred — separate dispatch)

- `STEP 3` label above the heading
- Heading rename `Audience` → `Build the audience`
- `Live audience` check-badge above the count
- `AUDIENCE TYPE` → `AUDIENCE MODE` rename
- Mode-card description copy refresh
- `All changes saved` indicator copy

## Validation

- ``pnpm typecheck`` — passed
- ``pnpm lint`` — passed
- ``pnpm boundaries`` — passed
- ``pnpm --filter @as-comms/web build`` — passed
- Targeted vitest (wizard test files) — all pass

Codex attempted browser-level verification but the sandbox doesn't permit binding a local dev-server port; CI is authoritative.

## Test plan

- [ ] CI green
- [ ] Visual check on staging: Step 3 renders immediately on entry (no white-screen wait), counter shows `Calculating audience…` until counts arrive
- [ ] Default state: all status pills unselected, counter shows 0, Continue disabled
- [ ] Click `Select all` → all populated pills selected, label flips to `Unselect all`, count populates
- [ ] Click `Unselect all` → all back to off, count returns to 0
- [ ] Single-project alias (`cabio@`): wide locked CA Biodiversity row, no picker affordance
- [ ] Multi-project alias (`forests@`): wide stacked Beech + Butternut rows, both default-selected, can deselect both
- [ ] Per-stage colors: TF=green, MF=blue, BF=purple, Off=red

🤖 Generated with [Claude Code](https://claude.com/claude-code) via Codex