### PR TITLE
Wizard Step 3 round 3: compact project pills, projectAlias chip, progressive disclosure mode selector

### DIFF
--- a/apps/web/app/broadcasts/_lib/audience-data-source.ts
+++ b/apps/web/app/broadcasts/_lib/audience-data-source.ts
@@ -40,6 +40,7 @@ export interface CampaignProjectOption {
   readonly id: string;
   readonly name: string;
   readonly alias: string | null;
+  readonly projectAlias: string | null;
   readonly aliasHint: string | null;
   readonly connectedToProjectId: string | null;
   readonly isSubProject: boolean;
@@ -67,6 +68,7 @@ export interface AudiencePreviewRow {
   readonly name: string;
   readonly email: string;
   readonly project: string | null;
+  readonly projectAlias: string | null;
   readonly projectAliasHint: string | null;
 }
 
@@ -93,6 +95,7 @@ export interface AudienceVolunteerSearchRow {
   readonly name: string;
   readonly email: string;
   readonly project: string | null;
+  readonly projectAlias: string | null;
   readonly projectAliasHint: string | null;
 }
 
@@ -555,6 +558,7 @@ export async function getAudienceBuilderBootstrap(): Promise<AudienceBuilderBoot
         id: project.projectId,
         name: project.projectName,
         alias: project.projectAlias,
+        projectAlias: project.projectAlias,
         aliasHint: normalizeAliasHint(
           project.connectedToProjectId === null ? primaryEmail : hostPrimaryEmail,
         ),
@@ -694,6 +698,10 @@ export async function previewAudienceAction(input: {
   try {
     const runtime = await getStage1WebRuntime();
     const aliasCache = new Map<string, Promise<string | null>>();
+    const settingsProjects = await runtime.settings.projects.listAll();
+    const projectsById = new Map(
+      settingsProjects.map((project) => [project.projectId, project] as const),
+    );
     const audience = await resolveWizardAudience(
       input.kind,
       input.criteria,
@@ -702,19 +710,27 @@ export async function previewAudienceAction(input: {
 
     return successResult(
       await Promise.all(
-        audience.slice(0, PREVIEW_LIMIT).map(async (member) => ({
-          contactId: member.contactId,
-          name: member.frozenFirstName ?? member.frozenEmail,
-          email: member.frozenEmail,
-          project: member.frozenProjectName,
-          projectAliasHint: normalizeAliasHint(
-            await resolvePrimaryAliasEmail(
-              runtime,
-              member.frozenProjectId ?? null,
-              aliasCache,
+        audience.slice(0, PREVIEW_LIMIT).map(async (member) => {
+          const project =
+            member.frozenProjectId == null
+              ? null
+              : (projectsById.get(member.frozenProjectId) ?? null);
+
+          return {
+            contactId: member.contactId,
+            name: member.frozenFirstName ?? member.frozenEmail,
+            email: member.frozenEmail,
+            project: member.frozenProjectName,
+            projectAlias: project?.projectAlias ?? null,
+            projectAliasHint: normalizeAliasHint(
+              await resolvePrimaryAliasEmail(
+                runtime,
+                member.frozenProjectId ?? null,
+                aliasCache,
+              ),
             ),
-          ),
-        })),
+          };
+        }),
       ),
     );
   } catch (error) {
@@ -857,6 +873,10 @@ export async function searchProjectVolunteersAction(input: {
   try {
     const runtime = await getStage1WebRuntime();
     const aliasCache = new Map<string, Promise<string | null>>();
+    const settingsProjects = await runtime.settings.projects.listAll();
+    const projectsById = new Map(
+      settingsProjects.map((project) => [project.projectId, project] as const),
+    );
     const contacts = await runtime.repositories.contacts.searchByQuery({
       query,
       limit: 25,
@@ -870,12 +890,6 @@ export async function searchProjectVolunteersAction(input: {
       await runtime.repositories.contactMemberships.listByContactIds(
         contacts.map((contact) => contact.id),
       );
-    const projects = await runtime.repositories.projectDimensions.listByIds(
-      aliasProjectIds,
-    );
-    const projectsById = new Map(
-      projects.map((project) => [project.projectId, project] as const),
-    );
     const membershipsByContact = new Map<
       string,
       (typeof memberships)[number][]
@@ -926,6 +940,7 @@ export async function searchProjectVolunteersAction(input: {
                 : (contact.primaryEmail ?? contact.id),
               email: contact.primaryEmail ?? "",
               project: project?.projectName ?? null,
+              projectAlias: project?.projectAlias ?? null,
               projectAliasHint: normalizeAliasHint(
                 await resolvePrimaryAliasEmail(
                   runtime,

--- a/apps/web/app/broadcasts/new/_components/audience-builder-step.tsx
+++ b/apps/web/app/broadcasts/new/_components/audience-builder-step.tsx
@@ -37,7 +37,7 @@ export type AudienceInitialFilter =
   | "all_approved";
 
 export type CampaignAudienceCriteria = AudienceCriteria & {
-  readonly initialFilter?: AudienceInitialFilter;
+  readonly initialFilter?: AudienceInitialFilter | undefined;
 };
 
 const MODE_META: Record<
@@ -63,6 +63,7 @@ const MODE_META: Record<
 
 interface AudienceBuilderStepProps {
   readonly availableModes: readonly AudienceInitialFilter[];
+  readonly hasPickedMode: boolean;
   readonly criteria: CampaignAudienceCriteria;
   readonly countState: AudienceCountData;
   readonly previewRows: readonly AudiencePreviewRow[];
@@ -90,6 +91,7 @@ interface AudienceBuilderStepProps {
 
 export function AudienceBuilderStep({
   availableModes,
+  hasPickedMode,
   criteria,
   countState,
   previewRows,
@@ -114,9 +116,10 @@ export function AudienceBuilderStep({
   onBack,
   onContinue,
 }: AudienceBuilderStepProps) {
-  const initialFilter = criteria.initialFilter ?? "project_status";
+  const initialFilter = criteria.initialFilter;
   const canContinue =
     !countLoading &&
+    initialFilter !== undefined &&
     (initialFilter === "project_status"
       ? [
           ...(criteria.projectId == null ? [] : [criteria.projectId]),
@@ -147,70 +150,80 @@ export function AudienceBuilderStep({
       <div className="space-y-4">
         <AudienceCountPanel countState={countState} loading={countLoading} />
 
-        <InitialFilterSelector
-          modes={availableModes}
-          value={initialFilter}
-          onChange={onInitialFilterChange}
-        />
-
-        {initialFilter === "project_status" ? (
+        {hasPickedMode ? (
           <>
-            <AudienceFilterPanel
-              criteria={criteria}
-              projectOptions={projectOptions}
-              statusOptions={statusOptions}
-              statusCounts={statusCounts}
-              statusCountsLoading={statusCountsLoading}
-              statusCountsErrorMessage={statusCountsErrorMessage}
-              onProjectChange={onProjectChange}
-              onToggleAllStatuses={onToggleAllStatuses}
-              onStatusToggle={onStatusToggle}
+            <ModeSegmentedControl
+              modes={availableModes}
+              value={initialFilter}
+              onChange={onInitialFilterChange}
             />
 
-            <AudiencePreviewList
-              rows={previewRows}
-              loading={previewLoading}
-              errorMessage={previewErrorMessage}
-            />
+            {initialFilter === "project_status" ? (
+              <>
+                <AudienceFilterPanel
+                  criteria={criteria}
+                  projectOptions={projectOptions}
+                  statusOptions={statusOptions}
+                  statusCounts={statusCounts}
+                  statusCountsLoading={statusCountsLoading}
+                  statusCountsErrorMessage={statusCountsErrorMessage}
+                  onProjectChange={onProjectChange}
+                  onToggleAllStatuses={onToggleAllStatuses}
+                  onStatusToggle={onStatusToggle}
+                />
+
+                <AudiencePreviewList
+                  rows={previewRows}
+                  loading={previewLoading}
+                  errorMessage={previewErrorMessage}
+                />
+              </>
+            ) : null}
+
+            {initialFilter === "specific" ? (
+              <>
+                <SpecificVolunteerSelector
+                  criteria={criteria}
+                  query={volunteerSearchQuery}
+                  rows={volunteerSearchRows}
+                  loading={volunteerSearchLoading}
+                  errorMessage={volunteerSearchErrorMessage}
+                  onQueryChange={onVolunteerSearchQueryChange}
+                  onToggle={onVolunteerToggle}
+                />
+
+                <AudiencePreviewList
+                  rows={previewRows}
+                  loading={previewLoading}
+                  errorMessage={previewErrorMessage}
+                />
+              </>
+            ) : null}
+
+            {initialFilter === "all_approved" ? (
+              <>
+                <section className="rounded-lg border border-slate-200 bg-white px-4 py-4">
+                  <p className="text-[13px] leading-relaxed text-slate-600">
+                    This broadcast goes to every approved contact across all
+                    projects, minus auto-exclusions.
+                  </p>
+                </section>
+
+                <AudiencePreviewList
+                  rows={previewRows}
+                  loading={previewLoading}
+                  errorMessage={previewErrorMessage}
+                />
+              </>
+            ) : null}
           </>
-        ) : null}
-
-        {initialFilter === "specific" ? (
-          <>
-            <SpecificVolunteerSelector
-              criteria={criteria}
-              query={volunteerSearchQuery}
-              rows={volunteerSearchRows}
-              loading={volunteerSearchLoading}
-              errorMessage={volunteerSearchErrorMessage}
-              onQueryChange={onVolunteerSearchQueryChange}
-              onToggle={onVolunteerToggle}
-            />
-
-            <AudiencePreviewList
-              rows={previewRows}
-              loading={previewLoading}
-              errorMessage={previewErrorMessage}
-            />
-          </>
-        ) : null}
-
-        {initialFilter === "all_approved" ? (
-          <>
-            <section className="rounded-lg border border-slate-200 bg-white px-4 py-4">
-              <p className="text-[13px] leading-relaxed text-slate-600">
-                This broadcast goes to every approved contact across all
-                projects, minus auto-exclusions.
-              </p>
-            </section>
-
-            <AudiencePreviewList
-              rows={previewRows}
-              loading={previewLoading}
-              errorMessage={previewErrorMessage}
-            />
-          </>
-        ) : null}
+        ) : (
+          <InitialFilterSelector
+            modes={availableModes}
+            value={undefined}
+            onChange={onInitialFilterChange}
+          />
+        )}
       </div>
 
       <div className="mt-5 flex items-center justify-between border-t border-slate-200 pt-5">
@@ -239,7 +252,7 @@ function InitialFilterSelector({
   onChange,
 }: {
   readonly modes: readonly AudienceInitialFilter[];
-  readonly value: AudienceInitialFilter;
+  readonly value: AudienceInitialFilter | undefined;
   readonly onChange: (value: AudienceInitialFilter) => void;
 }) {
   return (
@@ -301,6 +314,47 @@ function InitialFilterSelector({
   );
 }
 
+function ModeSegmentedControl({
+  modes,
+  value,
+  onChange,
+}: {
+  readonly modes: readonly AudienceInitialFilter[];
+  readonly value: AudienceInitialFilter | undefined;
+  readonly onChange: (value: AudienceInitialFilter) => void;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Audience mode"
+      className="inline-flex items-center gap-0 rounded-full border border-slate-200 bg-slate-50 p-0.5"
+    >
+      {modes.map((mode) => {
+        const selected = value === mode;
+        return (
+          <button
+            key={mode}
+            type="button"
+            role="tab"
+            aria-selected={selected}
+            onClick={() => {
+              onChange(mode);
+            }}
+            className={cn(
+              `rounded-full px-3.5 py-1.5 text-[12.5px] font-medium ${TRANSITION.fast} ${FOCUS_RING}`,
+              selected
+                ? "bg-slate-900 text-white shadow-sm"
+                : "text-slate-600 hover:text-slate-900",
+            )}
+          >
+            {MODE_META[mode].title}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 export function AudienceCountPanel({
   countState,
   loading,
@@ -358,7 +412,7 @@ export function AudienceCountPanel({
         </div>
         <p className="mt-2 text-[12.5px] text-slate-600">
           {!countState.hasAppliedFilters
-            ? "Pick a project or volunteer selection to start."
+            ? "Pick an audience mode to start."
             : countState.count > 0
               ? "The live audience is ready to inspect."
               : "No recipients match the current filters."}
@@ -487,7 +541,7 @@ function SpecificVolunteerSelector({
                   </span>
                   <span className="flex shrink-0 items-center gap-2">
                     <span className="rounded-full border border-slate-200 bg-slate-50 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-slate-600">
-                      {row.projectAliasHint ?? row.project ?? "No project"}
+                      {row.projectAlias ?? row.project ?? "No project"}
                     </span>
                     {selected ? (
                       <span

--- a/apps/web/app/broadcasts/new/_components/audience-filter-panel.tsx
+++ b/apps/web/app/broadcasts/new/_components/audience-filter-panel.tsx
@@ -6,6 +6,7 @@ import {
   FOCUS_RING,
   TONE_CLASSES,
   TRANSITION,
+  type ToneClassesV2,
   type ToneNameV2,
 } from "@/app/_lib/design-tokens-v2";
 import type { ExpeditionMemberStatus } from "@as-comms/contracts";
@@ -50,6 +51,16 @@ const STAGE_GROUPS = {
     readonly statuses: readonly ExpeditionMemberStatus[];
   }
 >;
+
+const PROJECT_PILL_TONES = [
+  "emerald",
+  "sky",
+  "violet",
+  "amber",
+  "rose",
+  "indigo",
+  "teal",
+] as const satisfies readonly ToneNameV2[];
 
 interface AudienceFilterPanelProps {
   readonly criteria: CampaignAudienceCriteria;
@@ -131,7 +142,7 @@ export function AudienceFilterPanel({
               )
             }
           >
-            <div className="space-y-2.5">
+            <div className="flex flex-wrap gap-2">
               {projectOptions.map((project) =>
                 hasSingleLockedProject ? (
                   <LockedProjectRow key={project.id} project={project} />
@@ -245,7 +256,7 @@ function ProjectOptionRow({
   readonly selected: boolean;
   readonly onSelect: (projectId: string) => void;
 }) {
-  const aliasAddress = readAliasAddress(project);
+  const tone = readProjectTone(project.id);
 
   return (
     <button
@@ -256,35 +267,24 @@ function ProjectOptionRow({
         onSelect(project.id);
       }}
       className={cn(
-        `flex w-full items-center justify-between gap-3 rounded-xl border px-4 py-3 text-left ${TRANSITION.fast} ${FOCUS_RING}`,
+        `inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[12.5px] font-medium ring-1 ring-inset ${TRANSITION.fast} ${FOCUS_RING}`,
         selected
-          ? "border-slate-900 bg-slate-900 text-white shadow-sm"
-          : "border-slate-200 bg-slate-50/70 text-slate-700 hover:border-slate-300 hover:bg-white hover:text-slate-900",
+          ? `${tone.bg} text-white ring-transparent shadow-sm`
+          : `${tone.subtle} ${tone.subtleText} ${tone.ring} hover:opacity-90`,
       )}
     >
-      <div className="flex min-w-0 items-center gap-3">
-        <ProjectSelectionIndicator selected={selected} />
+      {selected ? (
+        <Check className="size-3 shrink-0" aria-hidden="true" />
+      ) : (
         <span
           className={cn(
             "size-1.5 shrink-0 rounded-full",
-            selected ? "bg-white/70" : "bg-slate-300",
+            tone.dot,
           )}
           aria-hidden="true"
         />
-        <div className="min-w-0">
-          <p className="truncate text-[13px] font-semibold">{project.name}</p>
-          {aliasAddress ? (
-            <p
-              className={cn(
-                "truncate text-[11.5px]",
-                selected ? "text-white/70" : "text-slate-500",
-              )}
-            >
-              {aliasAddress}
-            </p>
-          ) : null}
-        </div>
-      </div>
+      )}
+      <span className="max-w-full truncate">{project.name}</span>
     </button>
   );
 }
@@ -381,24 +381,13 @@ function StageStatusSection({
   );
 }
 
-function ProjectSelectionIndicator({
-  selected,
-}: {
-  readonly selected: boolean;
-}) {
-  return (
-    <span
-      className={cn(
-        "flex size-5 shrink-0 items-center justify-center rounded-full border",
-        selected
-          ? "border-white/20 bg-white/15 text-white"
-          : "border-slate-300 bg-white text-transparent",
-      )}
-      aria-hidden="true"
-    >
-      {selected ? <Check className="size-3" aria-hidden="true" /> : null}
-    </span>
+function readProjectTone(projectId: string): ToneClassesV2 {
+  const hash = Array.from(projectId).reduce(
+    (total, character) => total + character.charCodeAt(0),
+    0,
   );
+  const toneName = PROJECT_PILL_TONES.at(hash % PROJECT_PILL_TONES.length) ?? "emerald";
+  return TONE_CLASSES[toneName];
 }
 
 function readAliasAddress(project: CampaignProjectOption): string | null {

--- a/apps/web/app/broadcasts/new/_components/audience-preview-list.tsx
+++ b/apps/web/app/broadcasts/new/_components/audience-preview-list.tsx
@@ -86,7 +86,7 @@ export function AudiencePreviewList({
             </div>
             <div className="min-w-0">
               <p className="truncate text-slate-500">
-                {row.projectAliasHint ?? row.project ?? "No project"}
+                {row.projectAlias ?? row.project ?? "No project"}
               </p>
             </div>
           </div>

--- a/apps/web/app/broadcasts/new/_components/new-campaign-wizard.tsx
+++ b/apps/web/app/broadcasts/new/_components/new-campaign-wizard.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useRef, useState, useTransition } from "react";
 
 import type {
+  AudienceCriteria,
   CampaignKind,
   ExpeditionMemberStatus,
   LaunchType,
@@ -108,7 +109,11 @@ function readAudienceModesForLaunchType(
 }
 
 function hasAppliedAudienceFilters(criteria: CampaignAudienceCriteria): boolean {
-  switch (criteria.initialFilter ?? "project_status") {
+  if (criteria.initialFilter === undefined) {
+    return false;
+  }
+
+  switch (criteria.initialFilter) {
     case "all_approved":
     case "project_status":
     case "specific":
@@ -118,14 +123,24 @@ function hasAppliedAudienceFilters(criteria: CampaignAudienceCriteria): boolean 
 
 function deriveInitialFilter(
   draft: CampaignWizardDraftData,
-): AudienceInitialFilter {
+): AudienceInitialFilter | undefined {
   if (draft.kind === "newsletter") {
     return "all_approved";
   }
 
-  return (draft.audienceCriteria.contactIds?.length ?? 0) > 0
-    ? "specific"
-    : defaultAudienceModeForLaunchType(draft.launchType);
+  if ((draft.audienceCriteria.contactIds?.length ?? 0) > 0) {
+    return "specific";
+  }
+
+  if (
+    draft.audienceCriteria.projectId !== null ||
+    draft.audienceCriteria.projectIds.length > 0 ||
+    draft.audienceCriteria.statuses.length > 0
+  ) {
+    return "project_status";
+  }
+
+  return undefined;
 }
 
 function kindForAudienceMode(mode: AudienceInitialFilter): CampaignKind {
@@ -302,6 +317,36 @@ function buildCriteriaForMode(input: {
   };
 }
 
+function clearAudienceCriteria(
+  criteria: CampaignAudienceCriteria,
+): CampaignAudienceCriteria {
+  return {
+    ...criteria,
+    initialFilter: undefined,
+    projectId: null,
+    projectIds: [],
+    statuses: [],
+    contactIds: [],
+  };
+}
+
+function toActionCriteria(
+  criteria: CampaignAudienceCriteria,
+): AudienceCriteria & {
+  readonly initialFilter?: AudienceInitialFilter;
+} {
+  if (criteria.initialFilter === undefined) {
+    const rest = { ...criteria };
+    delete rest.initialFilter;
+    return rest as Omit<CampaignAudienceCriteria, "initialFilter">;
+  }
+
+  return {
+    ...criteria,
+    initialFilter: criteria.initialFilter,
+  };
+}
+
 function readProjectChipLabel(
   kind: CampaignKind,
   criteria: CampaignAudienceCriteria,
@@ -345,6 +390,7 @@ export function NewCampaignWizard({
   readonly isAdmin: boolean;
 }) {
   const initialSchedule = buildDenverInputDefaults(new Date());
+  const initialAudienceMode = deriveInitialFilter(draft);
   const [currentStep, setCurrentStep] = useState(
     draft.state === "draft" ? 0 : 5,
   );
@@ -365,18 +411,21 @@ export function NewCampaignWizard({
       draft.audienceCriteria.projectIds[0] ??
       null,
     contactIds: draft.audienceCriteria.contactIds ?? [],
-    initialFilter: deriveInitialFilter(draft),
+    initialFilter: initialAudienceMode,
   });
+  const [hasPickedAudienceMode, setHasPickedAudienceMode] = useState(
+    initialAudienceMode !== undefined,
+  );
   const [countState, setCountState] = useState({
     count: draft.audienceSize ?? 0,
     hasAppliedFilters: hasAppliedAudienceFilters({
       ...draft.audienceCriteria,
       projectId:
-        draft.audienceCriteria.projectId ??
-        draft.audienceCriteria.projectIds[0] ??
-        null,
+      draft.audienceCriteria.projectId ??
+      draft.audienceCriteria.projectIds[0] ??
+      null,
       contactIds: draft.audienceCriteria.contactIds ?? [],
-      initialFilter: deriveInitialFilter(draft),
+      initialFilter: initialAudienceMode,
     }),
   });
   const [previewRows, setPreviewRows] = useState<readonly AudiencePreviewRow[]>(
@@ -464,7 +513,10 @@ export function NewCampaignWizard({
     () => normalizeProjectIds(aliasProjects.map((project) => project.id)),
     [aliasProjects],
   );
-  const kind = kindForAudienceMode(criteria.initialFilter ?? "project_status");
+  const kind =
+    criteria.initialFilter === undefined
+      ? draft.kind
+      : kindForAudienceMode(criteria.initialFilter);
   const fingerprint = useMemo(
     () =>
       JSON.stringify({
@@ -521,11 +573,14 @@ export function NewCampaignWizard({
         draft.audienceCriteria.projectIds[0] ??
         null,
       contactIds: draft.audienceCriteria.contactIds ?? [],
-      initialFilter: deriveInitialFilter(draft),
+      initialFilter: initialAudienceMode,
     };
     savedFingerprintRef.current = JSON.stringify({
       launchType: draft.launchType,
-      kind: kindForAudienceMode(initialCriteria.initialFilter),
+      kind:
+        initialCriteria.initialFilter === undefined
+          ? draft.kind
+          : kindForAudienceMode(initialCriteria.initialFilter),
       name: draft.name,
       fromEmail: draft.fromEmail,
       replyToEmail: draft.replyToEmail,
@@ -536,7 +591,7 @@ export function NewCampaignWizard({
       criteria: initialCriteria,
       audienceSize: draft.audienceSize,
     });
-  }, [draft]);
+  }, [draft, initialAudienceMode]);
 
   useEffect(() => {
     if (fromEmail === null && suggestedSenderEmail !== null) {
@@ -546,9 +601,11 @@ export function NewCampaignWizard({
   }, [fromEmail, suggestedSenderEmail]);
 
   useEffect(() => {
-    const currentMode = criteria.initialFilter ?? "project_status";
+    const currentMode = criteria.initialFilter;
     if (
+      !hasPickedAudienceMode ||
       selectedSenderOption === null ||
+      currentMode === undefined ||
       currentMode === "all_approved" ||
       aliasProjects.length === 0
     ) {
@@ -563,11 +620,11 @@ export function NewCampaignWizard({
     setCriteria((current) =>
       buildCriteriaForMode({
         current,
-        mode: current.initialFilter ?? "project_status",
+        mode: currentMode,
         aliasProjects,
       }),
     );
-  }, [aliasProjects, criteria, selectedSenderOption]);
+  }, [aliasProjects, criteria, criteria.initialFilter, hasPickedAudienceMode, selectedSenderOption]);
 
   useEffect(() => {
     if (previousLaunchTypeRef.current === launchType) {
@@ -575,17 +632,21 @@ export function NewCampaignWizard({
     }
 
     previousLaunchTypeRef.current = launchType;
-    setCriteria((current) =>
-      buildCriteriaForMode({
+    setCriteria((current) => {
+      if (!hasPickedAudienceMode) {
+        return clearAudienceCriteria(current);
+      }
+
+      return buildCriteriaForMode({
         current,
         mode: defaultAudienceModeForLaunchType(launchType),
         aliasProjects,
-      }),
-    );
+      });
+    });
     setVolunteerSearchQuery("");
     setVolunteerSearchRows([]);
     setVolunteerSearchErrorMessage(null);
-  }, [aliasProjects, launchType]);
+  }, [aliasProjects, hasPickedAudienceMode, launchType]);
 
   useEffect(() => {
     if (previousFromEmailRef.current === fromEmail) {
@@ -593,24 +654,28 @@ export function NewCampaignWizard({
     }
 
     previousFromEmailRef.current = fromEmail;
-    setCriteria((current) =>
-      buildCriteriaForMode({
+    setCriteria((current) => {
+      if (!hasPickedAudienceMode || current.initialFilter === undefined) {
+        return clearAudienceCriteria(current);
+      }
+
+      return buildCriteriaForMode({
         current,
-        mode: current.initialFilter ?? defaultAudienceModeForLaunchType(launchType),
+        mode: current.initialFilter,
         aliasProjects,
-      }),
-    );
+      });
+    });
     setVolunteerSearchQuery("");
     setVolunteerSearchRows([]);
     setVolunteerSearchErrorMessage(null);
-  }, [aliasProjects, criteria.initialFilter, fromEmail, launchType]);
+  }, [aliasProjects, criteria.initialFilter, fromEmail, hasPickedAudienceMode]);
 
   useEffect(() => {
     setReplyToEmail(fromEmail);
   }, [fromEmail]);
 
   useEffect(() => {
-    if ((criteria.initialFilter ?? "project_status") !== "project_status") {
+    if (!hasPickedAudienceMode || criteria.initialFilter !== "project_status") {
       setStatusCounts({});
       setStatusCountsLoading(false);
       setStatusCountsErrorMessage(null);
@@ -659,7 +724,7 @@ export function NewCampaignWizard({
             };
       });
     });
-  }, [bootstrap.statuses, criteria.initialFilter, selectedProjectIdsKey]);
+  }, [bootstrap.statuses, criteria.initialFilter, hasPickedAudienceMode, selectedProjectIdsKey]);
 
   useEffect(() => {
     const timer = setInterval(() => {
@@ -677,7 +742,14 @@ export function NewCampaignWizard({
       return;
     }
 
-    const audienceMode = criteria.initialFilter ?? "project_status";
+    if (!hasPickedAudienceMode || criteria.initialFilter === undefined) {
+      countRequestRef.current += 1;
+      setCountLoading(false);
+      setCountState({ count: 0, hasAppliedFilters: false });
+      return;
+    }
+
+    const audienceMode = criteria.initialFilter;
     if (audienceMode === "project_status" && criteria.statuses.length === 0) {
       countRequestRef.current += 1;
       setCountLoading(false);
@@ -688,7 +760,10 @@ export function NewCampaignWizard({
     const requestId = ++countRequestRef.current;
     setCountLoading(true);
     startCountTransition(async () => {
-      const result = await resolveAudienceCountAction({ kind, criteria });
+      const result = await resolveAudienceCountAction({
+        kind,
+        criteria: toActionCriteria(criteria),
+      });
       if (requestId !== countRequestRef.current) {
         return;
       }
@@ -701,11 +776,13 @@ export function NewCampaignWizard({
 
       setCountState(result.data);
     });
-  }, [criteria, frozen, kind]);
+  }, [criteria, frozen, hasPickedAudienceMode, kind]);
 
   useEffect(() => {
-    if (currentStep !== 2) {
+    if (currentStep !== 2 || !hasPickedAudienceMode) {
       setAudiencePreviewLoading(false);
+      setPreviewRows([]);
+      setPreviewErrorMessage(null);
       return;
     }
 
@@ -713,7 +790,10 @@ export function NewCampaignWizard({
     setAudiencePreviewLoading(true);
     setPreviewErrorMessage(null);
     void (async () => {
-      const result = await previewAudienceAction({ kind, criteria });
+      const result = await previewAudienceAction({
+        kind,
+        criteria: toActionCriteria(criteria),
+      });
       if (requestId !== audiencePreviewRequestRef.current) {
         return;
       }
@@ -727,10 +807,14 @@ export function NewCampaignWizard({
       setPreviewRows(result.data);
       setPreviewErrorMessage(null);
     })();
-  }, [criteria, currentStep, kind]);
+  }, [criteria, currentStep, hasPickedAudienceMode, kind]);
 
   useEffect(() => {
-    if (currentStep !== 2 || criteria.initialFilter !== "specific") {
+    if (
+      currentStep !== 2 ||
+      !hasPickedAudienceMode ||
+      criteria.initialFilter !== "specific"
+    ) {
       setVolunteerSearchRows([]);
       setVolunteerSearchErrorMessage(null);
       return;
@@ -770,6 +854,7 @@ export function NewCampaignWizard({
     aliasProjectIds,
     criteria.initialFilter,
     currentStep,
+    hasPickedAudienceMode,
     volunteerSearchQuery,
   ]);
 
@@ -783,7 +868,7 @@ export function NewCampaignWizard({
       startComposePreviewTransition(async () => {
         const result = await loadComposePreviewAction({
           kind,
-          criteria,
+          criteria: toActionCriteria(criteria),
           fromEmail,
           subjectTemplate: subject,
           bodyHtmlTemplate: bodyHtml,
@@ -890,7 +975,7 @@ export function NewCampaignWizard({
           bodyTextTemplate:
             bodyPlaintext.trim().length === 0 ? null : bodyPlaintext,
           preheader: preheader.trim().length === 0 ? null : preheader,
-          audienceCriteria: criteria,
+          audienceCriteria: toActionCriteria(criteria),
           audienceSize: countState.hasAppliedFilters ? countState.count : null,
         });
 
@@ -945,6 +1030,7 @@ export function NewCampaignWizard({
   }
 
   function changeInitialFilter(value: AudienceInitialFilter) {
+    setHasPickedAudienceMode(true);
     updateCriteria((current) =>
       buildCriteriaForMode({
         current,
@@ -1158,6 +1244,7 @@ export function NewCampaignWizard({
             {currentStep === 2 ? (
               <AudienceBuilderStep
                 availableModes={readAudienceModesForLaunchType(launchType)}
+                hasPickedMode={hasPickedAudienceMode}
                 criteria={criteria}
                 countState={countState}
                 previewRows={previewRows}

--- a/apps/web/tests/unit/campaign-audience-count-panel.test.tsx
+++ b/apps/web/tests/unit/campaign-audience-count-panel.test.tsx
@@ -33,7 +33,7 @@ describe("AudienceCountPanel snapshots", () => {
           loading={false}
         />,
       ),
-    ).toMatchInlineSnapshot(`"<div class="rounded-lg border border-slate-200 bg-slate-50 p-4"><div class="min-w-0"><div aria-live="polite" class="inline-flex items-center gap-2 rounded-full px-2.5 py-1 text-[11.5px] font-semibold bg-white text-slate-600 ring-1 ring-slate-200">Live audience</div><div class="mt-3 flex items-end gap-3"><span class="text-[32px] font-semibold leading-none tabular-nums text-slate-900">—</span><span class="pb-1 text-[12px] text-slate-500">recipients match · live as you change filters</span></div><p class="mt-2 text-[12.5px] text-slate-600">Pick a project or volunteer selection to start.</p></div></div>"`);
+    ).toMatchInlineSnapshot(`"<div class="rounded-lg border border-slate-200 bg-slate-50 p-4"><div class="min-w-0"><div aria-live="polite" class="inline-flex items-center gap-2 rounded-full px-2.5 py-1 text-[11.5px] font-semibold bg-white text-slate-600 ring-1 ring-slate-200">Live audience</div><div class="mt-3 flex items-end gap-3"><span class="text-[32px] font-semibold leading-none tabular-nums text-slate-900">—</span><span class="pb-1 text-[12px] text-slate-500">recipients match · live as you change filters</span></div><p class="mt-2 text-[12.5px] text-slate-600">Pick an audience mode to start.</p></div></div>"`);
   });
 
   it("renders the positive matched state", () => {

--- a/apps/web/tests/unit/campaign-audience-filter-panel.test.tsx
+++ b/apps/web/tests/unit/campaign-audience-filter-panel.test.tsx
@@ -76,6 +76,7 @@ function renderPanel(overrides: Partial<React.ComponentProps<typeof AudienceFilt
         id: "project-a",
         name: "Restoring Butternut Forest Health",
         alias: null,
+        projectAlias: "Beech & Butternut",
         aliasHint: "forests@",
         connectedToProjectId: "host-project",
         isSubProject: true,
@@ -84,6 +85,7 @@ function renderPanel(overrides: Partial<React.ComponentProps<typeof AudienceFilt
         id: "project-b",
         name: "Saving American Beech",
         alias: null,
+        projectAlias: "Beech & Butternut",
         aliasHint: "forests@",
         connectedToProjectId: "host-project",
         isSubProject: true,
@@ -307,6 +309,7 @@ describe("AudienceFilterPanel", () => {
           id: "project-a",
           name: "CA Biodiversity",
           alias: "cabio",
+          projectAlias: "CA Biodiversity",
           aliasHint: "cabio@",
           connectedToProjectId: null,
           isSubProject: false,
@@ -323,14 +326,53 @@ describe("AudienceFilterPanel", () => {
     ).toBe(false);
   });
 
-  it("renders both forests sub-projects as toggleable project rows when two options exist", () => {
-    renderPanel();
+  it("renders compact tone pills for multi-project aliases", () => {
+    renderPanel({
+      criteria: {
+        projectId: "project-a",
+        projectIds: ["project-a"],
+        statuses: [],
+        contactIds: [],
+        expeditionIds: [],
+        lastActivityWindow: "all_time",
+        hasReplied: "either",
+        hasClicked: "either",
+      },
+    });
 
     const projectButtons = Array.from(document.querySelectorAll("button")).filter(
       (button) => button.getAttribute("aria-label")?.startsWith("Choose project "),
     );
 
     expect(projectButtons).toHaveLength(2);
+    expect(projectButtons[0]?.className).toContain("rounded-full");
+    expect(projectButtons[1]?.className).toContain("rounded-full");
+    expect(projectButtons[0]?.className).not.toContain("rounded-xl");
+    expect(projectButtons[0]?.className).toContain("text-white");
+    expect(projectButtons[1]?.className).not.toContain("text-white");
+    expect(
+      [
+        "bg-emerald-600",
+        "bg-sky-600",
+        "bg-violet-500",
+        "bg-amber-500",
+        "bg-rose-500",
+        "bg-indigo-600",
+        "bg-teal-600",
+      ].some((className) => projectButtons[0]?.className.includes(className)),
+    ).toBe(true);
+    expect(
+      [
+        "bg-emerald-50",
+        "bg-sky-50",
+        "bg-violet-50",
+        "bg-amber-50",
+        "bg-rose-50",
+        "bg-indigo-50",
+        "bg-teal-50",
+      ].some((className) => projectButtons[1]?.className.includes(className)),
+    ).toBe(true);
+    expect(projectButtons[0]?.className).not.toBe(projectButtons[1]?.className);
     expect(
       document.querySelector(
         '[aria-label="Project Restoring Butternut Forest Health is locked to this sender alias"]',

--- a/apps/web/tests/unit/campaign-audience-step.test.tsx
+++ b/apps/web/tests/unit/campaign-audience-step.test.tsx
@@ -96,6 +96,7 @@ afterEach(() => {
 
 const baseProps: React.ComponentProps<typeof AudienceBuilderStep> = {
   availableModes: ["project_status", "specific"],
+  hasPickedMode: false,
   criteria: {
     projectId: null,
     projectIds: [],
@@ -105,7 +106,6 @@ const baseProps: React.ComponentProps<typeof AudienceBuilderStep> = {
     lastActivityWindow: "all_time",
     hasReplied: "either",
     hasClicked: "either",
-    initialFilter: "project_status",
   },
   countState: {
     count: 0,
@@ -135,17 +135,21 @@ const baseProps: React.ComponentProps<typeof AudienceBuilderStep> = {
 };
 
 describe("AudienceBuilderStep initial filter gate", () => {
-  it("renders the initial filter choices", () => {
+  it("renders the pre-choice mode chooser without the downstream panels", () => {
     const markup = renderToStaticMarkup(<AudienceBuilderStep {...baseProps} />);
 
     expect(markup).toContain("Project / status");
     expect(markup).toContain("Individual volunteers");
+    expect(markup).not.toContain("Audience filters");
+    expect(markup).not.toContain("Find volunteers");
+    expect(markup).not.toContain("Audience preview");
   });
 
   it("renders the all-approved branch copy for html mode", () => {
     const markup = renderToStaticMarkup(
       <AudienceBuilderStep
         {...baseProps}
+        hasPickedMode={true}
         availableModes={["all_approved", "project_status"]}
         criteria={{
           ...baseProps.criteria,
@@ -164,11 +168,13 @@ describe("AudienceBuilderStep initial filter gate", () => {
     const markup = renderToStaticMarkup(
       <AudienceBuilderStep
         {...baseProps}
+        hasPickedMode={true}
         projectOptions={[
           {
             id: "project-1",
             name: "Restoring Butternut Forest Health",
             alias: null,
+            projectAlias: "Beech & Butternut",
             aliasHint: "forests@",
             connectedToProjectId: "host-project",
             isSubProject: true,
@@ -177,6 +183,7 @@ describe("AudienceBuilderStep initial filter gate", () => {
             id: "project-2",
             name: "Saving American Beech",
             alias: null,
+            projectAlias: "Beech & Butternut",
             aliasHint: "forests@",
             connectedToProjectId: "host-project",
             isSubProject: true,
@@ -212,6 +219,7 @@ describe("AudienceBuilderStep initial filter gate", () => {
     const markup = renderToStaticMarkup(
       <AudienceBuilderStep
         {...baseProps}
+        hasPickedMode={true}
         criteria={{
           ...baseProps.criteria,
           projectId: "project-1",
@@ -229,12 +237,13 @@ describe("AudienceBuilderStep initial filter gate", () => {
     expect(markup).not.toContain("Toggle expedition-member status");
   });
 
-  it("renders alias labels for volunteer search results and preview rows", () => {
+  it("renders human project aliases for volunteer search results and preview rows", () => {
     const longProjectName =
       "Passive Acoustic Monitoring of Pacific Northwest Forests";
     const markup = renderToStaticMarkup(
       <AudienceBuilderStep
         {...baseProps}
+        hasPickedMode={true}
         criteria={{
           ...baseProps.criteria,
           projectId: "project-1",
@@ -249,6 +258,7 @@ describe("AudienceBuilderStep initial filter gate", () => {
             name: "Nicole Moss",
             email: "nic@example.org",
             project: longProjectName,
+            projectAlias: "PNW Biodiversity",
             projectAliasHint: "pnwbio@",
           },
         ]}
@@ -258,13 +268,15 @@ describe("AudienceBuilderStep initial filter gate", () => {
             name: "Nicole Moss",
             email: "nic@example.org",
             project: longProjectName,
+            projectAlias: "PNW Biodiversity",
             projectAliasHint: "pnwbio@",
           },
         ]}
       />,
     );
 
-    expect(markup).toContain("pnwbio@");
+    expect(markup).toContain("PNW Biodiversity");
+    expect(markup).not.toContain("pnwbio@");
     expect(markup).not.toContain(longProjectName);
   });
 
@@ -273,11 +285,13 @@ describe("AudienceBuilderStep initial filter gate", () => {
     const validMarkup = renderToStaticMarkup(
       <AudienceBuilderStep
         {...baseProps}
+        hasPickedMode={true}
         criteria={{
           ...baseProps.criteria,
           projectId: "project-1",
           projectIds: ["project-1"],
           statuses: ["Waitlist"],
+          initialFilter: "project_status",
         }}
         countState={{
           count: 12,
@@ -292,6 +306,58 @@ describe("AudienceBuilderStep initial filter gate", () => {
     expect(validMarkup).not.toMatch(
       /<button[^>]*aria-disabled="true"[^>]*>Continue to compose<\/button>/,
     );
+  });
+
+  it("collapses into the segmented control after the operator picks a mode", () => {
+    setupDom();
+
+    function Harness() {
+      const [criteria, setCriteria] = React.useState(baseProps.criteria);
+      const [hasPickedMode, setHasPickedMode] = React.useState(false);
+
+      return (
+        <AudienceBuilderStep
+          {...baseProps}
+          hasPickedMode={hasPickedMode}
+          criteria={criteria}
+          onInitialFilterChange={(value) => {
+            setHasPickedMode(true);
+            setCriteria((current) => ({
+              ...current,
+              initialFilter: value,
+            }));
+          }}
+        />
+      );
+    }
+
+    act(() => {
+      root?.render(<Harness />);
+    });
+
+    expect(document.body.textContent).toContain("Project / status");
+    expect(document.body.textContent).not.toContain("Audience filters");
+    expect(document.body.textContent).not.toContain("Find volunteers");
+
+    const projectStatusButton = Array.from(document.querySelectorAll("button")).find(
+      (button) => button.textContent.includes("Project / status"),
+    );
+    if (!(projectStatusButton instanceof HTMLButtonElement)) {
+      throw new Error("Project / status chooser button not found");
+    }
+
+    act(() => {
+      projectStatusButton.click();
+    });
+
+    const tablist = document.querySelector('[role="tablist"][aria-label="Audience mode"]');
+    if (!(tablist instanceof HTMLElement)) {
+      throw new Error("Audience mode segmented control not found");
+    }
+
+    expect(tablist.className).toContain("rounded-full");
+    expect(document.body.textContent).toContain("Audience filters");
+    expect(document.body.textContent).not.toContain("Find volunteers");
   });
 
   it("does not retrigger the member-status-counts fetch when only statuses change", async () => {
@@ -434,6 +500,7 @@ describe("AudienceBuilderStep initial filter gate", () => {
             id: "host-project",
             name: "Saving American Beech",
             alias: null,
+            projectAlias: "Beech & Butternut",
             aliasHint: "forests@",
             connectedToProjectId: null,
             isSubProject: false,
@@ -443,6 +510,7 @@ describe("AudienceBuilderStep initial filter gate", () => {
               id: "sub-project",
               name: "Restoring Butternut Forest Health",
               alias: null,
+              projectAlias: "Beech & Butternut",
               aliasHint: "forests@",
               connectedToProjectId: "host-project",
               isSubProject: true,
@@ -475,8 +543,8 @@ describe("AudienceBuilderStep initial filter gate", () => {
       bodyTextTemplate: null,
       preheader: null,
       audienceCriteria: {
-        projectId: null,
-        projectIds: [],
+        projectId: "host-project",
+        projectIds: ["host-project", "sub-project"],
         statuses: [],
         contactIds: [],
         expeditionIds: [],
@@ -676,6 +744,7 @@ describe("AudienceBuilderStep initial filter gate", () => {
             id: "project-1",
             name: "Pacific Northwest Bio",
             alias: null,
+            projectAlias: "PNW Biodiversity",
             aliasHint: "pnwbio@",
             connectedToProjectId: null,
             isSubProject: false,
@@ -708,8 +777,8 @@ describe("AudienceBuilderStep initial filter gate", () => {
       bodyTextTemplate: null,
       preheader: null,
       audienceCriteria: {
-        projectId: null,
-        projectIds: [],
+        projectId: "project-1",
+        projectIds: ["project-1"],
         statuses: [],
         contactIds: [],
         expeditionIds: [],
@@ -899,6 +968,7 @@ describe("AudienceBuilderStep initial filter gate", () => {
             id: "project-butternut",
             name: "Restoring Butternut Forest Health",
             alias: null,
+            projectAlias: "Beech & Butternut",
             aliasHint: "forests@",
             connectedToProjectId: null,
             isSubProject: false,
@@ -908,6 +978,7 @@ describe("AudienceBuilderStep initial filter gate", () => {
               id: "project-beech",
               name: "Saving American Beech",
               alias: null,
+              projectAlias: "Beech & Butternut",
               aliasHint: "forests@",
               connectedToProjectId: "project-butternut",
               isSubProject: true,
@@ -940,8 +1011,8 @@ describe("AudienceBuilderStep initial filter gate", () => {
       bodyTextTemplate: null,
       preheader: null,
       audienceCriteria: {
-        projectId: null,
-        projectIds: [],
+        projectId: "project-butternut",
+        projectIds: ["project-butternut", "project-beech"],
         statuses: [],
         contactIds: [],
         expeditionIds: [],


### PR DESCRIPTION
## Summary

Round 3 of Step 3 polish (after #451, #452). Three production-QA items:

1. **Compact tone-pill project selector** — replaced the heavy full-row dark cards with `rounded-full` tone-colored pills (one tone per project, rotated through `TONE_CLASSES`). Selected: solid tone + white text + Check icon. Unselected: subtle tone + tone-text + tone-ring. Wrapped in `flex flex-wrap gap-2`. Dropped the per-pill alias-address subtitle (operator already knows the alias from Step 2). Single-host aliases (pnwbio@, orcas@, whitebarkpine@) keep the `LockedProjectRow` rendering unchanged.

2. **Human project alias in search results + recipient preview** — added `projectAlias: string | null` to `CampaignProjectOption`, `AudienceVolunteerSearchRow`, and `AudiencePreviewRow`. Populated from `settings_projects.projectAlias`. UI now displays the human alias (`PNW Biodiversity`, `Whitebark Pine`, `Beech & Butternut`) instead of the email local-part (`PNWBIO@` etc.). Fallback chain: `projectAlias → project (projectName) → "No project"`.

3. **Progressive disclosure for the mode selector** — two distinct views:
   - **Pre-choice**: only the live audience counter + big mode-chooser cards. No mode pre-selected. Continue disabled.
   - **Post-choice**: counter + compact segmented control (two-button tab strip showing the chosen mode highlighted, one click switches) + relevant panel (project+status filters OR volunteer search) + audience preview.

   State tracking: UI-only `hasPickedMode` ref in the wizard. Treats existing-criteria drafts as already-picked so returning to Step 3 mid-draft goes straight to post-choice.

## Tests

- Extended `tests/unit/campaign-audience-filter-panel.test.tsx`: compact pill styling, tone rotation, selected/unselected variants for the 2-project forests@ case.
- Extended `tests/unit/campaign-audience-step.test.tsx`: pre-choice view (big chooser, no panel, Continue disabled), post-choice view (segmented control + panel rendering), projectAlias chip assertions for both volunteer-search and preview rows.

## Validation

\`\`\`text
pnpm --filter @as-comms/web exec vitest run tests/unit/campaign-audience-filter-panel.test.tsx tests/unit/campaign-audience-step.test.tsx
pnpm --filter @as-comms/web typecheck
pnpm --filter @as-comms/db  typecheck
pnpm --filter @as-comms/web lint
pnpm boundaries
pnpm build
\`\`\`

All green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Codex via brief .codex-worktrees/wizard-step3-polish-r3/.brief.md