### PR TITLE
fix(worker): normalize db.execute result so reconcile-stranded handles postgres-js array shape

### DIFF
--- a/apps/worker/src/ops/reconcile-stranded-campaign-runs.ts
+++ b/apps/worker/src/ops/reconcile-stranded-campaign-runs.ts
@@ -28,6 +28,25 @@ interface StrandedCampaignRunRow {
   readonly startedAt: Date | null
 }
 
+// postgres-js returns query results as an Array directly; PGlite (in tests)
+// wraps them in `{ rows }`. Drizzle's tx.execute() type permits either shape,
+// so the runtime cast `(result as { rows }).rows` blows up on production
+// with `TypeError: <var> is not iterable`. See PR #462 for the same fix in
+// broadcasts.
+function normalizeSqlResultRows<TRow>(
+  result:
+    | readonly TRow[]
+    | {
+        readonly rows?: readonly TRow[]
+      },
+): readonly TRow[] {
+  if (Array.isArray(result)) {
+    return result as readonly TRow[]
+  }
+
+  return (result as { readonly rows?: readonly TRow[] }).rows ?? []
+}
+
 export interface ReconcileStrandedCampaignRunsDependencies {
   readonly db: Stage1Database
   readonly repositories: Pick<Stage1RepositoryBundle, "auditEvidence">
@@ -49,26 +68,27 @@ export async function reconcileStrandedCampaignRuns(
   const maxRunAgeHours = dependencies.maxRunAgeHours ?? 24
   const cutoff = subtractHours(now(), maxRunAgeHours)
 
-  const strandedRuns = (
-    (await dependencies.db.execute(sql<StrandedCampaignRunRow>`
-      select
-        campaign_runs.id as "runId",
-        campaign_runs.started_at as "startedAt"
-      from campaign_runs
-      where campaign_runs.state = 'sending'
-        and not exists (
-          -- Use the private tables because graphile_worker.jobs is a public view without payload in graphile-worker 0.16+.
-          select 1
-          from graphile_worker._private_jobs jobs
-          join graphile_worker._private_tasks tasks on tasks.id = jobs.task_id
-          where tasks.identifier = ${campaignSendJobName}
-            and jobs.payload::jsonb ->> 'runId' = campaign_runs.id
-            and jobs.attempts < jobs.max_attempts
-        )
-    `)) as {
-      readonly rows: readonly StrandedCampaignRunRow[]
-    }
-  ).rows
+  const strandedRunsResult = await dependencies.db.execute(sql<StrandedCampaignRunRow>`
+    select
+      campaign_runs.id as "runId",
+      campaign_runs.started_at as "startedAt"
+    from campaign_runs
+    where campaign_runs.state = 'sending'
+      and not exists (
+        -- Use the private tables because graphile_worker.jobs is a public view without payload in graphile-worker 0.16+.
+        select 1
+        from graphile_worker._private_jobs jobs
+        join graphile_worker._private_tasks tasks on tasks.id = jobs.task_id
+        where tasks.identifier = ${campaignSendJobName}
+          and jobs.payload::jsonb ->> 'runId' = campaign_runs.id
+          and jobs.attempts < jobs.max_attempts
+      )
+  `)
+  const strandedRuns = normalizeSqlResultRows<StrandedCampaignRunRow>(
+    strandedRunsResult as
+      | readonly StrandedCampaignRunRow[]
+      | { readonly rows?: readonly StrandedCampaignRunRow[] },
+  )
   const errors: ReconcileStrandedCampaignRunsError[] = []
   const runIds: string[] = []
   let reenqueued = 0

--- a/apps/worker/test/reconcile-stranded-campaign-runs.test.ts
+++ b/apps/worker/test/reconcile-stranded-campaign-runs.test.ts
@@ -260,6 +260,58 @@ describe("reconcile stranded campaign runs", () => {
     }
   })
 
+  it("iterates rows when db.execute returns a postgres-js Array (no .rows wrapper)", async () => {
+    // postgres-js returns query results as an Array directly, while PGlite
+    // wraps them in { rows: [...] }. The Drizzle type permits both, so the
+    // op needs to normalize the shape before iterating. Regression test for
+    // the production `TypeError: strandedRuns is not iterable` failure.
+    const context = await createTestWorkerContext()
+    const scheduled: string[] = []
+
+    try {
+      await seedProject(context)
+      const runId = await seedSendingRun(context, {
+        runId: "run-array-shape",
+      })
+
+      const arrayShapeRow = {
+        runId,
+        startedAt: new Date("2026-05-15T13:00:00.000Z"),
+      }
+      const fakeDb = {
+        execute: () =>
+          Promise.resolve(
+            [arrayShapeRow] as unknown as ReturnType<
+              typeof context.db.execute
+            >,
+          ),
+      } as unknown as typeof context.db
+
+      const report = await reconcileStrandedCampaignRuns({
+        db: fakeDb,
+        repositories: context.repositories,
+        scheduleRecovery: (candidateRunId) => {
+          scheduled.push(candidateRunId)
+          return Promise.resolve()
+        },
+        now: () => new Date("2026-05-15T14:00:00.000Z"),
+        logger: {
+          log: () => undefined,
+        },
+      })
+
+      expect(report).toMatchObject({
+        scanned: 1,
+        reenqueued: 1,
+        agedOut: 0,
+        runIds: [runId],
+      })
+      expect(scheduled).toEqual([runId])
+    } finally {
+      await context.dispose()
+    }
+  })
+
   it("does not re-enqueue sending runs that still have a live campaign-send job", async () => {
     const context = await createTestWorkerContext()
     const scheduled: string[] = []


### PR DESCRIPTION
## Summary
Fixes the `TypeError: strandedRuns is not iterable` that `reconcile-stranded-campaign-runs` raises every 5 minutes on production worker (Railway logs: tasks 223390 at 2026-05-31 00:10 UTC, then 226695 / 226716 / 226737 / 226781 / 226802 every 5 min since).

The op casts `tx.execute(...)` to `{ rows }` and reads `.rows`, but postgres-js returns query results as an Array directly (PGlite, used in tests, wraps in `{ rows }` — which is why CI hadn't caught it). The cast produced `undefined`, which then threw on the `for ... of` iteration.

Same pattern fixed before in [PR #462](https://github.com/nico-kneler-as/as-comms-platform/pull/462) for broadcasts — this one was missed.

## Fix
Local `normalizeSqlResultRows<TRow>` helper that handles both shapes, mirroring the helpers already in [run-recipients.ts](apps/web/app/broadcasts/_lib/run-recipients.ts) and [repositories.ts](packages/db/src/repositories.ts).

## Test
- New regression test in [reconcile-stranded-campaign-runs.test.ts](apps/worker/test/reconcile-stranded-campaign-runs.test.ts) injects a stub `db.execute` that returns an Array directly so the postgres-js production shape gets exercised in CI. The existing PGlite-shaped tests stay as the `{ rows }` path coverage.
- `pnpm --filter @as-comms/worker typecheck / lint` green
- `pnpm boundaries` green
- All 4 reconcile-stranded-campaign-runs tests pass

## Test plan
- [x] Typecheck, lint, boundaries
- [x] Unit tests pass (4/4)
- [ ] CI green
- [ ] Post-deploy: confirm the `reconcile-stranded-campaign-runs` task transitions from `Failed` to `Completed` in Railway logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)