### PR TITLE
feat(worker): rebuild inbox projection after email-only contact merge

### DIFF
--- a/apps/worker/src/ops/merge-email-only-into-sf-anchored.ts
+++ b/apps/worker/src/ops/merge-email-only-into-sf-anchored.ts
@@ -5,8 +5,13 @@ import { pathToFileURL } from "node:url";
 import {
   closeDatabaseConnection,
   createDatabaseConnection,
+  createStage1RepositoryBundle,
   type Stage1Database,
 } from "@as-comms/db";
+import {
+  createStage1PersistenceService,
+  rebuildInboxProjectionForContact,
+} from "@as-comms/domain";
 import { sql as drizzleSql } from "drizzle-orm";
 
 import {
@@ -56,6 +61,7 @@ interface MergeExecutionResult {
   readonly notesRepointed: number;
   readonly routingRepointed: number;
   readonly identityCasesResolved: number;
+  readonly inboxProjectionsRebuilt: number;
   readonly contactsDeleted: number;
 }
 
@@ -67,6 +73,7 @@ interface MergeSummary {
   readonly notesRepointed: number;
   readonly routingRepointed: number;
   readonly identityCasesResolved: number;
+  readonly inboxProjectionsRebuilt: number;
   readonly contactsDeleted: number;
   readonly errors: readonly {
     readonly emailOnlyId: string;
@@ -256,6 +263,7 @@ function createEmptySummary(): MergeSummary {
     notesRepointed: 0,
     routingRepointed: 0,
     identityCasesResolved: 0,
+    inboxProjectionsRebuilt: 0,
     contactsDeleted: 0,
     errors: [],
   };
@@ -276,6 +284,8 @@ function addPairSuccess(
     routingRepointed: summary.routingRepointed + result.routingRepointed,
     identityCasesResolved:
       summary.identityCasesResolved + result.identityCasesResolved,
+    inboxProjectionsRebuilt:
+      summary.inboxProjectionsRebuilt + result.inboxProjectionsRebuilt,
     contactsDeleted: summary.contactsDeleted + result.contactsDeleted,
   };
 }
@@ -308,6 +318,7 @@ function buildPlanResult(plan: MergePlan): MergeExecutionResult {
     notesRepointed: plan.noteIds.length,
     routingRepointed: plan.routingRowIds.length,
     identityCasesResolved: plan.identityCaseIds.length,
+    inboxProjectionsRebuilt: 0,
     contactsDeleted: 1,
   };
 }
@@ -334,6 +345,8 @@ export async function applyMergeForPair(input: {
 
   const runInTransaction = async (tx: Stage1Database) => {
     const sql = createDbSqlRunner(tx);
+    const repositories = createStage1RepositoryBundle(tx);
+    const persistence = createStage1PersistenceService(repositories);
     const canonicalEventIds = await updateRowsAndReturnIds(
       sql,
       `
@@ -439,12 +452,19 @@ export async function applyMergeForPair(input: {
       throw new DryRunRollback();
     }
 
+    const inboxProjection =
+      await rebuildInboxProjectionForContact(
+        persistence,
+        input.pair.sfAnchoredId,
+      );
+
     return {
       canonicalEventsRepointed: canonicalEventIds.length,
       timelineRowsRepointed: timelineRowIds.length,
       notesRepointed: noteIds.length,
       routingRepointed: routingRowIds.length,
       identityCasesResolved: identityCaseIds.length,
+      inboxProjectionsRebuilt: inboxProjection === null ? 0 : 1,
       contactsDeleted: deletedContactIds.length,
     };
   };
@@ -480,6 +500,7 @@ function printPairAudit(input: {
   readonly logger: Logger;
   readonly dryRun: boolean;
   readonly plan: MergePlan;
+  readonly result?: MergeExecutionResult;
   readonly status: "planned" | "applied" | "error";
   readonly errorMessage?: string;
 }): void {
@@ -504,6 +525,7 @@ function printPairAudit(input: {
         routingRows: input.plan.routingRowIds.length,
         identityCases: input.plan.identityCaseIds.length,
         inboxRows: input.plan.inboxProjectionContactIds.length,
+        inboxProjectionsRebuilt: input.result?.inboxProjectionsRebuilt ?? 0,
       },
       ...(input.errorMessage === undefined
         ? {}
@@ -530,6 +552,7 @@ function printSummary(input: {
       notesRepointed: input.summary.notesRepointed,
       routingRepointed: input.summary.routingRepointed,
       identityCasesResolved: input.summary.identityCasesResolved,
+      inboxProjectionsRebuilt: input.summary.inboxProjectionsRebuilt,
       contactsDeleted: input.summary.contactsDeleted,
       errors: input.summary.errors,
     }),
@@ -593,6 +616,7 @@ export async function main(
           logger,
           dryRun,
           plan,
+          result,
           status: dryRun ? "planned" : "applied",
         });
         summary = addPairSuccess(summary, result);

--- a/apps/worker/test/merge-email-only-into-sf-anchored.test.ts
+++ b/apps/worker/test/merge-email-only-into-sf-anchored.test.ts
@@ -125,6 +125,17 @@ async function seedMergePair(
     idempotencyKey: "source-evidence:gmail:message:dupe-case-2",
     checksum: "checksum:dupe-case-2",
   });
+  await context.repositories.sourceEvidence.append({
+    id: "source-evidence:gmail:message:sf-anchor-older",
+    provider: "gmail",
+    providerRecordType: "message",
+    providerRecordId: "sf-anchor-older",
+    receivedAt: "2026-05-02T01:00:00.000Z",
+    occurredAt: "2026-05-02T01:00:00.000Z",
+    payloadRef: "gmail://message/sf-anchor-older",
+    idempotencyKey: "source-evidence:gmail:message:sf-anchor-older",
+    checksum: "checksum:sf-anchor-older",
+  });
 
   await context.repositories.canonicalEvents.upsert({
     id: "canonical-event:dupe-1",
@@ -141,6 +152,21 @@ async function seedMergePair(
     }),
     reviewState: "clear",
   });
+  await context.repositories.canonicalEvents.upsert({
+    id: "canonical-event:sf-anchor-older",
+    contactId: sfAnchoredId,
+    eventType: "communication.email.outbound",
+    channel: "email",
+    occurredAt: "2026-05-02T01:00:00.000Z",
+    contentFingerprint: null,
+    sourceEvidenceId: "source-evidence:gmail:message:sf-anchor-older",
+    idempotencyKey: "canonical-event:sf-anchor-older",
+    provenance: buildCanonicalProvenance({
+      sourceEvidenceId: "source-evidence:gmail:message:sf-anchor-older",
+      providerRecordId: "sf-anchor-older",
+    }),
+    reviewState: "clear",
+  });
 
   await context.db.insert(contactTimelineProjection).values({
     id: "timeline:dupe-1",
@@ -153,6 +179,31 @@ async function seedMergePair(
     channel: "email",
     primaryProvider: "gmail",
     reviewState: "clear",
+  });
+  await context.db.insert(contactTimelineProjection).values({
+    id: "timeline:sf-anchor-older",
+    contactId: sfAnchoredId,
+    canonicalEventId: "canonical-event:sf-anchor-older",
+    occurredAt: new Date("2026-05-02T01:00:00.000Z"),
+    sortKey: "2026-05-02T01:00:00.000Z#canonical-event:sf-anchor-older",
+    eventType: "communication.email.outbound",
+    summary: "Older outbound email",
+    channel: "email",
+    primaryProvider: "gmail",
+    reviewState: "clear",
+  });
+  await context.repositories.inboxProjection.upsert({
+    contactId: sfAnchoredId,
+    bucket: "Opened",
+    needsFollowUp: false,
+    hasUnresolved: true,
+    lastInboundAt: "2026-05-02T00:59:00.000Z",
+    lastOutboundAt: "2026-05-02T01:00:00.000Z",
+    lastActivityAt: "2026-05-02T01:00:00.000Z",
+    snippet: "Stale projection",
+    archivedAt: null,
+    lastCanonicalEventId: "canonical-event:sf-anchor-older",
+    lastEventType: "communication.email.outbound",
   });
 
   await context.repositories.identityResolutionQueue.upsert({
@@ -279,6 +330,7 @@ describe("merge-email-only-into-sf-anchored", () => {
         canonicalEventsRepointed: 1,
         timelineRowsRepointed: 1,
         identityCasesResolved: 2,
+        inboxProjectionsRebuilt: 0,
         contactsDeleted: 1,
       });
 
@@ -321,6 +373,15 @@ describe("merge-email-only-into-sf-anchored", () => {
           anchoredContactId: pairIds.emailOnlyId,
         },
       ]);
+      await expect(
+        context.repositories.inboxProjection.findByContactId(pairIds.sfAnchoredId),
+      ).resolves.toMatchObject({
+        contactId: pairIds.sfAnchoredId,
+        hasUnresolved: true,
+        lastInboundAt: "2026-05-02T00:59:00.000Z",
+        lastCanonicalEventId: "canonical-event:sf-anchor-older",
+        lastEventType: "communication.email.outbound",
+      });
     } finally {
       await context.dispose();
     }
@@ -357,6 +418,7 @@ describe("merge-email-only-into-sf-anchored", () => {
         canonicalEventsRepointed: 1,
         timelineRowsRepointed: 1,
         identityCasesResolved: 2,
+        inboxProjectionsRebuilt: 1,
         contactsDeleted: 1,
       });
 
@@ -432,6 +494,15 @@ describe("merge-email-only-into-sf-anchored", () => {
         `merged duplicate contact ${pairIds.emailOnlyId} into ${pairIds.sfAnchoredId} (architect cleanup 2026-05-02)`,
       );
 
+      await expect(
+        context.repositories.inboxProjection.findByContactId(pairIds.sfAnchoredId),
+      ).resolves.toMatchObject({
+        contactId: pairIds.sfAnchoredId,
+        hasUnresolved: false,
+        lastInboundAt: "2026-05-02T01:01:00.000Z",
+        lastCanonicalEventId: "canonical-event:dupe-1",
+        lastEventType: "communication.email.inbound",
+      });
       await expect(
         context.repositories.contacts.findById(pairIds.emailOnlyId),
       ).resolves.toBeNull();

--- a/packages/domain/src/normalization.ts
+++ b/packages/domain/src/normalization.ts
@@ -1124,7 +1124,7 @@ function resolveInboxSnippet(
   return "";
 }
 
-async function rebuildInboxProjectionForContact(
+export async function rebuildInboxProjectionForContact(
   persistence: Stage1PersistenceService,
   contactId: string,
 ): Promise<InboxProjectionRow | null> {


### PR DESCRIPTION
## Summary

Closes the projection-rebuild gap in `apps/worker/src/ops/merge-email-only-into-sf-anchored.ts`. The op already repointed canonical events / timeline / identity-queue rows from the email-only contact to the SF anchor and deleted the email-only contact — but it never recomputed `contact_inbox_projection` for the surviving SF anchor. Net effect in production: `has_unresolved` stayed `true` after merging, `last_inbound_at` / `last_canonical_event_id` / `snippet` / `bucket` reflected pre-merge state, and merged-in inbounds were invisible from the volunteer view.

- `applyMergeForPair` now constructs a transaction-scoped `Stage1PersistenceService` and calls the existing `rebuildInboxProjectionForContact` helper on the SF anchor, inside the same DB transaction, after the email-only contact delete and before commit.
- `rebuildInboxProjectionForContact` is exported from `@as-comms/domain` so the worker op can reuse the domain-layer rebuild semantics (same as `/api/internal/inbox-rebuild`).
- Dry-run path skips the rebuild (gated inside the existing `DryRunRollback` boundary).
- Adds `inboxProjectionsRebuilt` to `MergeExecutionResult` / `MergeSummary` and surfaces it in `printPairAudit` / `printSummary` JSON output.
- Test extension seeds an SF anchor with an older canonical event + stale `has_unresolved=true` projection; dry-run asserts projection stays stale, execute asserts projection rebuilt with `has_unresolved=false` and `last_inbound_at` from the merged inbound.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm --filter @as-comms/worker test` (extended)
- [x] `pnpm --filter @as-comms/domain test`
- [x] `pnpm boundaries`
- [ ] After merge: run the op with `--execute` against the 12 remaining stranded production pairs (or all 13 including Martin if his manual fix is still pending). Verify badges clear + inbounds project against SF anchors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)