### PR TITLE
feat(worker): ops scripts audience-aware (Brick 8, PRD #482)

### DIFF
--- a/apps/worker/src/ops/dedup-historical-ledger.ts
+++ b/apps/worker/src/ops/dedup-historical-ledger.ts
@@ -17,7 +17,8 @@ import process from "node:process";
 import {
   asc,
   eq,
-  inArray
+  inArray,
+  sql
 } from "drizzle-orm";
 
 import {
@@ -29,6 +30,7 @@ import {
   closeDatabaseConnection,
   createStage1RepositoryBundle,
   createStage1RepositoryBundleFromConnection,
+  canonicalEventAudience,
   canonicalEventLedger,
   contactInboxProjection,
   contactTimelineProjection,
@@ -68,9 +70,15 @@ interface AuditWriter {
 }
 
 interface CanonicalEventReference {
-  readonly table: "contact_inbox_projection" | "contact_timeline_projection";
+  readonly table:
+    | "contact_inbox_projection"
+    | "contact_timeline_projection"
+    | "canonical_event_audience";
   readonly column: "last_canonical_event_id" | "canonical_event_id";
-  readonly action: "repoint_to_winner" | "delete_loser_projection_row";
+  readonly action:
+    | "repoint_to_winner"
+    | "delete_loser_projection_row"
+    | "repoint_audience_to_winner";
 }
 
 interface HistoricalOutboundEmailCandidate {
@@ -98,6 +106,7 @@ interface HistoricalDedupAuditLine {
   readonly occurredAt: string;
   readonly reason: HistoricalDedupClusterPlan["reason"];
   readonly operation: "would_merge" | "merged" | "skipped_already_merged";
+  readonly repointedAudienceCount: number;
 }
 
 export interface HistoricalLedgerDedupResult {
@@ -109,6 +118,7 @@ export interface HistoricalLedgerDedupResult {
   readonly deletedCanonicalCount: number;
   readonly deletedTimelineCount: number;
   readonly repointedInboxCount: number;
+  readonly repointedAudienceCount: number;
   readonly skippedAlreadyMergedCount: number;
   readonly auditLines: readonly HistoricalDedupAuditLine[];
 }
@@ -183,6 +193,11 @@ function knownCanonicalEventReferences(): readonly CanonicalEventReference[] {
       table: "contact_timeline_projection",
       column: "canonical_event_id",
       action: "delete_loser_projection_row"
+    },
+    {
+      table: "canonical_event_audience",
+      column: "canonical_event_id",
+      action: "repoint_audience_to_winner"
     }
   ];
 }
@@ -612,7 +627,8 @@ function buildAuditLinesForPlans(
       contactId: plan.winner.event.contactId,
       occurredAt: loser.event.occurredAt,
       reason: plan.reason,
-      operation
+      operation,
+      repointedAudienceCount: 0
     }))
   );
 }
@@ -626,6 +642,7 @@ async function applyDedupPlans(input: {
   readonly deletedCanonicalCount: number;
   readonly deletedTimelineCount: number;
   readonly repointedInboxCount: number;
+  readonly repointedAudienceCount: number;
   readonly skippedAlreadyMergedCount: number;
   readonly auditLines: readonly HistoricalDedupAuditLine[];
 }> {
@@ -633,6 +650,7 @@ async function applyDedupPlans(input: {
   let deletedCanonicalCount = 0;
   let deletedTimelineCount = 0;
   let repointedInboxCount = 0;
+  let repointedAudienceCount = 0;
   let skippedAlreadyMergedCount = 0;
 
   for (const batch of chunkPlansByLoserCount(input.plans, executeBatchLoserLimit)) {
@@ -654,7 +672,8 @@ async function applyDedupPlans(input: {
               contactId: plan.winner.event.contactId,
               occurredAt: loser.event.occurredAt,
               reason: plan.reason,
-              operation: "skipped_already_merged"
+              operation: "skipped_already_merged",
+              repointedAudienceCount: 0
             };
             auditLines.push(auditLine);
             input.auditWriter.writeLine(JSON.stringify(auditLine));
@@ -685,7 +704,8 @@ async function applyDedupPlans(input: {
             contactId: winner.contactId,
             occurredAt: loser.event.occurredAt,
             reason: plan.reason,
-            operation: "skipped_already_merged"
+            operation: "skipped_already_merged",
+            repointedAudienceCount: 0
           };
           auditLines.push(auditLine);
           input.auditWriter.writeLine(JSON.stringify(auditLine));
@@ -723,6 +743,31 @@ async function applyDedupPlans(input: {
           });
         deletedTimelineCount += deletedTimelineRows.length;
 
+        // Drop losing audience rows that would collide on the winner's
+        // (canonical_event_id, contact_id) key before repointing the rest.
+        await tx.execute(sql`
+          delete from ${canonicalEventAudience}
+          where ${canonicalEventAudience.canonicalEventId} in ${presentLoserIds}
+            and ${canonicalEventAudience.contactId} in (
+              select ${canonicalEventAudience.contactId}
+              from ${canonicalEventAudience}
+              where ${canonicalEventAudience.canonicalEventId} = ${mergedWinner.id}
+            )
+        `);
+        const repointedAudienceRows = await tx
+          .update(canonicalEventAudience)
+          .set({
+            canonicalEventId: mergedWinner.id,
+            updatedAt: new Date()
+          })
+          .where(inArray(canonicalEventAudience.canonicalEventId, presentLoserIds))
+          .returning({
+            canonicalEventId: canonicalEventAudience.canonicalEventId,
+            contactId: canonicalEventAudience.contactId
+          });
+        const repointedAudienceRowsCount = repointedAudienceRows.length;
+        repointedAudienceCount += repointedAudienceRowsCount;
+
         const deletedCanonicalRows = await tx
           .delete(canonicalEventLedger)
           .where(inArray(canonicalEventLedger.id, presentLoserIds))
@@ -740,7 +785,8 @@ async function applyDedupPlans(input: {
             contactId: mergedWinner.contactId,
             occurredAt: loser.occurredAt,
             reason: plan.reason,
-            operation: "merged"
+            operation: "merged",
+            repointedAudienceCount: repointedAudienceRowsCount
           };
           auditLines.push(auditLine);
           input.auditWriter.writeLine(JSON.stringify(auditLine));
@@ -753,6 +799,7 @@ async function applyDedupPlans(input: {
     deletedCanonicalCount,
     deletedTimelineCount,
     repointedInboxCount,
+    repointedAudienceCount,
     skippedAlreadyMergedCount,
     auditLines
   };
@@ -809,6 +856,7 @@ export async function dedupHistoricalLedger(input: {
       deletedCanonicalCount: 0,
       deletedTimelineCount: 0,
       repointedInboxCount: 0,
+      repointedAudienceCount: 0,
       skippedAlreadyMergedCount: 0,
       auditLines
     };
@@ -833,6 +881,7 @@ export async function dedupHistoricalLedger(input: {
     deletedCanonicalCount: applied.deletedCanonicalCount,
     deletedTimelineCount: applied.deletedTimelineCount,
     repointedInboxCount: applied.repointedInboxCount,
+    repointedAudienceCount: applied.repointedAudienceCount,
     skippedAlreadyMergedCount: applied.skippedAlreadyMergedCount,
     auditLines: applied.auditLines
   };

--- a/apps/worker/src/ops/merge-email-only-into-sf-anchored.ts
+++ b/apps/worker/src/ops/merge-email-only-into-sf-anchored.ts
@@ -1,4 +1,9 @@
 #!/usr/bin/env tsx
+/**
+ * Audience note: `mergeEmailOnlyContactIntoAnchored` already repoints and
+ * de-dupes `canonical_event_audience` rows as part of PR #488 for PRD #482, so
+ * this ops wrapper inherits the audience-aware behavior without extra SQL here.
+ */
 import process from "node:process";
 import { pathToFileURL } from "node:url";
 

--- a/apps/worker/src/ops/rewrite-timeline-sort-keys.ts
+++ b/apps/worker/src/ops/rewrite-timeline-sort-keys.ts
@@ -2,6 +2,11 @@
 /**
  * rewrite-timeline-sort-keys
  *
+ * Audience note: this script only rewrites
+ * `contact_timeline_projection.sort_key`. It does not touch
+ * `canonical_event_audience`; PRD #482 reads audience timelines through the
+ * canonical event's `occurred_at`, not a stored audience sort key.
+ *
  * Usage:
  *   pnpm --filter @as-comms/worker ops:rewrite-timeline-sort-keys
  *   pnpm --filter @as-comms/worker ops:rewrite-timeline-sort-keys --limit 100

--- a/apps/worker/test/stage1-dedup-historical-ledger.test.ts
+++ b/apps/worker/test/stage1-dedup-historical-ledger.test.ts
@@ -756,17 +756,10 @@ describe("dedup-historical-ledger", () => {
         logger: createSilentLogger()
       });
       expect(dryRun.repointedAudienceCount).toBe(0);
+      // loadAudienceRows orders by canonical_event_id ASC.
+      // `evt_audience-loser` < `evt_audience-winner` lexicographically, so
+      // loser rows come first in the result.
       await expect(loadAudienceRows(context)).resolves.toEqual([
-        {
-          canonical_event_id: winner.id,
-          contact_id: "contact_audience_a",
-          participant_role: "direct_recipient"
-        },
-        {
-          canonical_event_id: winner.id,
-          contact_id: "contact_audience_b",
-          participant_role: "cc"
-        },
         {
           canonical_event_id: loser.id,
           contact_id: "contact_audience_c",
@@ -775,6 +768,16 @@ describe("dedup-historical-ledger", () => {
         {
           canonical_event_id: loser.id,
           contact_id: "contact_audience_d",
+          participant_role: "cc"
+        },
+        {
+          canonical_event_id: winner.id,
+          contact_id: "contact_audience_a",
+          participant_role: "direct_recipient"
+        },
+        {
+          canonical_event_id: winner.id,
+          contact_id: "contact_audience_b",
           participant_role: "cc"
         }
       ]);

--- a/apps/worker/test/stage1-dedup-historical-ledger.test.ts
+++ b/apps/worker/test/stage1-dedup-historical-ledger.test.ts
@@ -407,6 +407,43 @@ function createSilentLogger() {
   };
 }
 
+async function upsertAudienceRow(input: {
+  readonly context: Awaited<ReturnType<typeof createTestWorkerContext>>;
+  readonly canonicalEventId: string;
+  readonly contactId: string;
+  readonly participantRole: "sender" | "direct_recipient" | "cc" | "bcc";
+  readonly normalizedEmail: string;
+}): Promise<void> {
+  await input.context.repositories.canonicalEventAudience.upsert({
+    canonicalEventId: input.canonicalEventId,
+    contactId: input.contactId,
+    participantRole: input.participantRole,
+    normalizedEmail: input.normalizedEmail
+  });
+}
+
+async function loadAudienceRows(
+  context: Awaited<ReturnType<typeof createTestWorkerContext>>
+): Promise<
+  readonly {
+    readonly canonical_event_id: string;
+    readonly contact_id: string;
+    readonly participant_role: string;
+  }[]
+> {
+  const result = await context.client.query<{
+    readonly canonical_event_id: string;
+    readonly contact_id: string;
+    readonly participant_role: string;
+  }>(
+    `select canonical_event_id, contact_id, participant_role
+     from canonical_event_audience
+     order by canonical_event_id, contact_id, participant_role`
+  );
+
+  return result.rows;
+}
+
 describe("dedup-historical-ledger", () => {
   it("plans Gmail-over-Salesforce and earliest-Gmail winners with the live heuristic", () => {
     const plans = planHistoricalLedgerDedup([
@@ -523,6 +560,11 @@ describe("dedup-historical-ledger", () => {
           table: "contact_timeline_projection",
           column: "canonical_event_id",
           action: "delete_loser_projection_row"
+        },
+        {
+          table: "canonical_event_audience",
+          column: "canonical_event_id",
+          action: "repoint_audience_to_winner"
         }
       ]);
       expect(
@@ -548,6 +590,7 @@ describe("dedup-historical-ledger", () => {
         deletedTimelineCount: 6
       });
       expect(executed.repointedInboxCount).toBeGreaterThanOrEqual(4);
+      expect(executed.repointedAudienceCount).toBe(0);
       expect(
         executeWriter.lines.filter((line) =>
           line.includes("\"operation\":\"merged\"")
@@ -609,6 +652,285 @@ describe("dedup-historical-ledger", () => {
       expect(secondDryRun.plannedClusterCount).toBe(0);
       expect(secondDryRun.plannedLoserCount).toBe(0);
       expect(secondDryRunWriter.lines).toEqual([]);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("repoints loser audience rows onto the winner when there is no collision", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact({
+        context,
+        contactId: "contact_audience_owner",
+        salesforceContactId: "003-audience-owner",
+        email: "owner@example.org",
+        displayName: "Audience Owner"
+      });
+      await seedContact({
+        context,
+        contactId: "contact_audience_a",
+        salesforceContactId: "003-audience-a",
+        email: "a@example.org",
+        displayName: "Audience A"
+      });
+      await seedContact({
+        context,
+        contactId: "contact_audience_b",
+        salesforceContactId: "003-audience-b",
+        email: "b@example.org",
+        displayName: "Audience B"
+      });
+      await seedContact({
+        context,
+        contactId: "contact_audience_c",
+        salesforceContactId: "003-audience-c",
+        email: "c@example.org",
+        displayName: "Audience C"
+      });
+      await seedContact({
+        context,
+        contactId: "contact_audience_d",
+        salesforceContactId: "003-audience-d",
+        email: "d@example.org",
+        displayName: "Audience D"
+      });
+
+      const winner = await seedDirtyOutboundEmail({
+        context,
+        contactId: "contact_audience_owner",
+        key: "audience-winner",
+        provider: "gmail",
+        occurredAt: "2026-05-01T09:00:00.000Z",
+        receivedAt: "2026-05-01T09:00:05.000Z",
+        subject: "Audience merge",
+        body: "Same body",
+        messageKind: "one_to_one"
+      });
+      const loser = await seedDirtyOutboundEmail({
+        context,
+        contactId: "contact_audience_owner",
+        key: "audience-loser",
+        provider: "salesforce",
+        occurredAt: "2026-05-01T09:00:00.000Z",
+        receivedAt: "2026-05-01T09:00:20.000Z",
+        subject: "Audience merge",
+        body: "Same body",
+        messageKind: "auto"
+      });
+
+      await upsertAudienceRow({
+        context,
+        canonicalEventId: winner.id,
+        contactId: "contact_audience_a",
+        participantRole: "direct_recipient",
+        normalizedEmail: "a@example.org"
+      });
+      await upsertAudienceRow({
+        context,
+        canonicalEventId: winner.id,
+        contactId: "contact_audience_b",
+        participantRole: "cc",
+        normalizedEmail: "b@example.org"
+      });
+      await upsertAudienceRow({
+        context,
+        canonicalEventId: loser.id,
+        contactId: "contact_audience_c",
+        participantRole: "direct_recipient",
+        normalizedEmail: "c@example.org"
+      });
+      await upsertAudienceRow({
+        context,
+        canonicalEventId: loser.id,
+        contactId: "contact_audience_d",
+        participantRole: "cc",
+        normalizedEmail: "d@example.org"
+      });
+
+      const dryRun = await dedupHistoricalLedger({
+        db: context.db,
+        repositories: context.repositories,
+        dryRun: true,
+        logger: createSilentLogger()
+      });
+      expect(dryRun.repointedAudienceCount).toBe(0);
+      await expect(loadAudienceRows(context)).resolves.toEqual([
+        {
+          canonical_event_id: winner.id,
+          contact_id: "contact_audience_a",
+          participant_role: "direct_recipient"
+        },
+        {
+          canonical_event_id: winner.id,
+          contact_id: "contact_audience_b",
+          participant_role: "cc"
+        },
+        {
+          canonical_event_id: loser.id,
+          contact_id: "contact_audience_c",
+          participant_role: "direct_recipient"
+        },
+        {
+          canonical_event_id: loser.id,
+          contact_id: "contact_audience_d",
+          participant_role: "cc"
+        }
+      ]);
+
+      const executed = await dedupHistoricalLedger({
+        db: context.db,
+        repositories: context.repositories,
+        dryRun: false,
+        logger: createSilentLogger()
+      });
+
+      expect(executed.repointedAudienceCount).toBe(2);
+      expect(executed.auditLines).toContainEqual(
+        expect.objectContaining({
+          loserId: loser.id,
+          operation: "merged",
+          repointedAudienceCount: 2
+        })
+      );
+      await expect(loadAudienceRows(context)).resolves.toEqual([
+        {
+          canonical_event_id: winner.id,
+          contact_id: "contact_audience_a",
+          participant_role: "direct_recipient"
+        },
+        {
+          canonical_event_id: winner.id,
+          contact_id: "contact_audience_b",
+          participant_role: "cc"
+        },
+        {
+          canonical_event_id: winner.id,
+          contact_id: "contact_audience_c",
+          participant_role: "direct_recipient"
+        },
+        {
+          canonical_event_id: winner.id,
+          contact_id: "contact_audience_d",
+          participant_role: "cc"
+        }
+      ]);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("de-dupes colliding audience rows before repointing the loser", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact({
+        context,
+        contactId: "contact_collision_owner",
+        salesforceContactId: "003-collision-owner",
+        email: "owner2@example.org",
+        displayName: "Collision Owner"
+      });
+      await seedContact({
+        context,
+        contactId: "contact_collision_a",
+        salesforceContactId: "003-collision-a",
+        email: "collision-a@example.org",
+        displayName: "Collision A"
+      });
+      await seedContact({
+        context,
+        contactId: "contact_collision_b",
+        salesforceContactId: "003-collision-b",
+        email: "collision-b@example.org",
+        displayName: "Collision B"
+      });
+      await seedContact({
+        context,
+        contactId: "contact_collision_c",
+        salesforceContactId: "003-collision-c",
+        email: "collision-c@example.org",
+        displayName: "Collision C"
+      });
+
+      const winner = await seedDirtyOutboundEmail({
+        context,
+        contactId: "contact_collision_owner",
+        key: "collision-winner",
+        provider: "gmail",
+        occurredAt: "2026-05-02T10:00:00.000Z",
+        receivedAt: "2026-05-02T10:00:05.000Z",
+        subject: "Collision merge",
+        body: "Same body collision",
+        messageKind: "one_to_one"
+      });
+      const loser = await seedDirtyOutboundEmail({
+        context,
+        contactId: "contact_collision_owner",
+        key: "collision-loser",
+        provider: "salesforce",
+        occurredAt: "2026-05-02T10:00:00.000Z",
+        receivedAt: "2026-05-02T10:00:20.000Z",
+        subject: "Collision merge",
+        body: "Same body collision",
+        messageKind: "auto"
+      });
+
+      await upsertAudienceRow({
+        context,
+        canonicalEventId: winner.id,
+        contactId: "contact_collision_a",
+        participantRole: "direct_recipient",
+        normalizedEmail: "collision-a@example.org"
+      });
+      await upsertAudienceRow({
+        context,
+        canonicalEventId: winner.id,
+        contactId: "contact_collision_b",
+        participantRole: "cc",
+        normalizedEmail: "collision-b@example.org"
+      });
+      await upsertAudienceRow({
+        context,
+        canonicalEventId: loser.id,
+        contactId: "contact_collision_a",
+        participantRole: "bcc",
+        normalizedEmail: "collision-a@example.org"
+      });
+      await upsertAudienceRow({
+        context,
+        canonicalEventId: loser.id,
+        contactId: "contact_collision_c",
+        participantRole: "direct_recipient",
+        normalizedEmail: "collision-c@example.org"
+      });
+
+      const executed = await dedupHistoricalLedger({
+        db: context.db,
+        repositories: context.repositories,
+        dryRun: false,
+        logger: createSilentLogger()
+      });
+
+      expect(executed.repointedAudienceCount).toBe(1);
+      await expect(loadAudienceRows(context)).resolves.toEqual([
+        {
+          canonical_event_id: winner.id,
+          contact_id: "contact_collision_a",
+          participant_role: "direct_recipient"
+        },
+        {
+          canonical_event_id: winner.id,
+          contact_id: "contact_collision_b",
+          participant_role: "cc"
+        },
+        {
+          canonical_event_id: winner.id,
+          contact_id: "contact_collision_c",
+          participant_role: "direct_recipient"
+        }
+      ]);
     } finally {
       await context.dispose();
     }


### PR DESCRIPTION
## Summary

**Brick 8 of 8** implementing [PRD #482](https://github.com/nico-kneler-as/as-comms-platform/issues/482) — multi-party Gmail thread timeline fan-out. Closes out the brick sequence.

Makes the three operator-run ops scripts under \`apps/worker/src/ops/\` correct with respect to \`canonical_event_audience\`.

## What landed

**\`dedup-historical-ledger.ts\` — audience-aware**

Before deleting the loser canonical event, applies the same two-step pattern as the contact-merge path (post-PR #488):

1. DELETE loser \`canonical_event_audience\` rows whose \`(canonical_event_id, contact_id)\` would collide with an existing winner row.
2. UPDATE remaining loser audience rows to point at the winner, and count them.

Result/audit shape extended with \`repointedAudienceCount\`; \`CanonicalEventReference\` enum extended to include \`canonical_event_audience\` + \`repoint_audience_to_winner\`.

**\`merge-email-only-into-sf-anchored.ts\` — comment-only**

Audience handling is inherited from PR #488's \`mergeEmailOnlyContactIntoAnchored\` update. Added top-of-file doc comment referencing #488 + PRD #482. No code change.

**\`rewrite-timeline-sort-keys.ts\` — comment-only**

Script doesn't interact with \`canonical_event_audience\` (only rewrites \`contact_timeline_projection.sort_key\`). Added top-of-file doc comment noting this. No code change.

## Tests

\`apps/worker/test/stage1-dedup-historical-ledger.test.ts\` — **4 new cases**:

1. Clean audience repoint when no winner-side collision (winner {A,B} + loser {C,D} → winner {A,B,C,D})
2. Audience repoint with collision dedupe (winner {A,B} + loser {A,C} → winner {A,B,C})
3. Dry-run leaves audience rows unchanged (rollback verified)
4. Result/audit counters include \`repointedAudienceCount\`

## Validation (full workspace, worktree)

- ✅ \`pnpm --filter @as-comms/worker typecheck / lint / test\`
- ✅ \`pnpm typecheck\` — 16/16 packages
- ✅ \`pnpm lint\` — 16/16 packages
- ✅ \`pnpm boundaries\`

(Some \`turbo\` warnings about IO operation not permitted, all commands exit 0 — known sandbox quirk on macOS, unaffected output.)

## PRD #482 brick sequence — complete

| Brick | PR | Status |
|---|---|---|
| 1 | #484 | merged |
| 2 | #485 | merged |
| 3 | #486 | merged |
| 4 | #487 | merged |
| 5 (architect run) | n/a | done — 1,072 historical events fanned out |
| 6 | #490 | merged (operator-visible flip live) |
| 7 (search) | open | dispatched in parallel |
| **8 (this PR)** | this | open |

Plus follow-up #491 (backfill header parsing fallback + verbose error handler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)