### PR TITLE
fix(worker): ISO timestamp binding + verbose error handler in display-name backfill

### DIFF
--- a/apps/worker/src/ops/backfill-contact-display-names.ts
+++ b/apps/worker/src/ops/backfill-contact-display-names.ts
@@ -267,8 +267,8 @@ async function loadHeaderMatchesForContact(input: {
         on gmd.source_evidence_id = cel.source_evidence_id
       where sel.provider = 'gmail'
         and cel.contact_id = ${input.contactId}
-        and cel.occurred_at >= ${new Date(input.since)}
-        and cel.occurred_at <= ${new Date(input.until)}
+        and cel.occurred_at >= ${input.since}
+        and cel.occurred_at <= ${input.until}
         and (
           lower(coalesce(gmd.from_header, '')) like ${input.emailPattern}
           or lower(coalesce(gmd.to_header, '')) like ${input.emailPattern}
@@ -291,8 +291,8 @@ async function loadHeaderMatchesForContact(input: {
         on gmd.source_evidence_id = cel.source_evidence_id
       where sel.provider = 'gmail'
         and cea.contact_id = ${input.contactId}
-        and cel.occurred_at >= ${new Date(input.since)}
-        and cel.occurred_at <= ${new Date(input.until)}
+        and cel.occurred_at >= ${input.since}
+        and cel.occurred_at <= ${input.until}
         and (
           lower(coalesce(gmd.from_header, '')) like ${input.emailPattern}
           or lower(coalesce(gmd.to_header, '')) like ${input.emailPattern}
@@ -525,7 +525,31 @@ async function main(): Promise<void> {
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
   void main().catch((error: unknown) => {
-    console.error(error instanceof Error ? error.message : String(error));
+    if (error instanceof Error) {
+      console.error("Contact display-name backfill failed.");
+      console.error("message:", error.message);
+      const errAny = error as unknown as Record<string, unknown>;
+      for (const key of [
+        "name",
+        "code",
+        "severity",
+        "detail",
+        "hint",
+        "where",
+        "table",
+        "column",
+        "constraint",
+      ]) {
+        if (errAny[key] !== undefined) {
+          console.error(`${key}:`, errAny[key]);
+        }
+      }
+      if (error.cause !== undefined) {
+        console.error("cause:", error.cause);
+      }
+    } else {
+      console.error("Contact display-name backfill failed:", error);
+    }
     process.exitCode = 1;
   });
 }


### PR DESCRIPTION
Two follow-on fixes for #495 that surfaced when running the backfill against Railway Postgres tonight:

**1. Date binding in raw `db.execute(sql`…`)`**
The two header-matching SELECT queries interpolated `${new Date(input.since)}` into the raw template. postgres-js rejects Date objects with `ERR_INVALID_ARG_TYPE` ("The 'string' argument must be of type string … Received an instance of Date"). Drizzle's typed query builder handles this transparently via the column type adapter, but raw `sql`…`` does not. Pass the parsed ISO string directly — `input.since` and `input.until` are already validated ISO strings via `parseWindowTimestamp`.

**2. Verbose error handler**
The top-level `main().catch` only printed `error.message`, which under postgres-js means the failed SQL is shown but the underlying error code / detail / hint / `error.cause` is hidden. Added the same verbose handler we use in `backfill-canonical-event-audience` (which itself landed via #491 after the same kind of debug round-trip). One extra pattern enforced for ops scripts going forward.

**Verified live:** the backfill applied 46 contact `display_name`s on Railway production after this fix.

## Validation

- ✅ `pnpm --filter @as-comms/worker typecheck`
- ✅ `pnpm --filter @as-comms/worker lint`
- ✅ Backfill test suite (7/7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)