### PR TITLE
feat(db,domain): UNION timeline reads through audience junction (Brick 6, PRD #482)

### DIFF
--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -1982,13 +1982,27 @@ function createStage1RepositoriesInternal(
         const rows = await db
           .select()
           .from(canonicalEventLedger)
-          .where(eq(canonicalEventLedger.contactId, contactId))
+          .leftJoin(
+            canonicalEventAudience,
+            and(
+              eq(canonicalEventAudience.canonicalEventId, canonicalEventLedger.id),
+              eq(canonicalEventAudience.contactId, contactId),
+            ),
+          )
+          .where(
+            or(
+              eq(canonicalEventLedger.contactId, contactId),
+              eq(canonicalEventAudience.contactId, contactId),
+            ),
+          )
           .orderBy(
             asc(canonicalEventLedger.occurredAt),
-            asc(canonicalEventLedger.createdAt),
+            asc(canonicalEventLedger.id),
           );
 
-        return rows.map(mapCanonicalEventRow);
+        return rows.map((row) =>
+          mapCanonicalEventRow(row.canonical_event_ledger),
+        );
       },
 
       async listByContactIds(contactIds) {
@@ -4797,10 +4811,27 @@ function createStage1RepositoriesInternal(
         const rows = await db
           .select()
           .from(contactTimelineProjection)
-          .where(eq(contactTimelineProjection.contactId, contactId))
+          .leftJoin(
+            canonicalEventAudience,
+            and(
+              eq(
+                canonicalEventAudience.canonicalEventId,
+                contactTimelineProjection.canonicalEventId,
+              ),
+              eq(canonicalEventAudience.contactId, contactId),
+            ),
+          )
+          .where(
+            or(
+              eq(contactTimelineProjection.contactId, contactId),
+              eq(canonicalEventAudience.contactId, contactId),
+            ),
+          )
           .orderBy(asc(contactTimelineProjection.sortKey));
 
-        return rows.map(mapTimelineProjectionRow);
+        return rows.map((row) =>
+          mapTimelineProjectionRow(row.contact_timeline_projection),
+        );
       },
 
       async listRecentByContactId(input) {

--- a/packages/db/test/stage1-repositories.test.ts
+++ b/packages/db/test/stage1-repositories.test.ts
@@ -49,6 +49,100 @@ interface ManualNoteDetailRecord {
   readonly authorId: string | null;
 }
 
+type Stage1TestRepositories = Awaited<
+  ReturnType<typeof createTestStage1Context>
+>["repositories"];
+
+async function seedTimelineFanoutContact(
+  repositories: Stage1TestRepositories,
+  contactId: string,
+): Promise<void> {
+  await repositories.contacts.upsert({
+    id: contactId,
+    salesforceContactId: `003-${contactId}`,
+    displayName: `Contact ${contactId}`,
+    primaryEmail: `${contactId}@example.org`,
+    primaryPhone: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  });
+}
+
+async function seedTimelineFanoutEvent(input: {
+  readonly repositories: Stage1TestRepositories;
+  readonly eventId: string;
+  readonly anchorContactId: string;
+  readonly occurredAt: string;
+  readonly direction: "inbound" | "outbound";
+  readonly summary?: string;
+}): Promise<{
+  readonly canonicalEvent: Awaited<
+    ReturnType<Stage1TestRepositories["canonicalEvents"]["upsert"]>
+  >;
+  readonly timelineProjection: Awaited<
+    ReturnType<Stage1TestRepositories["timelineProjection"]["upsert"]>
+  >;
+}> {
+  const sourceEvidenceId = `sev:${input.eventId}`;
+  await input.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "gmail",
+    providerRecordType: "message",
+    providerRecordId: input.eventId,
+    receivedAt: input.occurredAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `payloads/gmail/${input.eventId}.json`,
+    idempotencyKey: `gmail:${input.eventId}`,
+    checksum: `checksum:${input.eventId}`,
+  });
+
+  const canonicalEvent = await input.repositories.canonicalEvents.upsert({
+    id: input.eventId,
+    contactId: input.anchorContactId,
+    eventType: `communication.email.${input.direction}`,
+    channel: "email",
+    occurredAt: input.occurredAt,
+    contentFingerprint: null,
+    sourceEvidenceId,
+    idempotencyKey: `canonical:${input.eventId}`,
+    provenance: {
+      primaryProvider: "gmail",
+      primarySourceEvidenceId: sourceEvidenceId,
+      supportingSourceEvidenceIds: [],
+      winnerReason: "single_source",
+      sourceRecordType: "message",
+      sourceRecordId: input.eventId,
+      messageKind: "one_to_one",
+      campaignRef: null,
+      threadRef: {
+        providerThreadId: `thread:${input.eventId}`,
+        crossProviderCollapseKey: null,
+      },
+      direction: input.direction,
+      notes: null,
+    },
+    reviewState: "clear",
+  });
+
+  const timelineProjection = await input.repositories.timelineProjection.upsert({
+    id: `timeline:${input.eventId}`,
+    contactId: input.anchorContactId,
+    canonicalEventId: input.eventId,
+    occurredAt: input.occurredAt,
+    sortKey: `${input.occurredAt}::${input.eventId}`,
+    eventType: canonicalEvent.eventType,
+    summary: input.summary ?? input.eventId,
+    channel: "email",
+    primaryProvider: "gmail",
+    reviewState: "clear",
+  });
+
+  return {
+    canonicalEvent,
+    timelineProjection,
+  };
+}
+
 async function seedSharedInboxRecencyFixture(): Promise<{
   readonly repositories: Awaited<
     ReturnType<typeof createTestStage1Context>
@@ -1041,6 +1135,184 @@ describe("Stage 1 DB repositories", () => {
         isActive: true,
       }),
     ]);
+  });
+
+  it("preserves anchor-only timeline reads when no audience rows exist", async () => {
+    const { repositories } = await createTestStage1Context();
+
+    await seedTimelineFanoutContact(repositories, "contact_anchor");
+    const event = await seedTimelineFanoutEvent({
+      repositories,
+      eventId: "evt_anchor_only",
+      anchorContactId: "contact_anchor",
+      occurredAt: "2026-02-01T00:00:00.000Z",
+      direction: "inbound",
+    });
+
+    await expect(
+      repositories.timelineProjection.listByContactId("contact_anchor"),
+    ).resolves.toEqual([event.timelineProjection]);
+    await expect(
+      repositories.canonicalEvents.listByContactId("contact_anchor"),
+    ).resolves.toEqual([event.canonicalEvent]);
+    await expect(
+      repositories.timelineProjection.listByContactId("contact_missing"),
+    ).resolves.toEqual([]);
+    await expect(
+      repositories.canonicalEvents.listByContactId("contact_missing"),
+    ).resolves.toEqual([]);
+  });
+
+  it("returns audience fan-in rows for non-anchor contacts", async () => {
+    const { repositories } = await createTestStage1Context();
+
+    await seedTimelineFanoutContact(repositories, "contact_anchor");
+    await seedTimelineFanoutContact(repositories, "contact_audience");
+    const event = await seedTimelineFanoutEvent({
+      repositories,
+      eventId: "evt_audience_only",
+      anchorContactId: "contact_anchor",
+      occurredAt: "2026-02-01T00:01:00.000Z",
+      direction: "outbound",
+    });
+    await repositories.canonicalEventAudience.upsert({
+      canonicalEventId: event.canonicalEvent.id,
+      contactId: "contact_audience",
+      participantRole: "direct_recipient",
+      normalizedEmail: "contact_audience@example.org",
+    });
+
+    await expect(
+      repositories.timelineProjection.listByContactId("contact_audience"),
+    ).resolves.toEqual([event.timelineProjection]);
+    await expect(
+      repositories.canonicalEvents.listByContactId("contact_audience"),
+    ).resolves.toEqual([event.canonicalEvent]);
+  });
+
+  it("de-duplicates rows when the anchor contact is also in audience", async () => {
+    const { repositories } = await createTestStage1Context();
+
+    await seedTimelineFanoutContact(repositories, "contact_anchor");
+    const event = await seedTimelineFanoutEvent({
+      repositories,
+      eventId: "evt_anchor_and_audience",
+      anchorContactId: "contact_anchor",
+      occurredAt: "2026-02-01T00:02:00.000Z",
+      direction: "inbound",
+    });
+    await repositories.canonicalEventAudience.upsert({
+      canonicalEventId: event.canonicalEvent.id,
+      contactId: "contact_anchor",
+      participantRole: "sender",
+      normalizedEmail: "contact_anchor@example.org",
+    });
+
+    await expect(
+      repositories.timelineProjection.listByContactId("contact_anchor"),
+    ).resolves.toEqual([event.timelineProjection]);
+    await expect(
+      repositories.canonicalEvents.listByContactId("contact_anchor"),
+    ).resolves.toEqual([event.canonicalEvent]);
+  });
+
+  it("preserves timeline and ledger ordering across anchor and audience rows", async () => {
+    const { repositories } = await createTestStage1Context();
+
+    await seedTimelineFanoutContact(repositories, "contact_anchor_a");
+    await seedTimelineFanoutContact(repositories, "contact_anchor_b");
+    await seedTimelineFanoutContact(repositories, "contact_reader");
+
+    const first = await seedTimelineFanoutEvent({
+      repositories,
+      eventId: "evt_b",
+      anchorContactId: "contact_anchor_a",
+      occurredAt: "2026-02-01T00:00:00.000Z",
+      direction: "inbound",
+    });
+    const second = await seedTimelineFanoutEvent({
+      repositories,
+      eventId: "evt_a",
+      anchorContactId: "contact_anchor_b",
+      occurredAt: "2026-02-01T00:00:00.000Z",
+      direction: "outbound",
+    });
+    const third = await seedTimelineFanoutEvent({
+      repositories,
+      eventId: "evt_c",
+      anchorContactId: "contact_reader",
+      occurredAt: "2026-02-01T00:03:00.000Z",
+      direction: "outbound",
+    });
+
+    for (const canonicalEventId of [
+      first.canonicalEvent.id,
+      second.canonicalEvent.id,
+    ]) {
+      await repositories.canonicalEventAudience.upsert({
+        canonicalEventId,
+        contactId: "contact_reader",
+        participantRole: "cc",
+        normalizedEmail: "contact_reader@example.org",
+      });
+    }
+
+    await expect(
+      repositories.timelineProjection.listByContactId("contact_reader"),
+    ).resolves.toEqual([
+      second.timelineProjection,
+      first.timelineProjection,
+      third.timelineProjection,
+    ]);
+    await expect(
+      repositories.canonicalEvents.listByContactId("contact_reader"),
+    ).resolves.toEqual([
+      second.canonicalEvent,
+      first.canonicalEvent,
+      third.canonicalEvent,
+    ]);
+  });
+
+  it("does not leak unrelated anchor rows across contacts", async () => {
+    const { repositories } = await createTestStage1Context();
+
+    await seedTimelineFanoutContact(repositories, "contact_anchor");
+    await seedTimelineFanoutContact(repositories, "contact_reader");
+    await seedTimelineFanoutContact(repositories, "contact_unrelated");
+
+    const sharedEvent = await seedTimelineFanoutEvent({
+      repositories,
+      eventId: "evt_shared",
+      anchorContactId: "contact_anchor",
+      occurredAt: "2026-02-01T00:04:00.000Z",
+      direction: "inbound",
+    });
+    const unrelatedEvent = await seedTimelineFanoutEvent({
+      repositories,
+      eventId: "evt_unrelated",
+      anchorContactId: "contact_unrelated",
+      occurredAt: "2026-02-01T00:05:00.000Z",
+      direction: "outbound",
+    });
+    await repositories.canonicalEventAudience.upsert({
+      canonicalEventId: sharedEvent.canonicalEvent.id,
+      contactId: "contact_reader",
+      participantRole: "direct_recipient",
+      normalizedEmail: "contact_reader@example.org",
+    });
+
+    await expect(
+      repositories.timelineProjection.listByContactId("contact_reader"),
+    ).resolves.toEqual([sharedEvent.timelineProjection]);
+    await expect(
+      repositories.canonicalEvents.listByContactId("contact_reader"),
+    ).resolves.toEqual([sharedEvent.canonicalEvent]);
+    await expect(
+      repositories.timelineProjection.listByContactId("contact_unrelated"),
+    ).resolves.toEqual([unrelatedEvent.timelineProjection]);
+    await expect(
+      repositories.canonicalEvents.listByContactId("contact_unrelated"),
+    ).resolves.toEqual([unrelatedEvent.canonicalEvent]);
   });
 
   it("preserves operator-managed AI knowledge fields when a resync upsert passes nulls", async () => {

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -1801,6 +1801,108 @@ describe("Stage 1 timeline presenter", () => {
     ]);
   });
 
+  it("shows gmail fan-out events on audience participant timelines without projection-gap warnings", async () => {
+    const fanoutEvent = buildGmailOutboundEmailEvent({
+      id: "evt_gmail_fanout",
+      sourceEvidenceId: "sev_gmail_fanout",
+      occurredAt: "2026-01-01T00:00:00.000Z",
+      subject: "Shared thread update",
+      snippet: "Reply all with every participant copied.",
+      bodyPreview: "Reply all with every participant copied.",
+    });
+    const audienceTimelineRow: TimelineProjectionRow = {
+      ...fanoutEvent.timelineRow,
+      contactId: "contact_1",
+    };
+    const repositories = createRepositoryBundle({
+      canonicalEvents: [fanoutEvent.canonicalEvent],
+      sourceEvidence: [
+        buildSourceEvidence({
+          id: "sev_gmail_fanout",
+          provider: "gmail",
+          providerRecordId: "gmail-fanout",
+          providerRecordType: "gmail_message",
+        }),
+      ],
+      gmailMessageDetails: [fanoutEvent.detail],
+      salesforceCommunicationDetails: [],
+      timelineRows: [audienceTimelineRow],
+    });
+    const audienceContact = {
+      id: "contact_2",
+      salesforceContactId: "003-stage1-audience",
+      displayName: "Audience Participant",
+      primaryEmail: "audience@example.org",
+      primaryPhone: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    } as const;
+    const fanoutRepositories = defineStage1RepositoryBundle({
+      ...repositories,
+      contacts: {
+        ...repositories.contacts,
+        findById: (contactId) =>
+          Promise.resolve(
+            contactId === audienceContact.id
+              ? audienceContact
+              : repositories.contacts.findById(contactId),
+          ),
+        listByIds: (contactIds) =>
+          Promise.all(contactIds.map((contactId) => {
+            if (contactId === audienceContact.id) {
+              return Promise.resolve(audienceContact);
+            }
+
+            return repositories.contacts.findById(contactId);
+          })).then((contacts) =>
+            contacts.filter((contact) => contact !== null),
+          ),
+      },
+      canonicalEvents: {
+        ...repositories.canonicalEvents,
+        listByContactId: (contactId) =>
+          contactId === audienceContact.id
+            ? Promise.resolve([
+                {
+                  ...fanoutEvent.canonicalEvent,
+                  contactId: audienceContact.id,
+                },
+              ])
+            : repositories.canonicalEvents.listByContactId(contactId),
+      },
+      timelineProjection: {
+        ...repositories.timelineProjection,
+        listByContactId: (contactId) =>
+          contactId === audienceContact.id
+            ? Promise.resolve([audienceTimelineRow])
+            : repositories.timelineProjection.listByContactId(contactId),
+      },
+    });
+    const presenter = createStage1TimelinePresentationService(fanoutRepositories);
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+
+    const items = await presenter.listTimelineItemsByContactId(audienceContact.id);
+    const page = await presenter.listTimelineItemsPageByContactId(
+      audienceContact.id,
+      {
+        limit: 10,
+        beforeSortKey: null,
+      },
+    );
+
+    expect(items.map((item) => item.canonicalEventId)).toEqual([
+      fanoutEvent.canonicalEvent.id,
+    ]);
+    expect(page.items.map((item) => item.canonicalEventId)).toEqual([
+      fanoutEvent.canonicalEvent.id,
+    ]);
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
   it("does not collapse duplicate internal notes", async () => {
     const repositories = createRepositoryBundle({
       canonicalEvents: [],


### PR DESCRIPTION
## Summary

Brick 6 of 8 implementing [PRD #482](https://github.com/nico-kneler-as/as-comms-platform/issues/482). **Operator-visible flip:** every contact page now shows messages the contact participated in, not just those anchored to them. This is the brick that makes fan-out real for operators.

## What landed

**`packages/db/src/repositories.ts`** — two repository functions modified:

- `timelineProjection.listByContactId` — `LEFT JOIN canonical_event_audience` filtered to the requested contact, then `WHERE anchor_contact_id = $1 OR audience_contact_id = $1`. The existing one-row-per-canonical-event invariant gives natural de-duplication; ordering stays `sort_key ASC`.
- `canonicalEvents.listByContactId` — same shape. Ordering `occurred_at ASC, id ASC`.

Both queries use the `canonical_event_audience_contact_idx` `(contact_id, canonical_event_id)` index for the audience-side lookup and existing anchor indices for the anchor side.

**`packages/domain/src/timeline.ts`** — intentionally unchanged. `listTimelineItemsByContactId` and `listTimelineItemsPageByContactId` merge the now-fan-out repo results correctly via `canonicalEventById`. `warnTimelineProjectionGaps` keys on canonical-event presence (not anchor identity), so no adjustment needed.

**Inbox queue reads — UNCHANGED.** Per PRD: `contact_inbox_projection` continues to use anchor-only semantics. Inbox row bucket state remains sender-driven; fan-out is timeline-only.

## Tests

- `packages/db/test/stage1-repositories.test.ts` — **5 new**:
  - Anchor-only preservation (no audience rows → same result as today)
  - Pure audience fan-in (contact only in audience, not anchor) returns the event
  - Both-anchor-and-audience → event appears exactly once
  - Ordering preserved (`sort_key` for projection, `occurred_at + id` for ledger)
  - Cross-contact isolation (contact A's read doesn't leak contact B's anchored events)
- `packages/domain/test/timeline.test.ts` — **1 new**: presenter-level fan-out with no spurious projection-gap warning

Total: domain tests now 146 (was 145), db tests pass.

## Validation (full workspace, worktree)

- ✅ `pnpm typecheck` — 16/16 packages
- ✅ `pnpm lint` — 16/16 packages
- ✅ `pnpm boundaries`
- ✅ `pnpm build` — 11/11 tasks including `next build` with all routes compiling
- ✅ `pnpm --filter @as-comms/db typecheck / lint / test`
- ✅ `pnpm --filter @as-comms/domain typecheck / lint / test` (146 pass)

## Operational impact

The moment this merges and Railway redeploys web, **every contact-page timeline starts UNION-reading**. The 1,072 historical audience rows + ongoing live writes will all be visible. Operators should immediately see multi-party Gmail threads on every participant's page (subject to the known 2,176 mbox-era events that have no header data — those continue to show only on their original anchor).

## Next bricks

| # | Brick | Status |
|---|---|---|
| 7 | Search by display name | Polish, can dispatch in parallel after merge |
| 8 | Ops scripts audience-aware | Polish, can dispatch in parallel after merge |

## Test plan
- [ ] CI green
- [ ] All 6 new tests pass
- [ ] Spot-check on production after merge: open a known multi-party Gmail thread on one participant's contact page, confirm it appears (previously only on the anchor's page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)