### PR TITLE
refactor(broadcasts): extract useNewCampaignWizardState hook

### DIFF
--- a/apps/web/app/broadcasts/new/_components/new-campaign-wizard.tsx
+++ b/apps/web/app/broadcasts/new/_components/new-campaign-wizard.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState, useTransition } from "react";
-
 import type {
   AudienceCriteria,
   CampaignKind,
@@ -11,23 +9,12 @@ import type {
 
 import type {
   AudienceBuilderBootstrap,
-  AudienceStatusCounts,
-  AudiencePreviewRow,
-  AudienceVolunteerSearchRow,
   CampaignProjectOption,
   CampaignSenderOption,
-  ComposePreviewData,
   CampaignWizardDraftData,
 } from "../../_lib/audience-data-source";
 import { cn } from "@/lib/utils";
-import {
-  loadMemberStatusCountsForProjects,
-  loadComposePreviewAction,
-  previewAudienceAction,
-  resolveAudienceCountAction,
-  saveCampaignWizardDraftAction,
-  searchProjectVolunteersAction,
-} from "../../_lib/audience-data-source";
+import { saveCampaignWizardDraftAction } from "../../_lib/audience-data-source";
 import { schedule, sendNow, testSend } from "../../actions";
 import {
   AudienceBuilderStep,
@@ -39,6 +26,7 @@ import { LaunchTypeStep } from "./launch-type-step";
 import { NameAndSenderStep } from "./name-and-sender-step";
 import { PreviewStep } from "./preview-step";
 import { ReviewStep } from "./review-step";
+import { useNewCampaignWizardState } from "./use-new-campaign-wizard-state";
 import { type CampaignWizardStepDefinition, WizardRail } from "./wizard-rail";
 
 const STEPS: readonly CampaignWizardStepDefinition[] = [
@@ -74,8 +62,8 @@ const STEPS: readonly CampaignWizardStepDefinition[] = [
   },
 ];
 
-type SaveState = "idle" | "saving" | "saved" | "error";
-type ToastState = {
+export type SaveState = "idle" | "saving" | "saved" | "error";
+export type ToastState = {
   readonly tone: "success" | "error";
   readonly message: string;
 } | null;
@@ -94,7 +82,7 @@ function readProjectIds(criteria: CampaignAudienceCriteria): string[] {
   ]);
 }
 
-function defaultAudienceModeForLaunchType(
+export function defaultAudienceModeForLaunchType(
   launchType: LaunchType,
 ): AudienceInitialFilter {
   return launchType === "html_email" ? "all_approved" : "project_status";
@@ -108,7 +96,9 @@ function readAudienceModesForLaunchType(
     : ["project_status", "specific"];
 }
 
-function hasAppliedAudienceFilters(criteria: CampaignAudienceCriteria): boolean {
+export function hasAppliedAudienceFilters(
+  criteria: CampaignAudienceCriteria,
+): boolean {
   if (criteria.initialFilter === undefined) {
     return false;
   }
@@ -121,7 +111,7 @@ function hasAppliedAudienceFilters(criteria: CampaignAudienceCriteria): boolean 
   }
 }
 
-function deriveInitialFilter(
+export function deriveInitialFilter(
   draft: CampaignWizardDraftData,
 ): AudienceInitialFilter | undefined {
   if (draft.kind === "newsletter") {
@@ -143,7 +133,9 @@ function deriveInitialFilter(
   return undefined;
 }
 
-function kindForAudienceMode(mode: AudienceInitialFilter): CampaignKind {
+export function kindForAudienceMode(
+  mode: AudienceInitialFilter,
+): CampaignKind {
   return mode === "all_approved" ? "newsletter" : "project";
 }
 
@@ -185,7 +177,7 @@ function readTimeZoneParts(
   );
 }
 
-function buildDenverInputDefaults(now: Date): {
+export function buildDenverInputDefaults(now: Date): {
   readonly date: string;
   readonly time: string;
 } {
@@ -228,7 +220,7 @@ function convertDenverInputToDate(date: string, time: string): Date | null {
   return new Date(guess.getTime() + (desiredUtc - observedUtc));
 }
 
-function deriveSuggestedSenderEmail(input: {
+export function deriveSuggestedSenderEmail(input: {
   readonly kind: CampaignKind;
   readonly criteria: CampaignAudienceCriteria;
   readonly bootstrap: AudienceBuilderBootstrap;
@@ -251,7 +243,7 @@ function deriveSuggestedSenderEmail(input: {
   );
 }
 
-function readAliasProjectsForSender(
+export function readAliasProjectsForSender(
   bootstrap: AudienceBuilderBootstrap,
   senderOption: CampaignSenderOption | null,
 ): readonly CampaignProjectOption[] {
@@ -309,7 +301,7 @@ function buildCriteriaForMode(input: {
   };
 }
 
-function clearAudienceCriteria(
+export function clearAudienceCriteria(
   criteria: CampaignAudienceCriteria,
 ): CampaignAudienceCriteria {
   return {
@@ -381,555 +373,86 @@ export function NewCampaignWizard({
   readonly draft: CampaignWizardDraftData;
   readonly isAdmin: boolean;
 }) {
-  const initialSchedule = buildDenverInputDefaults(new Date());
-  const initialAudienceMode = deriveInitialFilter(draft);
-  const [currentStep, setCurrentStep] = useState(
-    draft.state === "draft" ? 0 : 5,
-  );
-  const [launchType, setLaunchType] = useState<LaunchType>(draft.launchType);
-  const [name, setName] = useState(draft.name ?? "");
-  const [fromEmail, setFromEmail] = useState(draft.fromEmail);
-  const [replyToEmail, setReplyToEmail] = useState(draft.replyToEmail);
-  const [subject, setSubject] = useState(draft.subjectTemplate ?? "");
-  const [preheader, setPreheader] = useState(draft.preheader ?? "");
-  const [bodyPlaintext, setBodyPlaintext] = useState(
-    draft.bodyTextTemplate ?? "",
-  );
-  const [bodyHtml, setBodyHtml] = useState(draft.bodyHtmlTemplate ?? "");
-  const [criteria, setCriteria] = useState<CampaignAudienceCriteria>({
-    ...draft.audienceCriteria,
-    projectId:
-      draft.audienceCriteria.projectId ??
-      draft.audienceCriteria.projectIds[0] ??
-      null,
-    contactIds: draft.audienceCriteria.contactIds ?? [],
-    initialFilter: initialAudienceMode,
-  });
-  const [hasPickedAudienceMode, setHasPickedAudienceMode] = useState(
-    initialAudienceMode !== undefined,
-  );
-  const [countState, setCountState] = useState({
-    count: draft.audienceSize ?? 0,
-    hasAppliedFilters: hasAppliedAudienceFilters({
-      ...draft.audienceCriteria,
-      projectId:
-      draft.audienceCriteria.projectId ??
-      draft.audienceCriteria.projectIds[0] ??
-      null,
-      contactIds: draft.audienceCriteria.contactIds ?? [],
-      initialFilter: initialAudienceMode,
-    }),
-  });
-  const [previewRows, setPreviewRows] = useState<readonly AudiencePreviewRow[]>(
-    [],
-  );
-  const [previewErrorMessage, setPreviewErrorMessage] = useState<string | null>(
-    null,
-  );
-  const [statusCounts, setStatusCounts] = useState<AudienceStatusCounts>({});
-  const [statusCountsLoading, setStatusCountsLoading] = useState(false);
-  const [statusCountsErrorMessage, setStatusCountsErrorMessage] = useState<
-    string | null
-  >(null);
-  const [volunteerSearchQuery, setVolunteerSearchQuery] = useState("");
-  const [volunteerSearchRows, setVolunteerSearchRows] = useState<
-    readonly AudienceVolunteerSearchRow[]
-  >([]);
-  const [volunteerSearchErrorMessage, setVolunteerSearchErrorMessage] =
-    useState<string | null>(null);
-  const [composePreview, setComposePreview] =
-    useState<ComposePreviewData | null>(null);
-  const [sampleIndex, setSampleIndex] = useState(0);
-  const [saveState, setSaveState] = useState<SaveState>("idle");
-  const [saveMessage, setSaveMessage] = useState<string | null>(null);
-  const [warningDismissFingerprint, setWarningDismissFingerprint] = useState<
-    string | null
-  >(null);
-  const [testSendOpen, setTestSendOpen] = useState(false);
-  const [testRecipientEmail, setTestRecipientEmail] = useState(
-    draft.operatorEmail,
-  );
-  const [affectedContactsOpen, setAffectedContactsOpen] = useState(false);
-  const [sendMode, setSendMode] = useState<"now" | "later">("now");
-  const [scheduleDate, setScheduleDate] = useState(initialSchedule.date);
-  const [scheduleTime, setScheduleTime] = useState(initialSchedule.time);
-  const [confirmOpen, setConfirmOpen] = useState(false);
-  const [runState, setRunState] = useState(draft.state);
-  const [scheduledAt, setScheduledAt] = useState(draft.scheduledAt);
-  const [toast, setToast] = useState<ToastState>(null);
-  const [countLoading, setCountLoading] = useState(false);
-  const [audiencePreviewLoading, setAudiencePreviewLoading] = useState(false);
-  const [, startCountTransition] = useTransition();
-  const [composePreviewPending, startComposePreviewTransition] = useTransition();
-  const [, startStatusCountsTransition] = useTransition();
-  const [volunteerSearchPending, startVolunteerSearchTransition] =
-    useTransition();
-  const [savePending, startSaveTransition] = useTransition();
-  const [submitPending, startSubmitTransition] = useTransition();
-  const [testSendPending, startTestSendTransition] = useTransition();
-  const countRequestRef = useRef(0);
-  const statusCountsRequestRef = useRef(0);
-  const audiencePreviewRequestRef = useRef(0);
-  const volunteerSearchRequestRef = useRef(0);
-  const composePreviewRequestRef = useRef(0);
-  const savedFingerprintRef = useRef("");
-  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const previousLaunchTypeRef = useRef(draft.launchType);
-  const previousFromEmailRef = useRef(draft.fromEmail);
-
-  const frozen = runState !== "draft";
-  const previewFingerprint = useMemo(
-    () => JSON.stringify({ subject, bodyPlaintext, bodyHtml }),
-    [bodyHtml, bodyPlaintext, subject],
-  );
-  const selectedSenderOption = useMemo<CampaignSenderOption | null>(() => {
-    if (fromEmail === null) {
-      return null;
-    }
-
-    return (
-      bootstrap.senderOptions.find(
-        (option) => option.email === fromEmail && option.status === "verified",
-      ) ??
-      bootstrap.senderOptions.find((option) => option.email === fromEmail) ??
-      null
-    );
-  }, [bootstrap.senderOptions, fromEmail]);
-  const aliasProjects = useMemo(
-    () => readAliasProjectsForSender(bootstrap, selectedSenderOption),
-    [bootstrap, selectedSenderOption],
-  );
-  const aliasProjectIds = useMemo(
-    () => normalizeProjectIds(aliasProjects.map((project) => project.id)),
-    [aliasProjects],
-  );
-  const kind =
-    criteria.initialFilter === undefined
-      ? draft.kind
-      : kindForAudienceMode(criteria.initialFilter);
-  const fingerprint = useMemo(
-    () =>
-      JSON.stringify({
-        launchType,
-        kind,
-        name: name.trim() || null,
-        fromEmail,
-        replyToEmail,
-        subject,
-        preheader,
-        bodyPlaintext,
-        bodyHtml,
-        criteria,
-        audienceSize: countState.hasAppliedFilters ? countState.count : null,
-      }),
-    [
-      bodyHtml,
-      bodyPlaintext,
-      countState.count,
-      countState.hasAppliedFilters,
-      criteria,
-      fromEmail,
-      kind,
-      launchType,
-      name,
-      preheader,
-      replyToEmail,
-      subject,
-    ],
-  );
-  const dirty = fingerprint !== savedFingerprintRef.current;
-  const selectedSenderVerified = frozen
-    ? true
-    : selectedSenderOption?.status === "verified";
-  const suggestedSenderEmail = useMemo(
-    () => deriveSuggestedSenderEmail({ kind, criteria, bootstrap }),
-    [bootstrap, criteria, kind],
-  );
-  const selectedProjectIds = readProjectIds(criteria);
-  const selectedProjectIdsKey = selectedProjectIds.join(",");
-  const warningDismissed =
-    warningDismissFingerprint !== null &&
-    warningDismissFingerprint === previewFingerprint;
-
-  useEffect(() => {
-    const initialCriteria = {
-      ...draft.audienceCriteria,
-      projectId:
-        draft.audienceCriteria.projectId ??
-        draft.audienceCriteria.projectIds[0] ??
-        null,
-      contactIds: draft.audienceCriteria.contactIds ?? [],
-      initialFilter: initialAudienceMode,
-    };
-    savedFingerprintRef.current = JSON.stringify({
-      launchType: draft.launchType,
-      kind:
-        initialCriteria.initialFilter === undefined
-          ? draft.kind
-          : kindForAudienceMode(initialCriteria.initialFilter),
-      name: draft.name,
-      fromEmail: draft.fromEmail,
-      replyToEmail: draft.replyToEmail,
-      subject: draft.subjectTemplate ?? "",
-      preheader: draft.preheader ?? "",
-      bodyPlaintext: draft.bodyTextTemplate ?? "",
-      bodyHtml: draft.bodyHtmlTemplate ?? "",
-      criteria: initialCriteria,
-      audienceSize: draft.audienceSize,
-    });
-  }, [draft, initialAudienceMode]);
-
-  useEffect(() => {
-    if (fromEmail === null && suggestedSenderEmail !== null) {
-      setFromEmail(suggestedSenderEmail);
-      setReplyToEmail(suggestedSenderEmail);
-    }
-  }, [fromEmail, suggestedSenderEmail]);
-
-  useEffect(() => {
-    const currentMode = criteria.initialFilter;
-    if (
-      !hasPickedAudienceMode ||
-      selectedSenderOption === null ||
-      currentMode === undefined ||
-      currentMode === "all_approved" ||
-      aliasProjects.length === 0
-    ) {
-      return;
-    }
-
-    const currentProjectIds = readProjectIds(criteria);
-    if (currentProjectIds.length > 0) {
-      return;
-    }
-
-    setCriteria((current) =>
-      buildCriteriaForMode({
-        current,
-        mode: currentMode,
-        aliasProjects,
-      }),
-    );
-  }, [aliasProjects, criteria, criteria.initialFilter, hasPickedAudienceMode, selectedSenderOption]);
-
-  useEffect(() => {
-    if (previousLaunchTypeRef.current === launchType) {
-      return;
-    }
-
-    previousLaunchTypeRef.current = launchType;
-    setCriteria((current) => {
-      if (!hasPickedAudienceMode) {
-        return clearAudienceCriteria(current);
-      }
-
-      return buildCriteriaForMode({
-        current,
-        mode: defaultAudienceModeForLaunchType(launchType),
-        aliasProjects,
-      });
-    });
-    setVolunteerSearchQuery("");
-    setVolunteerSearchRows([]);
-    setVolunteerSearchErrorMessage(null);
-  }, [aliasProjects, hasPickedAudienceMode, launchType]);
-
-  useEffect(() => {
-    if (previousFromEmailRef.current === fromEmail) {
-      return;
-    }
-
-    previousFromEmailRef.current = fromEmail;
-    setCriteria((current) => {
-      if (!hasPickedAudienceMode || current.initialFilter === undefined) {
-        return clearAudienceCriteria(current);
-      }
-
-      return buildCriteriaForMode({
-        current,
-        mode: current.initialFilter,
-        aliasProjects,
-      });
-    });
-    setVolunteerSearchQuery("");
-    setVolunteerSearchRows([]);
-    setVolunteerSearchErrorMessage(null);
-  }, [aliasProjects, criteria.initialFilter, fromEmail, hasPickedAudienceMode]);
-
-  useEffect(() => {
-    setReplyToEmail(fromEmail);
-  }, [fromEmail]);
-
-  useEffect(() => {
-    if (!hasPickedAudienceMode || criteria.initialFilter !== "project_status") {
-      setStatusCounts({});
-      setStatusCountsLoading(false);
-      setStatusCountsErrorMessage(null);
-      return;
-    }
-
-    if (selectedProjectIds.length === 0) {
-      setStatusCounts({});
-      setStatusCountsLoading(false);
-      setStatusCountsErrorMessage(null);
-      return;
-    }
-
-    const requestId = ++statusCountsRequestRef.current;
-    setStatusCountsLoading(true);
-    setStatusCountsErrorMessage(null);
-    startStatusCountsTransition(async () => {
-      const result = await loadMemberStatusCountsForProjects(selectedProjectIds);
-      if (requestId !== statusCountsRequestRef.current) {
-        return;
-      }
-
-      if (!result.ok) {
-        setStatusCounts({});
-        setStatusCountsLoading(false);
-        setStatusCountsErrorMessage(result.message);
-        return;
-      }
-
-      setStatusCounts(result.data);
-      setStatusCountsLoading(false);
-      setStatusCountsErrorMessage(null);
-      setCriteria((current) => {
-        const availableStatuses = bootstrap.statuses.filter(
-          (status) => (result.data[status] ?? 0) > 0,
-        );
-        const selectedStatuses = current.statuses.filter((status) =>
-          availableStatuses.includes(status),
-        );
-
-        return selectedStatuses.length === current.statuses.length
-          ? current
-          : {
-              ...current,
-              statuses: selectedStatuses,
-            };
-      });
-    });
-  }, [bootstrap.statuses, criteria.initialFilter, hasPickedAudienceMode, selectedProjectIdsKey]);
-
-  useEffect(() => {
-    if (frozen) {
-      setCountLoading(false);
-      return;
-    }
-
-    if (!hasPickedAudienceMode || criteria.initialFilter === undefined) {
-      countRequestRef.current += 1;
-      setCountLoading(false);
-      setCountState({ count: 0, hasAppliedFilters: false });
-      return;
-    }
-
-    const audienceMode = criteria.initialFilter;
-    if (audienceMode === "project_status" && criteria.statuses.length === 0) {
-      countRequestRef.current += 1;
-      setCountLoading(false);
-      setCountState({ count: 0, hasAppliedFilters: true });
-      return;
-    }
-
-    const requestId = ++countRequestRef.current;
-    setCountLoading(true);
-    startCountTransition(async () => {
-      const result = await resolveAudienceCountAction({
-        kind,
-        criteria: toActionCriteria(criteria),
-      });
-      if (requestId !== countRequestRef.current) {
-        return;
-      }
-
-      setCountLoading(false);
-      if (!result.ok) {
-        setSaveMessage(result.message);
-        return;
-      }
-
-      setCountState(result.data);
-    });
-  }, [criteria, frozen, hasPickedAudienceMode, kind]);
-
-  useEffect(() => {
-    if (currentStep !== 2 || !hasPickedAudienceMode) {
-      setAudiencePreviewLoading(false);
-      setPreviewRows([]);
-      setPreviewErrorMessage(null);
-      return;
-    }
-
-    const requestId = ++audiencePreviewRequestRef.current;
-    setAudiencePreviewLoading(true);
-    setPreviewErrorMessage(null);
-    void (async () => {
-      const result = await previewAudienceAction({
-        kind,
-        criteria: toActionCriteria(criteria),
-      });
-      if (requestId !== audiencePreviewRequestRef.current) {
-        return;
-      }
-
-      setAudiencePreviewLoading(false);
-      if (!result.ok) {
-        setPreviewErrorMessage(result.message);
-        return;
-      }
-
-      setPreviewRows(result.data);
-      setPreviewErrorMessage(null);
-    })();
-  }, [criteria, currentStep, hasPickedAudienceMode, kind]);
-
-  useEffect(() => {
-    if (
-      currentStep !== 2 ||
-      !hasPickedAudienceMode ||
-      criteria.initialFilter !== "specific"
-    ) {
-      setVolunteerSearchRows([]);
-      setVolunteerSearchErrorMessage(null);
-      return;
-    }
-
-    if (aliasProjectIds.length === 0 || volunteerSearchQuery.trim().length < 2) {
-      setVolunteerSearchRows([]);
-      setVolunteerSearchErrorMessage(null);
-      return;
-    }
-
-    const requestId = ++volunteerSearchRequestRef.current;
-    const timer = setTimeout(() => {
-      startVolunteerSearchTransition(async () => {
-        const result = await searchProjectVolunteersAction({
-          aliasProjectIds,
-          query: volunteerSearchQuery,
-        });
-        if (requestId !== volunteerSearchRequestRef.current) {
-          return;
-        }
-
-        if (!result.ok) {
-          setVolunteerSearchErrorMessage(result.message);
-          return;
-        }
-
-        setVolunteerSearchRows(result.data);
-        setVolunteerSearchErrorMessage(null);
-      });
-    }, 250);
-
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [
-    aliasProjectIds,
-    criteria.initialFilter,
+  const {
     currentStep,
-    hasPickedAudienceMode,
-    volunteerSearchQuery,
-  ]);
-
-  useEffect(() => {
-    if (currentStep < 3) {
-      return;
-    }
-
-    const requestId = ++composePreviewRequestRef.current;
-    const timer = setTimeout(() => {
-      startComposePreviewTransition(async () => {
-        const result = await loadComposePreviewAction({
-          kind,
-          criteria: toActionCriteria(criteria),
-          fromEmail,
-          subjectTemplate: subject,
-          bodyHtmlTemplate: bodyHtml,
-          bodyTextTemplate: bodyPlaintext,
-          sampleIndex,
-        });
-        if (requestId !== composePreviewRequestRef.current) {
-          return;
-        }
-
-        if (!result.ok) {
-          setToast({
-            tone: "error",
-            message: result.message,
-          });
-          return;
-        }
-
-        setComposePreview(result.data);
-        setSampleIndex(result.data.sampleIndex);
-      });
-    }, 150);
-
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [
-    bodyHtml,
-    bodyPlaintext,
-    criteria,
-    currentStep,
+    setCurrentStep,
+    launchType,
+    setLaunchType,
+    name,
+    setName,
     fromEmail,
-    kind,
-    sampleIndex,
+    setFromEmail,
+    replyToEmail,
     subject,
-  ]);
-
-  useEffect(() => {
-    setSampleIndex(0);
-    setWarningDismissFingerprint(null);
-  }, [bodyHtml, bodyPlaintext, subject]);
-
-  useEffect(() => {
-    if (!dirty || frozen) {
-      return;
-    }
-
-    const handler = (event: BeforeUnloadEvent) => {
-      event.preventDefault();
-      Reflect.set(event, "returnValue", "");
-    };
-
-    window.addEventListener("beforeunload", handler);
-    return () => {
-      window.removeEventListener("beforeunload", handler);
-    };
-  }, [dirty, frozen]);
-
-  useEffect(() => {
-    if (!dirty || frozen) {
-      return;
-    }
-
-    const interval = setInterval(() => {
-      void persistDraft("Autosaved");
-    }, 30_000);
-
-    return () => {
-      clearInterval(interval);
-    };
-  }, [dirty, fingerprint, frozen]);
-
-  useEffect(() => {
-    if (toast === null) {
-      return;
-    }
-
-    const timer = setTimeout(() => {
-      setToast(null);
-    }, 3000);
-
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [toast]);
+    setSubject,
+    preheader,
+    setPreheader,
+    bodyPlaintext,
+    setBodyPlaintext,
+    bodyHtml,
+    setBodyHtml,
+    criteria,
+    setCriteria,
+    hasPickedAudienceMode,
+    setHasPickedAudienceMode,
+    countState,
+    previewRows,
+    previewErrorMessage,
+    statusCounts,
+    statusCountsLoading,
+    statusCountsErrorMessage,
+    volunteerSearchQuery,
+    setVolunteerSearchQuery,
+    volunteerSearchRows,
+    setVolunteerSearchRows,
+    volunteerSearchPending,
+    volunteerSearchErrorMessage,
+    setVolunteerSearchErrorMessage,
+    composePreview,
+    composePreviewPending,
+    setSampleIndex,
+    setSaveState,
+    setSaveMessage,
+    setWarningDismissFingerprint,
+    testSendOpen,
+    setTestSendOpen,
+    testRecipientEmail,
+    setTestRecipientEmail,
+    affectedContactsOpen,
+    setAffectedContactsOpen,
+    sendMode,
+    setSendMode,
+    scheduleDate,
+    setScheduleDate,
+    scheduleTime,
+    setScheduleTime,
+    confirmOpen,
+    setConfirmOpen,
+    runState,
+    setRunState,
+    scheduledAt,
+    setScheduledAt,
+    toast,
+    setToast,
+    countLoading,
+    audiencePreviewLoading,
+    startSaveTransition,
+    submitPending,
+    startSubmitTransition,
+    testSendPending,
+    startTestSendTransition,
+    savedFingerprintRef,
+    saveTimeoutRef,
+    autosavePersistDraftRef,
+    frozen,
+    kind,
+    dirty,
+    selectedSenderVerified,
+    aliasProjects,
+    previewFingerprint,
+    warningDismissed,
+    statusLabel,
+  } = useNewCampaignWizardState({ bootstrap, draft });
 
   async function persistDraft(successMessage: string): Promise<boolean> {
     if (frozen || !dirty) {
@@ -997,6 +520,8 @@ export function NewCampaignWizard({
       });
     });
   }
+
+  autosavePersistDraftRef.current = persistDraft;
 
   function updateCriteria(
     mutator: (current: CampaignAudienceCriteria) => CampaignAudienceCriteria,
@@ -1146,17 +671,6 @@ export function NewCampaignWizard({
       });
     });
   }
-
-  const statusLabel =
-    saveState === "saving" || savePending
-      ? "Saving draft…"
-      : saveState === "saved"
-        ? (saveMessage ?? "Saved")
-        : saveState === "error"
-          ? (saveMessage ?? "Save failed")
-          : dirty
-            ? "Unsaved changes"
-            : "All changes saved";
 
   return (
     <div className="flex min-h-dvh w-full bg-slate-100 max-lg:flex-col">

--- a/apps/web/app/broadcasts/new/_components/use-new-campaign-wizard-state.ts
+++ b/apps/web/app/broadcasts/new/_components/use-new-campaign-wizard-state.ts
@@ -1,0 +1,921 @@
+import { useEffect, useMemo, useRef, useState, useTransition } from "react";
+
+import type {
+  AudienceCriteria,
+  CampaignKind,
+  LaunchType,
+} from "@as-comms/contracts";
+
+import type {
+  AudienceBuilderBootstrap,
+  AudiencePreviewRow,
+  AudienceStatusCounts,
+  AudienceVolunteerSearchRow,
+  CampaignProjectOption,
+  CampaignSenderOption,
+  CampaignWizardDraftData,
+  ComposePreviewData,
+} from "../../_lib/audience-data-source";
+import {
+  loadComposePreviewAction,
+  loadMemberStatusCountsForProjects,
+  previewAudienceAction,
+  resolveAudienceCountAction,
+  searchProjectVolunteersAction,
+} from "../../_lib/audience-data-source";
+import type {
+  AudienceInitialFilter,
+  CampaignAudienceCriteria,
+} from "./audience-builder-step";
+
+type AutosavePersistDraft = (successMessage: string) => Promise<boolean>;
+
+function normalizeProjectIds(projectIds: readonly string[]): string[] {
+  return projectIds.filter(
+    (projectId, index, values) =>
+      projectId.trim().length > 0 && values.indexOf(projectId) === index,
+  );
+}
+
+function readProjectIds(criteria: CampaignAudienceCriteria): string[] {
+  return normalizeProjectIds([
+    ...(criteria.projectId == null ? [] : [criteria.projectId]),
+    ...criteria.projectIds,
+  ]);
+}
+
+function defaultAudienceModeForLaunchType(
+  launchType: LaunchType,
+): AudienceInitialFilter {
+  return launchType === "html_email" ? "all_approved" : "project_status";
+}
+
+function hasAppliedAudienceFilters(criteria: CampaignAudienceCriteria): boolean {
+  if (criteria.initialFilter === undefined) {
+    return false;
+  }
+
+  switch (criteria.initialFilter) {
+    case "all_approved":
+    case "project_status":
+    case "specific":
+      return true;
+  }
+}
+
+function deriveInitialFilter(
+  draft: CampaignWizardDraftData,
+): AudienceInitialFilter | undefined {
+  if (draft.kind === "newsletter") {
+    return "all_approved";
+  }
+
+  if ((draft.audienceCriteria.contactIds?.length ?? 0) > 0) {
+    return "specific";
+  }
+
+  if (
+    draft.audienceCriteria.projectId !== null ||
+    draft.audienceCriteria.projectIds.length > 0 ||
+    draft.audienceCriteria.statuses.length > 0
+  ) {
+    return "project_status";
+  }
+
+  return undefined;
+}
+
+function kindForAudienceMode(mode: AudienceInitialFilter): CampaignKind {
+  return mode === "all_approved" ? "newsletter" : "project";
+}
+
+function readTimeZoneParts(
+  date: Date,
+  timeZone: string,
+): Record<"year" | "month" | "day" | "hour" | "minute", string> {
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+
+  return formatter.formatToParts(date).reduce(
+    (parts, part) => {
+      if (
+        part.type === "year" ||
+        part.type === "month" ||
+        part.type === "day" ||
+        part.type === "hour" ||
+        part.type === "minute"
+      ) {
+        parts[part.type] = part.value;
+      }
+
+      return parts;
+    },
+    {
+      year: "0000",
+      month: "00",
+      day: "00",
+      hour: "00",
+      minute: "00",
+    },
+  );
+}
+
+function buildDenverInputDefaults(now: Date): {
+  readonly date: string;
+  readonly time: string;
+} {
+  const rounded = new Date(now);
+  rounded.setMinutes(rounded.getMinutes() + 60);
+  rounded.setSeconds(0, 0);
+
+  const parts = readTimeZoneParts(rounded, "America/Denver");
+  return {
+    date: `${parts.year}-${parts.month}-${parts.day}`,
+    time: `${parts.hour}:${parts.minute}`,
+  };
+}
+
+function deriveSuggestedSenderEmail(input: {
+  readonly kind: CampaignKind;
+  readonly criteria: CampaignAudienceCriteria;
+  readonly bootstrap: AudienceBuilderBootstrap;
+}): string | null {
+  if (input.kind !== "project") {
+    return null;
+  }
+
+  const projectId = readProjectIds(input.criteria)[0] ?? null;
+  if (projectId === null) {
+    return null;
+  }
+
+  return (
+    input.bootstrap.senderOptions.find(
+      (option) =>
+        option.projectId === projectId && option.status === "verified",
+    )?.email ?? null
+  );
+}
+
+function readAliasProjectsForSender(
+  bootstrap: AudienceBuilderBootstrap,
+  senderOption: CampaignSenderOption | null,
+): readonly CampaignProjectOption[] {
+  if (senderOption === null) {
+    return [];
+  }
+
+  const hostProjectId =
+    senderOption.connectedToProjectId ?? senderOption.projectId;
+  const group =
+    bootstrap.projects.find((candidate) => candidate.host.id === hostProjectId) ??
+    null;
+  if (group === null) {
+    return [];
+  }
+
+  return [group.host, ...group.connectedSubs];
+}
+
+function buildCriteriaForMode(input: {
+  readonly current: CampaignAudienceCriteria;
+  readonly mode: AudienceInitialFilter;
+  readonly aliasProjects: readonly CampaignProjectOption[];
+}): CampaignAudienceCriteria {
+  const aliasProjectIds = input.aliasProjects.map((project) => project.id);
+
+  if (input.mode === "all_approved") {
+    return {
+      ...input.current,
+      initialFilter: "all_approved",
+      projectId: null,
+      projectIds: [],
+      statuses: [],
+      contactIds: [],
+    };
+  }
+
+  if (input.mode === "specific") {
+    return {
+      ...input.current,
+      initialFilter: "specific",
+      projectId: aliasProjectIds[0] ?? null,
+      projectIds: aliasProjectIds,
+      statuses: [],
+      contactIds: [],
+    };
+  }
+
+  return {
+    ...input.current,
+    initialFilter: "project_status",
+    projectId: aliasProjectIds[0] ?? null,
+    projectIds: aliasProjectIds,
+    statuses: [],
+    contactIds: [],
+  };
+}
+
+function clearAudienceCriteria(
+  criteria: CampaignAudienceCriteria,
+): CampaignAudienceCriteria {
+  return {
+    ...criteria,
+    initialFilter: undefined,
+    projectId: null,
+    projectIds: [],
+    statuses: [],
+    contactIds: [],
+  };
+}
+
+function toActionCriteria(
+  criteria: CampaignAudienceCriteria,
+): AudienceCriteria & {
+  readonly initialFilter?: AudienceInitialFilter;
+} {
+  if (criteria.initialFilter === undefined) {
+    const rest = { ...criteria };
+    delete rest.initialFilter;
+    return rest as Omit<CampaignAudienceCriteria, "initialFilter">;
+  }
+
+  return {
+    ...criteria,
+    initialFilter: criteria.initialFilter,
+  };
+}
+
+export function useNewCampaignWizardState({
+  bootstrap,
+  draft,
+}: {
+  readonly bootstrap: AudienceBuilderBootstrap;
+  readonly draft: CampaignWizardDraftData;
+}) {
+  const initialSchedule = buildDenverInputDefaults(new Date());
+  const initialAudienceMode = deriveInitialFilter(draft);
+  const [currentStep, setCurrentStep] = useState(
+    draft.state === "draft" ? 0 : 5,
+  );
+  const [launchType, setLaunchType] = useState<LaunchType>(draft.launchType);
+  const [name, setName] = useState(draft.name ?? "");
+  const [fromEmail, setFromEmail] = useState(draft.fromEmail);
+  const [replyToEmail, setReplyToEmail] = useState(draft.replyToEmail);
+  const [subject, setSubject] = useState(draft.subjectTemplate ?? "");
+  const [preheader, setPreheader] = useState(draft.preheader ?? "");
+  const [bodyPlaintext, setBodyPlaintext] = useState(
+    draft.bodyTextTemplate ?? "",
+  );
+  const [bodyHtml, setBodyHtml] = useState(draft.bodyHtmlTemplate ?? "");
+  const [criteria, setCriteria] = useState<CampaignAudienceCriteria>({
+    ...draft.audienceCriteria,
+    projectId:
+      draft.audienceCriteria.projectId ??
+      draft.audienceCriteria.projectIds[0] ??
+      null,
+    contactIds: draft.audienceCriteria.contactIds ?? [],
+    initialFilter: initialAudienceMode,
+  });
+  const [hasPickedAudienceMode, setHasPickedAudienceMode] = useState(
+    initialAudienceMode !== undefined,
+  );
+  const [countState, setCountState] = useState({
+    count: draft.audienceSize ?? 0,
+    hasAppliedFilters: hasAppliedAudienceFilters({
+      ...draft.audienceCriteria,
+      projectId:
+        draft.audienceCriteria.projectId ??
+        draft.audienceCriteria.projectIds[0] ??
+        null,
+      contactIds: draft.audienceCriteria.contactIds ?? [],
+      initialFilter: initialAudienceMode,
+    }),
+  });
+  const [previewRows, setPreviewRows] = useState<readonly AudiencePreviewRow[]>(
+    [],
+  );
+  const [previewErrorMessage, setPreviewErrorMessage] = useState<string | null>(
+    null,
+  );
+  const [statusCounts, setStatusCounts] = useState<AudienceStatusCounts>({});
+  const [statusCountsLoading, setStatusCountsLoading] = useState(false);
+  const [statusCountsErrorMessage, setStatusCountsErrorMessage] = useState<
+    string | null
+  >(null);
+  const [volunteerSearchQuery, setVolunteerSearchQuery] = useState("");
+  const [volunteerSearchRows, setVolunteerSearchRows] = useState<
+    readonly AudienceVolunteerSearchRow[]
+  >([]);
+  const [volunteerSearchErrorMessage, setVolunteerSearchErrorMessage] =
+    useState<string | null>(null);
+  const [composePreview, setComposePreview] =
+    useState<ComposePreviewData | null>(null);
+  const [sampleIndex, setSampleIndex] = useState(0);
+  const [saveState, setSaveState] = useState<
+    "idle" | "saving" | "saved" | "error"
+  >("idle");
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const [warningDismissFingerprint, setWarningDismissFingerprint] = useState<
+    string | null
+  >(null);
+  const [testSendOpen, setTestSendOpen] = useState(false);
+  const [testRecipientEmail, setTestRecipientEmail] = useState(
+    draft.operatorEmail,
+  );
+  const [affectedContactsOpen, setAffectedContactsOpen] = useState(false);
+  const [sendMode, setSendMode] = useState<"now" | "later">("now");
+  const [scheduleDate, setScheduleDate] = useState(initialSchedule.date);
+  const [scheduleTime, setScheduleTime] = useState(initialSchedule.time);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [runState, setRunState] = useState(draft.state);
+  const [scheduledAt, setScheduledAt] = useState(draft.scheduledAt);
+  const [toast, setToast] = useState<{
+    readonly tone: "success" | "error";
+    readonly message: string;
+  } | null>(null);
+  const [countLoading, setCountLoading] = useState(false);
+  const [audiencePreviewLoading, setAudiencePreviewLoading] = useState(false);
+  const [, startCountTransition] = useTransition();
+  const [composePreviewPending, startComposePreviewTransition] = useTransition();
+  const [, startStatusCountsTransition] = useTransition();
+  const [volunteerSearchPending, startVolunteerSearchTransition] =
+    useTransition();
+  const [savePending, startSaveTransition] = useTransition();
+  const [submitPending, startSubmitTransition] = useTransition();
+  const [testSendPending, startTestSendTransition] = useTransition();
+  const countRequestRef = useRef(0);
+  const statusCountsRequestRef = useRef(0);
+  const audiencePreviewRequestRef = useRef(0);
+  const volunteerSearchRequestRef = useRef(0);
+  const composePreviewRequestRef = useRef(0);
+  const savedFingerprintRef = useRef("");
+  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const previousLaunchTypeRef = useRef(draft.launchType);
+  const previousFromEmailRef = useRef(draft.fromEmail);
+  const autosavePersistDraftRef = useRef<AutosavePersistDraft | null>(null);
+
+  const frozen = runState !== "draft";
+  const previewFingerprint = useMemo(
+    () => JSON.stringify({ subject, bodyPlaintext, bodyHtml }),
+    [bodyHtml, bodyPlaintext, subject],
+  );
+  const selectedSenderOption = useMemo<CampaignSenderOption | null>(() => {
+    if (fromEmail === null) {
+      return null;
+    }
+
+    return (
+      bootstrap.senderOptions.find(
+        (option) => option.email === fromEmail && option.status === "verified",
+      ) ??
+      bootstrap.senderOptions.find((option) => option.email === fromEmail) ??
+      null
+    );
+  }, [bootstrap.senderOptions, fromEmail]);
+  const aliasProjects = useMemo(
+    () => readAliasProjectsForSender(bootstrap, selectedSenderOption),
+    [bootstrap, selectedSenderOption],
+  );
+  const aliasProjectIds = useMemo(
+    () => normalizeProjectIds(aliasProjects.map((project) => project.id)),
+    [aliasProjects],
+  );
+  const kind =
+    criteria.initialFilter === undefined
+      ? draft.kind
+      : kindForAudienceMode(criteria.initialFilter);
+  const fingerprint = useMemo(
+    () =>
+      JSON.stringify({
+        launchType,
+        kind,
+        name: name.trim() || null,
+        fromEmail,
+        replyToEmail,
+        subject,
+        preheader,
+        bodyPlaintext,
+        bodyHtml,
+        criteria,
+        audienceSize: countState.hasAppliedFilters ? countState.count : null,
+      }),
+    [
+      bodyHtml,
+      bodyPlaintext,
+      countState.count,
+      countState.hasAppliedFilters,
+      criteria,
+      fromEmail,
+      kind,
+      launchType,
+      name,
+      preheader,
+      replyToEmail,
+      subject,
+    ],
+  );
+  const dirty = fingerprint !== savedFingerprintRef.current;
+  const selectedSenderVerified = frozen
+    ? true
+    : selectedSenderOption?.status === "verified";
+  const suggestedSenderEmail = useMemo(
+    () => deriveSuggestedSenderEmail({ kind, criteria, bootstrap }),
+    [bootstrap, criteria, kind],
+  );
+  const selectedProjectIds = readProjectIds(criteria);
+  const selectedProjectIdsKey = selectedProjectIds.join(",");
+  const warningDismissed =
+    warningDismissFingerprint !== null &&
+    warningDismissFingerprint === previewFingerprint;
+
+  useEffect(() => {
+    const initialCriteria = {
+      ...draft.audienceCriteria,
+      projectId:
+        draft.audienceCriteria.projectId ??
+        draft.audienceCriteria.projectIds[0] ??
+        null,
+      contactIds: draft.audienceCriteria.contactIds ?? [],
+      initialFilter: initialAudienceMode,
+    };
+    savedFingerprintRef.current = JSON.stringify({
+      launchType: draft.launchType,
+      kind:
+        initialCriteria.initialFilter === undefined
+          ? draft.kind
+          : kindForAudienceMode(initialCriteria.initialFilter),
+      name: draft.name,
+      fromEmail: draft.fromEmail,
+      replyToEmail: draft.replyToEmail,
+      subject: draft.subjectTemplate ?? "",
+      preheader: draft.preheader ?? "",
+      bodyPlaintext: draft.bodyTextTemplate ?? "",
+      bodyHtml: draft.bodyHtmlTemplate ?? "",
+      criteria: initialCriteria,
+      audienceSize: draft.audienceSize,
+    });
+  }, [draft, initialAudienceMode]);
+
+  useEffect(() => {
+    if (fromEmail === null && suggestedSenderEmail !== null) {
+      setFromEmail(suggestedSenderEmail);
+      setReplyToEmail(suggestedSenderEmail);
+    }
+  }, [fromEmail, suggestedSenderEmail]);
+
+  useEffect(() => {
+    const currentMode = criteria.initialFilter;
+    if (
+      !hasPickedAudienceMode ||
+      selectedSenderOption === null ||
+      currentMode === undefined ||
+      currentMode === "all_approved" ||
+      aliasProjects.length === 0
+    ) {
+      return;
+    }
+
+    const currentProjectIds = readProjectIds(criteria);
+    if (currentProjectIds.length > 0) {
+      return;
+    }
+
+    setCriteria((current) =>
+      buildCriteriaForMode({
+        current,
+        mode: currentMode,
+        aliasProjects,
+      }),
+    );
+  }, [
+    aliasProjects,
+    criteria,
+    criteria.initialFilter,
+    hasPickedAudienceMode,
+    selectedSenderOption,
+  ]);
+
+  useEffect(() => {
+    if (previousLaunchTypeRef.current === launchType) {
+      return;
+    }
+
+    previousLaunchTypeRef.current = launchType;
+    setCriteria((current) => {
+      if (!hasPickedAudienceMode) {
+        return clearAudienceCriteria(current);
+      }
+
+      return buildCriteriaForMode({
+        current,
+        mode: defaultAudienceModeForLaunchType(launchType),
+        aliasProjects,
+      });
+    });
+    setVolunteerSearchQuery("");
+    setVolunteerSearchRows([]);
+    setVolunteerSearchErrorMessage(null);
+  }, [aliasProjects, hasPickedAudienceMode, launchType]);
+
+  useEffect(() => {
+    if (previousFromEmailRef.current === fromEmail) {
+      return;
+    }
+
+    previousFromEmailRef.current = fromEmail;
+    setCriteria((current) => {
+      if (!hasPickedAudienceMode || current.initialFilter === undefined) {
+        return clearAudienceCriteria(current);
+      }
+
+      return buildCriteriaForMode({
+        current,
+        mode: current.initialFilter,
+        aliasProjects,
+      });
+    });
+    setVolunteerSearchQuery("");
+    setVolunteerSearchRows([]);
+    setVolunteerSearchErrorMessage(null);
+  }, [aliasProjects, criteria.initialFilter, fromEmail, hasPickedAudienceMode]);
+
+  useEffect(() => {
+    setReplyToEmail(fromEmail);
+  }, [fromEmail]);
+
+  useEffect(() => {
+    if (!hasPickedAudienceMode || criteria.initialFilter !== "project_status") {
+      setStatusCounts({});
+      setStatusCountsLoading(false);
+      setStatusCountsErrorMessage(null);
+      return;
+    }
+
+    if (selectedProjectIds.length === 0) {
+      setStatusCounts({});
+      setStatusCountsLoading(false);
+      setStatusCountsErrorMessage(null);
+      return;
+    }
+
+    const requestId = ++statusCountsRequestRef.current;
+    setStatusCountsLoading(true);
+    setStatusCountsErrorMessage(null);
+    startStatusCountsTransition(async () => {
+      const result = await loadMemberStatusCountsForProjects(selectedProjectIds);
+      if (requestId !== statusCountsRequestRef.current) {
+        return;
+      }
+
+      if (!result.ok) {
+        setStatusCounts({});
+        setStatusCountsLoading(false);
+        setStatusCountsErrorMessage(result.message);
+        return;
+      }
+
+      setStatusCounts(result.data);
+      setStatusCountsLoading(false);
+      setStatusCountsErrorMessage(null);
+      setCriteria((current) => {
+        const availableStatuses = bootstrap.statuses.filter(
+          (status) => (result.data[status] ?? 0) > 0,
+        );
+        const selectedStatuses = current.statuses.filter((status) =>
+          availableStatuses.includes(status),
+        );
+
+        return selectedStatuses.length === current.statuses.length
+          ? current
+          : {
+              ...current,
+              statuses: selectedStatuses,
+            };
+      });
+    });
+  }, [
+    bootstrap.statuses,
+    criteria.initialFilter,
+    hasPickedAudienceMode,
+    selectedProjectIdsKey,
+  ]);
+
+  useEffect(() => {
+    if (frozen) {
+      setCountLoading(false);
+      return;
+    }
+
+    if (!hasPickedAudienceMode || criteria.initialFilter === undefined) {
+      countRequestRef.current += 1;
+      setCountLoading(false);
+      setCountState({ count: 0, hasAppliedFilters: false });
+      return;
+    }
+
+    const audienceMode = criteria.initialFilter;
+    if (audienceMode === "project_status" && criteria.statuses.length === 0) {
+      countRequestRef.current += 1;
+      setCountLoading(false);
+      setCountState({ count: 0, hasAppliedFilters: true });
+      return;
+    }
+
+    const requestId = ++countRequestRef.current;
+    setCountLoading(true);
+    startCountTransition(async () => {
+      const result = await resolveAudienceCountAction({
+        kind,
+        criteria: toActionCriteria(criteria),
+      });
+      if (requestId !== countRequestRef.current) {
+        return;
+      }
+
+      setCountLoading(false);
+      if (!result.ok) {
+        setSaveMessage(result.message);
+        return;
+      }
+
+      setCountState(result.data);
+    });
+  }, [criteria, frozen, hasPickedAudienceMode, kind]);
+
+  useEffect(() => {
+    if (currentStep !== 2 || !hasPickedAudienceMode) {
+      setAudiencePreviewLoading(false);
+      setPreviewRows([]);
+      setPreviewErrorMessage(null);
+      return;
+    }
+
+    const requestId = ++audiencePreviewRequestRef.current;
+    setAudiencePreviewLoading(true);
+    setPreviewErrorMessage(null);
+    void (async () => {
+      const result = await previewAudienceAction({
+        kind,
+        criteria: toActionCriteria(criteria),
+      });
+      if (requestId !== audiencePreviewRequestRef.current) {
+        return;
+      }
+
+      setAudiencePreviewLoading(false);
+      if (!result.ok) {
+        setPreviewErrorMessage(result.message);
+        return;
+      }
+
+      setPreviewRows(result.data);
+      setPreviewErrorMessage(null);
+    })();
+  }, [criteria, currentStep, hasPickedAudienceMode, kind]);
+
+  useEffect(() => {
+    if (
+      currentStep !== 2 ||
+      !hasPickedAudienceMode ||
+      criteria.initialFilter !== "specific"
+    ) {
+      setVolunteerSearchRows([]);
+      setVolunteerSearchErrorMessage(null);
+      return;
+    }
+
+    if (aliasProjectIds.length === 0 || volunteerSearchQuery.trim().length < 2) {
+      setVolunteerSearchRows([]);
+      setVolunteerSearchErrorMessage(null);
+      return;
+    }
+
+    const requestId = ++volunteerSearchRequestRef.current;
+    const timer = setTimeout(() => {
+      startVolunteerSearchTransition(async () => {
+        const result = await searchProjectVolunteersAction({
+          aliasProjectIds,
+          query: volunteerSearchQuery,
+        });
+        if (requestId !== volunteerSearchRequestRef.current) {
+          return;
+        }
+
+        if (!result.ok) {
+          setVolunteerSearchErrorMessage(result.message);
+          return;
+        }
+
+        setVolunteerSearchRows(result.data);
+        setVolunteerSearchErrorMessage(null);
+      });
+    }, 250);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [
+    aliasProjectIds,
+    criteria.initialFilter,
+    currentStep,
+    hasPickedAudienceMode,
+    volunteerSearchQuery,
+  ]);
+
+  useEffect(() => {
+    if (currentStep < 3) {
+      return;
+    }
+
+    const requestId = ++composePreviewRequestRef.current;
+    const timer = setTimeout(() => {
+      startComposePreviewTransition(async () => {
+        const result = await loadComposePreviewAction({
+          kind,
+          criteria: toActionCriteria(criteria),
+          fromEmail,
+          subjectTemplate: subject,
+          bodyHtmlTemplate: bodyHtml,
+          bodyTextTemplate: bodyPlaintext,
+          sampleIndex,
+        });
+        if (requestId !== composePreviewRequestRef.current) {
+          return;
+        }
+
+        if (!result.ok) {
+          setToast({
+            tone: "error",
+            message: result.message,
+          });
+          return;
+        }
+
+        setComposePreview(result.data);
+        setSampleIndex(result.data.sampleIndex);
+      });
+    }, 150);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [
+    bodyHtml,
+    bodyPlaintext,
+    criteria,
+    currentStep,
+    fromEmail,
+    kind,
+    sampleIndex,
+    subject,
+  ]);
+
+  useEffect(() => {
+    setSampleIndex(0);
+    setWarningDismissFingerprint(null);
+  }, [bodyHtml, bodyPlaintext, subject]);
+
+  useEffect(() => {
+    if (!dirty || frozen) {
+      return;
+    }
+
+    const handler = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      Reflect.set(event, "returnValue", "");
+    };
+
+    window.addEventListener("beforeunload", handler);
+    return () => {
+      window.removeEventListener("beforeunload", handler);
+    };
+  }, [dirty, frozen]);
+
+  useEffect(() => {
+    if (!dirty || frozen) {
+      return;
+    }
+
+    const interval = setInterval(() => {
+      void autosavePersistDraftRef.current?.("Autosaved");
+    }, 30_000);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [dirty, fingerprint, frozen]);
+
+  useEffect(() => {
+    if (toast === null) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setToast(null);
+    }, 3000);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [toast]);
+
+  const statusLabel =
+    saveState === "saving" || savePending
+      ? "Saving draft…"
+      : saveState === "saved"
+        ? (saveMessage ?? "Saved")
+        : saveState === "error"
+          ? (saveMessage ?? "Save failed")
+          : dirty
+            ? "Unsaved changes"
+            : "All changes saved";
+
+  return {
+    currentStep,
+    setCurrentStep,
+    launchType,
+    setLaunchType,
+    name,
+    setName,
+    fromEmail,
+    setFromEmail,
+    replyToEmail,
+    subject,
+    setSubject,
+    preheader,
+    setPreheader,
+    bodyPlaintext,
+    setBodyPlaintext,
+    bodyHtml,
+    setBodyHtml,
+    criteria,
+    setCriteria,
+    hasPickedAudienceMode,
+    setHasPickedAudienceMode,
+    countState,
+    previewRows,
+    previewErrorMessage,
+    statusCounts,
+    statusCountsLoading,
+    statusCountsErrorMessage,
+    volunteerSearchQuery,
+    setVolunteerSearchQuery,
+    volunteerSearchRows,
+    setVolunteerSearchRows,
+    volunteerSearchPending,
+    volunteerSearchErrorMessage,
+    setVolunteerSearchErrorMessage,
+    composePreview,
+    composePreviewPending,
+    setSampleIndex,
+    setSaveState,
+    setSaveMessage,
+    setWarningDismissFingerprint,
+    testSendOpen,
+    setTestSendOpen,
+    testRecipientEmail,
+    setTestRecipientEmail,
+    affectedContactsOpen,
+    setAffectedContactsOpen,
+    sendMode,
+    setSendMode,
+    scheduleDate,
+    setScheduleDate,
+    scheduleTime,
+    setScheduleTime,
+    confirmOpen,
+    setConfirmOpen,
+    runState,
+    setRunState,
+    scheduledAt,
+    setScheduledAt,
+    toast,
+    setToast,
+    countLoading,
+    audiencePreviewLoading,
+    startSaveTransition,
+    submitPending,
+    startSubmitTransition,
+    testSendPending,
+    startTestSendTransition,
+    savedFingerprintRef,
+    saveTimeoutRef,
+    autosavePersistDraftRef,
+    frozen,
+    kind,
+    dirty,
+    selectedSenderVerified,
+    aliasProjects,
+    previewFingerprint,
+    warningDismissed,
+    statusLabel,
+  };
+}


### PR DESCRIPTION
## Summary

- Extracts a `useNewCampaignWizardState` hook from `NewCampaignWizard`, moving all 30+ `useState`, 8 `useRef`, 11 `useEffect`, `useTransition`, and `useMemo` calls into a sibling file.
- Component now consumes the hook and keeps only handlers (`persistDraft`, `updateCriteria`, `continueTo`, `handleSubmit`, etc.) + JSX.
- All 8 existing wizard tests pass **unmodified** — same public component API.

## Results

| Metric | Before | After |
|--------|--------|-------|
| `new-campaign-wizard.tsx` lines | 1351 | 865 |
| `NewCampaignWizard` cyclomatic complexity | 96 | **15** |
| New `use-new-campaign-wizard-state.ts` | — | 921 lines |
| Wizard tests | 8 passing | 8 passing (unmodified) |

## Source

Dispatched per [`docs/briefs-overnight-2026-05-21/01-new-campaign-wizard-tests-and-hook-extraction.md`](docs/briefs-overnight-2026-05-21/01-new-campaign-wizard-tests-and-hook-extraction.md) Task 2.

## Validation

All passed locally:

- \`pnpm --filter @as-comms/web typecheck\` ✅
- \`pnpm --filter @as-comms/web lint\` ✅
- \`pnpm --filter @as-comms/web test:unit\` ✅ (89 files, 677 tests, 5 skipped)
- \`pnpm --filter @as-comms/web build\` ✅

## Deviations from brief

- Exported a few pre-existing module-scope helpers from \`new-campaign-wizard.tsx\` so ESLint doesn't flag them as dead after the extraction. No new public API.
- The brief said the \`pnpm build\` command should pass directly; in this checkout it required building local workspace packages (\`@as-comms/domain\`, \`@as-comms/contracts\`, \`@as-comms/integrations\`, \`@as-comms/ui\`, \`@as-comms/db\`) first. Pre-existing build-chain quirk, not introduced by this refactor.

## Test plan

- [ ] CI green
- [ ] Quick sanity-check that the wizard's behavior is unchanged in the broadcasts UI (the 8 tests cover step transitions, autosave, etc. but a manual smoke is reassuring for a refactor this size)

🤖 Generated by Codex (gpt-5.4, xhigh effort) under Claude orchestration