### PR TITLE
fix(broadcasts): coerce timestamps + tolerate legacy audience statuses

### DIFF
--- a/apps/web/app/broadcasts/[runId]/_lib/run-detail.ts
+++ b/apps/web/app/broadcasts/[runId]/_lib/run-detail.ts
@@ -33,6 +33,13 @@ function normalizeSqlResultRows<TRow>(
   return (result as { readonly rows?: readonly TRow[] }).rows ?? [];
 }
 
+function requireIsoTimestamp(value: Date | string): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  return new Date(value).toISOString();
+}
+
 export interface RunMetricTileData {
   readonly key:
     | "queued"
@@ -107,7 +114,7 @@ interface ReplyRowDb {
   readonly contactId: string;
   readonly contactName: string | null;
   readonly email: string | null;
-  readonly occurredAt: Date;
+  readonly occurredAt: Date | string;
 }
 
 interface MailchimpCampaignAggregates {
@@ -568,7 +575,7 @@ export async function getRunDetailModel(input: {
       contactId: row.contactId,
       contactName: row.contactName ?? row.email ?? row.contactId,
       email: row.email,
-      occurredAt: row.occurredAt.toISOString(),
+      occurredAt: requireIsoTimestamp(row.occurredAt),
     }));
   }
 

--- a/apps/web/app/broadcasts/_lib/run-recipients.ts
+++ b/apps/web/app/broadcasts/_lib/run-recipients.ts
@@ -18,6 +18,14 @@ function normalizeSqlResultRows<TRow>(
   return (result as { readonly rows?: readonly TRow[] }).rows ?? [];
 }
 
+function coerceIsoTimestamp(value: Date | string | null): string | null {
+  if (value === null) return null;
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  return new Date(value).toISOString();
+}
+
 export type RecipientLatestState =
   | "queued"
   | "sent"
@@ -74,7 +82,7 @@ interface RecipientRowDb {
   readonly email: string | null;
   readonly project: string | null;
   readonly latestState: RecipientLatestState;
-  readonly lastEventAt: Date | null;
+  readonly lastEventAt: Date | string | null;
 }
 
 interface MailchimpRecipientRowSource {
@@ -300,7 +308,7 @@ function mapRecipientRow(row: RecipientRowDb): RecipientRowData {
     project: row.project,
     latestState: row.latestState,
     latestStateLabel: recipientStateLabel(row.latestState),
-    lastEventAt: row.lastEventAt?.toISOString() ?? null,
+    lastEventAt: coerceIsoTimestamp(row.lastEventAt),
   };
 }
 

--- a/apps/web/app/broadcasts/page.tsx
+++ b/apps/web/app/broadcasts/page.tsx
@@ -106,6 +106,18 @@ function normalizeSqlResultRows<TRow>(
   return (result as { readonly rows?: readonly TRow[] }).rows ?? [];
 }
 
+function requireIsoTimestamp(value: Date | string): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  return new Date(value).toISOString();
+}
+
+function coerceIsoTimestamp(value: Date | string | null): string | null {
+  if (value === null) return null;
+  return requireIsoTimestamp(value);
+}
+
 interface CampaignProjectionSqlRow {
   readonly runId: string;
   readonly provider: "postmark";
@@ -116,12 +128,12 @@ interface CampaignProjectionSqlRow {
   readonly sender: string;
   readonly subject: string;
   readonly audienceSize: number | null;
-  readonly scheduledAt: Date | null;
-  readonly startedAt: Date | null;
-  readonly completedAt: Date | null;
-  readonly cancelledAt: Date | null;
-  readonly createdAt: Date;
-  readonly updatedAt: Date;
+  readonly scheduledAt: Date | string | null;
+  readonly startedAt: Date | string | null;
+  readonly completedAt: Date | string | null;
+  readonly cancelledAt: Date | string | null;
+  readonly createdAt: Date | string;
+  readonly updatedAt: Date | string;
 }
 
 interface CampaignProjectionCountSqlRow {
@@ -199,12 +211,12 @@ function mapProjectionSqlRow(
     sender: row.sender,
     subject: row.subject,
     audienceSize: row.audienceSize,
-    scheduledAt: row.scheduledAt?.toISOString() ?? null,
-    startedAt: row.startedAt?.toISOString() ?? null,
-    completedAt: row.completedAt?.toISOString() ?? null,
-    cancelledAt: row.cancelledAt?.toISOString() ?? null,
-    createdAt: row.createdAt.toISOString(),
-    updatedAt: row.updatedAt.toISOString(),
+    scheduledAt: coerceIsoTimestamp(row.scheduledAt),
+    startedAt: coerceIsoTimestamp(row.startedAt),
+    completedAt: coerceIsoTimestamp(row.completedAt),
+    cancelledAt: coerceIsoTimestamp(row.cancelledAt),
+    createdAt: requireIsoTimestamp(row.createdAt),
+    updatedAt: requireIsoTimestamp(row.updatedAt),
   };
 }
 

--- a/packages/contracts/src/stage5-campaigns.ts
+++ b/packages/contracts/src/stage5-campaigns.ts
@@ -205,10 +205,17 @@ export const audienceCriteriaSchema = z
         : []),
     ].filter((entry, index, values) => values.indexOf(entry) === index);
 
+    const filteredStatuses = Array.isArray(input.statuses)
+      ? input.statuses.filter(
+          (entry) => expeditionMemberStatusSchema.safeParse(entry).success,
+        )
+      : input.statuses;
+
     return {
       ...input,
       projectId: normalizedProjectIds[0] ?? null,
       projectIds: normalizedProjectIds,
+      statuses: filteredStatuses,
     };
   }, z.object({
     projectId: coercingNullableString.default(audienceCriteriaDefaults.projectId),


### PR DESCRIPTION
## Summary

After [#462](https://github.com/nico-kneler-as/as-comms-platform/pull/462) un-hid the broadcasts list, prod surfaced two follow-on bugs that crashed the page. Both fixed here.

### Bug 1 — `TypeError: scheduledAt?.toISOString is not a function`
Postgres-js returns \`timestamptz\` columns as **strings**, not \`Date\` instances. \`mapProjectionSqlRow\` (and the reply-preview mapper in run-detail.ts) called \`.toISOString()\` directly on them. Before #462 this code path returned \`[]\` so the mapper never ran — fix exposed the next layer.

### Bug 2 — `ZodError: invalid enum value 'Active' at statuses[2]`
One draft created earlier in testing (run \`3c0bdec1\`) has \`audience_criteria.statuses\` containing \`"Active"\` — not a valid expedition-member status. \`mapCampaignRunRow\` strict-parses it, throws, and \`listByIds\` propagates the error to the page handler. One bad row was black-holing the entire list.

## Changes

| File | Change |
|---|---|
| `apps/web/app/broadcasts/page.tsx` | `requireIsoTimestamp` + `coerceIsoTimestamp` helpers; `mapProjectionSqlRow` uses them; row interface widened to `Date \| string` |
| `apps/web/app/broadcasts/[runId]/_lib/run-detail.ts` | Same coercion pattern in the reply-preview mapper |
| `apps/web/app/broadcasts/_lib/run-recipients.ts` | Same for `mapRecipientRow.lastEventAt` |
| `packages/contracts/src/stage5-campaigns.ts` | `audienceCriteriaSchema` preprocess filters invalid status entries before the strict enum runs — keeps one bad draft from killing the list |

## Verified

Local preview against the prod DB:

- ✅ `/broadcasts` renders **29 rows** (27 drafts + 2 scheduled)
- ✅ Header counts correct: `All 29 / Drafts 27 / Scheduled 2`
- ✅ Both scheduled broadcasts visible: \`cf7dc998 "dasd"\` (May 22) and \`f1974a2b "dsad"\` (May 20)
- ✅ \`pnpm --filter @as-comms/web typecheck\` clean
- ✅ \`pnpm build --filter @as-comms/web\` clean

## Test plan

- [ ] CI green
- [ ] Railway deploy → re-open \`/broadcasts\` in browser → confirm 29 rows render

🤖 Generated with [Claude Code](https://claude.com/claude-code)