### PR TITLE
fix(worker): correlate recompute-attachment-inline by partIndexPath, not ephemeral gmail_attachment_id

### DIFF
--- a/apps/worker/src/ops/recompute-attachment-inline.ts
+++ b/apps/worker/src/ops/recompute-attachment-inline.ts
@@ -41,6 +41,7 @@ interface CandidateAttachmentRow {
   readonly gmailAttachmentId: string;
   readonly mimeType: string;
   readonly isInline: boolean;
+  readonly partIndexPath: string | null;
 }
 
 interface CachedMessageData {
@@ -157,6 +158,25 @@ function logEntry(
   logger.log(JSON.stringify(entry));
 }
 
+function parsePartIndexPathFromAttachmentId(
+  attachmentId: string,
+): string | null {
+  const prefix = "att:gmail:";
+
+  if (!attachmentId.startsWith(prefix)) {
+    return null;
+  }
+
+  const messageIdDelimiterIndex = attachmentId.indexOf(":", prefix.length);
+
+  if (messageIdDelimiterIndex < 0) {
+    return null;
+  }
+
+  const partIndexPath = attachmentId.slice(messageIdDelimiterIndex + 1).trim();
+  return partIndexPath.length > 0 ? partIndexPath : null;
+}
+
 async function loadCandidateRows(input: {
   readonly db: Stage1Database;
   readonly since: string;
@@ -194,6 +214,7 @@ async function loadCandidateRows(input: {
       gmailAttachmentId: row.gmailAttachmentId,
       mimeType: row.mimeType,
       isInline: row.isInline,
+      partIndexPath: parsePartIndexPathFromAttachmentId(row.id),
     })),
     truncated: rows.length > input.limit,
   };
@@ -285,8 +306,20 @@ export async function recomputeAttachmentInline(input: {
       continue;
     }
 
+    if (candidate.partIndexPath === null) {
+      skipped += 1;
+      logEntry(logger, {
+        id: candidate.id,
+        sourceEvidenceId: candidate.sourceEvidenceId,
+        gmailAttachmentId: candidate.gmailAttachmentId,
+        action: "skipped",
+        reason: "attachment_not_in_message",
+      });
+      continue;
+    }
+
     const attachment = messageData.attachmentMetadata.find(
-      (value) => value.gmailAttachmentId === candidate.gmailAttachmentId,
+      (value) => value.partIndexPath === candidate.partIndexPath,
     );
 
     if (attachment === undefined) {

--- a/apps/worker/test/recompute-attachment-inline.test.ts
+++ b/apps/worker/test/recompute-attachment-inline.test.ts
@@ -17,6 +17,7 @@ function buildAttachmentPayload(input: {
   readonly gmailAttachmentId: string;
   readonly contentDisposition: string;
   readonly contentId?: string;
+  readonly attachmentAtRoot?: boolean;
 }): GmailMessageMetadata["payload"] {
   const html = input.contentId
     ? `<html><body><img src="cid:${input.contentId.replace(/^<|>$/gu, "")}" /></body></html>`
@@ -34,50 +35,68 @@ function buildAttachmentPayload(input: {
     body: {
       size: 0,
     },
-    parts: [
-      {
-        mimeType: "text/html",
-        filename: "",
-        headers: [
+    parts: input.attachmentAtRoot
+      ? [
           {
-            name: "Content-Type",
-            value: "text/html; charset=UTF-8",
+            mimeType: "text/html",
+            filename: "",
+            headers: [
+              {
+                name: "Content-Type",
+                value: "text/html; charset=UTF-8",
+              },
+            ],
+            body: {
+              data: Buffer.from(html, "utf8").toString("base64url"),
+              size: html.length,
+            },
+            parts: [],
+          },
+        ]
+      : [
+          {
+            mimeType: "text/html",
+            filename: "",
+            headers: [
+              {
+                name: "Content-Type",
+                value: "text/html; charset=UTF-8",
+              },
+            ],
+            body: {
+              data: Buffer.from(html, "utf8").toString("base64url"),
+              size: html.length,
+            },
+            parts: [],
+          },
+          {
+            mimeType: "image/png",
+            filename: "screenshot.png",
+            headers: [
+              {
+                name: "Content-Type",
+                value: 'image/png; name="screenshot.png"',
+              },
+              {
+                name: "Content-Disposition",
+                value: input.contentDisposition,
+              },
+              ...(input.contentId === undefined
+                ? []
+                : [
+                    {
+                      name: "Content-ID",
+                      value: input.contentId,
+                    },
+                  ]),
+            ],
+            body: {
+              attachmentId: input.gmailAttachmentId,
+              size: 128,
+            },
+            parts: [],
           },
         ],
-        body: {
-          data: Buffer.from(html, "utf8").toString("base64url"),
-          size: html.length,
-        },
-        parts: [],
-      },
-      {
-        mimeType: "image/png",
-        filename: "screenshot.png",
-        headers: [
-          {
-            name: "Content-Type",
-            value: 'image/png; name="screenshot.png"',
-          },
-          {
-            name: "Content-Disposition",
-            value: input.contentDisposition,
-          },
-          ...(input.contentId === undefined
-            ? []
-            : [
-                {
-                  name: "Content-ID",
-                  value: input.contentId,
-                },
-              ]),
-        ],
-        body: {
-          attachmentId: input.gmailAttachmentId,
-          size: 128,
-        },
-        parts: [],
-      },
-    ],
   };
 }
 
@@ -86,6 +105,7 @@ function buildMessageMetadata(input: {
   readonly gmailAttachmentId: string;
   readonly contentDisposition: string;
   readonly contentId?: string;
+  readonly attachmentAtRoot?: boolean;
 }): GmailMessageMetadata {
   return {
     id: input.messageId,
@@ -104,14 +124,17 @@ async function seedGmailMessageContext(input: {
   readonly createdAt: string;
   readonly mimeType?: string;
   readonly gmailAttachmentId?: string;
+  readonly partIndexPath?: string;
 }): Promise<{
   readonly attachmentId: string;
   readonly gmailAttachmentId: string;
+  readonly partIndexPath: string;
 }> {
   const gmailAttachmentId = input.gmailAttachmentId ?? "gmail-attachment-1";
+  const partIndexPath = input.partIndexPath ?? "1";
   const attachmentId = buildGmailMessageAttachmentId({
     messageId: input.messageId,
-    partIndexPath: "1.2",
+    partIndexPath,
   });
 
   await input.context.repositories.sourceEvidence.append({
@@ -160,6 +183,7 @@ async function seedGmailMessageContext(input: {
   return {
     attachmentId,
     gmailAttachmentId,
+    partIndexPath,
   };
 }
 
@@ -199,7 +223,7 @@ describe("recompute-attachment-inline", () => {
             Promise.resolve(
               buildMessageMetadata({
                 messageId: "msg-1",
-                gmailAttachmentId: seeded.gmailAttachmentId,
+                gmailAttachmentId: "ephemeral-live-id-1",
                 contentDisposition: "inline",
                 contentId: "<inline-image-1>",
               }),
@@ -258,7 +282,7 @@ describe("recompute-attachment-inline", () => {
             Promise.resolve(
               buildMessageMetadata({
                 messageId: "msg-2",
-                gmailAttachmentId: seeded.gmailAttachmentId,
+                gmailAttachmentId: "ephemeral-live-id-2",
                 contentDisposition: "inline",
                 contentId: "<inline-image-2>",
               }),
@@ -306,7 +330,7 @@ describe("recompute-attachment-inline", () => {
             Promise.resolve(
               buildMessageMetadata({
                 messageId: "msg-3",
-                gmailAttachmentId: seeded.gmailAttachmentId,
+                gmailAttachmentId: "ephemeral-live-id-3",
                 contentDisposition: "attachment",
               }),
             ),
@@ -404,6 +428,109 @@ describe("recompute-attachment-inline", () => {
         gmailAttachmentId: seeded.gmailAttachmentId,
         action: "skipped",
         reason: "gmail_message_not_found",
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("recomputes when the live Gmail attachment id changed but partIndexPath stayed stable", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      const sourceEvidenceId = buildSourceEvidenceId("gmail", "message", "msg-ephemeral");
+      const seeded = await seedGmailMessageContext({
+        context,
+        sourceEvidenceId,
+        messageId: "msg-ephemeral",
+        createdAt: "2026-05-20T10:00:00.000Z",
+        gmailAttachmentId: "OLD_ID",
+      });
+
+      const result = await recomputeAttachmentInline({
+        db: context.db,
+        repositories: context.repositories,
+        apiClient: {
+          listMessageIds: () => Promise.resolve([]),
+          getMessage: () =>
+            Promise.resolve(
+              buildMessageMetadata({
+                messageId: "msg-ephemeral",
+                gmailAttachmentId: "NEW_ID",
+                contentDisposition: "inline",
+                contentId: "<inline-image-ephemeral>",
+              }),
+            ),
+        },
+        mailbox: "volunteers@adventurescientists.org",
+        since: "2026-05-01T00:00:00.000Z",
+        until: "2026-05-29T23:59:59.999Z",
+        execute: true,
+        limit: 1000,
+      });
+
+      expect(result).toMatchObject({
+        recomputed: 1,
+        skipped: 0,
+      });
+      await expect(
+        context.repositories.messageAttachments.findById(seeded.attachmentId),
+      ).resolves.toMatchObject({
+        gmailAttachmentId: "OLD_ID",
+        isInline: true,
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("skips rows when the partIndexPath is no longer present in the live Gmail message", async () => {
+    const context = await createTestWorkerContext();
+    const logs: RecomputeAttachmentInlineLogEntry[] = [];
+
+    try {
+      const sourceEvidenceId = buildSourceEvidenceId("gmail", "message", "msg-missing-part");
+      const seeded = await seedGmailMessageContext({
+        context,
+        sourceEvidenceId,
+        messageId: "msg-missing-part",
+        createdAt: "2026-05-20T10:00:00.000Z",
+      });
+
+      const result = await recomputeAttachmentInline({
+        db: context.db,
+        repositories: context.repositories,
+        apiClient: {
+          listMessageIds: () => Promise.resolve([]),
+          getMessage: () =>
+            Promise.resolve(
+              buildMessageMetadata({
+                messageId: "msg-missing-part",
+                gmailAttachmentId: "other-live-id",
+                contentDisposition: "inline",
+                contentId: "<inline-image-missing-part>",
+                attachmentAtRoot: true,
+              }),
+            ),
+        },
+        mailbox: "volunteers@adventurescientists.org",
+        since: "2026-05-01T00:00:00.000Z",
+        until: "2026-05-29T23:59:59.999Z",
+        execute: false,
+        limit: 1000,
+        logger: createLogger(logs),
+      });
+
+      expect(result).toMatchObject({
+        skipped: 1,
+        recomputed: 0,
+      });
+      expect(logs).toContainEqual({
+        id: seeded.attachmentId,
+        sourceEvidenceId,
+        gmailAttachmentId: seeded.gmailAttachmentId,
+        action: "skipped",
+        reason: "attachment_not_in_message",
       });
     } finally {
       await context.dispose();


### PR DESCRIPTION
## Summary

- PR #475 shipped `ops:recompute-attachment-inline` to heal historical Gmail inline-attachment misclassifications (Michael Gast's quoted-screenshot case).
- Ran it tonight against 127 candidates → **recomputed 0** → every single one bailed out with `attachment_not_in_message`.
- Root cause: my (architect) brief told Codex to match attachments by `gmail_attachment_id`. **Gmail's attachment IDs are ephemeral** — they change on every `messages.get` call. The stored capture-time ID never matched the freshly-fetched ID, so the op silently skipped everything.
- The stable identifier is `partIndexPath` (MIME tree position). It's already encoded in our internal attachment id at [packages/integrations/src/providers/gmail-body.ts:843](packages/integrations/src/providers/gmail-body.ts:843): `att:gmail:${messageId}:${partIndexPath}`.

## What changed

[apps/worker/src/ops/recompute-attachment-inline.ts](apps/worker/src/ops/recompute-attachment-inline.ts):

- New `parsePartIndexPathFromAttachmentId` parses the partIndexPath suffix from our internal id (handles paths with `/`, e.g. `1/1`).
- The per-row "find this attachment in the re-fetched message" step now compares `metadata.partIndexPath === candidate.partIndexPath` instead of `metadata.gmailAttachmentId === candidate.gmailAttachmentId`.
- The `gmail_attachment_id` column stays in `message_attachments`; capture still uses it. Only the recovery-op match key changes.

## Tests

[apps/worker/test/recompute-attachment-inline.test.ts](apps/worker/test/recompute-attachment-inline.test.ts) — fixtures updated + new regression:

- Existing recompute cases seed canonical ids in the `att:gmail:<msgId>:<partIndexPath>` format.
- **NEW** ephemeral-gmailAttachmentId regression: live Gmail returns a different `gmailAttachmentId` at the same `partIndexPath`; the op still matches and recomputes (this is the exact failure mode from tonight).
- **NEW** true no-match case: when the partIndexPath isn't in the message, the op still logs `attachment_not_in_message` and skips.

201 tests pass total (was 199 — 2 new fixtures).

## After this merges + deploys

The architect re-runs in Railway SSH on the gmail-capture container:

```bash
pnpm --filter @as-comms/worker ops:recompute-attachment-inline \
  --since=2026-03-01T00:00:00Z \
  --until=2026-05-29T23:59:59Z
```

Should report a much smaller `skipped` count and a non-zero `recomputed`. Then re-run with `--execute` to actually flip the rows. Michael Gast's case (and any other historical quoted-screenshot attachments) should heal.

## Test plan

- [x] `pnpm --filter @as-comms/worker typecheck`
- [x] `pnpm --filter @as-comms/worker lint`
- [x] `pnpm --filter @as-comms/worker test` (201 passed; +2 new fixtures)
- [x] `pnpm boundaries`
- [ ] Post-merge + post-deploy: dry-run the op in Railway SSH and confirm `recomputed > 0`. If yes, `--execute`. Spot-check Michael Gast's "Re: Claim Your Adventure Today" thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code) + Codex (gpt-5.4)