### PR TITLE
fix(db,worker): preserve PG errors + close canonical_event_audience gap in contact merge

### DIFF
--- a/apps/worker/src/orchestration/service.ts
+++ b/apps/worker/src/orchestration/service.ts
@@ -525,12 +525,64 @@ function calculateFreshnessMetrics(
   };
 }
 
+// Postgres error fields surfaced by postgres-js. Captured into the failure
+// message so Stage1TaskOutcomeError prints the underlying ERROR cause (code,
+// severity, detail, constraint) alongside the original message — otherwise
+// only error.message survives, which often contains the SQL but not the
+// reason it failed (statement_timeout, FK violation, etc.).
+const POSTGRES_ERROR_DETAIL_KEYS = [
+  "severity",
+  "detail",
+  "hint",
+  "constraint_name",
+  "table_name",
+  "column_name",
+  "schema_name",
+  "where",
+  "position",
+  "routine"
+] as const;
+
+function formatPostgresErrorContext(error: unknown): string | null {
+  if (typeof error !== "object" || error === null) {
+    return null;
+  }
+
+  const record = error as Record<string, unknown>;
+  const code = typeof record.code === "string" ? record.code : null;
+
+  if (code === null) {
+    return null;
+  }
+
+  const parts: string[] = [`code=${code}`];
+
+  for (const key of POSTGRES_ERROR_DETAIL_KEYS) {
+    const value = record[key];
+
+    if (typeof value === "string" && value.length > 0) {
+      parts.push(`${key}=${value}`);
+    } else if (typeof value === "number") {
+      parts.push(`${key}=${value.toString()}`);
+    }
+  }
+
+  return `[pg ${parts.join(" ")}]`;
+}
+
+function formatJobFailureMessage(error: unknown): string {
+  const baseMessage = error instanceof Error ? error.message : String(error);
+  const pgContext = formatPostgresErrorContext(error);
+
+  return pgContext === null ? baseMessage : `${baseMessage} ${pgContext}`;
+}
+
 function buildJobFailure(
   error: unknown,
   attempt: number,
   maxAttempts: number
 ): Stage1JobFailure {
-  const message = error instanceof Error ? error.message : String(error);
+  const message = formatJobFailureMessage(error);
 
   if (error instanceof Stage1NonRetryableJobError || error instanceof ZodError) {
     return {

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -2763,13 +2763,17 @@ function createStage1RepositoriesInternal(
       readonly anchoredContactId: string;
     }) {
       return db.transaction(async (tx: Stage1Database) => {
+        // Note: UPDATE SET clauses use bare column names (e.g., `contact_id`,
+        // not `${table.column}`) because PostgreSQL treats `"table"."column"`
+        // in a SET target as a composite-type subfield reference, not a table
+        // qualification, and rejects it.
         const canonicalEventsResult = await tx.execute(sql<{
           readonly id: string;
         }>`
           update ${canonicalEventLedger}
           set
-            ${canonicalEventLedger.contactId} = ${input.anchoredContactId},
-            ${canonicalEventLedger.updatedAt} = timezone('utc', now())
+            contact_id = ${input.anchoredContactId},
+            updated_at = timezone('utc', now())
           where ${canonicalEventLedger.contactId} = ${input.emailOnlyContactId}
           returning ${canonicalEventLedger.id} as id
         `);
@@ -2778,8 +2782,8 @@ function createStage1RepositoriesInternal(
         }>`
           update ${contactTimelineProjection}
           set
-            ${contactTimelineProjection.contactId} = ${input.anchoredContactId},
-            ${contactTimelineProjection.updatedAt} = timezone('utc', now())
+            contact_id = ${input.anchoredContactId},
+            updated_at = timezone('utc', now())
           where ${contactTimelineProjection.contactId} = ${input.emailOnlyContactId}
           returning ${contactTimelineProjection.id} as id
         `);
@@ -2788,8 +2792,8 @@ function createStage1RepositoriesInternal(
         }>`
           update ${internalNotes}
           set
-            ${internalNotes.contactId} = ${input.anchoredContactId},
-            ${internalNotes.updatedAt} = timezone('utc', now())
+            contact_id = ${input.anchoredContactId},
+            updated_at = timezone('utc', now())
           where ${internalNotes.contactId} = ${input.emailOnlyContactId}
           returning ${internalNotes.id} as id
         `);
@@ -2798,8 +2802,8 @@ function createStage1RepositoriesInternal(
         }>`
           update ${routingReviewQueue}
           set
-            ${routingReviewQueue.contactId} = ${input.anchoredContactId},
-            ${routingReviewQueue.updatedAt} = timezone('utc', now())
+            contact_id = ${input.anchoredContactId},
+            updated_at = timezone('utc', now())
           where ${routingReviewQueue.contactId} = ${input.emailOnlyContactId}
           returning ${routingReviewQueue.id} as id
         `);
@@ -2808,12 +2812,12 @@ function createStage1RepositoriesInternal(
         }>`
           update ${identityResolutionQueue}
           set
-            ${identityResolutionQueue.anchoredContactId} = case
+            anchored_contact_id = case
               when ${identityResolutionQueue.anchoredContactId} = ${input.emailOnlyContactId}
                 then ${input.anchoredContactId}
               else ${identityResolutionQueue.anchoredContactId}
             end,
-            ${identityResolutionQueue.candidateContactIds} = (
+            candidate_contact_ids = (
               select coalesce(
                 array_agg(candidate_id order by candidate_id),
                 array[]::text[]
@@ -2834,10 +2838,33 @@ function createStage1RepositoriesInternal(
                 where candidate_id <> ${input.emailOnlyContactId}
               ) deduped_candidates
             ),
-            ${identityResolutionQueue.updatedAt} = timezone('utc', now())
+            updated_at = timezone('utc', now())
           where ${identityResolutionQueue.anchoredContactId} = ${input.emailOnlyContactId}
              or ${identityResolutionQueue.candidateContactIds} && array[${input.emailOnlyContactId}]::text[]
           returning ${identityResolutionQueue.id} as id
+        `);
+        // Drop email-only audience rows that would collide with an existing
+        // anchored row on the same canonical event before repointing the rest.
+        // canonical_event_audience cascades on contact deletion, so this must
+        // happen before the contact DELETE below.
+        await tx.execute(sql`
+          delete from ${canonicalEventAudience}
+          where ${canonicalEventAudience.contactId} = ${input.emailOnlyContactId}
+            and ${canonicalEventAudience.canonicalEventId} in (
+              select ${canonicalEventAudience.canonicalEventId}
+              from ${canonicalEventAudience}
+              where ${canonicalEventAudience.contactId} = ${input.anchoredContactId}
+            )
+        `);
+        const audienceRowsResult = await tx.execute(sql<{
+          readonly canonical_event_id: string;
+        }>`
+          update ${canonicalEventAudience}
+          set
+            contact_id = ${input.anchoredContactId},
+            updated_at = timezone('utc', now())
+          where ${canonicalEventAudience.contactId} = ${input.emailOnlyContactId}
+          returning ${canonicalEventAudience.canonicalEventId} as canonical_event_id
         `);
         const deletedContactsResult = await tx.execute(sql<{
           readonly id: string;
@@ -2890,6 +2917,13 @@ function createStage1RepositoriesInternal(
                 readonly rows?: readonly { readonly id: string }[];
               },
             ).length,
+          audienceRowsRepointed: normalizeSqlResultRows<{
+            readonly canonical_event_id: string;
+          }>(
+            audienceRowsResult as {
+              readonly rows?: readonly { readonly canonical_event_id: string }[];
+            },
+          ).length,
           contactDeleted: true,
         };
       });

--- a/packages/db/test/stage1-repositories.test.ts
+++ b/packages/db/test/stage1-repositories.test.ts
@@ -2047,4 +2047,189 @@ describe("Stage 1 DB repositories", () => {
       "contact:in-sub-c",
     ]);
   });
+
+  it("repoints canonical_event_audience rows when merging an email-only contact into an anchored one", async () => {
+    const { client, repositories } = await createTestStage1Context();
+
+    // Two contacts: email-only (to be merged away) and anchored (the survivor).
+    await repositories.contacts.upsert({
+      id: "contact:email-only",
+      salesforceContactId: null,
+      displayName: "Dean Schie (email-only)",
+      primaryEmail: "deanschie@example.org",
+      primaryPhone: null,
+      createdAt: "2026-05-01T00:00:00.000Z",
+      updatedAt: "2026-05-01T00:00:00.000Z",
+    });
+    await repositories.contacts.upsert({
+      id: "contact:anchored",
+      salesforceContactId: "0033600000ROVpSAAX",
+      displayName: "Dean Schie",
+      primaryEmail: "deanschie@example.org",
+      primaryPhone: null,
+      createdAt: "2026-05-01T00:00:00.000Z",
+      updatedAt: "2026-05-01T00:00:00.000Z",
+    });
+
+    // Two canonical events, one anchored on each contact.
+    await repositories.sourceEvidence.append({
+      id: "sev:merge-a",
+      provider: "gmail",
+      providerRecordType: "message",
+      providerRecordId: "gmail-merge-a",
+      receivedAt: "2026-05-01T12:00:00.000Z",
+      occurredAt: "2026-05-01T12:00:00.000Z",
+      payloadRef: "payloads/gmail/gmail-merge-a.json",
+      idempotencyKey: "gmail:message:gmail-merge-a",
+      checksum: "checksum-merge-a",
+    });
+    await repositories.canonicalEvents.upsert({
+      id: "evt:merge-a",
+      contactId: "contact:email-only",
+      eventType: "communication.email.inbound",
+      channel: "email",
+      occurredAt: "2026-05-01T12:00:00.000Z",
+      contentFingerprint: null,
+      sourceEvidenceId: "sev:merge-a",
+      idempotencyKey: "canonical:gmail-merge-a",
+      provenance: {
+        primaryProvider: "gmail",
+        primarySourceEvidenceId: "sev:merge-a",
+        supportingSourceEvidenceIds: [],
+        winnerReason: "single_source",
+        sourceRecordType: "message",
+        sourceRecordId: "gmail-merge-a",
+        messageKind: "one_to_one",
+        campaignRef: null,
+        threadRef: null,
+        direction: "inbound",
+        notes: null,
+      },
+      reviewState: "clear",
+    });
+    await repositories.sourceEvidence.append({
+      id: "sev:merge-b",
+      provider: "gmail",
+      providerRecordType: "message",
+      providerRecordId: "gmail-merge-b",
+      receivedAt: "2026-05-02T12:00:00.000Z",
+      occurredAt: "2026-05-02T12:00:00.000Z",
+      payloadRef: "payloads/gmail/gmail-merge-b.json",
+      idempotencyKey: "gmail:message:gmail-merge-b",
+      checksum: "checksum-merge-b",
+    });
+    await repositories.canonicalEvents.upsert({
+      id: "evt:merge-b",
+      contactId: "contact:anchored",
+      eventType: "communication.email.inbound",
+      channel: "email",
+      occurredAt: "2026-05-02T12:00:00.000Z",
+      contentFingerprint: null,
+      sourceEvidenceId: "sev:merge-b",
+      idempotencyKey: "canonical:gmail-merge-b",
+      provenance: {
+        primaryProvider: "gmail",
+        primarySourceEvidenceId: "sev:merge-b",
+        supportingSourceEvidenceIds: [],
+        winnerReason: "single_source",
+        sourceRecordType: "message",
+        sourceRecordId: "gmail-merge-b",
+        messageKind: "one_to_one",
+        campaignRef: null,
+        threadRef: null,
+        direction: "inbound",
+        notes: null,
+      },
+      reviewState: "clear",
+    });
+
+    // Audience setup:
+    //   evt:merge-a — email-only is a recipient (will be repointed).
+    //   evt:merge-b — BOTH email-only and anchored are recipients (collision:
+    //                 email-only side must drop, anchored side must survive).
+    await repositories.canonicalEventAudience.upsert({
+      canonicalEventId: "evt:merge-a",
+      contactId: "contact:email-only",
+      participantRole: "direct_recipient",
+      normalizedEmail: "deanschie@example.org",
+    });
+    await repositories.canonicalEventAudience.upsert({
+      canonicalEventId: "evt:merge-b",
+      contactId: "contact:email-only",
+      participantRole: "cc",
+      normalizedEmail: "deanschie@example.org",
+    });
+    await repositories.canonicalEventAudience.upsert({
+      canonicalEventId: "evt:merge-b",
+      contactId: "contact:anchored",
+      participantRole: "direct_recipient",
+      normalizedEmail: "deanschie@example.org",
+    });
+
+    // The merge method is exposed at runtime but not on the public
+    // Stage1RepositoryBundle interface (production callers reach it via
+    // the EmailOnlyContactMergeCapableRepositories extension type in
+    // packages/domain/src/persistence.ts).
+    const mergeCapable = repositories as typeof repositories & {
+      mergeEmailOnlyContactIntoAnchored(input: {
+        readonly emailOnlyContactId: string;
+        readonly anchoredContactId: string;
+      }): Promise<{
+        readonly canonicalEventsRepointed: number;
+        readonly timelineRowsRepointed: number;
+        readonly notesRepointed: number;
+        readonly routingRowsRepointed: number;
+        readonly identityCasesRepointed: number;
+        readonly audienceRowsRepointed: number;
+        readonly contactDeleted: boolean;
+      }>;
+    };
+    const result = await mergeCapable.mergeEmailOnlyContactIntoAnchored({
+      emailOnlyContactId: "contact:email-only",
+      anchoredContactId: "contact:anchored",
+    });
+
+    // Only one audience row had no collision and got repointed in place.
+    expect(result.audienceRowsRepointed).toBe(1);
+    expect(result.contactDeleted).toBe(true);
+
+    // Inspect surviving audience rows directly via raw SQL — we want to see
+    // both branches of the merge (repointed survivor + dedup of the collision).
+    const surviving = await client.query<{
+      readonly canonical_event_id: string;
+      readonly contact_id: string;
+      readonly participant_role: string;
+    }>(
+      `select canonical_event_id, contact_id, participant_role
+       from canonical_event_audience
+       order by canonical_event_id, contact_id`,
+    );
+
+    // No rows should reference the email-only contact (cascade safety net).
+    expect(
+      surviving.rows.every((row) => row.contact_id !== "contact:email-only"),
+    ).toBe(true);
+
+    // evt:merge-a should now point at the anchored contact (repointed).
+    expect(surviving.rows).toContainEqual(
+      expect.objectContaining({
+        canonical_event_id: "evt:merge-a",
+        contact_id: "contact:anchored",
+        participant_role: "direct_recipient",
+      }),
+    );
+
+    // evt:merge-b's anchored row survives, with the original 'direct_recipient'
+    // role (not overwritten by the 'cc' role that came from the email-only side).
+    expect(surviving.rows).toContainEqual(
+      expect.objectContaining({
+        canonical_event_id: "evt:merge-b",
+        contact_id: "contact:anchored",
+        participant_role: "direct_recipient",
+      }),
+    );
+
+    // Exactly two rows total — one repointed, one survivor of the collision.
+    expect(surviving.rows.length).toBe(2);
+  });
 });

--- a/packages/domain/src/normalization.ts
+++ b/packages/domain/src/normalization.ts
@@ -2249,6 +2249,7 @@ async function recordEmailOnlyAutoMergeAuditOnce(
       readonly notesRepointed: number;
       readonly routingRowsRepointed: number;
       readonly identityCasesRepointed: number;
+      readonly audienceRowsRepointed: number;
     };
   },
 ): Promise<AuditEvidenceRecord> {
@@ -2292,6 +2293,7 @@ async function recordEmailOnlyAutoMergeAuditOnce(
       notesRepointed: input.mergeResult.notesRepointed,
       routingRowsRepointed: input.mergeResult.routingRowsRepointed,
       identityCasesRepointed: input.mergeResult.identityCasesRepointed,
+      audienceRowsRepointed: input.mergeResult.audienceRowsRepointed,
     },
   });
 }

--- a/packages/domain/src/persistence.ts
+++ b/packages/domain/src/persistence.ts
@@ -84,6 +84,7 @@ export interface EmailOnlyContactMergeResult {
   readonly notesRepointed: number;
   readonly routingRowsRepointed: number;
   readonly identityCasesRepointed: number;
+  readonly audienceRowsRepointed: number;
 }
 
 interface EmailOnlyContactMergeCapableRepositories
@@ -97,6 +98,7 @@ interface EmailOnlyContactMergeCapableRepositories
     readonly notesRepointed: number;
     readonly routingRowsRepointed: number;
     readonly identityCasesRepointed: number;
+    readonly audienceRowsRepointed: number;
     readonly contactDeleted: boolean;
   }>;
 }
@@ -548,6 +550,7 @@ export function createStage1PersistenceService(
         notesRepointed: result.notesRepointed,
         routingRowsRepointed: result.routingRowsRepointed,
         identityCasesRepointed: result.identityCasesRepointed,
+        audienceRowsRepointed: result.audienceRowsRepointed,
       };
     }
   };

--- a/packages/domain/test/normalization.test.ts
+++ b/packages/domain/test/normalization.test.ts
@@ -728,6 +728,7 @@ function buildContext(input: {
         notesRepointed,
         routingRowsRepointed,
         identityCasesRepointed,
+        audienceRowsRepointed: 0,
         contactDeleted,
       });
     },


### PR DESCRIPTION
## Summary
Two production hotfixes that share the 2026-05-31 00:10:24 UTC incident context (Salesforce capture failure on `stage1.salesforce.capture.live` task 223392):

- **Surface underlying Postgres error reason** — `buildJobFailure` in [service.ts](apps/worker/src/orchestration/service.ts) used to keep only `error.message`, which for postgres-js errors is often just the failed SQL. The server-side reason (code, severity, detail, constraint, table) is now appended as `[pg code=<code> severity=<severity> ...]` so `Stage1TaskOutcomeError` surfaces the actual cause. Non-Postgres errors are unaffected.
- **Close the canonical_event_audience fan-out gap in the merge** — `mergeEmailOnlyContactIntoAnchored` ([repositories.ts:2761](packages/db/src/repositories.ts)) repointed five tables from the email-only contact to the anchored contact, then deleted the email-only contact. `canonical_event_audience` (Brick 1 of [PRD #482](https://github.com/nico-kneler-as/as-comms-platform/issues/482)) was missing from that list, so its rows cascade-deleted on the contact DELETE — silent audit/data loss for every thread the merged contact participated in. Adds a collision-dedup `DELETE` + a survivor `UPDATE` before the contact `DELETE`, plus a new `audienceRowsRepointed` counter that flows through the auto-merge audit.

### Drive-by

The merge's `UPDATE` statements used `${table.column}` in SET clauses, which Drizzle compiles to `"table"."column"`. Postgres parses qualified identifiers in a SET target as composite-type subfield references and rejects them with ``column "<table>" of relation "<table>" does not exist``. SET targets are now bare column names so the merge runs correctly under both postgres-js and PGlite — which is what lets the new integration test exercise it. The auto-merge path is rare enough that this latent bug had not surfaced obviously in production prior to the incident report (the 21s wall-clock the original task burned is consistent with attempt+wait retry cycles on the syntax error rather than lock contention).

## Test plan
- [x] `pnpm typecheck` — full repo, all 16 packages green
- [x] `pnpm lint` — full repo, all 16 packages green
- [x] `pnpm boundaries` — green
- [x] `pnpm --filter @as-comms/db vitest run test/stage1-repositories.test.ts` — 19/19 (new audience-merge test included)
- [x] `pnpm --filter @as-comms/domain vitest run` — 145/145 (mock updated for new counter)
- [x] `pnpm --filter @as-comms/worker vitest run` — 209/209 (no regressions in orchestration tests)
- [ ] CI green
- [ ] Post-deploy: confirm next Salesforce-capture failure log shows enriched `[pg ...]` context

## Issue context
Production Railway log on 2026-05-31 around 00:10 UTC, after the [PR #487](https://github.com/nico-kneler-as/as-comms-platform/pull/487) deploy. The third issue from that report — `reconcile-stranded-campaign-runs` raising `TypeError: strandedRuns is not iterable` every 5 minutes — is independent and ships in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)