### PR TITLE
feat(domain): audience resolver pure function (Brick 2, PRD #482)

### DIFF
--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "build": "node ../../scripts/clean-dist.mjs dist && tsc -p tsconfig.build.json",
     "lint": "eslint src test --max-warnings=0",
+    "test": "pnpm test:unit",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test:unit": "vitest run --config ../../vitest.config.ts"
   },

--- a/packages/domain/src/canonical-event-audience.ts
+++ b/packages/domain/src/canonical-event-audience.ts
@@ -1,0 +1,73 @@
+export type CanonicalEventParticipantRole =
+  | "sender"
+  | "direct_recipient"
+  | "cc"
+  | "bcc";
+
+export interface CanonicalEventAudienceParticipant {
+  readonly email: string;
+  readonly role: CanonicalEventParticipantRole;
+}
+
+export interface ResolveCanonicalEventAudienceInput {
+  readonly fromEmails: readonly string[];
+  readonly toEmails: readonly string[];
+  readonly ccEmails: readonly string[];
+  readonly bccEmails: readonly string[];
+}
+
+export interface ResolveCanonicalEventAudienceResult {
+  readonly participants: readonly CanonicalEventAudienceParticipant[];
+}
+
+const ROLE_PRECEDENCE: Record<CanonicalEventParticipantRole, number> = {
+  sender: 0,
+  direct_recipient: 1,
+  cc: 2,
+  bcc: 3,
+};
+
+type RoleInput = readonly [
+  CanonicalEventParticipantRole,
+  readonly string[],
+];
+
+function compareParticipants(
+  left: CanonicalEventAudienceParticipant,
+  right: CanonicalEventAudienceParticipant,
+): number {
+  const precedenceDifference =
+    ROLE_PRECEDENCE[left.role] - ROLE_PRECEDENCE[right.role];
+
+  if (precedenceDifference !== 0) {
+    return precedenceDifference;
+  }
+
+  return left.email.localeCompare(right.email);
+}
+
+export function resolveCanonicalEventAudience(
+  input: ResolveCanonicalEventAudienceInput,
+): ResolveCanonicalEventAudienceResult {
+  const participantsByEmail = new Map<string, CanonicalEventParticipantRole>();
+  const roleInputs: readonly RoleInput[] = [
+    ["sender", input.fromEmails],
+    ["direct_recipient", input.toEmails],
+    ["cc", input.ccEmails],
+    ["bcc", input.bccEmails],
+  ];
+
+  for (const [role, emails] of roleInputs) {
+    for (const email of emails) {
+      if (!participantsByEmail.has(email)) {
+        participantsByEmail.set(email, role);
+      }
+    }
+  }
+
+  const participants = [...participantsByEmail.entries()]
+    .map(([email, role]) => ({ email, role }))
+    .sort(compareParticipants);
+
+  return { participants };
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./audience-resolver.js";
+export * from "./canonical-event-audience.js";
 export * from "./campaign-run-projection.js";
 export * from "./campaign-send-orchestrator.js";
 export * from "./campaign-types.js";

--- a/packages/domain/test/canonical-event-audience.test.ts
+++ b/packages/domain/test/canonical-event-audience.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveCanonicalEventAudience,
+  type CanonicalEventAudienceParticipant,
+  type ResolveCanonicalEventAudienceInput,
+} from "../src/index.js";
+
+function participant(
+  email: string,
+  role: CanonicalEventAudienceParticipant["role"],
+): CanonicalEventAudienceParticipant {
+  return { email, role };
+}
+
+function resolve(
+  input: Partial<ResolveCanonicalEventAudienceInput> = {},
+): readonly CanonicalEventAudienceParticipant[] {
+  return resolveCanonicalEventAudience({
+    fromEmails: [],
+    toEmails: [],
+    ccEmails: [],
+    bccEmails: [],
+    ...input,
+  }).participants;
+}
+
+describe("resolveCanonicalEventAudience", () => {
+  it("resolves a single sender and direct recipient", () => {
+    expect(
+      resolve({
+        fromEmails: ["a@example.org"],
+        toEmails: ["b@example.org"],
+      }),
+    ).toEqual([
+      participant("a@example.org", "sender"),
+      participant("b@example.org", "direct_recipient"),
+    ]);
+  });
+
+  it("sorts multi-recipient inbound participants by role then email", () => {
+    expect(
+      resolve({
+        fromEmails: ["a@example.org"],
+        toEmails: ["d@example.org", "b@example.org", "c@example.org"],
+      }),
+    ).toEqual([
+      participant("a@example.org", "sender"),
+      participant("b@example.org", "direct_recipient"),
+      participant("c@example.org", "direct_recipient"),
+      participant("d@example.org", "direct_recipient"),
+    ]);
+  });
+
+  it("includes cc-only recipients", () => {
+    expect(
+      resolve({
+        fromEmails: ["a@example.org"],
+        ccEmails: ["c@example.org", "b@example.org"],
+      }),
+    ).toEqual([
+      participant("a@example.org", "sender"),
+      participant("b@example.org", "cc"),
+      participant("c@example.org", "cc"),
+    ]);
+  });
+
+  it("includes bcc recipients visible to the platform", () => {
+    expect(
+      resolve({
+        fromEmails: ["a@example.org"],
+        toEmails: ["b@example.org"],
+        bccEmails: ["c@example.org"],
+      }),
+    ).toEqual([
+      participant("a@example.org", "sender"),
+      participant("b@example.org", "direct_recipient"),
+      participant("c@example.org", "bcc"),
+    ]);
+  });
+
+  it("orders participants across all four header positions", () => {
+    expect(
+      resolve({
+        fromEmails: ["d@example.org"],
+        toEmails: ["c@example.org"],
+        ccEmails: ["b@example.org"],
+        bccEmails: ["a@example.org"],
+      }),
+    ).toEqual([
+      participant("d@example.org", "sender"),
+      participant("c@example.org", "direct_recipient"),
+      participant("b@example.org", "cc"),
+      participant("a@example.org", "bcc"),
+    ]);
+  });
+
+  it("prefers sender over direct recipient on collision", () => {
+    expect(
+      resolve({
+        fromEmails: ["a@example.org"],
+        toEmails: ["b@example.org", "a@example.org"],
+      }),
+    ).toEqual([
+      participant("a@example.org", "sender"),
+      participant("b@example.org", "direct_recipient"),
+    ]);
+  });
+
+  it("prefers direct recipient over cc on collision", () => {
+    expect(
+      resolve({
+        toEmails: ["a@example.org"],
+        ccEmails: ["b@example.org", "a@example.org"],
+      }),
+    ).toEqual([
+      participant("a@example.org", "direct_recipient"),
+      participant("b@example.org", "cc"),
+    ]);
+  });
+
+  it("prefers cc over bcc on collision", () => {
+    expect(
+      resolve({
+        ccEmails: ["a@example.org"],
+        bccEmails: ["b@example.org", "a@example.org"],
+      }),
+    ).toEqual([
+      participant("a@example.org", "cc"),
+      participant("b@example.org", "bcc"),
+    ]);
+  });
+
+  it("collapses an email present in all four arrays to sender", () => {
+    expect(
+      resolve({
+        fromEmails: ["a@example.org"],
+        toEmails: ["a@example.org"],
+        ccEmails: ["a@example.org"],
+        bccEmails: ["a@example.org"],
+      }),
+    ).toEqual([participant("a@example.org", "sender")]);
+  });
+
+  it("deduplicates duplicates within the same array", () => {
+    expect(
+      resolve({
+        toEmails: ["b@example.org", "a@example.org", "a@example.org"],
+      }),
+    ).toEqual([
+      participant("a@example.org", "direct_recipient"),
+      participant("b@example.org", "direct_recipient"),
+    ]);
+  });
+
+  it("returns an empty participant list for empty input", () => {
+    expect(resolve()).toEqual([]);
+  });
+
+  it("supports sender-only inputs", () => {
+    expect(
+      resolve({
+        fromEmails: ["a@example.org"],
+      }),
+    ).toEqual([participant("a@example.org", "sender")]);
+  });
+
+  it("is deterministic across repeated calls and differing input order", () => {
+    const input = {
+      fromEmails: ["sender@example.org"],
+      toEmails: ["b@example.org", "a@example.org"],
+      ccEmails: ["d@example.org", "c@example.org"],
+      bccEmails: ["f@example.org", "e@example.org"],
+    } satisfies ResolveCanonicalEventAudienceInput;
+
+    expect(resolveCanonicalEventAudience(input)).toEqual(
+      resolveCanonicalEventAudience(input),
+    );
+    expect(resolveCanonicalEventAudience(input)).toEqual(
+      resolveCanonicalEventAudience({
+        fromEmails: ["sender@example.org"],
+        toEmails: ["a@example.org", "b@example.org"],
+        ccEmails: ["c@example.org", "d@example.org"],
+        bccEmails: ["e@example.org", "f@example.org"],
+      }),
+    );
+  });
+
+  it("keeps the resolver scoped to per-message header emails for the Scotty alias case", () => {
+    // The resolver is intentionally ignorant of volunteer/staff identity.
+    // If Brick 3 passes only the actual message headers, only those aliases fan out.
+    expect(
+      resolve({
+        fromEmails: ["or-rural-coordinator@adventurescientists.org"],
+        toEmails: ["pnwbio@adventurescientists.org"],
+      }),
+    ).toEqual([
+      participant("or-rural-coordinator@adventurescientists.org", "sender"),
+      participant("pnwbio@adventurescientists.org", "direct_recipient"),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Brick 2 of 8 implementing [PRD #482](https://github.com/nico-kneler-as/as-comms-platform/issues/482) — multi-party Gmail thread timeline fan-out.

Adds the pure `resolveCanonicalEventAudience` function that takes the four header email arrays from a single Gmail message (`fromEmails / toEmails / ccEmails / bccEmails`) and returns the deduplicated participant list with roles. **Not wired into any flow yet** — Brick 3 will call it from the canonical event writer.

## Behavior

- **Role precedence on collision:** `sender > direct_recipient > cc > bcc`. If an email appears in multiple header positions, it gets the highest-precedence role.
- **Deduplicates** across and within input arrays.
- **Output sorted** by (role precedence, email lex) for replay-stability — same input always produces byte-identical output.
- **Pure function**, no I/O, no async, no throws under valid input.

## What landed

- `packages/domain/src/canonical-event-audience.ts` — implementation (~80 LOC).
- `packages/domain/test/canonical-event-audience.test.ts` — 14 table-driven cases including the Scotty staff-alias mental model, Cc/Bcc handling, collision precedence, dedup within arrays, empty input, determinism / replay-stability.
- `packages/domain/src/index.ts` — barrel export.
- `packages/domain/package.json` — added `\"test\": \"pnpm test:unit\"` script so the standardized validation command actually runs the suite (was a no-op before).

## Validation (worktree, before push)

- ✅ `pnpm --filter @as-comms/domain typecheck`
- ✅ `pnpm --filter @as-comms/domain lint`
- ✅ `pnpm --filter @as-comms/domain test` — **142 tests pass** (14 new + 128 existing)
- ✅ `pnpm boundaries`

## Next bricks

| # | Brick | Status |
|---|---|---|
| 1 | Schema migration for `canonical_event_audience` | #484 (parallel sibling) |
| 3 | Wire normalization to write audience + canon updates | Blocked on 1 + 2 |

## Test plan
- [ ] CI green
- [ ] All 14 new resolver tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)