### PR TITLE
fix(settings): raise Mailchimp tile threshold to 24h for transition-period cadence

### DIFF
--- a/.codex-g6-mailchimp-threshold-calibration-2026-05-20.md
+++ b/.codex-g6-mailchimp-threshold-calibration-2026-05-20.md
@@ -1,0 +1,81 @@
+# Codex Brief — G6: Mailchimp tile threshold calibration for transition-period cadence
+
+**Worktree**: `/Users/nicolas/Downloads/AS Comms Platform/.codex-worktrees/g6-mailchimp-threshold-calibration` on branch `codex/mailchimp-threshold-calibration-2026-05-20`
+**Suggested model**: GPT-5.4 **Low** (constant change + test update + comment)
+**Estimated PR size**: ~10-25 LOC net change
+**Origin**: incident on 2026-05-20 — Mailchimp tile flips "Sync stale" any time Mailchimp goes >70 min without a campaign. Observed cadence in `sync_state` shows natural gaps of 7-28 hours during transition period.
+
+## Problem
+
+[apps/web/src/server/settings/selectors.ts:274](apps/web/src/server/settings/selectors.ts:274) defines:
+
+```typescript
+const MAILCHIMP_HEALTHY_WINDOW_MS = 70 * 60 * 1000;  // 70 minutes
+```
+
+This threshold was calibrated when Mailchimp was the primary email channel. Per memory `project_stage_5a_campaigns_2026_05_14.md`, we are in the Mailchimp → Postmark transition. Per memory `project_campaigns_deferred.md` (D-046, 2026-05-19), Mailchimp is in `Sync stale`-but-not-broken state by design — we are draining off it, not running daily campaigns through it.
+
+Empirical evidence from `sync_state` query (`provider='mailchimp', job_type='live_ingest'`):
+
+| `last_successful_at` | Gap to next |
+|---|---|
+| 2026-05-19 22:00 | 7 hours |
+| 2026-05-19 15:00 | 24+ hours |
+| 2026-05-18 10:30 | 56+ hours |
+| 2026-05-15 21:00 | 6 hours |
+| ...etc | irregular |
+
+Gaps of 7-28 hours are routine. The 70-min threshold means the tile shows `Sync stale` essentially all the time.
+
+This isn't a critical bug — the tile is technically accurate ("sync hasn't run within 70 min") — but it trains the operator to ignore the Mailchimp tile, and that's the wrong signal-to-noise tradeoff for a transition-period integration that is gradually being decommissioned.
+
+## Solution
+
+Raise the threshold to a value calibrated for transition-period reality. Recommended: **24 hours** = `24 * 60 * 60 * 1000`.
+
+Reasoning:
+- The longest gaps observed in the last 30 days are ~56 hours; 24h would still flag those.
+- A typical "Mailchimp is broken" failure mode (e.g., OAuth revoked, API rejected) would manifest as 24h+ of no sync — caught at 24h.
+- For the Phase C newsletter migration (D-046 Stage 5C, target ~mid-June 2026), this constant will become moot once Mailchimp is fully decommissioned. Tuning it once for the transition phase is sufficient.
+
+### Change
+
+```typescript
+// At [apps/web/src/server/settings/selectors.ts:274]
+- const MAILCHIMP_HEALTHY_WINDOW_MS = 70 * 60 * 1000;
++ // Mailchimp is in transition-period scaling (D-046 Stage 5C, mid-June 2026 decommission).
++ // Newsletter cadence is irregular — gaps of 7-28h are normal. The threshold is set high
++ // so the tile only flips Sync stale on genuine breakage (OAuth revoked, API failure), not
++ // routine inter-newsletter quiet periods. Will be removed once Mailchimp fully decommissions.
++ const MAILCHIMP_HEALTHY_WINDOW_MS = 24 * 60 * 60 * 1000;
+```
+
+## In scope
+
+- [apps/web/src/server/settings/selectors.ts:274](apps/web/src/server/settings/selectors.ts:274) — single constant change plus the 4-line explanatory comment.
+- [apps/web/tests/unit/integrations-selectors.test.ts](apps/web/tests/unit/integrations-selectors.test.ts) (or wherever the existing Mailchimp tile assertion lives) — update any test that hardcodes the 70-min boundary. Update assertions that test the boundary to use the new 24-hour boundary.
+
+## Out of scope
+
+- Do **not** change the surrounding `hasFreshMailchimpSync` / `hasMailchimpEvidence` / `mailchimpBaseUrl` evaluation logic.
+- Do **not** change the Mailchimp auto-hide window (`MAILCHIMP_AUTO_HIDE_WINDOW_MS = 60 days`).
+- Do **not** wire this constant to an env var or config table; a hardcoded constant is appropriate for a temporary transition-period tuning.
+
+## Acceptance
+
+```bash
+pnpm --filter @as-comms/web typecheck
+pnpm --filter @as-comms/web lint
+pnpm --filter @as-comms/web build
+pnpm boundaries
+```
+
+(`test:unit` is intentionally omitted per project convention — CI is authoritative.)
+
+After deploy:
+- Settings → Integrations → Mailchimp tile should show `Healthy` instead of `Sync stale` (current state: last successful sync was 22:00 UTC 2026-05-19, ~13h ago, well within 24h).
+- Tile will flip to `Sync stale` only if no successful Mailchimp sync occurs within a rolling 24h.
+
+## Note on the latent risk
+
+If the Mailchimp transition decommission slips significantly past mid-June 2026 (per D-046 Stage 5C target), revisit this constant — a 24h threshold becomes too generous if Mailchimp is still the primary newsletter channel for months. For now, the calibration matches the deliberately reduced operator-attention level the tile deserves.

--- a/apps/web/src/server/settings/selectors.ts
+++ b/apps/web/src/server/settings/selectors.ts
@@ -271,7 +271,11 @@ const PROVIDER_LABEL: Record<Provider, string> = {
   mailchimp: "Mailchimp",
   postmark: "Postmark"
 };
-const MAILCHIMP_HEALTHY_WINDOW_MS = 70 * 60 * 1000;
+// Mailchimp is in transition-period scaling (D-046 Stage 5C, target mid-June 2026
+// decommission). Newsletter cadence is irregular, and multi-hour quiet periods are
+// routine, so only surface "Sync stale" for likely breakage rather than expected gaps
+// between campaigns. Remove this once Mailchimp is fully decommissioned.
+const MAILCHIMP_HEALTHY_WINDOW_MS = 24 * 60 * 60 * 1000;
 const MAILCHIMP_AUTO_HIDE_WINDOW_MS = 60 * 24 * 60 * 60 * 1000;
 
 interface MailchimpSnapshotRow {

--- a/apps/web/tests/unit/settings-selectors.test.ts
+++ b/apps/web/tests/unit/settings-selectors.test.ts
@@ -726,7 +726,7 @@ describe("settings selectors", () => {
     });
   });
 
-  it("marks Mailchimp stale when the last successful transition sync is older than 70 minutes", async () => {
+  it("marks Mailchimp stale when the last successful transition sync is older than 24 hours", async () => {
     if (!runtime) {
       throw new Error("runtime not initialized");
     }
@@ -740,13 +740,13 @@ describe("settings selectors", () => {
       provider: "mailchimp",
       jobType: "live_ingest",
       cursor: null,
-      windowStart: "2026-05-03T09:00:00.000Z",
-      windowEnd: "2026-05-03T09:10:00.000Z",
+      windowStart: "2026-05-02T11:00:00.000Z",
+      windowEnd: "2026-05-02T11:10:00.000Z",
       status: "succeeded",
       parityPercent: null,
       freshnessP95Seconds: null,
       freshnessP99Seconds: null,
-      lastSuccessfulAt: "2026-05-03T09:10:00.000Z",
+      lastSuccessfulAt: "2026-05-02T11:10:00.000Z",
       consecutiveFailureCount: 0,
       leaseOwner: null,
       heartbeatAt: null,


### PR DESCRIPTION
## Summary

- Raises `MAILCHIMP_HEALTHY_WINDOW_MS` from 70 min → 24 h, with an explanatory comment tying the constant to D-046 Stage 5C (mid-June 2026 Mailchimp decommission).
- Adjusts the corresponding boundary in `settings-selectors.test.ts`.
- Pure config tuning. No new env vars, no new contracts.

## Why

Observed `sync_state` cadence for `provider=mailchimp` shows 7-28h gaps between successful runs as routine (D-046 transition-period reality). At 70 min the Mailchimp tile spent essentially all its time showing "Sync stale," training operators to ignore it. Today's incident (Railway outage 2026-05-19 22:13 → 2026-05-20 02:15 UTC) demonstrated the noise — but raising the threshold also makes the tile a meaningful signal for actual Mailchimp breakage.

## Test plan

- [x] `pnpm --filter @as-comms/web typecheck`
- [x] `pnpm --filter @as-comms/web lint`
- [x] `pnpm boundaries`
- [ ] CI `verify` workflow (root `pnpm build` via turbo, which builds workspace deps in dependency order)
- [ ] Post-deploy: Settings → Integrations → Mailchimp tile should show `Healthy` (last successful sync was within 24h).

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Codex via brief `.codex-g6-mailchimp-threshold-calibration-2026-05-20.md`