### PR TITLE
fix(ai-knowledge): synthesis job writes ai_knowledge_entries directly

### DIFF
--- a/apps/worker/src/jobs/synthesize-project-knowledge/index.ts
+++ b/apps/worker/src/jobs/synthesize-project-knowledge/index.ts
@@ -1,4 +1,5 @@
 import type { Task } from "graphile-worker";
+import { and, eq, ne } from "drizzle-orm";
 
 import {
   synthesizeProjectKnowledgeJobName,
@@ -6,6 +7,10 @@ import {
   type ProjectDimensionRecord,
   type SynthesizeProjectKnowledgePayload,
 } from "@as-comms/contracts";
+import {
+  aiKnowledgeEntries,
+  type Stage1Database,
+} from "@as-comms/db";
 import type {
   ProjectDimensionRepository,
   SettingsProjectsRepository,
@@ -18,6 +23,11 @@ import {
   type NotionClient,
 } from "@as-comms/integrations";
 
+import {
+  upsertAiKnowledgeEntry,
+  type UpsertAiKnowledgeEntryInput,
+  type UpsertAiKnowledgeEntryResult,
+} from "../notion-knowledge-sync/upsert.js";
 import {
   synthesizeProjectKnowledgeOrchestrator,
   type SynthesizeProjectKnowledgeOrchestratorDependencies,
@@ -106,6 +116,17 @@ export interface SynthesizeProjectKnowledgeDependencies
     >;
     readonly settingsProjects: Pick<SettingsProjectsRepository, "setAiKnowledgeUrl">;
   };
+  /**
+   * DB connection used to write the synthesis output to ai_knowledge_entries
+   * (the cache the AI Draft retriever reads). Injected separately so the job
+   * tests can stub upsertEntry without standing up the full repository
+   * bundle. Mirrors the pattern in notion-knowledge-sync.
+   */
+  readonly db: Stage1Database;
+  readonly upsertEntry?: (
+    db: Stage1Database,
+    payload: UpsertAiKnowledgeEntryInput,
+  ) => Promise<UpsertAiKnowledgeEntryResult>;
 }
 
 export type SynthesizeProjectKnowledgeResult =
@@ -228,6 +249,50 @@ export async function runSynthesizeProjectKnowledge(
       payload.projectId,
       notionPage.url,
     );
+
+    // Write the synthesis output directly to ai_knowledge_entries so the
+    // AI Draft retriever (which reads from that cache, not from Notion)
+    // picks up the new content on the very next draft. Before this landed,
+    // operators had to separately enqueue notion-knowledge-sync to populate
+    // the cache, and the gap between synthesis and cache-write caused
+    // "Project-specific AI grounding is missing" warnings on every project
+    // that had synthesized but never been sync'd (root cause confirmed in
+    // prod 2026-05-29; all 4 active projects had empty cache while every
+    // synthesis run looked successful).
+    const upsertEntry = deps.upsertEntry ?? upsertAiKnowledgeEntry;
+    const normalizedPageId = normalizeNotionId(notionPage.id);
+    await upsertEntry(deps.db, {
+      scope: "project",
+      scopeKey: payload.projectId,
+      sourceProvider: "notion",
+      sourceId: normalizedPageId,
+      sourceUrl: notionPage.url,
+      title: pageTitle,
+      content,
+      metadata: {
+        projectId: payload.projectId,
+        trigger: "synthesize-project-knowledge",
+      },
+      sourceLastEditedAt: synthesizedAt,
+      syncedAt: synthesizedAt,
+    });
+
+    // Each synthesis creates a fresh Notion page (immutable archive), so
+    // older project-scoped Notion entries for this project are stale once
+    // the new one lands. Drop them so the retriever has exactly one
+    // Notion-sourced project entry per project — mirrors the cleanup in
+    // notion-knowledge-sync.
+    await deps.db
+      .delete(aiKnowledgeEntries)
+      .where(
+        and(
+          eq(aiKnowledgeEntries.scope, "project"),
+          eq(aiKnowledgeEntries.scopeKey, payload.projectId),
+          eq(aiKnowledgeEntries.sourceProvider, "notion"),
+          ne(aiKnowledgeEntries.sourceId, normalizedPageId),
+        ),
+      );
+
     await deps.repositories.projectDimensions.setSynthesisMetadata(
       payload.projectId,
       {

--- a/apps/worker/src/ops/synthesize-multi-source.ts
+++ b/apps/worker/src/ops/synthesize-multi-source.ts
@@ -64,6 +64,7 @@ function buildDependencies(): SynthesizeProjectKnowledgeDependencies {
     },
     model: readAnthropicModel(),
     invokeModel: (input) => invokeModel(anthropicClient, input),
+    db: connection.db,
   };
 
   return Object.assign(base, {

--- a/apps/worker/src/runtime.ts
+++ b/apps/worker/src/runtime.ts
@@ -9,6 +9,7 @@ import {
   createStage5RepositoryBundleFromConnection,
   createStage2RepositoryBundleFromConnection,
   type DatabaseConnection,
+  type Stage1Database,
 } from "@as-comms/db";
 import {
   createAudienceResolver,
@@ -273,6 +274,7 @@ function buildSynthesizeProjectKnowledgeDependencies(input: {
   readonly fetchImplementation: FetchImplementation;
   readonly repositories: ReturnType<typeof createStage1RepositoryBundleFromConnection>;
   readonly settings: ReturnType<typeof createStage2RepositoryBundleFromConnection>;
+  readonly db: Stage1Database;
 }): SynthesizeProjectKnowledgeDependencies | undefined {
   const notionApiKey = readOptionalTrimmedEnv(input.env.NOTION_API_KEY);
   const anthropicApiKey = readOptionalTrimmedEnv(input.env.ANTHROPIC_API_KEY);
@@ -311,6 +313,7 @@ function buildSynthesizeProjectKnowledgeDependencies(input: {
     },
     model,
     invokeModel: (payload) => invokeModel(anthropicClient, payload),
+    db: input.db,
   };
 }
 
@@ -538,6 +541,7 @@ export async function createStage1WorkerRuntimeServices(
       fetchImplementation,
       repositories,
       settings,
+      db: connection.db,
     },
   );
   const capture = {

--- a/apps/worker/test/synthesize-project-knowledge.test.ts
+++ b/apps/worker/test/synthesize-project-knowledge.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
-import { projectDimensions } from "@as-comms/db";
+import { aiKnowledgeEntries, projectDimensions } from "@as-comms/db";
 import type { AiKnowledgeSource } from "@as-comms/contracts";
 
 import { runSynthesizeProjectKnowledge } from "../src/jobs/synthesize-project-knowledge/index.js";
@@ -112,11 +112,14 @@ describe("runSynthesizeProjectKnowledge", () => {
           notion: {
             apiKey: "notion-key",
             createMarkdownPage: vi.fn().mockResolvedValue({
-              id: "new-notion-page-id",
+              // Real Notion returns a 32-hex-character page ID;
+              // normalizeNotionId rejects anything else.
+              id: "cccccccccccccccccccccccccccccccc",
               url: "https://www.notion.so/new-synthesized-page",
               blockCount: 12,
             }),
           },
+          db: context.db,
           now: () => new Date("2026-05-09T15:30:00.000Z"),
         },
         {
@@ -153,6 +156,129 @@ describe("runSynthesizeProjectKnowledge", () => {
         expect(source.last_sync_status).toBe("healthy");
         expect(source.source_content_hash).toBeTruthy();
       }
+
+      // The synthesis output should land in ai_knowledge_entries
+      // immediately (closes the synthesis-vs-cache seam that left every
+      // project's draft pipeline ungrounded until a separate
+      // notion-knowledge-sync was manually enqueued).
+      const [cacheEntry] = await context.db
+        .select()
+        .from(aiKnowledgeEntries)
+        .where(
+          and(
+            eq(aiKnowledgeEntries.scope, "project"),
+            eq(aiKnowledgeEntries.scopeKey, "project:synth"),
+          ),
+        );
+      expect(cacheEntry).toBeTruthy();
+      expect(cacheEntry?.content).toBe("# Synthesized AI Knowledge");
+      expect(cacheEntry?.sourceProvider).toBe("notion");
+      expect(cacheEntry?.sourceUrl).toBe(
+        "https://www.notion.so/new-synthesized-page",
+      );
+      expect(cacheEntry?.sourceLastEditedAt).toEqual(
+        new Date("2026-05-09T15:30:00.000Z"),
+      );
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("deletes stale Notion-scoped cache entries when synthesis publishes a new page", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await context.repositories.projectDimensions.upsert({
+        projectId: "project:stale",
+        projectName: "Stale Project",
+        projectAlias: "Stale",
+        source: "salesforce",
+        aiKnowledgeUrl: null,
+        aiKnowledgeSyncedAt: null,
+        aiKnowledgeSources: [
+          buildSource({
+            id: "44444444-4444-4444-8444-444444444444",
+            kind: "inline_text",
+            url: "https://example.test/inline-stale",
+          }),
+        ],
+      });
+
+      // Seed a stale project-scoped cache entry that references the OLD
+      // synthesis Notion page. After a fresh synthesis lands, this should
+      // be deleted in favour of the new entry. sourceId is in the dashed
+      // form normalizeNotionId emits (32-hex split into 8-4-4-4-12).
+      await context.db.insert(aiKnowledgeEntries).values({
+        id: "ai_knowledge:notion:aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        scope: "project",
+        scopeKey: "project:stale",
+        sourceProvider: "notion",
+        sourceId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        sourceUrl: "https://www.notion.so/old-stale-page",
+        title: "Stale Project — AI Knowledge (synthesized 2026-04-15T00:00)",
+        content: "# Old synthesized content",
+        contentHash: "hash:stale",
+        metadataJson: {},
+        sourceLastEditedAt: new Date("2026-04-15T00:00:00.000Z"),
+        syncedAt: new Date("2026-04-15T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-15T00:00:00.000Z"),
+        createdAt: new Date("2026-04-15T00:00:00.000Z"),
+      });
+
+      await runSynthesizeProjectKnowledge(
+        {
+          repositories: {
+            projectDimensions: context.repositories.projectDimensions,
+            projectKnowledge: context.repositories.projectKnowledge,
+            settingsProjects: context.settings.projects,
+          },
+          fetchers: {
+            inline_text: {
+              fetch: vi.fn().mockResolvedValue({
+                ok: true,
+                unchanged: false,
+                content: "Operator context refreshed",
+                contentHash: "hash:inline-2",
+                lastModified: null,
+              }),
+            },
+            notion: { fetch: vi.fn() },
+            web_page: { fetch: vi.fn() },
+          },
+          invokeModel: vi.fn().mockResolvedValue({
+            text: "# Fresh synthesized content",
+            usage: { inputTokens: 100, outputTokens: 50 },
+            stopReason: "end_turn",
+            model: "claude-sonnet-4-6",
+          }),
+          notion: {
+            apiKey: "notion-key",
+            createMarkdownPage: vi.fn().mockResolvedValue({
+              id: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+              url: "https://www.notion.so/new-stale-page",
+              blockCount: 5,
+            }),
+          },
+          db: context.db,
+          now: () => new Date("2026-05-21T12:00:00.000Z"),
+        },
+        { projectId: "project:stale" },
+      );
+
+      const cacheEntries = await context.db
+        .select()
+        .from(aiKnowledgeEntries)
+        .where(
+          and(
+            eq(aiKnowledgeEntries.scope, "project"),
+            eq(aiKnowledgeEntries.scopeKey, "project:stale"),
+          ),
+        );
+      expect(cacheEntries).toHaveLength(1);
+      expect(cacheEntries[0]?.content).toBe("# Fresh synthesized content");
+      expect(cacheEntries[0]?.sourceUrl).toBe(
+        "https://www.notion.so/new-stale-page",
+      );
     } finally {
       await context.dispose();
     }


### PR DESCRIPTION
## Summary

Layer 2 of today's cache-emptiness diagnosis. **PR #458** surfaced auto-sync activity in the UI; **this PR** closes the underlying architectural seam that left the cache empty in the first place.

## Background

The AI Draft retriever reads project grounding from `ai_knowledge_entries` (Tier 2 cache). Two worker jobs touch that table:

- `synthesize-project-knowledge` (new multi-source path, PRD #366) writes the synthesized markdown to a fresh Notion page and sets `project_dimensions.ai_knowledge_url`, but **does NOT touch `ai_knowledge_entries`**.
- `notion-knowledge-sync` (legacy single-page path) reads `project.ai_knowledge_url`, fetches the Notion page, and writes `ai_knowledge_entries`.

Once synthesis took over as the cron-driven job, nothing populated the cache. `notion-knowledge-sync` is no longer on cron; it has to be manually enqueued. Result: every active project ran synthesis successfully week after week while `ai_knowledge_entries` stayed empty, and the composer surfaced *"Project-specific AI grounding is missing for this contact"* on every draft.

Confirmed in prod 2026-05-29 against all 4 active projects (PNW Biodiversity, Killer Whales, Whitebark Pine, Beech & Butternut): `ai_knowledge_url` set, `ai_optimized_synthesized_at` recent, but `ai_knowledge_entries` empty for each. Fixed in flight by enqueuing `notion-knowledge-sync` once per project (~30s, no LLM cost). This PR makes the fix permanent.

## Changes

**`runSynthesizeProjectKnowledge`** — after `createMarkdownPage` and the existing `setAiKnowledgeUrl` call, upsert `ai_knowledge_entries` with the same markdown already in memory. No re-fetch from Notion needed.

**Stale cleanup** — after the upsert, delete other Notion-sourced project entries for this project. Each synthesis publishes a fresh immutable Notion page, so the previous run's cache row is now stale. Mirrors the cleanup pattern in `notion-knowledge-sync`.

**Dependency surface** — `SynthesizeProjectKnowledgeDependencies` grows two new fields: `db: Stage1Database` and optional `upsertEntry` callback. Same injection pattern `notion-knowledge-sync` already uses, so tests can stub `upsertEntry` without standing up the full repository bundle.

**Runtime wiring** — `runtime.ts` passes `connection.db` into the dependency builder; `ops/synthesize-multi-source.ts` (architect-facing ops command) wires it the same way so the manual + cron paths run identical code.

## Tests

- Existing test extended to assert the cache entry is created with the correct scope, scopeKey, sourceUrl, content, and sourceLastEditedAt after a successful synthesis run.
- New test seeds a stale Notion-sourced cache entry with a different page ID, runs synthesis, and asserts the old entry was deleted with exactly one cache entry remaining (the fresh one).

## After this lands

`notion-knowledge-sync` is only still needed for the **global Tier 1 training page** side-effect (refreshing the General Training entry). Project-scoped synthesis owns its own cache write end-to-end.

## Test plan

- [x] `pnpm -C apps/worker typecheck` clean
- [x] `pnpm -C apps/worker lint` clean
- [x] `pnpm -C apps/worker test:unit -- synthesize-project-knowledge` — 202 worker tests pass (2 new for this PR)
- [x] `pnpm -C apps/web typecheck` + lint clean
- [ ] Post-deploy: next auto-sync tick on any active project populates `ai_knowledge_entries` automatically. No manual `notion-knowledge-sync` enqueue needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)