### PR TITLE
fix(worker): correct reconcile-stranded query for graphile-worker 0.16+ schema

### DIFF
--- a/.codex-g4-reconcile-stranded-query-fix-2026-05-20.md
+++ b/.codex-g4-reconcile-stranded-query-fix-2026-05-20.md
@@ -1,0 +1,85 @@
+# Codex Brief — G4: Fix `reconcile-stranded-campaign-runs` query for graphile-worker 0.16+ schema
+
+**Worktree**: `/Users/nicolas/Downloads/AS Comms Platform/.codex-worktrees/g4-stranded-query-fix` on branch `codex/reconcile-stranded-query-fix-2026-05-20`
+**Suggested model**: GPT-5.4 **Medium** (schema-aware refactor, single file plus test update)
+**Estimated PR size**: ~30-60 LOC net change
+**Origin**: incident on 2026-05-20 — task errors on every cron tick. Blocks D-047 dispatch site #2 from ever firing.
+
+## Problem
+
+PR #437 introduced `reconcile-stranded-campaign-runs` ([apps/worker/src/ops/reconcile-stranded-campaign-runs.ts](apps/worker/src/ops/reconcile-stranded-campaign-runs.ts)). The query at lines 52-69 references `graphile_worker.jobs.payload`, but that column does **not exist** on the public `graphile_worker.jobs` view in graphile-worker 0.16+.
+
+Observed in Railway worker logs:
+
+```
+ERROR: Failed task <id> (reconcile-stranded-campaign-runs, ~10ms, attempt 1 of 1) with error 'Failed query: ...'
+```
+
+The actual Postgres error is `column jobs.payload does not exist`. Reproduced against prod by running the query directly:
+
+```sql
+SELECT 1 FROM graphile_worker.jobs jobs WHERE jobs.payload::jsonb ->> 'runId' = 'x';
+-- ERROR: column jobs.payload does not exist
+```
+
+In graphile-worker 0.16+, the schema is split:
+- `graphile_worker.jobs` is a public **view** that exposes high-level columns (no `payload`)
+- `graphile_worker._private_jobs` is the underlying **table** with `payload` (json) and `task_id` (integer FK to `_private_tasks`)
+- `graphile_worker._private_tasks` maps `task_id` to the human-readable `identifier`
+
+Reproduced corrected query against prod (returns 0 rows, no error):
+
+```sql
+SELECT 1
+FROM graphile_worker._private_jobs jobs
+JOIN graphile_worker._private_tasks tasks ON tasks.id = jobs.task_id
+WHERE tasks.identifier = 'campaign-send'
+  AND jobs.payload::jsonb ->> 'runId' = campaign_runs.id
+  AND jobs.attempts < jobs.max_attempts;
+```
+
+`campaign_runs.id` is `text` and `payload ->> 'runId'` returns `text`, so no cast is needed once the schema reference is correct.
+
+## In scope
+
+- [apps/worker/src/ops/reconcile-stranded-campaign-runs.ts:52-69](apps/worker/src/ops/reconcile-stranded-campaign-runs.ts:52) — replace the `graphile_worker.jobs` reference with the `_private_jobs` + `_private_tasks` join.
+- Add a single-line comment above the query explaining that the private schema is used because `graphile_worker.jobs` (the public view) does not expose `payload` in graphile-worker 0.16+.
+- Update any matching test that asserts SQL shape: [apps/worker/tests/unit/reconcile-stranded-campaign-runs.test.ts](apps/worker/tests/unit/reconcile-stranded-campaign-runs.test.ts) (if it exists; otherwise no test change needed).
+- If a PGlite integration fixture exercises this code path, ensure the test seeds `_private_jobs` + `_private_tasks` rows correctly (per memory: PGlite tests need explicit FK-parent seeding).
+
+## Out of scope
+
+- Do **not** change the surrounding `reconcileStrandedCampaignRuns` function signature, dependency injection shape, or audit-evidence emission.
+- Do **not** touch the `reconcile-stranded-campaign-runs` job wrapper at [apps/worker/src/jobs/reconcile-stranded-campaign-runs.ts](apps/worker/src/jobs/reconcile-stranded-campaign-runs.ts).
+- Do **not** alter retry / dead-letter behavior. The fix is purely the query.
+- Do **not** add new dependencies. Drizzle's `sql` template literal can express the JOIN directly.
+
+## Acceptance
+
+After this change, the task must run to completion (success or empty result set) without throwing a Postgres error. Confirm by:
+
+```bash
+pnpm --filter @as-comms/worker typecheck
+pnpm --filter @as-comms/worker lint
+pnpm --filter @as-comms/worker build
+pnpm --filter @as-comms/worker test:int   # if integration tests cover this path
+pnpm boundaries
+```
+
+(`test:unit` is intentionally omitted per project convention — CI is authoritative.)
+
+Then verify the query is well-formed against prod schema:
+
+```bash
+# After deploy, in Railway worker logs, look for:
+# "INFO: Completed task <id> (reconcile-stranded-campaign-runs, ...ms) with success"
+# and NO accompanying "ERROR: Failed task ... reconcile-stranded-campaign-runs"
+```
+
+## Why this matters
+
+This task is referenced as **D-047 dispatch site #2** ("Campaign send stuck") in the just-locked ops-alert architecture. Even when Brief 2 of PRD #444 wires the OpsAlertSender into this task, the alert will never fire because the query crashes before reaching the alerting code. Fixing this query unblocks D-047 dispatch site #2 end-to-end.
+
+## Validate-before-done
+
+Run all four validation commands above and report PASS/FAIL for each before declaring done. Capture any unexpected output.

--- a/apps/worker/src/ops/reconcile-stranded-campaign-runs.ts
+++ b/apps/worker/src/ops/reconcile-stranded-campaign-runs.ts
@@ -57,9 +57,11 @@ export async function reconcileStrandedCampaignRuns(
       from campaign_runs
       where campaign_runs.state = 'sending'
         and not exists (
+          -- Use the private tables because graphile_worker.jobs is a public view without payload in graphile-worker 0.16+.
           select 1
-          from graphile_worker.jobs jobs
-          where jobs.task_identifier = ${campaignSendJobName}
+          from graphile_worker._private_jobs jobs
+          join graphile_worker._private_tasks tasks on tasks.id = jobs.task_id
+          where tasks.identifier = ${campaignSendJobName}
             and jobs.payload::jsonb ->> 'runId' = campaign_runs.id
             and jobs.attempts < jobs.max_attempts
         )

--- a/apps/worker/test/reconcile-stranded-campaign-runs.test.ts
+++ b/apps/worker/test/reconcile-stranded-campaign-runs.test.ts
@@ -54,17 +54,67 @@ function buildDraftInput(
   }
 }
 
-async function installGraphileJobsTable(context: WorkerContext): Promise<void> {
+async function installGraphileWorkerSchema(context: WorkerContext): Promise<void> {
   await context.client.exec(`
     create schema if not exists graphile_worker;
-    create table if not exists graphile_worker.jobs (
+
+    create table if not exists graphile_worker._private_tasks (
+      id integer primary key,
+      identifier text not null unique
+    );
+
+    create table if not exists graphile_worker._private_jobs (
       id text primary key,
-      task_identifier text not null,
-      payload jsonb not null default '{}'::jsonb,
+      task_id integer not null references graphile_worker._private_tasks(id),
+      payload json not null default '{}'::json,
       run_at timestamptz not null default now(),
       attempts integer not null default 0,
       max_attempts integer not null default 25,
       locked_at timestamptz null
+    );
+
+    create or replace view graphile_worker.jobs as
+      select
+        jobs.id,
+        tasks.identifier as task_identifier,
+        jobs.run_at,
+        jobs.attempts,
+        jobs.max_attempts,
+        jobs.locked_at
+      from graphile_worker._private_jobs jobs
+      join graphile_worker._private_tasks tasks on tasks.id = jobs.task_id;
+  `)
+}
+
+async function seedGraphileWorkerJob(
+  context: WorkerContext,
+  input: {
+    readonly id: string
+    readonly taskIdentifier: string
+    readonly payload: string
+    readonly attempts?: number
+    readonly maxAttempts?: number
+  },
+): Promise<void> {
+  await context.client.exec(`
+    insert into graphile_worker._private_tasks (id, identifier)
+    values (1, '${input.taskIdentifier}')
+    on conflict (id) do update
+      set identifier = excluded.identifier;
+
+    insert into graphile_worker._private_jobs (
+      id,
+      task_id,
+      payload,
+      attempts,
+      max_attempts
+    )
+    values (
+      '${input.id}',
+      1,
+      '${input.payload}'::json,
+      ${String(input.attempts ?? 0)},
+      ${String(input.maxAttempts ?? campaignSendJobMaxAttempts)}
     );
   `)
 }
@@ -125,7 +175,7 @@ describe("reconcile stranded campaign runs", () => {
     const scheduled: string[] = []
 
     try {
-      await installGraphileJobsTable(context)
+      await installGraphileWorkerSchema(context)
       await seedProject(context)
       const runId = await seedSendingRun(context)
 
@@ -170,7 +220,7 @@ describe("reconcile stranded campaign runs", () => {
     const addJob = vi.fn(() => Promise.resolve(null))
 
     try {
-      await installGraphileJobsTable(context)
+      await installGraphileWorkerSchema(context)
       await seedProject(context)
       const runId = await seedSendingRun(context, {
         runId: "run-stranded-task",
@@ -205,6 +255,48 @@ describe("reconcile stranded campaign runs", () => {
       })
 
       expect(taskList[reconcileStrandedCampaignRunsJobName]).toBeDefined()
+    } finally {
+      await context.dispose()
+    }
+  })
+
+  it("does not re-enqueue sending runs that still have a live campaign-send job", async () => {
+    const context = await createTestWorkerContext()
+    const scheduled: string[] = []
+
+    try {
+      await installGraphileWorkerSchema(context)
+      await seedProject(context)
+      const runId = await seedSendingRun(context, {
+        runId: "run-live-job",
+      })
+
+      await seedGraphileWorkerJob(context, {
+        id: "job-live-run",
+        taskIdentifier: campaignSendJobName,
+        payload: JSON.stringify({ runId }),
+      })
+
+      const report = await reconcileStrandedCampaignRuns({
+        db: context.db,
+        repositories: context.repositories,
+        scheduleRecovery: (candidateRunId) => {
+          scheduled.push(candidateRunId)
+          return Promise.resolve()
+        },
+        now: () => new Date("2026-05-15T14:00:00.000Z"),
+        logger: {
+          log: () => undefined,
+        },
+      })
+
+      expect(report).toMatchObject({
+        scanned: 0,
+        reenqueued: 0,
+        agedOut: 0,
+        runIds: [],
+      })
+      expect(scheduled).toEqual([])
     } finally {
       await context.dispose()
     }


### PR DESCRIPTION
## Summary

- Production fix: `reconcile-stranded-campaign-runs` has been erroring on every cron tick since PR #437 with `column jobs.payload does not exist` — `graphile_worker.jobs` is a public view in graphile-worker 0.16+ that does not expose `payload`.
- Switches the not-exists subquery to JOIN `_private_jobs` + `_private_tasks`. Adds a one-line comment explaining the private-schema reference, plus a test case covering the not-exists path.
- Unblocks D-047 dispatch site #2 (campaign send stuck alerts) — even after PRD #444 Brief 2 wires the OpsAlertSender into this task, it would never fire because the upstream query crashes first.

## Test plan

- [x] `pnpm --filter @as-comms/worker typecheck`
- [x] `pnpm --filter @as-comms/worker lint`
- [x] `pnpm --filter @as-comms/worker build`
- [x] `pnpm boundaries`
- [x] `pnpm --filter @as-comms/worker exec vitest run test/reconcile-stranded-campaign-runs.test.ts` — 3/3 pass
- [ ] Post-deploy: confirm Railway worker log shows `Completed task ... (reconcile-stranded-campaign-runs, ...) with success` and no accompanying ERROR line on the next cron tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Codex via brief `.codex-g4-reconcile-stranded-query-fix-2026-05-20.md`