### PR TITLE
feat(domain): auto-merge email-only contact into SF anchor on capture race

### DIFF
--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -2741,6 +2741,143 @@ function createStage1RepositoriesInternal(
       },
     },
 
+    async mergeEmailOnlyContactIntoAnchored(input: {
+      readonly emailOnlyContactId: string;
+      readonly anchoredContactId: string;
+    }) {
+      return db.transaction(async (tx: Stage1Database) => {
+        const canonicalEventsResult = await tx.execute(sql<{
+          readonly id: string;
+        }>`
+          update ${canonicalEventLedger}
+          set
+            ${canonicalEventLedger.contactId} = ${input.anchoredContactId},
+            ${canonicalEventLedger.updatedAt} = timezone('utc', now())
+          where ${canonicalEventLedger.contactId} = ${input.emailOnlyContactId}
+          returning ${canonicalEventLedger.id} as id
+        `);
+        const timelineRowsResult = await tx.execute(sql<{
+          readonly id: string;
+        }>`
+          update ${contactTimelineProjection}
+          set
+            ${contactTimelineProjection.contactId} = ${input.anchoredContactId},
+            ${contactTimelineProjection.updatedAt} = timezone('utc', now())
+          where ${contactTimelineProjection.contactId} = ${input.emailOnlyContactId}
+          returning ${contactTimelineProjection.id} as id
+        `);
+        const noteRowsResult = await tx.execute(sql<{
+          readonly id: string;
+        }>`
+          update ${internalNotes}
+          set
+            ${internalNotes.contactId} = ${input.anchoredContactId},
+            ${internalNotes.updatedAt} = timezone('utc', now())
+          where ${internalNotes.contactId} = ${input.emailOnlyContactId}
+          returning ${internalNotes.id} as id
+        `);
+        const routingRowsResult = await tx.execute(sql<{
+          readonly id: string;
+        }>`
+          update ${routingReviewQueue}
+          set
+            ${routingReviewQueue.contactId} = ${input.anchoredContactId},
+            ${routingReviewQueue.updatedAt} = timezone('utc', now())
+          where ${routingReviewQueue.contactId} = ${input.emailOnlyContactId}
+          returning ${routingReviewQueue.id} as id
+        `);
+        const identityCasesResult = await tx.execute(sql<{
+          readonly id: string;
+        }>`
+          update ${identityResolutionQueue}
+          set
+            ${identityResolutionQueue.anchoredContactId} = case
+              when ${identityResolutionQueue.anchoredContactId} = ${input.emailOnlyContactId}
+                then ${input.anchoredContactId}
+              else ${identityResolutionQueue.anchoredContactId}
+            end,
+            ${identityResolutionQueue.candidateContactIds} = (
+              select coalesce(
+                array_agg(candidate_id order by candidate_id),
+                array[]::text[]
+              )
+              from (
+                select distinct candidate_id
+                from unnest(
+                  case
+                    when ${identityResolutionQueue.candidateContactIds} && array[${input.emailOnlyContactId}]::text[]
+                      then array_replace(
+                        ${identityResolutionQueue.candidateContactIds},
+                        ${input.emailOnlyContactId},
+                        ${input.anchoredContactId}
+                      )
+                    else ${identityResolutionQueue.candidateContactIds}
+                  end
+                ) as candidate_id
+                where candidate_id <> ${input.emailOnlyContactId}
+              ) deduped_candidates
+            ),
+            ${identityResolutionQueue.updatedAt} = timezone('utc', now())
+          where ${identityResolutionQueue.anchoredContactId} = ${input.emailOnlyContactId}
+             or ${identityResolutionQueue.candidateContactIds} && array[${input.emailOnlyContactId}]::text[]
+          returning ${identityResolutionQueue.id} as id
+        `);
+        const deletedContactsResult = await tx.execute(sql<{
+          readonly id: string;
+        }>`
+          delete from ${contacts}
+          where ${contacts.id} = ${input.emailOnlyContactId}
+          returning ${contacts.id} as id
+        `);
+        const deletedContactRows = normalizeSqlResultRows<{
+          readonly id: string;
+        }>(
+          deletedContactsResult as {
+            readonly rows?: readonly { readonly id: string }[];
+          },
+        );
+
+        if (deletedContactRows.length !== 1) {
+          throw new Error(
+            `Expected to delete exactly one email-only contact for ${input.emailOnlyContactId}; deleted ${deletedContactRows.length.toString()}.`,
+          );
+        }
+
+        return {
+          canonicalEventsRepointed:
+            normalizeSqlResultRows<{ readonly id: string }>(
+              canonicalEventsResult as {
+                readonly rows?: readonly { readonly id: string }[];
+              },
+            ).length,
+          timelineRowsRepointed:
+            normalizeSqlResultRows<{ readonly id: string }>(
+              timelineRowsResult as {
+                readonly rows?: readonly { readonly id: string }[];
+              },
+            ).length,
+          notesRepointed: normalizeSqlResultRows<{ readonly id: string }>(
+            noteRowsResult as {
+              readonly rows?: readonly { readonly id: string }[];
+            },
+          ).length,
+          routingRowsRepointed:
+            normalizeSqlResultRows<{ readonly id: string }>(
+              routingRowsResult as {
+                readonly rows?: readonly { readonly id: string }[];
+              },
+            ).length,
+          identityCasesRepointed:
+            normalizeSqlResultRows<{ readonly id: string }>(
+              identityCasesResult as {
+                readonly rows?: readonly { readonly id: string }[];
+              },
+            ).length,
+          contactDeleted: true,
+        };
+      });
+    },
+
     contactIdentities: {
       async listByContactId(contactId) {
         const rows = await db

--- a/packages/domain/src/normalization.ts
+++ b/packages/domain/src/normalization.ts
@@ -99,6 +99,7 @@ const lifecycleTimelineOrdinalByEventType: Partial<
 };
 
 interface IdentityResolutionContext {
+  readonly persistence: Stage1PersistenceService;
   loadContactsForIdentityKind(
     kind: ContactIdentityKind,
     values: readonly string[],
@@ -445,6 +446,13 @@ function buildSkipAuditId(
   action: "skipped_non_volunteer_task",
 ): string {
   return `audit:${entityType}:${entityId}:${action}`;
+}
+
+function buildEmailOnlyAutoMergeAuditId(
+  emailOnlyContactId: string,
+  anchoredContactId: string,
+): string {
+  return `audit:contact_merge:${emailOnlyContactId}:${anchoredContactId}:auto_merge_email_only_contact`;
 }
 
 function buildSyntheticContactId(input: {
@@ -1371,6 +1379,8 @@ function createIdentityResolutionContext(
   };
 
   return {
+    persistence,
+
     async loadContactsForIdentityKind(kind, values) {
       const contactGroups = await Promise.all(
         uniqueStrings(values).map(async (normalizedValue) => {
@@ -1438,6 +1448,58 @@ function createIdentityResolutionContext(
   };
 }
 
+function isPureEmailOnlyConflict(input: {
+  readonly contact: ContactRecord;
+  readonly emailMatches: ContactLookupMap;
+  readonly phoneMatches: ContactLookupMap;
+  readonly volunteerMatches: ContactLookupMap;
+}): boolean {
+  return (
+    input.contact.id.startsWith("contact:email:") &&
+    input.contact.salesforceContactId === null &&
+    input.emailMatches.has(input.contact.id) &&
+    !input.phoneMatches.has(input.contact.id) &&
+    !input.volunteerMatches.has(input.contact.id)
+  );
+}
+
+async function autoMergeEmailOnlyConflictsIntoAnchored(
+  context: IdentityResolutionContext,
+  input: {
+    readonly sourceEvidenceId: string;
+    readonly openedAt: string;
+    readonly normalizedIdentityValues: ReturnType<
+      typeof buildNormalizedIdentityValues
+    >;
+    readonly anchoredContactId: string;
+    readonly conflictingContacts: readonly ContactRecord[];
+  },
+): Promise<void> {
+  for (const conflictingContact of input.conflictingContacts) {
+    const mergeResult = await context.persistence.mergeEmailOnlyContactIntoAnchored(
+      {
+        emailOnlyContactId: conflictingContact.id,
+        anchoredContactId: input.anchoredContactId,
+      },
+    );
+
+    await recordEmailOnlyAutoMergeAuditOnce(context.persistence, {
+      sourceEvidenceId: input.sourceEvidenceId,
+      occurredAt: input.openedAt,
+      normalizedIdentityValues: input.normalizedIdentityValues,
+      emailOnlyContactId: conflictingContact.id,
+      anchoredContactId: input.anchoredContactId,
+      mergeResult,
+    });
+  }
+
+  context.clear();
+  await rebuildInboxProjectionForContact(
+    context.persistence,
+    input.anchoredContactId,
+  );
+}
+
 async function resolveIdentityDecision(
   context: IdentityResolutionContext,
   sourceEvidenceId: string,
@@ -1492,6 +1554,42 @@ async function resolveIdentityDecision(
     );
 
     if (conflictingContactIds.length > 0) {
+      const conflictingContacts = conflictingContactIds
+        .map(
+          (contactId) =>
+            emailMatches.get(contactId) ??
+            phoneMatches.get(contactId) ??
+            volunteerMatches.get(contactId) ??
+            null,
+        )
+        .filter((contact): contact is ContactRecord => contact !== null);
+      const allConflictsArePureEmailOnly =
+        conflictingContacts.length === conflictingContactIds.length &&
+        conflictingContacts.every((contact) =>
+          isPureEmailOnlyConflict({
+            contact,
+            emailMatches,
+            phoneMatches,
+            volunteerMatches,
+          }),
+        );
+
+      if (allConflictsArePureEmailOnly) {
+        await autoMergeEmailOnlyConflictsIntoAnchored(context, {
+          sourceEvidenceId,
+          openedAt,
+          normalizedIdentityValues,
+          anchoredContactId: anchored.id,
+          conflictingContacts,
+        });
+
+        return {
+          outcome: "resolved",
+          contact: anchored,
+          reviewInput: null,
+        };
+      }
+
       return {
         outcome: "resolved",
         contact: anchored,
@@ -1910,6 +2008,69 @@ async function recordQuarantineAuditOnce(
     result: "recorded",
     policyCode,
     metadataJson: input.metadataJson,
+  });
+}
+
+async function recordEmailOnlyAutoMergeAuditOnce(
+  persistence: Stage1PersistenceService,
+  input: {
+    readonly sourceEvidenceId: string;
+    readonly occurredAt: string;
+    readonly normalizedIdentityValues: ReturnType<
+      typeof buildNormalizedIdentityValues
+    >;
+    readonly emailOnlyContactId: string;
+    readonly anchoredContactId: string;
+    readonly mergeResult: {
+      readonly canonicalEventsRepointed: number;
+      readonly timelineRowsRepointed: number;
+      readonly notesRepointed: number;
+      readonly routingRowsRepointed: number;
+      readonly identityCasesRepointed: number;
+    };
+  },
+): Promise<AuditEvidenceRecord> {
+  const entityType = "contact_merge";
+  const entityId = `${input.emailOnlyContactId}->${input.anchoredContactId}`;
+  const policyCode =
+    "stage1.identity.auto_merge_email_only_into_salesforce_anchored";
+  const existingRecords =
+    await persistence.repositories.auditEvidence.listByEntity({
+      entityType,
+      entityId,
+    });
+  const existingRecord = existingRecords.find(
+    (record) => record.policyCode === policyCode,
+  );
+
+  if (existingRecord !== undefined) {
+    return existingRecord;
+  }
+
+  return persistence.recordAuditEvidence({
+    id: buildEmailOnlyAutoMergeAuditId(
+      input.emailOnlyContactId,
+      input.anchoredContactId,
+    ),
+    actorType: "system",
+    actorId: "stage1-normalization",
+    action: "auto_merge_email_only_contact",
+    entityType,
+    entityId,
+    occurredAt: input.occurredAt,
+    result: "recorded",
+    policyCode,
+    metadataJson: {
+      sourceEvidenceId: input.sourceEvidenceId,
+      emailOnlyContactId: input.emailOnlyContactId,
+      anchoredContactId: input.anchoredContactId,
+      normalizedIdentityValues: input.normalizedIdentityValues,
+      canonicalEventsRepointed: input.mergeResult.canonicalEventsRepointed,
+      timelineRowsRepointed: input.mergeResult.timelineRowsRepointed,
+      notesRepointed: input.mergeResult.notesRepointed,
+      routingRowsRepointed: input.mergeResult.routingRowsRepointed,
+      identityCasesRepointed: input.mergeResult.identityCasesRepointed,
+    },
   });
 }
 

--- a/packages/domain/src/persistence.ts
+++ b/packages/domain/src/persistence.ts
@@ -75,6 +75,30 @@ export type CanonicalEventWriteResult =
       readonly reason: CanonicalEventConflictReason;
     };
 
+export interface EmailOnlyContactMergeResult {
+  readonly anchoredContact: ContactRecord;
+  readonly canonicalEventsRepointed: number;
+  readonly timelineRowsRepointed: number;
+  readonly notesRepointed: number;
+  readonly routingRowsRepointed: number;
+  readonly identityCasesRepointed: number;
+}
+
+interface EmailOnlyContactMergeCapableRepositories
+  extends Stage1RepositoryBundle {
+  mergeEmailOnlyContactIntoAnchored?(input: {
+    readonly emailOnlyContactId: string;
+    readonly anchoredContactId: string;
+  }): Promise<{
+    readonly canonicalEventsRepointed: number;
+    readonly timelineRowsRepointed: number;
+    readonly notesRepointed: number;
+    readonly routingRowsRepointed: number;
+    readonly identityCasesRepointed: number;
+    readonly contactDeleted: boolean;
+  }>;
+}
+
 export interface Stage1PersistenceService {
   readonly repositories: Stage1RepositoryBundle;
   findSourceEvidenceByIdempotencyKey(
@@ -130,6 +154,10 @@ export interface Stage1PersistenceService {
   ): Promise<TimelineProjectionRow>;
   saveSyncState(record: SyncStateRecord): Promise<SyncStateRecord>;
   recordAuditEvidence(record: AuditEvidenceRecord): Promise<AuditEvidenceRecord>;
+  mergeEmailOnlyContactIntoAnchored(input: {
+    readonly emailOnlyContactId: string;
+    readonly anchoredContactId: string;
+  }): Promise<EmailOnlyContactMergeResult>;
 }
 
 function arraysEqual(
@@ -217,6 +245,9 @@ function buildSourceEvidenceQuarantineDetails(
 export function createStage1PersistenceService(
   repositories: Stage1RepositoryBundle
 ): Stage1PersistenceService {
+  const mergeCapableRepositories =
+    repositories as EmailOnlyContactMergeCapableRepositories;
+
   return {
     repositories,
 
@@ -471,6 +502,42 @@ export function createStage1PersistenceService(
 
     recordAuditEvidence(record) {
       return repositories.auditEvidence.append(auditEvidenceSchema.parse(record));
+    },
+
+    async mergeEmailOnlyContactIntoAnchored(input) {
+      const anchoredContact = await repositories.contacts.findById(
+        input.anchoredContactId,
+      );
+
+      if (anchoredContact === null) {
+        throw new Error(
+          `Cannot merge email-only contact ${input.emailOnlyContactId} into missing anchored contact ${input.anchoredContactId}.`,
+        );
+      }
+
+      if (mergeCapableRepositories.mergeEmailOnlyContactIntoAnchored === undefined) {
+        throw new Error(
+          "Stage1 repository bundle does not support mergeEmailOnlyContactIntoAnchored.",
+        );
+      }
+
+      const result =
+        await mergeCapableRepositories.mergeEmailOnlyContactIntoAnchored(input);
+
+      if (!result.contactDeleted) {
+        throw new Error(
+          `Expected to delete email-only contact ${input.emailOnlyContactId} during merge.`,
+        );
+      }
+
+      return {
+        anchoredContact,
+        canonicalEventsRepointed: result.canonicalEventsRepointed,
+        timelineRowsRepointed: result.timelineRowsRepointed,
+        notesRepointed: result.notesRepointed,
+        routingRowsRepointed: result.routingRowsRepointed,
+        identityCasesRepointed: result.identityCasesRepointed,
+      };
     }
   };
 }

--- a/packages/domain/test/normalization.test.ts
+++ b/packages/domain/test/normalization.test.ts
@@ -24,6 +24,7 @@ import type {
 } from "@as-comms/contracts";
 
 import {
+  buildTimelineSortKey,
   computePendingComposerOutboundFingerprint,
   createStage1NormalizationService,
   createStage1PersistenceService,
@@ -56,7 +57,16 @@ const emailIdentity: ContactIdentityRecord = {
 interface TestContext {
   readonly normalization: ReturnType<typeof createStage1NormalizationService>;
   readonly getInboxProjection: () => InboxProjectionRow | null;
+  readonly getInboxProjectionForContact: (
+    contactId: string,
+  ) => InboxProjectionRow | null;
   readonly getInboxSaveCount: () => number;
+  readonly getContact: (contactId: string) => ContactRecord | null;
+  readonly getCanonicalEvent: (eventId: string) => CanonicalEventRecord | null;
+  readonly getTimelineRow: (
+    canonicalEventId: string,
+  ) => TimelineProjectionRow | null;
+  readonly getAuditEvidence: () => readonly AuditEvidenceRecord[];
   readonly getPendingOutbound: (
     id: string,
   ) => PendingComposerOutboundRecord | null;
@@ -94,6 +104,7 @@ function buildSourceEvidence(input: {
 function buildEvent(input: {
   readonly key: string;
   readonly occurredAt: string;
+  readonly contactId?: string;
   readonly direction?: "inbound" | "outbound" | null;
   readonly eventType?: CanonicalEventRecord["eventType"];
   readonly provider?: CanonicalEventRecord["provenance"]["primaryProvider"];
@@ -120,7 +131,7 @@ function buildEvent(input: {
 
   return {
     id: `event:${input.key}`,
-    contactId: contact.id,
+    contactId: input.contactId ?? contact.id,
     eventType,
     channel,
     occurredAt: input.occurredAt,
@@ -145,12 +156,15 @@ function buildEvent(input: {
 }
 
 function buildExistingProjection(input: {
+  readonly contactId?: string;
   readonly bucket: InboxBucket;
   readonly needsFollowUp?: boolean;
+  readonly hasUnresolved?: boolean;
   readonly lastInboundAt: string | null;
   readonly lastOutboundAt?: string | null;
   readonly lastCanonicalEventId?: string;
   readonly lastEventType?: InboxProjectionRow["lastEventType"];
+  readonly snippet?: string;
 }): InboxProjectionRow {
   const lastOutboundAt = input.lastOutboundAt ?? null;
   const lastActivityAt =
@@ -165,14 +179,14 @@ function buildExistingProjection(input: {
   }
 
   return {
-    contactId: contact.id,
+    contactId: input.contactId ?? contact.id,
     bucket: input.bucket,
     needsFollowUp: input.needsFollowUp ?? false,
-    hasUnresolved: false,
+    hasUnresolved: input.hasUnresolved ?? false,
     lastInboundAt: input.lastInboundAt,
     lastOutboundAt,
     lastActivityAt,
-    snippet: "Existing snippet",
+    snippet: input.snippet ?? "Existing snippet",
     archivedAt: null,
     lastCanonicalEventId: input.lastCanonicalEventId ?? "event:existing",
     lastEventType: input.lastEventType ?? "communication.email.inbound",
@@ -302,9 +316,15 @@ function buildReplayInput(
 function buildContext(input: {
   readonly events: readonly CanonicalEventRecord[];
   readonly existingProjection?: InboxProjectionRow | null;
+  readonly inboxProjections?: readonly InboxProjectionRow[];
   readonly contacts?: readonly ContactRecord[];
   readonly contactIdentities?: readonly ContactIdentityRecord[];
+  readonly contactMemberships?: readonly ContactMembershipRecord[];
   readonly gmailMessageDetails?: readonly GmailMessageDetailRecord[];
+  readonly timelineRows?: readonly TimelineProjectionRow[];
+  readonly identityCases?: readonly IdentityResolutionCase[];
+  readonly routingCases?: readonly RoutingReviewCase[];
+  readonly auditEvidence?: readonly AuditEvidenceRecord[];
   readonly pendingOutbounds?: readonly PendingComposerOutboundRecord[];
   readonly sourceProvider?: SourceEvidenceRecord["provider"];
   readonly onContactIdentityUpsert?: (record: ContactIdentityRecord) => void;
@@ -319,17 +339,21 @@ function buildContext(input: {
   ) => void;
   readonly onPendingOutboundConfirmed?: (record: PendingComposerOutboundRecord) => void;
 }): TestContext {
-  const contacts = input.contacts ?? [contact];
-  const contactIdentities = input.contactIdentities ?? [emailIdentity];
-  const contactsById = new Map(contacts.map((entry) => [entry.id, entry]));
-  const contactsBySalesforceContactId = new Map(
-    contacts
-      .filter(
-        (entry): entry is ContactRecord & { salesforceContactId: string } =>
-          entry.salesforceContactId !== null,
-      )
-      .map((entry) => [entry.salesforceContactId, entry]),
+  interface StoredInternalNote {
+    readonly id: string;
+    readonly contactId: string;
+    readonly body: string;
+    readonly authorDisplayName: string | null;
+    readonly authorId: string;
+    readonly createdAt: Date;
+    readonly updatedAt: Date;
+  }
+
+  const contactRecords = new Map(
+    (input.contacts ?? [contact]).map((entry) => [entry.id, entry]),
   );
+  const contactIdentityRecords = [...(input.contactIdentities ?? [emailIdentity])];
+  const contactMembershipRecords = [...(input.contactMemberships ?? [])];
   const sourceEvidenceById = new Map(
     input.events.map((event) => [
       event.sourceEvidenceId,
@@ -359,7 +383,13 @@ function buildContext(input: {
   const timelineRowsByCanonicalEventId = new Map<
     string,
     TimelineProjectionRow
-  >();
+  >((input.timelineRows ?? []).map((row) => [row.canonicalEventId, row]));
+  const identityCasesById = new Map(
+    (input.identityCases ?? []).map((record) => [record.id, record]),
+  );
+  const routingCasesById = new Map(
+    (input.routingCases ?? []).map((record) => [record.id, record]),
+  );
   const gmailDetailsBySourceEvidenceId = new Map<
     string,
     GmailMessageDetailRecord
@@ -372,6 +402,8 @@ function buildContext(input: {
   const pendingOutboundsById = new Map(
     (input.pendingOutbounds ?? []).map((record) => [record.id, record]),
   );
+  const internalNotesById = new Map<string, StoredInternalNote>();
+  const auditEvidenceRecords = [...(input.auditEvidence ?? [])];
   const sourceEvidenceQuarantineEntries = new Array<{
     id: string;
     provider: SourceEvidenceRecord["provider"];
@@ -383,8 +415,22 @@ function buildContext(input: {
     details: Readonly<Record<string, unknown>>;
     createdAt: Date;
   }>();
-  let inboxProjection = input.existingProjection ?? null;
+  const inboxProjectionByContactId = new Map(
+    [
+      ...(input.inboxProjections ?? []),
+      ...(input.existingProjection === undefined || input.existingProjection === null
+        ? []
+        : [input.existingProjection]),
+    ].map((projection) => [projection.contactId, projection]),
+  );
   let inboxSaveCount = 0;
+
+  const listContacts = (): ContactRecord[] =>
+    [...contactRecords.values()].sort((left, right) => left.id.localeCompare(right.id));
+  const listContactIdentities = (): ContactIdentityRecord[] =>
+    [...contactIdentityRecords];
+  const getInboxProjection = (contactId: string): InboxProjectionRow | null =>
+    inboxProjectionByContactId.get(contactId) ?? null;
 
   const bundle: Stage1RepositoryBundle = defineStage1RepositoryBundle({
     sourceEvidence: {
@@ -525,55 +571,199 @@ function buildContext(input: {
       countCapturedSinceTimestamp: () => Promise.resolve(0),
     },
     contacts: {
-      findById: (id) => Promise.resolve(contactsById.get(id) ?? null),
+      findById: (id) => Promise.resolve(contactRecords.get(id) ?? null),
       findBySalesforceContactId: (salesforceContactId) =>
         Promise.resolve(
-          contactsBySalesforceContactId.get(salesforceContactId) ?? null,
+          listContacts().find(
+            (entry) => entry.salesforceContactId === salesforceContactId,
+          ) ?? null,
         ),
       findByPrimaryPhone: (phoneE164) =>
         Promise.resolve(
-          contacts.find((contact) => contact.primaryPhone === phoneE164) ??
+          listContacts().find((contact) => contact.primaryPhone === phoneE164) ??
             null,
         ),
-      listAll: () => Promise.resolve([...contacts]),
+      listAll: () => Promise.resolve(listContacts()),
       listByIds: (ids) =>
         Promise.resolve(
           ids
-            .map((id) => contactsById.get(id))
+            .map((id) => contactRecords.get(id))
             .filter((entry): entry is ContactRecord => entry !== undefined),
         ),
-      searchByQuery: () => Promise.resolve([...contacts]),
+      searchByQuery: () => Promise.resolve(listContacts()),
       searchInboxUnified: () =>
         Promise.resolve({
           volunteers: [],
           contacts: [],
           totals: { volunteers: 0, contacts: 0 },
         }),
-      upsert: (record) => Promise.resolve(record),
+      upsert: (record) => {
+        contactRecords.set(record.id, record);
+        return Promise.resolve(record);
+      },
+    },
+    mergeEmailOnlyContactIntoAnchored: (mergeInput: {
+      readonly emailOnlyContactId: string;
+      readonly anchoredContactId: string;
+    }) => {
+      let canonicalEventsRepointed = 0;
+      for (const [eventId, event] of canonicalEventsById.entries()) {
+        if (event.contactId !== mergeInput.emailOnlyContactId) {
+          continue;
+        }
+
+        canonicalEventsRepointed += 1;
+        canonicalEventsById.set(eventId, {
+          ...event,
+          contactId: mergeInput.anchoredContactId,
+        });
+      }
+
+      let timelineRowsRepointed = 0;
+      for (const [canonicalEventId, row] of timelineRowsByCanonicalEventId.entries()) {
+        if (row.contactId !== mergeInput.emailOnlyContactId) {
+          continue;
+        }
+
+        timelineRowsRepointed += 1;
+        timelineRowsByCanonicalEventId.set(canonicalEventId, {
+          ...row,
+          contactId: mergeInput.anchoredContactId,
+        });
+      }
+
+      let notesRepointed = 0;
+      for (const [noteId, note] of internalNotesById.entries()) {
+        if (note.contactId !== mergeInput.emailOnlyContactId) {
+          continue;
+        }
+
+        notesRepointed += 1;
+        internalNotesById.set(noteId, {
+          ...note,
+          contactId: mergeInput.anchoredContactId,
+          updatedAt: new Date(0),
+        });
+      }
+
+      let routingRowsRepointed = 0;
+      for (const [caseId, routingCase] of routingCasesById.entries()) {
+        if (routingCase.contactId !== mergeInput.emailOnlyContactId) {
+          continue;
+        }
+
+        routingRowsRepointed += 1;
+        routingCasesById.set(caseId, {
+          ...routingCase,
+          contactId: mergeInput.anchoredContactId,
+        });
+      }
+
+      let identityCasesRepointed = 0;
+      for (const [caseId, identityCase] of identityCasesById.entries()) {
+        const nextAnchoredContactId =
+          identityCase.anchoredContactId === mergeInput.emailOnlyContactId
+            ? mergeInput.anchoredContactId
+            : identityCase.anchoredContactId;
+        const nextCandidateContactIds = [
+          ...new Set(
+            identityCase.candidateContactIds
+              .map((contactId) =>
+                contactId === mergeInput.emailOnlyContactId
+                  ? mergeInput.anchoredContactId
+                  : contactId,
+              )
+              .filter((contactId) => contactId !== mergeInput.emailOnlyContactId),
+          ),
+        ];
+
+        if (
+          nextAnchoredContactId === identityCase.anchoredContactId &&
+          nextCandidateContactIds.length === identityCase.candidateContactIds.length &&
+          nextCandidateContactIds.every(
+            (contactId, index) =>
+              contactId === identityCase.candidateContactIds[index],
+          )
+        ) {
+          continue;
+        }
+
+        identityCasesRepointed += 1;
+        identityCasesById.set(caseId, {
+          ...identityCase,
+          anchoredContactId: nextAnchoredContactId,
+          candidateContactIds: nextCandidateContactIds,
+        });
+      }
+
+      const contactDeleted = contactRecords.delete(mergeInput.emailOnlyContactId);
+      inboxProjectionByContactId.delete(mergeInput.emailOnlyContactId);
+      for (let index = contactIdentityRecords.length - 1; index >= 0; index -= 1) {
+        if (contactIdentityRecords[index]?.contactId === mergeInput.emailOnlyContactId) {
+          contactIdentityRecords.splice(index, 1);
+        }
+      }
+
+      return Promise.resolve({
+        canonicalEventsRepointed,
+        timelineRowsRepointed,
+        notesRepointed,
+        routingRowsRepointed,
+        identityCasesRepointed,
+        contactDeleted,
+      });
     },
     contactIdentities: {
       listByContactId: (contactId) =>
         Promise.resolve(
-          contactIdentities.filter(
+          listContactIdentities().filter(
             (identity) => identity.contactId === contactId,
           ),
         ),
-      listByNormalizedValue: ({ normalizedValue }) =>
+      listByNormalizedValue: ({ kind, normalizedValue }) =>
         Promise.resolve(
-          contactIdentities.filter(
-            (identity) => identity.normalizedValue === normalizedValue,
+          listContactIdentities().filter(
+            (identity) =>
+              identity.kind === kind &&
+              identity.normalizedValue === normalizedValue,
           ),
         ),
       upsert: (record) => {
         input.onContactIdentityUpsert?.(record);
+        const existingIndex = contactIdentityRecords.findIndex(
+          (entry) => entry.id === record.id,
+        );
+        if (existingIndex >= 0) {
+          contactIdentityRecords.splice(existingIndex, 1, record);
+        } else {
+          contactIdentityRecords.push(record);
+        }
         return Promise.resolve(record);
       },
     },
     contactMemberships: {
-      listByContactId: () => Promise.resolve([]),
-      listByContactIds: () => Promise.resolve([]),
+      listByContactId: (contactId) =>
+        Promise.resolve(
+          contactMembershipRecords.filter(
+            (record) => record.contactId === contactId,
+          ),
+        ),
+      listByContactIds: (contactIds) =>
+        Promise.resolve(
+          contactMembershipRecords.filter((record) =>
+            contactIds.includes(record.contactId),
+          ),
+        ),
       upsert: (record: ContactMembershipRecord) => {
         input.onContactMembershipUpsert?.(record);
+        const existingIndex = contactMembershipRecords.findIndex(
+          (entry) => entry.id === record.id,
+        );
+        if (existingIndex >= 0) {
+          contactMembershipRecords.splice(existingIndex, 1, record);
+        } else {
+          contactMembershipRecords.push(record);
+        }
         return Promise.resolve(record);
       },
     },
@@ -686,26 +876,44 @@ function buildContext(input: {
       deleteByAuthor: () => Promise.resolve(0),
     },
     internalNotes: {
-      create: (input) =>
-        Promise.resolve({
-          ...input,
+      create: (noteInput) => {
+        const record: StoredInternalNote = {
+          id: noteInput.id,
+          contactId: noteInput.contactId,
+          body: noteInput.body,
           authorDisplayName: null,
-          createdAt: new Date(0),
-          updatedAt: new Date(0),
-        }),
-      findById: () => Promise.resolve(undefined),
-      findByContactId: () => Promise.resolve([]),
-      update: (input) =>
-        Promise.resolve({
-          id: input.id,
-          contactId: "contact_1",
-          body: input.body,
-          authorDisplayName: "Author",
-          authorId: "user:author",
-          createdAt: new Date(0),
-          updatedAt: new Date(0),
-        }),
-      delete: () => Promise.resolve(),
+          authorId: noteInput.authorId,
+          createdAt: noteInput.createdAt ?? new Date(0),
+          updatedAt: noteInput.updatedAt ?? new Date(0),
+        };
+        internalNotesById.set(record.id, record);
+        return Promise.resolve(record);
+      },
+      findById: (id) => Promise.resolve(internalNotesById.get(id)),
+      findByContactId: (contactId) =>
+        Promise.resolve(
+          [...internalNotesById.values()].filter(
+            (note) => note.contactId === contactId,
+          ),
+        ),
+      update: (noteInput) => {
+        const existing = internalNotesById.get(noteInput.id);
+        const updated: StoredInternalNote = {
+          id: noteInput.id,
+          contactId: existing?.contactId ?? "contact_1",
+          body: noteInput.body,
+          authorDisplayName: existing?.authorDisplayName ?? "Author",
+          authorId: existing?.authorId ?? "user:author",
+          createdAt: existing?.createdAt ?? new Date(0),
+          updatedAt: noteInput.updatedAt ?? new Date(0),
+        };
+        internalNotesById.set(updated.id, updated);
+        return Promise.resolve(updated);
+      },
+      delete: (id) => {
+        internalNotesById.delete(id);
+        return Promise.resolve();
+      },
     },
     pendingOutbounds: {
       insert: ({ id }) => Promise.resolve(id),
@@ -766,86 +974,143 @@ function buildContext(input: {
       findForContact: () => Promise.resolve([...pendingOutboundsById.values()]),
     },
     identityResolutionQueue: {
-      findById: () => Promise.resolve(null),
-      listOpenByContactId: () => Promise.resolve([]),
-      listOpenByReasonCode: () => Promise.resolve([]),
-      upsert: (record: IdentityResolutionCase) => Promise.resolve(record),
+      findById: (id) => Promise.resolve(identityCasesById.get(id) ?? null),
+      listOpenByContactId: (contactId) =>
+        Promise.resolve(
+          [...identityCasesById.values()].filter(
+            (record) =>
+              record.status === "open" &&
+              (record.anchoredContactId === contactId ||
+                record.candidateContactIds.includes(contactId)),
+          ),
+        ),
+      listOpenByReasonCode: (reasonCode) =>
+        Promise.resolve(
+          [...identityCasesById.values()].filter(
+            (record) =>
+              record.status === "open" && record.reasonCode === reasonCode,
+          ),
+        ),
+      upsert: (record: IdentityResolutionCase) => {
+        identityCasesById.set(record.id, record);
+        return Promise.resolve(record);
+      },
     },
     routingReviewQueue: {
-      findById: () => Promise.resolve(null),
-      listOpenByContactId: () => Promise.resolve([]),
-      listOpenByReasonCode: () => Promise.resolve([]),
-      upsert: (record: RoutingReviewCase) => Promise.resolve(record),
+      findById: (id) => Promise.resolve(routingCasesById.get(id) ?? null),
+      listOpenByContactId: (contactId) =>
+        Promise.resolve(
+          [...routingCasesById.values()].filter(
+            (record) =>
+              record.status === "open" && record.contactId === contactId,
+          ),
+        ),
+      listOpenByReasonCode: (reasonCode) =>
+        Promise.resolve(
+          [...routingCasesById.values()].filter(
+            (record) =>
+              record.status === "open" && record.reasonCode === reasonCode,
+          ),
+        ),
+      upsert: (record: RoutingReviewCase) => {
+        routingCasesById.set(record.id, record);
+        return Promise.resolve(record);
+      },
     },
     inboxProjection: {
-      countAll: () => Promise.resolve(inboxProjection === null ? 0 : 1),
+      countAll: () => Promise.resolve(inboxProjectionByContactId.size),
       countInvalidRecencyRows: () => Promise.resolve(0),
-      findByContactId: () => Promise.resolve(inboxProjection),
+      findByContactId: (contactId) =>
+        Promise.resolve(getInboxProjection(contactId)),
       listInvalidRecencyContactIds: () => Promise.resolve([]),
       listAllOrderedByRecency: () =>
-        Promise.resolve(inboxProjection === null ? [] : [inboxProjection]),
+        Promise.resolve([...inboxProjectionByContactId.values()]),
       searchPageOrderedByRecency: () =>
         Promise.resolve({
-          rows: inboxProjection === null ? [] : [inboxProjection],
-          total: inboxProjection === null ? 0 : 1,
+          rows: [...inboxProjectionByContactId.values()],
+          total: inboxProjectionByContactId.size,
         }),
       listPageOrderedByRecency: () =>
-        Promise.resolve(inboxProjection === null ? [] : [inboxProjection]),
+        Promise.resolve([...inboxProjectionByContactId.values()]),
       countByFilters: () =>
         Promise.resolve({
-          all: inboxProjection === null ? 0 : 1,
-          unread: inboxProjection?.bucket === "New" ? 1 : 0,
-          followUp: inboxProjection?.needsFollowUp === true ? 1 : 0,
-          unresolved: inboxProjection?.hasUnresolved === true ? 1 : 0,
-          sent: inboxProjection?.lastOutboundAt === null ? 0 : 1,
-          archived:
-            inboxProjection !== null && inboxProjection.archivedAt !== null
-              ? 1
-              : 0,
+          all: inboxProjectionByContactId.size,
+          unread: [...inboxProjectionByContactId.values()].filter(
+            (record) => record.bucket === "New",
+          ).length,
+          followUp: [...inboxProjectionByContactId.values()].filter(
+            (record) => record.needsFollowUp,
+          ).length,
+          unresolved: [...inboxProjectionByContactId.values()].filter(
+            (record) => record.hasUnresolved,
+          ).length,
+          sent: [...inboxProjectionByContactId.values()].filter(
+            (record) => record.lastOutboundAt !== null,
+          ).length,
+          archived: [...inboxProjectionByContactId.values()].filter(
+            (record) => record.archivedAt !== null,
+          ).length,
         }),
       getFreshness: () =>
         Promise.resolve({
-          total: inboxProjection === null ? 0 : 1,
+          total: inboxProjectionByContactId.size,
           latestUpdatedAt: null,
         }),
-      getFreshnessByContactId: () => Promise.resolve(null),
-      deleteByContactId: () => {
-        inboxProjection = null;
+      getFreshnessByContactId: (contactId) =>
+        Promise.resolve(
+          inboxProjectionByContactId.has(contactId)
+            ? { contactId, updatedAt: null }
+            : null,
+        ),
+      deleteByContactId: (contactId) => {
+        inboxProjectionByContactId.delete(contactId);
         return Promise.resolve();
       },
-      setNeedsFollowUp: ({ needsFollowUp }) => {
-        inboxProjection =
-          inboxProjection === null
+      setNeedsFollowUp: ({ contactId, needsFollowUp }) => {
+        const existing = inboxProjectionByContactId.get(contactId) ?? null;
+        const updated =
+          existing === null
             ? null
             : {
-                ...inboxProjection,
+                ...existing,
                 needsFollowUp,
               };
-        return Promise.resolve(inboxProjection);
+        if (updated !== null) {
+          inboxProjectionByContactId.set(contactId, updated);
+        }
+        return Promise.resolve(updated);
       },
-      setArchived: ({ archived }) => {
-        inboxProjection =
-          inboxProjection === null
+      setArchived: ({ contactId, archived }) => {
+        const existing = inboxProjectionByContactId.get(contactId) ?? null;
+        const updated =
+          existing === null
             ? null
             : {
-                ...inboxProjection,
+                ...existing,
                 archivedAt: archived ? "2026-04-14T00:00:00.000Z" : null,
               };
-        return Promise.resolve(inboxProjection);
+        if (updated !== null) {
+          inboxProjectionByContactId.set(contactId, updated);
+        }
+        return Promise.resolve(updated);
       },
-      setBucket: ({ bucket }) => {
-        inboxProjection =
-          inboxProjection === null
+      setBucket: ({ contactId, bucket }) => {
+        const existing = inboxProjectionByContactId.get(contactId) ?? null;
+        const updated =
+          existing === null
             ? null
             : {
-                ...inboxProjection,
+                ...existing,
                 bucket,
               };
-        return Promise.resolve(inboxProjection);
+        if (updated !== null) {
+          inboxProjectionByContactId.set(contactId, updated);
+        }
+        return Promise.resolve(updated);
       },
       upsert: (record) => {
         inboxSaveCount += 1;
-        inboxProjection = record;
+        inboxProjectionByContactId.set(record.contactId, record);
         return Promise.resolve(record);
       },
     },
@@ -855,16 +1120,30 @@ function buildContext(input: {
         Promise.resolve(
           timelineRowsByCanonicalEventId.get(canonicalEventId) ?? null,
         ),
-      listByContactId: () =>
-        Promise.resolve([...timelineRowsByCanonicalEventId.values()]),
-      listRecentByContactId: () =>
-        Promise.resolve([...timelineRowsByCanonicalEventId.values()]),
-      countByContactId: () =>
-        Promise.resolve(timelineRowsByCanonicalEventId.size),
-      getFreshnessByContactId: () =>
+      listByContactId: (contactId) =>
+        Promise.resolve(
+          [...timelineRowsByCanonicalEventId.values()].filter(
+            (record) => record.contactId === contactId,
+          ),
+        ),
+      listRecentByContactId: ({ contactId }) =>
+        Promise.resolve(
+          [...timelineRowsByCanonicalEventId.values()].filter(
+            (record) => record.contactId === contactId,
+          ),
+        ),
+      countByContactId: (contactId) =>
+        Promise.resolve(
+          [...timelineRowsByCanonicalEventId.values()].filter(
+            (record) => record.contactId === contactId,
+          ).length,
+        ),
+      getFreshnessByContactId: (contactId) =>
         Promise.resolve({
-          contactId: contacts[0]?.id ?? contact.id,
-          total: timelineRowsByCanonicalEventId.size,
+          contactId,
+          total: [...timelineRowsByCanonicalEventId.values()].filter(
+            (record) => record.contactId === contactId,
+          ).length,
           latestUpdatedAt: null,
           latestSortKey: null,
         }),
@@ -880,9 +1159,26 @@ function buildContext(input: {
       upsert: (record) => Promise.resolve(record),
     },
     auditEvidence: {
-      append: (record: AuditEvidenceRecord) => Promise.resolve(record),
-      listByEntity: () => Promise.resolve([]),
-      listByEntities: () => Promise.resolve([]),
+      append: (record: AuditEvidenceRecord) => {
+        auditEvidenceRecords.push(record);
+        return Promise.resolve(record);
+      },
+      listByEntity: ({ entityType, entityId }) =>
+        Promise.resolve(
+          auditEvidenceRecords.filter(
+            (record) =>
+              record.entityType === entityType &&
+              record.entityId === entityId,
+          ),
+        ),
+      listByEntities: ({ entityType, entityIds }) =>
+        Promise.resolve(
+          auditEvidenceRecords.filter(
+            (record) =>
+              record.entityType === entityType &&
+              entityIds.includes(record.entityId),
+          ),
+        ),
     },
   });
 
@@ -890,8 +1186,14 @@ function buildContext(input: {
 
   return {
     normalization: createStage1NormalizationService(persistence),
-    getInboxProjection: () => inboxProjection,
+    getInboxProjection: () => getInboxProjection(contact.id),
+    getInboxProjectionForContact: (contactId) => getInboxProjection(contactId),
     getInboxSaveCount: () => inboxSaveCount,
+    getContact: (contactId) => contactRecords.get(contactId) ?? null,
+    getCanonicalEvent: (eventId) => canonicalEventsById.get(eventId) ?? null,
+    getTimelineRow: (canonicalEventId) =>
+      timelineRowsByCanonicalEventId.get(canonicalEventId) ?? null,
+    getAuditEvidence: () => [...auditEvidenceRecords],
     getPendingOutbound: (id) => pendingOutboundsById.get(id) ?? null,
   };
 }
@@ -1360,6 +1662,148 @@ describe("identity resolution hardening", () => {
       throw new Error("Expected applied result.");
     }
     expect(result.canonicalEvent.contactId).toBe(anchoredContact.id);
+  });
+
+  it("auto-merges pure email-only conflicts into the Salesforce-anchored contact", async () => {
+    const sfAnchoredContact: ContactRecord = {
+      ...contact,
+      id: "contact:salesforce:sf-contact-1",
+      salesforceContactId: "sf-contact-1",
+      primaryEmail: "foo@bar.com",
+    };
+    const emailOnlyContact: ContactRecord = {
+      ...contact,
+      id: "contact:email:foo@bar.com",
+      primaryEmail: "foo@bar.com",
+      displayName: "Foo Bar",
+    };
+    const strandedInbound = buildEvent({
+      key: "stranded-inbound",
+      contactId: emailOnlyContact.id,
+      occurredAt: "2026-05-17T12:44:00.000Z",
+      direction: "inbound",
+    });
+    const context = buildContext({
+      events: [strandedInbound],
+      contacts: [emailOnlyContact, sfAnchoredContact],
+      contactIdentities: [
+        {
+          ...emailIdentity,
+          id: "identity:email-only:foo",
+          contactId: emailOnlyContact.id,
+          normalizedValue: "foo@bar.com",
+          source: "gmail",
+        },
+        {
+          ...emailIdentity,
+          id: "identity:sf:foo",
+          contactId: sfAnchoredContact.id,
+          normalizedValue: "foo@bar.com",
+          source: "salesforce",
+        },
+      ],
+      gmailMessageDetails: [
+        buildGmailDetail({
+          key: "stranded-inbound",
+          direction: "inbound",
+          subject: "Volunteer reply",
+          bodyTextPreview: "I can help this weekend.",
+        }),
+      ],
+      timelineRows: [
+        {
+          id: "timeline:event:stranded-inbound",
+          contactId: emailOnlyContact.id,
+          canonicalEventId: strandedInbound.id,
+          occurredAt: strandedInbound.occurredAt,
+          sortKey: buildTimelineSortKey(
+            strandedInbound.id,
+            strandedInbound.occurredAt,
+            strandedInbound.eventType,
+          ),
+          eventType: strandedInbound.eventType,
+          summary: "Volunteer replied",
+          channel: strandedInbound.channel,
+          primaryProvider: strandedInbound.provenance.primaryProvider,
+          reviewState: strandedInbound.reviewState,
+        },
+      ],
+      inboxProjections: [
+        buildExistingProjection({
+          contactId: emailOnlyContact.id,
+          bucket: "Opened",
+          lastInboundAt: strandedInbound.occurredAt,
+          lastCanonicalEventId: strandedInbound.id,
+          lastEventType: strandedInbound.eventType,
+          snippet: "I can help this weekend.",
+        }),
+      ],
+    });
+
+    const result = await context.normalization.applyNormalizedCanonicalEvent({
+      sourceEvidence: {
+        ...buildSourceEvidence({
+          key: "salesforce-signup",
+          occurredAt: "2026-05-17T12:45:00.000Z",
+          provider: "salesforce",
+          providerRecordType: "task",
+        }),
+        provider: "salesforce",
+      },
+      canonicalEvent: {
+        id: "event:salesforce-signup:replay",
+        eventType: "lifecycle.signed_up",
+        occurredAt: "2026-05-17T12:45:00.000Z",
+        idempotencyKey: "canonical:salesforce-signup",
+        summary: "Signed up",
+        snippet: "Signed up",
+      },
+      identity: {
+        salesforceContactId: "sf-contact-1",
+        volunteerIdPlainValues: [],
+        normalizedEmails: ["foo@bar.com"],
+        normalizedPhones: [],
+      },
+      routing: {
+        required: false,
+        projectId: null,
+        expeditionId: null,
+        projectName: null,
+        expeditionName: null,
+      },
+      supportingSources: [],
+    });
+
+    expect(result.outcome).toBe("applied");
+    if (result.outcome !== "applied") {
+      throw new Error("Expected applied result.");
+    }
+    expect(result.identityCase).toBeNull();
+    expect(context.getContact(emailOnlyContact.id)).toBeNull();
+    expect(context.getCanonicalEvent(strandedInbound.id)?.contactId).toBe(
+      sfAnchoredContact.id,
+    );
+    expect(context.getTimelineRow(strandedInbound.id)?.contactId).toBe(
+      sfAnchoredContact.id,
+    );
+    expect(context.getInboxProjectionForContact(emailOnlyContact.id)).toBeNull();
+
+    const anchoredProjection = context.getInboxProjectionForContact(
+      sfAnchoredContact.id,
+    );
+    expect(anchoredProjection?.hasUnresolved).toBe(false);
+    expect(anchoredProjection?.lastInboundAt).toBe(strandedInbound.occurredAt);
+
+    expect(
+      context.getAuditEvidence().find(
+        (record) =>
+          record.policyCode ===
+            "stage1.identity.auto_merge_email_only_into_salesforce_anchored" &&
+          record.entityType === "contact_merge" &&
+          record.entityId ===
+            `${emailOnlyContact.id}->${sfAnchoredContact.id}`,
+      ),
+    ).toBeDefined();
   });
 
   it("ignores salesforceContactId from non-Salesforce intakes", async () => {


### PR DESCRIPTION
## Summary

Prevents the Gmail-before-Salesforce capture race from opening `identity_anchor_mismatch` review cases that are never operator-actionable. Today, ~13 such pairs sit stranded in production (cleaned up reactively by the `merge-email-only-into-sf-anchored` ops tool); this PR stops new ones from being created in the first place.

Reference case: Martin Heckathorn — Gmail received his welcome-reply at 12:43 UTC, our Gmail webhook captured it at 12:44 UTC and created a `contact:email:heckathornmartin@gmail.com` (no SF anchor yet). Salesforce capture caught up at 12:45 UTC, created `contact:salesforce:003VK00000mB9IsYAK`, and normalization opened 2 `identity_anchor_mismatch` cases because the same email now belonged to two canonical contacts. The volunteer's actual reply was stranded on the email-only contact, invisible from the operator's volunteer view.

After this PR, when `resolveContactIdentity` would have opened `identity_anchor_mismatch` because the conflicting contact(s) are all pure email-only (id starts with `contact:email:`, no SF anchor, matched on email only):

1. Re-point `canonical_event_ledger`, `contact_timeline_projection`, `internal_notes`, `routing_review_queue`, and `identity_resolution_queue` rows from the email-only contact(s) to the SF anchor.
2. Delete the email-only contact rows.
3. Rebuild the SF anchor's `contact_inbox_projection` so `has_unresolved` / `last_inbound_at` / `last_canonical_event_id` / `snippet` / `bucket` reflect the merged events.
4. Record an audit-evidence row capturing the auto-merge (mirrors `recordQuarantineAuditOnce` pattern).
5. Return `{ outcome: "resolved", contact: anchored, reviewInput: null }` — no case opened.

Genuine conflicts (any conflicting contact with its own SF anchor, or matched via phone/volunteerId) still open `identity_anchor_mismatch`.

## Changes

- `packages/domain/src/normalization.ts` — new auto-merge branch + helper for the email-only race.
- `packages/domain/src/persistence.ts` — new `mergeEmailOnlyContactIntoAnchored` method on `Stage1PersistenceService`.
- `packages/db/src/repositories.ts` — DB-side transactional repoint/delete (mirrors the ops tool's SQL shape).
- `packages/domain/test/normalization.test.ts` — capture-race regression test + harness upgrades to verify contact deletion, event/timeline retargeting, projection rebuild, and audit-row creation.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm --filter @as-comms/domain test`
- [x] `pnpm --filter @as-comms/db test`
- [x] `pnpm boundaries`
- [ ] Pairs with this PR + #455 (merge-op projection rebuild). After both merge, run the existing op against the 13 stranded pairs in prod to clean them up; new pairs should not form going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)