### PR TITLE
feat(ai-knowledge): track last-checked timestamp + surface auto-sync activity

### DIFF
--- a/apps/web/app/settings/_components/project-ai-knowledge-section.tsx
+++ b/apps/web/app/settings/_components/project-ai-knowledge-section.tsx
@@ -172,6 +172,7 @@ export function ProjectAiKnowledgeSection({
   initialOperatingContext,
   initialAutoSyncSchedule,
   aiOptimizedSynthesizedAt,
+  aiOptimizedLastCheckedAt,
   aiKnowledgeSynthesisStale
 }: {
   readonly projectId: string;
@@ -180,6 +181,7 @@ export function ProjectAiKnowledgeSection({
   readonly initialOperatingContext: string;
   readonly initialAutoSyncSchedule: "never" | "daily" | "weekly";
   readonly aiOptimizedSynthesizedAt: string | null;
+  readonly aiOptimizedLastCheckedAt: string | null;
   readonly aiKnowledgeSynthesisStale: boolean;
 }) {
   const router = useRouter();
@@ -641,29 +643,39 @@ export function ProjectAiKnowledgeSection({
       <div className="grid grid-cols-1 gap-5 lg:grid-cols-2">
         <div className="rounded-xl border border-slate-200 bg-white p-4">
           <p className="text-sm font-medium text-slate-900">Synthesis status</p>
-          <p
-            className={cn(
-              TYPE.caption,
-              "mt-1 flex items-start gap-1.5 text-slate-600"
-            )}
-          >
-            {enqueuedAt !== null ? (
-              <>
-                <RefreshCw
-                  className="mt-0.5 size-3 shrink-0 animate-spin text-sky-600"
-                  aria-hidden="true"
-                />
-                <span>
-                  Synthesizing now — Claude call + Notion publish typically
-                  takes 30–90s.
-                </span>
-              </>
-            ) : aiOptimizedSynthesizedAt === null ? (
-              <span>Not yet synthesized.</span>
-            ) : (
-              <span>{`Last synthesized: ${formatTimestamp(aiOptimizedSynthesizedAt)} (${String(enabledHealthySources.length)} healthy enabled sources, model metadata unavailable).`}</span>
-            )}
-          </p>
+          {enqueuedAt !== null ? (
+            <p
+              className={cn(
+                TYPE.caption,
+                "mt-1 flex items-start gap-1.5 text-slate-600"
+              )}
+            >
+              <RefreshCw
+                className="mt-0.5 size-3 shrink-0 animate-spin text-sky-600"
+                aria-hidden="true"
+              />
+              <span>
+                Synthesizing now. Claude call + Notion publish typically takes
+                30 to 90 seconds.
+              </span>
+            </p>
+          ) : aiOptimizedSynthesizedAt === null ? (
+            <p className={cn(TYPE.caption, "mt-1 text-slate-600")}>
+              Not yet synthesized.
+            </p>
+          ) : (
+            <div className={cn(TYPE.caption, "mt-1 space-y-1 text-slate-600")}>
+              <p>
+                {`Last synthesized: ${formatTimestamp(aiOptimizedSynthesizedAt)} (${String(enabledHealthySources.length)} healthy enabled sources).`}
+              </p>
+              {aiOptimizedLastCheckedAt !== null &&
+              aiOptimizedLastCheckedAt !== aiOptimizedSynthesizedAt ? (
+                <p>
+                  {`Auto-sync last checked: ${formatTimestamp(aiOptimizedLastCheckedAt)} (sources unchanged, no re-synthesis needed).`}
+                </p>
+              ) : null}
+            </div>
+          )}
           {aiKnowledgeSynthesisStale && enqueuedAt === null ? (
             <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[12px] text-amber-900">
               Synthesis is stale. One or more source hashes no longer match the

--- a/apps/web/app/settings/_components/project-detail.tsx
+++ b/apps/web/app/settings/_components/project-detail.tsx
@@ -75,6 +75,7 @@ function buildProjectState(
     aiKnowledgeSources: project.aiKnowledgeSources,
     aiOperatingContext: project.aiOperatingContext,
     aiOptimizedSynthesizedAt: project.aiOptimizedSynthesizedAt,
+    aiOptimizedLastCheckedAt: project.aiOptimizedLastCheckedAt,
     aiOptimizedInputHash: project.aiOptimizedInputHash,
     activationRequirementsMet: project.activationRequirementsMet,
     emails: project.emails
@@ -1054,6 +1055,7 @@ export function ProjectDetail({
             initialOperatingContext={project.aiOperatingContext}
             initialAutoSyncSchedule={project.aiAutoSyncSchedule}
             aiOptimizedSynthesizedAt={project.aiOptimizedSynthesizedAt}
+            aiOptimizedLastCheckedAt={project.aiOptimizedLastCheckedAt}
             aiKnowledgeSynthesisStale={project.aiKnowledgeSynthesisStale}
           />
         )}

--- a/apps/web/app/settings/actions.ts
+++ b/apps/web/app/settings/actions.ts
@@ -277,6 +277,7 @@ function serializeProjectMutationData(input: {
   readonly aiKnowledgeSources?: readonly AiKnowledgeSource[];
   readonly aiOperatingContext?: string;
   readonly aiOptimizedSynthesizedAt?: Date | null;
+  readonly aiOptimizedLastCheckedAt?: Date | null;
   readonly aiOptimizedInputHash?: string | null;
   readonly emails: readonly {
     readonly id: string;
@@ -298,6 +299,8 @@ function serializeProjectMutationData(input: {
     aiOperatingContext: input.aiOperatingContext ?? "",
     aiOptimizedSynthesizedAt:
       input.aiOptimizedSynthesizedAt?.toISOString() ?? null,
+    aiOptimizedLastCheckedAt:
+      input.aiOptimizedLastCheckedAt?.toISOString() ?? null,
     aiOptimizedInputHash: input.aiOptimizedInputHash ?? null,
     activationRequirementsMet: hasActivationRequirements({
       projectAlias: input.projectAlias,
@@ -708,6 +711,7 @@ export interface ProjectMutationData {
   readonly aiKnowledgeSources: readonly AiKnowledgeSource[];
   readonly aiOperatingContext: string;
   readonly aiOptimizedSynthesizedAt: string | null;
+  readonly aiOptimizedLastCheckedAt: string | null;
   readonly aiOptimizedInputHash: string | null;
   readonly activationRequirementsMet: boolean;
   readonly emails: readonly ProjectEmailMutationData[];

--- a/apps/web/src/server/settings/selectors.ts
+++ b/apps/web/src/server/settings/selectors.ts
@@ -82,6 +82,7 @@ export interface ProjectSettingsDetailViewModel extends ProjectRowViewModel {
   readonly aiOperatingContext: string;
   readonly aiAutoSyncSchedule: "never" | "daily" | "weekly";
   readonly aiOptimizedSynthesizedAt: string | null;
+  readonly aiOptimizedLastCheckedAt: string | null;
   readonly aiOptimizedInputHash: string | null;
   readonly aiKnowledgeSynthesisStale: boolean;
   readonly emails: readonly {
@@ -750,6 +751,7 @@ async function readProjectSettingsDetail(
     aiOperatingContext: dimension?.aiOperatingContext ?? "",
     aiAutoSyncSchedule: dimension?.aiAutoSyncSchedule ?? "never",
     aiOptimizedSynthesizedAt: dimension?.aiOptimizedSynthesizedAt ?? null,
+    aiOptimizedLastCheckedAt: dimension?.aiOptimizedLastCheckedAt ?? null,
     aiOptimizedInputHash,
     // Only consider synthesis "stale" when a prior synthesis exists to
     // compare against. Otherwise (never-synthesized), the project is in a

--- a/apps/web/tests/unit/settings-project-detail-connected-projects.test.ts
+++ b/apps/web/tests/unit/settings-project-detail-connected-projects.test.ts
@@ -133,6 +133,7 @@ function makeProject(
     aiOperatingContext: "",
     aiAutoSyncSchedule: "never",
     aiOptimizedSynthesizedAt: null,
+    aiOptimizedLastCheckedAt: null,
     aiOptimizedInputHash: null,
     aiKnowledgeSynthesisStale: false,
     memberCount: 5,

--- a/apps/web/tests/unit/settings-project-detail-render.test.ts
+++ b/apps/web/tests/unit/settings-project-detail-render.test.ts
@@ -151,6 +151,7 @@ describe("ProjectDetail role-aware rendering", () => {
           aiOperatingContext: "",
           aiAutoSyncSchedule: "never",
           aiOptimizedSynthesizedAt: null,
+          aiOptimizedLastCheckedAt: null,
           aiOptimizedInputHash: null,
           aiKnowledgeSynthesisStale: false,
           memberCount: 0,

--- a/apps/worker/src/jobs/synthesize-project-knowledge/index.ts
+++ b/apps/worker/src/jobs/synthesize-project-knowledge/index.ts
@@ -168,6 +168,18 @@ export async function runSynthesizeProjectKnowledge(
   }
 
   if ("unchanged" in orchestratorResult) {
+    // Bump only ai_optimized_last_checked_at so operators can see auto-sync
+    // is running. Leave ai_optimized_synthesized_at alone — content was not
+    // regenerated. Re-stamp ai_optimized_input_hash with the same value
+    // we just compared against (no-op write, kept for symmetry).
+    await deps.repositories.projectDimensions.setSynthesisMetadata(
+      payload.projectId,
+      {
+        lastCheckedAt: now().toISOString(),
+        inputHash: orchestratorResult.inputHash,
+      },
+    );
+
     return {
       ok: true,
       unchanged: true,
@@ -220,6 +232,8 @@ export async function runSynthesizeProjectKnowledge(
       payload.projectId,
       {
         synthesizedAt: synthesizedAt.toISOString(),
+        // Content was just regenerated, so checked-at == synthesized-at.
+        lastCheckedAt: synthesizedAt.toISOString(),
         inputHash,
       },
     );

--- a/apps/worker/src/jobs/synthesize-project-knowledge/orchestrator.ts
+++ b/apps/worker/src/jobs/synthesize-project-knowledge/orchestrator.ts
@@ -157,6 +157,10 @@ export type SynthesizeProjectKnowledgeOrchestratorResult =
       readonly ok: true;
       readonly unchanged: true;
       readonly sourcesChecked: number;
+      // Carry the existing hash forward so the caller can stamp
+      // ai_optimized_last_checked_at without disturbing
+      // ai_optimized_synthesized_at or ai_optimized_input_hash.
+      readonly inputHash: string | null;
     }
   | {
       readonly ok: false;
@@ -423,6 +427,7 @@ export async function synthesizeProjectKnowledgeOrchestrator(
     return {
       ok: true,
       unchanged: true,
+      inputHash: nextInputHash,
       sourcesChecked: syncPass.sourcesChecked,
     };
   }

--- a/apps/worker/test/stage1-orchestration.test.ts
+++ b/apps/worker/test/stage1-orchestration.test.ts
@@ -504,6 +504,7 @@ Alias drift outbound message.
           aiOperatingContext: "",
           aiAutoSyncSchedule: "never",
           aiOptimizedSynthesizedAt: null,
+          aiOptimizedLastCheckedAt: null,
           aiOptimizedInputHash: null
         }
       ]);

--- a/apps/worker/test/synthesize-project-knowledge-orchestrator.test.ts
+++ b/apps/worker/test/synthesize-project-knowledge-orchestrator.test.ts
@@ -414,6 +414,7 @@ describe("synthesizeProjectKnowledgeOrchestrator", () => {
       ok: true,
       unchanged: true,
       sourcesChecked: 2,
+      inputHash: inputHashFromSources(sources),
     });
     expect(notionFetch).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/contracts/src/stage1-records.ts
+++ b/packages/contracts/src/stage1-records.ts
@@ -166,6 +166,10 @@ export const projectDimensionSchema = z.object({
   aiOperatingContext: z.string().optional(),
   aiAutoSyncSchedule: z.enum(["never", "daily", "weekly"]).optional(),
   aiOptimizedSynthesizedAt: optionalTimestampSchema.optional(),
+  // Bumped on every successful synthesis orchestrator run, including the
+  // skip-if-unchanged path. Lets the UI show "auto-sync ran at X, no
+  // changes detected" separately from "content last regenerated at Y".
+  aiOptimizedLastCheckedAt: optionalTimestampSchema.optional(),
   aiOptimizedInputHash: nullableStringSchema.optional(),
 });
 export type ProjectDimensionRecord = z.input<typeof projectDimensionSchema>;

--- a/packages/db/drizzle/0063_ai_optimized_last_checked_at.sql
+++ b/packages/db/drizzle/0063_ai_optimized_last_checked_at.sql
@@ -1,0 +1,30 @@
+-- Add ai_optimized_last_checked_at to project_dimensions.
+--
+-- Why: the synthesis orchestrator's skip-if-unchanged optimization
+-- (PRD #366 Phase 2) correctly skips Anthropic calls when source content
+-- hashes match the stored ai_optimized_input_hash. But that meant
+-- ai_optimized_synthesized_at stayed frozen at the last content-generating
+-- run, and the auto-sync hourly cron silently completed every hour with no
+-- visible signal. Operators reported "auto-sync is broken" (2026-05-21,
+-- PNW Biodiversity + Killer Whales stuck at May 10 despite Weekly schedule).
+--
+-- Solution: track a separate "last verified" timestamp that bumps on every
+-- successful orchestrator run, whether or not Anthropic was called. The
+-- UI then surfaces both:
+--   - "Last synthesized: <content gen time>"
+--   - "Last checked: <verification cycle>"
+-- so operators can confirm auto-sync is running even when nothing has
+-- changed.
+--
+-- Backfill: NULL is the correct seed value for never-checked projects.
+-- Already-active projects with a non-null ai_optimized_synthesized_at get
+-- their last_checked_at backfilled to the same timestamp so the first
+-- UI render after deploy doesn't show "Never" for a project that was
+-- demonstrably synthesized.
+
+ALTER TABLE "project_dimensions"
+ADD COLUMN "ai_optimized_last_checked_at" timestamp with time zone;
+
+UPDATE "project_dimensions"
+SET "ai_optimized_last_checked_at" = "ai_optimized_synthesized_at"
+WHERE "ai_optimized_synthesized_at" IS NOT NULL;

--- a/packages/db/src/mappers.ts
+++ b/packages/db/src/mappers.ts
@@ -546,6 +546,7 @@ export function mapProjectDimensionRow(
     aiOperatingContext: row.aiOperatingContext,
     aiAutoSyncSchedule: row.aiAutoSyncSchedule,
     aiOptimizedSynthesizedAt: fromDate(row.aiOptimizedSynthesizedAt),
+    aiOptimizedLastCheckedAt: fromDate(row.aiOptimizedLastCheckedAt),
     aiOptimizedInputHash: row.aiOptimizedInputHash,
   });
 }
@@ -579,6 +580,12 @@ export function mapProjectDimensionToInsert(
         : parsed.aiOptimizedSynthesizedAt === null
           ? null
           : toDate(parsed.aiOptimizedSynthesizedAt),
+    aiOptimizedLastCheckedAt:
+      parsed.aiOptimizedLastCheckedAt === undefined
+        ? undefined
+        : parsed.aiOptimizedLastCheckedAt === null
+          ? null
+          : toDate(parsed.aiOptimizedLastCheckedAt),
     aiOptimizedInputHash:
       parsed.aiOptimizedInputHash === undefined
         ? undefined

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -3176,16 +3176,27 @@ function createStage1RepositoriesInternal(
       },
 
       async setSynthesisMetadata(projectId, input) {
+        // Build the SET clause selectively: undefined means "leave the
+        // existing value alone" (e.g. the skip-if-unchanged path passes
+        // lastCheckedAt + inputHash but not synthesizedAt). Explicit null is
+        // still passed through to clear a field.
+        const updates: Partial<typeof projectDimensions.$inferInsert> = {
+          updatedAt: new Date(),
+        };
+        if (input.synthesizedAt !== undefined) {
+          updates.aiOptimizedSynthesizedAt =
+            input.synthesizedAt === null ? null : new Date(input.synthesizedAt);
+        }
+        if (input.lastCheckedAt !== undefined) {
+          updates.aiOptimizedLastCheckedAt =
+            input.lastCheckedAt === null ? null : new Date(input.lastCheckedAt);
+        }
+        if (input.inputHash !== undefined) {
+          updates.aiOptimizedInputHash = input.inputHash;
+        }
         await db
           .update(projectDimensions)
-          .set({
-            aiOptimizedSynthesizedAt:
-              input.synthesizedAt === null
-                ? null
-                : new Date(input.synthesizedAt),
-            aiOptimizedInputHash: input.inputHash,
-            updatedAt: new Date(),
-          })
+          .set(updates)
           .where(eq(projectDimensions.projectId, projectId));
       },
 

--- a/packages/db/src/schema/tables.ts
+++ b/packages/db/src/schema/tables.ts
@@ -337,6 +337,14 @@ export const projectDimensions = pgTable(
       mode: "date",
       withTimezone: true,
     }),
+    // Bumped on every successful synthesis orchestrator run, including
+    // skip-if-unchanged paths where Anthropic was not called. Lets the UI
+    // distinguish "content gen time" from "auto-sync verification cycle"
+    // so a Weekly schedule with stable sources doesn't look broken.
+    aiOptimizedLastCheckedAt: timestamp("ai_optimized_last_checked_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
     aiOptimizedInputHash: text("ai_optimized_input_hash"),
     source: recordSourceEnum("source").notNull(),
     createdAt: createdAtColumn,

--- a/packages/db/test/ai-knowledge-sources.test.ts
+++ b/packages/db/test/ai-knowledge-sources.test.ts
@@ -351,8 +351,9 @@ describe("0055_ai_knowledge_auto_sync_schedule migration", () => {
         "0055_ai_knowledge_auto_sync_schedule.sql",
       );
       // Apply later migrations so the table schema matches the Drizzle table
-      // definition (which includes connected_to_project_id from 0056 and
-      // postmark_sender_status from 0057).
+      // definition (which includes connected_to_project_id from 0056,
+      // postmark_sender_status from 0057, and ai_optimized_last_checked_at
+      // from 0063).
       await applySingleMigration(
         client,
         "0056_project_dimensions_connected_to.sql",
@@ -360,6 +361,10 @@ describe("0055_ai_knowledge_auto_sync_schedule migration", () => {
       await applySingleMigration(
         client,
         "0057_stage5_campaigns_schema.sql",
+      );
+      await applySingleMigration(
+        client,
+        "0063_ai_optimized_last_checked_at.sql",
       );
 
       const db = drizzle(client) as Stage1Database;
@@ -463,7 +468,8 @@ describe("0054_ai_knowledge_source_registry migration", () => {
       // Apply later migrations so the table schema matches the Drizzle table
       // definition (which includes columns added after 0054, e.g.,
       // ai_auto_sync_schedule from 0055, connected_to_project_id from 0056,
-      // and postmark_sender_status from 0057).
+      // postmark_sender_status from 0057, ai_optimized_last_checked_at
+      // from 0063).
       await applySingleMigration(
         client,
         "0055_ai_knowledge_auto_sync_schedule.sql",
@@ -475,6 +481,10 @@ describe("0054_ai_knowledge_source_registry migration", () => {
       await applySingleMigration(
         client,
         "0057_stage5_campaigns_schema.sql",
+      );
+      await applySingleMigration(
+        client,
+        "0063_ai_optimized_last_checked_at.sql",
       );
 
       const db = drizzle(client) as Stage1Database;

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -459,11 +459,22 @@ export interface ProjectDimensionRepository {
     projectId: string,
     schedule: "never" | "daily" | "weekly",
   ): Promise<void>;
+  /**
+   * Stamp synthesis-related timestamps + input hash for a project.
+   * - `synthesizedAt`: bump only on actual Anthropic synthesis runs (content
+   *   was regenerated). Pass `undefined` to leave the existing value alone.
+   * - `lastCheckedAt`: bump on every successful orchestrator run, including
+   *   skip-if-unchanged paths where no Anthropic call was made. Lets the UI
+   *   distinguish "content gen time" from "auto-sync verification cycle".
+   * - `inputHash`: source-content hash for the next skip-if-unchanged check.
+   *   Pass `undefined` to leave the existing value alone.
+   */
   setSynthesisMetadata(
     projectId: string,
     input: {
-      readonly synthesizedAt: string | null;
-      readonly inputHash: string | null;
+      readonly synthesizedAt?: string | null;
+      readonly lastCheckedAt?: string | null;
+      readonly inputHash?: string | null;
     },
   ): Promise<void>;
   upsert(record: ProjectDimensionRecord): Promise<ProjectDimensionRecord>;


### PR DESCRIPTION
## Summary

Operator-reported 2026-05-21: **PNW Biodiversity** and **Killer Whales** both on Weekly auto-sync schedule but "Last synthesized" stuck at May 10 — 11 days stale, looked like auto-sync was broken.

## Diagnosis (from prod queries + worker logs)

Cron `poll-ai-knowledge-auto-sync` is running fine every hour; last fire 2026-05-21 03:00 UTC. It enqueued 2 syntheses (PNW + KW) on that tick; both completed in ~2.5s — too fast for an LLM call.

The synthesis orchestrator's skip-if-unchanged path (PRD #366 Phase 2) correctly bails out when source content hashes match the stored `ai_optimized_input_hash`. PNW + KW have stable Notion source pages → hash unchanged → orchestrator returns `{ ok: true, unchanged: true }` without bumping `ai_optimized_synthesized_at`. The hourly cron tick was invisible in the UI, so operators legitimately read "stale" as broken.

(Beech & Butternut + Whitebark were getting re-synthesized because their sources HAD been edited between cron ticks. Their hashes advanced and the orchestrator ran the LLM normally.)

## Fix

Two semantic states matter to operators:

- **Last synthesized**: when content was last regenerated
- **Last checked**: when auto-sync last verified the synthesis is current

Add a separate column for the second one.

### Schema (migration 0063)

`ai_optimized_last_checked_at` nullable timestamp on `project_dimensions`. Backfills to `ai_optimized_synthesized_at` for projects with a prior synthesis so the first post-deploy render doesn't show "Never" for projects that were demonstrably synthesized.

### Orchestrator + job

- Orchestrator's `unchanged` result now carries the existing input hash forward.
- Job-level caller stamps `ai_optimized_last_checked_at` on **every** successful run (both skip-if-unchanged and content-gen paths). When synthesis actually runs, `lastCheckedAt` and `synthesizedAt` are bumped to the same instant.

### Repository

`setSynthesisMetadata` now accepts a partial input shape — pass only fields you want to touch. Skip-if-unchanged passes `lastCheckedAt + inputHash`; content-gen passes all three. `undefined` leaves existing values alone; explicit `null` still clears.

### UI (`project-ai-knowledge-section.tsx`)

The Synthesis status card renders two lines when the auto-sync has run more recently than the content was regenerated:

```
Last synthesized: May 10, 2026, 9:56 AM (8 healthy enabled sources).
Auto-sync last checked: May 21, 2026, 3:00 PM (sources unchanged, no re-synthesis needed).
```

When they're equal (a content-generating run just happened), only the first line shows.

Bonus: dropped the *"model metadata unavailable"* filler from the first line since we never plumbed that signal through and it added more confusion than value.

## Test plan

- [x] `pnpm -C packages/contracts typecheck` + lint + tests (15 pass)
- [x] `pnpm -C packages/db typecheck` + lint + tests (152 pass, including 2 migration tests that now apply 0063)
- [x] `pnpm -C packages/domain typecheck` + lint + tests (128 pass)
- [x] `pnpm -C apps/worker typecheck` + lint + tests (193 pass)
- [x] `pnpm -C apps/web typecheck` + lint + tests (646 pass / 5 skipped)
- [ ] Post-deploy: watch the next hourly cron tick on PNW Biodiversity; confirm `Auto-sync last checked: ...` advances even though `Last synthesized` stays at May 10. After the next Notion edit to a PNW source, both should advance together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)