### PR TITLE
fix(inbox): render polish — inline-image placeholders, inbound-on-inbound dedup, To-row fallback

### DIFF
--- a/apps/web/app/inbox/_lib/message-formatting.ts
+++ b/apps/web/app/inbox/_lib/message-formatting.ts
@@ -55,6 +55,7 @@ const FORWARDED_HEADER_LINE_PATTERN =
 const STRUCTURED_EMAIL_HEADER_PATTERN =
   /(?:^|\n)(From|To|Recipients|Cc|Bcc|Reply-To|Sent|Date|Subject|Body):/i;
 const FROM_HEADER_PATTERN = /(?:^|\n)From:\s*(.+?)(?:\n|$)/i;
+const INLINE_IMAGE_PLACEHOLDER_LINE_PATTERN = /^\s*\[image:[^\]]*\]\s*$/gm;
 const RECIPIENTS_HEADER_PATTERN = /(?:^|\n)(?:Recipients|To):\s*(.+?)(?:\n|$)/i;
 const CC_HEADER_PATTERN = /(?:^|\n)Cc:\s*(.+?)(?:\n|$)/i;
 const BCC_HEADER_PATTERN = /(?:^|\n)Bcc:\s*(.+?)(?:\n|$)/i;
@@ -188,6 +189,12 @@ export function sanitizePreviewText(value: string): string {
     .replace(/\n{3,}/g, "\n\n")
     .replace(/[ \t]{2,}/g, " ")
     .trim();
+}
+
+export function stripInlineImagePlaceholders(value: string): string {
+  return value
+    .replace(INLINE_IMAGE_PLACEHOLDER_LINE_PATTERN, "")
+    .replace(/\n{3,}/g, "\n\n");
 }
 
 function isLikelyPreviewNoise(value: string): boolean {

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -29,6 +29,7 @@ import {
   parseCommunicationPreview,
   resolvePreferredMessagePreview,
   sanitizePreviewText,
+  stripInlineImagePlaceholders,
   stripDuplicateOutboundEcho,
   stripSignature,
   trimQuotedReplyContent,
@@ -226,9 +227,9 @@ interface InboxDetailCacheData {
     string,
     readonly MessageAttachmentRecord[]
   >;
-  readonly inboundAttachmentSignaturesByThread: ReadonlyMap<
+  readonly inboundFirstOccurrenceByThread: ReadonlyMap<
     string,
-    ReadonlySet<string>
+    ReadonlyMap<string, string>
   >;
   /**
    * Captured project-inbox alias per timeline canonical event, sourced
@@ -2281,17 +2282,15 @@ function buildTimelineEntry(input: {
     readonly MessageAttachmentRecord[]
   >;
   /**
-   * Per-Gmail-thread set of `(filename:sizeBytes)` signatures for all
-   * inbound attachments seen across the loaded timeline. Used by the
-   * email attachment builder to hide outbound quoted duplicates so
-   * the screenshot the volunteer attached doesn't visually float
-   * under the operator's reply bubble (and vice versa for any later
-   * outbound quoting). Built once per page assembly; see
-   * `buildInboundAttachmentSignaturesByThread`.
+   * Per-Gmail-thread first-occurrence map for inbound attachment
+   * signatures: `threadId -> (filename:sizeBytes -> canonicalEventId)`.
+   * Used by the email attachment builder to hide both outbound quoted
+   * duplicates and later inbound quoted duplicates without stripping the
+   * original inbound attachment that introduced the file.
    */
-  readonly inboundAttachmentSignaturesByThread: ReadonlyMap<
+  readonly inboundFirstOccurrenceByThread: ReadonlyMap<
     string,
-    ReadonlySet<string>
+    ReadonlyMap<string, string>
   >;
   /**
    * Captured project-inbox alias (e.g. `pnwbio@…`) per timeline item,
@@ -2381,9 +2380,13 @@ function buildTimelineEntry(input: {
           }),
         })
       : resolvedBody;
+  const renderableEmailBody =
+    input.item.family === "one_to_one_email"
+      ? stripInlineImagePlaceholders(bodyWithDuplicateOutboundEchoStripped)
+      : bodyWithDuplicateOutboundEchoStripped;
   const hasRenderableEmailContent =
     kind === "inbound-email" || kind === "outbound-email"
-      ? subject !== null || bodyWithDuplicateOutboundEchoStripped.trim().length > 0
+      ? subject !== null || renderableEmailBody.trim().length > 0
       : true;
   const finalKind =
     !hasRenderableEmailContent && input.item.family === "one_to_one_email"
@@ -2418,13 +2421,12 @@ function buildTimelineEntry(input: {
               input.item.canonicalEventId,
             ) ?? [],
           pending: input.item.pendingAttachmentMetadata ?? [],
-          inboundAttachmentSignaturesOnThread:
-            input.item.direction === "outbound" &&
-            input.item.threadId !== null &&
-            input.item.threadId.length > 0
-              ? (input.inboundAttachmentSignaturesByThread.get(
-                  input.item.threadId,
-                ) ?? null)
+          itemDirection: input.item.direction,
+          canonicalEventId: input.item.canonicalEventId,
+          inboundFirstOccurrenceOnThread:
+            input.item.threadId !== null && input.item.threadId.length > 0
+              ? (input.inboundFirstOccurrenceByThread.get(input.item.threadId) ??
+                null)
               : null,
         })
       : [];
@@ -2494,7 +2496,7 @@ function buildTimelineEntry(input: {
       canonicalSenderDisplayName,
     ),
     subject,
-    body: bodyWithDuplicateOutboundEchoStripped,
+    body: renderableEmailBody,
     channel: timelineChannel(input.item),
     isUnread,
     isPreview: isPreviewTimelineItem(input.item),
@@ -2621,10 +2623,11 @@ function buildAttachmentSignature(input: {
 }
 
 /**
- * Walk the loaded timeline items once, collect `(filename, sizeBytes)`
- * signatures for every attachment on an INBOUND email, and group by
- * Gmail thread. Returned map is consumed by
- * `buildEmailAttachmentsForEntry` to suppress outbound quoted dupes.
+ * Walk the loaded timeline items once, record which inbound canonical
+ * event first introduced each `(filename, sizeBytes)` signature on a
+ * Gmail thread, and group by thread. Returned map is consumed by
+ * `buildEmailAttachmentsForEntry` to suppress outbound quoted dupes and
+ * later inbound quoted dupes while preserving the original inbound.
  *
  * Scope note: signature set is built from the items currently loaded
  * for the contact's detail page (i.e., the visible window). A
@@ -2637,15 +2640,15 @@ function buildAttachmentSignature(input: {
  * size) is acceptable given the operator can still see the original
  * copy on the inbound bubble.
  */
-function buildInboundAttachmentSignaturesByThread(input: {
+function buildInboundFirstOccurrenceByThread(input: {
   readonly items: readonly TimelineItem[];
   readonly attachmentsBySourceEvidenceId: ReadonlyMap<
     string,
     readonly MessageAttachmentRecord[]
   >;
   readonly sourceEvidenceIdByCanonicalEventId: ReadonlyMap<string, string>;
-}): Map<string, Set<string>> {
-  const byThread = new Map<string, Set<string>>();
+}): Map<string, Map<string, string>> {
+  const byThread = new Map<string, Map<string, string>>();
 
   for (const item of input.items) {
     if (item.family !== "one_to_one_email" || item.direction !== "inbound") {
@@ -2670,19 +2673,20 @@ function buildInboundAttachmentSignaturesByThread(input: {
       continue;
     }
 
-    let signatures = byThread.get(threadId);
-    if (signatures === undefined) {
-      signatures = new Set<string>();
-      byThread.set(threadId, signatures);
+    let firstOccurrenceBySignature = byThread.get(threadId);
+    if (firstOccurrenceBySignature === undefined) {
+      firstOccurrenceBySignature = new Map<string, string>();
+      byThread.set(threadId, firstOccurrenceBySignature);
     }
 
     for (const attachment of attachments) {
-      signatures.add(
-        buildAttachmentSignature({
-          filename: attachment.filename,
-          sizeBytes: attachment.sizeBytes,
-        }),
-      );
+      const signature = buildAttachmentSignature({
+        filename: attachment.filename,
+        sizeBytes: attachment.sizeBytes,
+      });
+      if (!firstOccurrenceBySignature.has(signature)) {
+        firstOccurrenceBySignature.set(signature, item.canonicalEventId);
+      }
     }
   }
 
@@ -2696,29 +2700,32 @@ function buildEmailAttachmentsForEntry(input: {
     readonly contentType: string;
     readonly sizeBytes: number;
   }[];
-  /**
-   * When the entry being rendered is outbound on a Gmail thread, this
-   * is the set of `(filename:sizeBytes)` signatures of attachments
-   * previously seen on inbound messages of the same thread. Any
-   * outbound canonical attachment whose signature is in this set is
-   * a quoted duplicate of the inbound's original and gets hidden
-   * from the outbound bubble (the original is still visible on the
-   * inbound bubble). `null` for inbound entries, or when the thread
-   * is unknown / has no inbound attachments to compare against.
-   */
-  readonly inboundAttachmentSignaturesOnThread: ReadonlySet<string> | null;
+  readonly itemDirection: "inbound" | "outbound";
+  readonly canonicalEventId: string;
+  readonly inboundFirstOccurrenceOnThread: ReadonlyMap<string, string> | null;
 }): InboxTimelineEntryViewModel["attachments"] {
   const canonicalAttachments = input.canonical
     .filter((attachment) => !attachment.isDecoration)
     .filter((attachment) => {
-      if (input.inboundAttachmentSignaturesOnThread === null) {
+      if (input.inboundFirstOccurrenceOnThread === null) {
         return true;
       }
       const signature = buildAttachmentSignature({
         filename: attachment.filename,
         sizeBytes: attachment.sizeBytes,
       });
-      return !input.inboundAttachmentSignaturesOnThread.has(signature);
+      const firstOccurrenceCanonicalEventId =
+        input.inboundFirstOccurrenceOnThread.get(signature);
+
+      if (firstOccurrenceCanonicalEventId === undefined) {
+        return true;
+      }
+
+      if (input.itemDirection === "outbound") {
+        return false;
+      }
+
+      return firstOccurrenceCanonicalEventId === input.canonicalEventId;
     })
     .map((attachment) => ({
       id: attachment.id,
@@ -2905,10 +2912,13 @@ function buildParticipantRows(input: {
       email: fromEmail,
     });
     // Inbound captures sometimes drop the To header (older
-    // Salesforce-derived items, mbox imports). Fall back to the
+    // Salesforce-derived items, mbox imports) or preserve a broken
+    // value equal to the sender's own address. Fall back to the
     // captured `mailbox` so the compact header always has a right
-    // side and the expanded view always shows a To row.
-    const inboundToEmail = toEmail ?? input.item.mailbox ?? null;
+    // side and the expanded view always shows a trustworthy To row.
+    const inboundToEmail = shouldFallbackToCapturedMailbox(toEmail, fromEmail)
+      ? (input.item.mailbox ?? null)
+      : toEmail;
     rows.push({
       label: "To",
       name: input.headerProjectLabel ?? "Adventure Scientists",
@@ -2925,6 +2935,17 @@ function buildParticipantRows(input: {
   }
 
   return rows;
+}
+
+function shouldFallbackToCapturedMailbox(
+  toEmail: string | null,
+  fromEmail: string | null,
+): boolean {
+  if (toEmail === null) {
+    return true;
+  }
+
+  return fromEmail !== null && toEmail.toLowerCase() === fromEmail.toLowerCase();
 }
 
 /**
@@ -4061,7 +4082,7 @@ async function readInboxDetailCacheData(
         ) ?? [],
       ]),
     ),
-    inboundAttachmentSignaturesByThread: buildInboundAttachmentSignaturesByThread(
+    inboundFirstOccurrenceByThread: buildInboundFirstOccurrenceByThread(
       {
         items: timelinePage.items,
         attachmentsBySourceEvidenceId,
@@ -4706,8 +4727,8 @@ function buildInboxDetailTimelineViewModel(input: {
       activityTimelineItems: input.cachedData.activityTimelineItems,
       attachmentsByCanonicalEventId:
         input.cachedData.attachmentsByCanonicalEventId,
-      inboundAttachmentSignaturesByThread:
-        input.cachedData.inboundAttachmentSignaturesByThread,
+      inboundFirstOccurrenceByThread:
+        input.cachedData.inboundFirstOccurrenceByThread,
       gmailMailboxAliasByCanonicalEventId:
         input.cachedData.gmailMailboxAliasByCanonicalEventId,
     }),

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -7305,7 +7305,7 @@ describe("real inbox selectors", () => {
         "",
         "[image: Image]",
         "",
-        "thanks",
+        "Trees were leafing up last week.",
       ].join("\n"),
     });
     await seedInboxProjection(runtime.context, {
@@ -7323,7 +7323,9 @@ describe("real inbox selectors", () => {
 
     const detail = await getInboxDetail("contact:inline-image-placeholder");
 
-    expect(detail?.timeline[0]?.body).toBe("Hi\n\nIMG_1234.jpeg\n\nthanks");
+    expect(detail?.timeline[0]?.body).toBe(
+      "Hi\n\nIMG_1234.jpeg\n\nTrees were leafing up last week.",
+    );
   });
 
   it("shows non-decoration image attachments as chips with a proxy URL", async () => {

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -7205,6 +7205,127 @@ describe("real inbox selectors", () => {
     ]);
   });
 
+  it("falls back to captured mailbox when inbound To matches inbound From", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:captured-mailbox-fallback",
+      salesforceContactId: "003-captured-mailbox-fallback",
+      displayName: "Captured Mailbox Fallback",
+      primaryEmail: "fallback@example.org",
+      primaryPhone: null,
+    });
+    const latest = await seedInboxEmailEvent(runtime.context, {
+      id: "captured-mailbox-fallback-1",
+      contactId: "contact:captured-mailbox-fallback",
+      occurredAt: "2026-05-28T11:00:00.000Z",
+      direction: "inbound",
+      subject: "Newsletter",
+      snippet: "Mailing list test.",
+      fromHeader: "Foo <a@b.com>",
+      toHeader: "Adventure Scientists <a@b.com>",
+    });
+    await runtime.context.repositories.gmailMessageDetails.upsert({
+      sourceEvidenceId: "source:captured-mailbox-fallback-1",
+      providerRecordId: "captured-mailbox-fallback-1",
+      gmailThreadId: "thread:contact:captured-mailbox-fallback",
+      rfc822MessageId: "<captured-mailbox-fallback-1@example.org>",
+      direction: "inbound",
+      subject: "Newsletter",
+      fromHeader: "Foo <a@b.com>",
+      toHeader: "Adventure Scientists <a@b.com>",
+      ccHeader: null,
+      fromEmails: [],
+      toEmails: [],
+      ccEmails: [],
+      bccEmails: [],
+      snippetClean: "Mailing list test.",
+      bodyTextPreview: "Mailing list test.",
+      bodyKind: "plaintext",
+      capturedMailbox: "orcas@adventurescientists.org",
+      projectInboxAlias: "orcas@adventurescientists.org",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:captured-mailbox-fallback",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-05-28T11:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-05-28T11:00:00.000Z",
+      snippet: "Mailing list test.",
+      lastCanonicalEventId: latest.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+
+    const detail = await getInboxDetail("contact:captured-mailbox-fallback");
+    const entry = detail?.timeline[0];
+
+    expect(entry?.participantRows).toEqual([
+      {
+        label: "From",
+        name: "Foo",
+        email: "a@b.com",
+      },
+      {
+        label: "To",
+        name: "Adventure Scientists",
+        email: "orcas@adventurescientists.org",
+      },
+    ]);
+  });
+
+  it("strips standalone inline-image placeholders from rendered email bodies", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:inline-image-placeholder",
+      salesforceContactId: "003-inline-image-placeholder",
+      displayName: "Inline Image Placeholder",
+      primaryEmail: "inline-image@example.org",
+      primaryPhone: null,
+    });
+    const latest = await seedInboxEmailEvent(runtime.context, {
+      id: "inline-image-placeholder-1",
+      contactId: "contact:inline-image-placeholder",
+      occurredAt: "2026-05-28T12:00:00.000Z",
+      direction: "inbound",
+      subject: "Winter check-in",
+      snippet: "Hi there, see attached.",
+      bodyTextPreview: [
+        "Hi",
+        "",
+        "[image: Image]",
+        "",
+        "IMG_1234.jpeg",
+        "",
+        "[image: Image]",
+        "",
+        "thanks",
+      ].join("\n"),
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:inline-image-placeholder",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-05-28T12:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-05-28T12:00:00.000Z",
+      snippet: "Hi there, see attached.",
+      lastCanonicalEventId: latest.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+
+    const detail = await getInboxDetail("contact:inline-image-placeholder");
+
+    expect(detail?.timeline[0]?.body).toBe("Hi\n\nIMG_1234.jpeg\n\nthanks");
+  });
+
   it("shows non-decoration image attachments as chips with a proxy URL", async () => {
     if (runtime === null) {
       throw new Error("Expected inbox test runtime");
@@ -7357,6 +7478,100 @@ describe("real inbox selectors", () => {
     // survives.
     expect(outboundEntry?.attachments).toHaveLength(1);
     expect(outboundEntry?.attachments[0]?.filename).toBe("instructions.pdf");
+  });
+
+  it("hides inbound attachments that duplicate a strictly earlier inbound on the same thread", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:inbound-dupe",
+      salesforceContactId: "003-inbound-dupe",
+      displayName: "Inbound Dupe Test",
+      primaryEmail: "inbound-dupe@example.org",
+      primaryPhone: null,
+    });
+    await seedInboxEmailEvent(runtime.context, {
+      id: "inbound-dupe-1",
+      contactId: "contact:inbound-dupe",
+      occurredAt: "2026-05-28T07:44:00.000Z",
+      direction: "inbound",
+      subject: "Re: Trail update",
+      snippet: "First reply with attachment.",
+    });
+    await seedInboxEmailEvent(runtime.context, {
+      id: "inbound-dupe-2",
+      contactId: "contact:inbound-dupe",
+      occurredAt: "2026-05-28T08:10:00.000Z",
+      direction: "inbound",
+      subject: "Re: Trail update",
+      snippet: "Quoted reply with the same screenshot.",
+    });
+    const thirdInbound = await seedInboxEmailEvent(runtime.context, {
+      id: "inbound-dupe-3",
+      contactId: "contact:inbound-dupe",
+      occurredAt: "2026-05-28T08:30:00.000Z",
+      direction: "inbound",
+      subject: "Re: Trail update",
+      snippet: "Fresh attachment in a later reply.",
+    });
+    await seedInboxMessageAttachment(runtime.context, {
+      sourceEvidenceId: "source:inbound-dupe-1",
+      id: "att:gmail:inbound-dupe-1:1",
+      mimeType: "image/jpeg",
+      filename: "photo.jpg",
+      sizeBytes: 45_817,
+      storageKey: "gmail/dupe/att:gmail:inbound-dupe-1:1",
+    });
+    await seedInboxMessageAttachment(runtime.context, {
+      sourceEvidenceId: "source:inbound-dupe-2",
+      id: "att:gmail:inbound-dupe-2:1",
+      mimeType: "image/jpeg",
+      filename: "photo.jpg",
+      sizeBytes: 45_817,
+      storageKey: "gmail/dupe/att:gmail:inbound-dupe-2:1",
+    });
+    await seedInboxMessageAttachment(runtime.context, {
+      sourceEvidenceId: "source:inbound-dupe-3",
+      id: "att:gmail:inbound-dupe-3:1",
+      mimeType: "image/jpeg",
+      filename: "different.jpg",
+      sizeBytes: 22_222,
+      storageKey: "gmail/dupe/att:gmail:inbound-dupe-3:1",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:inbound-dupe",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-05-28T08:30:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-05-28T08:30:00.000Z",
+      snippet: "Fresh attachment in a later reply.",
+      lastCanonicalEventId: thirdInbound.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+
+    const detail = await getInboxDetail("contact:inbound-dupe");
+
+    const firstEntry = detail?.timeline.find(
+      (entry) => entry.id === "timeline:inbound-dupe-1",
+    );
+    const secondEntry = detail?.timeline.find(
+      (entry) => entry.id === "timeline:inbound-dupe-2",
+    );
+    const thirdEntry = detail?.timeline.find(
+      (entry) => entry.id === "timeline:inbound-dupe-3",
+    );
+
+    expect(firstEntry?.attachments.map((attachment) => attachment.filename)).toEqual([
+      "photo.jpg",
+    ]);
+    expect(secondEntry?.attachments).toEqual([]);
+    expect(thirdEntry?.attachments.map((attachment) => attachment.filename)).toEqual([
+      "different.jpg",
+    ]);
   });
 
   it("falls back to pending attachment metadata when pending outbounds have no canonical attachments yet", async () => {


### PR DESCRIPTION
## Summary

Three small surgical fixes in the timeline renderer, all in `apps/web/app/inbox/_lib/selectors.ts` + `message-formatting.ts`. No schema change, no backfill required.

### A. Strip `[image: …]` placeholders

Mailparser emits `[image: Image]` lines into plaintext when an email has inline images. The actual attachments still render as chips via the existing path — these placeholder lines were just noise. Regex `/^\s*\[image:[^\]]*\]\s*$/gm` only matches whole-line placeholders.

Production repro: Hillie Larson's butternut-tree question with 5 attached photos.

### C. Inbound-on-inbound attachment dedup

Prior PR #480 dedup was directional (outbound vs inbound). When reply 2 quoted reply 1 and the inline screenshot from reply 1 was re-attached to reply 2, both bubbles showed the screenshot. New shape: `Map<threadId, Map<signature, firstOccurrenceCanonicalEventId>>`. Attachment stripped only if a strictly earlier inbound on the same thread already introduced its `(filename, sizeBytes)` signature.

Production repro: Adam Dasinger's thread showed the same FormAssembly error screenshot under two consecutive inbound replies.

### D. To-row fallback when parsed To == From

External newsletters arriving via BCC/list-expansion sometimes have the sender's own address in the visible To header. Existing fallback to `captured_mailbox` only fired when `toEmail` was null. Extended: also falls back when `toEmail.toLowerCase() === fromEmail.toLowerCase()`.

Production repro: NSF Tech Accelerators newsletter rendered `To: Adventure Scientists <tech-accelerators@nsf.gov>`.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm boundaries`, `pnpm build` — all green
- [x] New unit tests for each fix
- [ ] CI green
- [ ] After merge: spot-check Hillie / Adam / NSF threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)