### PR TITLE
fix(test): seed project_aliases for D-049 bubble-side test

### DIFF
--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -4452,19 +4452,44 @@ describe("real inbox selectors", () => {
       throw new Error("Expected inbox test runtime");
     }
 
+    // Source of truth for bubble-side matching is `project_aliases.alias`
+    // (admin-managed inbox emails), NOT `project_dimensions.project_alias`
+    // (which is a project label like "PNW Biodiversity"). Seed both: the
+    // project rows satisfy the FK from `project_aliases.project_id`, and the
+    // alias rows are what `listAllProjectAliases()` reads.
     await runtime.context.repositories.projectDimensions.upsert({
       projectId: "project:active-alias",
       projectName: "Active Alias Project",
-      projectAlias: "pnwbio@adventurescientists.org",
+      projectAlias: "Active Alias Project",
       source: "salesforce",
       isActive: true,
     });
     await runtime.context.repositories.projectDimensions.upsert({
       projectId: "project:inactive-alias",
       projectName: "Inactive Alias Project",
-      projectAlias: "past-orcas@adventurescientists.org",
+      projectAlias: "Inactive Alias Project",
       source: "salesforce",
       isActive: false,
+    });
+    await runtime.context.settings.aliases.create({
+      id: "alias:active-bubble",
+      alias: "pnwbio@adventurescientists.org",
+      signature: "",
+      projectId: "project:active-alias",
+      createdAt: new Date("2026-04-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+      createdBy: null,
+      updatedBy: null,
+    });
+    await runtime.context.settings.aliases.create({
+      id: "alias:inactive-bubble",
+      alias: "past-orcas@adventurescientists.org",
+      signature: "",
+      projectId: "project:inactive-alias",
+      createdAt: new Date("2026-04-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+      createdBy: null,
+      updatedBy: null,
     });
 
     const cases = [

--- a/package.json
+++ b/package.json
@@ -44,6 +44,11 @@
   "pnpm": {
     "overrides": {
       "vite": "^7.3.2"
+    },
+    "auditConfig": {
+      "ignoreGhsas": [
+        "GHSA-5xrq-8626-4rwp"
+      ]
     }
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Two changes, both required to ship the D-049 bubble-side fix to production:

1. **Test seed fix** ([inbox-selectors.test.ts:4455](apps/web/tests/unit/inbox-selectors.test.ts:4455)) — PR #499 hotfix repointed `listAllProjectAliases` to `project_aliases.alias` but left the web-level selector test seeding the now-dead `project_dimensions.project_alias` column. Switched the seed to `settings.aliases.create` (matching the existing pattern at line 1461) so the test populates the table the hotfix now reads.

2. **Audit allowlist** ([package.json:48-52](package.json:48)) — `GHSA-5xrq-8626-4rwp` (CVE-2026-47429), disclosed 2026-06-01 14:09 UTC, has been failing the `security` step on every PR since (including the original hotfix). The CVE only affects the Vitest UI server when (a) exposed via `--api.host`, or (b) running on Windows. We run `vitest run` headless in CI and locally on macOS/Linux — never the UI server — so this CVE is inapplicable. Allowlisting it unblocks every queued PR.

   Follow-up: bump vitest 3 → 4.1+ in a separate PR and remove the allowlist entry. Vitest 4 has breaking changes around config and worker model so it needs its own validation pass.

Without (1), CI fails on the bubble-side test. Without (2), CI fails on the unrelated audit. Production has been serving PR #494's broken code (every outbound bubble on the left) for ~24h because Railway has been waiting for green CI.

## Test plan

- [x] `pnpm --filter @as-comms/web test:unit` — 686 pass / 5 skipped
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm boundaries`
- [x] `CI=true pnpm security` — `Dependency audit passed.`
- [ ] Once merged, confirm Railway picks up the deploy and an outbound message from a `pnwbio@/forests@/orcas@/whitebarkpine@adventurescientists.org` alias renders on the right in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)