### PR TITLE
fix(gmail-capture): surface silent 500 with structured error log

### DIFF
--- a/packages/integrations/src/capture-services/gmail.ts
+++ b/packages/integrations/src/capture-services/gmail.ts
@@ -690,6 +690,18 @@ export function createGmailCaptureService(
           });
         }
 
+        const cause = error instanceof Error ? error : new Error(String(error));
+        console.error(
+          JSON.stringify({
+            event: "gmail_capture.http.unhandled_error",
+            method: request.method,
+            path: request.path,
+            errorName: cause.name,
+            errorMessage: cause.message,
+            errorStack: cause.stack
+          })
+        );
+
         return jsonResponse(500, {
           error: "internal_error"
         });

--- a/packages/integrations/test/stage1-gmail-capture-service.test.ts
+++ b/packages/integrations/test/stage1-gmail-capture-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   createGmailCaptureService,
@@ -7,6 +7,15 @@ import {
   gmailMessageRecordSchema
 } from "../src/index.js";
 import { sha256Json } from "../src/capture-services/shared.js";
+
+interface LoggedUnhandledHttpError {
+  readonly event: string;
+  readonly method: string;
+  readonly path: string;
+  readonly errorName: string;
+  readonly errorMessage: string;
+  readonly errorStack?: string;
+}
 
 function buildFullMessagePayload(input: {
   readonly bodyText: string;
@@ -297,6 +306,84 @@ describe("Gmail capture service", () => {
       capturedMailbox: "volunteers@example.org",
       projectInboxAlias: "project-oceans@example.org"
     });
+  });
+
+  it("logs one-line structured error payloads for unhandled live capture failures", async () => {
+    const syntheticFailure = new Error("synthetic failure");
+    const errorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const service = createGmailCaptureService(
+      {
+        bearerToken: "gmail-token",
+        liveAccount: "volunteers@example.org",
+        projectInboxAliases: ["project-oceans@example.org"],
+        oauthClientId: "gmail-oauth-client-id",
+        oauthClientSecret: "gmail-oauth-client-secret",
+        oauthRefreshToken: "gmail-oauth-refresh-token"
+      },
+      {
+        apiClient: {
+          listMessageIds: () => Promise.resolve([]),
+          getMessage: () => Promise.resolve(null)
+        }
+      }
+    );
+
+    const captureLiveBatchSpy = vi
+      .spyOn(service, "captureLiveBatch")
+      .mockRejectedValue(syntheticFailure);
+
+    try {
+      const response = await service.handleHttpRequest({
+        method: "POST",
+        path: "/live",
+        headers: {
+          authorization: "Bearer gmail-token"
+        },
+        bodyText: JSON.stringify({
+          version: 1,
+          jobId: "job:gmail:live:error",
+          correlationId: "corr:gmail:live:error",
+          traceId: null,
+          batchId: "batch:gmail:live:error",
+          syncStateId: "sync:gmail:live:error",
+          attempt: 1,
+          maxAttempts: 3,
+          provider: "gmail",
+          mode: "live",
+          jobType: "live_ingest",
+          cursor: null,
+          checkpoint: null,
+          windowStart: "2026-01-05T00:00:00.000Z",
+          windowEnd: "2026-01-05T00:05:00.000Z",
+          recordIds: [],
+          maxRecords: 25
+        })
+      });
+
+      expect(response.status).toBe(500);
+      expect(JSON.parse(response.body)).toEqual({
+        error: "internal_error"
+      });
+      expect(captureLiveBatchSpy).toHaveBeenCalledOnce();
+      expect(errorSpy).toHaveBeenCalledOnce();
+
+      const loggedPayload: LoggedUnhandledHttpError = JSON.parse(
+        String(errorSpy.mock.calls[0]?.[0] ?? "")
+      ) as LoggedUnhandledHttpError;
+      expect(loggedPayload).toMatchObject({
+        event: "gmail_capture.http.unhandled_error",
+        method: "POST",
+        path: "/live",
+        errorName: syntheticFailure.name,
+        errorMessage: syntheticFailure.message,
+        errorStack: syntheticFailure.stack
+      });
+    } finally {
+      captureLiveBatchSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
   });
 
   it("keeps live Gmail checksum material backward-compatible when Subject is fetched", async () => {


### PR DESCRIPTION
## Summary

The HTTP handler in `packages/integrations/src/capture-services/gmail.ts` catches errors from `captureLiveBatch` and returns 500 **without logging anything**. This is why the worker has been alarming `Provider capture request failed with status 500 for /live` once a minute with no visible cause in gmail-capture's logs.

A misdiagnosis based on this silence almost triggered a destructive Railway rollback earlier today. The proposed rollback target predates the `is_decoration` column migration that has already run in prod — confirmed via direct DB inspection (column exists NOT NULL DEFAULT false, attachments are being inserted right now with `is_decoration` populated). Rolling back would have caused the very outage it was meant to prevent. Fixing the silence is fix-for-the-fix.

## Change

In the catch block at `gmail.ts:~690`, on the path that returns 500, add one `console.error(JSON.stringify(...))` line:

```json
{
  "event": "gmail_capture.http.unhandled_error",
  "method": "...",
  "path": "...",
  "errorName": "...",
  "errorMessage": "...",
  "errorStack": "..."
}
```

Does NOT log request body or headers (avoids leaking OAuth tokens / PII). Does NOT change the 500 response shape.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm boundaries` — green
- [x] New unit test: handler returns 500 AND `console.error` is called once with the expected JSON fields when `captureLiveBatch` throws
- [ ] CI green
- [ ] After deploy: read Railway gmail-capture logs for the `gmail_capture.http.unhandled_error` event — that's the actual failure we've been chasing

🤖 Generated with [Claude Code](https://claude.com/claude-code)