### PR TITLE
feat(gmail-capture): stop silently dropping spam-flagged inbounds + add recovery op

### DIFF
--- a/apps/web/app/inbox/_components/inbox-detail.tsx
+++ b/apps/web/app/inbox/_components/inbox-detail.tsx
@@ -400,7 +400,12 @@ export function InboxDetail({ detail, timelineSlot }: DetailProps) {
                 </span>
               )}
             </div>
-            <div className="hidden items-center gap-1.5 sm:flex">
+            <div className="flex items-center gap-1.5">
+              {detail.isSpam === true ? (
+                <span className="inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700 ring-1 ring-inset ring-amber-200">
+                  Spam
+                </span>
+              ) : null}
               {contact.hasUnresolved ? (
                 <span className="inline-flex items-center rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-800">
                   Unresolved

--- a/apps/web/app/inbox/_components/inbox-row.tsx
+++ b/apps/web/app/inbox/_components/inbox-row.tsx
@@ -49,6 +49,7 @@ export function InboxRow({ item, isActive }: RowProps) {
     Boolean(item.projectLabel) ||
     showAsBadge ||
     showExternalBadge ||
+    item.isSpam === true ||
     item.needsFollowUp;
 
   const prefetchDetail = useCallback(() => {
@@ -154,6 +155,11 @@ export function InboxRow({ item, isActive }: RowProps) {
                 {showExternalBadge ? (
                   <span className="inline-flex items-center rounded bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 ring-1 ring-inset ring-amber-200">
                     External
+                  </span>
+                ) : null}
+                {item.isSpam === true ? (
+                  <span className="inline-flex items-center rounded bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 ring-1 ring-inset ring-amber-200">
+                    Spam
                   </span>
                 ) : null}
                 {item.needsFollowUp ? (

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -115,6 +115,29 @@ function findNewestCanonicalEvent(
   return newestEvent;
 }
 
+function hasSpamLabel(labelIds: readonly string[] | null | undefined): boolean {
+  return Array.isArray(labelIds) && labelIds.includes("SPAM");
+}
+
+function hasSpamLabeledInboundGmailEvidence<
+  TGmailDetail extends {
+    readonly labelIds?: readonly string[] | null | undefined;
+  },
+>(input: {
+  readonly events: readonly CanonicalEventRecord[];
+  readonly gmailDetailBySourceEvidenceId: ReadonlyMap<string, TGmailDetail>;
+}): boolean {
+  return input.events.some((event) => {
+    if (event.eventType !== "communication.email.inbound") {
+      return false;
+    }
+
+    return hasSpamLabel(
+      input.gmailDetailBySourceEvidenceId.get(event.sourceEvidenceId)?.labelIds,
+    );
+  });
+}
+
 interface InboxListCacheRow {
   readonly contact: ContactRecord;
   readonly inboxProjection: InboxProjectionRow;
@@ -126,6 +149,7 @@ interface InboxListCacheRow {
   readonly lastInboundAlias: string | null;
   readonly lastNonAliasMessageAt: string | null;
   readonly isUnread: boolean;
+  readonly isSpam: boolean;
   /**
    * Per-contact map of `projectId -> latest occurredAt` for that project's
    * Salesforce lifecycle events. Powers the same "primary project by last
@@ -173,6 +197,7 @@ interface InboxDetailCacheData {
   readonly inboxProjection: InboxDetailProjection;
   readonly projectionAvailable: boolean;
   readonly isUnread: boolean;
+  readonly isSpam: boolean;
   readonly memberships: readonly ContactMembershipRecord[];
   readonly latestNote: {
     readonly body: string;
@@ -208,6 +233,7 @@ interface InboxDetailSummaryCacheData {
   readonly inboxProjection: InboxDetailProjection;
   readonly projectionAvailable: boolean;
   readonly isUnread: boolean;
+  readonly isSpam: boolean;
   readonly memberships: readonly ContactMembershipRecord[];
   readonly latestNote: {
     readonly body: string;
@@ -3363,16 +3389,14 @@ async function readInboxListCacheData(input: {
   const canonicalEventsByContactId =
     groupCanonicalEventsByContactId(canonicalEvents);
   const auditEntriesByContactId = groupAuditEntriesByEntityId(auditEntries);
-  const gmailSourceEvidenceIds = uniqueStrings(
-    canonicalEvents
-      .filter((event) => event.eventType === "communication.email.outbound")
-      .map((event) => event.sourceEvidenceId),
+  const canonicalSourceEvidenceIds = uniqueStrings(
+    canonicalEvents.map((event) => event.sourceEvidenceId),
   );
   const gmailDetails =
-    gmailSourceEvidenceIds.length === 0
+    canonicalSourceEvidenceIds.length === 0
       ? []
       : await runtime.repositories.gmailMessageDetails.listBySourceEvidenceIds(
-          gmailSourceEvidenceIds,
+          canonicalSourceEvidenceIds,
         );
   const gmailDetailBySourceEvidenceId = new Map(
     gmailDetails.map((detail) => [detail.sourceEvidenceId, detail]),
@@ -3471,6 +3495,10 @@ async function readInboxListCacheData(input: {
           lastInboundAliasByContactId.get(inboxProjection.contactId) ?? null,
         lastNonAliasMessageAt,
         isUnread,
+        isSpam: hasSpamLabeledInboundGmailEvidence({
+          events: rowCanonicalEvents,
+          gmailDetailBySourceEvidenceId,
+        }),
         lastOccurredAtByProjectId,
         conversationProjectFallback,
       } satisfies InboxListCacheRow,
@@ -3650,19 +3678,14 @@ async function readInboxDetailCacheData(
     canonicalEvents.some((event) =>
       occurredAtIsBeforePlatformFullCaptureCutover(event.occurredAt),
     );
-  const gmailSourceEvidenceIds = uniqueStrings(
-    canonicalEvents
-      .filter((event) => event.eventType === "communication.email.outbound")
-      .map((event) => event.sourceEvidenceId),
-  );
   const canonicalSourceEvidenceIds = uniqueStrings(
     canonicalEvents.map((event) => event.sourceEvidenceId),
   );
   const gmailDetails =
-    gmailSourceEvidenceIds.length === 0
+    canonicalSourceEvidenceIds.length === 0
       ? []
       : await runtime.repositories.gmailMessageDetails.listBySourceEvidenceIds(
-          gmailSourceEvidenceIds,
+          canonicalSourceEvidenceIds,
         );
   const salesforceEventContexts =
     canonicalSourceEvidenceIds.length === 0
@@ -3770,6 +3793,10 @@ async function readInboxDetailCacheData(
     inboxProjection: detailProjection,
     projectionAvailable,
     isUnread,
+    isSpam: hasSpamLabeledInboundGmailEvidence({
+      events: canonicalEvents,
+      gmailDetailBySourceEvidenceId,
+    }),
     memberships,
     latestNote,
     activityTimelineItems,
@@ -3902,19 +3929,14 @@ async function readInboxDetailSummaryCacheData(
     aliasesByProjectId.set(aliasRecord.projectId, aliases);
   }
 
-  const gmailSourceEvidenceIds = uniqueStrings(
-    canonicalEvents
-      .filter((event) => event.eventType === "communication.email.outbound")
-      .map((event) => event.sourceEvidenceId),
-  );
   const canonicalSourceEvidenceIds = uniqueStrings(
     canonicalEvents.map((event) => event.sourceEvidenceId),
   );
   const [gmailDetails, salesforceEventContexts] = await Promise.all([
-    gmailSourceEvidenceIds.length === 0
+    canonicalSourceEvidenceIds.length === 0
       ? Promise.resolve([])
       : runtime.repositories.gmailMessageDetails.listBySourceEvidenceIds(
-          gmailSourceEvidenceIds,
+          canonicalSourceEvidenceIds,
         ),
     canonicalSourceEvidenceIds.length === 0
       ? Promise.resolve([])
@@ -3948,6 +3970,10 @@ async function readInboxDetailSummaryCacheData(
     inboxProjection: detailProjection,
     projectionAvailable,
     isUnread,
+    isSpam: hasSpamLabeledInboundGmailEvidence({
+      events: canonicalEvents,
+      gmailDetailBySourceEvidenceId,
+    }),
     memberships,
     latestNote,
     activityTimelineItems,
@@ -4176,6 +4202,7 @@ function toListItemViewModel(
     volunteerStage: mapVolunteerStage(sortedMemberships),
     bucket: mapBucket(row.inboxProjection.bucket),
     needsFollowUp: row.inboxProjection.needsFollowUp,
+    isSpam: row.isSpam,
     hasUnresolved: row.inboxProjection.hasUnresolved,
     isArchived: row.inboxProjection.archivedAt !== null,
     isUnread: row.isUnread,
@@ -4391,6 +4418,7 @@ function buildInboxDetailSummaryViewModel(input: {
     avatarTone: avatarToneForContact(input.cachedData.contact.id),
     bucket: mapBucket(input.cachedData.inboxProjection.bucket),
     needsFollowUp: input.cachedData.inboxProjection.needsFollowUp,
+    isSpam: input.cachedData.isSpam,
     isArchived: input.cachedData.inboxProjection.archivedAt !== null,
     isUnread: input.cachedData.isUnread,
     smsEligible: input.cachedData.contact.primaryPhone !== null,

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -93,6 +93,7 @@ export interface InboxListItemViewModel {
   // ── Row states (all separate, not collapsed) ──
   readonly bucket: InboxBucket;
   readonly needsFollowUp: boolean;
+  readonly isSpam?: boolean;
   readonly hasUnresolved: boolean;
   readonly isArchived: boolean;
   readonly isUnread: boolean;
@@ -461,6 +462,7 @@ export interface InboxDetailSummaryViewModel {
   readonly avatarTone: InboxAvatarTone;
   readonly bucket: InboxBucket;
   readonly needsFollowUp: boolean;
+  readonly isSpam?: boolean;
   readonly isArchived: boolean;
   readonly isUnread: boolean;
   readonly smsEligible: boolean;

--- a/apps/web/tests/unit/inbox-detail-header.test.tsx
+++ b/apps/web/tests/unit/inbox-detail-header.test.tsx
@@ -183,6 +183,7 @@ function buildDetail(
     timeline: [],
     bucket: "opened",
     needsFollowUp: false,
+    isSpam: false,
     isArchived: false,
     isUnread: false,
     smsEligible: false,
@@ -450,6 +451,16 @@ describe("Inbox detail header", () => {
 
     expect(activeSession.container.textContent).toContain("Amazon Basin");
     expect(activeSession.container.textContent).not.toContain("via ");
+  });
+
+  it("renders a Spam badge in the header when the conversation is spam-flagged", async () => {
+    activeSession = await renderDetail(
+      buildDetail({
+        isSpam: true,
+      }),
+    );
+
+    expect(activeSession.container.textContent).toContain("Spam");
   });
 
   it("keeps the follow-up toggle clickable while a request is in flight and queues the latest intent", async () => {

--- a/apps/web/tests/unit/inbox-row.test.tsx
+++ b/apps/web/tests/unit/inbox-row.test.tsx
@@ -93,6 +93,7 @@ const baseItem: InboxListItemViewModel = {
   volunteerStage: "active",
   bucket: "new",
   needsFollowUp: false,
+  isSpam: false,
   hasUnresolved: false,
   isArchived: false,
   isUnread: true,
@@ -245,5 +246,18 @@ describe("InboxRow unread dot", () => {
       container.querySelector('[data-testid="inbox-row-unread-dot"]'),
     ).toBeNull();
     expect(container.textContent).not.toContain("Unread");
+  });
+
+  it("renders a Spam badge when the inbox row is flagged as spam", () => {
+    const container = renderRow({
+      isSpam: true,
+      projectLabel: null,
+      needsFollowUp: false,
+      volunteerStage: "active",
+      primaryEmail: "alex@example.com",
+    });
+
+    expect(container.textContent).toContain("Spam");
+    expect(container.textContent).not.toContain("External");
   });
 });

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -27,6 +27,7 @@
     "ops:audit-salesforce-task-ingest": "tsx src/ops/audit-salesforce-task-ingest.ts",
     "ops:cleanup-salesforce-owner-scope": "tsx src/ops/cleanup-salesforce-owner-scope.ts",
     "ops:backfill-inbox-projection-coverage": "tsx src/ops/backfill-inbox-projection-coverage.ts",
+    "ops:recover-gmail-spam-window": "tsx src/ops/recover-gmail-spam-window.ts",
     "ops:recover-orphan-gmail-details": "tsx src/ops/recover-orphan-gmail-details.ts",
     "ops:recover-orphan-task-details": "tsx src/ops/recover-orphan-task-details.ts",
     "ops:rewrite-timeline-sort-keys": "tsx src/ops/rewrite-timeline-sort-keys.ts",

--- a/apps/worker/src/ops/cli.ts
+++ b/apps/worker/src/ops/cli.ts
@@ -45,6 +45,7 @@ import { runMailchimpHistoricalCaptureCommand } from "./mailchimp-capture-histor
 import { runCleanupGmailDraftEventsCommand } from "./cleanup-gmail-draft-events.js";
 import { runCleanupSalesforceOwnerScopeCommand } from "./cleanup-salesforce-owner-scope.js";
 import { main as runMergeEmailOnlyIntoSfAnchoredCommand } from "./merge-email-only-into-sf-anchored.js";
+import { runRecoverGmailSpamWindowCommand } from "./recover-gmail-spam-window.js";
 import { runRecoverOrphanGmailDetailsCommand } from "./recover-orphan-gmail-details.js";
 import { reconcileIdentityQueue } from "./reconcile-identity-queue.js";
 import { reconcileRoutingReviewQueue } from "./reconcile-routing-review-queue.js";
@@ -470,6 +471,9 @@ async function main(): Promise<void> {
     case "recover-orphan-gmail-details":
       await runRecoverOrphanGmailDetailsCommand(rest, process.env);
       return;
+    case "recover-gmail-spam-window":
+      await runRecoverGmailSpamWindowCommand(rest, process.env);
+      return;
     case "reprocess-pending-campaign-sends":
       await runReprocessPendingCampaignSends(rest);
       return;
@@ -499,7 +503,7 @@ async function main(): Promise<void> {
       return;
     default:
       throw new Error(
-        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-membership-sf-ids, backfill-gmail-mbox-bodies, backfill-content-fingerprint, backfill-garbled-message-bodies, re-extract-signed-envelope-bodies, backfill-mailchimp-campaign-body, mailchimp-capture-historical, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, recover-orphan-gmail-details, reprocess-pending-campaign-sends, dedup-historical-ledger, merge-email-only-into-sf-anchored, reconcile-identity-queue, reconcile-routing-review-queue, reclassify-sf-direction, reconcile-stale-canonical, reconcile-superseded-projections.",
+        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-membership-sf-ids, backfill-gmail-mbox-bodies, backfill-content-fingerprint, backfill-garbled-message-bodies, re-extract-signed-envelope-bodies, backfill-mailchimp-campaign-body, mailchimp-capture-historical, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, recover-orphan-gmail-details, recover-gmail-spam-window, reprocess-pending-campaign-sends, dedup-historical-ledger, merge-email-only-into-sf-anchored, reconcile-identity-queue, reconcile-routing-review-queue, reclassify-sf-direction, reconcile-stale-canonical, reconcile-superseded-projections.",
       );
   }
 }

--- a/apps/worker/src/ops/recover-gmail-spam-window.ts
+++ b/apps/worker/src/ops/recover-gmail-spam-window.ts
@@ -1,0 +1,307 @@
+#!/usr/bin/env tsx
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+import {
+  closeDatabaseConnection,
+  createDatabaseConnection,
+  createStage1RepositoryBundleFromConnection,
+} from "@as-comms/db";
+import { createStage1NormalizationService, createStage1PersistenceService, type Stage1RepositoryBundle } from "@as-comms/domain";
+import {
+  buildGmailListQuery,
+  createGmailMailboxApiClient,
+  mapLiveGmailMessageToRecord,
+  type GmailCaptureServiceConfig,
+  type GmailMailboxApiClient,
+} from "@as-comms/integrations";
+
+import { createStage1IngestService, type Stage1IngestService } from "../ingest/index.js";
+import { readStage1LaunchScopeGmailConfig } from "./config.js";
+import {
+  parseCliFlags,
+  readOptionalBooleanFlag,
+  readRequiredFlag,
+} from "./helpers.js";
+
+interface Logger {
+  log(...args: readonly unknown[]): void;
+  error(...args: readonly unknown[]): void;
+}
+
+export interface RecoverGmailSpamWindowLogEntry {
+  readonly id: string;
+  readonly foundInDb: boolean;
+  readonly action: "skipped" | "captured";
+  readonly labelIds: readonly string[] | null;
+}
+
+export interface RecoverGmailSpamWindowResult {
+  readonly dryRun: boolean;
+  readonly mailbox: string;
+  readonly windowStart: string;
+  readonly windowEnd: string;
+  readonly query: string;
+  readonly checked: number;
+  readonly foundInDb: number;
+  readonly missing: number;
+  readonly skipped: number;
+  readonly captured: number;
+  readonly notFoundInMailbox: number;
+}
+
+function readConnectionString(env: NodeJS.ProcessEnv): string {
+  const connectionString = env.WORKER_DATABASE_URL ?? env.DATABASE_URL;
+
+  if (connectionString === undefined || connectionString.trim().length === 0) {
+    throw new Error(
+      "DATABASE_URL or WORKER_DATABASE_URL is required for Stage 1 ops commands.",
+    );
+  }
+
+  return connectionString;
+}
+
+function readRequiredStringEnv(env: NodeJS.ProcessEnv, key: string): string {
+  const value = env[key];
+
+  if (value === undefined || value.trim().length === 0) {
+    throw new Error(`${key} is required for Gmail spam-window recovery.`);
+  }
+
+  return value.trim();
+}
+
+function parseWindowTimestamp(value: string, flagName: string): string {
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Flag --${flagName} must be a valid ISO-8601 timestamp.`);
+  }
+
+  return parsed.toISOString();
+}
+
+function buildGmailApiClientFromEnv(
+  env: NodeJS.ProcessEnv,
+): {
+  readonly mailbox: string;
+  readonly liveAccount: string;
+  readonly projectInboxAliases: readonly string[];
+  readonly client: GmailMailboxApiClient;
+} {
+  const gmailConfig = readStage1LaunchScopeGmailConfig(env);
+  const clientConfig: GmailCaptureServiceConfig = {
+    bearerToken: "ops-recover-gmail-spam-window",
+    liveAccount: gmailConfig.liveAccount,
+    projectInboxAliases: [...gmailConfig.projectInboxAliases],
+    oauthClientId: readRequiredStringEnv(env, "GMAIL_GOOGLE_OAUTH_CLIENT_ID"),
+    oauthClientSecret: readRequiredStringEnv(
+      env,
+      "GMAIL_GOOGLE_OAUTH_CLIENT_SECRET",
+    ),
+    oauthRefreshToken: readRequiredStringEnv(
+      env,
+      "GMAIL_GOOGLE_OAUTH_REFRESH_TOKEN",
+    ),
+    tokenUri:
+      env.GMAIL_GOOGLE_TOKEN_URI?.trim().length
+        ? env.GMAIL_GOOGLE_TOKEN_URI.trim()
+        : "https://oauth2.googleapis.com/token",
+    timeoutMs:
+      env.GMAIL_CAPTURE_TIMEOUT_MS === undefined
+        ? 15_000
+        : Number.parseInt(env.GMAIL_CAPTURE_TIMEOUT_MS, 10),
+  };
+
+  return {
+    mailbox: gmailConfig.liveAccount,
+    liveAccount: gmailConfig.liveAccount,
+    projectInboxAliases: [...gmailConfig.projectInboxAliases],
+    client: createGmailMailboxApiClient(clientConfig),
+  };
+}
+
+function logEntry(
+  logger: Logger,
+  entry: RecoverGmailSpamWindowLogEntry,
+): void {
+  logger.log(JSON.stringify(entry));
+}
+
+export async function recoverGmailSpamWindow(input: {
+  readonly repositories: Pick<Stage1RepositoryBundle, "sourceEvidence">;
+  readonly ingest: Pick<Stage1IngestService, "ingestGmailHistoricalRecord">;
+  readonly apiClient: GmailMailboxApiClient;
+  readonly mailbox: string;
+  readonly liveAccount: string;
+  readonly projectInboxAliases: readonly string[];
+  readonly windowStart: string;
+  readonly windowEnd: string;
+  readonly execute: boolean;
+  readonly logger?: Logger;
+}): Promise<RecoverGmailSpamWindowResult> {
+  const logger = input.logger ?? console;
+  const query = buildGmailListQuery({
+    windowStart: input.windowStart,
+    windowEnd: input.windowEnd,
+  });
+
+  if (query === null) {
+    throw new Error("Window start and end are required for Gmail spam recovery.");
+  }
+
+  const messageIds = await input.apiClient.listMessageIds({
+    mailbox: input.mailbox,
+    query,
+  });
+
+  let foundInDb = 0;
+  let missing = 0;
+  let skipped = 0;
+  let captured = 0;
+  let notFoundInMailbox = 0;
+
+  for (const id of messageIds) {
+    const existingRows = await input.repositories.sourceEvidence.listByProviderRecord({
+      provider: "gmail",
+      providerRecordType: "message",
+      providerRecordId: id,
+    });
+
+    if (existingRows.length > 0) {
+      foundInDb += 1;
+      skipped += 1;
+      logEntry(logger, {
+        id,
+        foundInDb: true,
+        action: "skipped",
+        labelIds: null,
+      });
+      continue;
+    }
+
+    missing += 1;
+
+    const message = await input.apiClient.getMessage({
+      mailbox: input.mailbox,
+      messageId: id,
+    });
+
+    if (message === null) {
+      notFoundInMailbox += 1;
+      skipped += 1;
+      logEntry(logger, {
+        id,
+        foundInDb: false,
+        action: "skipped",
+        labelIds: null,
+      });
+      continue;
+    }
+
+    if (!input.execute) {
+      skipped += 1;
+      logEntry(logger, {
+        id,
+        foundInDb: false,
+        action: "skipped",
+        labelIds: message.labelIds,
+      });
+      continue;
+    }
+
+    const record = await mapLiveGmailMessageToRecord({
+      message,
+      capturedMailbox: input.mailbox,
+      liveAccount: input.liveAccount,
+      projectInboxAliases: input.projectInboxAliases,
+      receivedAt: new Date().toISOString(),
+    });
+
+    await input.ingest.ingestGmailHistoricalRecord(record, {
+      overwriteDuplicateGmailMessageDetail: false,
+    });
+
+    captured += 1;
+    logEntry(logger, {
+      id,
+      foundInDb: false,
+      action: "captured",
+      labelIds: message.labelIds,
+    });
+  }
+
+  return {
+    dryRun: !input.execute,
+    mailbox: input.mailbox,
+    windowStart: input.windowStart,
+    windowEnd: input.windowEnd,
+    query,
+    checked: messageIds.length,
+    foundInDb,
+    missing,
+    skipped,
+    captured,
+    notFoundInMailbox,
+  };
+}
+
+export async function runRecoverGmailSpamWindowCommand(
+  args: readonly string[] = process.argv.slice(2),
+  env: NodeJS.ProcessEnv = process.env,
+  logger: Logger = console,
+): Promise<void> {
+  const flags = parseCliFlags(args);
+  const windowStart = parseWindowTimestamp(
+    readRequiredFlag(flags, "window-start"),
+    "window-start",
+  );
+  const windowEnd = parseWindowTimestamp(
+    readRequiredFlag(flags, "window-end"),
+    "window-end",
+  );
+  const execute = readOptionalBooleanFlag(flags, "execute", false);
+  const connection = createDatabaseConnection({
+    connectionString: readConnectionString(env),
+  });
+
+  try {
+    const repositories = createStage1RepositoryBundleFromConnection(connection);
+    const persistence = createStage1PersistenceService(repositories);
+    const normalization = createStage1NormalizationService(persistence);
+    const ingest = createStage1IngestService(normalization);
+    const gmail = buildGmailApiClientFromEnv(env);
+    const result = await recoverGmailSpamWindow({
+      repositories,
+      ingest,
+      apiClient: gmail.client,
+      mailbox: gmail.mailbox,
+      liveAccount: gmail.liveAccount,
+      projectInboxAliases: gmail.projectInboxAliases,
+      windowStart,
+      windowEnd,
+      execute,
+      logger,
+    });
+
+    logger.log(JSON.stringify(result, null, 2));
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}
+
+async function main(): Promise<void> {
+  await runRecoverGmailSpamWindowCommand(process.argv.slice(2), process.env);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  void main().catch((error: unknown) => {
+    console.error(
+      error instanceof Error
+        ? error.message
+        : "Gmail spam-window recovery failed.",
+    );
+    process.exitCode = 1;
+  });
+}

--- a/apps/worker/test/recover-gmail-spam-window.test.ts
+++ b/apps/worker/test/recover-gmail-spam-window.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSourceEvidenceId,
+  type GmailMessageMetadata,
+} from "@as-comms/integrations";
+
+import {
+  recoverGmailSpamWindow,
+  type RecoverGmailSpamWindowLogEntry,
+} from "../src/ops/recover-gmail-spam-window.js";
+import { createTestWorkerContext } from "./helpers.js";
+
+const contactId = "contact:recover-spam";
+
+function buildFullMessagePayload(input: {
+  readonly bodyText: string;
+  readonly headers: Readonly<Record<string, string>>;
+}): GmailMessageMetadata["payload"] {
+  return {
+    mimeType: "text/plain",
+    filename: "",
+    headers: [
+      ...Object.entries(input.headers).map(([name, value]) => ({
+        name,
+        value,
+      })),
+      {
+        name: "Content-Type",
+        value: "text/plain; charset=UTF-8",
+      },
+      {
+        name: "Content-Transfer-Encoding",
+        value: "7bit",
+      },
+    ],
+    body: {
+      data: Buffer.from(input.bodyText, "utf8").toString("base64url"),
+    },
+    parts: [],
+  };
+}
+
+async function seedContact(
+  context: Awaited<ReturnType<typeof createTestWorkerContext>>,
+): Promise<void> {
+  await context.normalization.upsertNormalizedContactGraph({
+    contact: {
+      id: contactId,
+      salesforceContactId: null,
+      displayName: "Nathaniel McCrady",
+      primaryEmail: "nathanielmc@outlook.com",
+      primaryPhone: null,
+      createdAt: "2026-05-16T00:00:00.000Z",
+      updatedAt: "2026-05-16T00:00:00.000Z",
+    },
+    identities: [
+      {
+        id: `identity:${contactId}:email`,
+        contactId,
+        kind: "email",
+        normalizedValue: "nathanielmc@outlook.com",
+        isPrimary: true,
+        source: "manual",
+        verifiedAt: "2026-05-16T00:00:00.000Z",
+      },
+    ],
+    memberships: [],
+  });
+}
+
+async function appendExistingSourceEvidence(
+  context: Awaited<ReturnType<typeof createTestWorkerContext>>,
+  providerRecordId: string,
+): Promise<void> {
+  await context.repositories.sourceEvidence.append({
+    id: buildSourceEvidenceId("gmail", "message", providerRecordId),
+    provider: "gmail",
+    providerRecordType: "message",
+    providerRecordId,
+    receivedAt: "2026-05-18T22:05:00.000Z",
+    occurredAt: "2026-05-16T00:05:00.000Z",
+    payloadRef: `gmail://volunteers%40adventurescientists.org/messages/${providerRecordId}`,
+    idempotencyKey: `gmail:message:${providerRecordId}`,
+    checksum: `checksum:${providerRecordId}`,
+  });
+}
+
+function buildMessageMetadata(messageId: string): GmailMessageMetadata {
+  return {
+    id: messageId,
+    threadId: "thread-recover-spam-1",
+    labelIds: ["INBOX", "SPAM"],
+    snippet: "Can my friends join me on Hex 34571?",
+    internalDate: String(Date.parse("2026-05-17T00:05:00.000Z")),
+    payload: buildFullMessagePayload({
+      bodyText: "Can my friends join me on Hex 34571?",
+      headers: {
+        Date: "Sat, 16 May 2026 17:05:00 -0700",
+        From: "Nathaniel McCrady <nathanielmc@outlook.com>",
+        To: "PNW Bio <pnwbio@adventurescientists.org>",
+        Subject: "Adding others to a Hex",
+        "Message-ID": `<${messageId}@example.org>`,
+      },
+    }),
+  };
+}
+
+describe("recover-gmail-spam-window", () => {
+  it("reports dry-run counts without writing and captures the missing message on execute", async () => {
+    const context = await createTestWorkerContext();
+    const logs: RecoverGmailSpamWindowLogEntry[] = [];
+    const logger = {
+      log(value: unknown) {
+        if (typeof value === "string") {
+          logs.push(JSON.parse(value) as RecoverGmailSpamWindowLogEntry);
+        }
+      },
+      error() {
+        return undefined;
+      },
+    };
+
+    try {
+      await seedContact(context);
+      await appendExistingSourceEvidence(context, "gmail-existing-1");
+      await appendExistingSourceEvidence(context, "gmail-existing-2");
+
+      const apiClient = {
+        listMessageIds: () =>
+          Promise.resolve([
+            "gmail-existing-1",
+            "gmail-existing-2",
+            "gmail-missing-1",
+          ]),
+        getMessage: ({ messageId }: { readonly messageId: string }) =>
+          Promise.resolve(
+            messageId === "gmail-missing-1"
+              ? buildMessageMetadata(messageId)
+              : null,
+          ),
+      };
+
+      const dryRun = await recoverGmailSpamWindow({
+        repositories: context.repositories,
+        ingest: context.ingest,
+        apiClient,
+        mailbox: "volunteers@adventurescientists.org",
+        liveAccount: "volunteers@adventurescientists.org",
+        projectInboxAliases: ["pnwbio@adventurescientists.org"],
+        windowStart: "2026-04-01T00:00:00.000Z",
+        windowEnd: "2026-05-20T00:00:00.000Z",
+        execute: false,
+        logger,
+      });
+
+      expect(dryRun).toMatchObject({
+        checked: 3,
+        missing: 1,
+        captured: 0,
+      });
+      await expect(
+        context.repositories.sourceEvidence.listByProviderRecord({
+          provider: "gmail",
+          providerRecordType: "message",
+          providerRecordId: "gmail-missing-1",
+        }),
+      ).resolves.toEqual([]);
+
+      logs.length = 0;
+
+      const executeResult = await recoverGmailSpamWindow({
+        repositories: context.repositories,
+        ingest: context.ingest,
+        apiClient,
+        mailbox: "volunteers@adventurescientists.org",
+        liveAccount: "volunteers@adventurescientists.org",
+        projectInboxAliases: ["pnwbio@adventurescientists.org"],
+        windowStart: "2026-04-01T00:00:00.000Z",
+        windowEnd: "2026-05-20T00:00:00.000Z",
+        execute: true,
+        logger,
+      });
+
+      expect(executeResult).toMatchObject({
+        checked: 3,
+        missing: 1,
+        captured: 1,
+      });
+
+      const sourceEvidence =
+        await context.repositories.sourceEvidence.listByProviderRecord({
+          provider: "gmail",
+          providerRecordType: "message",
+          providerRecordId: "gmail-missing-1",
+        });
+
+      expect(sourceEvidence).toHaveLength(1);
+
+      const sourceEvidenceId = sourceEvidence[0]?.id;
+
+      if (sourceEvidenceId === undefined) {
+        throw new Error("Expected recovered Gmail source evidence to exist.");
+      }
+
+      await expect(
+        context.repositories.gmailMessageDetails.listBySourceEvidenceIds([
+          sourceEvidenceId,
+        ]),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          sourceEvidenceId,
+          providerRecordId: "gmail-missing-1",
+          labelIds: ["INBOX", "SPAM"],
+        }),
+      ]);
+
+      expect(logs).toContainEqual({
+        id: "gmail-missing-1",
+        foundInDb: false,
+        action: "captured",
+        labelIds: ["INBOX", "SPAM"],
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+});

--- a/apps/worker/test/stage1-gmail-spam-capture.test.ts
+++ b/apps/worker/test/stage1-gmail-spam-capture.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildGmailMessageRecord,
+} from "@as-comms/integrations";
+
+import { createTestWorkerContext } from "./helpers.js";
+
+const contactId = "contact:spam-volunteer";
+
+async function seedContact(
+  context: Awaited<ReturnType<typeof createTestWorkerContext>>,
+): Promise<void> {
+  await context.normalization.upsertNormalizedContactGraph({
+    contact: {
+      id: contactId,
+      salesforceContactId: null,
+      displayName: "Nathaniel McCrady",
+      primaryEmail: "nathanielmc@outlook.com",
+      primaryPhone: null,
+      createdAt: "2026-05-16T00:00:00.000Z",
+      updatedAt: "2026-05-16T00:00:00.000Z",
+    },
+    identities: [
+      {
+        id: `identity:${contactId}:email`,
+        contactId,
+        kind: "email",
+        normalizedValue: "nathanielmc@outlook.com",
+        isPrimary: true,
+        source: "manual",
+        verifiedAt: "2026-05-16T00:00:00.000Z",
+      },
+    ],
+    memberships: [],
+  });
+}
+
+describe("Stage 1 Gmail spam capture", () => {
+  it("normalizes a spam-labeled inbound Gmail message into source evidence, gmail detail, and inbox projection", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact(context);
+
+      const record = buildGmailMessageRecord({
+        recordId: "gmail-spam-1",
+        threadId: "thread-spam-1",
+        labelIds: ["INBOX", "SPAM"],
+        snippet: "Can my friends join me on Hex 34571?",
+        snippetClean: "Can my friends join me on Hex 34571?",
+        bodyTextPreview: "Can my friends join me on Hex 34571?",
+        internalDate: "2026-05-17T00:05:00.000Z",
+        headers: {
+          Date: "Sat, 16 May 2026 17:05:00 -0700",
+          From: "Nathaniel McCrady <nathanielmc@outlook.com>",
+          To: "PNW Bio <pnwbio@adventurescientists.org>",
+          Subject: "Adding others to a Hex",
+          "Message-ID": "<gmail-spam-1@example.org>",
+        },
+        payloadRef:
+          "gmail://volunteers%40adventurescientists.org/messages/gmail-spam-1",
+        checksum: "checksum:gmail-spam-1",
+        capturedMailbox: "volunteers@adventurescientists.org",
+        receivedAt: "2026-05-18T22:05:00.000Z",
+        internalAddresses: [
+          "volunteers@adventurescientists.org",
+          "pnwbio@adventurescientists.org",
+        ],
+        projectInboxAliases: ["pnwbio@adventurescientists.org"],
+      });
+
+      const result = await context.ingest.ingestGmailHistoricalRecord(record);
+
+      expect(result.outcome).toBe("normalized");
+
+      const sourceEvidence =
+        await context.repositories.sourceEvidence.listByProviderRecord({
+          provider: "gmail",
+          providerRecordType: "message",
+          providerRecordId: "gmail-spam-1",
+        });
+
+      expect(sourceEvidence).toHaveLength(1);
+
+      const sourceEvidenceId = sourceEvidence[0]?.id;
+
+      if (sourceEvidenceId === undefined) {
+        throw new Error("Expected Gmail source evidence to be persisted.");
+      }
+
+      await expect(
+        context.repositories.gmailMessageDetails.listBySourceEvidenceIds([
+          sourceEvidenceId,
+        ]),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          sourceEvidenceId,
+          providerRecordId: "gmail-spam-1",
+          direction: "inbound",
+          subject: "Adding others to a Hex",
+          labelIds: ["INBOX", "SPAM"],
+        }),
+      ]);
+
+      await expect(
+        context.repositories.canonicalEvents.listByContactId(contactId),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          contactId,
+          eventType: "communication.email.inbound",
+          sourceEvidenceId,
+        }),
+      ]);
+
+      await expect(
+        context.repositories.inboxProjection.findByContactId(contactId),
+      ).resolves.toMatchObject({
+        contactId,
+        bucket: "New",
+        lastEventType: "communication.email.inbound",
+        snippet: "Can my friends join me on Hex 34571?",
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+});

--- a/packages/integrations/src/capture-services/gmail.ts
+++ b/packages/integrations/src/capture-services/gmail.ts
@@ -334,7 +334,7 @@ export function createGmailMailboxApiClient(
           `https://gmail.googleapis.com/gmail/v1/users/${encodeURIComponent(mailbox)}/messages`
         );
         url.searchParams.set("maxResults", "500");
-        url.searchParams.set("includeSpamTrash", "false");
+        url.searchParams.set("includeSpamTrash", "true");
         if (query !== null) {
           url.searchParams.set("q", query);
         }
@@ -397,7 +397,7 @@ function isGmailMessageRecord(record: GmailRecord): record is GmailMessageRecord
   return record.recordType === "message";
 }
 
-function buildGmailListQuery(input: {
+export function buildGmailListQuery(input: {
   readonly windowStart: string | null;
   readonly windowEnd: string | null;
 }): string | null {

--- a/packages/integrations/test/stage1-gmail-capture-service.test.ts
+++ b/packages/integrations/test/stage1-gmail-capture-service.test.ts
@@ -446,6 +446,72 @@ describe("Gmail capture service", () => {
     expect(record.bodyTextPreview).toHaveLength(longBody.length);
   });
 
+  it("captures spam-labeled inbound Gmail messages and preserves the SPAM label", async () => {
+    const service = createGmailCaptureService(
+      {
+        bearerToken: "gmail-token",
+        liveAccount: "volunteers@example.org",
+        projectInboxAliases: ["project-oceans@example.org"],
+        oauthClientId: "gmail-oauth-client-id",
+        oauthClientSecret: "gmail-oauth-client-secret",
+        oauthRefreshToken: "gmail-oauth-refresh-token"
+      },
+      {
+        apiClient: {
+          listMessageIds: () => Promise.resolve(["gmail-spam-1"]),
+          getMessage: ({ messageId }) =>
+            Promise.resolve({
+              id: messageId,
+              threadId: "thread-spam-1",
+              labelIds: ["INBOX", "SPAM"],
+              snippet: "Question from a volunteer that Gmail marked as spam.",
+              internalDate: String(Date.parse("2026-01-05T00:00:00.000Z")),
+              payload: buildFullMessagePayload({
+                bodyText:
+                  "Can my friends join me on this hex if they have accounts too?",
+                headers: {
+                  Date: "Mon, 05 Jan 2026 00:00:00 +0000",
+                  From: "Volunteer <volunteer@example.org>",
+                  To: "Project Oceans <project-oceans@example.org>",
+                  Subject: "Adding others to a Hex",
+                  "Message-ID": "<gmail-spam-1@example.org>"
+                }
+              })
+            })
+        },
+        now: () => new Date("2026-01-05T00:01:00.000Z")
+      }
+    );
+
+    const result = await service.captureLiveBatch({
+      version: 1,
+      jobId: "job:gmail:live:spam",
+      correlationId: "corr:gmail:live:spam",
+      traceId: null,
+      batchId: "batch:gmail:live:spam",
+      syncStateId: "sync:gmail:live:spam",
+      attempt: 1,
+      maxAttempts: 3,
+      provider: "gmail",
+      mode: "live",
+      jobType: "live_ingest",
+      cursor: null,
+      checkpoint: null,
+      windowStart: "2026-01-05T00:00:00.000Z",
+      windowEnd: "2026-01-05T00:05:00.000Z",
+      recordIds: [],
+      maxRecords: 25
+    });
+
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0]).toMatchObject({
+      recordType: "message",
+      direction: "inbound",
+      subject: "Adding others to a Hex",
+      labelIds: ["INBOX", "SPAM"],
+    });
+  });
+
   it("uses OAuth refresh-token exchange before polling the live mailbox", async () => {
     const requests: {
       readonly url: string;
@@ -536,6 +602,8 @@ describe("Gmail capture service", () => {
     expect(requests[1]?.url).toContain(
       "/gmail/v1/users/volunteers%40example.org/messages"
     );
+    expect(new URL(requests[1]?.url ?? "").searchParams.get("includeSpamTrash"))
+      .toBe("true");
   });
 
   it("accepts Gmail API message parts with empty body data", async () => {


### PR DESCRIPTION
## Summary

P0 capture-layer fix. Two existing volunteer emails to `pnwbio@` were silently lost (Nathaniel McCrady's "Adding others to a Hex" reply on 2026-05-16, Max Krien's "Question About Next Steps" on 2026-05-20 — both false-positive spam classifications). Multi-layer cause: `includeSpamTrash=false` on the Gmail `listMessageIds` API call meant spam-flagged inbounds never returned to capture, and the live-poll cursor is forward-only so anything missed at window-time is permanently invisible — even after the operator removes the SPAM label in Gmail.

### Changes

**Capture** — `packages/integrations/src/capture-services/gmail.ts`: flip `includeSpamTrash` to `true`. Spam now flows through `source_evidence_log` / `gmail_message_details` / canonical event / inbox projection like any other inbound. `label_ids` already get stored, so downstream code can tell which evidence came from spam.

**Inbox UI** — `apps/web/app/inbox/_lib/selectors.ts` + `view-models.ts` derive a spam status from `gmail_message_details.label_ids`. `inbox-row.tsx` + `inbox-detail.tsx` render a `Spam` badge next to the existing `External` badge when the underlying evidence has `SPAM` in its labels. Spam still appears in the normal Inbox (no separate bucket), but the visual marker tells operators Gmail flagged it.

**Recovery op** — `apps/worker/src/ops/recover-gmail-spam-window.ts` (new CLI: `ops:recover-gmail-spam-window`). Takes `--window-start` + `--window-end`, re-queries Gmail with `includeSpamTrash=true`, finds messages missing from `source_evidence_log`, and force-ingests them through the same normalization pipeline as live capture. Dry-run by default; `--execute` writes. Wired into `apps/worker/src/ops/cli.ts`.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm boundaries`
- [x] Full `@as-comms/integrations` Vitest suite passed (includes new spam-path test).
- [x] Full `@as-comms/worker` Vitest suite passed (includes new `stage1-gmail-spam-capture.test.ts` + `recover-gmail-spam-window.test.ts`).
- [x] Narrow web spam-badge Vitest run passed (`inbox-row.test.tsx`, `inbox-detail-header.test.tsx`).
- [ ] After merge: run `pnpm --filter @as-comms/worker ops:recover-gmail-spam-window --window-start=<launch> --window-end=<now> --execute` to backfill the silently-lost emails. Verify Nathaniel + Max Krien threads land with both inbound + outbound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)