### PR TITLE
feat(domain,worker): backfill + capture contact display_name from headers

### DIFF
--- a/apps/worker/src/ops/backfill-contact-display-names.ts
+++ b/apps/worker/src/ops/backfill-contact-display-names.ts
@@ -1,0 +1,521 @@
+#!/usr/bin/env tsx
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+import {
+  closeDatabaseConnection,
+  contacts,
+  createDatabaseConnection,
+  type Stage1Database,
+} from "@as-comms/db";
+import { parseHeaderDisplayNameForEmail } from "@as-comms/integrations";
+import { and, eq, or, sql } from "drizzle-orm";
+
+import {
+  parseCliFlags,
+  readOptionalBooleanFlag,
+  readOptionalIntegerFlag,
+  readOptionalStringFlag,
+} from "./helpers.js";
+
+interface Logger {
+  log(...args: readonly unknown[]): void;
+  error(...args: readonly unknown[]): void;
+}
+
+type SkipReason =
+  | "no_header_match"
+  | "no_display_name_in_header"
+  | "display_name_equals_email_local_part";
+
+interface CandidateContactRow {
+  readonly id: string;
+  readonly primaryEmail: string;
+  readonly displayName: string | null;
+}
+
+interface HeaderMatchRow {
+  readonly occurredAt: Date;
+  readonly fromHeader: string | null;
+  readonly toHeader: string | null;
+  readonly ccHeader: string | null;
+}
+
+export interface BackfillContactDisplayNamesLogEntry {
+  readonly action: "dryRun" | "updated" | "skipped";
+  readonly contactId: string;
+  readonly primaryEmail: string;
+  readonly displayName?: string;
+  readonly dryRun?: boolean;
+  readonly reason?: SkipReason;
+}
+
+export interface BackfillContactDisplayNamesResult {
+  readonly dryRun: boolean;
+  readonly since: string;
+  readonly until: string;
+  readonly candidates: number;
+  readonly updated: number;
+  readonly skipped: number;
+  readonly truncated: boolean;
+  readonly byReason: Readonly<Record<SkipReason, number>>;
+}
+
+function readConnectionString(env: NodeJS.ProcessEnv): string {
+  const connectionString = env.WORKER_DATABASE_URL ?? env.DATABASE_URL;
+
+  if (connectionString === undefined || connectionString.trim().length === 0) {
+    throw new Error(
+      "DATABASE_URL or WORKER_DATABASE_URL is required for Stage 1 ops commands.",
+    );
+  }
+
+  return connectionString;
+}
+
+function parseWindowTimestamp(value: string, flagName: string): string {
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Flag --${flagName} must be a valid ISO-8601 timestamp.`);
+  }
+
+  return parsed.toISOString();
+}
+
+function buildDefaultSince(): string {
+  return "2024-01-01T00:00:00.000Z";
+}
+
+function buildDefaultUntil(): string {
+  return new Date().toISOString();
+}
+
+function logEntry(
+  logger: Logger,
+  entry: BackfillContactDisplayNamesLogEntry,
+): void {
+  logger.log(JSON.stringify(entry));
+}
+
+function normalizeEmail(value: string | null | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized.length === 0 ? null : normalized;
+}
+
+function splitHeaderEntries(value: string): string[] {
+  return value
+    .split(/,(?=(?:[^"]*"[^"]*")*[^"]*$)/gu)
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+function parseHeaderEntry(value: string): {
+  readonly email: string | null;
+  readonly displayName: string | null;
+} {
+  const bracketMatch = /^(.*?)(?:<([^>]+)>)$/u.exec(value);
+
+  if (bracketMatch !== null) {
+    const [, rawDisplayName = "", rawEmail = ""] = bracketMatch;
+    return {
+      email: normalizeEmail(rawEmail),
+      displayName: rawDisplayName.trim().length > 0 ? rawDisplayName.trim() : null,
+    };
+  }
+
+  const emailMatch = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/iu.exec(value);
+
+  if (emailMatch === null) {
+    return {
+      email: null,
+      displayName: null,
+    };
+  }
+
+  const rawEmail = emailMatch[0];
+  const displayName = value.replace(rawEmail, "").trim();
+
+  return {
+    email: normalizeEmail(rawEmail),
+    displayName: displayName.length > 0 ? displayName : null,
+  };
+}
+
+function headerMatchClassification(
+  header: string | null,
+  targetEmail: string,
+):
+  | { readonly kind: "no_match" }
+  | { readonly kind: "missing_display_name" }
+  | { readonly kind: "equals_email_or_local_part" }
+  | { readonly kind: "display_name"; readonly displayName: string } {
+  if (typeof header !== "string" || header.trim().length === 0) {
+    return { kind: "no_match" };
+  }
+
+  const normalizedTargetEmail = normalizeEmail(targetEmail);
+
+  if (normalizedTargetEmail === null) {
+    return { kind: "no_match" };
+  }
+
+  for (const entry of splitHeaderEntries(header)) {
+    const parsed = parseHeaderEntry(entry);
+
+    if (parsed.email !== normalizedTargetEmail) {
+      continue;
+    }
+
+    const displayName = parseHeaderDisplayNameForEmail(entry, targetEmail);
+
+    if (displayName !== null) {
+      return {
+        kind: "display_name",
+        displayName,
+      };
+    }
+
+    if (parsed.displayName === null) {
+      return { kind: "missing_display_name" };
+    }
+
+    const normalizedDisplayName = parsed.displayName
+      .trim()
+      .replace(/^"(.*)"$/u, "$1")
+      .trim()
+      .toLowerCase();
+    const localPart =
+      normalizedTargetEmail.split("@", 1)[0] ?? normalizedTargetEmail;
+
+    if (
+      normalizedDisplayName === normalizedTargetEmail ||
+      normalizedDisplayName === localPart
+    ) {
+      return { kind: "equals_email_or_local_part" };
+    }
+
+    return { kind: "missing_display_name" };
+  }
+
+  return { kind: "no_match" };
+}
+
+async function loadCandidateRows(input: {
+  readonly db: Stage1Database;
+  readonly limit: number;
+}): Promise<{
+  readonly candidates: readonly CandidateContactRow[];
+  readonly truncated: boolean;
+}> {
+  const result = await input.db.execute(sql<CandidateContactRow>`
+    select
+      id,
+      primary_email as "primaryEmail",
+      display_name as "displayName"
+    from contacts
+    where primary_email is not null
+      and (
+        display_name is null
+        or lower(btrim(display_name)) = lower(btrim(primary_email))
+      )
+    order by id asc
+    limit ${input.limit + 1}
+  `);
+
+  const rows = (result as { readonly rows: readonly CandidateContactRow[] }).rows.map((row) => ({
+    id: row.id,
+    primaryEmail: row.primaryEmail,
+    displayName:
+      typeof row.displayName === "string" ? row.displayName : null,
+  }));
+
+  return {
+    candidates: rows.slice(0, input.limit),
+    truncated: rows.length > input.limit,
+  };
+}
+
+async function loadHeaderMatchesForContact(input: {
+  readonly db: Stage1Database;
+  readonly contactId: string;
+  readonly emailPattern: string;
+  readonly since: string;
+  readonly until: string;
+}): Promise<readonly HeaderMatchRow[]> {
+  const result = await input.db.execute(sql<HeaderMatchRow>`
+    (
+      select
+        cel.occurred_at as "occurredAt",
+        gmd.from_header as "fromHeader",
+        gmd.to_header as "toHeader",
+        gmd.cc_header as "ccHeader"
+      from canonical_event_ledger cel
+      inner join source_evidence_log sel
+        on sel.id = cel.source_evidence_id
+      inner join gmail_message_details gmd
+        on gmd.source_evidence_id = cel.source_evidence_id
+      where sel.provider = 'gmail'
+        and cel.contact_id = ${input.contactId}
+        and cel.occurred_at >= ${new Date(input.since)}
+        and cel.occurred_at <= ${new Date(input.until)}
+        and (
+          lower(coalesce(gmd.from_header, '')) like ${input.emailPattern}
+          or lower(coalesce(gmd.to_header, '')) like ${input.emailPattern}
+          or lower(coalesce(gmd.cc_header, '')) like ${input.emailPattern}
+        )
+    )
+    union
+    (
+      select
+        cel.occurred_at as "occurredAt",
+        gmd.from_header as "fromHeader",
+        gmd.to_header as "toHeader",
+        gmd.cc_header as "ccHeader"
+      from canonical_event_audience cea
+      inner join canonical_event_ledger cel
+        on cel.id = cea.canonical_event_id
+      inner join source_evidence_log sel
+        on sel.id = cel.source_evidence_id
+      inner join gmail_message_details gmd
+        on gmd.source_evidence_id = cel.source_evidence_id
+      where sel.provider = 'gmail'
+        and cea.contact_id = ${input.contactId}
+        and cel.occurred_at >= ${new Date(input.since)}
+        and cel.occurred_at <= ${new Date(input.until)}
+        and (
+          lower(coalesce(gmd.from_header, '')) like ${input.emailPattern}
+          or lower(coalesce(gmd.to_header, '')) like ${input.emailPattern}
+          or lower(coalesce(gmd.cc_header, '')) like ${input.emailPattern}
+        )
+    )
+    order by "occurredAt" desc
+  `);
+
+  return (result as { readonly rows: readonly HeaderMatchRow[] }).rows.map((row) => ({
+    occurredAt: row.occurredAt,
+    fromHeader: row.fromHeader,
+    toHeader: row.toHeader,
+    ccHeader: row.ccHeader,
+  }));
+}
+
+async function resolveObservedDisplayName(input: {
+  readonly db: Stage1Database;
+  readonly contactId: string;
+  readonly primaryEmail: string;
+  readonly since: string;
+  readonly until: string;
+}):
+  Promise<
+    | { readonly outcome: "display_name"; readonly displayName: string }
+    | { readonly outcome: "skipped"; readonly reason: SkipReason }
+  > {
+  const matches = await loadHeaderMatchesForContact({
+    db: input.db,
+    contactId: input.contactId,
+    emailPattern: `%${input.primaryEmail.toLowerCase()}%`,
+    since: input.since,
+    until: input.until,
+  });
+
+  if (matches.length === 0) {
+    return {
+      outcome: "skipped",
+      reason: "no_header_match",
+    };
+  }
+
+  let sawLocalPartEquivalent = false;
+  let sawMatchedHeaderWithoutDisplayName = false;
+
+  for (const match of matches) {
+    for (const header of [match.fromHeader, match.toHeader, match.ccHeader]) {
+      const classification = headerMatchClassification(header, input.primaryEmail);
+
+      if (classification.kind === "display_name") {
+        return {
+          outcome: "display_name",
+          displayName: classification.displayName,
+        };
+      }
+
+      if (classification.kind === "equals_email_or_local_part") {
+        sawLocalPartEquivalent = true;
+      }
+
+      if (classification.kind === "missing_display_name") {
+        sawMatchedHeaderWithoutDisplayName = true;
+      }
+    }
+  }
+
+  if (sawLocalPartEquivalent) {
+    return {
+      outcome: "skipped",
+      reason: "display_name_equals_email_local_part",
+    };
+  }
+
+  if (sawMatchedHeaderWithoutDisplayName) {
+    return {
+      outcome: "skipped",
+      reason: "no_display_name_in_header",
+    };
+  }
+
+  return {
+    outcome: "skipped",
+    reason: "no_header_match",
+  };
+}
+
+async function updateContactDisplayName(input: {
+  readonly db: Stage1Database;
+  readonly contactId: string;
+  readonly displayName: string;
+}): Promise<void> {
+  await input.db
+    .update(contacts)
+    .set({
+      displayName: input.displayName,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(contacts.id, input.contactId),
+        or(
+          sql`${contacts.displayName} is null`,
+          sql`lower(btrim(${contacts.displayName})) = lower(btrim(${contacts.primaryEmail}))`,
+        ),
+      ),
+    );
+}
+
+export async function backfillContactDisplayNames(input: {
+  readonly db: Stage1Database;
+  readonly since: string;
+  readonly until: string;
+  readonly execute: boolean;
+  readonly limit: number;
+  readonly logger?: Logger;
+}): Promise<BackfillContactDisplayNamesResult> {
+  const logger = input.logger ?? console;
+  const { candidates, truncated } = await loadCandidateRows({
+    db: input.db,
+    limit: input.limit,
+  });
+  const byReason: Record<SkipReason, number> = {
+    no_header_match: 0,
+    no_display_name_in_header: 0,
+    display_name_equals_email_local_part: 0,
+  };
+  let updated = 0;
+  let skipped = 0;
+
+  for (const candidate of candidates) {
+    const resolution = await resolveObservedDisplayName({
+      db: input.db,
+      contactId: candidate.id,
+      primaryEmail: candidate.primaryEmail,
+      since: input.since,
+      until: input.until,
+    });
+
+    if (resolution.outcome === "skipped") {
+      skipped += 1;
+      byReason[resolution.reason] += 1;
+      logEntry(logger, {
+        action: "skipped",
+        contactId: candidate.id,
+        primaryEmail: candidate.primaryEmail,
+        reason: resolution.reason,
+      });
+      continue;
+    }
+
+    if (input.execute) {
+      await updateContactDisplayName({
+        db: input.db,
+        contactId: candidate.id,
+        displayName: resolution.displayName,
+      });
+    }
+
+    updated += 1;
+    logEntry(logger, {
+      action: input.execute ? "updated" : "dryRun",
+      contactId: candidate.id,
+      primaryEmail: candidate.primaryEmail,
+      displayName: resolution.displayName,
+      dryRun: !input.execute,
+    });
+  }
+
+  return {
+    dryRun: !input.execute,
+    since: input.since,
+    until: input.until,
+    candidates: candidates.length,
+    updated,
+    skipped,
+    truncated,
+    byReason,
+  };
+}
+
+export async function runBackfillContactDisplayNamesCommand(
+  args: readonly string[] = process.argv.slice(2),
+  env: NodeJS.ProcessEnv = process.env,
+  logger: Logger = console,
+): Promise<void> {
+  const flags = parseCliFlags(args);
+  const since = parseWindowTimestamp(
+    readOptionalStringFlag(flags, "since") ?? buildDefaultSince(),
+    "since",
+  );
+  const until = parseWindowTimestamp(
+    readOptionalStringFlag(flags, "until") ?? buildDefaultUntil(),
+    "until",
+  );
+  const execute = readOptionalBooleanFlag(flags, "execute", false);
+  const limit = readOptionalIntegerFlag(flags, "limit", 5000);
+
+  if (new Date(since).getTime() > new Date(until).getTime()) {
+    throw new Error("Flag --since must be earlier than or equal to --until.");
+  }
+
+  const connection = createDatabaseConnection({
+    connectionString: readConnectionString(env),
+  });
+
+  try {
+    const result = await backfillContactDisplayNames({
+      db: connection.db,
+      since,
+      until,
+      execute,
+      limit,
+      logger,
+    });
+
+    logger.log(JSON.stringify(result, null, 2));
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}
+
+async function main(): Promise<void> {
+  await runBackfillContactDisplayNamesCommand();
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  void main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/apps/worker/test/backfill-contact-display-names.test.ts
+++ b/apps/worker/test/backfill-contact-display-names.test.ts
@@ -1,0 +1,456 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canonicalEventAudience,
+  contacts,
+} from "@as-comms/db";
+import { eq } from "drizzle-orm";
+
+import {
+  backfillContactDisplayNames,
+  type BackfillContactDisplayNamesLogEntry,
+} from "../src/ops/backfill-contact-display-names.js";
+import { createTestWorkerContext } from "./helpers.js";
+
+function buildCanonicalProvenance(input: {
+  readonly sourceEvidenceId: string;
+  readonly providerRecordId: string;
+}) {
+  return {
+    primaryProvider: "gmail" as const,
+    primarySourceEvidenceId: input.sourceEvidenceId,
+    supportingSourceEvidenceIds: [],
+    winnerReason: "single_source" as const,
+    sourceRecordType: "message",
+    sourceRecordId: input.providerRecordId,
+    messageKind: "one_to_one" as const,
+    campaignRef: null,
+    threadRef: {
+      crossProviderCollapseKey: `rfc822:<${input.providerRecordId}@example.org>`,
+      providerThreadId: `thread:${input.providerRecordId}`,
+    },
+    direction: "inbound" as const,
+    notes: null,
+  };
+}
+
+async function seedContact(input: {
+  readonly repositories: Awaited<
+    ReturnType<typeof createTestWorkerContext>
+  >["repositories"];
+  readonly id: string;
+  readonly primaryEmail: string;
+  readonly displayName: string;
+}): Promise<void> {
+  await input.repositories.contacts.upsert({
+    id: input.id,
+    salesforceContactId: null,
+    displayName: input.displayName,
+    primaryEmail: input.primaryEmail,
+    primaryPhone: null,
+    createdAt: "2026-05-10T09:00:00.000Z",
+    updatedAt: "2026-05-10T09:00:00.000Z",
+  });
+
+  await input.repositories.contactIdentities.upsert({
+    id: `identity:${input.id}:email:${input.primaryEmail}`,
+    contactId: input.id,
+    kind: "email",
+    normalizedValue: input.primaryEmail,
+    isPrimary: true,
+    source: "gmail",
+    verifiedAt: "2026-05-10T09:00:00.000Z",
+  });
+}
+
+async function seedGmailEvent(input: {
+  readonly repositories: Awaited<
+    ReturnType<typeof createTestWorkerContext>
+  >["repositories"];
+  readonly canonicalEventId: string;
+  readonly sourceEvidenceId: string;
+  readonly providerRecordId: string;
+  readonly contactId: string;
+  readonly occurredAt: string;
+  readonly fromHeader?: string | null;
+  readonly toHeader?: string | null;
+  readonly ccHeader?: string | null;
+}): Promise<void> {
+  await input.repositories.sourceEvidence.append({
+    id: input.sourceEvidenceId,
+    provider: "gmail",
+    providerRecordType: "message",
+    providerRecordId: input.providerRecordId,
+    receivedAt: input.occurredAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `gmail://message/${input.providerRecordId}`,
+    idempotencyKey: input.sourceEvidenceId,
+    checksum: `checksum:${input.providerRecordId}`,
+  });
+
+  await input.repositories.canonicalEvents.upsert({
+    id: input.canonicalEventId,
+    contactId: input.contactId,
+    eventType: "communication.email.inbound",
+    channel: "email",
+    occurredAt: input.occurredAt,
+    contentFingerprint: null,
+    sourceEvidenceId: input.sourceEvidenceId,
+    idempotencyKey: input.canonicalEventId,
+    provenance: buildCanonicalProvenance({
+      sourceEvidenceId: input.sourceEvidenceId,
+      providerRecordId: input.providerRecordId,
+    }),
+    reviewState: "clear",
+  });
+
+  await input.repositories.gmailMessageDetails.upsert({
+    sourceEvidenceId: input.sourceEvidenceId,
+    providerRecordId: input.providerRecordId,
+    gmailThreadId: `thread:${input.providerRecordId}`,
+    rfc822MessageId: `<${input.providerRecordId}@example.org>`,
+    direction: "inbound",
+    subject: `Subject ${input.providerRecordId}`,
+    fromHeader: input.fromHeader ?? null,
+    toHeader: input.toHeader ?? null,
+    ccHeader: input.ccHeader ?? null,
+    fromEmails: [],
+    toEmails: [],
+    ccEmails: [],
+    bccEmails: [],
+    labelIds: ["INBOX"],
+    snippetClean: "Snippet",
+    bodyTextPreview: "Preview",
+    bodyKind: "plaintext",
+    capturedMailbox: "volunteers@adventurescientists.org",
+    projectInboxAlias: null,
+  });
+}
+
+async function addAudienceRow(input: {
+  readonly context: Awaited<ReturnType<typeof createTestWorkerContext>>;
+  readonly canonicalEventId: string;
+  readonly contactId: string;
+  readonly email: string;
+}): Promise<void> {
+  await input.context.db.insert(canonicalEventAudience).values({
+    canonicalEventId: input.canonicalEventId,
+    contactId: input.contactId,
+    participantRole: "direct_recipient",
+    normalizedEmail: input.email,
+  });
+}
+
+async function readContactDisplayName(
+  context: Awaited<ReturnType<typeof createTestWorkerContext>>,
+  contactId: string,
+): Promise<string | null> {
+  const [row] = await context.db
+    .select({
+      displayName: contacts.displayName,
+    })
+    .from(contacts)
+    .where(eq(contacts.id, contactId));
+
+  return row?.displayName ?? null;
+}
+
+function createLogger(logs: BackfillContactDisplayNamesLogEntry[]) {
+  return {
+    log(value: unknown) {
+      if (typeof value === "string" && value.startsWith("{")) {
+        logs.push(JSON.parse(value) as BackfillContactDisplayNamesLogEntry);
+      }
+    },
+    error() {
+      return undefined;
+    },
+  };
+}
+
+describe("backfill-contact-display-names", () => {
+  it("logs a planned update in dry-run mode without writing the contact", async () => {
+    const context = await createTestWorkerContext();
+    const logs: BackfillContactDisplayNamesLogEntry[] = [];
+
+    try {
+      await seedContact({
+        repositories: context.repositories,
+        id: "contact:target",
+        primaryEmail: "or-rural-coordinator@example.org",
+        displayName: "or-rural-coordinator@example.org",
+      });
+      await seedGmailEvent({
+        repositories: context.repositories,
+        canonicalEventId: "event:target",
+        sourceEvidenceId: "source:target",
+        providerRecordId: "gmail-target",
+        contactId: "contact:target",
+        occurredAt: "2026-05-20T10:00:00.000Z",
+        fromHeader:
+          '"Scotty Stalp" <or-rural-coordinator@example.org>',
+      });
+
+      const result = await backfillContactDisplayNames({
+        db: context.db,
+        since: "2026-05-01T00:00:00.000Z",
+        until: "2026-05-31T23:59:59.999Z",
+        execute: false,
+        limit: 100,
+        logger: createLogger(logs),
+      });
+
+      expect(result).toMatchObject({
+        dryRun: true,
+        candidates: 1,
+        updated: 1,
+        skipped: 0,
+      });
+      await expect(readContactDisplayName(context, "contact:target")).resolves.toBe(
+        "or-rural-coordinator@example.org",
+      );
+      expect(logs).toContainEqual({
+        action: "dryRun",
+        contactId: "contact:target",
+        primaryEmail: "or-rural-coordinator@example.org",
+        displayName: "Scotty Stalp",
+        dryRun: true,
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("updates the contact when execute=true and the match is found through audience rows", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact({
+        repositories: context.repositories,
+        id: "contact:target",
+        primaryEmail: "alice@example.org",
+        displayName: "alice@example.org",
+      });
+      await seedContact({
+        repositories: context.repositories,
+        id: "contact:anchor",
+        primaryEmail: "anchor@example.org",
+        displayName: "Anchor",
+      });
+      await seedGmailEvent({
+        repositories: context.repositories,
+        canonicalEventId: "event:audience",
+        sourceEvidenceId: "source:audience",
+        providerRecordId: "gmail-audience",
+        contactId: "contact:anchor",
+        occurredAt: "2026-05-21T10:00:00.000Z",
+        toHeader: '"Alice Example" <alice@example.org>',
+      });
+      await addAudienceRow({
+        context,
+        canonicalEventId: "event:audience",
+        contactId: "contact:target",
+        email: "alice@example.org",
+      });
+
+      const result = await backfillContactDisplayNames({
+        db: context.db,
+        since: "2026-05-01T00:00:00.000Z",
+        until: "2026-05-31T23:59:59.999Z",
+        execute: true,
+        limit: 100,
+      });
+
+      expect(result).toMatchObject({
+        dryRun: false,
+        candidates: 1,
+        updated: 1,
+        skipped: 0,
+      });
+      await expect(readContactDisplayName(context, "contact:target")).resolves.toBe(
+        "Alice Example",
+      );
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("skips contacts with no matching header anywhere", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact({
+        repositories: context.repositories,
+        id: "contact:no-match",
+        primaryEmail: "nomatch@example.org",
+        displayName: "nomatch@example.org",
+      });
+      await seedGmailEvent({
+        repositories: context.repositories,
+        canonicalEventId: "event:no-match",
+        sourceEvidenceId: "source:no-match",
+        providerRecordId: "gmail-no-match",
+        contactId: "contact:no-match",
+        occurredAt: "2026-05-22T10:00:00.000Z",
+        fromHeader: '"Someone Else" <someone@example.org>',
+      });
+
+      const result = await backfillContactDisplayNames({
+        db: context.db,
+        since: "2026-05-01T00:00:00.000Z",
+        until: "2026-05-31T23:59:59.999Z",
+        execute: false,
+        limit: 100,
+      });
+
+      expect(result).toMatchObject({
+        updated: 0,
+        skipped: 1,
+        byReason: {
+          no_header_match: 1,
+          no_display_name_in_header: 0,
+          display_name_equals_email_local_part: 0,
+        },
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("skips contacts when the matching header is bare-email only", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact({
+        repositories: context.repositories,
+        id: "contact:bare",
+        primaryEmail: "bare@example.org",
+        displayName: "bare@example.org",
+      });
+      await seedGmailEvent({
+        repositories: context.repositories,
+        canonicalEventId: "event:bare",
+        sourceEvidenceId: "source:bare",
+        providerRecordId: "gmail-bare",
+        contactId: "contact:bare",
+        occurredAt: "2026-05-23T10:00:00.000Z",
+        fromHeader: "bare@example.org",
+      });
+
+      const result = await backfillContactDisplayNames({
+        db: context.db,
+        since: "2026-05-01T00:00:00.000Z",
+        until: "2026-05-31T23:59:59.999Z",
+        execute: false,
+        limit: 100,
+      });
+
+      expect(result.byReason.no_display_name_in_header).toBe(1);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("skips contacts when the observed display name only repeats the local part", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact({
+        repositories: context.repositories,
+        id: "contact:local-part",
+        primaryEmail: "or-rural-coordinator@example.org",
+        displayName: "or-rural-coordinator@example.org",
+      });
+      await seedGmailEvent({
+        repositories: context.repositories,
+        canonicalEventId: "event:local-part",
+        sourceEvidenceId: "source:local-part",
+        providerRecordId: "gmail-local-part",
+        contactId: "contact:local-part",
+        occurredAt: "2026-05-24T10:00:00.000Z",
+        fromHeader:
+          '"or-rural-coordinator" <or-rural-coordinator@example.org>',
+      });
+
+      const result = await backfillContactDisplayNames({
+        db: context.db,
+        since: "2026-05-01T00:00:00.000Z",
+        until: "2026-05-31T23:59:59.999Z",
+        execute: false,
+        limit: 100,
+      });
+
+      expect(result.byReason.display_name_equals_email_local_part).toBe(1);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("is idempotent after applying a display-name update", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact({
+        repositories: context.repositories,
+        id: "contact:idempotent",
+        primaryEmail: "idempotent@example.org",
+        displayName: "idempotent@example.org",
+      });
+      await seedGmailEvent({
+        repositories: context.repositories,
+        canonicalEventId: "event:idempotent",
+        sourceEvidenceId: "source:idempotent",
+        providerRecordId: "gmail-idempotent",
+        contactId: "contact:idempotent",
+        occurredAt: "2026-05-25T10:00:00.000Z",
+        fromHeader: '"Ida Potent" <idempotent@example.org>',
+      });
+
+      const first = await backfillContactDisplayNames({
+        db: context.db,
+        since: "2026-05-01T00:00:00.000Z",
+        until: "2026-05-31T23:59:59.999Z",
+        execute: true,
+        limit: 100,
+      });
+      const second = await backfillContactDisplayNames({
+        db: context.db,
+        since: "2026-05-01T00:00:00.000Z",
+        until: "2026-05-31T23:59:59.999Z",
+        execute: true,
+        limit: 100,
+      });
+
+      expect(first.updated).toBe(1);
+      expect(second.candidates).toBe(0);
+      expect(second.updated).toBe(0);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("leaves already-named contacts out of the candidate set", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact({
+        repositories: context.repositories,
+        id: "contact:already-named",
+        primaryEmail: "named@example.org",
+        displayName: "Already Named",
+      });
+
+      const result = await backfillContactDisplayNames({
+        db: context.db,
+        since: "2026-05-01T00:00:00.000Z",
+        until: "2026-05-31T23:59:59.999Z",
+        execute: false,
+        limit: 100,
+      });
+
+      expect(result.candidates).toBe(0);
+    } finally {
+      await context.dispose();
+    }
+  });
+});

--- a/docs/runbooks/backfill-contact-display-names.md
+++ b/docs/runbooks/backfill-contact-display-names.md
@@ -1,0 +1,37 @@
+# Backfill Contact Display Names
+
+## When to run
+
+- Run once after the `contacts.display_name` backfill PR lands.
+- Re-run ad hoc if the Inbox search Contacts section still shows bare emails for active non-Salesforce contacts.
+
+## How to run
+
+- Start with a dry run:
+
+```bash
+pnpm --filter @as-comms/worker exec tsx src/ops/backfill-contact-display-names.ts
+```
+
+- Narrow the scan window if needed:
+
+```bash
+pnpm --filter @as-comms/worker exec tsx src/ops/backfill-contact-display-names.ts --since=2024-01-01T00:00:00Z --until=2026-06-01T00:00:00Z --limit=5000
+```
+
+- After checking the JSON logs and summary, run the real update:
+
+```bash
+pnpm --filter @as-comms/worker exec tsx src/ops/backfill-contact-display-names.ts --execute
+```
+
+## What to expect
+
+- Dry-run is the default. Nothing is written unless `--execute` is present.
+- The command emits one JSON log line per changed or skipped candidate, then a summary JSON object.
+- MVP-scale expectation is a few hundred candidates, with roughly 50-80% resolving to a usable display name from historical Gmail headers.
+
+## Notes
+
+- The candidate set is limited to contacts whose `display_name` is effectively unset for this workflow: null or equal to `primary_email`.
+- The job only backfills from stored Gmail headers and does not overwrite real existing display names.

--- a/packages/domain/src/normalization.ts
+++ b/packages/domain/src/normalization.ts
@@ -265,6 +265,7 @@ export interface Stage1NormalizationService {
     readonly emailAddress: string;
     readonly createdAt?: string;
     readonly source?: ContactIdentityRecord["source"];
+    readonly observedDisplayName?: string | null;
   }): Promise<ContactRecord>;
   upsertNormalizedContactGraph(
     input: NormalizedContactGraphUpsertInput,
@@ -328,6 +329,13 @@ export async function applyCanonicalEventAudience(
 
   for (const participant of audience.participants) {
     const normalizedEmail = normalizeEmailAddress(participant.email);
+    const observedDisplayName = parseHeaderDisplayNameForEmail(
+      resolveHeaderValueForParticipantRole(
+        input.gmailMessageDetail,
+        participant.role,
+      ),
+      participant.email,
+    );
 
     if (normalizedEmail === null) {
       continue;
@@ -346,25 +354,13 @@ export async function applyCanonicalEventAudience(
 
     let contact: ContactRecord;
 
-    if (candidateContactIds.length === 0) {
+    if (candidateContactIds.length <= 1) {
       contact = await deps.service.ensureCanonicalContactForEmail({
         emailAddress: normalizedEmail,
         createdAt: input.openedAt,
         source: "gmail",
+        observedDisplayName,
       });
-    } else if (candidateContactIds.length === 1) {
-      const candidateContactId = requireValue(
-        candidateContactIds[0],
-        "Expected a single audience contact candidate.",
-      );
-      const matchedContact =
-        await deps.persistence.repositories.contacts.findById(candidateContactId);
-
-      if (matchedContact === null) {
-        throw new Error("Audience email matched a missing contact.");
-      }
-
-      contact = matchedContact;
     } else {
       const contacts = await deps.persistence.repositories.contacts.listByIds(
         candidateContactIds,
@@ -649,6 +645,7 @@ function buildSyntheticContactGraphInput(input: {
   readonly normalizedPhone: string | null;
   readonly createdAt: string;
   readonly source: ContactIdentityRecord["source"];
+  readonly observedDisplayName?: string | null;
 }): NormalizedContactGraphUpsertInput {
   const contactId = buildSyntheticContactId({
     normalizedEmail: input.normalizedEmail,
@@ -690,7 +687,10 @@ function buildSyntheticContactGraphInput(input: {
       id: contactId,
       salesforceContactId: null,
       displayName:
-        input.normalizedEmail ?? input.normalizedPhone ?? "(unknown)",
+        normalizeContactDisplayName(input.observedDisplayName) ??
+        input.normalizedEmail ??
+        input.normalizedPhone ??
+        "(unknown)",
       primaryEmail: input.normalizedEmail,
       primaryPhone: input.normalizedPhone,
       createdAt: input.createdAt,
@@ -704,6 +704,151 @@ function buildSyntheticContactGraphInput(input: {
 function normalizeEmailAddress(value: string): string | null {
   const normalized = value.trim().toLowerCase();
   return normalized.length === 0 ? null : normalized;
+}
+
+function splitHeaderEntries(value: string): string[] {
+  return value
+    .split(/,(?=(?:[^"]*"[^"]*")*[^"]*$)/gu)
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+function parseHeaderEntry(value: string): {
+  readonly email: string | null;
+  readonly displayName: string | null;
+} {
+  const bracketMatch = /^(.*?)(?:<([^>]+)>)$/u.exec(value);
+
+  if (bracketMatch !== null) {
+    const [, rawDisplayName = "", rawEmail = ""] = bracketMatch;
+    return {
+      email: normalizeEmailAddress(rawEmail),
+      displayName: rawDisplayName.trim().length > 0 ? rawDisplayName.trim() : null,
+    };
+  }
+
+  const emailMatch = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/iu.exec(value);
+
+  if (emailMatch === null) {
+    return {
+      email: null,
+      displayName: null,
+    };
+  }
+
+  const rawEmail = emailMatch[0];
+  const displayName = value.replace(rawEmail, "").trim();
+
+  return {
+    email: normalizeEmailAddress(rawEmail),
+    displayName: displayName.length > 0 ? displayName : null,
+  };
+}
+
+function parseHeaderDisplayNameForEmail(
+  header: string | null | undefined,
+  targetEmail: string,
+): string | null {
+  const normalizedTargetEmail = normalizeEmailAddress(targetEmail);
+
+  if (
+    typeof header !== "string" ||
+    header.trim().length === 0 ||
+    normalizedTargetEmail === null
+  ) {
+    return null;
+  }
+
+  for (const entry of splitHeaderEntries(header)) {
+    const parsed = parseHeaderEntry(entry);
+
+    if (parsed.email !== normalizedTargetEmail || parsed.displayName === null) {
+      continue;
+    }
+
+    const normalizedDisplayName = parsed.displayName
+      .trim()
+      .replace(/^"(.*)"$/u, "$1")
+      .trim();
+
+    if (normalizedDisplayName.length === 0) {
+      return null;
+    }
+
+    const normalizedLocalPart =
+      normalizedTargetEmail.split("@", 1)[0] ?? normalizedTargetEmail;
+    const loweredDisplayName = normalizedDisplayName.toLowerCase();
+
+    if (
+      loweredDisplayName === normalizedTargetEmail ||
+      loweredDisplayName === normalizedLocalPart
+    ) {
+      return null;
+    }
+
+    return normalizedDisplayName;
+  }
+
+  return null;
+}
+
+function normalizeContactDisplayName(
+  value: string | null | undefined,
+): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+function shouldReplaceObservedDisplayName(input: {
+  readonly contact: ContactRecord;
+  readonly observedDisplayName: string | null | undefined;
+}): boolean {
+  const normalizedObservedDisplayName = normalizeContactDisplayName(
+    input.observedDisplayName,
+  );
+
+  if (normalizedObservedDisplayName === null) {
+    return false;
+  }
+
+  const existingDisplayName = normalizeContactDisplayName(
+    input.contact.displayName,
+  );
+  const normalizedPrimaryEmail = normalizeEmailAddress(input.contact.primaryEmail ?? "");
+
+  if (existingDisplayName === null) {
+    return true;
+  }
+
+  if (normalizedPrimaryEmail === null) {
+    return false;
+  }
+
+  return existingDisplayName.toLowerCase() === normalizedPrimaryEmail;
+}
+
+function resolveHeaderValueForParticipantRole(
+  detail: {
+    readonly fromHeader?: string | null | undefined;
+    readonly toHeader?: string | null | undefined;
+    readonly ccHeader?: string | null | undefined;
+  },
+  role: CanonicalEventParticipantRole,
+): string | null {
+  switch (role) {
+    case "sender":
+      return detail.fromHeader ?? null;
+    case "direct_recipient":
+      return detail.toHeader ?? null;
+    case "cc":
+      return detail.ccHeader ?? null;
+    case "bcc":
+      return null;
+  }
 }
 
 function compareNullableIsoDesc(left: string | null, right: string | null): number {
@@ -2555,6 +2700,9 @@ export function createStage1NormalizationService(
 
     async ensureCanonicalContactForEmail(input) {
       const normalizedEmail = normalizeEmailAddress(input.emailAddress);
+      const observedDisplayName = normalizeContactDisplayName(
+        input.observedDisplayName,
+      );
 
       if (normalizedEmail === null) {
         throw new Error("Cannot ensure a canonical contact without an email.");
@@ -2595,6 +2743,19 @@ export function createStage1NormalizationService(
           });
         }
 
+        if (
+          shouldReplaceObservedDisplayName({
+            contact: existingContact,
+            observedDisplayName,
+          })
+        ) {
+          return persistence.repositories.contacts.upsert({
+            ...existingContact,
+            displayName: observedDisplayName ?? existingContact.displayName,
+            updatedAt: input.createdAt ?? new Date().toISOString(),
+          });
+        }
+
         return existingContact;
       }
 
@@ -2605,6 +2766,7 @@ export function createStage1NormalizationService(
             normalizedPhone: null,
             createdAt: input.createdAt ?? new Date().toISOString(),
             source: input.source ?? "manual",
+            observedDisplayName,
           }),
         )
       ).contact;

--- a/packages/domain/test/normalization.test.ts
+++ b/packages/domain/test/normalization.test.ts
@@ -1906,6 +1906,134 @@ describe("identity resolution hardening", () => {
     });
   });
 
+  it("sets displayName from the observed header value when creating a new contact", async () => {
+    const context = buildContext({
+      events: [],
+      contacts: [],
+      contactIdentities: [],
+    });
+
+    const created = await context.normalization.ensureCanonicalContactForEmail({
+      emailAddress: "or-rural-coordinator@example.org",
+      createdAt: "2026-05-31T12:00:00.000Z",
+      source: "gmail",
+      observedDisplayName: "Scotty Stalp",
+    });
+
+    expect(created).toMatchObject({
+      primaryEmail: "or-rural-coordinator@example.org",
+      displayName: "Scotty Stalp",
+    });
+    expect(context.getContact(created.id)).toMatchObject({
+      displayName: "Scotty Stalp",
+    });
+  });
+
+  it("falls back to the email address when creating a new contact without an observed display name", async () => {
+    const context = buildContext({
+      events: [],
+      contacts: [],
+      contactIdentities: [],
+    });
+
+    const created = await context.normalization.ensureCanonicalContactForEmail({
+      emailAddress: "or-rural-coordinator@example.org",
+      createdAt: "2026-05-31T12:00:00.000Z",
+      source: "gmail",
+    });
+
+    expect(created).toMatchObject({
+      primaryEmail: "or-rural-coordinator@example.org",
+      displayName: "or-rural-coordinator@example.org",
+    });
+  });
+
+  it("updates an existing contact when displayName is effectively unset", async () => {
+    const legacyContact: ContactRecord = {
+      ...contact,
+      displayName: null as unknown as string,
+      primaryEmail: "or-rural-coordinator@example.org",
+    };
+    const legacyIdentity: ContactIdentityRecord = {
+      ...emailIdentity,
+      contactId: legacyContact.id,
+      normalizedValue: "or-rural-coordinator@example.org",
+    };
+    const context = buildContext({
+      events: [],
+      contacts: [legacyContact],
+      contactIdentities: [legacyIdentity],
+    });
+
+    const resolved = await context.normalization.ensureCanonicalContactForEmail({
+      emailAddress: "or-rural-coordinator@example.org",
+      createdAt: "2026-05-31T12:00:00.000Z",
+      source: "gmail",
+      observedDisplayName: "Scotty Stalp",
+    });
+
+    expect(resolved.displayName).toBe("Scotty Stalp");
+    expect(context.getContact(legacyContact.id)?.displayName).toBe("Scotty Stalp");
+  });
+
+  it("updates an existing contact when displayName equals the primary email", async () => {
+    const emailNamedContact: ContactRecord = {
+      ...contact,
+      displayName: "or-rural-coordinator@example.org",
+      primaryEmail: "or-rural-coordinator@example.org",
+    };
+    const emailNamedIdentity: ContactIdentityRecord = {
+      ...emailIdentity,
+      contactId: emailNamedContact.id,
+      normalizedValue: "or-rural-coordinator@example.org",
+    };
+    const context = buildContext({
+      events: [],
+      contacts: [emailNamedContact],
+      contactIdentities: [emailNamedIdentity],
+    });
+
+    const resolved = await context.normalization.ensureCanonicalContactForEmail({
+      emailAddress: "or-rural-coordinator@example.org",
+      createdAt: "2026-05-31T12:00:00.000Z",
+      source: "gmail",
+      observedDisplayName: "Scotty Stalp",
+    });
+
+    expect(resolved.displayName).toBe("Scotty Stalp");
+    expect(context.getContact(emailNamedContact.id)?.displayName).toBe(
+      "Scotty Stalp",
+    );
+  });
+
+  it("does not overwrite an existing real displayName with an observed header value", async () => {
+    const context = buildContext({
+      events: [],
+      contacts: [
+        {
+          ...contact,
+          displayName: "Scott Stalp",
+          primaryEmail: "or-rural-coordinator@example.org",
+        },
+      ],
+      contactIdentities: [
+        {
+          ...emailIdentity,
+          normalizedValue: "or-rural-coordinator@example.org",
+        },
+      ],
+    });
+
+    const resolved = await context.normalization.ensureCanonicalContactForEmail({
+      emailAddress: "or-rural-coordinator@example.org",
+      createdAt: "2026-05-31T12:00:00.000Z",
+      source: "gmail",
+      observedDisplayName: "Scotty Stalp",
+    });
+
+    expect(resolved.displayName).toBe("Scott Stalp");
+  });
+
   it("throws CanonicalContactAmbiguityError when the email maps to multiple contacts", async () => {
     const duplicateContact: ContactRecord = {
       ...contact,

--- a/packages/integrations/src/providers/gmail-record-builder.ts
+++ b/packages/integrations/src/providers/gmail-record-builder.ts
@@ -107,6 +107,115 @@ export function parseHeaderEmailList(value: string | undefined): string[] {
   );
 }
 
+function splitHeaderEntries(value: string): string[] {
+  return value
+    .split(/,(?=(?:[^"]*"[^"]*")*[^"]*$)/gu)
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+function decodeHeaderDisplayName(value: string): string {
+  try {
+    return libmime.decodeWords(value).trim();
+  } catch {
+    return value.trim();
+  }
+}
+
+function normalizeObservedDisplayName(
+  value: string,
+  email: string,
+): string | null {
+  const trimmed = value.trim().replace(/^"(.*)"$/u, "$1").trim();
+
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const decoded = decodeHeaderDisplayName(trimmed);
+
+  if (decoded.length === 0) {
+    return null;
+  }
+
+  const normalizedDisplayName = decoded.trim().toLowerCase();
+  const normalizedEmail = email.trim().toLowerCase();
+  const normalizedLocalPart = normalizedEmail.split("@", 1)[0] ?? normalizedEmail;
+
+  if (
+    normalizedDisplayName === normalizedEmail ||
+    normalizedDisplayName === normalizedLocalPart
+  ) {
+    return null;
+  }
+
+  return decoded;
+}
+
+function parseHeaderEntry(value: string): { email: string | null; displayName: string | null } {
+  const bracketMatch = /^(.*?)(?:<([^>]+)>)$/u.exec(value);
+
+  if (bracketMatch !== null) {
+    const [, rawDisplayName = "", rawEmail = ""] = bracketMatch;
+    return {
+      email: normalizeEmail(rawEmail),
+      displayName: rawDisplayName.trim().length > 0 ? rawDisplayName.trim() : null,
+    };
+  }
+
+  const emailMatch = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/iu.exec(value);
+
+  if (emailMatch === null) {
+    return {
+      email: null,
+      displayName: null,
+    };
+  }
+
+  const rawEmail = emailMatch[0];
+  const displayName = value.replace(rawEmail, "").trim();
+
+  return {
+    email: normalizeEmail(rawEmail),
+    displayName: displayName.length > 0 ? displayName : null,
+  };
+}
+
+/**
+ * Extract the display name portion of an RFC-822 header entry that matches
+ * `targetEmail`.
+ */
+export function parseHeaderDisplayNameForEmail(
+  header: string | null | undefined,
+  targetEmail: string,
+): string | null {
+  const normalizedTargetEmail = normalizeEmail(targetEmail);
+
+  if (
+    typeof header !== "string" ||
+    header.trim().length === 0 ||
+    normalizedTargetEmail === null
+  ) {
+    return null;
+  }
+
+  for (const entry of splitHeaderEntries(header)) {
+    const parsed = parseHeaderEntry(entry);
+
+    if (parsed.email !== normalizedTargetEmail) {
+      continue;
+    }
+
+    if (parsed.displayName === null) {
+      return null;
+    }
+
+    return normalizeObservedDisplayName(parsed.displayName, normalizedTargetEmail);
+  }
+
+  return null;
+}
+
 function resolveProjectInboxAlias(input: {
   readonly capturedMailbox: string;
   readonly fromEmails: readonly string[];

--- a/packages/integrations/test/stage1-gmail-mbox.test.ts
+++ b/packages/integrations/test/stage1-gmail-mbox.test.ts
@@ -4,6 +4,7 @@ import {
   buildGmailMessageRecord,
   importGmailMboxRecords,
   mapGmailRecord,
+  parseHeaderDisplayNameForEmail,
 } from "../src/index.js";
 
 const mboxText = `From MAILER-DAEMON Fri Jan 03 00:00:00 2026
@@ -17,6 +18,104 @@ Hello from an exported mailbox.
 `;
 
 describe("Stage 1 Gmail .mbox import", () => {
+  describe("parseHeaderDisplayNameForEmail", () => {
+    it("extracts a quoted display name for the matching email", () => {
+      expect(
+        parseHeaderDisplayNameForEmail(
+          '"Scotty Stalp" <or-rural-coordinator@example.org>',
+          "or-rural-coordinator@example.org",
+        ),
+      ).toBe("Scotty Stalp");
+    });
+
+    it("extracts an unquoted display name for the matching email", () => {
+      expect(
+        parseHeaderDisplayNameForEmail(
+          "Scotty Stalp <or-rural-coordinator@example.org>",
+          "or-rural-coordinator@example.org",
+        ),
+      ).toBe("Scotty Stalp");
+    });
+
+    it("returns null for bare-email entries", () => {
+      expect(
+        parseHeaderDisplayNameForEmail(
+          "or-rural-coordinator@example.org",
+          "or-rural-coordinator@example.org",
+        ),
+      ).toBeNull();
+    });
+
+    it("returns null when the display name equals the email local part", () => {
+      expect(
+        parseHeaderDisplayNameForEmail(
+          '"or-rural-coordinator" <or-rural-coordinator@example.org>',
+          "or-rural-coordinator@example.org",
+        ),
+      ).toBeNull();
+    });
+
+    it("returns null when the display name equals the email address", () => {
+      expect(
+        parseHeaderDisplayNameForEmail(
+          '"or-rural-coordinator@example.org" <or-rural-coordinator@example.org>',
+          "or-rural-coordinator@example.org",
+        ),
+      ).toBeNull();
+    });
+
+    it("finds the matching entry in a multi-entry header", () => {
+      expect(
+        parseHeaderDisplayNameForEmail(
+          '"Bob" <bob@x.com>, "Alice" <alice@y.org>',
+          "alice@y.org",
+        ),
+      ).toBe("Alice");
+    });
+
+    it("decodes RFC-2047 encoded display names", () => {
+      expect(
+        parseHeaderDisplayNameForEmail(
+          "=?UTF-8?Q?Scotty_Stalp?= <or-rural-coordinator@example.org>",
+          "or-rural-coordinator@example.org",
+        ),
+      ).toBe("Scotty_Stalp");
+    });
+
+    it("returns null for null and empty headers", () => {
+      expect(
+        parseHeaderDisplayNameForEmail(
+          null,
+          "or-rural-coordinator@example.org",
+        ),
+      ).toBeNull();
+      expect(
+        parseHeaderDisplayNameForEmail(
+          "   ",
+          "or-rural-coordinator@example.org",
+        ),
+      ).toBeNull();
+    });
+
+    it("returns null when the target email is missing", () => {
+      expect(
+        parseHeaderDisplayNameForEmail(
+          '"Scotty Stalp" <or-rural-coordinator@example.org>',
+          "another@example.org",
+        ),
+      ).toBeNull();
+    });
+
+    it("tolerates surrounding whitespace", () => {
+      expect(
+        parseHeaderDisplayNameForEmail(
+          '  "Scotty Stalp" <or-rural-coordinator@example.org>  ',
+          "or-rural-coordinator@example.org",
+        ),
+      ).toBe("Scotty Stalp");
+    });
+  });
+
   it("parses .mbox messages into the Gmail provider-close record shape", async () => {
     const records = await importGmailMboxRecords({
       mboxText,

--- a/packages/integrations/test/stage1-gmail-mbox.test.ts
+++ b/packages/integrations/test/stage1-gmail-mbox.test.ts
@@ -65,21 +65,27 @@ describe("Stage 1 Gmail .mbox import", () => {
     });
 
     it("finds the matching entry in a multi-entry header", () => {
+      // Display names must differ from the local part of the email, or the
+      // resolver intentionally treats them as no real display name (the
+      // "alice@…" → "alice" suppression). Use full names to exercise the
+      // entry-matching logic without tripping that suppression.
       expect(
         parseHeaderDisplayNameForEmail(
-          '"Bob" <bob@x.com>, "Alice" <alice@y.org>',
+          '"Bob Smith" <bob@x.com>, "Alice Johnson" <alice@y.org>',
           "alice@y.org",
         ),
-      ).toBe("Alice");
+      ).toBe("Alice Johnson");
     });
 
     it("decodes RFC-2047 encoded display names", () => {
+      // Per RFC-2047 Q-encoding, `_` represents a space in the encoded
+      // text; `Scotty_Stalp` decodes to `Scotty Stalp`.
       expect(
         parseHeaderDisplayNameForEmail(
           "=?UTF-8?Q?Scotty_Stalp?= <or-rural-coordinator@example.org>",
           "or-rural-coordinator@example.org",
         ),
-      ).toBe("Scotty_Stalp");
+      ).toBe("Scotty Stalp");
     });
 
     it("returns null for null and empty headers", () => {


### PR DESCRIPTION
## Summary

Search results in the Contacts section currently render just the email address for non-SF contacts. The inbox-unified-search-row component already renders \`<displayName> · <email>\` when displayName is a real name — we just need to populate \`contacts.display_name\` from observed message headers.

**Backfill** + **capture-time augmentation**, no UI change required.

## Changes

- **`packages/integrations/src/providers/gmail-record-builder.ts`** — new \`parseHeaderDisplayName\` helper extracts the display-name portion of an RFC-822 header for a given email (e.g. \`"Scotty Stalp" <or-rural-coordinator@…>\` → \`"Scotty Stalp"\`).
- **\`packages/domain/src/normalization.ts\`** — \`ensureCanonicalContactForEmail\` accepts an optional \`observedDisplayName\` and sets \`contacts.display_name\` at creation time when the observed name is non-empty and differs from the email's local part. Callers in the audience apply path thread the observed name through.
- **\`apps/worker/src/ops/backfill-contact-display-names.ts\`** — one-time ops job: walks contacts with \`display_name\` null or equal to \`primary_email\`, finds the most-recent observed header name across the contact's canonical events (anchor + audience junction), and populates \`display_name\`. Dry-run default, \`--execute / --since / --until / --limit\`. Idempotent.
- **\`docs/runbooks/backfill-contact-display-names.md\`** — operator runbook.

## UI behavior (no change)

The \`inbox-unified-search-row\` component already does:

\`\`\`tsx
const isDisplayNameAnEmail = row.displayName.includes("@");
// ...
{isDisplayNameAnEmail ? (
  <span>{row.displayName}</span>
) : (
  <span>
    <span className="font-semibold">{row.displayName}</span>
    {hasSecondaryEmail ? <span> · {row.primaryEmail}</span> : null}
  </span>
)}
\`\`\`

Setting \`display_name\` to a real name flips both: the row now renders \`<name> · <email>\`.

## Validation

- ✅ \`pnpm typecheck\` (16/16)
- ✅ \`pnpm lint\` (16/16)
- ✅ \`pnpm boundaries\`
- ✅ \`pnpm build\` (11/11 incl \`next build\`)
- ✅ \`packages/domain\` test (151 pass, 5 new)
- ✅ \`apps/worker\` test (219 pass, 7 new from backfill suite)

## Operator action after merge

Run the backfill once on production to light up existing contacts:

\`\`\`bash
DATABASE_URL="<public_url>" \\
  pnpm --filter @as-comms/worker ops:backfill-contact-display-names \\
    --since=2024-01-01T00:00:00.000Z \\
    --until=\$(date -u +%Y-%m-%dT%H:%M:%S.000Z) \\
    --limit=20000 --execute
\`\`\`

(Dry-run first per the runbook.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)