### PR TITLE
fix(gmail-capture): trust Content-Disposition: inline when CID roundtrip fails

### DIFF
--- a/apps/gmail-capture/src/attachments.ts
+++ b/apps/gmail-capture/src/attachments.ts
@@ -90,6 +90,18 @@ function isInlineAttachment(input: {
   };
   readonly htmlBodyCidReferences: ReadonlySet<string>;
 }): boolean {
+  const dispositionType = resolveContentDispositionType(
+    input.attachment.contentDisposition,
+  );
+
+  if (dispositionType === "attachment") {
+    return false;
+  }
+
+  if (dispositionType === "inline") {
+    return true;
+  }
+
   const normalizedContentId = normalizeContentId(input.attachment.contentId);
   if (
     normalizedContentId === null ||
@@ -98,10 +110,7 @@ function isInlineAttachment(input: {
     return false;
   }
 
-  return (
-    resolveContentDispositionType(input.attachment.contentDisposition) !==
-    "attachment"
-  );
+  return true;
 }
 
 function decodeBase64Url(value: string): Buffer {

--- a/apps/gmail-capture/test/attachments.test.ts
+++ b/apps/gmail-capture/test/attachments.test.ts
@@ -270,7 +270,7 @@ describe("gmail attachment sync", () => {
     }
   });
 
-  it("keeps inline disposition attachments visible when the HTML body does not reference their CID", async () => {
+  it("marks inline disposition attachments as inline when the HTML body does not reference their CID", async () => {
     const context = await createTestStage1Context();
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "gmail-attachments-"));
     const attachmentBytes = Buffer.from("inline-image", "utf8");
@@ -311,7 +311,7 @@ describe("gmail attachment sync", () => {
       ).resolves.toMatchObject([
         {
           sourceEvidenceId,
-          isInline: false,
+          isInline: true,
         },
       ]);
     } finally {


### PR DESCRIPTION
## Summary

- When Gmail re-encodes inline images in quoted replies (operator hits Reply on a thread with an inline screenshot), the `Content-ID` header is often dropped or rewritten, breaking our cid-in-HTML-body inline detection.
- Surfaced as Issue 2 in the 2026-05-28 debug session: Michael Gast's GoDaddy-firewall screenshot appearing as a fresh attachment under the operator's outbound reply bubble instead of staying tucked inside the quoted history.
- Loosens `isInlineAttachment` to treat an explicit `Content-Disposition: inline` as sufficient on its own. The cid-match path remains as fallback for senders that omit the disposition header entirely. Explicit `Content-Disposition: attachment` still wins (regression protection preserved by the new test).

## Behavior matrix

| `Content-Disposition` | `Content-ID` in HTML cid refs | Before | After |
|---|---|---|---|
| `inline` | yes | inline ✓ | inline ✓ |
| `inline` | no / missing | **attachment ✗** | **inline ✓** (fix) |
| `attachment` | yes | attachment ✓ | attachment ✓ |
| `attachment` | no | attachment ✓ | attachment ✓ |
| missing | yes | inline ✓ | inline ✓ |
| missing | no | attachment ✓ | attachment ✓ |

## Out of scope (documented in commit body)

- Historical `message_attachments` rows with stale `is_inline=false` are NOT backfilled. `message_attachments` does not persist the original `Content-Disposition` / `Content-ID` headers, so backfill would require Gmail API re-fetch. Scoped as a separate brief if volume justifies later.

## Test plan

- [x] `pnpm --filter @as-comms/gmail-capture typecheck`
- [x] `pnpm --filter @as-comms/gmail-capture lint`
- [x] `pnpm --filter @as-comms/gmail-capture test` (20 passed)
- [x] `pnpm boundaries`
- [ ] Spot-check in production after merge: open Michael Gast's "Re: Claim Your Adventure Today" thread and confirm new operator replies stop attaching the quoted screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code) + Codex (gpt-5.4)