### PR TITLE
fix(test): drop unused inbound binding in quoted-dupe attachment test

### DIFF
--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -7025,7 +7025,7 @@ describe("real inbox selectors", () => {
     // Inbound from volunteer with a screenshot attached. The seed helper
     // groups events by contactId into one Gmail thread, so the outbound
     // below sits on the same `threadId` automatically.
-    const inbound = await seedInboxEmailEvent(runtime.context, {
+    await seedInboxEmailEvent(runtime.context, {
       id: "qd-inbound-1",
       contactId: "contact:quoted-dupe",
       occurredAt: "2026-05-28T07:44:00.000Z",


### PR DESCRIPTION
Lint fixup for PR #480. The test refactor mid-write left an orphan `const inbound = await ...` binding that the local lint pass didn't catch (the file wasn't re-linted between iterations). CI caught it on main, failed at the Lint step, and Railway skipped all 3 service deploys.

One-line fix: drop the unused binding.

## Test plan

- [x] `pnpm --filter @as-comms/web lint` — passes
- [x] `pnpm --filter @as-comms/web test` — the quoted-dupe test still passes (kind-based find unaffected)
- [ ] On merge, CI green → Railway auto-deploys → Michael Gast screenshot drops from outbound bubbles