### PR TITLE
Wizard Step 3 polish: packed pills, stable status fetch, forests@ Beech+Butternut

### DIFF
--- a/apps/web/app/broadcasts/_lib/audience-data-source.ts
+++ b/apps/web/app/broadcasts/_lib/audience-data-source.ts
@@ -530,14 +530,17 @@ export async function getCampaignWizardDraft(
 export async function getAudienceBuilderBootstrap(): Promise<AudienceBuilderBootstrap> {
   await requireSession();
   const runtime = await getStage1WebRuntime();
-  const settingsProjects = (await runtime.settings.projects.listAll()).filter(
+  const allConnectedProjects = (await runtime.settings.projects.listAll()).filter(
+    (project) => project.isActive || project.connectedToProjectId !== null,
+  );
+  const activeProjects = allConnectedProjects.filter(
     (project) => project.isActive,
   );
   const projectsById = new Map(
-    settingsProjects.map((project) => [project.projectId, project] as const),
+    allConnectedProjects.map((project) => [project.projectId, project] as const),
   );
 
-  const projectOptions = settingsProjects
+  const projectOptions = allConnectedProjects
     .map((project) => {
       const primaryEmail = readPrimaryEmail(project);
       const hostProject =
@@ -569,7 +572,7 @@ export async function getAudienceBuilderBootstrap(): Promise<AudienceBuilderBoot
       (project) => project.connectedToProjectId === host.id,
     ),
   }));
-  const senderOptions = settingsProjects
+  const senderOptions = activeProjects
     .map((project) => {
       const email = readPrimaryEmail(project);
       if (email === null) {

--- a/apps/web/app/broadcasts/new/_components/audience-filter-panel.tsx
+++ b/apps/web/app/broadcasts/new/_components/audience-filter-panel.tsx
@@ -56,17 +56,6 @@ const STAGE_GROUPS = {
   }
 >;
 
-const SELECTED_RING_CLASSES: Record<ToneNameV2, string> = {
-  slate: "ring-slate-600",
-  sky: "ring-sky-600",
-  indigo: "ring-indigo-600",
-  emerald: "ring-emerald-600",
-  amber: "ring-amber-500",
-  rose: "ring-rose-500",
-  violet: "ring-violet-500",
-  teal: "ring-teal-600",
-};
-
 interface AudienceFilterPanelProps {
   readonly criteria: CampaignAudienceCriteria;
   readonly projectOptions: readonly CampaignProjectOption[];
@@ -379,7 +368,7 @@ function StageStatusSection({
         )}
       </div>
 
-      <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+      <div className="flex flex-wrap gap-1.5">
         {statuses.map((status) => {
           const selected = selectedStatuses.includes(status);
           const countForStatus = statusCounts[status] ?? 0;
@@ -395,16 +384,21 @@ function StageStatusSection({
                 onStatusToggle(status);
               }}
               className={cn(
-                `flex min-h-[48px] items-center justify-between gap-3 rounded-xl border px-3.5 py-3 text-left text-[12.5px] font-semibold ${TRANSITION.fast} ${FOCUS_RING}`,
+                `inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[12px] font-medium ring-1 ring-inset ${TRANSITION.fast} ${FOCUS_RING}`,
                 selected
-                  ? `${tone.bg} text-white ring-1 ${SELECTED_RING_CLASSES[color]}`
-                  : `${tone.subtle} ${tone.subtleText} border-transparent ring-1 ${tone.ring} hover:opacity-90`,
+                  ? `${tone.bg} text-white ring-transparent`
+                  : "bg-white text-slate-700 ring-slate-200 hover:bg-slate-50",
               )}
             >
-              <span className="flex min-w-0 items-center gap-3">
-                <StatusSelectionIndicator color={color} selected={selected} />
-                <span className="truncate">{status}</span>
-              </span>
+              {selected ? (
+                <Check className="size-2.5 shrink-0" aria-hidden="true" />
+              ) : (
+                <span
+                  className={cn("size-1.5 shrink-0 rounded-full", tone.dot)}
+                  aria-hidden="true"
+                />
+              )}
+              <span>{status}</span>
               {loading ? (
                 <span
                   aria-hidden="true"
@@ -413,8 +407,8 @@ function StageStatusSection({
               ) : (
                 <span
                   className={cn(
-                    "shrink-0 tabular-nums",
-                    selected ? "text-white" : tone.text,
+                    "tabular-nums text-[11.5px]",
+                    selected ? "text-white/90" : "text-slate-500/90",
                   )}
                 >
                   {countForStatus.toLocaleString()}
@@ -444,32 +438,6 @@ function ProjectSelectionIndicator({
       aria-hidden="true"
     >
       {selected ? <Check className="size-3" aria-hidden="true" /> : null}
-    </span>
-  );
-}
-
-function StatusSelectionIndicator({
-  color,
-  selected,
-}: {
-  readonly color: ToneNameV2;
-  readonly selected: boolean;
-}) {
-  const tone = TONE_CLASSES[color];
-
-  return (
-    <span
-      className={cn(
-        "flex size-5 shrink-0 items-center justify-center rounded-full border",
-        selected
-          ? "border-white/30 bg-white/15 text-white"
-          : `bg-white/70 ${tone.text} ${tone.ring}`,
-      )}
-      aria-hidden="true"
-    >
-      {selected ? (
-        <Check className="size-3" aria-hidden="true" />
-      ) : null}
     </span>
   );
 }

--- a/apps/web/app/broadcasts/new/_components/new-campaign-wizard.tsx
+++ b/apps/web/app/broadcasts/new/_components/new-campaign-wizard.tsx
@@ -507,7 +507,8 @@ export function NewCampaignWizard({
     () => formatAutosaveLabel(lastSavedAtIso),
     [autosaveTick, lastSavedAtIso],
   );
-  const selectedProjectIds = useMemo(() => readProjectIds(criteria), [criteria]);
+  const selectedProjectIds = readProjectIds(criteria);
+  const selectedProjectIdsKey = selectedProjectIds.join(",");
   const warningDismissed =
     warningDismissFingerprint !== null &&
     warningDismissFingerprint === previewFingerprint;
@@ -658,7 +659,7 @@ export function NewCampaignWizard({
             };
       });
     });
-  }, [bootstrap.statuses, criteria.initialFilter, selectedProjectIds]);
+  }, [bootstrap.statuses, criteria.initialFilter, selectedProjectIdsKey]);
 
   useEffect(() => {
     const timer = setInterval(() => {

--- a/apps/web/tests/unit/campaign-audience-filter-panel.test.tsx
+++ b/apps/web/tests/unit/campaign-audience-filter-panel.test.tsx
@@ -238,8 +238,48 @@ describe("AudienceFilterPanel", () => {
 
     expect(waitlistButton.getAttribute("aria-checked")).toBe("true");
     expect(waitlistButton.className).toContain("bg-emerald-600");
-    expect(deniedButton.className).toContain("bg-rose-50");
+    expect(deniedButton.className).toContain("bg-white");
+    expect(deniedButton.querySelector(".bg-rose-500")).not.toBeNull();
     expect(document.body.textContent).not.toContain("MID-FUNNEL");
+  });
+
+  it("renders packed status pills in a flex-wrap row instead of the old grid", () => {
+    renderPanel();
+
+    const waitlistButton = Array.from(document.querySelectorAll("button")).find(
+      (button) =>
+        button.getAttribute("aria-label") ===
+        "Toggle expedition-member status Waitlist",
+    );
+
+    if (!(waitlistButton instanceof HTMLButtonElement)) {
+      throw new Error("Waitlist status button not found");
+    }
+
+    const pillContainer = waitlistButton.parentElement;
+    if (!(pillContainer instanceof HTMLElement)) {
+      throw new Error("Status pill container not found");
+    }
+
+    expect(pillContainer.className).toContain("flex-wrap");
+    expect(pillContainer.className).not.toContain("grid-cols-");
+  });
+
+  it("renders compact rounded-full status pills without the legacy fixed height", () => {
+    renderPanel();
+
+    const waitlistButton = Array.from(document.querySelectorAll("button")).find(
+      (button) =>
+        button.getAttribute("aria-label") ===
+        "Toggle expedition-member status Waitlist",
+    );
+
+    if (!(waitlistButton instanceof HTMLButtonElement)) {
+      throw new Error("Waitlist status button not found");
+    }
+
+    expect(waitlistButton.className).toContain("rounded-full");
+    expect(waitlistButton.className).not.toContain("min-h-[48px]");
   });
 
   it("renders a locked pill for single-project aliases", () => {
@@ -273,5 +313,25 @@ describe("AudienceFilterPanel", () => {
         button.getAttribute("aria-label")?.startsWith("Choose project "),
       ),
     ).toBe(false);
+  });
+
+  it("renders both forests sub-projects as toggleable project rows when two options exist", () => {
+    renderPanel();
+
+    const projectButtons = Array.from(document.querySelectorAll("button")).filter(
+      (button) => button.getAttribute("aria-label")?.startsWith("Choose project "),
+    );
+
+    expect(projectButtons).toHaveLength(2);
+    expect(
+      document.querySelector(
+        '[aria-label="Project Restoring Butternut Forest Health is locked to this sender alias"]',
+      ),
+    ).toBeNull();
+    expect(
+      document.querySelector(
+        '[aria-label="Project Saving American Beech is locked to this sender alias"]',
+      ),
+    ).toBeNull();
   });
 });

--- a/apps/web/tests/unit/campaign-audience-step.test.tsx
+++ b/apps/web/tests/unit/campaign-audience-step.test.tsx
@@ -1,6 +1,10 @@
+import { createRequire } from "node:module";
+
 import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 Object.assign(globalThis, { React });
 
@@ -26,6 +30,68 @@ vi.mock("@/components/ui/input", () => ({
 }));
 
 import { AudienceBuilderStep } from "../../app/broadcasts/new/_components/audience-builder-step";
+import type {
+  AudienceBuilderBootstrap,
+  CampaignWizardDraftData,
+} from "../../app/broadcasts/_lib/audience-data-source";
+
+const workerRequire = createRequire(import.meta.url);
+const { JSDOM } = workerRequire("jsdom") as {
+  readonly JSDOM: new (
+    html?: string,
+    options?: {
+      readonly url?: string;
+      readonly pretendToBeVisual?: boolean;
+    },
+  ) => {
+    readonly window: Window & typeof globalThis;
+  };
+};
+
+let root: Root | null = null;
+
+function setupDom() {
+  const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+    url: "http://localhost/broadcasts/new",
+    pretendToBeVisual: true,
+  });
+
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: dom.window.navigator,
+  });
+  globalThis.HTMLElement = dom.window.HTMLElement;
+  globalThis.HTMLButtonElement = dom.window.HTMLButtonElement;
+  globalThis.HTMLInputElement = dom.window.HTMLInputElement;
+  globalThis.MouseEvent = dom.window.MouseEvent;
+  globalThis.Event = dom.window.Event;
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+
+  const container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+}
+
+async function settleAsyncWork() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  if (typeof document !== "undefined") {
+    document.body.innerHTML = "";
+  }
+  root = null;
+  vi.resetModules();
+  vi.clearAllMocks();
+});
 
 const baseProps: React.ComponentProps<typeof AudienceBuilderStep> = {
   availableModes: ["project_status", "specific"],
@@ -184,6 +250,262 @@ describe("AudienceBuilderStep initial filter gate", () => {
     );
     expect(validMarkup).not.toMatch(
       /<button[^>]*aria-disabled="true"[^>]*>Continue to compose<\/button>/,
+    );
+  });
+
+  it("does not retrigger the member-status-counts fetch when only statuses change", async () => {
+    setupDom();
+
+    const loadMemberStatusCountsForProjects = vi.fn(() =>
+      Promise.resolve({
+        ok: true as const,
+        data: { Waitlist: 5 },
+      }),
+    );
+    const resolveAudienceCountAction = vi.fn(() =>
+      Promise.resolve({
+        ok: true as const,
+        data: { count: 5, hasAppliedFilters: true },
+      }),
+    );
+    const previewAudienceAction = vi.fn(() =>
+      Promise.resolve({
+        ok: true as const,
+        data: [],
+      }),
+    );
+    const searchProjectVolunteersAction = vi.fn(() =>
+      Promise.resolve({
+        ok: true as const,
+        data: [],
+      }),
+    );
+    const loadComposePreviewAction = vi.fn(() =>
+      Promise.resolve({
+        ok: true as const,
+        data: {
+          audienceSize: 0,
+          sampleIndex: 0,
+          sampleCount: 0,
+          sample: null,
+          warningCount: 0,
+          affectedContacts: [],
+          footerAddress: null,
+        },
+      }),
+    );
+    const saveCampaignWizardDraftAction = vi.fn(() =>
+      Promise.resolve({
+        ok: true as const,
+        data: {
+          runId: "run-1",
+          launchType: "normal_email",
+          kind: "project",
+          name: null,
+          fromEmail: "forests@adventurescientists.org",
+          replyToEmail: "forests@adventurescientists.org",
+          subjectTemplate: null,
+          bodyHtmlTemplate: null,
+          bodyTextTemplate: null,
+          preheader: null,
+          audienceCriteria: {
+            projectId: null,
+            projectIds: [],
+            statuses: [],
+            contactIds: [],
+            expeditionIds: [],
+            lastActivityWindow: "all_time",
+            hasReplied: "either",
+            hasClicked: "either",
+          },
+          audienceSize: null,
+          state: "draft",
+          scheduledAt: null,
+          updatedAt: "2026-05-20T12:00:00.000Z",
+          operatorEmail: "operator@example.com",
+        },
+      }),
+    );
+
+    vi.doMock("../../app/broadcasts/_lib/audience-data-source", () => ({
+      loadMemberStatusCountsForProjects,
+      loadComposePreviewAction,
+      previewAudienceAction,
+      resolveAudienceCountAction,
+      saveCampaignWizardDraftAction,
+      searchProjectVolunteersAction,
+    }));
+    vi.doMock("../../app/broadcasts/actions", () => ({
+      schedule: vi.fn(),
+      sendNow: vi.fn(),
+      testSend: vi.fn(),
+    }));
+    vi.doMock("../../app/broadcasts/new/_components/launch-type-step", () => ({
+      LaunchTypeStep: ({
+        onContinue,
+      }: {
+        readonly onContinue: () => void;
+      }) => <button onClick={onContinue}>Launch continue</button>,
+    }));
+    vi.doMock("../../app/broadcasts/new/_components/name-and-sender-step", () => ({
+      NameAndSenderStep: ({
+        onContinue,
+      }: {
+        readonly onContinue: () => void;
+      }) => <button onClick={onContinue}>Sender continue</button>,
+    }));
+    vi.doMock("../../app/broadcasts/new/_components/audience-builder-step", () => ({
+      AudienceBuilderStep: ({
+        onStatusToggle,
+      }: {
+        readonly onStatusToggle: (status: string) => void;
+      }) => (
+        <button
+          onClick={() => {
+            onStatusToggle("Waitlist");
+          }}
+        >
+          Toggle Waitlist
+        </button>
+      ),
+    }));
+    vi.doMock("../../app/broadcasts/new/_components/compose-step", () => ({
+      ComposeStep: () => <div>Compose</div>,
+    }));
+    vi.doMock("../../app/broadcasts/new/_components/preview-step", () => ({
+      PreviewStep: () => <div>Preview</div>,
+    }));
+    vi.doMock("../../app/broadcasts/new/_components/review-step", () => ({
+      ReviewStep: () => <div>Review</div>,
+    }));
+    vi.doMock("../../app/broadcasts/new/_components/wizard-rail", () => ({
+      WizardRail: () => null,
+    }));
+
+    const { NewCampaignWizard } = await import(
+      "../../app/broadcasts/new/_components/new-campaign-wizard"
+    );
+
+    const bootstrap: AudienceBuilderBootstrap = {
+      projects: [
+        {
+          host: {
+            id: "host-project",
+            name: "Saving American Beech",
+            alias: null,
+            aliasHint: "forests@",
+            connectedToProjectId: null,
+            isSubProject: false,
+          },
+          connectedSubs: [
+            {
+              id: "sub-project",
+              name: "Restoring Butternut Forest Health",
+              alias: null,
+              aliasHint: "forests@",
+              connectedToProjectId: "host-project",
+              isSubProject: true,
+            },
+          ],
+        },
+      ],
+      expeditions: [],
+      statuses: ["Waitlist", "Denied"],
+      senderOptions: [
+        {
+          projectId: "host-project",
+          projectName: "Saving American Beech",
+          projectAliasLabel: "forests@",
+          email: "forests@adventurescientists.org",
+          connectedToProjectId: null,
+          status: "verified",
+        },
+      ],
+    };
+    const draft: CampaignWizardDraftData = {
+      runId: "run-1",
+      launchType: "normal_email",
+      kind: "project",
+      name: null,
+      fromEmail: "forests@adventurescientists.org",
+      replyToEmail: "forests@adventurescientists.org",
+      subjectTemplate: null,
+      bodyHtmlTemplate: null,
+      bodyTextTemplate: null,
+      preheader: null,
+      audienceCriteria: {
+        projectId: null,
+        projectIds: [],
+        statuses: [],
+        contactIds: [],
+        expeditionIds: [],
+        lastActivityWindow: "all_time",
+        hasReplied: "either",
+        hasClicked: "either",
+      },
+      audienceSize: null,
+      state: "draft",
+      scheduledAt: null,
+      updatedAt: "2026-05-20T12:00:00.000Z",
+      operatorEmail: "operator@example.com",
+    };
+
+    act(() => {
+      root?.render(
+        <NewCampaignWizard bootstrap={bootstrap} draft={draft} isAdmin={true} />,
+      );
+    });
+    await settleAsyncWork();
+
+    const launchContinueButton = Array.from(
+      document.querySelectorAll("button"),
+    ).find((button) => button.textContent === "Launch continue");
+    if (!(launchContinueButton instanceof HTMLButtonElement)) {
+      throw new Error("Launch continue button not found");
+    }
+
+    act(() => {
+      launchContinueButton.click();
+    });
+    await settleAsyncWork();
+
+    const senderContinueButton = Array.from(
+      document.querySelectorAll("button"),
+    ).find((button) => button.textContent === "Sender continue");
+    if (!(senderContinueButton instanceof HTMLButtonElement)) {
+      throw new Error("Sender continue button not found");
+    }
+
+    act(() => {
+      senderContinueButton.click();
+    });
+    await settleAsyncWork();
+    await settleAsyncWork();
+    await settleAsyncWork();
+
+    expect(loadMemberStatusCountsForProjects).toHaveBeenCalledTimes(1);
+    const initialAudienceCountCalls = resolveAudienceCountAction.mock.calls.length;
+
+    const toggleWaitlistButton = Array.from(document.querySelectorAll("button")).find(
+      (button) => button.textContent === "Toggle Waitlist",
+    );
+    if (!(toggleWaitlistButton instanceof HTMLButtonElement)) {
+      throw new Error("Toggle Waitlist button not found");
+    }
+
+    act(() => {
+      toggleWaitlistButton.click();
+    });
+    await settleAsyncWork();
+
+    act(() => {
+      toggleWaitlistButton.click();
+    });
+    await settleAsyncWork();
+
+    expect(loadMemberStatusCountsForProjects).toHaveBeenCalledTimes(1);
+    expect(resolveAudienceCountAction.mock.calls.length).toBeGreaterThan(
+      initialAudienceCountCalls,
     );
   });
 });


### PR DESCRIPTION
## Summary
- switch Step 3 member-status filters from the old sparse grid cards to compact packed pills that match the pixel-perfect reference while preserving the existing stage grouping and populated-only filtering
- stabilize the member-status counts effect so it refetches only when the selected project set changes, which removes the visible `all → some` status flash when toggling pills
- include inactive-but-connected sub-projects in the Step 3 bootstrap so the `forests@` alias surfaces both Beech and Butternut, while keeping sender options active-only

## Tests
- extended `campaign-audience-filter-panel.test.tsx` for the flex-wrap packed pill layout, compact pill classes, and the two-project forests@ toggleable project rows
- extended `campaign-audience-step.test.tsx` with a wizard-level regression test asserting status toggles do not retrigger `loadMemberStatusCountsForProjects`

## Validation
```text
pnpm --filter @as-comms/web exec vitest run tests/unit/campaign-audience-filter-panel.test.tsx tests/unit/campaign-audience-step.test.tsx
✓ 2 files passed, 13 tests passed

pnpm --filter @as-comms/web typecheck
✓ passed

pnpm --filter @as-comms/web lint
✓ passed

pnpm boundaries
✓ Boundary check passed

pnpm build
✓ turbo build passed
✓ Runtime export verification passed
```
