### PR TITLE
feat(worker): backfill canonical_event_audience for historical Gmail events (Brick 4, PRD #482)

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -29,6 +29,7 @@
     "ops:backfill-inbox-projection-coverage": "tsx src/ops/backfill-inbox-projection-coverage.ts",
     "ops:recover-gmail-spam-window": "tsx src/ops/recover-gmail-spam-window.ts",
     "ops:recompute-attachment-inline": "tsx src/ops/recompute-attachment-inline.ts",
+    "ops:backfill-canonical-event-audience": "tsx src/ops/backfill-canonical-event-audience.ts",
     "ops:recover-orphan-gmail-details": "tsx src/ops/recover-orphan-gmail-details.ts",
     "ops:recover-orphan-task-details": "tsx src/ops/recover-orphan-task-details.ts",
     "ops:rewrite-timeline-sort-keys": "tsx src/ops/rewrite-timeline-sort-keys.ts",

--- a/apps/worker/src/ops/backfill-canonical-event-audience.ts
+++ b/apps/worker/src/ops/backfill-canonical-event-audience.ts
@@ -1,0 +1,367 @@
+#!/usr/bin/env tsx
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+import {
+  canonicalEventAudience,
+  canonicalEventLedger,
+  closeDatabaseConnection,
+  createDatabaseConnection,
+  createStage1RepositoryBundle,
+  createStage1RepositoryBundleFromConnection,
+  sourceEvidenceLog,
+  type Stage1Database,
+} from "@as-comms/db";
+import {
+  type CanonicalEventRecord,
+  applyCanonicalEventAudience,
+  createStage1NormalizationService,
+  createStage1PersistenceService,
+} from "@as-comms/domain";
+import type { GmailMessageDetailRecord } from "@as-comms/contracts";
+import { and, asc, eq, gte, isNull, lte } from "drizzle-orm";
+
+import {
+  parseCliFlags,
+  readOptionalBooleanFlag,
+  readOptionalIntegerFlag,
+  readOptionalStringFlag,
+} from "./helpers.js";
+
+interface Logger {
+  log(...args: readonly unknown[]): void;
+  error(...args: readonly unknown[]): void;
+}
+
+type SkipReason = "no_gmail_detail" | "no_header_emails";
+
+interface CandidateCanonicalEventRow {
+  readonly canonicalEventId: string;
+  readonly sourceEvidenceId: string;
+}
+
+export interface BackfillCanonicalEventAudienceLogEntry {
+  readonly action: "applied" | "dryRun" | "skipped";
+  readonly canonicalEventId: string;
+  readonly sourceEvidenceId: string;
+  readonly audienceCount?: number;
+  readonly reason?: SkipReason;
+}
+
+export interface BackfillCanonicalEventAudienceResult {
+  readonly dryRun: boolean;
+  readonly since: string;
+  readonly until: string;
+  readonly candidates: number;
+  readonly applied: number;
+  readonly skipped: number;
+  readonly truncated: boolean;
+  readonly byReason: Readonly<Record<SkipReason, number>>;
+}
+
+class DryRunRollback extends Error {
+  constructor() {
+    super("Dry run rollback");
+  }
+}
+
+function readConnectionString(env: NodeJS.ProcessEnv): string {
+  const connectionString = env.WORKER_DATABASE_URL ?? env.DATABASE_URL;
+
+  if (connectionString === undefined || connectionString.trim().length === 0) {
+    throw new Error(
+      "DATABASE_URL or WORKER_DATABASE_URL is required for Stage 1 ops commands.",
+    );
+  }
+
+  return connectionString;
+}
+
+function parseWindowTimestamp(value: string, flagName: string): string {
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Flag --${flagName} must be a valid ISO-8601 timestamp.`);
+  }
+
+  return parsed.toISOString();
+}
+
+function buildDefaultSince(): string {
+  return "2026-01-01T00:00:00.000Z";
+}
+
+function buildDefaultUntil(): string {
+  return new Date().toISOString();
+}
+
+function logEntry(
+  logger: Logger,
+  entry: BackfillCanonicalEventAudienceLogEntry,
+): void {
+  logger.log(JSON.stringify(entry));
+}
+
+function hasHeaderEmails(detail: {
+  readonly fromEmails: readonly string[];
+  readonly toEmails: readonly string[];
+  readonly ccEmails: readonly string[];
+  readonly bccEmails: readonly string[];
+}): boolean {
+  return (
+    detail.fromEmails.length > 0 ||
+    detail.toEmails.length > 0 ||
+    detail.ccEmails.length > 0 ||
+    detail.bccEmails.length > 0
+  );
+}
+
+async function loadCandidateRows(input: {
+  readonly db: Stage1Database;
+  readonly since: string;
+  readonly until: string;
+  readonly limit: number;
+}): Promise<{
+  readonly candidates: readonly CandidateCanonicalEventRow[];
+  readonly truncated: boolean;
+}> {
+  const rows = await input.db
+    .select({
+      canonicalEventId: canonicalEventLedger.id,
+      sourceEvidenceId: canonicalEventLedger.sourceEvidenceId,
+    })
+    .from(canonicalEventLedger)
+    .innerJoin(
+      sourceEvidenceLog,
+      eq(canonicalEventLedger.sourceEvidenceId, sourceEvidenceLog.id),
+    )
+    .leftJoin(
+      canonicalEventAudience,
+      eq(canonicalEventAudience.canonicalEventId, canonicalEventLedger.id),
+    )
+    .where(
+      and(
+        eq(canonicalEventLedger.channel, "email"),
+        eq(sourceEvidenceLog.provider, "gmail"),
+        gte(canonicalEventLedger.occurredAt, new Date(input.since)),
+        lte(canonicalEventLedger.occurredAt, new Date(input.until)),
+        isNull(canonicalEventAudience.canonicalEventId),
+      ),
+    )
+    .orderBy(asc(canonicalEventLedger.occurredAt), asc(canonicalEventLedger.id))
+    .limit(input.limit + 1);
+
+  return {
+    candidates: rows.slice(0, input.limit),
+    truncated: rows.length > input.limit,
+  };
+}
+
+async function applyAudienceBackfillForEvent(input: {
+  readonly db: Stage1Database;
+  readonly canonicalEvent: CanonicalEventRecord;
+  readonly gmailMessageDetail: GmailMessageDetailRecord;
+  readonly execute: boolean;
+}): Promise<number> {
+  let dryRunAudienceCount = 0;
+
+  const runInTransaction = async (tx: Stage1Database) => {
+    const repositories = createStage1RepositoryBundle(tx);
+    const persistence = createStage1PersistenceService(repositories);
+    const normalization = createStage1NormalizationService(persistence);
+    const audienceCount = await applyCanonicalEventAudience(
+      {
+        persistence,
+        service: normalization,
+      },
+      {
+        canonicalEvent: input.canonicalEvent,
+        gmailMessageDetail: input.gmailMessageDetail,
+        openedAt: input.canonicalEvent.occurredAt,
+      },
+    );
+
+    if (!input.execute) {
+      dryRunAudienceCount = audienceCount;
+      throw new DryRunRollback();
+    }
+
+    return audienceCount;
+  };
+
+  if (!input.execute) {
+    try {
+      await input.db.transaction(runInTransaction);
+    } catch (error) {
+      if (!(error instanceof DryRunRollback)) {
+        throw error;
+      }
+    }
+
+    return dryRunAudienceCount;
+  }
+
+  return input.db.transaction(runInTransaction);
+}
+
+export async function backfillCanonicalEventAudience(input: {
+  readonly db: Stage1Database;
+  readonly repositories: ReturnType<typeof createStage1RepositoryBundleFromConnection>;
+  readonly since: string;
+  readonly until: string;
+  readonly execute: boolean;
+  readonly limit: number;
+  readonly logger?: Logger;
+}): Promise<BackfillCanonicalEventAudienceResult> {
+  const logger = input.logger ?? console;
+  const { candidates, truncated } = await loadCandidateRows({
+    db: input.db,
+    since: input.since,
+    until: input.until,
+    limit: input.limit,
+  });
+  const canonicalEvents = await input.repositories.canonicalEvents.listByIds(
+    candidates.map((candidate) => candidate.canonicalEventId),
+  );
+  const canonicalEventsById = new Map(
+    canonicalEvents.map((event) => [event.id, event]),
+  );
+  const gmailDetails = await input.repositories.gmailMessageDetails.listBySourceEvidenceIds(
+    candidates.map((candidate) => candidate.sourceEvidenceId),
+  );
+  const gmailDetailsBySourceEvidenceId = new Map(
+    gmailDetails.map((detail) => [detail.sourceEvidenceId, detail]),
+  );
+
+  let applied = 0;
+  let skipped = 0;
+  const byReason: Record<SkipReason, number> = {
+    no_gmail_detail: 0,
+    no_header_emails: 0,
+  };
+
+  for (const candidate of candidates) {
+    const canonicalEvent = canonicalEventsById.get(candidate.canonicalEventId);
+
+    if (canonicalEvent === undefined) {
+      throw new Error(
+        `Expected canonical event ${candidate.canonicalEventId} to exist.`,
+      );
+    }
+
+    const gmailMessageDetail = gmailDetailsBySourceEvidenceId.get(
+      candidate.sourceEvidenceId,
+    );
+
+    if (gmailMessageDetail === undefined) {
+      skipped += 1;
+      byReason.no_gmail_detail += 1;
+      logEntry(logger, {
+        action: "skipped",
+        canonicalEventId: canonicalEvent.id,
+        sourceEvidenceId: canonicalEvent.sourceEvidenceId,
+        reason: "no_gmail_detail",
+      });
+      continue;
+    }
+
+    if (!hasHeaderEmails(gmailMessageDetail)) {
+      skipped += 1;
+      byReason.no_header_emails += 1;
+      logEntry(logger, {
+        action: "skipped",
+        canonicalEventId: canonicalEvent.id,
+        sourceEvidenceId: canonicalEvent.sourceEvidenceId,
+        reason: "no_header_emails",
+      });
+      continue;
+    }
+
+    const audienceCount = await applyAudienceBackfillForEvent({
+      db: input.db,
+      canonicalEvent,
+      gmailMessageDetail,
+      execute: input.execute,
+    });
+
+    applied += 1;
+    logEntry(logger, {
+      action: input.execute ? "applied" : "dryRun",
+      canonicalEventId: canonicalEvent.id,
+      sourceEvidenceId: canonicalEvent.sourceEvidenceId,
+      audienceCount,
+    });
+  }
+
+  return {
+    dryRun: !input.execute,
+    since: input.since,
+    until: input.until,
+    candidates: candidates.length,
+    applied,
+    skipped,
+    truncated,
+    byReason,
+  };
+}
+
+export async function runBackfillCanonicalEventAudienceCommand(
+  args: readonly string[] = process.argv.slice(2),
+  env: NodeJS.ProcessEnv = process.env,
+  logger: Logger = console,
+): Promise<void> {
+  const flags = parseCliFlags(args);
+  const since = parseWindowTimestamp(
+    readOptionalStringFlag(flags, "since") ?? buildDefaultSince(),
+    "since",
+  );
+  const until = parseWindowTimestamp(
+    readOptionalStringFlag(flags, "until") ?? buildDefaultUntil(),
+    "until",
+  );
+  const execute = readOptionalBooleanFlag(flags, "execute", false);
+  const limit = readOptionalIntegerFlag(flags, "limit", 5000);
+
+  if (new Date(since).getTime() > new Date(until).getTime()) {
+    throw new Error("Flag --since must be earlier than or equal to --until.");
+  }
+
+  const connection = createDatabaseConnection({
+    connectionString: readConnectionString(env),
+  });
+
+  try {
+    const repositories = createStage1RepositoryBundleFromConnection(connection);
+    const result = await backfillCanonicalEventAudience({
+      db: connection.db,
+      repositories,
+      since,
+      until,
+      execute,
+      limit,
+      logger,
+    });
+
+    logger.log(JSON.stringify(result, null, 2));
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}
+
+async function main(): Promise<void> {
+  await runBackfillCanonicalEventAudienceCommand(
+    process.argv.slice(2),
+    process.env,
+  );
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  void main().catch((error: unknown) => {
+    console.error(
+      error instanceof Error
+        ? error.message
+        : "Canonical event audience backfill failed.",
+    );
+    process.exitCode = 1;
+  });
+}

--- a/apps/worker/src/ops/cli.ts
+++ b/apps/worker/src/ops/cli.ts
@@ -47,6 +47,7 @@ import { runCleanupSalesforceOwnerScopeCommand } from "./cleanup-salesforce-owne
 import { main as runMergeEmailOnlyIntoSfAnchoredCommand } from "./merge-email-only-into-sf-anchored.js";
 import { runRecoverGmailSpamWindowCommand } from "./recover-gmail-spam-window.js";
 import { runRecomputeAttachmentInlineCommand } from "./recompute-attachment-inline.js";
+import { runBackfillCanonicalEventAudienceCommand } from "./backfill-canonical-event-audience.js";
 import { runRecoverOrphanGmailDetailsCommand } from "./recover-orphan-gmail-details.js";
 import { reconcileIdentityQueue } from "./reconcile-identity-queue.js";
 import { reconcileRoutingReviewQueue } from "./reconcile-routing-review-queue.js";
@@ -478,6 +479,9 @@ async function main(): Promise<void> {
     case "recompute-attachment-inline":
       await runRecomputeAttachmentInlineCommand(rest, process.env);
       return;
+    case "backfill-canonical-event-audience":
+      await runBackfillCanonicalEventAudienceCommand(rest, process.env);
+      return;
     case "reprocess-pending-campaign-sends":
       await runReprocessPendingCampaignSends(rest);
       return;
@@ -507,7 +511,7 @@ async function main(): Promise<void> {
       return;
     default:
       throw new Error(
-        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-membership-sf-ids, backfill-gmail-mbox-bodies, backfill-content-fingerprint, backfill-garbled-message-bodies, re-extract-signed-envelope-bodies, backfill-mailchimp-campaign-body, mailchimp-capture-historical, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, recover-orphan-gmail-details, recover-gmail-spam-window, recompute-attachment-inline, reprocess-pending-campaign-sends, dedup-historical-ledger, merge-email-only-into-sf-anchored, reconcile-identity-queue, reconcile-routing-review-queue, reclassify-sf-direction, reconcile-stale-canonical, reconcile-superseded-projections.",
+        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-membership-sf-ids, backfill-gmail-mbox-bodies, backfill-content-fingerprint, backfill-garbled-message-bodies, re-extract-signed-envelope-bodies, backfill-mailchimp-campaign-body, mailchimp-capture-historical, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, recover-orphan-gmail-details, recover-gmail-spam-window, recompute-attachment-inline, backfill-canonical-event-audience, reprocess-pending-campaign-sends, dedup-historical-ledger, merge-email-only-into-sf-anchored, reconcile-identity-queue, reconcile-routing-review-queue, reclassify-sf-direction, reconcile-stale-canonical, reconcile-superseded-projections.",
       );
   }
 }

--- a/apps/worker/test/backfill-canonical-event-audience.test.ts
+++ b/apps/worker/test/backfill-canonical-event-audience.test.ts
@@ -1,0 +1,687 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canonicalEventAudience,
+  contactInboxProjection,
+  identityResolutionQueue,
+} from "@as-comms/db";
+import { asc, eq } from "drizzle-orm";
+
+import {
+  backfillCanonicalEventAudience,
+  type BackfillCanonicalEventAudienceLogEntry,
+} from "../src/ops/backfill-canonical-event-audience.js";
+import { createTestWorkerContext } from "./helpers.js";
+
+function buildCanonicalProvenance(input: {
+  readonly sourceEvidenceId: string;
+  readonly providerRecordId: string;
+  readonly direction?: "inbound" | "outbound";
+}) {
+  return {
+    primaryProvider: "gmail" as const,
+    primarySourceEvidenceId: input.sourceEvidenceId,
+    supportingSourceEvidenceIds: [],
+    winnerReason: "single_source" as const,
+    sourceRecordType: "message",
+    sourceRecordId: input.providerRecordId,
+    messageKind: "one_to_one" as const,
+    campaignRef: null,
+    threadRef: {
+      crossProviderCollapseKey: `rfc822:<${input.providerRecordId}@example.org>`,
+      providerThreadId: `thread:${input.providerRecordId}`,
+    },
+    direction: input.direction ?? "inbound",
+    notes: null,
+  };
+}
+
+async function seedContact(input: {
+  readonly context: Awaited<ReturnType<typeof createTestWorkerContext>>;
+  readonly id: string;
+  readonly email: string | null;
+  readonly displayName?: string;
+  readonly salesforceContactId?: string | null;
+}): Promise<void> {
+  await input.context.repositories.contacts.upsert({
+    id: input.id,
+    salesforceContactId: input.salesforceContactId ?? null,
+    displayName: input.displayName ?? input.id,
+    primaryEmail: input.email,
+    primaryPhone: null,
+    createdAt: "2026-05-10T09:00:00.000Z",
+    updatedAt: "2026-05-10T09:00:00.000Z",
+  });
+
+  if (input.email !== null) {
+    await input.context.repositories.contactIdentities.upsert({
+      id: `identity:${input.id}:email:${input.email}`,
+      contactId: input.id,
+      kind: "email",
+      normalizedValue: input.email,
+      isPrimary: true,
+      source: input.salesforceContactId == null ? "manual" : "salesforce",
+      verifiedAt: "2026-05-10T09:00:00.000Z",
+    });
+  }
+}
+
+async function seedInboxProjection(input: {
+  readonly context: Awaited<ReturnType<typeof createTestWorkerContext>>;
+  readonly contactId: string;
+  readonly lastInboundAt?: string | null;
+  readonly lastOutboundAt?: string | null;
+  readonly lastActivityAt: string;
+  readonly hasUnresolved?: boolean;
+  readonly lastCanonicalEventId: string;
+  readonly lastEventType?: "communication.email.inbound" | "communication.email.outbound";
+}): Promise<void> {
+  await input.context.repositories.inboxProjection.upsert({
+    contactId: input.contactId,
+    bucket: "Opened",
+    needsFollowUp: false,
+    hasUnresolved: input.hasUnresolved ?? false,
+    lastInboundAt: input.lastInboundAt ?? null,
+    lastOutboundAt: input.lastOutboundAt ?? null,
+    lastActivityAt: input.lastActivityAt,
+    snippet: `Projection for ${input.contactId}`,
+    archivedAt: null,
+    lastCanonicalEventId: input.lastCanonicalEventId,
+    lastEventType: input.lastEventType ?? "communication.email.inbound",
+  });
+}
+
+async function seedGmailCanonicalEvent(input: {
+  readonly context: Awaited<ReturnType<typeof createTestWorkerContext>>;
+  readonly canonicalEventId: string;
+  readonly sourceEvidenceId: string;
+  readonly providerRecordId: string;
+  readonly contactId: string;
+  readonly occurredAt: string;
+  readonly direction?: "inbound" | "outbound";
+  readonly fromEmails?: readonly string[];
+  readonly toEmails?: readonly string[];
+  readonly ccEmails?: readonly string[];
+  readonly bccEmails?: readonly string[];
+}): Promise<void> {
+  await input.context.repositories.sourceEvidence.append({
+    id: input.sourceEvidenceId,
+    provider: "gmail",
+    providerRecordType: "message",
+    providerRecordId: input.providerRecordId,
+    receivedAt: input.occurredAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `gmail://message/${input.providerRecordId}`,
+    idempotencyKey: input.sourceEvidenceId,
+    checksum: `checksum:${input.providerRecordId}`,
+  });
+
+  await input.context.repositories.canonicalEvents.upsert({
+    id: input.canonicalEventId,
+    contactId: input.contactId,
+    eventType:
+      (input.direction ?? "inbound") === "outbound"
+        ? "communication.email.outbound"
+        : "communication.email.inbound",
+    channel: "email",
+    occurredAt: input.occurredAt,
+    contentFingerprint: null,
+    sourceEvidenceId: input.sourceEvidenceId,
+    idempotencyKey: input.canonicalEventId,
+    provenance: buildCanonicalProvenance(
+      input.direction === undefined
+        ? {
+            sourceEvidenceId: input.sourceEvidenceId,
+            providerRecordId: input.providerRecordId,
+          }
+        : {
+            sourceEvidenceId: input.sourceEvidenceId,
+            providerRecordId: input.providerRecordId,
+            direction: input.direction,
+          },
+    ),
+    reviewState: "clear",
+  });
+
+  await input.context.repositories.gmailMessageDetails.upsert({
+    sourceEvidenceId: input.sourceEvidenceId,
+    providerRecordId: input.providerRecordId,
+    gmailThreadId: `thread:${input.providerRecordId}`,
+    rfc822MessageId: `<${input.providerRecordId}@example.org>`,
+    direction: input.direction ?? "inbound",
+    subject: `Subject ${input.providerRecordId}`,
+    fromHeader: null,
+    toHeader: null,
+    ccHeader: null,
+    fromEmails: [...(input.fromEmails ?? [])],
+    toEmails: [...(input.toEmails ?? [])],
+    ccEmails: [...(input.ccEmails ?? [])],
+    bccEmails: [...(input.bccEmails ?? [])],
+    labelIds: ["INBOX"],
+    snippetClean: "Snippet",
+    bodyTextPreview: "Preview",
+    bodyKind: "plaintext",
+    capturedMailbox: "volunteers@adventurescientists.org",
+    projectInboxAlias: null,
+  });
+}
+
+async function loadAudienceRows(
+  context: Awaited<ReturnType<typeof createTestWorkerContext>>,
+) {
+  return context.db
+    .select()
+    .from(canonicalEventAudience)
+    .orderBy(
+      asc(canonicalEventAudience.canonicalEventId),
+      asc(canonicalEventAudience.contactId),
+    );
+}
+
+function createLogger(logs: BackfillCanonicalEventAudienceLogEntry[]) {
+  return {
+    log(value: unknown) {
+      if (typeof value === "string" && value.startsWith("{")) {
+        logs.push(JSON.parse(value) as BackfillCanonicalEventAudienceLogEntry);
+      }
+    },
+    error() {
+      return undefined;
+    },
+  };
+}
+
+describe("backfill-canonical-event-audience", () => {
+  it("dry-runs then commits a multi-recipient inbound Gmail event", async () => {
+    const context = await createTestWorkerContext();
+    const logs: BackfillCanonicalEventAudienceLogEntry[] = [];
+
+    try {
+      await seedContact({
+        context,
+        id: "contact:sender",
+        email: "sender@example.org",
+        salesforceContactId: "003SENDER",
+      });
+      await seedContact({
+        context,
+        id: "contact:to",
+        email: "to@example.org",
+        salesforceContactId: "003TO",
+      });
+      await seedContact({
+        context,
+        id: "contact:cc",
+        email: "cc@example.org",
+        salesforceContactId: "003CC",
+      });
+      await seedGmailCanonicalEvent({
+        context,
+        canonicalEventId: "canonical-event:multi",
+        sourceEvidenceId: "source-evidence:gmail:multi",
+        providerRecordId: "gmail-multi",
+        contactId: "contact:sender",
+        occurredAt: "2026-05-20T10:00:00.000Z",
+        fromEmails: ["sender@example.org"],
+        toEmails: ["to@example.org"],
+        ccEmails: ["cc@example.org"],
+      });
+
+      const dryRun = await backfillCanonicalEventAudience({
+        db: context.db,
+        repositories: context.repositories,
+        since: "2026-05-01T00:00:00.000Z",
+        until: "2026-05-31T23:59:59.999Z",
+        execute: false,
+        limit: 100,
+        logger: createLogger(logs),
+      });
+
+      expect(dryRun).toMatchObject({
+        dryRun: true,
+        candidates: 1,
+        applied: 1,
+        skipped: 0,
+      });
+      await expect(loadAudienceRows(context)).resolves.toHaveLength(0);
+      expect(logs).toContainEqual({
+        action: "dryRun",
+        canonicalEventId: "canonical-event:multi",
+        sourceEvidenceId: "source-evidence:gmail:multi",
+        audienceCount: 3,
+      });
+
+      const executeResult = await backfillCanonicalEventAudience({
+        db: context.db,
+        repositories: context.repositories,
+        since: "2026-05-01T00:00:00.000Z",
+        until: "2026-05-31T23:59:59.999Z",
+        execute: true,
+        limit: 100,
+        logger: createLogger([]),
+      });
+
+      expect(executeResult).toMatchObject({
+        dryRun: false,
+        candidates: 1,
+        applied: 1,
+      });
+      await expect(loadAudienceRows(context)).resolves.toEqual([
+        expect.objectContaining({
+          canonicalEventId: "canonical-event:multi",
+          contactId: "contact:cc",
+          participantRole: "cc",
+          normalizedEmail: "cc@example.org",
+        }),
+        expect.objectContaining({
+          canonicalEventId: "canonical-event:multi",
+          contactId: "contact:sender",
+          participantRole: "sender",
+          normalizedEmail: "sender@example.org",
+        }),
+        expect.objectContaining({
+          canonicalEventId: "canonical-event:multi",
+          contactId: "contact:to",
+          participantRole: "direct_recipient",
+          normalizedEmail: "to@example.org",
+        }),
+      ]);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("creates a new contact for an unseen external audience participant", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact({
+        context,
+        id: "contact:staff",
+        email: "staff@adventurescientists.org",
+        salesforceContactId: "003STAFF",
+      });
+      await seedGmailCanonicalEvent({
+        context,
+        canonicalEventId: "canonical-event:new-external",
+        sourceEvidenceId: "source-evidence:gmail:new-external",
+        providerRecordId: "gmail-new-external",
+        contactId: "contact:staff",
+        occurredAt: "2026-05-21T12:00:00.000Z",
+        direction: "outbound",
+        fromEmails: ["staff@adventurescientists.org"],
+        toEmails: ["new.external@example.org"],
+      });
+
+      const beforeContacts = await context.repositories.contacts.listAll();
+      const result = await backfillCanonicalEventAudience({
+        db: context.db,
+        repositories: context.repositories,
+        since: "2026-05-01T00:00:00.000Z",
+        until: "2026-05-31T23:59:59.999Z",
+        execute: true,
+        limit: 100,
+      });
+      const afterContacts = await context.repositories.contacts.listAll();
+      const audienceRows = await loadAudienceRows(context);
+
+      expect(result).toMatchObject({
+        candidates: 1,
+        applied: 1,
+      });
+      expect(afterContacts).toHaveLength(beforeContacts.length + 1);
+      expect(afterContacts.some((contact) => contact.primaryEmail === "new.external@example.org")).toBe(true);
+      expect(audienceRows).toHaveLength(2);
+      expect(audienceRows.map((row) => row.normalizedEmail)).toEqual([
+        "new.external@example.org",
+        "staff@adventurescientists.org",
+      ]);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("opens an identity case and refreshes the inbox overlay for multi-candidate email matches", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact({
+        context,
+        id: "contact:anchor",
+        email: "anchor@example.org",
+        salesforceContactId: "003ANCHOR",
+      });
+      await seedContact({
+        context,
+        id: "contact:winner",
+        email: "shared@example.org",
+        salesforceContactId: "003WINNER",
+      });
+      await seedContact({
+        context,
+        id: "contact:loser",
+        email: "shared@example.org",
+        salesforceContactId: "003LOSER",
+      });
+      await seedGmailCanonicalEvent({
+        context,
+        canonicalEventId: "canonical-event:winner-history",
+        sourceEvidenceId: "source-evidence:gmail:winner-history",
+        providerRecordId: "gmail-winner-history",
+        contactId: "contact:winner",
+        occurredAt: "2026-04-19T12:00:00.000Z",
+        fromEmails: ["shared@example.org"],
+      });
+      await seedGmailCanonicalEvent({
+        context,
+        canonicalEventId: "canonical-event:loser-history",
+        sourceEvidenceId: "source-evidence:gmail:loser-history",
+        providerRecordId: "gmail-loser-history",
+        contactId: "contact:loser",
+        occurredAt: "2026-04-10T12:00:00.000Z",
+        fromEmails: ["shared@example.org"],
+      });
+      await seedInboxProjection({
+        context,
+        contactId: "contact:winner",
+        lastInboundAt: "2026-05-19T12:00:00.000Z",
+        lastActivityAt: "2026-05-19T12:00:00.000Z",
+        hasUnresolved: false,
+        lastCanonicalEventId: "canonical-event:winner-history",
+      });
+      await seedInboxProjection({
+        context,
+        contactId: "contact:loser",
+        lastInboundAt: "2026-05-10T12:00:00.000Z",
+        lastActivityAt: "2026-05-10T12:00:00.000Z",
+        hasUnresolved: false,
+        lastCanonicalEventId: "canonical-event:loser-history",
+      });
+      await seedGmailCanonicalEvent({
+        context,
+        canonicalEventId: "canonical-event:multi-candidate",
+        sourceEvidenceId: "source-evidence:gmail:multi-candidate",
+        providerRecordId: "gmail-multi-candidate",
+        contactId: "contact:anchor",
+        occurredAt: "2026-05-22T08:00:00.000Z",
+        fromEmails: ["anchor@example.org"],
+        toEmails: ["shared@example.org"],
+      });
+
+      const result = await backfillCanonicalEventAudience({
+        db: context.db,
+        repositories: context.repositories,
+        since: "2026-05-01T00:00:00.000Z",
+        until: "2026-05-31T23:59:59.999Z",
+        execute: true,
+        limit: 100,
+      });
+      const audienceRows = await loadAudienceRows(context);
+      const identityCases = await context.db
+        .select()
+        .from(identityResolutionQueue)
+        .where(
+          eq(
+            identityResolutionQueue.sourceEvidenceId,
+            "source-evidence:gmail:multi-candidate",
+          ),
+        );
+      const [winnerProjection] = await context.db
+        .select()
+        .from(contactInboxProjection)
+        .where(eq(contactInboxProjection.contactId, "contact:winner"));
+
+      expect(result).toMatchObject({
+        candidates: 1,
+        applied: 1,
+      });
+      expect(audienceRows).toEqual([
+        expect.objectContaining({
+          canonicalEventId: "canonical-event:multi-candidate",
+          contactId: "contact:anchor",
+          participantRole: "sender",
+        }),
+        expect.objectContaining({
+          canonicalEventId: "canonical-event:multi-candidate",
+          contactId: "contact:winner",
+          participantRole: "direct_recipient",
+          normalizedEmail: "shared@example.org",
+        }),
+      ]);
+      expect(identityCases).toHaveLength(1);
+      expect(identityCases[0]).toMatchObject({
+        reasonCode: "identity_multi_candidate",
+        anchoredContactId: "contact:winner",
+        candidateContactIds: ["contact:loser"],
+        normalizedIdentityValues: ["shared@example.org"],
+        status: "open",
+      });
+      expect(winnerProjection).toMatchObject({
+        hasUnresolved: true,
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("skips events that already have audience rows", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact({
+        context,
+        id: "contact:existing",
+        email: "existing@example.org",
+        salesforceContactId: "003EXISTING",
+      });
+      await seedGmailCanonicalEvent({
+        context,
+        canonicalEventId: "canonical-event:existing-audience",
+        sourceEvidenceId: "source-evidence:gmail:existing-audience",
+        providerRecordId: "gmail-existing-audience",
+        contactId: "contact:existing",
+        occurredAt: "2026-05-23T08:00:00.000Z",
+        fromEmails: ["existing@example.org"],
+      });
+      await context.repositories.canonicalEventAudience.upsert({
+        canonicalEventId: "canonical-event:existing-audience",
+        contactId: "contact:existing",
+        participantRole: "sender",
+        normalizedEmail: "existing@example.org",
+      });
+
+      const result = await backfillCanonicalEventAudience({
+        db: context.db,
+        repositories: context.repositories,
+        since: "2026-05-01T00:00:00.000Z",
+        until: "2026-05-31T23:59:59.999Z",
+        execute: true,
+        limit: 100,
+      });
+
+      expect(result).toMatchObject({
+        candidates: 0,
+        applied: 0,
+        skipped: 0,
+      });
+      await expect(loadAudienceRows(context)).resolves.toHaveLength(1);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("excludes non-Gmail events from the candidate set", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact({
+        context,
+        id: "contact:salesforce-email",
+        email: "sf@example.org",
+        salesforceContactId: "003SF",
+      });
+      await context.repositories.sourceEvidence.append({
+        id: "source-evidence:salesforce:email-1",
+        provider: "salesforce",
+        providerRecordType: "task_communication",
+        providerRecordId: "task-1",
+        receivedAt: "2026-05-24T08:00:00.000Z",
+        occurredAt: "2026-05-24T08:00:00.000Z",
+        payloadRef: "salesforce://task/task-1",
+        idempotencyKey: "source-evidence:salesforce:email-1",
+        checksum: "checksum:task-1",
+      });
+      await context.repositories.canonicalEvents.upsert({
+        id: "canonical-event:salesforce-email",
+        contactId: "contact:salesforce-email",
+        eventType: "communication.email.inbound",
+        channel: "email",
+        occurredAt: "2026-05-24T08:00:00.000Z",
+        contentFingerprint: null,
+        sourceEvidenceId: "source-evidence:salesforce:email-1",
+        idempotencyKey: "canonical-event:salesforce-email",
+        provenance: {
+          primaryProvider: "salesforce" as const,
+          primarySourceEvidenceId: "source-evidence:salesforce:email-1",
+          supportingSourceEvidenceIds: [],
+          winnerReason: "single_source" as const,
+          sourceRecordType: "task_communication",
+          sourceRecordId: "task-1",
+          messageKind: "one_to_one" as const,
+          campaignRef: null,
+          threadRef: null,
+          direction: "inbound" as const,
+          notes: null,
+        },
+        reviewState: "clear",
+      });
+
+      const result = await backfillCanonicalEventAudience({
+        db: context.db,
+        repositories: context.repositories,
+        since: "2026-05-01T00:00:00.000Z",
+        until: "2026-05-31T23:59:59.999Z",
+        execute: true,
+        limit: 100,
+      });
+
+      expect(result).toMatchObject({
+        candidates: 0,
+        applied: 0,
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("respects the since and until window", async () => {
+    const context = await createTestWorkerContext();
+    const logs: BackfillCanonicalEventAudienceLogEntry[] = [];
+
+    try {
+      await seedContact({
+        context,
+        id: "contact:window",
+        email: "window@example.org",
+        salesforceContactId: "003WINDOW",
+      });
+      await seedGmailCanonicalEvent({
+        context,
+        canonicalEventId: "canonical-event:window-inside",
+        sourceEvidenceId: "source-evidence:gmail:window-inside",
+        providerRecordId: "gmail-window-inside",
+        contactId: "contact:window",
+        occurredAt: "2026-05-20T10:00:00.000Z",
+        fromEmails: ["window@example.org"],
+      });
+      await seedGmailCanonicalEvent({
+        context,
+        canonicalEventId: "canonical-event:window-outside",
+        sourceEvidenceId: "source-evidence:gmail:window-outside",
+        providerRecordId: "gmail-window-outside",
+        contactId: "contact:window",
+        occurredAt: "2026-04-20T10:00:00.000Z",
+        fromEmails: ["window@example.org"],
+      });
+
+      const result = await backfillCanonicalEventAudience({
+        db: context.db,
+        repositories: context.repositories,
+        since: "2026-05-01T00:00:00.000Z",
+        until: "2026-05-31T23:59:59.999Z",
+        execute: false,
+        limit: 100,
+        logger: createLogger(logs),
+      });
+
+      expect(result).toMatchObject({
+        candidates: 1,
+        applied: 1,
+      });
+      expect(logs).toContainEqual({
+        action: "dryRun",
+        canonicalEventId: "canonical-event:window-inside",
+        sourceEvidenceId: "source-evidence:gmail:window-inside",
+        audienceCount: 1,
+      });
+      expect(
+        logs.some(
+          (entry) => entry.canonicalEventId === "canonical-event:window-outside",
+        ),
+      ).toBe(false);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("skips Gmail events whose header email arrays are empty", async () => {
+    const context = await createTestWorkerContext();
+    const logs: BackfillCanonicalEventAudienceLogEntry[] = [];
+
+    try {
+      await seedContact({
+        context,
+        id: "contact:empty",
+        email: "empty@example.org",
+        salesforceContactId: "003EMPTY",
+      });
+      await seedGmailCanonicalEvent({
+        context,
+        canonicalEventId: "canonical-event:empty-headers",
+        sourceEvidenceId: "source-evidence:gmail:empty-headers",
+        providerRecordId: "gmail-empty-headers",
+        contactId: "contact:empty",
+        occurredAt: "2026-05-25T08:00:00.000Z",
+      });
+
+      const result = await backfillCanonicalEventAudience({
+        db: context.db,
+        repositories: context.repositories,
+        since: "2026-05-01T00:00:00.000Z",
+        until: "2026-05-31T23:59:59.999Z",
+        execute: true,
+        limit: 100,
+        logger: createLogger(logs),
+      });
+
+      expect(result).toMatchObject({
+        candidates: 1,
+        applied: 0,
+        skipped: 1,
+        byReason: {
+          no_gmail_detail: 0,
+          no_header_emails: 1,
+        },
+      });
+      expect(logs).toContainEqual({
+        action: "skipped",
+        canonicalEventId: "canonical-event:empty-headers",
+        sourceEvidenceId: "source-evidence:gmail:empty-headers",
+        reason: "no_header_emails",
+      });
+      await expect(loadAudienceRows(context)).resolves.toHaveLength(0);
+    } finally {
+      await context.dispose();
+    }
+  });
+});

--- a/docs/runbooks/backfill-canonical-event-audience.md
+++ b/docs/runbooks/backfill-canonical-event-audience.md
@@ -1,0 +1,45 @@
+# Runbook: Backfill Gmail canonical event audience
+
+**Severity:** planned maintenance
+**Average time to recover:** depends on row count; validate on staging first
+**Last verified:** 2026-05-30 against current worktree
+
+## When to run
+
+Run this once after PRD #482 fan-out writer changes are deployed.
+It backfills `canonical_event_audience` for historical Gmail canonical events
+that predate the live writer.
+
+## Dry-run first
+
+1. Run the worker command without `--execute`.
+2. Review the per-row JSON output and final summary JSON.
+3. Confirm skipped rows are expected.
+4. Repeat on staging with `--execute`.
+5. Only then run production with `--execute`.
+
+## Command
+
+```bash
+pnpm --filter @as-comms/worker ops:backfill-canonical-event-audience --since=2026-01-01T00:00:00.000Z --until=2026-05-30T23:59:59.999Z --limit=5000
+```
+
+Add `--execute` only after the dry-run summary looks correct.
+
+## Expected skips
+
+- `no_gmail_detail`: the canonical event exists but its
+  `gmail_message_details` row is missing.
+- `no_header_emails`: the Gmail detail row exists but all of
+  `from_emails / to_emails / cc_emails / bcc_emails` are empty. This is
+  expected for pre-0065 historical captures that have not been re-imported.
+
+## Related
+
+- **Code paths:**
+  - [backfill-canonical-event-audience.ts](../../apps/worker/src/ops/backfill-canonical-event-audience.ts) — one-time worker command
+  - [normalization.ts](../../packages/domain/src/normalization.ts) — shared `applyCanonicalEventAudience` logic used by live ingest and the backfill
+  - [canonical-event-audience.ts](../../packages/domain/src/canonical-event-audience.ts) — pure audience resolver
+- **Schema:**
+  - [0064_canonical_event_audience.sql](../../packages/db/drizzle/0064_canonical_event_audience.sql)
+  - [0065_gmail_message_audience_headers.sql](../../packages/db/drizzle/0065_gmail_message_audience_headers.sql)

--- a/packages/domain/src/normalization.ts
+++ b/packages/domain/src/normalization.ts
@@ -293,6 +293,172 @@ export interface Stage1NormalizationService {
   ): Promise<NormalizedCanonicalEventResult>;
 }
 
+export interface CanonicalEventAudienceApplyDeps {
+  readonly persistence: Stage1PersistenceService;
+  readonly service: Pick<
+    Stage1NormalizationService,
+    "ensureCanonicalContactForEmail" | "refreshInboxReviewOverlay"
+  >;
+}
+
+export async function applyCanonicalEventAudience(
+  deps: CanonicalEventAudienceApplyDeps,
+  input: {
+    readonly canonicalEvent: CanonicalEventRecord;
+    readonly gmailMessageDetail: NormalizedCanonicalEventIntake["gmailMessageDetail"];
+    readonly openedAt: string;
+  },
+): Promise<number> {
+  if (input.gmailMessageDetail === undefined) {
+    return 0;
+  }
+
+  const audience = resolveCanonicalEventAudience({
+    fromEmails: input.gmailMessageDetail.fromEmails ?? [],
+    toEmails: input.gmailMessageDetail.toEmails ?? [],
+    ccEmails: input.gmailMessageDetail.ccEmails ?? [],
+    bccEmails: input.gmailMessageDetail.bccEmails ?? [],
+  });
+
+  if (audience.participants.length === 0) {
+    return 0;
+  }
+
+  const rowsByContactId = new Map<string, CanonicalEventAudienceRecord>();
+
+  for (const participant of audience.participants) {
+    const normalizedEmail = normalizeEmailAddress(participant.email);
+
+    if (normalizedEmail === null) {
+      continue;
+    }
+
+    const identities =
+      await deps.persistence.repositories.contactIdentities.listByNormalizedValue(
+        {
+          kind: "email",
+          normalizedValue: normalizedEmail,
+        },
+      );
+    const candidateContactIds = uniqueStrings(
+      identities.map((identity) => identity.contactId),
+    );
+
+    let contact: ContactRecord;
+
+    if (candidateContactIds.length === 0) {
+      contact = await deps.service.ensureCanonicalContactForEmail({
+        emailAddress: normalizedEmail,
+        createdAt: input.openedAt,
+        source: "gmail",
+      });
+    } else if (candidateContactIds.length === 1) {
+      const candidateContactId = requireValue(
+        candidateContactIds[0],
+        "Expected a single audience contact candidate.",
+      );
+      const matchedContact =
+        await deps.persistence.repositories.contacts.findById(candidateContactId);
+
+      if (matchedContact === null) {
+        throw new Error("Audience email matched a missing contact.");
+      }
+
+      contact = matchedContact;
+    } else {
+      const contacts = await deps.persistence.repositories.contacts.listByIds(
+        candidateContactIds,
+      );
+      const projections = await Promise.all(
+        contacts.map(async (candidateContact) => ({
+          contact: candidateContact,
+          projection:
+            await deps.persistence.repositories.inboxProjection.findByContactId(
+              candidateContact.id,
+            ),
+        })),
+      );
+      const [winner] = projections.sort((left, right) => {
+        const inboundComparison = compareNullableIsoDesc(
+          left.projection?.lastInboundAt ?? null,
+          right.projection?.lastInboundAt ?? null,
+        );
+
+        if (inboundComparison !== 0) {
+          return inboundComparison;
+        }
+
+        const activityComparison = compareNullableIsoDesc(
+          left.projection?.lastActivityAt ?? null,
+          right.projection?.lastActivityAt ?? null,
+        );
+
+        if (activityComparison !== 0) {
+          return activityComparison;
+        }
+
+        return left.contact.id.localeCompare(right.contact.id);
+      });
+
+      if (winner === undefined) {
+        throw new Error(
+          "Audience email candidates did not resolve to canonical contacts.",
+        );
+      }
+
+      contact = winner.contact;
+
+      await deps.persistence.saveIdentityResolutionCase({
+        id: buildAudienceIdentityCaseId(
+          input.canonicalEvent.sourceEvidenceId,
+          normalizedEmail,
+          "identity_multi_candidate",
+        ),
+        sourceEvidenceId: input.canonicalEvent.sourceEvidenceId,
+        candidateContactIds: candidateContactIds.filter(
+          (contactId) => contactId !== contact.id,
+        ),
+        reasonCode: "identity_multi_candidate",
+        status: "open",
+        openedAt: input.openedAt,
+        resolvedAt: null,
+        normalizedIdentityValues: [normalizedEmail],
+        anchoredContactId: contact.id,
+        explanation: buildIdentityConflictExplanation(
+          "identity_multi_candidate",
+        ),
+      });
+      await deps.service.refreshInboxReviewOverlay({
+        contactId: contact.id,
+      });
+    }
+
+    const nextRecord = canonicalEventAudienceSchema.parse({
+      canonicalEventId: input.canonicalEvent.id,
+      contactId: contact.id,
+      participantRole: participant.role,
+      normalizedEmail,
+    });
+    const existingRecord = rowsByContactId.get(contact.id);
+    rowsByContactId.set(
+      contact.id,
+      existingRecord === undefined
+        ? nextRecord
+        : preferAudienceRecord(existingRecord, nextRecord),
+    );
+  }
+
+  const rows = [...rowsByContactId.values()].sort((left, right) =>
+    left.contactId.localeCompare(right.contactId),
+  );
+
+  for (const row of rows) {
+    await deps.persistence.saveCanonicalEventAudience(row);
+  }
+
+  return rows.length;
+}
+
 function uniqueStrings(values: readonly string[]): string[] {
   return Array.from(new Set(values)).sort((left, right) =>
     left.localeCompare(right),
@@ -2922,11 +3088,17 @@ export function createStage1NormalizationService(
                   canonicalEvent: persistedEvent,
                   summary: existingTimelineProjection.summary,
                 });
-        await applyCanonicalEventAudience({
-          canonicalEvent: persistedEvent,
-          gmailMessageDetail: parsed.gmailMessageDetail,
-          openedAt: parsed.sourceEvidence.receivedAt,
-        });
+        await applyCanonicalEventAudience(
+          {
+            persistence,
+            service,
+          },
+          {
+            canonicalEvent: persistedEvent,
+            gmailMessageDetail: parsed.gmailMessageDetail,
+            openedAt: parsed.sourceEvidence.receivedAt,
+          },
+        );
         const inboxProjection = qualifiesForInboxProjection(persistedEvent)
           ? await rebuildInboxProjectionForContact(
               persistence,
@@ -3106,11 +3278,17 @@ export function createStage1NormalizationService(
             : (duplicateMatch.existingTimelineProjection?.summary ??
               parsed.canonicalEvent.summary),
         });
-        await applyCanonicalEventAudience({
-          canonicalEvent: persistedEvent,
-          gmailMessageDetail: parsed.gmailMessageDetail,
-          openedAt: parsed.sourceEvidence.receivedAt,
-        });
+        await applyCanonicalEventAudience(
+          {
+            persistence,
+            service,
+          },
+          {
+            canonicalEvent: persistedEvent,
+            gmailMessageDetail: parsed.gmailMessageDetail,
+            openedAt: parsed.sourceEvidence.receivedAt,
+          },
+        );
         const inboxProjection = await rebuildInboxProjectionForContact(
           persistence,
           persistedEvent.contactId,
@@ -3178,11 +3356,17 @@ export function createStage1NormalizationService(
         canonicalEvent: persistedEvent,
         summary: parsed.canonicalEvent.summary,
       });
-      await applyCanonicalEventAudience({
-        canonicalEvent: persistedEvent,
-        gmailMessageDetail: parsed.gmailMessageDetail,
-        openedAt: parsed.sourceEvidence.receivedAt,
-      });
+      await applyCanonicalEventAudience(
+        {
+          persistence,
+          service,
+        },
+        {
+          canonicalEvent: persistedEvent,
+          gmailMessageDetail: parsed.gmailMessageDetail,
+          openedAt: parsed.sourceEvidence.receivedAt,
+        },
+      );
       const inboxProjection = qualifiesForInboxProjection(persistedEvent)
         ? await service.applyInboxProjection({
             canonicalEvent: persistedEvent,
@@ -3208,157 +3392,6 @@ export function createStage1NormalizationService(
         auditEvidence: null,
       };
     },
-  };
-
-  const applyCanonicalEventAudience = async (input: {
-    readonly canonicalEvent: CanonicalEventRecord;
-    readonly gmailMessageDetail: NormalizedCanonicalEventIntake["gmailMessageDetail"];
-    readonly openedAt: string;
-  }): Promise<void> => {
-    if (input.gmailMessageDetail === undefined) {
-      return;
-    }
-
-    const audience = resolveCanonicalEventAudience({
-      fromEmails: input.gmailMessageDetail.fromEmails ?? [],
-      toEmails: input.gmailMessageDetail.toEmails ?? [],
-      ccEmails: input.gmailMessageDetail.ccEmails ?? [],
-      bccEmails: input.gmailMessageDetail.bccEmails ?? [],
-    });
-
-    if (audience.participants.length === 0) {
-      return;
-    }
-
-    const rowsByContactId = new Map<string, CanonicalEventAudienceRecord>();
-
-    for (const participant of audience.participants) {
-      const normalizedEmail = normalizeEmailAddress(participant.email);
-
-      if (normalizedEmail === null) {
-        continue;
-      }
-
-      const identities =
-        await persistence.repositories.contactIdentities.listByNormalizedValue({
-          kind: "email",
-          normalizedValue: normalizedEmail,
-        });
-      const candidateContactIds = uniqueStrings(
-        identities.map((identity) => identity.contactId),
-      );
-
-      let contact: ContactRecord;
-
-      if (candidateContactIds.length === 0) {
-        contact = await service.ensureCanonicalContactForEmail({
-          emailAddress: normalizedEmail,
-          createdAt: input.openedAt,
-          source: "gmail",
-        });
-      } else if (candidateContactIds.length === 1) {
-        const candidateContactId = requireValue(
-          candidateContactIds[0],
-          "Expected a single audience contact candidate.",
-        );
-        const matchedContact =
-          await persistence.repositories.contacts.findById(candidateContactId);
-
-        if (matchedContact === null) {
-          throw new Error("Audience email matched a missing contact.");
-        }
-
-        contact = matchedContact;
-      } else {
-        const contacts = await persistence.repositories.contacts.listByIds(
-          candidateContactIds,
-        );
-        const projections = await Promise.all(
-          contacts.map(async (candidateContact) => ({
-            contact: candidateContact,
-            projection:
-              await persistence.repositories.inboxProjection.findByContactId(
-                candidateContact.id,
-              ),
-          })),
-        );
-        const [winner] = projections.sort((left, right) => {
-          const inboundComparison = compareNullableIsoDesc(
-            left.projection?.lastInboundAt ?? null,
-            right.projection?.lastInboundAt ?? null,
-          );
-
-          if (inboundComparison !== 0) {
-            return inboundComparison;
-          }
-
-          const activityComparison = compareNullableIsoDesc(
-            left.projection?.lastActivityAt ?? null,
-            right.projection?.lastActivityAt ?? null,
-          );
-
-          if (activityComparison !== 0) {
-            return activityComparison;
-          }
-
-          return left.contact.id.localeCompare(right.contact.id);
-        });
-
-        if (winner === undefined) {
-          throw new Error(
-            "Audience email candidates did not resolve to canonical contacts.",
-          );
-        }
-
-        contact = winner.contact;
-
-        await persistence.saveIdentityResolutionCase({
-          id: buildAudienceIdentityCaseId(
-            input.canonicalEvent.sourceEvidenceId,
-            normalizedEmail,
-            "identity_multi_candidate",
-          ),
-          sourceEvidenceId: input.canonicalEvent.sourceEvidenceId,
-          candidateContactIds: candidateContactIds.filter(
-            (contactId) => contactId !== contact.id,
-          ),
-          reasonCode: "identity_multi_candidate",
-          status: "open",
-          openedAt: input.openedAt,
-          resolvedAt: null,
-          normalizedIdentityValues: [normalizedEmail],
-          anchoredContactId: contact.id,
-          explanation: buildIdentityConflictExplanation(
-            "identity_multi_candidate",
-          ),
-        });
-        await service.refreshInboxReviewOverlay({
-          contactId: contact.id,
-        });
-      }
-
-      const nextRecord = canonicalEventAudienceSchema.parse({
-        canonicalEventId: input.canonicalEvent.id,
-        contactId: contact.id,
-        participantRole: participant.role,
-        normalizedEmail,
-      });
-      const existingRecord = rowsByContactId.get(contact.id);
-      rowsByContactId.set(
-        contact.id,
-        existingRecord === undefined
-          ? nextRecord
-          : preferAudienceRecord(existingRecord, nextRecord),
-      );
-    }
-
-    const rows = [...rowsByContactId.values()].sort((left, right) =>
-      left.contactId.localeCompare(right.contactId),
-    );
-
-    for (const row of rows) {
-      await persistence.saveCanonicalEventAudience(row);
-    }
   };
 
   return service;


### PR DESCRIPTION
## Summary

Brick 4 of 8 implementing [PRD #482](https://github.com/nico-kneler-as/as-comms-platform/issues/482) — multi-party Gmail thread timeline fan-out. One-time backfill that walks historical Gmail canonical events and reconstructs their audience via **the same code path** as the live writer (no logic duplication).

## What landed

**Refactor — shared code path for live ingest + backfill**

- `packages/domain/src/normalization.ts` — extracted `applyCanonicalEventAudience` from a closure inside `applyNormalizedIntake` to a top-level exported function. Takes `{ persistence, service }` as deps + per-event payload as input.
- The three existing live call sites in `applyNormalizedCanonicalEvent` now invoke the new top-level function. **No behavior change for live ingest** — verified by the existing domain test suite (145+ passing).

**New ops command**

- `apps/worker/src/ops/backfill-canonical-event-audience.ts` — mirrors the shape of `recompute-attachment-inline.ts`.
  - Dry-run by default; `--execute` commits.
  - `--since` / `--until` / `--limit` flags follow existing ops convention.
  - **Per-event transactions:** dry-run rolls back, `--execute` commits — so each event's audience rows + identity-case rows + inbox-overlay refresh are atomic.
  - Filters: Gmail-provider canonical events only, those without existing audience rows, skips empty-header detail rows with `reason: 'no_header_emails'` (expected for pre-0065 captures).
- `apps/worker/src/ops/cli.ts` + `apps/worker/package.json` — dispatcher + `ops:backfill-canonical-event-audience` script.

**Tests** — `apps/worker/test/backfill-canonical-event-audience.test.ts` — 7 cases:

1. Multi-recipient inbound, all SF-anchored → dry-run leaves DB unchanged; `--execute` commits audience rows with correct roles
2. Single sender + new external recipient → resolver creates new contact, audience includes both
3. Multi-candidate participant → deterministic best-guess winner, identity-resolution case opened, inbox overlay refreshed
4. Idempotency → re-running excludes events that already have audience rows
5. Non-Gmail event (SMS / lifecycle) → not a candidate
6. Window filter respected (`--since` / `--until`)
7. Empty-header detail row → skipped with `reason: 'no_header_emails'`

**Operator runbook**

- `docs/runbooks/backfill-canonical-event-audience.md` — dry-run-first protocol, expected skips for pre-0065 captures, staging-before-production guidance.

## Validation (worktree, before push — full repo this time)

- ✅ `pnpm --filter @as-comms/domain typecheck / lint / test` (145+ tests)
- ✅ `pnpm --filter @as-comms/worker typecheck / lint / test:unit`
- ✅ Full repo `pnpm typecheck` — 16/16 packages
- ✅ Full repo `pnpm lint` — 16/16 packages
- ✅ `pnpm boundaries`

## Next bricks

| # | Brick | Status |
|---|---|---|
| 5 | (architect) Run backfill on staging then production | Blocked on this merging |
| 6 | Timeline UNION read (operator-visible flip) | Blocked on Step 5 |
| 7 | Search by display name | Polish, parallel after 6 |
| 8 | Ops scripts audience-aware | Polish, parallel after 6 |

## Test plan
- [ ] CI green
- [ ] Manual: dry-run on staging shows reasonable candidate count + zero `audienceCount=0` surprises before going to `--execute`

🤖 Generated with [Claude Code](https://claude.com/claude-code)