### PR TITLE
feat(worker): backfill op to recompute message_attachments.is_inline from Gmail API

### DIFF
--- a/apps/gmail-capture/src/attachments.ts
+++ b/apps/gmail-capture/src/attachments.ts
@@ -7,7 +7,9 @@ import {
   buildGmailMessageAttachmentStorageKey,
   exchangeGmailAccessToken,
   gmailMessageRecordSchema,
+  isInlineAttachment,
   mapGmailRecord,
+  normalizeContentId,
   type GmailAccessTokenCacheEntry,
   type GmailRecord,
 } from "@as-comms/integrations";
@@ -54,64 +56,6 @@ const attachmentLogger: AttachmentLogger = {
     console.warn(message, metadata);
   },
 };
-
-function normalizeContentId(value: string | null | undefined): string | null {
-  if (typeof value !== "string") {
-    return null;
-  }
-
-  const trimmed = value.trim();
-
-  if (trimmed.length === 0) {
-    return null;
-  }
-
-  const normalized = trimmed.replace(/^<|>$/gu, "").toLowerCase();
-  return normalized.length > 0 ? normalized : null;
-}
-
-function resolveContentDispositionType(
-  contentDisposition: string | null | undefined,
-): string | null {
-  if (typeof contentDisposition !== "string") {
-    return null;
-  }
-
-  const dispositionType = contentDisposition.split(";")[0]?.trim().toLowerCase();
-  return dispositionType && dispositionType.length > 0
-    ? dispositionType
-    : null;
-}
-
-function isInlineAttachment(input: {
-  readonly attachment: {
-    readonly contentDisposition?: string | null;
-    readonly contentId?: string | null;
-  };
-  readonly htmlBodyCidReferences: ReadonlySet<string>;
-}): boolean {
-  const dispositionType = resolveContentDispositionType(
-    input.attachment.contentDisposition,
-  );
-
-  if (dispositionType === "attachment") {
-    return false;
-  }
-
-  if (dispositionType === "inline") {
-    return true;
-  }
-
-  const normalizedContentId = normalizeContentId(input.attachment.contentId);
-  if (
-    normalizedContentId === null ||
-    !input.htmlBodyCidReferences.has(normalizedContentId)
-  ) {
-    return false;
-  }
-
-  return true;
-}
 
 function decodeBase64Url(value: string): Buffer {
   const paddedValue =

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -28,6 +28,7 @@
     "ops:cleanup-salesforce-owner-scope": "tsx src/ops/cleanup-salesforce-owner-scope.ts",
     "ops:backfill-inbox-projection-coverage": "tsx src/ops/backfill-inbox-projection-coverage.ts",
     "ops:recover-gmail-spam-window": "tsx src/ops/recover-gmail-spam-window.ts",
+    "ops:recompute-attachment-inline": "tsx src/ops/recompute-attachment-inline.ts",
     "ops:recover-orphan-gmail-details": "tsx src/ops/recover-orphan-gmail-details.ts",
     "ops:recover-orphan-task-details": "tsx src/ops/recover-orphan-task-details.ts",
     "ops:rewrite-timeline-sort-keys": "tsx src/ops/rewrite-timeline-sort-keys.ts",

--- a/apps/worker/src/ops/cli.ts
+++ b/apps/worker/src/ops/cli.ts
@@ -46,6 +46,7 @@ import { runCleanupGmailDraftEventsCommand } from "./cleanup-gmail-draft-events.
 import { runCleanupSalesforceOwnerScopeCommand } from "./cleanup-salesforce-owner-scope.js";
 import { main as runMergeEmailOnlyIntoSfAnchoredCommand } from "./merge-email-only-into-sf-anchored.js";
 import { runRecoverGmailSpamWindowCommand } from "./recover-gmail-spam-window.js";
+import { runRecomputeAttachmentInlineCommand } from "./recompute-attachment-inline.js";
 import { runRecoverOrphanGmailDetailsCommand } from "./recover-orphan-gmail-details.js";
 import { reconcileIdentityQueue } from "./reconcile-identity-queue.js";
 import { reconcileRoutingReviewQueue } from "./reconcile-routing-review-queue.js";
@@ -474,6 +475,9 @@ async function main(): Promise<void> {
     case "recover-gmail-spam-window":
       await runRecoverGmailSpamWindowCommand(rest, process.env);
       return;
+    case "recompute-attachment-inline":
+      await runRecomputeAttachmentInlineCommand(rest, process.env);
+      return;
     case "reprocess-pending-campaign-sends":
       await runReprocessPendingCampaignSends(rest);
       return;
@@ -503,7 +507,7 @@ async function main(): Promise<void> {
       return;
     default:
       throw new Error(
-        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-membership-sf-ids, backfill-gmail-mbox-bodies, backfill-content-fingerprint, backfill-garbled-message-bodies, re-extract-signed-envelope-bodies, backfill-mailchimp-campaign-body, mailchimp-capture-historical, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, recover-orphan-gmail-details, recover-gmail-spam-window, reprocess-pending-campaign-sends, dedup-historical-ledger, merge-email-only-into-sf-anchored, reconcile-identity-queue, reconcile-routing-review-queue, reclassify-sf-direction, reconcile-stale-canonical, reconcile-superseded-projections.",
+        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-membership-sf-ids, backfill-gmail-mbox-bodies, backfill-content-fingerprint, backfill-garbled-message-bodies, re-extract-signed-envelope-bodies, backfill-mailchimp-campaign-body, mailchimp-capture-historical, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, recover-orphan-gmail-details, recover-gmail-spam-window, recompute-attachment-inline, reprocess-pending-campaign-sends, dedup-historical-ledger, merge-email-only-into-sf-anchored, reconcile-identity-queue, reconcile-routing-review-queue, reclassify-sf-direction, reconcile-stale-canonical, reconcile-superseded-projections.",
       );
   }
 }

--- a/apps/worker/src/ops/recompute-attachment-inline.ts
+++ b/apps/worker/src/ops/recompute-attachment-inline.ts
@@ -1,0 +1,411 @@
+#!/usr/bin/env tsx
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+import {
+  closeDatabaseConnection,
+  createDatabaseConnection,
+  createStage1RepositoryBundleFromConnection,
+  messageAttachments,
+  type Stage1Database,
+} from "@as-comms/db";
+import {
+  collectGmailAttachmentMetadata,
+  collectGmailHtmlCidReferences,
+  createGmailMailboxApiClient,
+  isInlineAttachment,
+  normalizeContentId,
+  type GmailAttachmentMetadata,
+  type GmailCaptureServiceConfig,
+  type GmailMailboxApiClient,
+  type GmailMessageMetadata,
+} from "@as-comms/integrations";
+import { and, asc, eq, gte, like, lte } from "drizzle-orm";
+
+import { readStage1LaunchScopeGmailConfig } from "./config.js";
+import {
+  parseCliFlags,
+  readOptionalBooleanFlag,
+  readOptionalIntegerFlag,
+  readOptionalStringFlag,
+} from "./helpers.js";
+
+interface Logger {
+  log(...args: readonly unknown[]): void;
+  error(...args: readonly unknown[]): void;
+}
+
+interface CandidateAttachmentRow {
+  readonly id: string;
+  readonly sourceEvidenceId: string;
+  readonly gmailAttachmentId: string;
+  readonly mimeType: string;
+  readonly isInline: boolean;
+}
+
+interface CachedMessageData {
+  readonly attachmentMetadata: readonly GmailAttachmentMetadata[];
+  readonly htmlBodyCidReferences: ReadonlySet<string>;
+}
+
+export interface RecomputeAttachmentInlineLogEntry {
+  readonly id: string;
+  readonly sourceEvidenceId: string;
+  readonly gmailAttachmentId: string;
+  readonly action: "skipped" | "unchanged" | "recomputed";
+  readonly reason?:
+    | "no_gmail_detail"
+    | "gmail_message_not_found"
+    | "attachment_not_in_message";
+  readonly before?: boolean;
+  readonly after?: boolean;
+  readonly dryRun?: boolean;
+}
+
+export interface RecomputeAttachmentInlineResult {
+  readonly dryRun: boolean;
+  readonly since: string;
+  readonly until: string;
+  readonly mailbox: string;
+  readonly candidates: number;
+  readonly recomputed: number;
+  readonly unchanged: number;
+  readonly skipped: number;
+  readonly truncated: boolean;
+}
+
+function readConnectionString(env: NodeJS.ProcessEnv): string {
+  const connectionString = env.WORKER_DATABASE_URL ?? env.DATABASE_URL;
+
+  if (connectionString === undefined || connectionString.trim().length === 0) {
+    throw new Error(
+      "DATABASE_URL or WORKER_DATABASE_URL is required for Stage 1 ops commands.",
+    );
+  }
+
+  return connectionString;
+}
+
+function readRequiredStringEnv(env: NodeJS.ProcessEnv, key: string): string {
+  const value = env[key];
+
+  if (value === undefined || value.trim().length === 0) {
+    throw new Error(`${key} is required for attachment inline recompute.`);
+  }
+
+  return value.trim();
+}
+
+function parseWindowTimestamp(value: string, flagName: string): string {
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Flag --${flagName} must be a valid ISO-8601 timestamp.`);
+  }
+
+  return parsed.toISOString();
+}
+
+function buildDefaultSince(): string {
+  return new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function buildDefaultUntil(): string {
+  return new Date().toISOString();
+}
+
+function buildGmailApiClientFromEnv(
+  env: NodeJS.ProcessEnv,
+): {
+  readonly mailbox: string;
+  readonly client: GmailMailboxApiClient;
+} {
+  const gmailConfig = readStage1LaunchScopeGmailConfig(env);
+  const clientConfig: GmailCaptureServiceConfig = {
+    bearerToken: "ops-recompute-attachment-inline",
+    liveAccount: gmailConfig.liveAccount,
+    projectInboxAliases: [...gmailConfig.projectInboxAliases],
+    oauthClientId: readRequiredStringEnv(env, "GMAIL_GOOGLE_OAUTH_CLIENT_ID"),
+    oauthClientSecret: readRequiredStringEnv(
+      env,
+      "GMAIL_GOOGLE_OAUTH_CLIENT_SECRET",
+    ),
+    oauthRefreshToken: readRequiredStringEnv(
+      env,
+      "GMAIL_GOOGLE_OAUTH_REFRESH_TOKEN",
+    ),
+    tokenUri:
+      env.GMAIL_GOOGLE_TOKEN_URI?.trim().length
+        ? env.GMAIL_GOOGLE_TOKEN_URI.trim()
+        : "https://oauth2.googleapis.com/token",
+    timeoutMs:
+      env.GMAIL_CAPTURE_TIMEOUT_MS === undefined
+        ? 15_000
+        : Number.parseInt(env.GMAIL_CAPTURE_TIMEOUT_MS, 10),
+  };
+
+  return {
+    mailbox: gmailConfig.liveAccount,
+    client: createGmailMailboxApiClient(clientConfig),
+  };
+}
+
+function logEntry(
+  logger: Logger,
+  entry: RecomputeAttachmentInlineLogEntry,
+): void {
+  logger.log(JSON.stringify(entry));
+}
+
+async function loadCandidateRows(input: {
+  readonly db: Stage1Database;
+  readonly since: string;
+  readonly until: string;
+  readonly limit: number;
+}): Promise<{
+  readonly candidates: readonly CandidateAttachmentRow[];
+  readonly truncated: boolean;
+}> {
+  const rows = await input.db
+    .select({
+      id: messageAttachments.id,
+      sourceEvidenceId: messageAttachments.sourceEvidenceId,
+      gmailAttachmentId: messageAttachments.gmailAttachmentId,
+      mimeType: messageAttachments.mimeType,
+      isInline: messageAttachments.isInline,
+      createdAt: messageAttachments.createdAt,
+    })
+    .from(messageAttachments)
+    .where(
+      and(
+        eq(messageAttachments.isInline, false),
+        like(messageAttachments.mimeType, "image/%"),
+        gte(messageAttachments.createdAt, new Date(input.since)),
+        lte(messageAttachments.createdAt, new Date(input.until)),
+      ),
+    )
+    .orderBy(asc(messageAttachments.createdAt), asc(messageAttachments.id))
+    .limit(input.limit + 1);
+
+  return {
+    candidates: rows.slice(0, input.limit).map((row) => ({
+      id: row.id,
+      sourceEvidenceId: row.sourceEvidenceId,
+      gmailAttachmentId: row.gmailAttachmentId,
+      mimeType: row.mimeType,
+      isInline: row.isInline,
+    })),
+    truncated: rows.length > input.limit,
+  };
+}
+
+export async function recomputeAttachmentInline(input: {
+  readonly db: Stage1Database;
+  readonly repositories: ReturnType<typeof createStage1RepositoryBundleFromConnection>;
+  readonly apiClient: GmailMailboxApiClient;
+  readonly mailbox: string;
+  readonly since: string;
+  readonly until: string;
+  readonly execute: boolean;
+  readonly limit: number;
+  readonly logger?: Logger;
+}): Promise<RecomputeAttachmentInlineResult> {
+  const logger = input.logger ?? console;
+  const { candidates, truncated } = await loadCandidateRows({
+    db: input.db,
+    since: input.since,
+    until: input.until,
+    limit: input.limit,
+  });
+  const gmailDetails = await input.repositories.gmailMessageDetails.listBySourceEvidenceIds(
+    candidates.map((candidate) => candidate.sourceEvidenceId),
+  );
+  const gmailDetailsBySourceEvidenceId = new Map(
+    gmailDetails.map((detail) => [detail.sourceEvidenceId, detail]),
+  );
+  const messageCache = new Map<string, Promise<CachedMessageData | null>>();
+
+  let recomputed = 0;
+  let unchanged = 0;
+  let skipped = 0;
+
+  for (const candidate of candidates) {
+    const detail = gmailDetailsBySourceEvidenceId.get(candidate.sourceEvidenceId);
+
+    if (detail === undefined) {
+      skipped += 1;
+      logEntry(logger, {
+        id: candidate.id,
+        sourceEvidenceId: candidate.sourceEvidenceId,
+        gmailAttachmentId: candidate.gmailAttachmentId,
+        action: "skipped",
+        reason: "no_gmail_detail",
+      });
+      continue;
+    }
+
+    let cachedMessage = messageCache.get(candidate.sourceEvidenceId);
+
+    if (cachedMessage === undefined) {
+      cachedMessage = input.apiClient
+        .getMessage({
+          mailbox: input.mailbox,
+          messageId: detail.providerRecordId,
+        })
+        .then((message: GmailMessageMetadata | null) => {
+          if (message === null) {
+            return null;
+          }
+
+          return {
+            attachmentMetadata: collectGmailAttachmentMetadata(message.payload),
+            htmlBodyCidReferences: new Set(
+              collectGmailHtmlCidReferences(message.payload, {
+                messageIdentifier: detail.providerRecordId,
+              })
+                .map((value) => normalizeContentId(value))
+                .filter((value): value is string => value !== null),
+            ),
+          };
+        });
+      messageCache.set(candidate.sourceEvidenceId, cachedMessage);
+    }
+
+    const messageData = await cachedMessage;
+
+    if (messageData === null) {
+      skipped += 1;
+      logEntry(logger, {
+        id: candidate.id,
+        sourceEvidenceId: candidate.sourceEvidenceId,
+        gmailAttachmentId: candidate.gmailAttachmentId,
+        action: "skipped",
+        reason: "gmail_message_not_found",
+      });
+      continue;
+    }
+
+    const attachment = messageData.attachmentMetadata.find(
+      (value) => value.gmailAttachmentId === candidate.gmailAttachmentId,
+    );
+
+    if (attachment === undefined) {
+      skipped += 1;
+      logEntry(logger, {
+        id: candidate.id,
+        sourceEvidenceId: candidate.sourceEvidenceId,
+        gmailAttachmentId: candidate.gmailAttachmentId,
+        action: "skipped",
+        reason: "attachment_not_in_message",
+      });
+      continue;
+    }
+
+    const nextIsInline = isInlineAttachment({
+      attachment,
+      htmlBodyCidReferences: messageData.htmlBodyCidReferences,
+    });
+
+    if (nextIsInline === candidate.isInline) {
+      unchanged += 1;
+      logEntry(logger, {
+        id: candidate.id,
+        sourceEvidenceId: candidate.sourceEvidenceId,
+        gmailAttachmentId: candidate.gmailAttachmentId,
+        action: "unchanged",
+      });
+      continue;
+    }
+
+    if (input.execute) {
+      await input.db
+        .update(messageAttachments)
+        .set({ isInline: nextIsInline })
+        .where(eq(messageAttachments.id, candidate.id));
+    }
+
+    recomputed += 1;
+    logEntry(logger, {
+      id: candidate.id,
+      sourceEvidenceId: candidate.sourceEvidenceId,
+      gmailAttachmentId: candidate.gmailAttachmentId,
+      action: "recomputed",
+      before: candidate.isInline,
+      after: nextIsInline,
+      dryRun: !input.execute,
+    });
+  }
+
+  return {
+    dryRun: !input.execute,
+    since: input.since,
+    until: input.until,
+    mailbox: input.mailbox,
+    candidates: candidates.length,
+    recomputed,
+    unchanged,
+    skipped,
+    truncated,
+  };
+}
+
+export async function runRecomputeAttachmentInlineCommand(
+  args: readonly string[] = process.argv.slice(2),
+  env: NodeJS.ProcessEnv = process.env,
+  logger: Logger = console,
+): Promise<void> {
+  const flags = parseCliFlags(args);
+  const since = parseWindowTimestamp(
+    readOptionalStringFlag(flags, "since") ?? buildDefaultSince(),
+    "since",
+  );
+  const until = parseWindowTimestamp(
+    readOptionalStringFlag(flags, "until") ?? buildDefaultUntil(),
+    "until",
+  );
+  const execute = readOptionalBooleanFlag(flags, "execute", false);
+  const limit = readOptionalIntegerFlag(flags, "limit", 1000);
+
+  if (new Date(since).getTime() > new Date(until).getTime()) {
+    throw new Error("Flag --since must be earlier than or equal to --until.");
+  }
+
+  const connection = createDatabaseConnection({
+    connectionString: readConnectionString(env),
+  });
+
+  try {
+    const repositories = createStage1RepositoryBundleFromConnection(connection);
+    const gmail = buildGmailApiClientFromEnv(env);
+    const result = await recomputeAttachmentInline({
+      db: connection.db,
+      repositories,
+      apiClient: gmail.client,
+      mailbox: gmail.mailbox,
+      since,
+      until,
+      execute,
+      limit,
+      logger,
+    });
+
+    logger.log(JSON.stringify(result, null, 2));
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}
+
+async function main(): Promise<void> {
+  await runRecomputeAttachmentInlineCommand(process.argv.slice(2), process.env);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  void main().catch((error: unknown) => {
+    console.error(
+      error instanceof Error
+        ? error.message
+        : "Attachment inline recompute failed.",
+    );
+    process.exitCode = 1;
+  });
+}

--- a/apps/worker/test/recompute-attachment-inline.test.ts
+++ b/apps/worker/test/recompute-attachment-inline.test.ts
@@ -1,0 +1,460 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildGmailMessageAttachmentId,
+  buildSourceEvidenceId,
+  type GmailMessageMetadata,
+} from "@as-comms/integrations";
+import { messageAttachments } from "@as-comms/db";
+
+import {
+  recomputeAttachmentInline,
+  type RecomputeAttachmentInlineLogEntry,
+} from "../src/ops/recompute-attachment-inline.js";
+import { createTestWorkerContext } from "./helpers.js";
+
+function buildAttachmentPayload(input: {
+  readonly gmailAttachmentId: string;
+  readonly contentDisposition: string;
+  readonly contentId?: string;
+}): GmailMessageMetadata["payload"] {
+  const html = input.contentId
+    ? `<html><body><img src="cid:${input.contentId.replace(/^<|>$/gu, "")}" /></body></html>`
+    : "<html><body><p>No inline image</p></body></html>";
+
+  return {
+    mimeType: "multipart/related",
+    filename: "",
+    headers: [
+      {
+        name: "Content-Type",
+        value: 'multipart/related; boundary="boundary-1"',
+      },
+    ],
+    body: {
+      size: 0,
+    },
+    parts: [
+      {
+        mimeType: "text/html",
+        filename: "",
+        headers: [
+          {
+            name: "Content-Type",
+            value: "text/html; charset=UTF-8",
+          },
+        ],
+        body: {
+          data: Buffer.from(html, "utf8").toString("base64url"),
+          size: html.length,
+        },
+        parts: [],
+      },
+      {
+        mimeType: "image/png",
+        filename: "screenshot.png",
+        headers: [
+          {
+            name: "Content-Type",
+            value: 'image/png; name="screenshot.png"',
+          },
+          {
+            name: "Content-Disposition",
+            value: input.contentDisposition,
+          },
+          ...(input.contentId === undefined
+            ? []
+            : [
+                {
+                  name: "Content-ID",
+                  value: input.contentId,
+                },
+              ]),
+        ],
+        body: {
+          attachmentId: input.gmailAttachmentId,
+          size: 128,
+        },
+        parts: [],
+      },
+    ],
+  };
+}
+
+function buildMessageMetadata(input: {
+  readonly messageId: string;
+  readonly gmailAttachmentId: string;
+  readonly contentDisposition: string;
+  readonly contentId?: string;
+}): GmailMessageMetadata {
+  return {
+    id: input.messageId,
+    threadId: `thread:${input.messageId}`,
+    labelIds: ["INBOX"],
+    snippet: "Quoted screenshot",
+    internalDate: String(Date.parse("2026-05-20T10:00:00.000Z")),
+    payload: buildAttachmentPayload(input),
+  };
+}
+
+async function seedGmailMessageContext(input: {
+  readonly context: Awaited<ReturnType<typeof createTestWorkerContext>>;
+  readonly sourceEvidenceId: string;
+  readonly messageId: string;
+  readonly createdAt: string;
+  readonly mimeType?: string;
+  readonly gmailAttachmentId?: string;
+}): Promise<{
+  readonly attachmentId: string;
+  readonly gmailAttachmentId: string;
+}> {
+  const gmailAttachmentId = input.gmailAttachmentId ?? "gmail-attachment-1";
+  const attachmentId = buildGmailMessageAttachmentId({
+    messageId: input.messageId,
+    partIndexPath: "1.2",
+  });
+
+  await input.context.repositories.sourceEvidence.append({
+    id: input.sourceEvidenceId,
+    provider: "gmail",
+    providerRecordType: "message",
+    providerRecordId: input.messageId,
+    receivedAt: input.createdAt,
+    occurredAt: input.createdAt,
+    payloadRef: `gmail://volunteers/messages/${input.messageId}`,
+    idempotencyKey: `gmail:message:${input.messageId}`,
+    checksum: `checksum:${input.messageId}`,
+  });
+
+  await input.context.repositories.gmailMessageDetails.upsert({
+    sourceEvidenceId: input.sourceEvidenceId,
+    providerRecordId: input.messageId,
+    gmailThreadId: `thread:${input.messageId}`,
+    rfc822MessageId: `<${input.messageId}@example.test>`,
+    direction: "inbound",
+    subject: "Screenshot follow-up",
+    fromHeader: "Michael Gast <michael@example.com>",
+    toHeader: "volunteers@adventurescientists.org",
+    ccHeader: null,
+    labelIds: ["INBOX"],
+    snippetClean: "Quoted screenshot",
+    bodyTextPreview: "Quoted screenshot",
+    bodyKind: "plaintext",
+    capturedMailbox: "volunteers@adventurescientists.org",
+    projectInboxAlias: null,
+  });
+
+  await input.context.db.insert(messageAttachments).values({
+    id: attachmentId,
+    sourceEvidenceId: input.sourceEvidenceId,
+    provider: "gmail",
+    gmailAttachmentId,
+    mimeType: input.mimeType ?? "image/png",
+    filename: "screenshot.png",
+    sizeBytes: 128,
+    storageKey: `attachments/${attachmentId}`,
+    isInline: false,
+    createdAt: new Date(input.createdAt),
+  });
+
+  return {
+    attachmentId,
+    gmailAttachmentId,
+  };
+}
+
+function createLogger(logs: RecomputeAttachmentInlineLogEntry[]) {
+  return {
+    log(value: unknown) {
+      if (typeof value === "string" && value.startsWith("{")) {
+        logs.push(JSON.parse(value) as RecomputeAttachmentInlineLogEntry);
+      }
+    },
+    error() {
+      return undefined;
+    },
+  };
+}
+
+describe("recompute-attachment-inline", () => {
+  it("reports recompute in dry-run mode without writing the row", async () => {
+    const context = await createTestWorkerContext();
+    const logs: RecomputeAttachmentInlineLogEntry[] = [];
+
+    try {
+      const sourceEvidenceId = buildSourceEvidenceId("gmail", "message", "msg-1");
+      const seeded = await seedGmailMessageContext({
+        context,
+        sourceEvidenceId,
+        messageId: "msg-1",
+        createdAt: "2026-05-20T10:00:00.000Z",
+      });
+
+      const result = await recomputeAttachmentInline({
+        db: context.db,
+        repositories: context.repositories,
+        apiClient: {
+          listMessageIds: () => Promise.resolve([]),
+          getMessage: () =>
+            Promise.resolve(
+              buildMessageMetadata({
+                messageId: "msg-1",
+                gmailAttachmentId: seeded.gmailAttachmentId,
+                contentDisposition: "inline",
+                contentId: "<inline-image-1>",
+              }),
+            ),
+        },
+        mailbox: "volunteers@adventurescientists.org",
+        since: "2026-05-01T00:00:00.000Z",
+        until: "2026-05-29T23:59:59.999Z",
+        execute: false,
+        limit: 1000,
+        logger: createLogger(logs),
+      });
+
+      expect(result).toMatchObject({
+        dryRun: true,
+        candidates: 1,
+        recomputed: 1,
+      });
+      await expect(
+        context.repositories.messageAttachments.findById(seeded.attachmentId),
+      ).resolves.toMatchObject({
+        isInline: false,
+      });
+      expect(logs).toContainEqual({
+        id: seeded.attachmentId,
+        sourceEvidenceId,
+        gmailAttachmentId: seeded.gmailAttachmentId,
+        action: "recomputed",
+        before: false,
+        after: true,
+        dryRun: true,
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("writes the updated inline flag when execute is enabled", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      const sourceEvidenceId = buildSourceEvidenceId("gmail", "message", "msg-2");
+      const seeded = await seedGmailMessageContext({
+        context,
+        sourceEvidenceId,
+        messageId: "msg-2",
+        createdAt: "2026-05-20T10:00:00.000Z",
+      });
+
+      const result = await recomputeAttachmentInline({
+        db: context.db,
+        repositories: context.repositories,
+        apiClient: {
+          listMessageIds: () => Promise.resolve([]),
+          getMessage: () =>
+            Promise.resolve(
+              buildMessageMetadata({
+                messageId: "msg-2",
+                gmailAttachmentId: seeded.gmailAttachmentId,
+                contentDisposition: "inline",
+                contentId: "<inline-image-2>",
+              }),
+            ),
+        },
+        mailbox: "volunteers@adventurescientists.org",
+        since: "2026-05-01T00:00:00.000Z",
+        until: "2026-05-29T23:59:59.999Z",
+        execute: true,
+        limit: 1000,
+      });
+
+      expect(result).toMatchObject({
+        dryRun: false,
+        recomputed: 1,
+      });
+      await expect(
+        context.repositories.messageAttachments.findById(seeded.attachmentId),
+      ).resolves.toMatchObject({
+        isInline: true,
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("leaves non-inline attachments unchanged", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      const sourceEvidenceId = buildSourceEvidenceId("gmail", "message", "msg-3");
+      const seeded = await seedGmailMessageContext({
+        context,
+        sourceEvidenceId,
+        messageId: "msg-3",
+        createdAt: "2026-05-20T10:00:00.000Z",
+      });
+
+      const result = await recomputeAttachmentInline({
+        db: context.db,
+        repositories: context.repositories,
+        apiClient: {
+          listMessageIds: () => Promise.resolve([]),
+          getMessage: () =>
+            Promise.resolve(
+              buildMessageMetadata({
+                messageId: "msg-3",
+                gmailAttachmentId: seeded.gmailAttachmentId,
+                contentDisposition: "attachment",
+              }),
+            ),
+        },
+        mailbox: "volunteers@adventurescientists.org",
+        since: "2026-05-01T00:00:00.000Z",
+        until: "2026-05-29T23:59:59.999Z",
+        execute: true,
+        limit: 1000,
+      });
+
+      expect(result).toMatchObject({
+        unchanged: 1,
+        recomputed: 0,
+      });
+      await expect(
+        context.repositories.messageAttachments.findById(seeded.attachmentId),
+      ).resolves.toMatchObject({
+        isInline: false,
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("does not consider non-image attachments as candidates", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedGmailMessageContext({
+        context,
+        sourceEvidenceId: buildSourceEvidenceId("gmail", "message", "msg-4"),
+        messageId: "msg-4",
+        createdAt: "2026-05-20T10:00:00.000Z",
+        mimeType: "application/pdf",
+      });
+
+      const result = await recomputeAttachmentInline({
+        db: context.db,
+        repositories: context.repositories,
+        apiClient: {
+          listMessageIds: () => Promise.resolve([]),
+          getMessage: () => Promise.resolve(null),
+        },
+        mailbox: "volunteers@adventurescientists.org",
+        since: "2026-05-01T00:00:00.000Z",
+        until: "2026-05-29T23:59:59.999Z",
+        execute: false,
+        limit: 1000,
+      });
+
+      expect(result).toMatchObject({
+        candidates: 0,
+        recomputed: 0,
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("skips rows whose Gmail message is no longer available", async () => {
+    const context = await createTestWorkerContext();
+    const logs: RecomputeAttachmentInlineLogEntry[] = [];
+
+    try {
+      const sourceEvidenceId = buildSourceEvidenceId("gmail", "message", "msg-5");
+      const seeded = await seedGmailMessageContext({
+        context,
+        sourceEvidenceId,
+        messageId: "msg-5",
+        createdAt: "2026-05-20T10:00:00.000Z",
+      });
+
+      const result = await recomputeAttachmentInline({
+        db: context.db,
+        repositories: context.repositories,
+        apiClient: {
+          listMessageIds: () => Promise.resolve([]),
+          getMessage: () => Promise.resolve(null),
+        },
+        mailbox: "volunteers@adventurescientists.org",
+        since: "2026-05-01T00:00:00.000Z",
+        until: "2026-05-29T23:59:59.999Z",
+        execute: false,
+        limit: 1000,
+        logger: createLogger(logs),
+      });
+
+      expect(result).toMatchObject({
+        skipped: 1,
+      });
+      expect(logs).toContainEqual({
+        id: seeded.attachmentId,
+        sourceEvidenceId,
+        gmailAttachmentId: seeded.gmailAttachmentId,
+        action: "skipped",
+        reason: "gmail_message_not_found",
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("respects the since/until window", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      const inside = await seedGmailMessageContext({
+        context,
+        sourceEvidenceId: buildSourceEvidenceId("gmail", "message", "msg-6"),
+        messageId: "msg-6",
+        createdAt: "2026-05-20T10:00:00.000Z",
+      });
+      await seedGmailMessageContext({
+        context,
+        sourceEvidenceId: buildSourceEvidenceId("gmail", "message", "msg-7"),
+        messageId: "msg-7",
+        createdAt: "2026-02-20T10:00:00.000Z",
+      });
+
+      const result = await recomputeAttachmentInline({
+        db: context.db,
+        repositories: context.repositories,
+        apiClient: {
+          listMessageIds: () => Promise.resolve([]),
+          getMessage: ({ messageId }: { readonly messageId: string }) =>
+            Promise.resolve(
+              buildMessageMetadata({
+                messageId,
+                gmailAttachmentId: inside.gmailAttachmentId,
+                contentDisposition: "inline",
+                contentId: "<inline-image-6>",
+              }),
+            ),
+        },
+        mailbox: "volunteers@adventurescientists.org",
+        since: "2026-05-01T00:00:00.000Z",
+        until: "2026-05-29T23:59:59.999Z",
+        execute: false,
+        limit: 1000,
+      });
+
+      expect(result).toMatchObject({
+        candidates: 1,
+        recomputed: 1,
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+});

--- a/packages/integrations/src/index.ts
+++ b/packages/integrations/src/index.ts
@@ -28,6 +28,7 @@ export * from "./providers/gmail-oauth.js";
 export * from "./providers/gmail-send.js";
 export * from "./providers/gmail-thread-resolver.js";
 export * from "./providers/gmail-record-builder.js";
+export * from "./providers/gmail-attachment-classification.js";
 export * from "./providers/mailchimp.js";
 export * from "./providers/anthropic.js";
 export * from "./providers/notion.js";

--- a/packages/integrations/src/providers/gmail-attachment-classification.ts
+++ b/packages/integrations/src/providers/gmail-attachment-classification.ts
@@ -1,0 +1,59 @@
+export function normalizeContentId(
+  value: string | null | undefined,
+): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const normalized = trimmed.replace(/^<|>$/gu, "").toLowerCase();
+  return normalized.length > 0 ? normalized : null;
+}
+
+export function resolveContentDispositionType(
+  contentDisposition: string | null | undefined,
+): string | null {
+  if (typeof contentDisposition !== "string") {
+    return null;
+  }
+
+  const dispositionType = contentDisposition.split(";")[0]?.trim().toLowerCase();
+  return dispositionType && dispositionType.length > 0
+    ? dispositionType
+    : null;
+}
+
+export function isInlineAttachment(input: {
+  readonly attachment: {
+    readonly contentDisposition?: string | null;
+    readonly contentId?: string | null;
+  };
+  readonly htmlBodyCidReferences: ReadonlySet<string>;
+}): boolean {
+  const dispositionType = resolveContentDispositionType(
+    input.attachment.contentDisposition,
+  );
+
+  if (dispositionType === "attachment") {
+    return false;
+  }
+
+  if (dispositionType === "inline") {
+    return true;
+  }
+
+  const normalizedContentId = normalizeContentId(input.attachment.contentId);
+  if (
+    normalizedContentId === null ||
+    !input.htmlBodyCidReferences.has(normalizedContentId)
+  ) {
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Summary

- Closes the deferred backfill from PR #472. Historical `message_attachments` rows with stale `is_inline=false` (notably Michael Gast's quoted GoDaddy-firewall screenshot) get recomputed using the same rule capture now uses.
- New worker ops command `ops:recompute-attachment-inline`, dry-run by default, scoped to a `created_at` window and `image/*` mime types.
- Shared classification helper extracted to `packages/integrations/src/providers/gmail-attachment-classification.ts` so capture and backfill stay aligned (single source of truth).

## How to use after merge

```bash
# Dry-run (read-only — reports which rows would flip)
railway ssh --service gmail-capture
pnpm --filter @as-comms/worker ops:recompute-attachment-inline \
  --since=2026-03-01T00:00:00Z \
  --until=2026-05-29T23:59:59Z

# Execute (writes the is_inline updates)
pnpm --filter @as-comms/worker ops:recompute-attachment-inline \
  --since=2026-03-01T00:00:00Z \
  --until=2026-05-29T23:59:59Z \
  --execute
```

The op:
1. Loads `message_attachments` where `is_inline=false AND mime_type LIKE 'image/%' AND created_at BETWEEN <since> AND <until>`
2. For each row, looks up `gmail_message_details` by `source_evidence_id` to get the Gmail message ID
3. Re-fetches the message via Gmail API to read `Content-Disposition` / `Content-ID` headers and HTML CID references
4. Recomputes `is_inline` using the new rule
5. Logs per-row outcome + emits summary JSON

## Test plan

- [x] `pnpm --filter @as-comms/worker typecheck`
- [x] `pnpm --filter @as-comms/worker lint`
- [x] `pnpm --filter @as-comms/worker test` (199 passed across 54 files, includes 6 new fixtures for the new op)
- [x] `pnpm --filter @as-comms/gmail-capture typecheck`
- [x] `pnpm --filter @as-comms/gmail-capture lint`
- [x] `pnpm --filter @as-comms/gmail-capture test` (13 passed; the macOS `internal-attachments-route` EPERM is the known sandbox gotcha, unrelated to this change)
- [x] `pnpm --filter @as-comms/integrations lint`
- [x] `pnpm boundaries`
- [ ] Spot-check in prod: after merge, run dry-run for a 90-day window, eyeball the candidate count, then `--execute`. Verify Michael Gast's "Re: Claim Your Adventure Today" thread no longer shows the screenshot under the outbound bubble.

🤖 Generated with [Claude Code](https://claude.com/claude-code) + Codex (gpt-5.4)