### PR TITLE
ci: split Playwright smoke into a separate non-required job (#471)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,25 +44,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
 
-      # Playwright browser binary lives in ~/.cache/ms-playwright by default
-      # (we no longer pin PLAYWRIGHT_BROWSERS_PATH=0 — that forced install
-      # into node_modules and defeated this cache). Key includes the
-      # Playwright version pulled into the lockfile so a Playwright upgrade
-      # invalidates automatically. ubuntu-latest ships the system libs
-      # Chromium needs, so we drop the `--with-deps` apt path that was
-      # hanging for >1h on transient apt-mirror stalls.
-      - name: Cache Playwright browser
-        id: playwright-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-
-      - name: Install Playwright browser
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        timeout-minutes: 5
-        run: pnpm exec playwright install chromium
-
       - name: Lint
         run: pnpm lint
 
@@ -83,9 +64,6 @@ jobs:
             psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$migration"
           done
 
-      - name: Playwright smoke
-        run: pnpm test:e2e
-
       - name: Boundary check
         run: pnpm boundaries
 
@@ -94,3 +72,73 @@ jobs:
 
       - name: Verification gate
         run: pnpm verify
+
+  playwright-smoke:
+    runs-on: ubuntu-latest
+    needs: verify
+    continue-on-error: true
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d test"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    env:
+      CI: "true"
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Apply database migrations
+        shell: bash
+        run: |
+          set -euo pipefail
+          for migration in packages/db/drizzle/*.sql; do
+            psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$migration"
+          done
+
+      # Playwright browser binary lives in ~/.cache/ms-playwright by default
+      # (we no longer pin PLAYWRIGHT_BROWSERS_PATH=0 — that forced install
+      # into node_modules and defeated this cache). Key includes the
+      # Playwright version pulled into the lockfile so a Playwright upgrade
+      # invalidates automatically. ubuntu-latest ships the system libs
+      # Chromium needs, so we drop the `--with-deps` apt path that was
+      # hanging for >1h on transient apt-mirror stalls.
+      - name: Cache Playwright browser
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright browser
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 5
+        run: pnpm exec playwright install chromium
+
+      - name: Playwright smoke
+        run: pnpm test:e2e


### PR DESCRIPTION
## Summary

- Closes #471.
- Today's session was a real-time demonstration of why this matters: 5 merged PRs (#470, #472, #473, #474, #475) all failed the existing single-job `Stage 0 CI` workflow on the same transient Playwright install stall. Railway's per-service "Wait for CI" gate then **SKIPPED every deploy attempt since 2026-05-27** — none of the merges actually reached production until we triggered manual redeploys.
- This PR fixes it durably so future flakes don't block deploys.

## What changed

Two-job split in [.github/workflows/ci.yml](.github/workflows/ci.yml):

### `verify` (required)
Lint → Typecheck → Build → Unit tests → Apply DB migrations → Boundary check → Security check → Verification gate.

**Removed from this job:** `PLAYWRIGHT_BROWSERS_PATH: 0` env, Playwright cache step, Playwright install step, Playwright smoke step. Workflow concludes on this job alone for required-check purposes.

### `playwright-smoke` (advisory)
- `needs: verify` (only runs once the required job is clean)
- `continue-on-error: true` at the **job level** (failures don't change workflow conclusion)
- `timeout-minutes: 15` on the whole job
- 5-min `timeout-minutes` on the Playwright install step (so a future apt/CDN stall fails fast)
- `actions/cache@v4` for `~/.cache/ms-playwright` (cache hit skips the install entirely)
- Same Postgres service container and migration step as `verify` (jobs don't share state)

Smoke failures still surface in the PR check list — devs can click in to see the log — but they don't block merge OR deploy.

## Architect to-do AFTER this merges

1. Go to GitHub → repo → Settings → Branches → main → Edit rule
2. Under "Required status checks", make sure ONLY `verify` is required (not `playwright-smoke`)
3. Save
4. (Optional) If Railway "Wait for CI" was bypassed for the recovery redeploys today, reset it to its normal state — the workflow will now conclude `success` on flaky-Playwright PRs, so the gate works correctly again.

## Test plan

YAML-only change; no code-level validation applies.

- [x] `cat .github/workflows/ci.yml` — structure visually confirmed
- [x] Per-step ordering preserved in `verify` (lint, typecheck, build, unit tests, migrations, boundaries, security, verify)
- [x] `playwright-smoke` reuses the existing cache + install pattern, no new actions added
- [ ] On merge, watch the first PR after this lands — verify the workflow runs both jobs and the `verify` check goes ✅ even if `playwright-smoke` flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code) + Codex (gpt-5.4)