### PR TITLE
fix(inbox): use mailbox alias as bubble-side fallback for mbox imports

### DIFF
--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -230,6 +230,14 @@ interface InboxDetailCacheData {
     string,
     ReadonlySet<string>
   >;
+  /**
+   * Captured project-inbox alias per timeline canonical event, sourced
+   * from `gmail_message_details.project_inbox_alias`. Used by
+   * `buildTimelineEntry` as a fallback when the wire-level `from_header`
+   * is absent (mbox-imported rows). See the field doc on the
+   * `buildTimelineEntry` input for direction-gating rules.
+   */
+  readonly gmailMailboxAliasByCanonicalEventId: ReadonlyMap<string, string>;
   readonly timelinePage: InboxDetailTimelinePageViewModel;
   readonly freshness: InboxDetailFreshnessViewModel;
 }
@@ -2285,6 +2293,19 @@ function buildTimelineEntry(input: {
     string,
     ReadonlySet<string>
   >;
+  /**
+   * Captured project-inbox alias (e.g. `pnwbio@…`) per timeline item,
+   * keyed by canonical event id. Sourced from
+   * `gmail_message_details.project_inbox_alias`. Populated for both
+   * directions; downstream code MUST gate by outbound-email before using
+   * it as a sender signal (see `resolveEmailBubbleSide` /
+   * `buildParticipantRows`).
+   *
+   * The mbox importer never populated `from_header` — without this
+   * fallback every mbox-imported outbound row silently rendered on the
+   * left because the wire-level sender was unknown.
+   */
+  readonly gmailMailboxAliasByCanonicalEventId: ReadonlyMap<string, string>;
 }): InboxTimelineEntryViewModel {
   const allProjectAliasesLowerSet = new Set(input.allProjectAliasesLower);
   const latestProjectionSnippet =
@@ -2422,6 +2443,12 @@ function buildTimelineEntry(input: {
           participantHeaderEmail(input.item.fromHeader ?? null) ?? "",
         ) ?? null)
       : null;
+  const itemMailboxAlias =
+    input.item.family === "one_to_one_email"
+      ? (input.gmailMailboxAliasByCanonicalEventId.get(
+          input.item.canonicalEventId,
+        ) ?? null)
+      : null;
   const participantRows =
     input.item.family === "one_to_one_email"
       ? buildParticipantRows({
@@ -2433,6 +2460,10 @@ function buildTimelineEntry(input: {
           operatorDisplayName: input.operatorDisplayName,
           headerProjectLabel,
           visualDirection: visualEmailDirection ?? input.item.direction,
+          mailboxAlias:
+            (visualEmailDirection ?? input.item.direction) === "outbound"
+              ? itemMailboxAlias
+              : null,
         })
       : undefined;
   const sideOfBubble =
@@ -2441,6 +2472,8 @@ function buildTimelineEntry(input: {
           fromHeader: input.item.family === "one_to_one_email" ? input.item.fromHeader : null,
           participantRows,
           allProjectAliasesLowerSet,
+          mailboxAlias:
+            finalKind === "outbound-email" ? itemMailboxAlias : null,
         })
       : undefined;
 
@@ -2543,11 +2576,25 @@ function resolveEmailBubbleSide(input: {
     | readonly InboxTimelineEntryParticipantRowViewModel[]
     | undefined;
   readonly allProjectAliasesLowerSet: ReadonlySet<string>;
+  /**
+   * Captured project-inbox alias for this message (e.g. `pnwbio@…`), or
+   * null when unavailable. Used as a fallback when the From header is
+   * missing — mbox-imported outbound rows have an empty `from_header` but
+   * a populated `project_inbox_alias`, so without this fallback they
+   * silently render on the left.
+   *
+   * Caller MUST gate this to outbound-email entries — for inbound rows the
+   * mailbox alias represents the recipient mailbox (where the message was
+   * received), so using it as the "sender" signal would flip volunteer
+   * replies to the right side.
+   */
+  readonly mailboxAlias: string | null;
 }): "right" | "left" {
   const senderFromParticipantRows = input.participantRows?.[0]?.email ?? null;
   const senderEmail =
     normalizeEmailAddress(senderFromParticipantRows) ??
-    participantHeaderEmail(input.fromHeader);
+    participantHeaderEmail(input.fromHeader) ??
+    normalizeEmailAddress(input.mailboxAlias);
 
   if (senderEmail === null) {
     return "left";
@@ -2808,12 +2855,22 @@ function buildParticipantRows(input: {
   readonly operatorDisplayName: string;
   readonly headerProjectLabel: string | null;
   readonly visualDirection: "inbound" | "outbound";
+  /**
+   * Captured project-inbox alias (e.g. `pnwbio@…`). Used as a fallback
+   * for the outbound From slot when the wire-level `from_header` is
+   * absent — mbox-imported outbound rows have an empty header but a
+   * populated `project_inbox_alias`, and without this fallback their
+   * compact bubble header reads as the operator name instead of the
+   * project. Caller MUST pass null for inbound entries; using the
+   * mailbox alias as a From signal there would flip volunteer replies.
+   */
+  readonly mailboxAlias: string | null;
 }): readonly InboxTimelineEntryParticipantRowViewModel[] {
   const fromEmail =
     participantHeaderEmail(input.item.fromHeader ?? null) ??
     (input.visualDirection === "inbound"
       ? normalizeEmailAddress(input.contactPrimaryEmail)
-      : null);
+      : normalizeEmailAddress(input.mailboxAlias));
   const toEmail = participantHeaderEmail(input.item.toHeader ?? null);
   const fromHeaderDisplayName = participantHeaderLabel(
     input.item.fromHeader ?? null,
@@ -4054,6 +4111,21 @@ async function readInboxDetailCacheData(
         sourceEvidenceIdByCanonicalEventId,
       },
     ),
+    gmailMailboxAliasByCanonicalEventId: new Map(
+      timelinePage.items.flatMap((item) => {
+        const sourceEvidenceId = sourceEvidenceIdByCanonicalEventId.get(
+          item.canonicalEventId,
+        );
+        if (sourceEvidenceId === undefined) {
+          return [];
+        }
+        const detail = gmailDetailBySourceEvidenceId.get(sourceEvidenceId);
+        const alias = normalizeEmailAddress(detail?.projectInboxAlias ?? null);
+        return alias === null
+          ? []
+          : [[item.canonicalEventId, alias] as const];
+      }),
+    ),
     timelinePage: {
       hasMore: timelinePage.hasMore,
       hasHiddenEarlierHistory,
@@ -4679,6 +4751,8 @@ function buildInboxDetailTimelineViewModel(input: {
         input.cachedData.attachmentsByCanonicalEventId,
       inboundAttachmentSignaturesByThread:
         input.cachedData.inboundAttachmentSignaturesByThread,
+      gmailMailboxAliasByCanonicalEventId:
+        input.cachedData.gmailMailboxAliasByCanonicalEventId,
     }),
   );
 

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -4533,6 +4533,32 @@ describe("real inbox selectors", () => {
         fromHeader: null,
         expected: "left" as const,
       },
+      {
+        // Mbox-imported outbound: wire-level fromHeader is empty (the
+        // mbox importer never preserved From), but project_inbox_alias
+        // is populated with the project's alias. Without the
+        // mailbox-alias fallback this row would silently render left.
+        contactId: "contact:mbox-outbound-side",
+        displayName: "Mbox Outbound Side",
+        primaryEmail: "mbox-outbound-side@example.org",
+        direction: "outbound" as const,
+        fromHeader: null,
+        projectInboxAlias: "pnwbio@adventurescientists.org",
+        expected: "right" as const,
+      },
+      {
+        // Mbox-imported inbound: project_inbox_alias is the *recipient*
+        // mailbox, not a sender signal. The fallback MUST be
+        // direction-gated; using the alias for an inbound row would
+        // flip volunteer replies to the right side.
+        contactId: "contact:mbox-inbound-side",
+        displayName: "Mbox Inbound Side",
+        primaryEmail: "mbox-inbound-side@example.org",
+        direction: "inbound" as const,
+        fromHeader: null,
+        projectInboxAlias: "pnwbio@adventurescientists.org",
+        expected: "left" as const,
+      },
     ] as const;
 
     for (const entry of cases) {
@@ -4552,6 +4578,9 @@ describe("real inbox selectors", () => {
         snippet: "Bubble side body.",
         bodyTextPreview: "Bubble side body.",
         fromHeader: entry.fromHeader,
+        ...("projectInboxAlias" in entry
+          ? { projectInboxAlias: entry.projectInboxAlias }
+          : {}),
       });
       await seedInboxProjection(runtime.context, {
         contactId: entry.contactId,


### PR DESCRIPTION
## Summary

Mbox-imported outbound rows (1,389 in production) have an empty `gmail_message_details.from_header` — the mbox importer never preserved the wire-level From — but they DO have `project_inbox_alias` set to the sender's project alias (`pnwbio@`, `forests@`, `orcas@`, `whitebarkpine@`). After PR #500, these still rendered on the left because the bubble resolver only consulted the From header.

This change plumbs a per-canonical-event mailbox-alias map from `readInboxDetailCacheData` down through `buildTimelineEntry` and uses it as a fallback in both [resolveEmailBubbleSide](apps/web/app/inbox/_lib/selectors.ts) and [buildParticipantRows](apps/web/app/inbox/_lib/selectors.ts). Result: mbox-imported outbound rows now render right with the project label in the From slot — visually identical to modern Gmail captures.

### Direction gating

The fallback is gated to **outbound-email entries only**. For inbound rows, `project_inbox_alias` represents the *recipient* mailbox (where the message was received), not a sender signal — using it for inbound would flip volunteer replies to the right side. 928 inbound rows in production also have empty `from_header` and would hit the same bug otherwise.

Both helpers receive `mailboxAlias: null` for inbound entries, and the test suite includes a `contact:mbox-inbound-side` regression case that asserts `sideOfBubble === "left"` to lock this invariant in.

### What stays on the left (D-041)

Personal AS sends (e.g., `Lila Sadler <lila@adventurescientists.org>`) still render left because their `from_header` is populated with a personal email — the fallback only kicks in when the header yields no sender at all.

## Test plan

- [x] `pnpm --filter @as-comms/web test:unit` — 686 pass / 5 skipped (incl. 2 new bubble-side cases)
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm boundaries`
- [x] `CI=true pnpm security` — passes (Vitest allowlist from PR #500 still in place)
- [ ] Post-merge: confirm an mbox-imported outbound from any of the 4 aliased projects renders right in production, with the project label ("PNW Biodiversity") in the From slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)