### PR TITLE
fix(broadcasts): un-hide every broadcast from the list (postgres-js row extraction)

### DIFF
--- a/apps/web/app/broadcasts/[runId]/_lib/run-detail.ts
+++ b/apps/web/app/broadcasts/[runId]/_lib/run-detail.ts
@@ -19,6 +19,20 @@ import {
   type RunMetricCounts,
 } from "../../_lib/run-recipients";
 
+function normalizeSqlResultRows<TRow>(
+  result:
+    | readonly TRow[]
+    | {
+        readonly rows?: readonly TRow[];
+      },
+): readonly TRow[] {
+  if (Array.isArray(result)) {
+    return result as readonly TRow[];
+  }
+
+  return (result as { readonly rows?: readonly TRow[] }).rows ?? [];
+}
+
 export interface RunMetricTileData {
   readonly key:
     | "queued"
@@ -540,14 +554,14 @@ export async function getRunDetailModel(input: {
           )
       `,
     );
-    const recentReplyRows =
-      (replyRowsResult as { readonly rows?: readonly ReplyRowDb[] }).rows ?? [];
-    const [countRow] =
-      (
-        countResult as {
-          readonly rows?: readonly { readonly count: number }[];
-        }
-      ).rows ?? [];
+    const recentReplyRows = normalizeSqlResultRows<ReplyRowDb>(
+      replyRowsResult as { readonly rows?: readonly ReplyRowDb[] },
+    );
+    const [countRow] = normalizeSqlResultRows<{ readonly count: number }>(
+      countResult as {
+        readonly rows?: readonly { readonly count: number }[];
+      },
+    );
 
     repliesCount = countRow?.count ?? 0;
     recentReplies = recentReplyRows.map((row) => ({

--- a/apps/web/app/broadcasts/_lib/run-recipients.ts
+++ b/apps/web/app/broadcasts/_lib/run-recipients.ts
@@ -4,6 +4,20 @@ import type { AudienceSnapshotRecord } from "@as-comms/contracts";
 
 import { getStage1WebRuntime } from "@/src/server/stage1-runtime";
 
+function normalizeSqlResultRows<TRow>(
+  result:
+    | readonly TRow[]
+    | {
+        readonly rows?: readonly TRow[];
+      },
+): readonly TRow[] {
+  if (Array.isArray(result)) {
+    return result as readonly TRow[];
+  }
+
+  return (result as { readonly rows?: readonly TRow[] }).rows ?? [];
+}
+
 export type RecipientLatestState =
   | "queued"
   | "sent"
@@ -439,17 +453,19 @@ export async function listRunRecipients(input: {
     `),
   ]);
 
-  const rows = (rowsResult as { readonly rows?: readonly RecipientRowDb[] })
-    .rows;
-  const [countRow] =
-    (
-      countResult as {
-        readonly rows?: readonly { readonly count: number | string }[];
-      }
-    ).rows ?? [];
+  const rows = normalizeSqlResultRows<RecipientRowDb>(
+    rowsResult as { readonly rows?: readonly RecipientRowDb[] },
+  );
+  const [countRow] = normalizeSqlResultRows<{
+    readonly count: number | string;
+  }>(
+    countResult as {
+      readonly rows?: readonly { readonly count: number | string }[];
+    },
+  );
 
   return {
-    rows: (rows ?? []).map(mapRecipientRow),
+    rows: rows.map(mapRecipientRow),
     total: Number(countRow?.count ?? 0),
   };
 }
@@ -487,8 +503,9 @@ export async function readRunMetricCounts(input: {
     from audience_snapshots
     where campaign_run_id = ${input.runId}
   `);
-  const [row] =
-    (result as { readonly rows?: readonly RunMetricCounts[] }).rows ?? [];
+  const [row] = normalizeSqlResultRows<RunMetricCounts>(
+    result as { readonly rows?: readonly RunMetricCounts[] },
+  );
 
   return (
     row ?? {

--- a/apps/web/app/broadcasts/page.tsx
+++ b/apps/web/app/broadcasts/page.tsx
@@ -92,6 +92,20 @@ function resolveFilterStates(filterId: CampaignFilterId) {
   );
 }
 
+function normalizeSqlResultRows<TRow>(
+  result:
+    | readonly TRow[]
+    | {
+        readonly rows?: readonly TRow[];
+      },
+): readonly TRow[] {
+  if (Array.isArray(result)) {
+    return result as readonly TRow[];
+  }
+
+  return (result as { readonly rows?: readonly TRow[] }).rows ?? [];
+}
+
 interface CampaignProjectionSqlRow {
   readonly runId: string;
   readonly provider: "postmark";
@@ -249,9 +263,9 @@ async function listRecentPostmarkRows(input: {
     offset ${input.offset}
   `);
 
-  const rows =
-    (result as { readonly rows?: readonly CampaignProjectionSqlRow[] }).rows ??
-    [];
+  const rows = normalizeSqlResultRows<CampaignProjectionSqlRow>(
+    result as { readonly rows?: readonly CampaignProjectionSqlRow[] },
+  );
   return rows.map(mapProjectionSqlRow);
 }
 
@@ -287,12 +301,9 @@ async function countPostmarkRows(input: {
       searchQuery: input.searchQuery.length === 0 ? null : input.searchQuery,
     })}
   `);
-  const [row] =
-    (
-      result as {
-        readonly rows?: readonly CampaignProjectionCountSqlRow[];
-      }
-    ).rows ?? [];
+  const [row] = normalizeSqlResultRows<CampaignProjectionCountSqlRow>(
+    result as { readonly rows?: readonly CampaignProjectionCountSqlRow[] },
+  );
 
   return Number(row?.total ?? 0);
 }
@@ -324,12 +335,9 @@ async function countPostmarkRowsByState(input: {
     })}
     group by "state"
   `);
-  const rows =
-    (
-      result as {
-        readonly rows?: readonly CampaignProjectionStateCountSqlRow[];
-      }
-    ).rows ?? [];
+  const rows = normalizeSqlResultRows<CampaignProjectionStateCountSqlRow>(
+    result as { readonly rows?: readonly CampaignProjectionStateCountSqlRow[] },
+  );
   const counts: Partial<Record<RunState, number>> = {};
   for (const row of rows) {
     counts[row.state] = Number(row.total);
@@ -367,8 +375,9 @@ async function readMetricsByRunId(input: {
     group by campaign_run_id
   `);
 
-  const rows =
-    (result as { readonly rows?: readonly CampaignMetricSqlRow[] }).rows ?? [];
+  const rows = normalizeSqlResultRows<CampaignMetricSqlRow>(
+    result as { readonly rows?: readonly CampaignMetricSqlRow[] },
+  );
   return new Map(
     rows.map((row) => [
       row.runId,


### PR DESCRIPTION
## Summary
- Broadcasts list, run detail, and run recipients all extracted rows from raw `db.execute(sql\`…\`)` as `(result as { rows? }).rows ?? []`.
- With the **postgres-js** driver in production, `execute()` returns a `RowList` (extends `Array`), so `.rows` is `undefined` → `?? []` → every broadcast is silently dropped.
- DB currently has **29 rows in `campaign_runs`** (2 scheduled, 27 drafts). The page shows "No broadcasts yet" / count `0`.
- Inbox + settings already normalize this with a local `normalizeSqlResultRows` helper. Adds the same helper to the 3 broadcasts files and routes all 8 extraction points through it.

## Root cause (one line)
`drizzle-orm/postgres-js` `execute()` returns the array directly when no fields binding is set (see `session.js:30-35` — `return await client.unsafe(query, params)`).

## Files
- `apps/web/app/broadcasts/page.tsx` — list, count, count-by-state, metrics
- `apps/web/app/broadcasts/_lib/run-recipients.ts` — recipient list, run metric counts
- `apps/web/app/broadcasts/[runId]/_lib/run-detail.ts` — reply preview + count

## Test plan
- [ ] CI: typecheck + build green (build verified locally; route.ts/page.tsx changes per the build-before-push rule).
- [ ] Smoke after deploy: open `/broadcasts` — should show 29 rows including the 2 scheduled (`cf7dc998` "dasd" and `f1974a2b` "dsad").
- [ ] Open one run-detail page — recipient list should populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)