### PR TITLE
feat(worker/ops): mbox direction backfill — apply (Phase 2)

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -27,6 +27,7 @@
     "ops:audit-salesforce-task-ingest": "tsx src/ops/audit-salesforce-task-ingest.ts",
     "ops:cleanup-salesforce-owner-scope": "tsx src/ops/cleanup-salesforce-owner-scope.ts",
     "ops:detect-mbox-direction-misclassification": "tsx src/ops/cli.ts detect-mbox-direction-misclassification",
+    "ops:apply-mbox-direction-backfill": "tsx src/ops/cli.ts apply-mbox-direction-backfill",
     "ops:backfill-inbox-projection-coverage": "tsx src/ops/backfill-inbox-projection-coverage.ts",
     "ops:recover-gmail-spam-window": "tsx src/ops/recover-gmail-spam-window.ts",
     "ops:recompute-attachment-decoration": "tsx src/ops/recompute-attachment-decoration.ts",

--- a/apps/worker/src/ops/apply-mbox-direction-backfill.ts
+++ b/apps/worker/src/ops/apply-mbox-direction-backfill.ts
@@ -1,0 +1,380 @@
+#!/usr/bin/env tsx
+import { readFile } from "node:fs/promises";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+import { eq } from "drizzle-orm";
+
+import {
+  canonicalEventLedger,
+  closeDatabaseConnection,
+  createDatabaseConnection,
+  createStage1RepositoryBundle,
+  gmailMessageDetails,
+  type Stage1Database,
+} from "@as-comms/db";
+import {
+  createStage1PersistenceService,
+  rebuildInboxProjectionForContact,
+} from "@as-comms/domain";
+
+import { parseCliFlags, readOptionalBooleanFlag, readRequiredFlag } from "./helpers.js";
+
+interface Logger {
+  log(message: string): void;
+  error(message: string): void;
+}
+
+interface ApplyCsvRow {
+  readonly canonicalEventId: string;
+  readonly sourceEvidenceId: string | null;
+  readonly currentDirection: string;
+  readonly suggestedDirection: string;
+  readonly confidence: string;
+}
+
+interface LiveCandidateState {
+  readonly canonicalEventId: string;
+  readonly contactId: string;
+  readonly sourceEvidenceId: string;
+  readonly direction: string | null;
+  readonly eventType: string;
+}
+
+export interface ApplyMboxDirectionBackfillResult {
+  readonly csvRowsConsidered: number;
+  readonly flipped: number;
+  readonly skippedAlreadyOutbound: number;
+  readonly skippedFilterMismatch: number;
+  readonly skippedUnexpectedState: number;
+  readonly contactsAffected: number;
+  readonly projectionsRebuilt: number;
+  readonly dryRun: boolean;
+}
+
+function readConnectionString(env: NodeJS.ProcessEnv): string {
+  const connectionString = env.WORKER_DATABASE_URL ?? env.DATABASE_URL;
+
+  if (connectionString === undefined || connectionString.trim().length === 0) {
+    throw new Error(
+      "DATABASE_URL or WORKER_DATABASE_URL is required for this ops command.",
+    );
+  }
+
+  return connectionString.trim();
+}
+
+function parseCsv(text: string): Record<string, string>[] {
+  const rows: string[][] = [];
+  let currentCell = "";
+  let currentRow: string[] = [];
+  let inQuotes = false;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    const nextChar = text[index + 1];
+
+    if (char === undefined) {
+      continue;
+    }
+
+    if (char === '"') {
+      if (inQuotes && nextChar === '"') {
+        currentCell += '"';
+        index += 1;
+        continue;
+      }
+
+      inQuotes = !inQuotes;
+      continue;
+    }
+
+    if (!inQuotes && char === ",") {
+      currentRow.push(currentCell);
+      currentCell = "";
+      continue;
+    }
+
+    if (!inQuotes && char === "\n") {
+      currentRow.push(currentCell);
+      rows.push(currentRow);
+      currentCell = "";
+      currentRow = [];
+      continue;
+    }
+
+    if (char !== "\r") {
+      currentCell += char;
+    }
+  }
+
+  if (currentCell.length > 0 || currentRow.length > 0) {
+    currentRow.push(currentCell);
+    rows.push(currentRow);
+  }
+
+  const [header, ...body] = rows;
+
+  if (header === undefined) {
+    return [];
+  }
+
+  return body
+    .filter((row) => row.length === header.length)
+    .map((row) =>
+      Object.fromEntries(header.map((column, index) => [column, row[index] ?? ""])),
+    );
+}
+
+function readRequiredCsvCell(row: Record<string, string>, key: string): string {
+  const value = row[key];
+
+  if (value === undefined || value.trim().length === 0) {
+    throw new Error(`CSV row is missing required column ${key}.`);
+  }
+
+  return value.trim();
+}
+
+function parseApplyCsvRow(row: Record<string, string>): ApplyCsvRow {
+  const sourceEvidenceId = row.source_evidence_id?.trim();
+
+  return {
+    canonicalEventId: readRequiredCsvCell(row, "canonical_event_id"),
+    sourceEvidenceId:
+      sourceEvidenceId === undefined || sourceEvidenceId.length === 0
+        ? null
+        : sourceEvidenceId,
+    currentDirection: readRequiredCsvCell(row, "current_direction"),
+    suggestedDirection: readRequiredCsvCell(row, "suggested_direction"),
+    confidence: readRequiredCsvCell(row, "confidence"),
+  };
+}
+
+function buildFilterMismatchReason(row: ApplyCsvRow): string {
+  return `filter mismatch: suggested_direction=${row.suggestedDirection}, confidence=${row.confidence}, current_direction=${row.currentDirection}`;
+}
+
+async function loadLiveCandidateState(
+  db: Stage1Database,
+  row: ApplyCsvRow,
+): Promise<LiveCandidateState | null> {
+  const [ledgerRow] = await db
+    .select({
+      canonicalEventId: canonicalEventLedger.id,
+      contactId: canonicalEventLedger.contactId,
+      sourceEvidenceId: canonicalEventLedger.sourceEvidenceId,
+      eventType: canonicalEventLedger.eventType,
+    })
+    .from(canonicalEventLedger)
+    .where(eq(canonicalEventLedger.id, row.canonicalEventId));
+
+  if (ledgerRow === undefined) {
+    return null;
+  }
+
+  const [gmailDetail] = await db
+    .select({
+      direction: gmailMessageDetails.direction,
+    })
+    .from(gmailMessageDetails)
+    .where(eq(gmailMessageDetails.sourceEvidenceId, ledgerRow.sourceEvidenceId));
+
+  return {
+    canonicalEventId: ledgerRow.canonicalEventId,
+    contactId: ledgerRow.contactId,
+    sourceEvidenceId: ledgerRow.sourceEvidenceId,
+    direction: gmailDetail?.direction ?? null,
+    eventType: ledgerRow.eventType,
+  };
+}
+
+function logSummary(
+  logger: Logger,
+  result: ApplyMboxDirectionBackfillResult,
+): void {
+  logger.log(`[apply] CSV rows considered: ${String(result.csvRowsConsidered)}`);
+  logger.log(`[apply] flipped: ${String(result.flipped)}`);
+  logger.log(
+    `[apply] skipped (already outbound): ${String(result.skippedAlreadyOutbound)}`,
+  );
+  logger.log(
+    `[apply] skipped (filter mismatch): ${String(result.skippedFilterMismatch)}`,
+  );
+  logger.log(
+    `[apply] skipped (unexpected state): ${String(result.skippedUnexpectedState)}`,
+  );
+  logger.log(`[apply] contacts affected: ${String(result.contactsAffected)}`);
+  logger.log(`[apply] projections rebuilt: ${String(result.projectionsRebuilt)}`);
+
+  if (result.dryRun) {
+    logger.log("[apply] DRY RUN - no changes persisted");
+  }
+}
+
+export async function applyMboxDirectionBackfill(input: {
+  readonly db: Stage1Database;
+  readonly csvPath: string;
+  readonly dryRun: boolean;
+  readonly logger?: Logger;
+}): Promise<ApplyMboxDirectionBackfillResult> {
+  const logger = input.logger ?? {
+    log(message: string) {
+      console.log(message);
+    },
+    error(message: string) {
+      console.error(message);
+    },
+  };
+  const repositories = createStage1RepositoryBundle(input.db);
+  const persistence = createStage1PersistenceService(repositories);
+  const csvText = await readFile(input.csvPath, "utf8");
+  const csvRows = parseCsv(csvText).map(parseApplyCsvRow);
+  const affectedContactIds = new Set<string>();
+  let flipped = 0;
+  let skippedAlreadyOutbound = 0;
+  let skippedFilterMismatch = 0;
+  let skippedUnexpectedState = 0;
+
+  for (const row of csvRows) {
+    const matchesFilter =
+      row.suggestedDirection === "outbound" &&
+      row.confidence === "high" &&
+      row.currentDirection === "inbound";
+
+    if (!matchesFilter) {
+      skippedFilterMismatch += 1;
+      logger.log(
+        `[apply] skip event=${row.canonicalEventId} reason=${buildFilterMismatchReason(row)}`,
+      );
+      continue;
+    }
+
+    const liveState = await loadLiveCandidateState(input.db, row);
+
+    if (liveState === null) {
+      skippedUnexpectedState += 1;
+      logger.log(
+        `[apply] event=${row.canonicalEventId} skipped (unexpected state: direction=null, event_type=null)`,
+      );
+      continue;
+    }
+
+    if (
+      liveState.direction === "outbound" ||
+      liveState.eventType.endsWith(".outbound")
+    ) {
+      skippedAlreadyOutbound += 1;
+      logger.log(`[apply] event=${row.canonicalEventId} skipped (already outbound)`);
+      continue;
+    }
+
+    if (
+      liveState.direction !== "inbound" ||
+      !liveState.eventType.endsWith(".inbound")
+    ) {
+      skippedUnexpectedState += 1;
+      logger.log(
+        `[apply] event=${row.canonicalEventId} skipped (unexpected state: direction=${liveState.direction ?? "null"}, event_type=${liveState.eventType})`,
+      );
+      continue;
+    }
+
+    if (!input.dryRun) {
+      const updatedAt = new Date();
+
+      await input.db.transaction(async (tx) => {
+        await tx
+          .update(gmailMessageDetails)
+          .set({
+            direction: "outbound",
+            updatedAt,
+          })
+          .where(eq(gmailMessageDetails.sourceEvidenceId, liveState.sourceEvidenceId));
+
+        await tx
+          .update(canonicalEventLedger)
+          .set({
+            eventType: "communication.email.outbound",
+            updatedAt,
+          })
+          .where(eq(canonicalEventLedger.id, liveState.canonicalEventId));
+      });
+
+      logger.log(
+        `[apply] event=${row.canonicalEventId} flipped inbound->outbound contact=${liveState.contactId}`,
+      );
+    } else {
+      logger.log(
+        `[apply] event=${row.canonicalEventId} would flip inbound->outbound contact=${liveState.contactId}`,
+      );
+    }
+
+    flipped += 1;
+    affectedContactIds.add(liveState.contactId);
+  }
+
+  let projectionsRebuilt = 0;
+  const dedupedContactIds = [...affectedContactIds].sort((left, right) =>
+    left.localeCompare(right),
+  );
+
+  if (!input.dryRun) {
+    for (const [index, contactId] of dedupedContactIds.entries()) {
+      await rebuildInboxProjectionForContact(persistence, contactId);
+      projectionsRebuilt += 1;
+      logger.log(
+        `[apply] rebuilt projection for contact=${contactId} (${String(index + 1)} of ${String(dedupedContactIds.length)})`,
+      );
+    }
+  }
+
+  const result: ApplyMboxDirectionBackfillResult = {
+    csvRowsConsidered: csvRows.length,
+    flipped,
+    skippedAlreadyOutbound,
+    skippedFilterMismatch,
+    skippedUnexpectedState,
+    contactsAffected: dedupedContactIds.length,
+    projectionsRebuilt,
+    dryRun: input.dryRun,
+  };
+
+  logSummary(logger, result);
+  return result;
+}
+
+export async function runApplyMboxDirectionBackfillCommand(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<ApplyMboxDirectionBackfillResult> {
+  const flags = parseCliFlags(args);
+  const csvPath = readRequiredFlag(flags, "csv-path");
+  const dryRun = readOptionalBooleanFlag(flags, "dry-run", false);
+  const connection = createDatabaseConnection({
+    connectionString: readConnectionString(env),
+  });
+
+  try {
+    return await applyMboxDirectionBackfill({
+      db: connection.db as Stage1Database,
+      csvPath,
+      dryRun,
+    });
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  void runApplyMboxDirectionBackfillCommand(process.argv.slice(2)).catch(
+    (error: unknown) => {
+      const resolvedError =
+        error instanceof Error ? error : new Error(String(error));
+
+      console.error(`[apply:fatal] ${resolvedError.message}`);
+      console.error(resolvedError.stack ?? "(no stack)");
+      process.exitCode = 1;
+    },
+  );
+}

--- a/apps/worker/src/ops/cli.ts
+++ b/apps/worker/src/ops/cli.ts
@@ -45,6 +45,7 @@ import { runMailchimpHistoricalCaptureCommand } from "./mailchimp-capture-histor
 import { runCleanupGmailDraftEventsCommand } from "./cleanup-gmail-draft-events.js";
 import { runCleanupSalesforceOwnerScopeCommand } from "./cleanup-salesforce-owner-scope.js";
 import { runDetectMboxDirectionMisclassificationCommand } from "./detect-mbox-direction-misclassification.js";
+import { runApplyMboxDirectionBackfillCommand } from "./apply-mbox-direction-backfill.js";
 import { main as runMergeEmailOnlyIntoSfAnchoredCommand } from "./merge-email-only-into-sf-anchored.js";
 import { runRecoverGmailSpamWindowCommand } from "./recover-gmail-spam-window.js";
 import { runRecomputeAttachmentDecorationCommand } from "./recompute-attachment-decoration.js";
@@ -475,6 +476,9 @@ async function main(): Promise<void> {
     case "detect-mbox-direction-misclassification":
       await runDetectMboxDirectionMisclassificationCommand(rest, process.env);
       return;
+    case "apply-mbox-direction-backfill":
+      await runApplyMboxDirectionBackfillCommand(rest, process.env);
+      return;
     case "recover-orphan-gmail-details":
       await runRecoverOrphanGmailDetailsCommand(rest, process.env);
       return;
@@ -519,7 +523,7 @@ async function main(): Promise<void> {
       return;
     default:
       throw new Error(
-        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-membership-sf-ids, backfill-gmail-mbox-bodies, backfill-content-fingerprint, backfill-garbled-message-bodies, re-extract-signed-envelope-bodies, backfill-mailchimp-campaign-body, mailchimp-capture-historical, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, detect-mbox-direction-misclassification, recover-orphan-gmail-details, recover-gmail-spam-window, recompute-attachment-decoration, rebuild-inbox-projection-stuck-on-new, backfill-canonical-event-audience, reprocess-pending-campaign-sends, dedup-historical-ledger, merge-email-only-into-sf-anchored, reconcile-identity-queue, reconcile-routing-review-queue, reclassify-sf-direction, reconcile-stale-canonical, reconcile-superseded-projections.",
+        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-membership-sf-ids, backfill-gmail-mbox-bodies, backfill-content-fingerprint, backfill-garbled-message-bodies, re-extract-signed-envelope-bodies, backfill-mailchimp-campaign-body, mailchimp-capture-historical, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, detect-mbox-direction-misclassification, apply-mbox-direction-backfill, recover-orphan-gmail-details, recover-gmail-spam-window, recompute-attachment-decoration, rebuild-inbox-projection-stuck-on-new, backfill-canonical-event-audience, reprocess-pending-campaign-sends, dedup-historical-ledger, merge-email-only-into-sf-anchored, reconcile-identity-queue, reconcile-routing-review-queue, reclassify-sf-direction, reconcile-stale-canonical, reconcile-superseded-projections.",
       );
   }
 }

--- a/apps/worker/test/apply-mbox-direction-backfill.test.ts
+++ b/apps/worker/test/apply-mbox-direction-backfill.test.ts
@@ -1,0 +1,519 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { eq } from "drizzle-orm";
+import {
+  canonicalEventLedger,
+  gmailMessageDetails,
+} from "@as-comms/db";
+import { describe, expect, it } from "vitest";
+
+import { applyMboxDirectionBackfill } from "../src/ops/apply-mbox-direction-backfill.js";
+import { createTestWorkerContext, type TestWorkerContext } from "./helpers.js";
+
+interface TestLogger {
+  readonly lines: string[];
+  readonly logger: {
+    log(message: string): void;
+    error(message: string): void;
+  };
+}
+
+function createLogger(): TestLogger {
+  const lines: string[] = [];
+
+  return {
+    lines,
+    logger: {
+      log(message: string) {
+        lines.push(message);
+      },
+      error(message: string) {
+        lines.push(message);
+      },
+    },
+  };
+}
+
+async function seedContact(input: {
+  readonly context: TestWorkerContext;
+  readonly contactId: string;
+  readonly email: string;
+  readonly displayName: string;
+}): Promise<void> {
+  await input.context.normalization.upsertNormalizedContactGraph({
+    contact: {
+      id: input.contactId,
+      salesforceContactId: null,
+      displayName: input.displayName,
+      primaryEmail: input.email,
+      primaryPhone: null,
+      createdAt: "2026-06-01T00:00:00.000Z",
+      updatedAt: "2026-06-01T00:00:00.000Z",
+    },
+    identities: [
+      {
+        id: `identity:${input.contactId}:email`,
+        contactId: input.contactId,
+        kind: "email",
+        normalizedValue: input.email,
+        isPrimary: true,
+        source: "salesforce",
+        verifiedAt: "2026-06-01T00:00:00.000Z",
+      },
+    ],
+    memberships: [],
+  });
+}
+
+async function seedMisclassifiedOutbound(input: {
+  readonly context: TestWorkerContext;
+  readonly key: string;
+  readonly contactId: string;
+  readonly occurredAt: string;
+}): Promise<{
+  readonly canonicalEventId: string;
+  readonly sourceEvidenceId: string;
+}> {
+  const sourceEvidenceId = `sev:${input.key}`;
+  const canonicalEventId = `event:${input.key}`;
+
+  await input.context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "gmail",
+    providerRecordType: "message",
+    providerRecordId: `gmail:${input.key}`,
+    receivedAt: input.occurredAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `gmail://message/${input.key}`,
+    idempotencyKey: `source-evidence:${input.key}`,
+    checksum: `checksum:${input.key}`,
+  });
+
+  await input.context.repositories.canonicalEvents.upsert({
+    id: canonicalEventId,
+    contactId: input.contactId,
+    eventType: "communication.email.inbound",
+    channel: "email",
+    occurredAt: input.occurredAt,
+    contentFingerprint: null,
+    sourceEvidenceId,
+    idempotencyKey: `canonical:${input.key}`,
+    provenance: {
+      primaryProvider: "gmail",
+      primarySourceEvidenceId: sourceEvidenceId,
+      supportingSourceEvidenceIds: [],
+      winnerReason: "single_source",
+      sourceRecordType: "message",
+      sourceRecordId: `gmail:${input.key}`,
+      messageKind: "one_to_one",
+      campaignRef: null,
+      threadRef: {
+        crossProviderCollapseKey: `rfc822:<${input.key}@example.org>`,
+        providerThreadId: `thread:${input.key}`,
+      },
+      direction: "inbound",
+      notes: null,
+    },
+    reviewState: "clear",
+  });
+
+  await input.context.repositories.gmailMessageDetails.upsert({
+    sourceEvidenceId,
+    providerRecordId: `gmail:${input.key}`,
+    gmailThreadId: `thread:${input.key}`,
+    rfc822MessageId: `<${input.key}@example.org>`,
+    direction: "inbound",
+    subject: `Subject ${input.key}`,
+    fromHeader: "Inbox <orcas@adventurescientists.org>",
+    toHeader: "Inbox <orcas@adventurescientists.org>",
+    ccHeader: null,
+    fromEmails: [],
+    toEmails: ["orcas@adventurescientists.org"],
+    ccEmails: [],
+    bccEmails: [],
+    labelIds: ["INBOX"],
+    snippetClean: `Snippet ${input.key}`,
+    bodyTextPreview: `Hi there from ${input.key}`,
+    bodyKind: "plaintext",
+    capturedMailbox: "volunteers@adventurescientists.org",
+    projectInboxAlias: "orcas@adventurescientists.org",
+  });
+
+  return {
+    canonicalEventId,
+    sourceEvidenceId,
+  };
+}
+
+async function writeCsv(input: {
+  readonly rows: readonly {
+    readonly canonicalEventId: string;
+    readonly sourceEvidenceId: string;
+    readonly currentDirection: string;
+    readonly suggestedDirection: string;
+    readonly confidence: string;
+  }[];
+}): Promise<{
+  readonly dir: string;
+  readonly path: string;
+}> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "apply-mbox-direction-"));
+  const csvPath = path.join(dir, "report.csv");
+  const header =
+    "canonical_event_id,source_evidence_id,current_direction,suggested_direction,confidence\n";
+  const body = input.rows
+    .map(
+      (row) =>
+        `${row.canonicalEventId},${row.sourceEvidenceId},${row.currentDirection},${row.suggestedDirection},${row.confidence}`,
+    )
+    .join("\n");
+
+  await writeFile(csvPath, `${header}${body}\n`, "utf8");
+
+  return {
+    dir,
+    path: csvPath,
+  };
+}
+
+async function readDirection(
+  context: TestWorkerContext,
+  sourceEvidenceId: string,
+): Promise<string | null> {
+  const [row] = await context.db
+    .select({
+      direction: gmailMessageDetails.direction,
+    })
+    .from(gmailMessageDetails)
+    .where(eq(gmailMessageDetails.sourceEvidenceId, sourceEvidenceId));
+
+  return row?.direction ?? null;
+}
+
+async function readEventType(
+  context: TestWorkerContext,
+  canonicalEventId: string,
+): Promise<string | null> {
+  const [row] = await context.db
+    .select({
+      eventType: canonicalEventLedger.eventType,
+    })
+    .from(canonicalEventLedger)
+    .where(eq(canonicalEventLedger.id, canonicalEventId));
+
+  return row?.eventType ?? null;
+}
+
+describe("apply-mbox-direction-backfill", () => {
+  it("flips misclassified rows and rebuilds inbox projections for affected contacts", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact({
+        context,
+        contactId: "contact:one",
+        email: "one@example.org",
+        displayName: "Contact One",
+      });
+      await seedContact({
+        context,
+        contactId: "contact:two",
+        email: "two@example.org",
+        displayName: "Contact Two",
+      });
+
+      const first = await seedMisclassifiedOutbound({
+        context,
+        key: "one",
+        contactId: "contact:one",
+        occurredAt: "2026-06-03T10:00:00.000Z",
+      });
+      const second = await seedMisclassifiedOutbound({
+        context,
+        key: "two",
+        contactId: "contact:two",
+        occurredAt: "2026-06-03T11:00:00.000Z",
+      });
+      const csv = await writeCsv({
+        rows: [
+          {
+            canonicalEventId: first.canonicalEventId,
+            sourceEvidenceId: first.sourceEvidenceId,
+            currentDirection: "inbound",
+            suggestedDirection: "outbound",
+            confidence: "high",
+          },
+          {
+            canonicalEventId: second.canonicalEventId,
+            sourceEvidenceId: second.sourceEvidenceId,
+            currentDirection: "inbound",
+            suggestedDirection: "outbound",
+            confidence: "high",
+          },
+        ],
+      });
+
+      try {
+        const result = await applyMboxDirectionBackfill({
+          db: context.db,
+          csvPath: csv.path,
+          dryRun: false,
+          logger: createLogger().logger,
+        });
+
+        expect(result).toMatchObject({
+          csvRowsConsidered: 2,
+          flipped: 2,
+          skippedAlreadyOutbound: 0,
+          skippedFilterMismatch: 0,
+          skippedUnexpectedState: 0,
+          contactsAffected: 2,
+          projectionsRebuilt: 2,
+          dryRun: false,
+        });
+      } finally {
+        await rm(csv.dir, { recursive: true, force: true });
+      }
+
+      await expect(readDirection(context, first.sourceEvidenceId)).resolves.toBe(
+        "outbound",
+      );
+      await expect(readDirection(context, second.sourceEvidenceId)).resolves.toBe(
+        "outbound",
+      );
+      await expect(readEventType(context, first.canonicalEventId)).resolves.toBe(
+        "communication.email.outbound",
+      );
+      await expect(readEventType(context, second.canonicalEventId)).resolves.toBe(
+        "communication.email.outbound",
+      );
+
+      const firstProjection =
+        await context.repositories.inboxProjection.findByContactId("contact:one");
+      const secondProjection =
+        await context.repositories.inboxProjection.findByContactId("contact:two");
+
+      expect(firstProjection?.lastOutboundAt).toBe("2026-06-03T10:00:00.000Z");
+      expect(secondProjection?.lastOutboundAt).toBe("2026-06-03T11:00:00.000Z");
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("is idempotent when the same CSV is applied twice", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact({
+        context,
+        contactId: "contact:one",
+        email: "one@example.org",
+        displayName: "Contact One",
+      });
+      await seedContact({
+        context,
+        contactId: "contact:two",
+        email: "two@example.org",
+        displayName: "Contact Two",
+      });
+
+      const first = await seedMisclassifiedOutbound({
+        context,
+        key: "one",
+        contactId: "contact:one",
+        occurredAt: "2026-06-03T10:00:00.000Z",
+      });
+      const second = await seedMisclassifiedOutbound({
+        context,
+        key: "two",
+        contactId: "contact:two",
+        occurredAt: "2026-06-03T11:00:00.000Z",
+      });
+      const csv = await writeCsv({
+        rows: [
+          {
+            canonicalEventId: first.canonicalEventId,
+            sourceEvidenceId: first.sourceEvidenceId,
+            currentDirection: "inbound",
+            suggestedDirection: "outbound",
+            confidence: "high",
+          },
+          {
+            canonicalEventId: second.canonicalEventId,
+            sourceEvidenceId: second.sourceEvidenceId,
+            currentDirection: "inbound",
+            suggestedDirection: "outbound",
+            confidence: "high",
+          },
+        ],
+      });
+
+      try {
+        await applyMboxDirectionBackfill({
+          db: context.db,
+          csvPath: csv.path,
+          dryRun: false,
+          logger: createLogger().logger,
+        });
+
+        const secondRunLogger = createLogger();
+        const secondRun = await applyMboxDirectionBackfill({
+          db: context.db,
+          csvPath: csv.path,
+          dryRun: false,
+          logger: secondRunLogger.logger,
+        });
+
+        expect(secondRun).toMatchObject({
+          csvRowsConsidered: 2,
+          flipped: 0,
+          skippedAlreadyOutbound: 2,
+          skippedFilterMismatch: 0,
+          skippedUnexpectedState: 0,
+          contactsAffected: 0,
+          projectionsRebuilt: 0,
+          dryRun: false,
+        });
+        expect(
+          secondRunLogger.lines.filter((line) =>
+            /^\[apply\] event=.* skipped \(already outbound\)$/u.test(line),
+          ),
+        ).toHaveLength(2);
+      } finally {
+        await rm(csv.dir, { recursive: true, force: true });
+      }
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("skips rows that do not match the approved outbound/high/inbound filter", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact({
+        context,
+        contactId: "contact:one",
+        email: "one@example.org",
+        displayName: "Contact One",
+      });
+
+      const seeded = await seedMisclassifiedOutbound({
+        context,
+        key: "one",
+        contactId: "contact:one",
+        occurredAt: "2026-06-03T10:00:00.000Z",
+      });
+      const csv = await writeCsv({
+        rows: [
+          {
+            canonicalEventId: seeded.canonicalEventId,
+            sourceEvidenceId: seeded.sourceEvidenceId,
+            currentDirection: "inbound",
+            suggestedDirection: "outbound",
+            confidence: "low",
+          },
+        ],
+      });
+
+      try {
+        const result = await applyMboxDirectionBackfill({
+          db: context.db,
+          csvPath: csv.path,
+          dryRun: false,
+          logger: createLogger().logger,
+        });
+
+        expect(result).toMatchObject({
+          csvRowsConsidered: 1,
+          flipped: 0,
+          skippedAlreadyOutbound: 0,
+          skippedFilterMismatch: 1,
+          skippedUnexpectedState: 0,
+          contactsAffected: 0,
+          projectionsRebuilt: 0,
+          dryRun: false,
+        });
+      } finally {
+        await rm(csv.dir, { recursive: true, force: true });
+      }
+
+      await expect(readDirection(context, seeded.sourceEvidenceId)).resolves.toBe(
+        "inbound",
+      );
+      await expect(readEventType(context, seeded.canonicalEventId)).resolves.toBe(
+        "communication.email.inbound",
+      );
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("logs intended flips in dry-run mode without persisting changes", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact({
+        context,
+        contactId: "contact:one",
+        email: "one@example.org",
+        displayName: "Contact One",
+      });
+
+      const seeded = await seedMisclassifiedOutbound({
+        context,
+        key: "one",
+        contactId: "contact:one",
+        occurredAt: "2026-06-03T10:00:00.000Z",
+      });
+      const csv = await writeCsv({
+        rows: [
+          {
+            canonicalEventId: seeded.canonicalEventId,
+            sourceEvidenceId: seeded.sourceEvidenceId,
+            currentDirection: "inbound",
+            suggestedDirection: "outbound",
+            confidence: "high",
+          },
+        ],
+      });
+
+      try {
+        const logger = createLogger();
+        const result = await applyMboxDirectionBackfill({
+          db: context.db,
+          csvPath: csv.path,
+          dryRun: true,
+          logger: logger.logger,
+        });
+
+        expect(result).toMatchObject({
+          csvRowsConsidered: 1,
+          flipped: 1,
+          skippedAlreadyOutbound: 0,
+          skippedFilterMismatch: 0,
+          skippedUnexpectedState: 0,
+          contactsAffected: 1,
+          projectionsRebuilt: 0,
+          dryRun: true,
+        });
+        expect(
+          logger.lines.some((line) => line.includes("would flip inbound->outbound")),
+        ).toBe(true);
+      } finally {
+        await rm(csv.dir, { recursive: true, force: true });
+      }
+
+      await expect(readDirection(context, seeded.sourceEvidenceId)).resolves.toBe(
+        "inbound",
+      );
+      await expect(readEventType(context, seeded.canonicalEventId)).resolves.toBe(
+        "communication.email.inbound",
+      );
+    } finally {
+      await context.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Companion to PR #506 (Phase 1 read-only detection). Phase 2 reads the operator-approved CSV from Phase 1, flips the 759 high-confidence rows from direction=inbound → outbound, and rebuilds inbox projections for affected contacts.

**Architect-validated cohort (2026-06-03):**
- 759 rows tagged `suggested_direction=outbound, confidence=high` — all manually confirmed as real outbound messages currently stored as inbound. These get flipped.
- 120 rows tagged `suggested_direction=inbound, confidence=high` — all confirmed correctly classified. No-op.

## How to run

```
pnpm --filter @as-comms/worker ops:apply-mbox-direction-backfill --csv-path=.codex-briefs/mbox-direction-report-2026-06-03T22:30:00.000Z.csv
```

Optional `--dry-run` to log intended flips without writes.

## Per-row processing

1. Re-fetch live `canonical_event_ledger` + `gmail_message_details` (idempotent: skip if already outbound).
2. Transaction per flip:
   - `UPDATE gmail_message_details SET direction='outbound'`
   - `UPDATE canonical_event_ledger SET event_type='communication.email.outbound'`
3. After all flips: `rebuildInboxProjectionForContact` for each distinct affected contact.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm boundaries` — green
- [x] PGlite integration test: happy-path flip + idempotent re-run + filter-mismatch skip + dry-run no-op
- [ ] CI green
- [ ] After merge: architect runs against prod with the validated CSV, expects ~759 flips + ~N contacts rebuilt

🤖 Generated with [Claude Code](https://claude.com/claude-code)