### PR TITLE
fix(inbox): hide outbound attachments that duplicate inbound on same thread

### DIFF
--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -225,6 +225,10 @@ interface InboxDetailCacheData {
     string,
     readonly MessageAttachmentRecord[]
   >;
+  readonly inboundAttachmentSignaturesByThread: ReadonlyMap<
+    string,
+    ReadonlySet<string>
+  >;
   readonly timelinePage: InboxDetailTimelinePageViewModel;
   readonly freshness: InboxDetailFreshnessViewModel;
 }
@@ -2266,6 +2270,19 @@ function buildTimelineEntry(input: {
     string,
     readonly MessageAttachmentRecord[]
   >;
+  /**
+   * Per-Gmail-thread set of `(filename:sizeBytes)` signatures for all
+   * inbound attachments seen across the loaded timeline. Used by the
+   * email attachment builder to hide outbound quoted duplicates so
+   * the screenshot the volunteer attached doesn't visually float
+   * under the operator's reply bubble (and vice versa for any later
+   * outbound quoting). Built once per page assembly; see
+   * `buildInboundAttachmentSignaturesByThread`.
+   */
+  readonly inboundAttachmentSignaturesByThread: ReadonlyMap<
+    string,
+    ReadonlySet<string>
+  >;
 }): InboxTimelineEntryViewModel {
   const latestProjectionSnippet =
     input.item.family === "one_to_one_email" &&
@@ -2377,6 +2394,14 @@ function buildTimelineEntry(input: {
               input.item.canonicalEventId,
             ) ?? [],
           pending: input.item.pendingAttachmentMetadata ?? [],
+          inboundAttachmentSignaturesOnThread:
+            input.item.direction === "outbound" &&
+            input.item.threadId !== null &&
+            input.item.threadId.length > 0
+              ? (input.inboundAttachmentSignaturesByThread.get(
+                  input.item.threadId,
+                ) ?? null)
+              : null,
         })
       : [];
   const headerProjectLabel =
@@ -2540,6 +2565,92 @@ function looksLikeInlineSignatureImage(attachment: {
   return INLINE_SIGNATURE_FILENAME_PATTERN.test(trimmed);
 }
 
+/**
+ * Build a thread-scoped signature for a given message attachment.
+ * Used to detect outbound attachments that are quoted copies of an
+ * inbound attachment on the same Gmail thread — Gmail's reply-quote
+ * machinery re-attaches images with `Content-Disposition: attachment`
+ * (not inline), so the capture-time inline classifier can't tell
+ * them apart from a real new attachment. We catch those at render
+ * time by matching `(filename, sizeBytes)` against the set of
+ * inbound attachments already seen on the thread.
+ */
+function buildAttachmentSignature(input: {
+  readonly filename: string | null;
+  readonly sizeBytes: number;
+}): string {
+  return `${input.filename ?? ""}:${String(input.sizeBytes)}`;
+}
+
+/**
+ * Walk the loaded timeline items once, collect `(filename, sizeBytes)`
+ * signatures for every attachment on an INBOUND email, and group by
+ * Gmail thread. Returned map is consumed by
+ * `buildEmailAttachmentsForEntry` to suppress outbound quoted dupes.
+ *
+ * Scope note: signature set is built from the items currently loaded
+ * for the contact's detail page (i.e., the visible window). A
+ * thread spanning more pages than what's loaded only filters within
+ * the loaded slice; the operator can still scroll to see the older
+ * inbound original. The signature itself is intentionally minimal
+ * (filename + size) — Gmail's quote-reply preserves both byte-for-byte
+ * for the attachment parts we care about, and the false-positive risk
+ * (volunteer legitimately re-sends an identical filename and exact
+ * size) is acceptable given the operator can still see the original
+ * copy on the inbound bubble.
+ */
+function buildInboundAttachmentSignaturesByThread(input: {
+  readonly items: readonly TimelineItem[];
+  readonly attachmentsBySourceEvidenceId: ReadonlyMap<
+    string,
+    readonly MessageAttachmentRecord[]
+  >;
+  readonly sourceEvidenceIdByCanonicalEventId: ReadonlyMap<string, string>;
+}): Map<string, Set<string>> {
+  const byThread = new Map<string, Set<string>>();
+
+  for (const item of input.items) {
+    if (item.family !== "one_to_one_email" || item.direction !== "inbound") {
+      continue;
+    }
+
+    const threadId = item.threadId;
+    if (threadId === null || threadId.length === 0) {
+      continue;
+    }
+
+    const sourceEvidenceId = input.sourceEvidenceIdByCanonicalEventId.get(
+      item.canonicalEventId,
+    );
+    if (sourceEvidenceId === undefined) {
+      continue;
+    }
+
+    const attachments =
+      input.attachmentsBySourceEvidenceId.get(sourceEvidenceId);
+    if (attachments === undefined || attachments.length === 0) {
+      continue;
+    }
+
+    let signatures = byThread.get(threadId);
+    if (signatures === undefined) {
+      signatures = new Set<string>();
+      byThread.set(threadId, signatures);
+    }
+
+    for (const attachment of attachments) {
+      signatures.add(
+        buildAttachmentSignature({
+          filename: attachment.filename,
+          sizeBytes: attachment.sizeBytes,
+        }),
+      );
+    }
+  }
+
+  return byThread;
+}
+
 function buildEmailAttachmentsForEntry(input: {
   readonly canonical: readonly MessageAttachmentRecord[];
   readonly pending: readonly {
@@ -2547,12 +2658,33 @@ function buildEmailAttachmentsForEntry(input: {
     readonly contentType: string;
     readonly sizeBytes: number;
   }[];
+  /**
+   * When the entry being rendered is outbound on a Gmail thread, this
+   * is the set of `(filename:sizeBytes)` signatures of attachments
+   * previously seen on inbound messages of the same thread. Any
+   * outbound canonical attachment whose signature is in this set is
+   * a quoted duplicate of the inbound's original and gets hidden
+   * from the outbound bubble (the original is still visible on the
+   * inbound bubble). `null` for inbound entries, or when the thread
+   * is unknown / has no inbound attachments to compare against.
+   */
+  readonly inboundAttachmentSignaturesOnThread: ReadonlySet<string> | null;
 }): InboxTimelineEntryViewModel["attachments"] {
   const canonicalAttachments = input.canonical
     .filter(
       (attachment) =>
         !attachment.isInline && !looksLikeInlineSignatureImage(attachment),
     )
+    .filter((attachment) => {
+      if (input.inboundAttachmentSignaturesOnThread === null) {
+        return true;
+      }
+      const signature = buildAttachmentSignature({
+        filename: attachment.filename,
+        sizeBytes: attachment.sizeBytes,
+      });
+      return !input.inboundAttachmentSignaturesOnThread.has(signature);
+    })
     .map((attachment) => ({
       id: attachment.id,
       mimeType: attachment.mimeType,
@@ -3881,6 +4013,13 @@ async function readInboxDetailCacheData(
         ) ?? [],
       ]),
     ),
+    inboundAttachmentSignaturesByThread: buildInboundAttachmentSignaturesByThread(
+      {
+        items: timelinePage.items,
+        attachmentsBySourceEvidenceId,
+        sourceEvidenceIdByCanonicalEventId,
+      },
+    ),
     timelinePage: {
       hasMore: timelinePage.hasMore,
       hasHiddenEarlierHistory,
@@ -4503,6 +4642,8 @@ function buildInboxDetailTimelineViewModel(input: {
       activityTimelineItems: input.cachedData.activityTimelineItems,
       attachmentsByCanonicalEventId:
         input.cachedData.attachmentsByCanonicalEventId,
+      inboundAttachmentSignaturesByThread:
+        input.cachedData.inboundAttachmentSignaturesByThread,
     }),
   );
 

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -7010,6 +7010,104 @@ describe("real inbox selectors", () => {
     ]);
   });
 
+  it("hides outbound attachments that are quoted duplicates of an inbound on the same thread", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:quoted-dupe",
+      salesforceContactId: "003-quoted-dupe",
+      displayName: "Quoted Dupe Test",
+      primaryEmail: "qd@example.org",
+      primaryPhone: null,
+    });
+    // Inbound from volunteer with a screenshot attached. The seed helper
+    // groups events by contactId into one Gmail thread, so the outbound
+    // below sits on the same `threadId` automatically.
+    const inbound = await seedInboxEmailEvent(runtime.context, {
+      id: "qd-inbound-1",
+      contactId: "contact:quoted-dupe",
+      occurredAt: "2026-05-28T07:44:00.000Z",
+      direction: "inbound",
+      subject: "Re: Claim Your Adventure Today",
+      snippet: "Hi Samantha, I tried to claim a zone…",
+    });
+    await seedInboxMessageAttachment(runtime.context, {
+      sourceEvidenceId: "source:qd-inbound-1",
+      id: "att:gmail:qd-inbound-1:1",
+      mimeType: "image/png",
+      filename: "Screenshot 2026-05-28 at 10.21.54 AM.png",
+      sizeBytes: 45_817,
+      storageKey: "gmail/qd/att:gmail:qd-inbound-1:1",
+    });
+    // Operator's reply quotes the inbound. Gmail re-attaches the
+    // screenshot byte-for-byte with the same filename, but as a fresh
+    // MIME part with Content-Disposition: attachment (so the
+    // capture-time inline classifier can't tell it's a dupe). Plus a
+    // unique outbound-only attachment to confirm it survives the filter.
+    const outbound = await seedInboxEmailEvent(runtime.context, {
+      id: "qd-outbound-1",
+      contactId: "contact:quoted-dupe",
+      occurredAt: "2026-05-28T09:12:00.000Z",
+      direction: "outbound",
+      subject: "Re: Claim Your Adventure Today",
+      snippet: "Hey Michael! I will look into why this message is popping up…",
+    });
+    await seedInboxMessageAttachment(runtime.context, {
+      sourceEvidenceId: "source:qd-outbound-1",
+      id: "att:gmail:qd-outbound-1:1",
+      mimeType: "image/png",
+      filename: "Screenshot 2026-05-28 at 10.21.54 AM.png",
+      sizeBytes: 45_817,
+      storageKey: "gmail/qd/att:gmail:qd-outbound-1:1",
+    });
+    await seedInboxMessageAttachment(runtime.context, {
+      sourceEvidenceId: "source:qd-outbound-1",
+      id: "att:gmail:qd-outbound-1:2",
+      mimeType: "application/pdf",
+      filename: "instructions.pdf",
+      sizeBytes: 12_345,
+      storageKey: "gmail/qd/att:gmail:qd-outbound-1:2",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:quoted-dupe",
+      bucket: "Opened",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-05-28T07:44:00.000Z",
+      lastOutboundAt: "2026-05-28T09:12:00.000Z",
+      lastActivityAt: "2026-05-28T09:12:00.000Z",
+      snippet: "Hey Michael! I will look into why this message is popping up…",
+      lastCanonicalEventId: outbound.canonicalEventId,
+      lastEventType: "communication.email.outbound",
+    });
+
+    const detail = await getInboxDetail("contact:quoted-dupe");
+
+    const inboundEntry = detail?.timeline.find(
+      (entry) => entry.kind === "inbound-email",
+    );
+    const outboundEntry = detail?.timeline.find(
+      (entry) => entry.kind === "outbound-email",
+    );
+
+    // Inbound original screenshot stays visible (it's the real file
+    // the volunteer attached; this is the only copy the operator
+    // should see).
+    expect(inboundEntry?.attachments).toHaveLength(1);
+    expect(inboundEntry?.attachments[0]?.filename).toBe(
+      "Screenshot 2026-05-28 at 10.21.54 AM.png",
+    );
+
+    // Outbound's quoted copy of the screenshot is filtered (same
+    // filename + sizeBytes as the inbound on the same thread).
+    // The genuinely-new outbound attachment (instructions.pdf)
+    // survives.
+    expect(outboundEntry?.attachments).toHaveLength(1);
+    expect(outboundEntry?.attachments[0]?.filename).toBe("instructions.pdf");
+  });
+
   it("falls back to pending attachment metadata when pending outbounds have no canonical attachments yet", async () => {
     if (runtime === null) {
       throw new Error("Expected inbox test runtime");


### PR DESCRIPTION
## Summary

- When a volunteer sends an email with an inline screenshot and the operator clicks **Reply** in Gmail, Gmail's reply-quote machinery re-attaches the screenshot byte-for-byte as a fresh MIME part with `Content-Disposition: attachment` (not inline).
- PR #472's capture-time classifier correctly leaves these as `is_inline=false` because the disposition genuinely IS `attachment`. So even after #472 + the backfill ran, Michael Gast's GoDaddy-firewall screenshot was still rendering under the operator's outbound bubble.
- **Confirmed via DB query:** the outbound canonical attachment rows have the exact same `(filename, sizeBytes)` as the inbound rows on the same Gmail thread — `Screenshot 2026-05-28 at 10.21.54 AM.png` (45,817 bytes) and `1779975766133blob.jpg` (105,974 bytes), each duplicated on 3 outbound replies.

## What changed

[apps/web/app/inbox/_lib/selectors.ts](apps/web/app/inbox/_lib/selectors.ts) — render-time filter:

1. New helper `buildAttachmentSignature` produces a stable `${filename}:${sizeBytes}` string for any attachment.
2. New helper `buildInboundAttachmentSignaturesByThread` walks the loaded timeline once, collects signatures for every **inbound** email attachment, groups by `gmailThreadId`. Built alongside the existing `attachmentsByCanonicalEventId` map; one extra pass over the same data.
3. `buildEmailAttachmentsForEntry` gains an `inboundAttachmentSignaturesOnThread` parameter. When the entry is **outbound** on a known thread, any canonical attachment whose signature is in the inbound set is filtered out. Inbound entries always pass `null` (never filter the original).

No schema change, no capture change, no migration. Pure presentation-layer fix.

## Trade-off explicitly accepted

If a volunteer legitimately re-sends an identical file (same filename AND exact byte size — a high coincidence bar), it would be hidden on the outbound bubble. The original copy is still on the inbound message they sent, so the operator never loses visibility of the file itself.

## Test

[apps/web/tests/unit/inbox-selectors.test.ts](apps/web/tests/unit/inbox-selectors.test.ts): one new fixture seeds:
- An inbound with a screenshot attached
- An outbound on the same thread with the same `(filename, sizeBytes)` screenshot (the quoted dupe)
- A second outbound attachment that is **unique** (different filename)

Asserts:
- Inbound entry shows the screenshot ✓ (original stays visible)
- Outbound entry hides the quoted screenshot ✓ (the bug)
- Outbound entry still shows the unique attachment ✓ (no over-filtering)

## Test plan

- [x] `pnpm --filter @as-comms/web typecheck`
- [x] `pnpm --filter @as-comms/web lint`
- [x] `pnpm --filter @as-comms/web test` (135 inbox-selectors tests pass; was 134, +1 new)
- [x] `pnpm --filter @as-comms/web build`
- [x] `pnpm boundaries`
- [ ] Spot-check in prod after merge: open Michael Gast's "Re: Claim Your Adventure Today" thread. The screenshot should now only appear under Michael's inbound bubble — gone from all 3 operator outbound replies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)