### PR TITLE
feat(worker/ops): mbox direction misclassification detector (Phase 1, read-only)

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -26,6 +26,7 @@
     "ops:inspect-sf-statuses": "tsx src/ops/cli.ts inspect-sf-expedition-member-statuses",
     "ops:audit-salesforce-task-ingest": "tsx src/ops/audit-salesforce-task-ingest.ts",
     "ops:cleanup-salesforce-owner-scope": "tsx src/ops/cleanup-salesforce-owner-scope.ts",
+    "ops:detect-mbox-direction-misclassification": "tsx src/ops/cli.ts detect-mbox-direction-misclassification",
     "ops:backfill-inbox-projection-coverage": "tsx src/ops/backfill-inbox-projection-coverage.ts",
     "ops:recover-gmail-spam-window": "tsx src/ops/recover-gmail-spam-window.ts",
     "ops:recompute-attachment-decoration": "tsx src/ops/recompute-attachment-decoration.ts",

--- a/apps/worker/src/ops/cli.ts
+++ b/apps/worker/src/ops/cli.ts
@@ -44,6 +44,7 @@ import { runBackfillMailchimpCampaignBodyCommand } from "./backfill-mailchimp-ca
 import { runMailchimpHistoricalCaptureCommand } from "./mailchimp-capture-historical.js";
 import { runCleanupGmailDraftEventsCommand } from "./cleanup-gmail-draft-events.js";
 import { runCleanupSalesforceOwnerScopeCommand } from "./cleanup-salesforce-owner-scope.js";
+import { runDetectMboxDirectionMisclassificationCommand } from "./detect-mbox-direction-misclassification.js";
 import { main as runMergeEmailOnlyIntoSfAnchoredCommand } from "./merge-email-only-into-sf-anchored.js";
 import { runRecoverGmailSpamWindowCommand } from "./recover-gmail-spam-window.js";
 import { runRecomputeAttachmentDecorationCommand } from "./recompute-attachment-decoration.js";
@@ -470,6 +471,9 @@ async function main(): Promise<void> {
     case "cleanup-gmail-draft-events":
       await runCleanupGmailDraftEventsCommand(rest, process.env);
       return;
+    case "detect-mbox-direction-misclassification":
+      await runDetectMboxDirectionMisclassificationCommand(rest, process.env);
+      return;
     case "recover-orphan-gmail-details":
       await runRecoverOrphanGmailDetailsCommand(rest, process.env);
       return;
@@ -511,7 +515,7 @@ async function main(): Promise<void> {
       return;
     default:
       throw new Error(
-        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-membership-sf-ids, backfill-gmail-mbox-bodies, backfill-content-fingerprint, backfill-garbled-message-bodies, re-extract-signed-envelope-bodies, backfill-mailchimp-campaign-body, mailchimp-capture-historical, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, recover-orphan-gmail-details, recover-gmail-spam-window, recompute-attachment-decoration, backfill-canonical-event-audience, reprocess-pending-campaign-sends, dedup-historical-ledger, merge-email-only-into-sf-anchored, reconcile-identity-queue, reconcile-routing-review-queue, reclassify-sf-direction, reconcile-stale-canonical, reconcile-superseded-projections.",
+        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-membership-sf-ids, backfill-gmail-mbox-bodies, backfill-content-fingerprint, backfill-garbled-message-bodies, re-extract-signed-envelope-bodies, backfill-mailchimp-campaign-body, mailchimp-capture-historical, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, detect-mbox-direction-misclassification, recover-orphan-gmail-details, recover-gmail-spam-window, recompute-attachment-decoration, backfill-canonical-event-audience, reprocess-pending-campaign-sends, dedup-historical-ledger, merge-email-only-into-sf-anchored, reconcile-identity-queue, reconcile-routing-review-queue, reclassify-sf-direction, reconcile-stale-canonical, reconcile-superseded-projections.",
       );
   }
 }

--- a/apps/worker/src/ops/detect-mbox-direction-misclassification.ts
+++ b/apps/worker/src/ops/detect-mbox-direction-misclassification.ts
@@ -1,0 +1,662 @@
+#!/usr/bin/env tsx
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+import {
+  and,
+  asc,
+  eq,
+  inArray,
+  isNotNull,
+  like,
+  ne,
+  or,
+  sql,
+} from "drizzle-orm";
+
+import {
+  canonicalEventLedger,
+  closeDatabaseConnection,
+  contactIdentities,
+  contacts,
+  createDatabaseConnection,
+  gmailMessageDetails,
+  projectAliases,
+  type Stage1Database,
+} from "@as-comms/db";
+
+import { parseCliFlags, readRequiredFlag } from "./helpers.js";
+
+type SuggestedDirection =
+  | "inbound"
+  | "outbound"
+  | "unknown"
+  | "no_signal"
+  | "excluded";
+type Confidence = "high" | "medium" | "low";
+
+interface Logger {
+  info(message: string): void;
+  error(message: string): void;
+}
+
+interface CandidateRow {
+  readonly canonicalEventId: string;
+  readonly contactId: string;
+  readonly contactDisplayName: string;
+  readonly capturedMailbox: string;
+  readonly currentDirection: string;
+  readonly occurredAt: string;
+  readonly subject: string | null;
+  readonly bodyTextPreview: string;
+  readonly snippetClean: string;
+}
+
+interface TeamDirectory {
+  readonly projectAliases: readonly string[];
+  readonly teamEmails: readonly string[];
+  readonly teamNameVariants: ReadonlySet<string>;
+}
+
+export interface DirectionReportRow {
+  readonly canonicalEventId: string;
+  readonly contactId: string;
+  readonly contactDisplayName: string;
+  readonly capturedMailbox: string;
+  readonly currentDirection: string;
+  readonly suggestedDirection: SuggestedDirection;
+  readonly confidence: Confidence;
+  readonly signalsMatched: readonly string[];
+  readonly occurredAt: string;
+  readonly subject: string;
+  readonly bodyFirst120Chars: string;
+}
+
+export interface DetectionSummary {
+  readonly candidateRows: number;
+  readonly suggestedOutboundHigh: number;
+  readonly suggestedInboundHigh: number;
+  readonly suggestedOutboundMedium: number;
+  readonly suggestedUnknownLow: number;
+  readonly noSignal: number;
+  readonly campaignAutomatedExcluded: number;
+}
+
+export interface DetectionReport {
+  readonly outputPath: string;
+  readonly summary: DetectionSummary;
+  readonly rows: readonly DirectionReportRow[];
+}
+
+const SIGNATURE_REGION_LENGTH = 400;
+const BODY_PREVIEW_LENGTH = 120;
+const GREETING_SCAN_LENGTH = 30;
+const CAMPAIGN_MARKERS = [
+  "unsubscribe",
+  "view in browser",
+  "[image:",
+  "sent from my iphone",
+  "sent from my ipad",
+  "manage preferences",
+];
+
+function readConnectionString(env: NodeJS.ProcessEnv): string {
+  const connectionString = env.WORKER_DATABASE_URL ?? env.DATABASE_URL;
+
+  if (connectionString === undefined || connectionString.trim().length === 0) {
+    throw new Error(
+      "DATABASE_URL or WORKER_DATABASE_URL is required for Stage 1 ops commands.",
+    );
+  }
+
+  return connectionString.trim();
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/gu, " ").trim();
+}
+
+function normalizeNameToken(value: string): string {
+  return normalizeWhitespace(value)
+    .toLowerCase()
+    .replace(/[^a-z\s'-]/gu, "")
+    .trim();
+}
+
+function buildNameVariants(displayName: string): string[] {
+  const normalized = normalizeNameToken(displayName);
+
+  if (normalized.length === 0) {
+    return [];
+  }
+
+  const variants = new Set<string>([normalized]);
+  const parts = normalized.split(/\s+/u).filter((part) => part.length > 0);
+
+  if (parts[0] !== undefined) {
+    variants.add(parts[0]);
+  }
+
+  return [...variants];
+}
+
+function bodyForClassification(candidate: CandidateRow): string {
+  const preferred = normalizeWhitespace(candidate.bodyTextPreview);
+
+  if (preferred.length > 0) {
+    return preferred;
+  }
+
+  return normalizeWhitespace(candidate.snippetClean);
+}
+
+function extractGreetingName(body: string): string | null {
+  const opening = body.slice(0, GREETING_SCAN_LENGTH);
+  const match = /^\s*(?:hey|hi)\s+([a-z][a-z' -]*)/iu.exec(opening);
+
+  if (match?.[1] === undefined) {
+    return null;
+  }
+
+  return normalizeNameToken(match[1]);
+}
+
+function containsCampaignMarker(bodyLower: string): string | null {
+  for (const marker of CAMPAIGN_MARKERS) {
+    if (bodyLower.includes(marker)) {
+      return marker;
+    }
+  }
+
+  return null;
+}
+
+function containsInternalReference(
+  bodyLower: string,
+  teamEmails: readonly string[],
+): string | null {
+  if (bodyLower.includes("https://www.adventurescientists.org")) {
+    return "internal_url_reference";
+  }
+
+  const matchedTeamEmail = teamEmails.find((teamEmail) =>
+    bodyLower.includes(teamEmail),
+  );
+
+  if (matchedTeamEmail !== undefined) {
+    return `internal_email_reference:${matchedTeamEmail}`;
+  }
+
+  const genericEmailMatch =
+    /\b[a-z0-9._%+-]+@adventurescientists\.org\b/iu.exec(bodyLower);
+
+  if (genericEmailMatch?.[0] !== undefined) {
+    return `internal_email_reference:${genericEmailMatch[0].toLowerCase()}`;
+  }
+
+  return null;
+}
+
+function classifyCandidate(
+  candidate: CandidateRow,
+  directory: TeamDirectory,
+): DirectionReportRow {
+  const body = bodyForClassification(candidate);
+  const bodyLower = body.toLowerCase();
+  const signatureRegion = bodyLower.slice(
+    Math.max(0, bodyLower.length - SIGNATURE_REGION_LENGTH),
+  );
+
+  for (const teamEmail of directory.teamEmails) {
+    if (bodyLower.includes(teamEmail) && signatureRegion.includes(teamEmail)) {
+      return {
+        canonicalEventId: candidate.canonicalEventId,
+        contactId: candidate.contactId,
+        contactDisplayName: candidate.contactDisplayName,
+        capturedMailbox: candidate.capturedMailbox,
+        currentDirection: candidate.currentDirection,
+        suggestedDirection: "outbound",
+        confidence: "high",
+        signalsMatched: [`signature_email:${teamEmail}`],
+        occurredAt: candidate.occurredAt,
+        subject: candidate.subject ?? "",
+        bodyFirst120Chars: body.slice(0, BODY_PREVIEW_LENGTH),
+      };
+    }
+  }
+
+  const greetingName = extractGreetingName(body);
+  if (greetingName !== null) {
+    const contactVariants = buildNameVariants(candidate.contactDisplayName);
+
+    if (contactVariants.includes(greetingName)) {
+      return {
+        canonicalEventId: candidate.canonicalEventId,
+        contactId: candidate.contactId,
+        contactDisplayName: candidate.contactDisplayName,
+        capturedMailbox: candidate.capturedMailbox,
+        currentDirection: candidate.currentDirection,
+        suggestedDirection: "outbound",
+        confidence: "high",
+        signalsMatched: [`greeting_contact:${greetingName}`],
+        occurredAt: candidate.occurredAt,
+        subject: candidate.subject ?? "",
+        bodyFirst120Chars: body.slice(0, BODY_PREVIEW_LENGTH),
+      };
+    }
+
+    if (directory.teamNameVariants.has(greetingName)) {
+      return {
+        canonicalEventId: candidate.canonicalEventId,
+        contactId: candidate.contactId,
+        contactDisplayName: candidate.contactDisplayName,
+        capturedMailbox: candidate.capturedMailbox,
+        currentDirection: candidate.currentDirection,
+        suggestedDirection: "inbound",
+        confidence: "high",
+        signalsMatched: [`greeting_team:${greetingName}`],
+        occurredAt: candidate.occurredAt,
+        subject: candidate.subject ?? "",
+        bodyFirst120Chars: body.slice(0, BODY_PREVIEW_LENGTH),
+      };
+    }
+  }
+
+  const internalReference = containsInternalReference(bodyLower, directory.teamEmails);
+  if (internalReference !== null) {
+    return {
+      canonicalEventId: candidate.canonicalEventId,
+      contactId: candidate.contactId,
+      contactDisplayName: candidate.contactDisplayName,
+      capturedMailbox: candidate.capturedMailbox,
+      currentDirection: candidate.currentDirection,
+      suggestedDirection: "unknown",
+      confidence: "low",
+      signalsMatched: [internalReference],
+      occurredAt: candidate.occurredAt,
+      subject: candidate.subject ?? "",
+      bodyFirst120Chars: body.slice(0, BODY_PREVIEW_LENGTH),
+    };
+  }
+
+  const campaignMarker = containsCampaignMarker(bodyLower);
+  if (campaignMarker !== null) {
+    return {
+      canonicalEventId: candidate.canonicalEventId,
+      contactId: candidate.contactId,
+      contactDisplayName: candidate.contactDisplayName,
+      capturedMailbox: candidate.capturedMailbox,
+      currentDirection: candidate.currentDirection,
+      suggestedDirection: "excluded",
+      confidence: "low",
+      signalsMatched: [`campaign_marker:${campaignMarker}`],
+      occurredAt: candidate.occurredAt,
+      subject: candidate.subject ?? "",
+      bodyFirst120Chars: body.slice(0, BODY_PREVIEW_LENGTH),
+    };
+  }
+
+  return {
+    canonicalEventId: candidate.canonicalEventId,
+    contactId: candidate.contactId,
+    contactDisplayName: candidate.contactDisplayName,
+    capturedMailbox: candidate.capturedMailbox,
+    currentDirection: candidate.currentDirection,
+    suggestedDirection: "no_signal",
+    confidence: "low",
+    signalsMatched: ["no_signal"],
+    occurredAt: candidate.occurredAt,
+    subject: candidate.subject ?? "",
+    bodyFirst120Chars: body.slice(0, BODY_PREVIEW_LENGTH),
+  };
+}
+
+function escapeCsvCell(value: string): string {
+  if (/[",\n\r]/u.test(value)) {
+    return `"${value.replaceAll('"', '""')}"`;
+  }
+
+  return value;
+}
+
+function buildCsv(rows: readonly DirectionReportRow[]): string {
+  const header = [
+    "canonical_event_id",
+    "contact_id",
+    "contact_display_name",
+    "captured_mailbox",
+    "current_direction",
+    "suggested_direction",
+    "confidence",
+    "signals_matched",
+    "occurred_at",
+    "subject",
+    "body_first_120_chars",
+  ];
+  const lines = [header.join(",")];
+
+  for (const row of rows) {
+    lines.push(
+      [
+        row.canonicalEventId,
+        row.contactId,
+        row.contactDisplayName,
+        row.capturedMailbox,
+        row.currentDirection,
+        row.suggestedDirection,
+        row.confidence,
+        row.signalsMatched.join("|"),
+        row.occurredAt,
+        row.subject,
+        row.bodyFirst120Chars,
+      ]
+        .map((value) => escapeCsvCell(value))
+        .join(","),
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function summarizeRows(rows: readonly DirectionReportRow[]): DetectionSummary {
+  let suggestedOutboundHigh = 0;
+  let suggestedInboundHigh = 0;
+  let suggestedOutboundMedium = 0;
+  let suggestedUnknownLow = 0;
+  let noSignal = 0;
+  let campaignAutomatedExcluded = 0;
+
+  for (const row of rows) {
+    if (
+      row.suggestedDirection === "outbound" &&
+      row.confidence === "high"
+    ) {
+      suggestedOutboundHigh += 1;
+      continue;
+    }
+
+    if (row.suggestedDirection === "inbound" && row.confidence === "high") {
+      suggestedInboundHigh += 1;
+      continue;
+    }
+
+    if (
+      row.suggestedDirection === "outbound" &&
+      row.confidence === "medium"
+    ) {
+      suggestedOutboundMedium += 1;
+      continue;
+    }
+
+    if (row.suggestedDirection === "unknown" && row.confidence === "low") {
+      suggestedUnknownLow += 1;
+      continue;
+    }
+
+    if (row.suggestedDirection === "excluded") {
+      campaignAutomatedExcluded += 1;
+      continue;
+    }
+
+    if (row.suggestedDirection === "no_signal") {
+      noSignal += 1;
+    }
+  }
+
+  return {
+    candidateRows: rows.length,
+    suggestedOutboundHigh,
+    suggestedInboundHigh,
+    suggestedOutboundMedium,
+    suggestedUnknownLow,
+    noSignal,
+    campaignAutomatedExcluded,
+  };
+}
+
+async function loadProjectAliases(
+  db: Stage1Database,
+): Promise<readonly string[]> {
+  const rows = await db
+    .select({
+      alias: sql<string>`lower(trim(${projectAliases.alias}))`,
+    })
+    .from(projectAliases)
+    .where(ne(sql`coalesce(trim(${projectAliases.alias}), '')`, sql`''`))
+    .orderBy(asc(projectAliases.alias));
+
+  return Array.from(
+    new Set(
+      rows
+        .map((row) => row.alias.trim())
+        .filter((alias) => alias.length > 0),
+    ),
+  ).sort((left, right) => left.localeCompare(right));
+}
+
+async function loadTeamDirectory(
+  db: Stage1Database,
+  aliases: readonly string[],
+): Promise<TeamDirectory> {
+  const identityRows = await db
+    .select({
+      normalizedValue: contactIdentities.normalizedValue,
+    })
+    .from(contactIdentities)
+    .where(
+      and(
+        eq(contactIdentities.kind, "email"),
+        or(
+          eq(contactIdentities.source, "gmail"),
+          eq(contactIdentities.source, "salesforce"),
+        ),
+        like(contactIdentities.normalizedValue, "%@adventurescientists.org"),
+      ),
+    );
+
+  const contactRows = await db
+    .select({
+      displayName: contacts.displayName,
+      primaryEmail: contacts.primaryEmail,
+    })
+    .from(contacts)
+    .where(
+      and(
+        like(contacts.id, "contact:salesforce:%"),
+        isNotNull(contacts.primaryEmail),
+        like(sql`lower(${contacts.primaryEmail})`, "%@adventurescientists.org"),
+      ),
+    );
+
+  const aliasSet = new Set(aliases.map((alias) => alias.toLowerCase()));
+  const teamEmails = Array.from(
+    new Set(
+      [
+        ...identityRows.map((row) => row.normalizedValue.toLowerCase()),
+        ...contactRows
+          .map((row) => row.primaryEmail?.toLowerCase() ?? "")
+          .filter((email) => email.length > 0),
+      ].filter((email) => !aliasSet.has(email)),
+    ),
+  ).sort((left, right) => left.localeCompare(right));
+
+  const teamNameVariants = new Set<string>();
+  for (const row of contactRows) {
+    for (const variant of buildNameVariants(row.displayName)) {
+      teamNameVariants.add(variant);
+    }
+  }
+
+  return {
+    projectAliases: aliases,
+    teamEmails,
+    teamNameVariants,
+  };
+}
+
+async function loadCandidates(
+  db: Stage1Database,
+  aliases: readonly string[],
+): Promise<readonly CandidateRow[]> {
+  if (aliases.length === 0) {
+    return [];
+  }
+
+  const rows = await db
+    .select({
+      canonicalEventId: canonicalEventLedger.id,
+      contactId: canonicalEventLedger.contactId,
+      contactDisplayName: contacts.displayName,
+      capturedMailbox: gmailMessageDetails.capturedMailbox,
+      currentDirection: gmailMessageDetails.direction,
+      occurredAt: canonicalEventLedger.occurredAt,
+      subject: gmailMessageDetails.subject,
+      bodyTextPreview: gmailMessageDetails.bodyTextPreview,
+      snippetClean: gmailMessageDetails.snippetClean,
+    })
+    .from(gmailMessageDetails)
+    .innerJoin(
+      canonicalEventLedger,
+      eq(canonicalEventLedger.sourceEvidenceId, gmailMessageDetails.sourceEvidenceId),
+    )
+    .innerJoin(contacts, eq(contacts.id, canonicalEventLedger.contactId))
+    .where(
+      and(
+        inArray(gmailMessageDetails.capturedMailbox, [...aliases]),
+        or(
+          sql`${gmailMessageDetails.fromHeader} is null`,
+          eq(gmailMessageDetails.fromHeader, ""),
+        ),
+      ),
+    )
+    .orderBy(asc(canonicalEventLedger.occurredAt), asc(canonicalEventLedger.id));
+
+  return rows.map((row) => ({
+    canonicalEventId: row.canonicalEventId,
+    contactId: row.contactId,
+    contactDisplayName: row.contactDisplayName,
+    capturedMailbox: row.capturedMailbox ?? "",
+    currentDirection: row.currentDirection,
+    occurredAt: row.occurredAt.toISOString(),
+    subject: row.subject,
+    bodyTextPreview: row.bodyTextPreview,
+    snippetClean: row.snippetClean,
+  }));
+}
+
+export async function detectMboxDirectionMisclassification(input: {
+  readonly db: Stage1Database;
+  readonly reportTimestamp: string;
+  readonly outputDir?: string;
+  readonly logger?: Logger;
+}): Promise<DetectionReport> {
+  const logger = input.logger ?? {
+    info(message: string) {
+      console.log(message);
+    },
+    error(message: string) {
+      console.error(message);
+    },
+  };
+  const outputDir = input.outputDir ?? path.resolve(process.cwd(), "tmp");
+  const outputPath = path.join(
+    outputDir,
+    `mbox-direction-report-${input.reportTimestamp}.csv`,
+  );
+
+  const aliases = await loadProjectAliases(input.db);
+  const directory = await loadTeamDirectory(input.db, aliases);
+  const candidates = await loadCandidates(input.db, aliases);
+  const rows = candidates.map((candidate) =>
+    classifyCandidate(candidate, directory),
+  );
+  const summary = summarizeRows(rows);
+
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(outputPath, buildCsv(rows), "utf8");
+
+  logger.info(`[mbox-direction] candidate rows: ${String(summary.candidateRows)}`);
+  logger.info(
+    `[mbox-direction] suggested outbound (high conf): ${String(summary.suggestedOutboundHigh)}`,
+  );
+  logger.info(
+    `[mbox-direction] suggested inbound (high conf): ${String(summary.suggestedInboundHigh)}`,
+  );
+  logger.info(
+    `[mbox-direction] suggested outbound (medium): ${String(summary.suggestedOutboundMedium)}`,
+  );
+  logger.info(
+    `[mbox-direction] suggested unknown (low): ${String(summary.suggestedUnknownLow)}`,
+  );
+  logger.info(`[mbox-direction] no_signal: ${String(summary.noSignal)}`);
+  logger.info(
+    `[mbox-direction] campaign/automated (excluded): ${String(summary.campaignAutomatedExcluded)}`,
+  );
+  logger.info(`[mbox-direction] wrote report to ${outputPath}`);
+
+  return {
+    outputPath,
+    summary,
+    rows,
+  };
+}
+
+export async function runDetectMboxDirectionMisclassificationCommand(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+): Promise<void> {
+  const flags = parseCliFlags(args);
+  const reportTimestamp = readRequiredFlag(flags, "timestamp");
+  const connection = createDatabaseConnection({
+    connectionString: readConnectionString(env),
+  });
+
+  try {
+    await detectMboxDirectionMisclassification({
+      db: connection.db as Stage1Database,
+      reportTimestamp,
+    });
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}
+
+async function main(): Promise<void> {
+  await runDetectMboxDirectionMisclassificationCommand(
+    process.argv.slice(2),
+    process.env,
+  );
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  void main().catch((error: unknown) => {
+    if (error instanceof Error) {
+      console.error("Mbox direction detection failed.");
+      console.error("message:", error.message);
+      const errAny = error as unknown as Record<string, unknown>;
+      for (const key of [
+        "name",
+        "code",
+        "severity",
+        "detail",
+        "hint",
+        "where",
+        "table",
+        "column",
+        "constraint",
+      ]) {
+        if (errAny[key] !== undefined) {
+          console.error(`${key}:`, errAny[key]);
+        }
+      }
+      if (error.cause !== undefined) {
+        console.error("cause:", error.cause);
+      }
+    } else {
+      console.error("Mbox direction detection failed:", error);
+    }
+    process.exitCode = 1;
+  });
+}

--- a/apps/worker/test/detect-mbox-direction-misclassification.test.ts
+++ b/apps/worker/test/detect-mbox-direction-misclassification.test.ts
@@ -1,0 +1,372 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { gmailMessageDetails } from "@as-comms/db";
+import { describe, expect, it } from "vitest";
+
+import { createTestStage1Context } from "./helpers.js";
+import { detectMboxDirectionMisclassification } from "../src/ops/detect-mbox-direction-misclassification.js";
+
+function parseCsv(text: string): Record<string, string>[] {
+  const rows: string[][] = [];
+  let currentCell = "";
+  let currentRow: string[] = [];
+  let inQuotes = false;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    const nextChar = text[index + 1];
+
+    if (char === undefined) {
+      continue;
+    }
+
+    if (char === '"') {
+      if (inQuotes && nextChar === '"') {
+        currentCell += '"';
+        index += 1;
+        continue;
+      }
+
+      inQuotes = !inQuotes;
+      continue;
+    }
+
+    if (!inQuotes && char === ",") {
+      currentRow.push(currentCell);
+      currentCell = "";
+      continue;
+    }
+
+    if (!inQuotes && char === "\n") {
+      currentRow.push(currentCell);
+      rows.push(currentRow);
+      currentCell = "";
+      currentRow = [];
+      continue;
+    }
+
+    if (char !== "\r") {
+      currentCell += char;
+    }
+  }
+
+  if (currentCell.length > 0 || currentRow.length > 0) {
+    currentRow.push(currentCell);
+    rows.push(currentRow);
+  }
+
+  const [header, ...body] = rows;
+  if (header === undefined) {
+    return [];
+  }
+
+  return body
+    .filter((row) => row.length === header.length)
+    .map((row) =>
+      Object.fromEntries(header.map((column, index) => [column, row[index] ?? ""])),
+    );
+}
+
+async function seedContact(
+  context: Awaited<ReturnType<typeof createTestStage1Context>>,
+  input: {
+    readonly id: string;
+    readonly displayName: string;
+    readonly primaryEmail: string | null;
+    readonly salesforceContactId?: string | null;
+  },
+): Promise<void> {
+  await context.repositories.contacts.upsert({
+    id: input.id,
+    displayName: input.displayName,
+    primaryEmail: input.primaryEmail,
+    primaryPhone: null,
+    salesforceContactId: input.salesforceContactId ?? null,
+    createdAt: "2026-06-04T00:00:00.000Z",
+    updatedAt: "2026-06-04T00:00:00.000Z",
+  });
+}
+
+async function seedTeamIdentity(
+  context: Awaited<ReturnType<typeof createTestStage1Context>>,
+  input: {
+    readonly contactId: string;
+    readonly normalizedValue: string;
+  },
+): Promise<void> {
+  await context.repositories.contactIdentities.upsert({
+    id: `identity:${input.contactId}:${input.normalizedValue}`,
+    contactId: input.contactId,
+    kind: "email",
+    normalizedValue: input.normalizedValue,
+    isPrimary: true,
+    source: "salesforce",
+    verifiedAt: "2026-06-04T00:00:00.000Z",
+  });
+}
+
+async function seedProjectAlias(
+  context: Awaited<ReturnType<typeof createTestStage1Context>>,
+  alias: string,
+): Promise<void> {
+  await context.settings.aliases.create({
+    id: `alias:${alias}`,
+    alias,
+    signature: "",
+    projectId: null,
+    createdAt: new Date("2026-06-04T00:00:00.000Z"),
+    updatedAt: new Date("2026-06-04T00:00:00.000Z"),
+    createdBy: null,
+    updatedBy: null,
+  });
+}
+
+async function seedCandidate(
+  context: Awaited<ReturnType<typeof createTestStage1Context>>,
+  input: {
+    readonly canonicalEventId: string;
+    readonly sourceEvidenceId: string;
+    readonly providerRecordId: string;
+    readonly contactId: string;
+    readonly direction: "inbound" | "outbound";
+    readonly bodyTextPreview: string;
+    readonly subject?: string | null;
+    readonly capturedMailbox?: string;
+    readonly fromHeader?: string | null;
+  },
+): Promise<void> {
+  await context.repositories.sourceEvidence.append({
+    id: input.sourceEvidenceId,
+    provider: "gmail",
+    providerRecordType: "message",
+    providerRecordId: input.providerRecordId,
+    payloadRef: `gmail://message/${input.providerRecordId}`,
+    checksum: `checksum:${input.providerRecordId}`,
+    occurredAt: "2026-06-04T00:00:00.000Z",
+    receivedAt: "2026-06-04T00:00:00.000Z",
+    idempotencyKey: `source:${input.providerRecordId}`,
+  });
+
+  await context.repositories.canonicalEvents.upsert({
+    id: input.canonicalEventId,
+    contactId: input.contactId,
+    eventType:
+      input.direction === "inbound"
+        ? "communication.email.inbound"
+        : "communication.email.outbound",
+    channel: "email",
+    occurredAt: "2026-06-04T00:00:00.000Z",
+    contentFingerprint: null,
+    sourceEvidenceId: input.sourceEvidenceId,
+    idempotencyKey: `canonical:${input.canonicalEventId}`,
+    provenance: {
+      primaryProvider: "gmail",
+      primarySourceEvidenceId: input.sourceEvidenceId,
+      supportingSourceEvidenceIds: [],
+      winnerReason: "single_source",
+      sourceRecordType: "message",
+      sourceRecordId: input.providerRecordId,
+      messageKind: "one_to_one",
+      campaignRef: null,
+      threadRef: {
+        crossProviderCollapseKey: `rfc822:<${input.providerRecordId}@example.org>`,
+        providerThreadId: "gmail-thread-1",
+      },
+      direction: input.direction,
+      notes: null,
+    },
+    reviewState: "clear",
+  });
+
+  await context.db.insert(gmailMessageDetails).values({
+    sourceEvidenceId: input.sourceEvidenceId,
+    providerRecordId: input.providerRecordId,
+    gmailThreadId: "gmail-thread-1",
+    rfc822MessageId: `<${input.providerRecordId}@example.org>`,
+    direction: input.direction,
+    subject: input.subject ?? "Test subject",
+    fromHeader: input.fromHeader ?? "",
+    toHeader: "",
+    ccHeader: "",
+    fromEmails: [],
+    toEmails: [],
+    ccEmails: [],
+    bccEmails: [],
+    labelIds: [],
+    snippetClean: input.bodyTextPreview,
+    bodyTextPreview: input.bodyTextPreview,
+    bodyKind: "text/plain",
+    capturedMailbox:
+      input.capturedMailbox ?? "orcas@adventurescientists.org",
+    projectInboxAlias: "orcas@adventurescientists.org",
+    createdAt: new Date("2026-06-04T00:00:00.000Z"),
+    updatedAt: new Date("2026-06-04T00:00:00.000Z"),
+  });
+}
+
+describe("detect-mbox-direction-misclassification", () => {
+  it("classifies blank-from mbox rows across each heuristic branch and writes CSV output", async () => {
+    const context = await createTestStage1Context();
+    const outputDir = await mkdtemp(
+      path.join(os.tmpdir(), "mbox-direction-report-"),
+    );
+
+    try {
+      await seedProjectAlias(context, "orcas@adventurescientists.org");
+
+      await seedContact(context, {
+        id: "contact:salesforce:ricky",
+        displayName: "Ricky",
+        primaryEmail: "ricky@adventurescientists.org",
+        salesforceContactId: "003RICKY",
+      });
+      await seedTeamIdentity(context, {
+        contactId: "contact:salesforce:ricky",
+        normalizedValue: "ricky@adventurescientists.org",
+      });
+
+      await seedContact(context, {
+        id: "contact:external:crystal",
+        displayName: "Crystal Roy",
+        primaryEmail: "crystal@example.org",
+      });
+      await seedContact(context, {
+        id: "contact:external:pat",
+        displayName: "Pat Client",
+        primaryEmail: "pat@example.org",
+      });
+      await seedContact(context, {
+        id: "contact:external:url",
+        displayName: "URL Contact",
+        primaryEmail: "url@example.org",
+      });
+      await seedContact(context, {
+        id: "contact:external:campaign",
+        displayName: "Campaign Contact",
+        primaryEmail: "campaign@example.org",
+      });
+      await seedContact(context, {
+        id: "contact:external:nosignal",
+        displayName: "No Signal",
+        primaryEmail: "nosignal@example.org",
+      });
+      await seedContact(context, {
+        id: "contact:external:ignored",
+        displayName: "Ignored Contact",
+        primaryEmail: "ignored@example.org",
+      });
+
+      await seedCandidate(context, {
+        canonicalEventId: "canonical:signature",
+        sourceEvidenceId: "source:signature",
+        providerRecordId: "message-signature",
+        contactId: "contact:external:crystal",
+        direction: "inbound",
+        bodyTextPreview:
+          "Thanks for helping.\nBest,\nRicky\nricky@adventurescientists.org",
+      });
+      await seedCandidate(context, {
+        canonicalEventId: "canonical:greeting-contact",
+        sourceEvidenceId: "source:greeting-contact",
+        providerRecordId: "message-greeting-contact",
+        contactId: "contact:external:crystal",
+        direction: "inbound",
+        bodyTextPreview: "Hey Crystal, congratulations on getting out there.",
+      });
+      await seedCandidate(context, {
+        canonicalEventId: "canonical:greeting-team",
+        sourceEvidenceId: "source:greeting-team",
+        providerRecordId: "message-greeting-team",
+        contactId: "contact:external:pat",
+        direction: "outbound",
+        bodyTextPreview: "Hi Ricky, thanks for the update from the field.",
+      });
+      await seedCandidate(context, {
+        canonicalEventId: "canonical:url",
+        sourceEvidenceId: "source:url",
+        providerRecordId: "message-url",
+        contactId: "contact:external:url",
+        direction: "inbound",
+        bodyTextPreview:
+          "Learn more at https://www.adventurescientists.org/contact",
+      });
+      await seedCandidate(context, {
+        canonicalEventId: "canonical:campaign",
+        sourceEvidenceId: "source:campaign",
+        providerRecordId: "message-campaign",
+        contactId: "contact:external:campaign",
+        direction: "inbound",
+        bodyTextPreview: "View in browser\nunsubscribe\n[image: logo]",
+      });
+      await seedCandidate(context, {
+        canonicalEventId: "canonical:no-signal",
+        sourceEvidenceId: "source:no-signal",
+        providerRecordId: "message-no-signal",
+        contactId: "contact:external:nosignal",
+        direction: "outbound",
+        bodyTextPreview: "Checking in about the trailhead schedule.",
+      });
+      await seedCandidate(context, {
+        canonicalEventId: "canonical:ignored",
+        sourceEvidenceId: "source:ignored",
+        providerRecordId: "message-ignored",
+        contactId: "contact:external:ignored",
+        direction: "inbound",
+        bodyTextPreview: "Hey Ignored, this should not be scanned.",
+        fromHeader: "ignored@example.org",
+      });
+
+      const result = await detectMboxDirectionMisclassification({
+        db: context.db,
+        reportTimestamp: "2026-06-04T12-00-00.000Z",
+        outputDir,
+      });
+
+      expect(result.summary).toMatchObject({
+        candidateRows: 6,
+        suggestedOutboundHigh: 2,
+        suggestedInboundHigh: 1,
+        suggestedOutboundMedium: 0,
+        suggestedUnknownLow: 1,
+        noSignal: 1,
+        campaignAutomatedExcluded: 1,
+      });
+
+      const csvRows = parseCsv(await readFile(result.outputPath, "utf8"));
+      const byCanonicalEventId = new Map(
+        csvRows.map((row) => [row.canonical_event_id, row] as const),
+      );
+
+      expect(byCanonicalEventId.get("canonical:signature")).toMatchObject({
+        suggested_direction: "outbound",
+        confidence: "high",
+      });
+      expect(byCanonicalEventId.get("canonical:greeting-contact")).toMatchObject({
+        suggested_direction: "outbound",
+        confidence: "high",
+      });
+      expect(byCanonicalEventId.get("canonical:greeting-team")).toMatchObject({
+        suggested_direction: "inbound",
+        confidence: "high",
+      });
+      expect(byCanonicalEventId.get("canonical:url")).toMatchObject({
+        suggested_direction: "unknown",
+        confidence: "low",
+      });
+      expect(byCanonicalEventId.get("canonical:campaign")).toMatchObject({
+        suggested_direction: "excluded",
+        confidence: "low",
+      });
+      expect(byCanonicalEventId.get("canonical:no-signal")).toMatchObject({
+        suggested_direction: "no_signal",
+        confidence: "low",
+      });
+      expect(byCanonicalEventId.has("canonical:ignored")).toBe(false);
+    } finally {
+      await rm(outputDir, { recursive: true, force: true });
+      await context.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of a two-phase backfill for mbox-import data damage. Detection only — no writes to production. Produces a CSV that the architect reviews before drafting the Phase 2 apply script.

**Scope**: 2,317 of 3,709 `gmail_message_details` rows (62%) have blank `from_header`, almost all from mbox-imported mailboxes (`pnwbio@`, `whitebarkpine@`, `orcas@`). The `direction` column is unreliable on these — Florence thread is the canonical reproduction: 4 messages all stored as inbound, 2 are clearly outbound from Ricky/orcas@ based on body content.

**Approach**: ops script with body-content heuristics, ranked by confidence. Read-only against prod.

| Tier | Signal | Suggestion |
|---|---|---|
| high | Team-email signature in last 400 chars of body | outbound |
| high | "Hey/Hi <contact-name>" greeting | outbound |
| high | "Hey/Hi <team-member-name>" greeting | inbound |
| low | Bare @adventurescientists.org URL or domain reference | unknown |
| low | Campaign markers (unsubscribe, [image:, view in browser) | excluded |
| – | No match | no_signal |

## How to run

```
pnpm --filter @as-comms/worker ops:detect-mbox-direction-misclassification --report-timestamp=2026-06-03T22:00:00.000Z
```

Output: `tmp/mbox-direction-report-2026-06-03T22:00:00.000Z.csv` + stdout tier counts.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm boundaries` — all green locally
- [x] New PGlite integration test seeds rows for every heuristic branch + asserts CSV output
- [ ] CI green
- [ ] After merge: architect runs the script against prod, reviews CSV, drafts Phase 2 brief

## Phase 2 (not in this PR)

The follow-up `apply-mbox-direction-backfill` brief reads the operator-approved CSV and applies flips to `gmail_message_details.direction` + `canonical_event_ledger.event_type` + projection rebuild. Drafted only after this Phase 1 output is reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)