### PR TITLE
fix(ci): drop pnpm test:e2e from verify-stage0 required-command list

### DIFF
--- a/scripts/verify-stage0.mjs
+++ b/scripts/verify-stage0.mjs
@@ -201,12 +201,15 @@ async function main() {
 
   try {
     const ciWorkflow = await readText(".github/workflows/ci.yml");
+    // `pnpm test:e2e` intentionally NOT in this list — the Playwright job
+    // was removed from CI in #477 because of an upstream Chromium-install
+    // hang. The `test:e2e` script stays in package.json for local runs and
+    // can be restored to CI in one commit when the upstream issue clears.
     for (const command of [
       "pnpm lint",
       "pnpm typecheck",
       "pnpm build",
       "pnpm test:unit",
-      "pnpm test:e2e",
       "pnpm boundaries",
       "pnpm security",
       "pnpm verify"


### PR DESCRIPTION
## Summary

- After PR #477 removed the playwright-smoke job from CI, every subsequent PR has failed the `Verification gate` step (and Railway has skipped every deploy as a result).
- Root cause: [scripts/verify-stage0.mjs](scripts/verify-stage0.mjs) hardcodes a list of required CI workflow commands that still includes `pnpm test:e2e`. Since we intentionally removed that from CI, the guard fires.
- This PR removes `pnpm test:e2e` from the required-commands list, with a comment explaining the deliberate exception and the path to restore it.

## What changed

[scripts/verify-stage0.mjs:203-218](scripts/verify-stage0.mjs:203): one element removed from the array (`"pnpm test:e2e"`), plus a comment block explaining the deliberate exception. The `test:e2e` script in `package.json` is **NOT** affected — that's checked separately in `requiredRootScripts` and still works for local runs (`pnpm test:e2e`).

## Test plan

- [x] `pnpm verify` locally → "Stage 0 verification gate passed."
- [ ] On merge: confirm CI's `verify` job now finishes ✅ on this PR's commit. Railway auto-deploys all 3 services.
- [ ] After deploys: re-run the attachment backfill op (PR #478) — should now actually recompute the 127 candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)