### PR TITLE
fix(db): SF capture must not clobber operator-managed AI knowledge URL

### DIFF
--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -3075,8 +3075,16 @@ function createStage1RepositoriesInternal(
               )}, ${projectDimensions.connectedToProjectId})`,
               // isActive intentionally NOT updated: admins manage it in Settings,
               // and Salesforce capture must not overwrite that app-owned state.
-              aiKnowledgeUrl: values.aiKnowledgeUrl,
-              aiKnowledgeSyncedAt: values.aiKnowledgeSyncedAt,
+              // aiKnowledgeUrl / aiKnowledgeSyncedAt follow the same
+              // operator-managed rule as alias/connected host metadata:
+              // Salesforce capture has no opinion here and must not wipe
+              // Settings-managed or synthesis-managed state with nulls.
+              aiKnowledgeUrl: sql`COALESCE(EXCLUDED.${sql.identifier(
+                "ai_knowledge_url",
+              )}, ${projectDimensions.aiKnowledgeUrl})`,
+              aiKnowledgeSyncedAt: sql`COALESCE(EXCLUDED.${sql.identifier(
+                "ai_knowledge_synced_at",
+              )}, ${projectDimensions.aiKnowledgeSyncedAt})`,
               aiKnowledgeSources:
                 values.aiKnowledgeSources ??
                 projectDimensions.aiKnowledgeSources,

--- a/packages/db/test/stage1-repositories.test.ts
+++ b/packages/db/test/stage1-repositories.test.ts
@@ -1039,6 +1039,76 @@ describe("Stage 1 DB repositories", () => {
     ]);
   });
 
+  it("preserves operator-managed AI knowledge fields when a resync upsert passes nulls", async () => {
+    const { repositories } = await createTestStage1Context();
+
+    await repositories.projectDimensions.upsert({
+      projectId: "project_1",
+      projectName: "Project Antarctica",
+      projectAlias: "Antarctica",
+      source: "salesforce",
+      isActive: true,
+      aiKnowledgeUrl: "https://www.notion.so/abc",
+      aiKnowledgeSyncedAt: "2026-05-01T00:00:00.000Z",
+    });
+
+    await repositories.projectDimensions.upsert({
+      projectId: "project_1",
+      projectName: "Project Antarctica Resynced",
+      projectAlias: "Antarctica",
+      source: "salesforce",
+      isActive: true,
+      aiKnowledgeUrl: null,
+      aiKnowledgeSyncedAt: null,
+    });
+
+    await expect(
+      repositories.projectDimensions.listByIds(["project_1"]),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        projectId: "project_1",
+        projectName: "Project Antarctica Resynced",
+        aiKnowledgeUrl: "https://www.notion.so/abc",
+        aiKnowledgeSyncedAt: "2026-05-01T00:00:00.000Z",
+      }),
+    ]);
+  });
+
+  it("allows explicit non-null AI knowledge fields to overwrite existing values", async () => {
+    const { repositories } = await createTestStage1Context();
+
+    await repositories.projectDimensions.upsert({
+      projectId: "project_1",
+      projectName: "Project Antarctica",
+      projectAlias: "Antarctica",
+      source: "salesforce",
+      isActive: true,
+      aiKnowledgeUrl: "https://www.notion.so/abc",
+      aiKnowledgeSyncedAt: "2026-05-01T00:00:00.000Z",
+    });
+
+    await repositories.projectDimensions.upsert({
+      projectId: "project_1",
+      projectName: "Project Antarctica Resynced",
+      projectAlias: "Antarctica",
+      source: "salesforce",
+      isActive: true,
+      aiKnowledgeUrl: "https://www.notion.so/xyz",
+      aiKnowledgeSyncedAt: "2026-05-03T00:00:00.000Z",
+    });
+
+    await expect(
+      repositories.projectDimensions.listByIds(["project_1"]),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        projectId: "project_1",
+        projectName: "Project Antarctica Resynced",
+        aiKnowledgeUrl: "https://www.notion.so/xyz",
+        aiKnowledgeSyncedAt: "2026-05-03T00:00:00.000Z",
+      }),
+    ]);
+  });
+
   it("persists sync state and audit evidence with contract-shaped results", async () => {
     const { repositories } = await createTestStage1Context();
 


### PR DESCRIPTION
## Summary

P0 fix for the AI Draft composer "Project-specific AI grounding is missing for this contact" banner. Same shape as the 2026-04-30 PR #218 regression but on a different pair of columns.

`projectDimensions.upsert` in [packages/db/src/repositories.ts:3078-3079](packages/db/src/repositories.ts) unconditionally overwrote `aiKnowledgeUrl` and `aiKnowledgeSyncedAt`. Salesforce capture (the heaviest caller of this upsert) has no opinion on these fields and passes `null`. Result: every SF pulse for a project silently wiped the operator-configured Notion URL, the notion-knowledge-sync worker then returned `invalid_source`, no row landed in `ai_knowledge_entries`, and the AI Draft retriever returned `projectContext: null` → composer banner.

Apply the same `COALESCE(EXCLUDED.<col>, <existing>)` pattern already used for `projectAlias` / `connectedToProjectId` in the same `set` object. Explicit clear paths (`setAiKnowledgeUrl(projectId, null)` and `unlinkAiKnowledge(projectId)`) bypass the upsert and remain unchanged.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm --filter @as-comms/db test` — new coverage in `stage1-repositories.test.ts:1042` for both directions (null preserves, explicit value overwrites)
- [x] `pnpm --filter @as-comms/domain test`
- [x] `pnpm boundaries`
- [ ] After merge: re-trigger AI Knowledge synthesis on the 2 forests projects (Restoring Butternut Forest Health + Saving American Beech) so `setAiKnowledgeUrl` repopulates the URL and notion-knowledge-sync ingests the page. Confirm composer banner clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)