### PR TITLE
fix(worker): register ops:backfill-contact-display-names pnpm script

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -30,6 +30,7 @@
     "ops:recover-gmail-spam-window": "tsx src/ops/recover-gmail-spam-window.ts",
     "ops:recompute-attachment-inline": "tsx src/ops/recompute-attachment-inline.ts",
     "ops:backfill-canonical-event-audience": "tsx src/ops/backfill-canonical-event-audience.ts",
+    "ops:backfill-contact-display-names": "tsx src/ops/backfill-contact-display-names.ts",
     "ops:recover-orphan-gmail-details": "tsx src/ops/recover-orphan-gmail-details.ts",
     "ops:recover-orphan-task-details": "tsx src/ops/recover-orphan-task-details.ts",
     "ops:rewrite-timeline-sort-keys": "tsx src/ops/rewrite-timeline-sort-keys.ts",


### PR DESCRIPTION
One-line fix. PR #495 shipped the ops file (`apps/worker/src/ops/backfill-contact-display-names.ts`) but missed the pnpm script entry in `apps/worker/package.json`, so running the backfill failed with "none of the selected packages has a 'ops:backfill-contact-display-names' script".

This adds the missing line alongside the other ops:backfill-* entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)