### PR TITLE
fix(worker): normalize db.execute result in backfill-contact-display-names

### DIFF
--- a/apps/worker/src/ops/backfill-contact-display-names.ts
+++ b/apps/worker/src/ops/backfill-contact-display-names.ts
@@ -227,7 +227,13 @@ async function loadCandidateRows(input: {
     limit ${input.limit + 1}
   `);
 
-  const rows = (result as { readonly rows: readonly CandidateContactRow[] }).rows.map((row) => ({
+  // postgres-js (Railway prod) returns `db.execute(sql\`…\`)` as an Array
+  // directly; PGlite (tests) wraps the rows under `{ rows }`. Normalize
+  // before reading or `.map` throws "Cannot read properties of undefined".
+  const rawRows = Array.isArray(result)
+    ? (result as readonly CandidateContactRow[])
+    : ((result as { readonly rows?: readonly CandidateContactRow[] }).rows ?? []);
+  const rows = rawRows.map((row) => ({
     id: row.id,
     primaryEmail: row.primaryEmail,
     displayName:
@@ -296,7 +302,11 @@ async function loadHeaderMatchesForContact(input: {
     order by "occurredAt" desc
   `);
 
-  return (result as { readonly rows: readonly HeaderMatchRow[] }).rows.map((row) => ({
+  // Same Array-vs-{rows} normalization as loadCandidateContacts above.
+  const rawRows = Array.isArray(result)
+    ? (result as readonly HeaderMatchRow[])
+    : ((result as { readonly rows?: readonly HeaderMatchRow[] }).rows ?? []);
+  return rawRows.map((row) => ({
     occurredAt: row.occurredAt,
     fromHeader: row.fromHeader,
     toHeader: row.toHeader,


### PR DESCRIPTION
Hotfix: `backfill-contact-display-names` throws "Cannot read properties of undefined (reading 'map')" against Railway prod. postgres-js returns `db.execute(sql`…`)` as an Array directly; PGlite wraps under `{ rows }`. The script's two SELECT call sites read `result.rows.map(...)` which works on PGlite (tests) but breaks on real Postgres.

Matches the existing pattern flagged in project memory `project_postgres_js_execute_returns_array.md` and the broadcasts fix in PR #462.

Validation: typecheck, lint, backfill test suite (7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)