### PR TITLE
feat(db): canonical_event_audience junction table (Brick 1, PRD #482)

### DIFF
--- a/packages/db/drizzle/0064_canonical_event_audience.sql
+++ b/packages/db/drizzle/0064_canonical_event_audience.sql
@@ -1,0 +1,32 @@
+-- canonical_event_audience: junction table mapping each canonical event to every
+-- contact who should see it on their timeline. See PRD #482.
+--
+-- One row per (canonical event × audience contact). The primary key prevents
+-- duplicates. Replay is idempotent: re-deriving the audience from a canonical
+-- event produces the same rows.
+--
+-- This table is additive — contact_timeline_projection stays 1-to-1 with
+-- canonical events (its canonical_event_id unique invariant is preserved).
+-- Contact-page reads will UNION anchor projection rows with audience rows
+-- (a later brick).
+--
+-- This brick only creates the table. Writers and readers land in subsequent
+-- bricks of the fan-out PRD.
+
+CREATE TABLE "canonical_event_audience" (
+  "canonical_event_id" text NOT NULL REFERENCES "canonical_event_ledger" ("id") ON DELETE CASCADE,
+  "contact_id" text NOT NULL REFERENCES "contacts" ("id") ON DELETE CASCADE,
+  "participant_role" text NOT NULL,
+  "normalized_email" text NOT NULL,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "updated_at" timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT "canonical_event_audience_pkey"
+    PRIMARY KEY ("canonical_event_id", "contact_id"),
+  CONSTRAINT "canonical_event_audience_role_check"
+    CHECK ("participant_role" IN ('sender', 'direct_recipient', 'cc', 'bcc'))
+);
+
+-- Contact-direction index for the per-contact-page timeline read path
+-- (a later brick will UNION-join through this).
+CREATE INDEX "canonical_event_audience_contact_idx"
+  ON "canonical_event_audience" ("contact_id", "canonical_event_id");

--- a/packages/db/src/schema/tables.ts
+++ b/packages/db/src/schema/tables.ts
@@ -934,6 +934,37 @@ export const contactTimelineProjection = pgTable(
   ],
 );
 
+/*
+ * Junction table for PRD #482 Gmail timeline fan-out. Stores one row per
+ * canonical event and audience contact so later read paths can project the
+ * same canonical event onto every participant's contact timeline.
+ */
+export const canonicalEventAudience = pgTable(
+  "canonical_event_audience",
+  {
+    canonicalEventId: text("canonical_event_id")
+      .notNull()
+      .references(() => canonicalEventLedger.id, { onDelete: "cascade" }),
+    contactId: text("contact_id")
+      .notNull()
+      .references(() => contacts.id, { onDelete: "cascade" }),
+    participantRole: text("participant_role").notNull(),
+    normalizedEmail: text("normalized_email").notNull(),
+    createdAt: createdAtColumn,
+    updatedAt: updatedAtColumn,
+  },
+  (table) => [
+    primaryKey({
+      columns: [table.canonicalEventId, table.contactId],
+      name: "canonical_event_audience_pkey",
+    }),
+    index("canonical_event_audience_contact_idx").on(
+      table.contactId,
+      table.canonicalEventId,
+    ),
+  ],
+);
+
 export const syncState = pgTable(
   "sync_state",
   {


### PR DESCRIPTION
## Summary

Brick 1 of 8 implementing [PRD #482](https://github.com/nico-kneler-as/as-comms-platform/issues/482) — multi-party Gmail thread timeline fan-out.

Adds the `canonical_event_audience` junction table (one row per canonical event × audience contact) and its Drizzle schema entry. **No business logic, no writers, no readers — those land in subsequent bricks.** This brick is purely additive and preserves the existing `contact_timeline_projection_canonical_event_unique` invariant.

## What landed

- `packages/db/drizzle/0064_canonical_event_audience.sql` — new migration with composite PK `(canonical_event_id, contact_id)`, cascading FKs on both columns, `participant_role` CHECK constraint (`sender` / `direct_recipient` / `cc` / `bcc`), `normalized_email` audit column, and a contact-direction secondary index for the per-contact-page UNION read (Brick 6).
- `packages/db/src/schema/tables.ts` — `canonicalEventAudience` Drizzle table object, placed adjacent to `contactTimelineProjection`.

## Validation (worktree, before push)

- ✅ `pnpm --filter @as-comms/db typecheck`
- ✅ `pnpm --filter @as-comms/db lint`
- ✅ `pnpm boundaries`

## Next bricks

| # | Brick | Status |
|---|---|---|
| 2 | Audience resolver in `@as-comms/domain` | PR opening now |
| 3 | Wire normalization to write audience + canon updates | Blocked on 1 + 2 |
| 4 | Backfill worker job for historical events | Blocked on 3 |
| 5 | (architect) Run backfill on staging then production | Blocked on 4 |
| 6 | Timeline UNION read (operator-visible flip) | Blocked on 5 |
| 7 | Search by display name | Polish, parallel after 6 |
| 8 | Ops scripts audience-aware | Polish, parallel after 6 |

## Test plan
- [ ] CI green
- [ ] Migration applies cleanly against a fresh DB
- [ ] `drizzle-kit` schema parses without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)