### PR TITLE
fix(domain,worker): inbox snippet prefers human comm over campaign events

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -32,6 +32,7 @@
     "ops:recover-gmail-spam-window": "tsx src/ops/recover-gmail-spam-window.ts",
     "ops:recompute-attachment-decoration": "tsx src/ops/recompute-attachment-decoration.ts",
     "ops:rebuild-inbox-projection-stuck-on-new": "tsx src/ops/rebuild-inbox-projection-stuck-on-new.ts",
+    "ops:rebuild-inbox-projection-snippet-bias": "tsx src/ops/rebuild-inbox-projection-snippet-bias.ts",
     "ops:backfill-canonical-event-audience": "tsx src/ops/backfill-canonical-event-audience.ts",
     "ops:backfill-contact-display-names": "tsx src/ops/backfill-contact-display-names.ts",
     "ops:recover-orphan-gmail-details": "tsx src/ops/recover-orphan-gmail-details.ts",

--- a/apps/worker/src/ops/cli.ts
+++ b/apps/worker/src/ops/cli.ts
@@ -52,6 +52,7 @@ import { runRecomputeAttachmentDecorationCommand } from "./recompute-attachment-
 import { runBackfillCanonicalEventAudienceCommand } from "./backfill-canonical-event-audience.js";
 import { runRecoverOrphanGmailDetailsCommand } from "./recover-orphan-gmail-details.js";
 import { runRebuildInboxProjectionStuckOnNewCommand } from "./rebuild-inbox-projection-stuck-on-new.js";
+import { runRebuildInboxProjectionSnippetBiasCommand } from "./rebuild-inbox-projection-snippet-bias.js";
 import { reconcileIdentityQueue } from "./reconcile-identity-queue.js";
 import { reconcileRoutingReviewQueue } from "./reconcile-routing-review-queue.js";
 import { runReconcileStaleCanonicalCommand } from "./reconcile-stale-canonical.js";
@@ -491,6 +492,9 @@ async function main(): Promise<void> {
     case "rebuild-inbox-projection-stuck-on-new":
       await runRebuildInboxProjectionStuckOnNewCommand(process.env);
       return;
+    case "rebuild-inbox-projection-snippet-bias":
+      await runRebuildInboxProjectionSnippetBiasCommand(process.env);
+      return;
     case "backfill-canonical-event-audience":
       await runBackfillCanonicalEventAudienceCommand(rest, process.env);
       return;
@@ -523,7 +527,7 @@ async function main(): Promise<void> {
       return;
     default:
       throw new Error(
-        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-membership-sf-ids, backfill-gmail-mbox-bodies, backfill-content-fingerprint, backfill-garbled-message-bodies, re-extract-signed-envelope-bodies, backfill-mailchimp-campaign-body, mailchimp-capture-historical, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, detect-mbox-direction-misclassification, apply-mbox-direction-backfill, recover-orphan-gmail-details, recover-gmail-spam-window, recompute-attachment-decoration, rebuild-inbox-projection-stuck-on-new, backfill-canonical-event-audience, reprocess-pending-campaign-sends, dedup-historical-ledger, merge-email-only-into-sf-anchored, reconcile-identity-queue, reconcile-routing-review-queue, reclassify-sf-direction, reconcile-stale-canonical, reconcile-superseded-projections.",
+        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-membership-sf-ids, backfill-gmail-mbox-bodies, backfill-content-fingerprint, backfill-garbled-message-bodies, re-extract-signed-envelope-bodies, backfill-mailchimp-campaign-body, mailchimp-capture-historical, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, detect-mbox-direction-misclassification, apply-mbox-direction-backfill, recover-orphan-gmail-details, recover-gmail-spam-window, recompute-attachment-decoration, rebuild-inbox-projection-stuck-on-new, rebuild-inbox-projection-snippet-bias, backfill-canonical-event-audience, reprocess-pending-campaign-sends, dedup-historical-ledger, merge-email-only-into-sf-anchored, reconcile-identity-queue, reconcile-routing-review-queue, reclassify-sf-direction, reconcile-stale-canonical, reconcile-superseded-projections.",
       );
   }
 }

--- a/apps/worker/src/ops/rebuild-inbox-projection-snippet-bias.ts
+++ b/apps/worker/src/ops/rebuild-inbox-projection-snippet-bias.ts
@@ -1,0 +1,170 @@
+#!/usr/bin/env tsx
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+import { sql } from "drizzle-orm";
+
+import {
+  closeDatabaseConnection,
+  contactInboxProjection,
+  createDatabaseConnection,
+  createStage1RepositoryBundle,
+  type Stage1Database,
+} from "@as-comms/db";
+import {
+  createStage1PersistenceService,
+  rebuildInboxProjectionForContact,
+} from "@as-comms/domain";
+
+interface Logger {
+  log(...args: readonly unknown[]): void;
+  error(...args: readonly unknown[]): void;
+}
+
+interface InboxProjectionSnippetRow {
+  readonly contactId: string;
+  readonly snippet: string;
+}
+
+export interface RebuildInboxProjectionSnippetBiasResult {
+  readonly processed: number;
+  readonly changed: number;
+  readonly unchanged: number;
+}
+
+function readConnectionString(env: NodeJS.ProcessEnv): string {
+  const connectionString = env.WORKER_DATABASE_URL ?? env.DATABASE_URL;
+
+  if (connectionString === undefined || connectionString.trim().length === 0) {
+    throw new Error(
+      "DATABASE_URL or WORKER_DATABASE_URL is required for this ops command.",
+    );
+  }
+
+  return connectionString;
+}
+
+function normalizeSqlResultRows<TRow>(
+  result:
+    | readonly TRow[]
+    | {
+        readonly rows?: readonly TRow[];
+      },
+): readonly TRow[] {
+  if (Array.isArray(result)) {
+    return result as readonly TRow[];
+  }
+
+  return (result as { readonly rows?: readonly TRow[] }).rows ?? [];
+}
+
+export async function loadInboxProjectionSnippetRows(
+  db: Stage1Database,
+): Promise<readonly InboxProjectionSnippetRow[]> {
+  const result = await db.execute(sql<InboxProjectionSnippetRow>`
+    select
+      ${contactInboxProjection.contactId} as "contactId",
+      ${contactInboxProjection.snippet} as "snippet"
+    from ${contactInboxProjection}
+    order by ${contactInboxProjection.contactId} asc
+  `);
+
+  return normalizeSqlResultRows(
+    result as
+      | readonly InboxProjectionSnippetRow[]
+      | {
+          readonly rows?: readonly InboxProjectionSnippetRow[];
+        },
+  );
+}
+
+export async function rebuildInboxProjectionSnippetBias(input: {
+  readonly connection: {
+    readonly db: Stage1Database;
+  };
+  readonly logger?: Logger;
+}): Promise<RebuildInboxProjectionSnippetBiasResult> {
+  const logger = input.logger ?? console;
+  const repositories = createStage1RepositoryBundle(input.connection.db);
+  const persistence = createStage1PersistenceService(repositories);
+  const rows = await loadInboxProjectionSnippetRows(input.connection.db);
+  let changed = 0;
+  let unchanged = 0;
+
+  for (const row of rows) {
+    const rebuilt = await rebuildInboxProjectionForContact(
+      persistence,
+      row.contactId,
+    );
+    const nextSnippet = rebuilt?.snippet ?? "";
+
+    if (nextSnippet === row.snippet) {
+      unchanged += 1;
+    } else {
+      changed += 1;
+    }
+
+    logger.log(
+      `[snippet-bias] contact=${row.contactId} snippet=${JSON.stringify(row.snippet)}→${JSON.stringify(nextSnippet)}`,
+    );
+  }
+
+  return {
+    processed: rows.length,
+    changed,
+    unchanged,
+  };
+}
+
+export async function runRebuildInboxProjectionSnippetBiasCommand(
+  env: NodeJS.ProcessEnv = process.env,
+  logger: Logger = console,
+): Promise<RebuildInboxProjectionSnippetBiasResult> {
+  const connection = createDatabaseConnection({
+    connectionString: readConnectionString(env),
+  });
+
+  try {
+    return await rebuildInboxProjectionSnippetBias({
+      connection,
+      logger,
+    });
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  void runRebuildInboxProjectionSnippetBiasCommand().catch((error: unknown) => {
+    const resolvedError =
+      error instanceof Error ? error : new Error(String(error));
+
+    console.error(`[snippet-bias:fatal] ${resolvedError.message}`);
+    console.error(resolvedError.stack ?? "(no stack)");
+
+    const anyError = resolvedError as Error & Record<string, unknown>;
+    for (const key of [
+      "cause",
+      "code",
+      "detail",
+      "constraint",
+      "column",
+      "table",
+      "schema",
+      "severity",
+      "position",
+      "where",
+      "hint",
+      "errno",
+      "syscall",
+    ]) {
+      if (anyError[key] !== undefined) {
+        console.error(
+          `[snippet-bias:fatal:${key}] ${JSON.stringify(anyError[key])}`,
+        );
+      }
+    }
+
+    process.exitCode = 1;
+  });
+}

--- a/apps/worker/test/rebuild-inbox-projection-snippet-bias.test.ts
+++ b/apps/worker/test/rebuild-inbox-projection-snippet-bias.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canonicalEventSchema,
+  resolveCanonicalChannel,
+  type CanonicalEventRecord,
+  type GmailMessageDetailRecord,
+  type SourceEvidenceRecord,
+} from "@as-comms/contracts";
+
+import {
+  rebuildInboxProjectionSnippetBias,
+} from "../src/ops/rebuild-inbox-projection-snippet-bias.js";
+import { createTestWorkerContext, type TestWorkerContext } from "./helpers.js";
+
+async function seedContact(input: {
+  readonly context: TestWorkerContext;
+  readonly contactId: string;
+  readonly email: string;
+  readonly displayName: string;
+}): Promise<void> {
+  await input.context.normalization.upsertNormalizedContactGraph({
+    contact: {
+      id: input.contactId,
+      salesforceContactId: null,
+      displayName: input.displayName,
+      primaryEmail: input.email,
+      primaryPhone: null,
+      createdAt: "2026-06-03T00:00:00.000Z",
+      updatedAt: "2026-06-03T00:00:00.000Z",
+    },
+    identities: [
+      {
+        id: `identity:${input.contactId}:email`,
+        contactId: input.contactId,
+        kind: "email",
+        normalizedValue: input.email,
+        isPrimary: true,
+        source: "gmail",
+        verifiedAt: "2026-06-03T00:00:00.000Z",
+      },
+    ],
+    memberships: [],
+  });
+}
+
+function buildSourceEvidence(input: {
+  readonly key: string;
+  readonly occurredAt: string;
+  readonly provider: SourceEvidenceRecord["provider"];
+  readonly providerRecordType: SourceEvidenceRecord["providerRecordType"];
+}): SourceEvidenceRecord {
+  return {
+    id: `source:${input.key}`,
+    provider: input.provider,
+    providerRecordType: input.providerRecordType,
+    providerRecordId: `${input.provider}:${input.key}`,
+    receivedAt: input.occurredAt,
+    occurredAt: input.occurredAt,
+    payloadRef: `payloads/${input.provider}/${input.key}.json`,
+    idempotencyKey: `${input.provider}:${input.providerRecordType}:${input.key}`,
+    checksum: `checksum:${input.key}`,
+  };
+}
+
+function buildCanonicalEvent(input: {
+  readonly key: string;
+  readonly contactId: string;
+  readonly occurredAt: string;
+  readonly eventType: CanonicalEventRecord["eventType"];
+  readonly provider: CanonicalEventRecord["provenance"]["primaryProvider"];
+  readonly sourceRecordType: CanonicalEventRecord["provenance"]["sourceRecordType"];
+  readonly direction: "inbound" | "outbound" | null;
+  readonly messageKind: CanonicalEventRecord["provenance"]["messageKind"];
+}): CanonicalEventRecord {
+  return canonicalEventSchema.parse({
+    id: `event:${input.key}`,
+    contactId: input.contactId,
+    eventType: input.eventType,
+    channel: resolveCanonicalChannel(input.eventType),
+    occurredAt: input.occurredAt,
+    contentFingerprint: null,
+    sourceEvidenceId: `source:${input.key}`,
+    idempotencyKey: `canonical:${input.key}`,
+    provenance: {
+      primaryProvider: input.provider,
+      primarySourceEvidenceId: `source:${input.key}`,
+      supportingSourceEvidenceIds: [],
+      winnerReason: "single_source",
+      sourceRecordType: input.sourceRecordType,
+      sourceRecordId: `${input.provider}:${input.key}`,
+      messageKind: input.messageKind,
+      campaignRef: null,
+      threadRef: null,
+      direction: input.direction,
+      notes: null,
+    },
+    reviewState: "clear",
+  });
+}
+
+function buildGmailDetail(input: {
+  readonly key: string;
+  readonly direction: GmailMessageDetailRecord["direction"];
+  readonly gmailThreadId: string;
+  readonly rfc822MessageId: string;
+  readonly snippet: string;
+}): GmailMessageDetailRecord {
+  return {
+    sourceEvidenceId: `source:${input.key}`,
+    providerRecordId: `gmail:${input.key}`,
+    gmailThreadId: input.gmailThreadId,
+    rfc822MessageId: input.rfc822MessageId,
+    direction: input.direction,
+    subject: `Subject ${input.key}`,
+    fromHeader:
+      input.direction === "outbound"
+        ? "Inbox <forests@adventurescientists.org>"
+        : "Volunteer <volunteer@example.org>",
+    toHeader:
+      input.direction === "outbound"
+        ? "Volunteer <volunteer@example.org>"
+        : "Inbox <forests@adventurescientists.org>",
+    ccHeader: null,
+    fromEmails:
+      input.direction === "outbound"
+        ? ["forests@adventurescientists.org"]
+        : ["volunteer@example.org"],
+    toEmails:
+      input.direction === "outbound"
+        ? ["volunteer@example.org"]
+        : ["forests@adventurescientists.org"],
+    ccEmails: [],
+    bccEmails: [],
+    snippetClean: input.snippet,
+    bodyTextPreview: input.snippet,
+    capturedMailbox: "volunteers@adventurescientists.org",
+    projectInboxAlias: "forests@adventurescientists.org",
+  };
+}
+
+async function seedCanonicalEvent(input: {
+  readonly context: TestWorkerContext;
+  readonly event: CanonicalEventRecord;
+  readonly sourceEvidence: SourceEvidenceRecord;
+  readonly gmailDetail?: GmailMessageDetailRecord;
+}): Promise<void> {
+  await input.context.repositories.sourceEvidence.append(input.sourceEvidence);
+  await input.context.repositories.canonicalEvents.upsert(input.event);
+
+  if (input.gmailDetail !== undefined) {
+    await input.context.repositories.gmailMessageDetails.upsert(input.gmailDetail);
+  }
+}
+
+describe("rebuild-inbox-projection-snippet-bias ops", () => {
+  it("rebuilds stale Gary-like snippets toward the latest meaningful inbound", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedContact({
+        context,
+        contactId: "contact:gary",
+        email: "gary@example.org",
+        displayName: "Gary Steele",
+      });
+
+      const inbound = buildCanonicalEvent({
+        key: "gary-inbound",
+        contactId: "contact:gary",
+        occurredAt: "2026-06-03T10:00:00.000Z",
+        eventType: "communication.email.inbound",
+        provider: "gmail",
+        sourceRecordType: "message",
+        direction: "inbound",
+        messageKind: "one_to_one",
+      });
+      const campaignOpened = buildCanonicalEvent({
+        key: "gary-opened",
+        contactId: "contact:gary",
+        occurredAt: "2026-06-03T11:00:00.000Z",
+        eventType: "campaign.email.opened",
+        provider: "mailchimp",
+        sourceRecordType: "campaign_activity",
+        direction: null,
+        messageKind: "campaign",
+      });
+
+      await seedCanonicalEvent({
+        context,
+        event: inbound,
+        sourceEvidence: buildSourceEvidence({
+          key: "gary-inbound",
+          occurredAt: inbound.occurredAt,
+          provider: "gmail",
+          providerRecordType: "message",
+        }),
+        gmailDetail: buildGmailDetail({
+          key: "gary-inbound",
+          direction: "inbound",
+          gmailThreadId: "thread:gary",
+          rfc822MessageId: "<gary-inbound@example.org>",
+          snippet:
+            "I went to pick it up today and Weaverville had no units to give me.",
+        }),
+      });
+      await seedCanonicalEvent({
+        context,
+        event: campaignOpened,
+        sourceEvidence: buildSourceEvidence({
+          key: "gary-opened",
+          occurredAt: campaignOpened.occurredAt,
+          provider: "mailchimp",
+          providerRecordType: "campaign_activity",
+        }),
+      });
+
+      await context.repositories.inboxProjection.upsert({
+        contactId: "contact:gary",
+        bucket: "New",
+        needsFollowUp: false,
+        hasUnresolved: false,
+        lastInboundAt: inbound.occurredAt,
+        lastOutboundAt: null,
+        lastActivityAt: campaignOpened.occurredAt,
+        snippet: "Broadcast email opened",
+        archivedAt: null,
+        lastCanonicalEventId: campaignOpened.id,
+        lastEventType: campaignOpened.eventType,
+      });
+
+      const result = await rebuildInboxProjectionSnippetBias({
+        connection: { db: context.db },
+        logger: {
+          log(..._args) {
+            void _args;
+          },
+          error(..._args) {
+            void _args;
+          },
+        },
+      });
+      const projection =
+        await context.repositories.inboxProjection.findByContactId("contact:gary");
+
+      expect(result).toMatchObject({
+        processed: 1,
+        changed: 1,
+        unchanged: 0,
+      });
+      expect(projection?.snippet).toBe(
+        "I went to pick it up today and Weaverville had no units to give me.",
+      );
+      expect(projection?.lastEventType).toBe("campaign.email.opened");
+    } finally {
+      await context.dispose();
+    }
+  });
+});

--- a/packages/domain/src/normalization.ts
+++ b/packages/domain/src/normalization.ts
@@ -525,6 +525,34 @@ function isOutboundProjectionEvent(
   );
 }
 
+function tierRankForEventType(
+  eventType: CanonicalEventRecord["eventType"],
+): 1 | 2 | 3 {
+  switch (eventType) {
+    case "communication.email.inbound":
+    case "communication.email.outbound":
+    case "communication.sms.inbound":
+    case "communication.sms.outbound":
+    case "note.internal.created":
+      return 1;
+    case "lifecycle.signed_up":
+    case "lifecycle.received_training":
+    case "lifecycle.completed_training":
+    case "lifecycle.submitted_first_data":
+    case "communication.sms.opt_in":
+    case "communication.sms.opt_out":
+    case "campaign.email.unsubscribed":
+      return 2;
+    case "campaign.email.sent":
+    case "campaign.email.delivered":
+    case "campaign.email.opened":
+    case "campaign.email.clicked":
+    case "campaign.email.bounced":
+    case "campaign.email.complained":
+      return 3;
+  }
+}
+
 function compareCanonicalEventRecency(
   left: Pick<CanonicalEventRecord, "id" | "occurredAt">,
   right: Pick<CanonicalEventRecord, "id" | "occurredAt">,
@@ -1475,28 +1503,70 @@ function resolveInboxSnippet(
       return "";
     }
 
-    return detail.snippetClean.length > 0
+    const snippet =
+      detail.snippetClean.length > 0
       ? detail.snippetClean
       : detail.bodyTextPreview;
+
+    if (snippet.length > 0) {
+      return snippet;
+    }
   }
 
   if (event.provenance.primaryProvider === "salesforce") {
-    return (
+    const snippet =
       detailMaps.salesforceCommunicationDetailBySourceEvidenceId.get(
         event.sourceEvidenceId,
-      )?.snippet ?? ""
-    );
+      )?.snippet ?? "";
+
+    if (snippet.length > 0) {
+      return snippet;
+    }
   }
 
   if (event.provenance.primaryProvider === "simpletexting") {
-    return (
+    const snippet =
       detailMaps.simpleTextingMessageDetailBySourceEvidenceId.get(
         event.sourceEvidenceId,
-      )?.messageTextPreview ?? ""
-    );
+      )?.messageTextPreview ?? "";
+
+    if (snippet.length > 0) {
+      return snippet;
+    }
   }
 
-  return "";
+  switch (event.eventType) {
+    case "lifecycle.signed_up":
+      return "Signed up";
+    case "lifecycle.received_training":
+      return "Received training";
+    case "lifecycle.completed_training":
+      return "Completed training";
+    case "lifecycle.submitted_first_data":
+      return "Submitted first data";
+    case "communication.sms.opt_in":
+      return "SMS opted in";
+    case "communication.sms.opt_out":
+      return "SMS opted out";
+    case "campaign.email.sent":
+      return "Campaign email sent";
+    case "campaign.email.delivered":
+      return "Campaign email delivered";
+    case "campaign.email.opened":
+      return "Campaign email opened";
+    case "campaign.email.clicked":
+      return "Campaign email clicked";
+    case "campaign.email.bounced":
+      return "Campaign email bounced";
+    case "campaign.email.complained":
+      return "Campaign email complained";
+    case "campaign.email.unsubscribed":
+      return "Campaign email unsubscribed";
+    case "note.internal.created":
+      return "Internal note added";
+    default:
+      return "";
+  }
 }
 
 function latestOutboundMatchesEarlierInboundThread(input: {
@@ -1597,10 +1667,40 @@ export async function rebuildInboxProjectionForContact(
         : latest,
     null,
   );
+  const snippetEvent = qualifyingEvents.reduce<CanonicalEventRecord | null>(
+    (currentSnippetEvent, event) => {
+      if (currentSnippetEvent === null) {
+        return event;
+      }
+
+      const currentTierRank = tierRankForEventType(
+        currentSnippetEvent.eventType,
+      );
+      const nextTierRank = tierRankForEventType(event.eventType);
+
+      if (nextTierRank < currentTierRank) {
+        return event;
+      }
+
+      if (nextTierRank > currentTierRank) {
+        return currentSnippetEvent;
+      }
+
+      return compareCanonicalEventRecency(event, currentSnippetEvent) > 0
+        ? event
+        : currentSnippetEvent;
+    },
+    null,
+  );
 
   if (latestEvent === null) {
     throw new Error(
       "Expected a qualifying event when rebuilding inbox projection.",
+    );
+  }
+  if (snippetEvent === null) {
+    throw new Error(
+      "Expected a snippet event when rebuilding inbox projection.",
     );
   }
   let lastInboundAt: string | null = null;
@@ -1652,7 +1752,7 @@ export async function rebuildInboxProjectionForContact(
     lastInboundAt,
     lastOutboundAt,
     lastActivityAt,
-    snippet: resolveInboxSnippet(latestEvent, detailMaps),
+    snippet: resolveInboxSnippet(snippetEvent, detailMaps),
     archivedAt: existing?.archivedAt ?? null,
     lastCanonicalEventId: latestEvent.id,
     lastEventType: latestEvent.eventType,

--- a/packages/domain/test/normalization.test.ts
+++ b/packages/domain/test/normalization.test.ts
@@ -1708,6 +1708,108 @@ describe("rebuildInboxProjectionForContact bucket semantics", () => {
   });
 });
 
+describe("rebuildInboxProjectionForContact snippet selection", () => {
+  it("prefers the latest tier-1 communication snippet over newer campaign engagement", async () => {
+    const inbound = buildEvent({
+      key: "snippet-tier-1-inbound",
+      occurredAt: "2026-04-24T10:00:00.000Z",
+      direction: "inbound",
+    });
+    const campaignOpened = buildEvent({
+      key: "snippet-tier-3-open",
+      occurredAt: "2026-04-24T12:00:00.000Z",
+      eventType: "campaign.email.opened",
+      direction: null,
+      provider: "mailchimp",
+      sourceRecordType: "campaign_activity",
+      messageKind: "campaign",
+    });
+    const context = buildContext({
+      events: [inbound, campaignOpened],
+      gmailMessageDetails: [
+        buildGmailDetail({
+          key: "snippet-tier-1-inbound",
+          direction: "inbound",
+          bodyTextPreview:
+            "I went to pick it up today and Weaverville had no units to give me.",
+        }),
+      ],
+    });
+
+    const projection = await rebuildInboxProjectionForContact(
+      context.normalization.persistence,
+      inbound.contactId,
+    );
+
+    expect(projection).toMatchObject({
+      snippet:
+        "I went to pick it up today and Weaverville had no units to give me.",
+      lastEventType: "campaign.email.opened",
+      lastCanonicalEventId: campaignOpened.id,
+    });
+  });
+
+  it("falls back to a friendly campaign label when only campaign opens exist", async () => {
+    const campaignOpened = buildEvent({
+      key: "snippet-campaign-only-open",
+      occurredAt: "2026-04-24T12:00:00.000Z",
+      eventType: "campaign.email.opened",
+      direction: null,
+      provider: "mailchimp",
+      sourceRecordType: "campaign_activity",
+      messageKind: "campaign",
+    });
+    const context = buildContext({
+      events: [campaignOpened],
+    });
+
+    const projection = await rebuildInboxProjectionForContact(
+      context.normalization.persistence,
+      campaignOpened.contactId,
+    );
+
+    expect(projection).toMatchObject({
+      snippet: "Campaign email opened",
+      lastEventType: "campaign.email.opened",
+    });
+  });
+
+  it("prefers the latest tier-2 lifecycle snippet over newer tier-3 campaign activity", async () => {
+    const lifecycle = buildEvent({
+      key: "snippet-tier-2-lifecycle",
+      occurredAt: "2026-04-24T11:00:00.000Z",
+      eventType: "lifecycle.signed_up",
+      direction: null,
+      provider: "salesforce",
+      sourceRecordType: "contact_membership",
+      messageKind: null,
+    });
+    const campaignSent = buildEvent({
+      key: "snippet-tier-3-sent",
+      occurredAt: "2026-04-24T12:00:00.000Z",
+      eventType: "campaign.email.sent",
+      direction: null,
+      provider: "mailchimp",
+      sourceRecordType: "campaign_activity",
+      messageKind: "campaign",
+    });
+    const context = buildContext({
+      events: [lifecycle, campaignSent],
+    });
+
+    const projection = await rebuildInboxProjectionForContact(
+      context.normalization.persistence,
+      lifecycle.contactId,
+    );
+
+    expect(projection).toMatchObject({
+      snippet: "Signed up",
+      lastEventType: "campaign.email.sent",
+      lastCanonicalEventId: campaignSent.id,
+    });
+  });
+});
+
 describe("upsertNormalizedContactGraph write ordering", () => {
   it("writes project and expedition dimensions before contact memberships for a new expedition", async () => {
     const callOrder: { kind: string; id: string }[] = [];


### PR DESCRIPTION
## Summary

Inbox snippets sometimes show campaign-engagement events ("Broadcast email opened", "campaign delivered") instead of the volunteer's most recent meaningful reply. Concrete repro: Gary Steele's row shows "Broadcast email opened" even though his real most-recent inbound is about Weaverville having no ARUs.

Fix: in `rebuildInboxProjectionForContact`, separate the *snippet event* from the *latest event*. All other `last_*` fields and the bucket logic remain unchanged.

## Tiers

| Tier | Event types | Behavior |
|---|---|---|
| 1 | communication.email/sms.inbound/outbound, note.internal.created | Always claims snippet if present |
| 2 | lifecycle.*, communication.sms.opt_in/out, campaign.email.unsubscribed | Claims if no tier 1 |
| 3 | campaign.email.sent/delivered/opened/clicked/bounced/complained | Falls through |

Within a tier, latest `occurredAt` wins.

## Backfill

One-shot ops script `ops:rebuild-inbox-projection-snippet-bias` walks every contact and rebuilds. Idempotent — re-run safe.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm boundaries` — green
- [x] Unit test: inbound + later campaign-open → snippet = inbound, last_event_type = campaign.email.opened
- [x] Unit test: only campaign opens → snippet falls back to opens
- [x] Unit test: lifecycle + later campaign sent → snippet picks lifecycle
- [x] PGlite test for backfill script
- [ ] CI green
- [ ] After merge: architect runs the backfill script in prod, spot-checks Gary's row

🤖 Generated with [Claude Code](https://claude.com/claude-code)