### PR TITLE
Wizard Step 3 round 2: alias-scoped search, alias chip, default-zero count, drop funnel labels, forests@ host+subs

### DIFF
--- a/apps/web/app/broadcasts/_lib/audience-data-source.ts
+++ b/apps/web/app/broadcasts/_lib/audience-data-source.ts
@@ -67,6 +67,7 @@ export interface AudiencePreviewRow {
   readonly name: string;
   readonly email: string;
   readonly project: string | null;
+  readonly projectAliasHint: string | null;
 }
 
 export interface AudienceCountData {
@@ -691,6 +692,8 @@ export async function previewAudienceAction(input: {
   await requireSession();
 
   try {
+    const runtime = await getStage1WebRuntime();
+    const aliasCache = new Map<string, Promise<string | null>>();
     const audience = await resolveWizardAudience(
       input.kind,
       input.criteria,
@@ -698,12 +701,21 @@ export async function previewAudienceAction(input: {
     );
 
     return successResult(
-      audience.slice(0, PREVIEW_LIMIT).map((member) => ({
-        contactId: member.contactId,
-        name: member.frozenFirstName ?? member.frozenEmail,
-        email: member.frozenEmail,
-        project: member.frozenProjectName,
-      })),
+      await Promise.all(
+        audience.slice(0, PREVIEW_LIMIT).map(async (member) => ({
+          contactId: member.contactId,
+          name: member.frozenFirstName ?? member.frozenEmail,
+          email: member.frozenEmail,
+          project: member.frozenProjectName,
+          projectAliasHint: normalizeAliasHint(
+            await resolvePrimaryAliasEmail(
+              runtime,
+              member.frozenProjectId ?? null,
+              aliasCache,
+            ),
+          ),
+        })),
+      ),
     );
   } catch (error) {
     return errorResult(
@@ -848,6 +860,7 @@ export async function searchProjectVolunteersAction(input: {
     const contacts = await runtime.repositories.contacts.searchByQuery({
       query,
       limit: 25,
+      projectIds: aliasProjectIds,
     });
     if (contacts.length === 0) {
       return successResult([]);
@@ -863,16 +876,12 @@ export async function searchProjectVolunteersAction(input: {
     const projectsById = new Map(
       projects.map((project) => [project.projectId, project] as const),
     );
-    const selectedProjectIds = new Set(aliasProjectIds);
     const membershipsByContact = new Map<
       string,
       (typeof memberships)[number][]
     >(contacts.map((contact) => [contact.id, []]));
     for (const membership of memberships) {
-      if (
-        membership.projectId === null ||
-        !selectedProjectIds.has(membership.projectId)
-      ) {
+      if (membership.projectId === null) {
         continue;
       }
 

--- a/apps/web/app/broadcasts/new/_components/audience-builder-step.tsx
+++ b/apps/web/app/broadcasts/new/_components/audience-builder-step.tsx
@@ -487,7 +487,7 @@ function SpecificVolunteerSelector({
                   </span>
                   <span className="flex shrink-0 items-center gap-2">
                     <span className="rounded-full border border-slate-200 bg-slate-50 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-slate-600">
-                      {row.project ?? "No project"}
+                      {row.projectAliasHint ?? row.project ?? "No project"}
                     </span>
                     {selected ? (
                       <span

--- a/apps/web/app/broadcasts/new/_components/audience-filter-panel.tsx
+++ b/apps/web/app/broadcasts/new/_components/audience-filter-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, LoaderCircle, Lock } from "lucide-react";
+import { Check, Lock } from "lucide-react";
 
 import {
   FOCUS_RING,
@@ -20,7 +20,6 @@ import type { CampaignAudienceCriteria } from "./audience-builder-step";
 
 const STAGE_GROUPS = {
   top: {
-    label: "TOP-FUNNEL",
     color: "emerald",
     statuses: [
       "Waitlist",
@@ -33,24 +32,20 @@ const STAGE_GROUPS = {
     ],
   },
   mid: {
-    label: "MID-FUNNEL",
     color: "sky",
     statuses: ["In Progress", "Trip Planning", "In the Field"],
   },
   bottom: {
-    label: "BOTTOM-FUNNEL",
     color: "violet",
     statuses: ["Successful", "Completed", "Returning Gear"],
   },
   off: {
-    label: "OFF-FUNNEL",
     color: "rose",
     statuses: ["Denied", "Aborted", "Soft Denied", "Failed"],
   },
 } as const satisfies Record<
   string,
   {
-    readonly label: string;
     readonly color: ToneNameV2;
     readonly statuses: readonly ExpeditionMemberStatus[];
   }
@@ -106,10 +101,6 @@ export function AudienceFilterPanel({
       return {
         ...group,
         statuses,
-        count: statuses.reduce(
-          (total, status) => total + (statusCounts[status] ?? 0),
-          0,
-        ),
       };
     })
     .filter((group) => group.statuses.length > 0);
@@ -196,11 +187,8 @@ export function AudienceFilterPanel({
               <div className="space-y-5">
                 {stageSections.map((group) => (
                   <StageStatusSection
-                    key={group.label}
-                    count={group.count}
+                    key={group.color}
                     color={group.color}
-                    label={group.label}
-                    loading={statusCountsLoading}
                     selectedStatuses={criteria.statuses}
                     statusCounts={statusCounts}
                     statuses={group.statuses}
@@ -330,44 +318,22 @@ function LockedProjectRow({
 }
 
 function StageStatusSection({
-  label,
   color,
   statuses,
   statusCounts,
   selectedStatuses,
-  count,
-  loading,
   onStatusToggle,
 }: {
-  readonly label: string;
   readonly color: ToneNameV2;
   readonly statuses: readonly ExpeditionMemberStatus[];
   readonly statusCounts: AudienceStatusCounts;
   readonly selectedStatuses: readonly ExpeditionMemberStatus[];
-  readonly count: number;
-  readonly loading: boolean;
   readonly onStatusToggle: (status: ExpeditionMemberStatus) => void;
 }) {
   const tone = TONE_CLASSES[color];
 
   return (
-    <section className="space-y-3">
-      <div className="flex items-center justify-between gap-3 border-b border-slate-200/80 pb-2">
-        <p className="text-[10.5px] font-semibold tracking-wider text-slate-500">
-          {label}
-        </p>
-        {loading ? (
-          <LoaderCircle
-            className={cn(`size-3.5 animate-spin ${tone.text}`)}
-            aria-label={`Loading ${label} total`}
-          />
-        ) : (
-          <span className="text-[12px] font-medium tabular-nums text-slate-500">
-            {count.toLocaleString()}
-          </span>
-        )}
-      </div>
-
+    <section>
       <div className="flex flex-wrap gap-1.5">
         {statuses.map((status) => {
           const selected = selectedStatuses.includes(status);
@@ -399,21 +365,14 @@ function StageStatusSection({
                 />
               )}
               <span>{status}</span>
-              {loading ? (
-                <span
-                  aria-hidden="true"
-                  className="skeleton-pulse block h-3.5 w-5 shrink-0 rounded"
-                />
-              ) : (
-                <span
-                  className={cn(
-                    "tabular-nums text-[11.5px]",
-                    selected ? "text-white/90" : "text-slate-500/90",
-                  )}
-                >
-                  {countForStatus.toLocaleString()}
-                </span>
-              )}
+              <span
+                className={cn(
+                  "tabular-nums text-[11.5px]",
+                  selected ? "text-white/90" : "text-slate-500/90",
+                )}
+              >
+                {countForStatus.toLocaleString()}
+              </span>
             </button>
           );
         })}

--- a/apps/web/app/broadcasts/new/_components/audience-preview-list.tsx
+++ b/apps/web/app/broadcasts/new/_components/audience-preview-list.tsx
@@ -85,7 +85,9 @@ export function AudiencePreviewList({
               <p className="truncate text-slate-600">{row.email}</p>
             </div>
             <div className="min-w-0">
-              <p className="truncate text-slate-500">{row.project ?? "No project"}</p>
+              <p className="truncate text-slate-500">
+                {row.projectAliasHint ?? row.project ?? "No project"}
+              </p>
             </div>
           </div>
         ))}

--- a/apps/web/app/broadcasts/new/_components/new-campaign-wizard.tsx
+++ b/apps/web/app/broadcasts/new/_components/new-campaign-wizard.tsx
@@ -260,7 +260,7 @@ function readAliasProjectsForSender(
     return [];
   }
 
-  return group.connectedSubs.length > 0 ? group.connectedSubs : [group.host];
+  return [group.host, ...group.connectedSubs];
 }
 
 function buildCriteriaForMode(input: {
@@ -674,6 +674,14 @@ export function NewCampaignWizard({
   useEffect(() => {
     if (frozen) {
       setCountLoading(false);
+      return;
+    }
+
+    const audienceMode = criteria.initialFilter ?? "project_status";
+    if (audienceMode === "project_status" && criteria.statuses.length === 0) {
+      countRequestRef.current += 1;
+      setCountLoading(false);
+      setCountState({ count: 0, hasAppliedFilters: true });
       return;
     }
 

--- a/apps/web/tests/unit/campaign-audience-filter-panel.test.tsx
+++ b/apps/web/tests/unit/campaign-audience-filter-panel.test.tsx
@@ -146,9 +146,11 @@ describe("AudienceFilterPanel", () => {
         "Toggle expedition-member status Waitlist",
       ),
     ).toBe(true);
-    expect(document.body.textContent).toContain("TOP-FUNNEL");
-    expect(document.body.textContent).toContain("OFF-FUNNEL");
+    expect(document.body.textContent).toContain("Waitlist");
+    expect(document.body.textContent).toContain("Denied");
+    expect(document.body.textContent).not.toContain("TOP-FUNNEL");
     expect(document.body.textContent).not.toContain("MID-FUNNEL");
+    expect(document.body.textContent).not.toContain("OFF-FUNNEL");
   });
 
   it("fires project, select-all, and status callbacks when those controls change", () => {
@@ -204,7 +206,7 @@ describe("AudienceFilterPanel", () => {
     expect(toggleAllStatuses).toHaveBeenCalledWith(true);
   });
 
-  it("applies the stage tone classes and hides empty stages", () => {
+  it("applies the stage tone classes and hides pills from empty stages", () => {
     renderPanel({
       criteria: {
         projectId: "project-a",
@@ -216,6 +218,11 @@ describe("AudienceFilterPanel", () => {
         hasReplied: "either",
         hasClicked: "either",
       },
+      statusCounts: {
+        Waitlist: 12,
+        "In Progress": 0,
+        Denied: 0,
+      },
     });
 
     const waitlistButton = Array.from(document.querySelectorAll("button")).find(
@@ -223,24 +230,25 @@ describe("AudienceFilterPanel", () => {
         button.getAttribute("aria-label") ===
         "Toggle expedition-member status Waitlist",
     );
-    const deniedButton = Array.from(document.querySelectorAll("button")).find(
-      (button) =>
-        button.getAttribute("aria-label") ===
-        "Toggle expedition-member status Denied",
-    );
 
     if (!(waitlistButton instanceof HTMLButtonElement)) {
       throw new Error("Waitlist status button not found");
     }
-    if (!(deniedButton instanceof HTMLButtonElement)) {
-      throw new Error("Denied status button not found");
-    }
 
     expect(waitlistButton.getAttribute("aria-checked")).toBe("true");
     expect(waitlistButton.className).toContain("bg-emerald-600");
-    expect(deniedButton.className).toContain("bg-white");
-    expect(deniedButton.querySelector(".bg-rose-500")).not.toBeNull();
+    expect(
+      document.querySelector(
+        '[aria-label="Toggle expedition-member status Denied"]',
+      ),
+    ).toBeNull();
+    expect(
+      document.querySelector(
+        '[aria-label="Toggle expedition-member status Failed"]',
+      ),
+    ).toBeNull();
     expect(document.body.textContent).not.toContain("MID-FUNNEL");
+    expect(document.body.textContent).not.toContain("OFF-FUNNEL");
   });
 
   it("renders packed status pills in a flex-wrap row instead of the old grid", () => {

--- a/apps/web/tests/unit/campaign-audience-step.test.tsx
+++ b/apps/web/tests/unit/campaign-audience-step.test.tsx
@@ -12,6 +12,7 @@ vi.mock("lucide-react", () => ({
   AlertTriangle: () => null,
   Check: () => null,
   CheckCircle2: () => null,
+  Eye: () => null,
   LoaderCircle: () => null,
   Lock: () => null,
   Search: () => null,
@@ -201,7 +202,8 @@ describe("AudienceBuilderStep initial filter gate", () => {
     expect(markup).toContain("Audience filters");
     expect(markup).toContain("Inherited from forests@");
     expect(markup).toContain("Member status");
-    expect(markup).toContain("TOP-FUNNEL");
+    expect(markup).toContain("Waitlist");
+    expect(markup).not.toContain("TOP-FUNNEL");
     expect(markup).not.toContain("Search by name or email");
     expect(markup).not.toContain("Find volunteers");
   });
@@ -225,6 +227,45 @@ describe("AudienceBuilderStep initial filter gate", () => {
     expect(markup).not.toContain("Audience filters");
     expect(markup).not.toContain("Member status");
     expect(markup).not.toContain("Toggle expedition-member status");
+  });
+
+  it("renders alias labels for volunteer search results and preview rows", () => {
+    const longProjectName =
+      "Passive Acoustic Monitoring of Pacific Northwest Forests";
+    const markup = renderToStaticMarkup(
+      <AudienceBuilderStep
+        {...baseProps}
+        criteria={{
+          ...baseProps.criteria,
+          projectId: "project-1",
+          projectIds: ["project-1"],
+          contactIds: ["contact-1"],
+          initialFilter: "specific",
+        }}
+        volunteerSearchQuery="nic"
+        volunteerSearchRows={[
+          {
+            contactId: "contact-1",
+            name: "Nicole Moss",
+            email: "nic@example.org",
+            project: longProjectName,
+            projectAliasHint: "pnwbio@",
+          },
+        ]}
+        previewRows={[
+          {
+            contactId: "contact-1",
+            name: "Nicole Moss",
+            email: "nic@example.org",
+            project: longProjectName,
+            projectAliasHint: "pnwbio@",
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("pnwbio@");
+    expect(markup).not.toContain(longProjectName);
   });
 
   it("disables continue when the live audience is zero", () => {
@@ -507,5 +548,461 @@ describe("AudienceBuilderStep initial filter gate", () => {
     expect(resolveAudienceCountAction.mock.calls.length).toBeGreaterThan(
       initialAudienceCountCalls,
     );
+  });
+
+  it("shows a default zero audience and skips the count action until a status is selected", async () => {
+    setupDom();
+
+    const loadMemberStatusCountsForProjects = vi.fn(() =>
+      Promise.resolve({
+        ok: true as const,
+        data: { Waitlist: 5 },
+      }),
+    );
+    const resolveAudienceCountAction = vi.fn(() =>
+      Promise.resolve({
+        ok: true as const,
+        data: { count: 5, hasAppliedFilters: true },
+      }),
+    );
+    const previewAudienceAction = vi.fn(() =>
+      Promise.resolve({
+        ok: true as const,
+        data: [],
+      }),
+    );
+    const searchProjectVolunteersAction = vi.fn(() =>
+      Promise.resolve({
+        ok: true as const,
+        data: [],
+      }),
+    );
+    const loadComposePreviewAction = vi.fn(() =>
+      Promise.resolve({
+        ok: true as const,
+        data: {
+          audienceSize: 0,
+          sampleIndex: 0,
+          sampleCount: 0,
+          sample: null,
+          warningCount: 0,
+          affectedContacts: [],
+          footerAddress: null,
+        },
+      }),
+    );
+    const saveCampaignWizardDraftAction = vi.fn(() =>
+      Promise.resolve({
+        ok: true as const,
+        data: {
+          runId: "run-1",
+          launchType: "normal_email",
+          kind: "project",
+          name: null,
+          fromEmail: "pnwbio@adventurescientists.org",
+          replyToEmail: "pnwbio@adventurescientists.org",
+          subjectTemplate: null,
+          bodyHtmlTemplate: null,
+          bodyTextTemplate: null,
+          preheader: null,
+          audienceCriteria: {
+            projectId: null,
+            projectIds: [],
+            statuses: [],
+            contactIds: [],
+            expeditionIds: [],
+            lastActivityWindow: "all_time",
+            hasReplied: "either",
+            hasClicked: "either",
+          },
+          audienceSize: null,
+          state: "draft",
+          scheduledAt: null,
+          updatedAt: "2026-05-20T12:00:00.000Z",
+          operatorEmail: "operator@example.com",
+        },
+      }),
+    );
+
+    vi.doMock("../../app/broadcasts/_lib/audience-data-source", () => ({
+      loadMemberStatusCountsForProjects,
+      loadComposePreviewAction,
+      previewAudienceAction,
+      resolveAudienceCountAction,
+      saveCampaignWizardDraftAction,
+      searchProjectVolunteersAction,
+    }));
+    vi.doMock("../../app/broadcasts/actions", () => ({
+      schedule: vi.fn(),
+      sendNow: vi.fn(),
+      testSend: vi.fn(),
+    }));
+    vi.doMock("../../app/broadcasts/new/_components/launch-type-step", () => ({
+      LaunchTypeStep: ({
+        onContinue,
+      }: {
+        readonly onContinue: () => void;
+      }) => <button onClick={onContinue}>Launch continue</button>,
+    }));
+    vi.doMock("../../app/broadcasts/new/_components/name-and-sender-step", () => ({
+      NameAndSenderStep: ({
+        onContinue,
+      }: {
+        readonly onContinue: () => void;
+      }) => <button onClick={onContinue}>Sender continue</button>,
+    }));
+    vi.doMock("../../app/broadcasts/new/_components/compose-step", () => ({
+      ComposeStep: () => <div>Compose</div>,
+    }));
+    vi.doMock("../../app/broadcasts/new/_components/preview-step", () => ({
+      PreviewStep: () => <div>Preview</div>,
+    }));
+    vi.doMock("../../app/broadcasts/new/_components/review-step", () => ({
+      ReviewStep: () => <div>Review</div>,
+    }));
+    vi.doMock("../../app/broadcasts/new/_components/wizard-rail", () => ({
+      WizardRail: () => null,
+    }));
+    vi.doUnmock("../../app/broadcasts/new/_components/audience-builder-step");
+
+    const { NewCampaignWizard } = await import(
+      "../../app/broadcasts/new/_components/new-campaign-wizard"
+    );
+
+    const bootstrap: AudienceBuilderBootstrap = {
+      projects: [
+        {
+          host: {
+            id: "project-1",
+            name: "Pacific Northwest Bio",
+            alias: null,
+            aliasHint: "pnwbio@",
+            connectedToProjectId: null,
+            isSubProject: false,
+          },
+          connectedSubs: [],
+        },
+      ],
+      expeditions: [],
+      statuses: ["Waitlist"],
+      senderOptions: [
+        {
+          projectId: "project-1",
+          projectName: "Pacific Northwest Bio",
+          projectAliasLabel: "pnwbio@",
+          email: "pnwbio@adventurescientists.org",
+          connectedToProjectId: null,
+          status: "verified",
+        },
+      ],
+    };
+    const draft: CampaignWizardDraftData = {
+      runId: "run-1",
+      launchType: "normal_email",
+      kind: "project",
+      name: null,
+      fromEmail: "pnwbio@adventurescientists.org",
+      replyToEmail: "pnwbio@adventurescientists.org",
+      subjectTemplate: null,
+      bodyHtmlTemplate: null,
+      bodyTextTemplate: null,
+      preheader: null,
+      audienceCriteria: {
+        projectId: null,
+        projectIds: [],
+        statuses: [],
+        contactIds: [],
+        expeditionIds: [],
+        lastActivityWindow: "all_time",
+        hasReplied: "either",
+        hasClicked: "either",
+      },
+      audienceSize: null,
+      state: "draft",
+      scheduledAt: null,
+      updatedAt: "2026-05-20T12:00:00.000Z",
+      operatorEmail: "operator@example.com",
+    };
+
+    act(() => {
+      root?.render(
+        <NewCampaignWizard bootstrap={bootstrap} draft={draft} isAdmin={true} />,
+      );
+    });
+    await settleAsyncWork();
+
+    const launchContinueButton = Array.from(
+      document.querySelectorAll("button"),
+    ).find((button) => button.textContent === "Launch continue");
+    if (!(launchContinueButton instanceof HTMLButtonElement)) {
+      throw new Error("Launch continue button not found");
+    }
+
+    act(() => {
+      launchContinueButton.click();
+    });
+    await settleAsyncWork();
+
+    const senderContinueButton = Array.from(
+      document.querySelectorAll("button"),
+    ).find((button) => button.textContent === "Sender continue");
+    if (!(senderContinueButton instanceof HTMLButtonElement)) {
+      throw new Error("Sender continue button not found");
+    }
+
+    act(() => {
+      senderContinueButton.click();
+    });
+    await settleAsyncWork();
+    await settleAsyncWork();
+    await settleAsyncWork();
+
+    expect(resolveAudienceCountAction).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain(
+      "No recipients match the current filters.",
+    );
+
+    const continueButton = Array.from(document.querySelectorAll("button")).find(
+      (button) => button.textContent === "Continue to compose",
+    );
+    if (!(continueButton instanceof HTMLButtonElement)) {
+      throw new Error("Continue button not found");
+    }
+
+    expect(continueButton.disabled).toBe(true);
+    expect(continueButton.getAttribute("aria-disabled")).toBe("true");
+    expect(document.body.textContent).toContain("0");
+  });
+
+  it("renders both forests host and connected sub-projects as toggleable project rows", async () => {
+    setupDom();
+
+    const loadMemberStatusCountsForProjects = vi.fn(() =>
+      Promise.resolve({
+        ok: true as const,
+        data: { Waitlist: 8 },
+      }),
+    );
+    const resolveAudienceCountAction = vi.fn(() =>
+      Promise.resolve({
+        ok: true as const,
+        data: { count: 8, hasAppliedFilters: true },
+      }),
+    );
+    const previewAudienceAction = vi.fn(() =>
+      Promise.resolve({
+        ok: true as const,
+        data: [],
+      }),
+    );
+    const searchProjectVolunteersAction = vi.fn(() =>
+      Promise.resolve({
+        ok: true as const,
+        data: [],
+      }),
+    );
+    const loadComposePreviewAction = vi.fn(() =>
+      Promise.resolve({
+        ok: true as const,
+        data: {
+          audienceSize: 0,
+          sampleIndex: 0,
+          sampleCount: 0,
+          sample: null,
+          warningCount: 0,
+          affectedContacts: [],
+          footerAddress: null,
+        },
+      }),
+    );
+    const saveCampaignWizardDraftAction = vi.fn(() =>
+      Promise.resolve({
+        ok: true as const,
+        data: {
+          runId: "run-1",
+          launchType: "normal_email",
+          kind: "project",
+          name: null,
+          fromEmail: "forests@adventurescientists.org",
+          replyToEmail: "forests@adventurescientists.org",
+          subjectTemplate: null,
+          bodyHtmlTemplate: null,
+          bodyTextTemplate: null,
+          preheader: null,
+          audienceCriteria: {
+            projectId: null,
+            projectIds: [],
+            statuses: [],
+            contactIds: [],
+            expeditionIds: [],
+            lastActivityWindow: "all_time",
+            hasReplied: "either",
+            hasClicked: "either",
+          },
+          audienceSize: null,
+          state: "draft",
+          scheduledAt: null,
+          updatedAt: "2026-05-20T12:00:00.000Z",
+          operatorEmail: "operator@example.com",
+        },
+      }),
+    );
+
+    vi.doMock("../../app/broadcasts/_lib/audience-data-source", () => ({
+      loadMemberStatusCountsForProjects,
+      loadComposePreviewAction,
+      previewAudienceAction,
+      resolveAudienceCountAction,
+      saveCampaignWizardDraftAction,
+      searchProjectVolunteersAction,
+    }));
+    vi.doMock("../../app/broadcasts/actions", () => ({
+      schedule: vi.fn(),
+      sendNow: vi.fn(),
+      testSend: vi.fn(),
+    }));
+    vi.doMock("../../app/broadcasts/new/_components/launch-type-step", () => ({
+      LaunchTypeStep: ({
+        onContinue,
+      }: {
+        readonly onContinue: () => void;
+      }) => <button onClick={onContinue}>Launch continue</button>,
+    }));
+    vi.doMock("../../app/broadcasts/new/_components/name-and-sender-step", () => ({
+      NameAndSenderStep: ({
+        onContinue,
+      }: {
+        readonly onContinue: () => void;
+      }) => <button onClick={onContinue}>Sender continue</button>,
+    }));
+    vi.doMock("../../app/broadcasts/new/_components/compose-step", () => ({
+      ComposeStep: () => <div>Compose</div>,
+    }));
+    vi.doMock("../../app/broadcasts/new/_components/preview-step", () => ({
+      PreviewStep: () => <div>Preview</div>,
+    }));
+    vi.doMock("../../app/broadcasts/new/_components/review-step", () => ({
+      ReviewStep: () => <div>Review</div>,
+    }));
+    vi.doMock("../../app/broadcasts/new/_components/wizard-rail", () => ({
+      WizardRail: () => null,
+    }));
+
+    const { NewCampaignWizard } = await import(
+      "../../app/broadcasts/new/_components/new-campaign-wizard"
+    );
+
+    const bootstrap: AudienceBuilderBootstrap = {
+      projects: [
+        {
+          host: {
+            id: "project-butternut",
+            name: "Restoring Butternut Forest Health",
+            alias: null,
+            aliasHint: "forests@",
+            connectedToProjectId: null,
+            isSubProject: false,
+          },
+          connectedSubs: [
+            {
+              id: "project-beech",
+              name: "Saving American Beech",
+              alias: null,
+              aliasHint: "forests@",
+              connectedToProjectId: "project-butternut",
+              isSubProject: true,
+            },
+          ],
+        },
+      ],
+      expeditions: [],
+      statuses: ["Waitlist"],
+      senderOptions: [
+        {
+          projectId: "project-butternut",
+          projectName: "Restoring Butternut Forest Health",
+          projectAliasLabel: "forests@",
+          email: "forests@adventurescientists.org",
+          connectedToProjectId: null,
+          status: "verified",
+        },
+      ],
+    };
+    const draft: CampaignWizardDraftData = {
+      runId: "run-1",
+      launchType: "normal_email",
+      kind: "project",
+      name: null,
+      fromEmail: "forests@adventurescientists.org",
+      replyToEmail: "forests@adventurescientists.org",
+      subjectTemplate: null,
+      bodyHtmlTemplate: null,
+      bodyTextTemplate: null,
+      preheader: null,
+      audienceCriteria: {
+        projectId: null,
+        projectIds: [],
+        statuses: [],
+        contactIds: [],
+        expeditionIds: [],
+        lastActivityWindow: "all_time",
+        hasReplied: "either",
+        hasClicked: "either",
+      },
+      audienceSize: null,
+      state: "draft",
+      scheduledAt: null,
+      updatedAt: "2026-05-20T12:00:00.000Z",
+      operatorEmail: "operator@example.com",
+    };
+
+    act(() => {
+      root?.render(
+        <NewCampaignWizard bootstrap={bootstrap} draft={draft} isAdmin={true} />,
+      );
+    });
+    await settleAsyncWork();
+
+    const launchContinueButton = Array.from(
+      document.querySelectorAll("button"),
+    ).find((button) => button.textContent === "Launch continue");
+    if (!(launchContinueButton instanceof HTMLButtonElement)) {
+      throw new Error("Launch continue button not found");
+    }
+
+    act(() => {
+      launchContinueButton.click();
+    });
+    await settleAsyncWork();
+
+    const senderContinueButton = Array.from(
+      document.querySelectorAll("button"),
+    ).find((button) => button.textContent === "Sender continue");
+    if (!(senderContinueButton instanceof HTMLButtonElement)) {
+      throw new Error("Sender continue button not found");
+    }
+
+    act(() => {
+      senderContinueButton.click();
+    });
+    await settleAsyncWork();
+    await settleAsyncWork();
+    await settleAsyncWork();
+
+    const projectButtons = Array.from(document.querySelectorAll("button")).filter(
+      (button) => button.getAttribute("aria-label")?.startsWith("Choose project "),
+    );
+
+    expect(projectButtons).toHaveLength(2);
+    expect(
+      document.querySelector(
+        '[aria-label="Project Restoring Butternut Forest Health is locked to this sender alias"]',
+      ),
+    ).toBeNull();
+    expect(
+      document.querySelector(
+        '[aria-label="Project Saving American Beech is locked to this sender alias"]',
+      ),
+    ).toBeNull();
   });
 });

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -2437,17 +2437,31 @@ function createStage1RepositoriesInternal(
           return [];
         }
 
-        const limit = Math.max(1, Math.min(input.limit, 8));
+        const limit = Math.max(1, Math.min(input.limit, 50));
         const pattern = `%${normalizedQuery}%`;
+        const baseWhere = or(
+          sql`lower(${contacts.displayName}) like ${pattern}`,
+          sql`lower(coalesce(${contacts.primaryEmail}, '')) like ${pattern}`,
+        );
+        const projectIdList = (input.projectIds ?? []).filter(
+          (projectId) => projectId.trim().length > 0,
+        );
+        const whereClause =
+          projectIdList.length === 0
+            ? baseWhere
+            : and(
+                baseWhere,
+                sql`exists (
+                  select 1
+                  from ${contactMemberships}
+                  where ${contactMemberships.contactId} = ${contacts.id}
+                    and ${inArray(contactMemberships.projectId, projectIdList)}
+                )`,
+              );
         const rows = await db
           .select()
           .from(contacts)
-          .where(
-            or(
-              sql`lower(${contacts.displayName}) like ${pattern}`,
-              sql`lower(coalesce(${contacts.primaryEmail}, '')) like ${pattern}`,
-            ),
-          )
+          .where(whereClause)
           .orderBy(
             sql`case when lower(${contacts.displayName}) like ${pattern} then 0 else 1 end`,
             asc(contacts.displayName),

--- a/packages/db/test/stage3-contact-search.test.ts
+++ b/packages/db/test/stage3-contact-search.test.ts
@@ -37,6 +37,70 @@ async function seedContactSearchFixture() {
   return context;
 }
 
+async function seedProjectScopedSearchFixture() {
+  const context = await createTestStage1Context();
+  const createdAt = "2026-04-21T12:00:00.000Z";
+
+  await context.repositories.projectDimensions.upsert({
+    projectId: "project-in-scope",
+    projectName: "Pacific Northwest Forests",
+    source: "salesforce",
+  });
+  await context.repositories.projectDimensions.upsert({
+    projectId: "project-out-of-scope",
+    projectName: "Out of Scope Project",
+    source: "salesforce",
+  });
+
+  await context.repositories.contacts.upsert({
+    id: "contact:nicole-in-scope",
+    salesforceContactId: "003-nicole",
+    displayName: "Nicole In Scope",
+    primaryEmail: "nicole@example.org",
+    primaryPhone: null,
+    createdAt,
+    updatedAt: createdAt,
+  });
+  await context.repositories.contactMemberships.upsert({
+    id: "membership:nicole-in-scope",
+    contactId: "contact:nicole-in-scope",
+    projectId: "project-in-scope",
+    expeditionId: null,
+    salesforceMembershipId: "a0B-nicole",
+    role: "volunteer",
+    status: "active",
+    source: "salesforce",
+    createdAt,
+  });
+
+  for (const index of Array.from({ length: 12 }, (_, value) => value + 1)) {
+    const paddedIndex = index.toString().padStart(2, "0");
+    const contactId = `contact:nic-out-${paddedIndex}`;
+    await context.repositories.contacts.upsert({
+      id: contactId,
+      salesforceContactId: `003-out-${paddedIndex}`,
+      displayName: `Nic Outside ${paddedIndex}`,
+      primaryEmail: `nic-out-${paddedIndex}@example.org`,
+      primaryPhone: null,
+      createdAt,
+      updatedAt: createdAt,
+    });
+    await context.repositories.contactMemberships.upsert({
+      id: `membership:nic-out-${paddedIndex}`,
+      contactId,
+      projectId: "project-out-of-scope",
+      expeditionId: null,
+      salesforceMembershipId: `a0B-out-${paddedIndex}`,
+      role: "volunteer",
+      status: "active",
+      source: "salesforce",
+      createdAt,
+    });
+  }
+
+  return context;
+}
+
 describe("contact repository searchByQuery", () => {
   it("matches display names case-insensitively", async () => {
     const context = await seedContactSearchFixture();
@@ -110,6 +174,27 @@ describe("contact repository searchByQuery", () => {
           limit: 8,
         }),
       ).resolves.toEqual([]);
+    } finally {
+      await context.client.close();
+    }
+  });
+
+  it("scopes query matches to the requested alias projects before applying the result limit", async () => {
+    const context = await seedProjectScopedSearchFixture();
+
+    try {
+      await expect(
+        context.repositories.contacts.searchByQuery({
+          query: "nic",
+          limit: 25,
+          projectIds: ["project-in-scope"],
+        }),
+      ).resolves.toMatchObject([
+        {
+          id: "contact:nicole-in-scope",
+          displayName: "Nicole In Scope",
+        },
+      ]);
     } finally {
       await context.client.close();
     }

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -307,6 +307,7 @@ export interface ContactRepository {
   searchByQuery(input: {
     readonly query: string;
     readonly limit: number;
+    readonly projectIds?: readonly string[];
   }): Promise<readonly ContactRecord[]>;
   /**
    * Unified inbox search. Returns contacts matching name / primary email /


### PR DESCRIPTION
## Summary

Round 2 of Step 3 polish (after #451). Five user-reported issues from production QA:

1. **Individual-volunteer search misses real matches** — `contacts.searchByQuery` capped at 8 rows globally, so the alias-scope membership filter dropped everything when "nic" matched >8 contacts org-wide. Pushed project-scope filtering into the DB query and raised the cap to 50. Search now matches across `display_name` and `primaryEmail` within the alias's projects.
2. **Result rows + recipient preview showed the full project name** — swapped to `projectAliasHint` (`pnwbio@`-style label). Added the new field to `AudiencePreviewRow` and populated it in `previewAudienceAction` so the recipient list matches the search-row chip.
3. **Audience count showed full project population when no statuses selected** — client-side guard in the count effect: when `mode === project_status` and `statuses.length === 0`, set `{count: 0, hasAppliedFilters: true}` without round-tripping. Continue button stays disabled per existing `canContinue` logic.
4. **Dropped the `TOP-FUNNEL` / `MID-FUNNEL` / `OFF-FUNNEL` labels + subtotals** — pills now stack naturally in funnel-color tone-grouped rows. `StageStatusSection` lost the unused `label` / `count` props.
5. **forests@ project selector only showed Beech** — `readAliasProjectsForSender` returned `connectedSubs` OR `[host]`, never both. Fixed to `[group.host, ...group.connectedSubs]`. Single-host aliases (pnwbio@, orcas@, whitebarkpine@) keep their current locked single-project rendering. forests@ now surfaces both Butternut (host) and Beech (sub) as toggleable, both pre-selected.

## Tests

- Extended `tests/unit/campaign-audience-step.test.tsx`: alias chip rendering, default-zero count + skipped count action, forests@ host+sub renders 2 toggleable rows.
- Extended `tests/unit/campaign-audience-filter-panel.test.tsx`: assertions updated for the label-less stage rendering.
- New `packages/db/test/stage3-contact-search.test.ts`: asserts `searchByQuery` honors `projectIds` filter and surfaces alias-scoped matches even when the global match set exceeds the limit.

## Validation

\`\`\`text
pnpm --filter @as-comms/web exec vitest run tests/unit/campaign-audience-filter-panel.test.tsx tests/unit/campaign-audience-step.test.tsx
pnpm --filter @as-comms/db  exec vitest run test/stage3-contact-search.test.ts
pnpm --filter @as-comms/web typecheck
pnpm --filter @as-comms/db  typecheck
pnpm --filter @as-comms/web lint
pnpm boundaries
pnpm build
\`\`\`

All green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Codex via brief .codex-worktrees/wizard-step3-polish-r2/.brief.md