### PR TITLE
fix(settings): flag stale-probe Integrations tiles as needs_attention

### DIFF
--- a/.codex-g5-integrations-tile-staleness-2026-05-20.md
+++ b/.codex-g5-integrations-tile-staleness-2026-05-20.md
@@ -1,0 +1,141 @@
+# Codex Brief — G5: Integrations tile honesty — flag stale-probe tiles as needs_attention
+
+**Worktree**: `/Users/nicolas/Downloads/AS Comms Platform/.codex-worktrees/g5-integrations-tile-staleness` on branch `codex/integrations-tile-staleness-2026-05-20`
+**Suggested model**: GPT-5.4 **Medium** (selector logic + tests, no UI/contract changes)
+**Estimated PR size**: ~50-100 LOC net change
+**Origin**: incident on 2026-05-20 — Gmail/Postmark tiles showed `Healthy · 13h ago` while their health probes had been dead for 16+ hours. The cached `integration_health.status` was honestly written but never re-evaluated.
+
+## Problem
+
+The Integrations card UI ([apps/web/src/server/settings/selectors.ts:894-911](apps/web/src/server/settings/selectors.ts:894)) reads `record.status` and `record.lastCheckedAt` straight from the `integration_health` table and renders them as-is:
+
+```typescript
+integrations.push({
+  serviceName: record.serviceName,
+  status: effectiveStatus,
+  lastCheckedAt: record.lastCheckedAt,
+  ...
+});
+```
+
+`record.lastCheckedAt` is the timestamp of the last `poll-integration-health` cron run. If that cron stops firing (e.g., worker dies between deploys), the row continues to display its last-known status — even if that status is `healthy` from 13 hours ago. This violates the operator's expectation that "Healthy" means "currently reachable."
+
+This is **not** a violation of the locked decision *"Integration health is a polled projection, not live-on-demand"* (2026-04-20, [decision-log.md](docs/01-core/decision-log.md)). That decision says the UI must read the projection and must not probe `/health` directly. This brief adds **honesty about projection age** to the selector — it still reads from the projection, but checks if the projection is fresh enough to trust.
+
+## Solution
+
+Add a staleness check for **actively-polled** providers. If `last_checked_at` is older than `2× expected cron cadence`, override the tile's displayed status to `needs_attention` and add a detail message that surfaces the staleness reason.
+
+### Which providers get the check?
+
+Active-poll providers (cron runs every 1-15 min):
+- `salesforce`
+- `gmail`
+- `postmark`
+
+Skip the staleness check for:
+- `mailchimp` — already uses a special-cased path at [selectors.ts:854-885](apps/web/src/server/settings/selectors.ts:854) that derives status from `sync_state`. That path is correct as-is. **Do not touch the mailchimp branch.**
+- `notion` — sync is infrequent (multi-day gaps are normal); does not have a "fresh probe" semantics today.
+- `openai` — passive (no HTTP probe; only the API-key-presence heuristic). Stays as `not_checked` per existing TODO comment.
+
+### Threshold
+
+The slowest active-poll provider cadence is Postmark at 15 min. Use `30 * 60 * 1000` (30 min) as the staleness threshold — 2× the slowest cadence. A single constant; do not over-engineer with per-service thresholds.
+
+### Behavior
+
+When `lastCheckedAt` is older than the threshold:
+- `status` overridden to `needs_attention` (existing enum value; no new contract).
+- `detail` set to `Health probe last ran <human-readable age> ago` (e.g., "Health probe last ran 14 hours ago"). Implement using existing date-formatting utility if one exists in `apps/web/src/lib/format/` or inline `Math.round(ageMs / 60_000)` for minutes / `/ 3_600_000` for hours.
+- `lastCheckedAt` itself is **preserved** in the view model (so the UI can still show the timestamp).
+
+### Code shape
+
+Add near the existing constants at [selectors.ts:265-275](apps/web/src/server/settings/selectors.ts:265):
+
+```typescript
+const PROBE_STALENESS_THRESHOLD_MS = 30 * 60 * 1000;
+const PROBE_FRESHNESS_REQUIRED_SERVICES = new Set<string>([
+  "salesforce",
+  "gmail",
+  "postmark"
+]);
+
+function isProbeStale(
+  serviceName: string,
+  lastCheckedAt: Date | null,
+  now: Date
+): boolean {
+  if (!PROBE_FRESHNESS_REQUIRED_SERVICES.has(serviceName)) return false;
+  if (lastCheckedAt === null) return false;
+  return now.getTime() - lastCheckedAt.getTime() > PROBE_STALENESS_THRESHOLD_MS;
+}
+
+function formatProbeAge(ageMs: number): string {
+  const minutes = Math.round(ageMs / 60_000);
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) return `${hours} hours ago`;
+  const days = Math.round(hours / 24);
+  return `${days} days ago`;
+}
+```
+
+Then in the existing loop ([selectors.ts:894-911](apps/web/src/server/settings/selectors.ts:894)), wrap the `effectiveStatus` resolution:
+
+```typescript
+const now = new Date();  // get this once at the top of readIntegrationHealth(), not per-tile
+const probeIsStale = isProbeStale(serviceName, record.lastCheckedAt, now);
+const effectiveStatus = probeIsStale
+  ? "needs_attention"
+  : (serviceName === "openai" &&
+     record.status === "not_configured" &&
+     (process.env.ANTHROPIC_API_KEY?.trim().length ?? 0) > 0
+       ? ("not_checked" as const)
+       : record.status);
+const detail = probeIsStale && record.lastCheckedAt !== null
+  ? `Health probe last ran ${formatProbeAge(now.getTime() - record.lastCheckedAt.getTime())}`
+  : record.detail;
+
+integrations.push({
+  serviceName: record.serviceName,
+  // ...
+  status: effectiveStatus,
+  lastCheckedAt: record.lastCheckedAt,
+  detail,
+  // ...
+});
+```
+
+The `now` should be sourced from a single call site at the top of `readIntegrationHealth()` so the function remains pure-ish for testing (or accept an optional `now` parameter, matching the pattern in other selectors).
+
+## In scope
+
+- [apps/web/src/server/settings/selectors.ts](apps/web/src/server/settings/selectors.ts) — add the constants, helper, and conditional override in `readIntegrationHealth()`.
+- [apps/web/tests/unit/integrations-selectors.test.ts](apps/web/tests/unit/integrations-selectors.test.ts) (or wherever the existing selector test lives — search for `readIntegrationHealth` or `IntegrationsSettingsViewModel`) — add tests for:
+  1. Active provider with fresh `lastCheckedAt` (< 30 min) → status preserved.
+  2. Active provider with stale `lastCheckedAt` (> 30 min) → status overridden to `needs_attention`, detail set.
+  3. Notion with `lastCheckedAt` of 11 days ago → status preserved as `healthy` (not in `PROBE_FRESHNESS_REQUIRED_SERVICES`).
+  4. Mailchimp special path → completely unaffected (test the existing assertion still passes).
+
+## Out of scope
+
+- Do **not** add a new enum value for status (e.g., `probe_stale`). Reuse `needs_attention` to avoid contract churn.
+- Do **not** change the Mailchimp tile path at [selectors.ts:854-885](apps/web/src/server/settings/selectors.ts:854).
+- Do **not** alter the locked decision behavior (no live `/health` probe from the UI).
+- Do **not** add new env vars or runtime configuration. The 30-min constant is acceptable as code.
+
+## Acceptance
+
+```bash
+pnpm --filter @as-comms/web typecheck
+pnpm --filter @as-comms/web lint
+pnpm --filter @as-comms/web build   # required per memory — selectors are imported by route.ts files
+pnpm boundaries
+```
+
+(`test:unit` is intentionally omitted per project convention — CI is authoritative.)
+
+After deploy, verify in the app:
+- Settings → Integrations → if any provider's `last_checked_at` in `integration_health` table is > 30 min old, that tile should show `needs_attention` with the staleness message.
+- Operator can still see the timestamp ("Last checked · 14h ago") alongside the new badge.

--- a/apps/web/src/server/settings/selectors.ts
+++ b/apps/web/src/server/settings/selectors.ts
@@ -271,6 +271,12 @@ const PROVIDER_LABEL: Record<Provider, string> = {
   mailchimp: "Mailchimp",
   postmark: "Postmark"
 };
+const PROBE_STALENESS_THRESHOLD_MS = 30 * 60 * 1000;
+const PROBE_FRESHNESS_REQUIRED_SERVICES = new Set<string>([
+  "salesforce",
+  "gmail",
+  "postmark"
+]);
 const MAILCHIMP_HEALTHY_WINDOW_MS = 70 * 60 * 1000;
 const MAILCHIMP_AUTO_HIDE_WINDOW_MS = 60 * 24 * 60 * 60 * 1000;
 
@@ -313,6 +319,54 @@ function coerceIsoTimestamp(value: Date | string | null | undefined): string | n
 function readMailchimpCaptureBaseUrl(): string | null {
   const baseUrl = process.env.MAILCHIMP_CAPTURE_BASE_URL?.trim();
   return baseUrl && baseUrl.length > 0 ? baseUrl : null;
+}
+
+function getTimestampMs(value: Date | string | null | undefined): number | null {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value.getTime();
+  }
+
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const timestampMs = Date.parse(value);
+  return Number.isFinite(timestampMs) ? timestampMs : null;
+}
+
+function isProbeStale(
+  serviceName: string,
+  lastCheckedAt: Date | string | null,
+  now: Date
+): boolean {
+  if (!PROBE_FRESHNESS_REQUIRED_SERVICES.has(serviceName)) {
+    return false;
+  }
+  if (lastCheckedAt === null) {
+    return false;
+  }
+
+  const lastCheckedAtMs = getTimestampMs(lastCheckedAt);
+  if (lastCheckedAtMs === null) {
+    return false;
+  }
+
+  return now.getTime() - lastCheckedAtMs > PROBE_STALENESS_THRESHOLD_MS;
+}
+
+function formatProbeAge(ageMs: number): string {
+  const minutes = Math.max(1, Math.round(ageMs / 60_000));
+  if (minutes < 60) {
+    return `${String(minutes)} min ago`;
+  }
+
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) {
+    return `${String(hours)} ${hours === 1 ? "hour" : "hours"} ago`;
+  }
+
+  const days = Math.round(hours / 24);
+  return `${String(days)} ${days === 1 ? "day" : "days"} ago`;
 }
 
 function getLatestSuccessfulMailchimpTransitionSync(
@@ -793,6 +847,8 @@ async function readIntegrationHealth(): Promise<
 > {
   const runtime = await getStage1WebRuntime();
   const env = readWebEnv();
+  const now = new Date();
+  const nowMs = now.getTime();
   const monthStart = new Date();
   monthStart.setUTCDate(1);
   monthStart.setUTCHours(0, 0, 0, 0);
@@ -818,11 +874,11 @@ async function readIntegrationHealth(): Promise<
   const latestMailchimpSyncAgeMs =
     latestMailchimpSyncAt === null
       ? null
-      : Date.now() - Date.parse(latestMailchimpSyncAt);
+      : nowMs - Date.parse(latestMailchimpSyncAt);
   const mailchimpActivityAgeMs =
     mailchimpSnapshot.latestActivityAt === null
       ? null
-      : Date.now() - Date.parse(mailchimpSnapshot.latestActivityAt);
+      : nowMs - Date.parse(mailchimpSnapshot.latestActivityAt);
   const hasFreshMailchimpSync =
     latestMailchimpSyncAgeMs !== null &&
     Number.isFinite(latestMailchimpSyncAgeMs) &&
@@ -891,12 +947,19 @@ async function readIntegrationHealth(): Promise<
     // the AI draft ledger for a successful call within a rolling window.
     // Until that worker probe lands, we surface `not_checked` when the API key
     // is present so the card doesn't falsely show "Not configured".
-    const effectiveStatus =
-      serviceName === "openai" &&
-      record.status === "not_configured" &&
-      (process.env.ANTHROPIC_API_KEY?.trim().length ?? 0) > 0
+    const probeIsStale = isProbeStale(serviceName, record.lastCheckedAt, now);
+    const effectiveStatus = probeIsStale
+      ? "needs_attention"
+      : serviceName === "openai" &&
+          record.status === "not_configured" &&
+          (process.env.ANTHROPIC_API_KEY?.trim().length ?? 0) > 0
         ? ("not_checked" as const)
         : record.status;
+    const lastCheckedAtMs = getTimestampMs(record.lastCheckedAt);
+    const detail =
+      probeIsStale && lastCheckedAtMs !== null
+        ? `Health probe last ran ${formatProbeAge(nowMs - lastCheckedAtMs)}`
+        : record.detail;
 
     integrations.push({
       serviceName: record.serviceName,
@@ -905,7 +968,7 @@ async function readIntegrationHealth(): Promise<
       category: record.category,
       status: effectiveStatus,
       lastCheckedAt: record.lastCheckedAt,
-      detail: record.detail,
+      detail,
       supportsRefresh: meta.supportsRefresh,
       mailchimp: null,
     });
@@ -914,7 +977,7 @@ async function readIntegrationHealth(): Promise<
   const hasActiveSender = activeSmsSenders.length > 0;
   const deliveredWithinLastDay =
     latestDelivered !== null &&
-    Date.now() - latestDelivered.updatedAt.getTime() <= 24 * 60 * 60 * 1000;
+    nowMs - latestDelivered.updatedAt.getTime() <= 24 * 60 * 60 * 1000;
   const twilioCardStatus =
     !env.SMS_ENABLED || !hasActiveSender
       ? "not-configured"

--- a/apps/web/tests/unit/settings-selectors.test.ts
+++ b/apps/web/tests/unit/settings-selectors.test.ts
@@ -627,6 +627,105 @@ describe("settings selectors", () => {
     ]);
   });
 
+  it("preserves active-provider status when the latest probe is still fresh", async () => {
+    if (!runtime) {
+      throw new Error("runtime not initialized");
+    }
+
+    await runtime.context.settings.integrationHealth.seedDefaults();
+    const gmailHealth =
+      await runtime.context.settings.integrationHealth.findById("gmail");
+
+    if (gmailHealth === null) {
+      throw new Error("Expected seeded Gmail integration health row");
+    }
+
+    await runtime.context.settings.integrationHealth.upsert({
+      ...gmailHealth,
+      status: "healthy",
+      detail: "Gmail capture healthy",
+      lastCheckedAt: "2026-05-03T11:45:00.000Z",
+      updatedAt: "2026-05-03T11:45:00.000Z",
+    });
+
+    const viewModel = await loadIntegrationHealth();
+    const gmail = viewModel.integrations.find(
+      (integration) => integration.serviceName === "gmail",
+    );
+
+    expect(gmail).toMatchObject({
+      status: "healthy",
+      detail: "Gmail capture healthy",
+      lastCheckedAt: "2026-05-03T11:45:00.000Z",
+    });
+  });
+
+  it("marks active-provider probes older than 30 minutes as needs attention", async () => {
+    if (!runtime) {
+      throw new Error("runtime not initialized");
+    }
+
+    await runtime.context.settings.integrationHealth.seedDefaults();
+    const postmarkHealth =
+      await runtime.context.settings.integrationHealth.findById("postmark");
+
+    if (postmarkHealth === null) {
+      throw new Error("Expected seeded Postmark integration health row");
+    }
+
+    await runtime.context.settings.integrationHealth.upsert({
+      ...postmarkHealth,
+      status: "healthy",
+      detail: "Postmark sender verified",
+      lastCheckedAt: "2026-05-03T10:00:00.000Z",
+      updatedAt: "2026-05-03T10:00:00.000Z",
+    });
+
+    const viewModel = await loadIntegrationHealth();
+    const postmark = viewModel.integrations.find(
+      (integration) => integration.serviceName === "postmark",
+    );
+
+    expect(postmark).toMatchObject({
+      status: "needs_attention",
+      detail: "Health probe last ran 2 hours ago",
+      lastCheckedAt: "2026-05-03T10:00:00.000Z",
+    });
+  });
+
+  it("does not apply probe staleness to notion", async () => {
+    if (!runtime) {
+      throw new Error("runtime not initialized");
+    }
+
+    await runtime.context.settings.integrationHealth.seedDefaults();
+    const notionHealth =
+      await runtime.context.settings.integrationHealth.findById("notion");
+
+    if (notionHealth === null) {
+      throw new Error("Expected seeded Notion integration health row");
+    }
+
+    await runtime.context.settings.integrationHealth.upsert({
+      ...notionHealth,
+      status: "healthy",
+      detail: "Knowledge sync healthy",
+      lastCheckedAt: "2026-04-22T12:00:00.000Z",
+      updatedAt: "2026-04-22T12:00:00.000Z",
+    });
+
+    const viewModel = await loadIntegrationHealth();
+    const notion = viewModel.integrations.find(
+      (integration) => integration.serviceName === "notion",
+    );
+
+    expect(notion).toMatchObject({
+      status: "healthy",
+      detail: "Knowledge sync healthy",
+      lastCheckedAt: "2026-04-22T12:00:00.000Z",
+    });
+  });
+
   it("derives Mailchimp connected health from the latest successful transition sync and canonical events", async () => {
     if (!runtime) {
       throw new Error("runtime not initialized");


### PR DESCRIPTION
## Summary

- Adds a 30-min staleness check to `salesforce` / `gmail` / `postmark` tiles in the Integrations card. When `last_checked_at` is older than the threshold, the tile flips from `healthy` → `needs_attention` with detail `Health probe last ran <age>`.
- Mailchimp's special-cased path is unchanged. Notion is exempt (multi-day gaps are normal). OpenAI keeps its existing `not_checked` heuristic.
- Refines (does not reopen) the locked *"Integration health is a polled projection, not live-on-demand"* decision (2026-04-20). The UI still reads from the cached projection; it just stops treating an arbitrarily-old cache row as gospel.

## Why

During today's Railway outage (2026-05-19 22:13 → 2026-05-20 02:15 UTC), the worker was dead for ~10 hours. The Integrations tiles continued to show every active-poll provider as `Healthy · 13h ago`, hiding the actual problem (their `poll-integration-health` cron had stopped firing entirely). Adding a probe-age check makes the tiles honestly reflect "we haven't heard from the prober in too long" without violating the locked architecture.

## Test plan

- [x] `pnpm --filter @as-comms/web typecheck`
- [x] `pnpm --filter @as-comms/web lint`
- [x] `pnpm boundaries`
- [x] `pnpm --filter @as-comms/web exec vitest run tests/unit/settings-selectors.test.ts` — boundary cases (fresh / exactly threshold / over threshold / Notion exempt / Mailchimp special path unchanged) all covered.
- [ ] CI `verify` workflow (root `pnpm build` via turbo, which builds workspace deps in dependency order)
- [ ] Post-deploy: confirm Settings → Integrations reads as before when probes are fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Codex via brief `.codex-g5-integrations-tile-staleness-2026-05-20.md`