### PR TITLE
feat(worker/ops): recover-gmail-date-window — manual backfill (Brick A of PRD #512)

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -29,6 +29,7 @@
     "ops:detect-mbox-direction-misclassification": "tsx src/ops/cli.ts detect-mbox-direction-misclassification",
     "ops:apply-mbox-direction-backfill": "tsx src/ops/cli.ts apply-mbox-direction-backfill",
     "ops:backfill-inbox-projection-coverage": "tsx src/ops/backfill-inbox-projection-coverage.ts",
+    "ops:recover-gmail-date-window": "tsx src/ops/cli.ts recover-gmail-date-window",
     "ops:recover-gmail-spam-window": "tsx src/ops/recover-gmail-spam-window.ts",
     "ops:recompute-attachment-decoration": "tsx src/ops/recompute-attachment-decoration.ts",
     "ops:rebuild-inbox-projection-stuck-on-new": "tsx src/ops/rebuild-inbox-projection-stuck-on-new.ts",

--- a/apps/worker/src/ops/cli.ts
+++ b/apps/worker/src/ops/cli.ts
@@ -47,6 +47,7 @@ import { runCleanupSalesforceOwnerScopeCommand } from "./cleanup-salesforce-owne
 import { runDetectMboxDirectionMisclassificationCommand } from "./detect-mbox-direction-misclassification.js";
 import { runApplyMboxDirectionBackfillCommand } from "./apply-mbox-direction-backfill.js";
 import { main as runMergeEmailOnlyIntoSfAnchoredCommand } from "./merge-email-only-into-sf-anchored.js";
+import { runRecoverGmailDateWindowCommand } from "./recover-gmail-date-window.js";
 import { runRecoverGmailSpamWindowCommand } from "./recover-gmail-spam-window.js";
 import { runRecomputeAttachmentDecorationCommand } from "./recompute-attachment-decoration.js";
 import { runBackfillCanonicalEventAudienceCommand } from "./backfill-canonical-event-audience.js";
@@ -483,6 +484,9 @@ async function main(): Promise<void> {
     case "recover-orphan-gmail-details":
       await runRecoverOrphanGmailDetailsCommand(rest, process.env);
       return;
+    case "recover-gmail-date-window":
+      await runRecoverGmailDateWindowCommand(rest, process.env);
+      return;
     case "recover-gmail-spam-window":
       await runRecoverGmailSpamWindowCommand(rest, process.env);
       return;
@@ -527,7 +531,7 @@ async function main(): Promise<void> {
       return;
     default:
       throw new Error(
-        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-membership-sf-ids, backfill-gmail-mbox-bodies, backfill-content-fingerprint, backfill-garbled-message-bodies, re-extract-signed-envelope-bodies, backfill-mailchimp-campaign-body, mailchimp-capture-historical, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, detect-mbox-direction-misclassification, apply-mbox-direction-backfill, recover-orphan-gmail-details, recover-gmail-spam-window, recompute-attachment-decoration, rebuild-inbox-projection-stuck-on-new, rebuild-inbox-projection-snippet-bias, backfill-canonical-event-audience, reprocess-pending-campaign-sends, dedup-historical-ledger, merge-email-only-into-sf-anchored, reconcile-identity-queue, reconcile-routing-review-queue, reclassify-sf-direction, reconcile-stale-canonical, reconcile-superseded-projections.",
+        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-membership-sf-ids, backfill-gmail-mbox-bodies, backfill-content-fingerprint, backfill-garbled-message-bodies, re-extract-signed-envelope-bodies, backfill-mailchimp-campaign-body, mailchimp-capture-historical, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, detect-mbox-direction-misclassification, apply-mbox-direction-backfill, recover-orphan-gmail-details, recover-gmail-date-window, recover-gmail-spam-window, recompute-attachment-decoration, rebuild-inbox-projection-stuck-on-new, rebuild-inbox-projection-snippet-bias, backfill-canonical-event-audience, reprocess-pending-campaign-sends, dedup-historical-ledger, merge-email-only-into-sf-anchored, reconcile-identity-queue, reconcile-routing-review-queue, reclassify-sf-direction, reconcile-stale-canonical, reconcile-superseded-projections.",
       );
   }
 }

--- a/apps/worker/src/ops/recover-gmail-date-window.ts
+++ b/apps/worker/src/ops/recover-gmail-date-window.ts
@@ -1,0 +1,313 @@
+#!/usr/bin/env tsx
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+import {
+  closeDatabaseConnection,
+  createDatabaseConnection,
+  createStage1RepositoryBundleFromConnection,
+} from "@as-comms/db";
+import {
+  createStage1NormalizationService,
+  createStage1PersistenceService,
+  type Stage1RepositoryBundle,
+} from "@as-comms/domain";
+import {
+  buildGmailListQuery,
+  createGmailMailboxApiClient,
+  mapLiveGmailMessageToRecord,
+  type GmailCaptureServiceConfig,
+  type GmailMailboxApiClient,
+} from "@as-comms/integrations";
+
+import { createStage1IngestService, type Stage1IngestService } from "../ingest/index.js";
+import { readStage1LaunchScopeGmailConfig } from "./config.js";
+import {
+  parseCliFlags,
+  readOptionalBooleanFlag,
+  readOptionalStringFlag,
+  readRequiredFlag,
+} from "./helpers.js";
+
+interface Logger {
+  log(...args: readonly unknown[]): void;
+  error(...args: readonly unknown[]): void;
+}
+
+export interface RecoverGmailDateWindowLogEntry {
+  readonly id: string;
+  readonly foundInDb: boolean;
+  readonly action: "skipped" | "would-capture" | "captured";
+  readonly labelIds: readonly string[] | null;
+}
+
+export interface RecoverGmailDateWindowResult {
+  readonly dryRun: boolean;
+  readonly mailbox: string;
+  readonly windowStart: string;
+  readonly windowEnd: string;
+  readonly query: string;
+  readonly checked: number;
+  readonly foundInDb: number;
+  readonly missing: number;
+  readonly skipped: number;
+  readonly captured: number;
+  readonly notFoundInMailbox: number;
+}
+
+function readConnectionString(env: NodeJS.ProcessEnv): string {
+  const connectionString = env.WORKER_DATABASE_URL ?? env.DATABASE_URL;
+
+  if (connectionString === undefined || connectionString.trim().length === 0) {
+    throw new Error(
+      "DATABASE_URL or WORKER_DATABASE_URL is required for Stage 1 ops commands.",
+    );
+  }
+
+  return connectionString;
+}
+
+function readRequiredStringEnv(env: NodeJS.ProcessEnv, key: string): string {
+  const value = env[key];
+
+  if (value === undefined || value.trim().length === 0) {
+    throw new Error(`${key} is required for Gmail date-window recovery.`);
+  }
+
+  return value.trim();
+}
+
+function parseWindowTimestamp(value: string, flagName: string): string {
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Flag --${flagName} must be a valid ISO-8601 timestamp.`);
+  }
+
+  return parsed.toISOString();
+}
+
+function buildGmailApiClientFromEnv(
+  env: NodeJS.ProcessEnv,
+  mailbox: string | null,
+): {
+  readonly mailbox: string;
+  readonly liveAccount: string;
+  readonly projectInboxAliases: readonly string[];
+  readonly client: GmailMailboxApiClient;
+} {
+  const gmailConfig = readStage1LaunchScopeGmailConfig(env);
+  const clientConfig: GmailCaptureServiceConfig = {
+    bearerToken: "ops-recover-gmail-date-window",
+    liveAccount: gmailConfig.liveAccount,
+    projectInboxAliases: [...gmailConfig.projectInboxAliases],
+    oauthClientId: readRequiredStringEnv(env, "GMAIL_GOOGLE_OAUTH_CLIENT_ID"),
+    oauthClientSecret: readRequiredStringEnv(
+      env,
+      "GMAIL_GOOGLE_OAUTH_CLIENT_SECRET",
+    ),
+    oauthRefreshToken: readRequiredStringEnv(
+      env,
+      "GMAIL_GOOGLE_OAUTH_REFRESH_TOKEN",
+    ),
+    tokenUri:
+      env.GMAIL_GOOGLE_TOKEN_URI?.trim().length
+        ? env.GMAIL_GOOGLE_TOKEN_URI.trim()
+        : "https://oauth2.googleapis.com/token",
+    timeoutMs:
+      env.GMAIL_CAPTURE_TIMEOUT_MS === undefined
+        ? 15_000
+        : Number.parseInt(env.GMAIL_CAPTURE_TIMEOUT_MS, 10),
+  };
+
+  return {
+    mailbox: mailbox ?? gmailConfig.liveAccount,
+    liveAccount: gmailConfig.liveAccount,
+    projectInboxAliases: [...gmailConfig.projectInboxAliases],
+    client: createGmailMailboxApiClient(clientConfig),
+  };
+}
+
+function logEntry(
+  logger: Logger,
+  entry: RecoverGmailDateWindowLogEntry,
+): void {
+  logger.log(JSON.stringify(entry));
+}
+
+export async function recoverGmailDateWindow(input: {
+  readonly repositories: Pick<Stage1RepositoryBundle, "sourceEvidence">;
+  readonly ingest: Pick<Stage1IngestService, "ingestGmailHistoricalRecord">;
+  readonly apiClient: GmailMailboxApiClient;
+  readonly mailbox: string;
+  readonly liveAccount: string;
+  readonly projectInboxAliases: readonly string[];
+  readonly windowStart: string;
+  readonly windowEnd: string;
+  readonly execute: boolean;
+  readonly logger?: Logger;
+}): Promise<RecoverGmailDateWindowResult> {
+  const logger = input.logger ?? console;
+  const query = buildGmailListQuery({
+    windowStart: input.windowStart,
+    windowEnd: input.windowEnd,
+  });
+
+  if (query === null) {
+    throw new Error("Window start and end are required for Gmail date recovery.");
+  }
+
+  const messageIds = await input.apiClient.listMessageIds({
+    mailbox: input.mailbox,
+    query,
+  });
+
+  let foundInDb = 0;
+  let missing = 0;
+  let skipped = 0;
+  let captured = 0;
+  let notFoundInMailbox = 0;
+
+  for (const id of messageIds) {
+    const existingRows = await input.repositories.sourceEvidence.listByProviderRecord({
+      provider: "gmail",
+      providerRecordType: "message",
+      providerRecordId: id,
+    });
+
+    if (existingRows.length > 0) {
+      foundInDb += 1;
+      skipped += 1;
+      logEntry(logger, {
+        id,
+        foundInDb: true,
+        action: "skipped",
+        labelIds: null,
+      });
+      continue;
+    }
+
+    missing += 1;
+
+    if (!input.execute) {
+      logEntry(logger, {
+        id,
+        foundInDb: false,
+        action: "would-capture",
+        labelIds: null,
+      });
+      continue;
+    }
+
+    const message = await input.apiClient.getMessage({
+      mailbox: input.mailbox,
+      messageId: id,
+    });
+
+    if (message === null) {
+      notFoundInMailbox += 1;
+      skipped += 1;
+      logEntry(logger, {
+        id,
+        foundInDb: false,
+        action: "skipped",
+        labelIds: null,
+      });
+      continue;
+    }
+
+    const record = await mapLiveGmailMessageToRecord({
+      message,
+      capturedMailbox: input.mailbox,
+      liveAccount: input.liveAccount,
+      projectInboxAliases: input.projectInboxAliases,
+      receivedAt: new Date().toISOString(),
+    });
+
+    await input.ingest.ingestGmailHistoricalRecord(record, {
+      overwriteDuplicateGmailMessageDetail: false,
+    });
+
+    captured += 1;
+    logEntry(logger, {
+      id,
+      foundInDb: false,
+      action: "captured",
+      labelIds: message.labelIds,
+    });
+  }
+
+  return {
+    dryRun: !input.execute,
+    mailbox: input.mailbox,
+    windowStart: input.windowStart,
+    windowEnd: input.windowEnd,
+    query,
+    checked: messageIds.length,
+    foundInDb,
+    missing,
+    skipped,
+    captured,
+    notFoundInMailbox,
+  };
+}
+
+export async function runRecoverGmailDateWindowCommand(
+  args: readonly string[] = process.argv.slice(2),
+  env: NodeJS.ProcessEnv = process.env,
+  logger: Logger = console,
+): Promise<void> {
+  const flags = parseCliFlags(args);
+  const windowStart = parseWindowTimestamp(
+    readRequiredFlag(flags, "window-start"),
+    "window-start",
+  );
+  const windowEnd = parseWindowTimestamp(
+    readRequiredFlag(flags, "window-end"),
+    "window-end",
+  );
+  const dryRun = readOptionalBooleanFlag(flags, "dry-run", false);
+  const mailbox = readOptionalStringFlag(flags, "mailbox");
+  const connection = createDatabaseConnection({
+    connectionString: readConnectionString(env),
+  });
+
+  try {
+    const repositories = createStage1RepositoryBundleFromConnection(connection);
+    const persistence = createStage1PersistenceService(repositories);
+    const normalization = createStage1NormalizationService(persistence);
+    const ingest = createStage1IngestService(normalization);
+    const gmail = buildGmailApiClientFromEnv(env, mailbox);
+    const result = await recoverGmailDateWindow({
+      repositories,
+      ingest,
+      apiClient: gmail.client,
+      mailbox: gmail.mailbox,
+      liveAccount: gmail.liveAccount,
+      projectInboxAliases: gmail.projectInboxAliases,
+      windowStart,
+      windowEnd,
+      execute: !dryRun,
+      logger,
+    });
+
+    logger.log(JSON.stringify(result, null, 2));
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}
+
+async function main(): Promise<void> {
+  await runRecoverGmailDateWindowCommand(process.argv.slice(2), process.env);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  void main().catch((error: unknown) => {
+    console.error(
+      error instanceof Error
+        ? error.message
+        : "Gmail date-window recovery failed.",
+    );
+    process.exitCode = 1;
+  });
+}

--- a/apps/worker/test/recover-gmail-date-window.test.ts
+++ b/apps/worker/test/recover-gmail-date-window.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSourceEvidenceId,
+  type GmailMessageMetadata,
+} from "@as-comms/integrations";
+
+import {
+  recoverGmailDateWindow,
+  type RecoverGmailDateWindowLogEntry,
+} from "../src/ops/recover-gmail-date-window.js";
+import { createTestWorkerContext } from "./helpers.js";
+
+const contactId = "contact:recover-date-window";
+
+function buildFullMessagePayload(input: {
+  readonly bodyText: string;
+  readonly headers: Readonly<Record<string, string>>;
+}): GmailMessageMetadata["payload"] {
+  return {
+    mimeType: "text/plain",
+    filename: "",
+    headers: [
+      ...Object.entries(input.headers).map(([name, value]) => ({
+        name,
+        value,
+      })),
+      {
+        name: "Content-Type",
+        value: "text/plain; charset=UTF-8",
+      },
+      {
+        name: "Content-Transfer-Encoding",
+        value: "7bit",
+      },
+    ],
+    body: {
+      data: Buffer.from(input.bodyText, "utf8").toString("base64url"),
+    },
+    parts: [],
+  };
+}
+
+async function seedContact(
+  context: Awaited<ReturnType<typeof createTestWorkerContext>>,
+): Promise<void> {
+  await context.normalization.upsertNormalizedContactGraph({
+    contact: {
+      id: contactId,
+      salesforceContactId: null,
+      displayName: "Nathaniel McCrady",
+      primaryEmail: "nathanielmc@outlook.com",
+      primaryPhone: null,
+      createdAt: "2026-06-04T00:00:00.000Z",
+      updatedAt: "2026-06-04T00:00:00.000Z",
+    },
+    identities: [
+      {
+        id: `identity:${contactId}:email`,
+        contactId,
+        kind: "email",
+        normalizedValue: "nathanielmc@outlook.com",
+        isPrimary: true,
+        source: "manual",
+        verifiedAt: "2026-06-04T00:00:00.000Z",
+      },
+    ],
+    memberships: [],
+  });
+}
+
+async function appendExistingSourceEvidence(
+  context: Awaited<ReturnType<typeof createTestWorkerContext>>,
+  providerRecordId: string,
+): Promise<void> {
+  await context.repositories.sourceEvidence.append({
+    id: buildSourceEvidenceId("gmail", "message", providerRecordId),
+    provider: "gmail",
+    providerRecordType: "message",
+    providerRecordId,
+    receivedAt: "2026-06-04T22:05:00.000Z",
+    occurredAt: "2026-06-04T20:05:00.000Z",
+    payloadRef: `gmail://volunteers%40adventurescientists.org/messages/${providerRecordId}`,
+    idempotencyKey: `gmail:message:${providerRecordId}`,
+    checksum: `checksum:${providerRecordId}`,
+  });
+}
+
+function buildMessageMetadata(messageId: string): GmailMessageMetadata {
+  return {
+    id: messageId,
+    threadId: `thread-${messageId}`,
+    labelIds: ["INBOX"],
+    snippet: "Can my friends join me on Hex 34571?",
+    internalDate: String(Date.parse("2026-06-04T20:05:00.000Z")),
+    payload: buildFullMessagePayload({
+      bodyText: "Can my friends join me on Hex 34571?",
+      headers: {
+        Date: "Thu, 04 Jun 2026 14:05:00 -0600",
+        From: "Nathaniel McCrady <nathanielmc@outlook.com>",
+        To: "PNW Bio <pnwbio@adventurescientists.org>",
+        Subject: `Adding others to a Hex (${messageId})`,
+        "Message-ID": `<${messageId}@example.org>`,
+      },
+    }),
+  };
+}
+
+describe("recover-gmail-date-window", () => {
+  it("captures missing messages in the window and is idempotent on re-run", async () => {
+    const context = await createTestWorkerContext();
+    const logs: RecoverGmailDateWindowLogEntry[] = [];
+    const logger = {
+      log(value: unknown) {
+        if (typeof value === "string") {
+          logs.push(JSON.parse(value) as RecoverGmailDateWindowLogEntry);
+        }
+      },
+      error() {
+        return undefined;
+      },
+    };
+
+    try {
+      await seedContact(context);
+      await appendExistingSourceEvidence(context, "gmail-existing-1");
+
+      const apiClient = {
+        listMessageIds: () =>
+          Promise.resolve([
+            "gmail-existing-1",
+            "gmail-missing-1",
+            "gmail-missing-2",
+          ]),
+        getMessage: ({ messageId }: { readonly messageId: string }) =>
+          Promise.resolve(buildMessageMetadata(messageId)),
+      };
+
+      const firstRun = await recoverGmailDateWindow({
+        repositories: context.repositories,
+        ingest: context.ingest,
+        apiClient,
+        mailbox: "volunteers@adventurescientists.org",
+        liveAccount: "volunteers@adventurescientists.org",
+        projectInboxAliases: ["pnwbio@adventurescientists.org"],
+        windowStart: "2026-06-04T20:00:00.000Z",
+        windowEnd: "2026-06-05T00:00:00.000Z",
+        execute: true,
+        logger,
+      });
+
+      expect(firstRun).toMatchObject({
+        checked: 3,
+        foundInDb: 1,
+        missing: 2,
+        skipped: 1,
+        captured: 2,
+        notFoundInMailbox: 0,
+      });
+
+      const capturedEvidenceIds = await Promise.all(
+        ["gmail-missing-1", "gmail-missing-2"].map(async (providerRecordId) => {
+          const rows =
+            await context.repositories.sourceEvidence.listByProviderRecord({
+              provider: "gmail",
+              providerRecordType: "message",
+              providerRecordId,
+            });
+
+          expect(rows).toHaveLength(1);
+          return rows[0]?.id ?? "";
+        }),
+      );
+
+      const gmailDetails =
+        await context.repositories.gmailMessageDetails.listBySourceEvidenceIds(
+          capturedEvidenceIds,
+        );
+
+      expect(gmailDetails).toEqual([
+        expect.objectContaining({
+          providerRecordId: "gmail-missing-1",
+          direction: "inbound",
+          capturedMailbox: "volunteers@adventurescientists.org",
+        }),
+        expect.objectContaining({
+          providerRecordId: "gmail-missing-2",
+          direction: "inbound",
+          capturedMailbox: "volunteers@adventurescientists.org",
+        }),
+      ]);
+
+      expect(logs).toContainEqual({
+        id: "gmail-existing-1",
+        foundInDb: true,
+        action: "skipped",
+        labelIds: null,
+      });
+      expect(logs).toContainEqual({
+        id: "gmail-missing-1",
+        foundInDb: false,
+        action: "captured",
+        labelIds: ["INBOX"],
+      });
+      expect(logs).toContainEqual({
+        id: "gmail-missing-2",
+        foundInDb: false,
+        action: "captured",
+        labelIds: ["INBOX"],
+      });
+
+      logs.length = 0;
+
+      const secondRun = await recoverGmailDateWindow({
+        repositories: context.repositories,
+        ingest: context.ingest,
+        apiClient,
+        mailbox: "volunteers@adventurescientists.org",
+        liveAccount: "volunteers@adventurescientists.org",
+        projectInboxAliases: ["pnwbio@adventurescientists.org"],
+        windowStart: "2026-06-04T20:00:00.000Z",
+        windowEnd: "2026-06-05T00:00:00.000Z",
+        execute: true,
+        logger,
+      });
+
+      expect(secondRun).toMatchObject({
+        checked: 3,
+        foundInDb: 3,
+        missing: 0,
+        skipped: 3,
+        captured: 0,
+        notFoundInMailbox: 0,
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Brick A of PRD #512 (auto-backfill on integration recovery). This PR ships the underlying recovery code path as a manual one-shot ops command. Bricks B + C will wrap it in a graphile-worker task and an automatic enqueue from `poll-integration-health`.

**Why now:** today's incident lost ~11 inbound `volunteers@` messages during a 5-hour gmail-capture degradation. PR #511 added telemetry to catch the root cause next time; this PR gives us the tool to actually recover the lost window.

## How to run

```
pnpm --filter @as-comms/worker ops:recover-gmail-date-window \
  --window-start=2026-06-04T20:00:00Z \
  --window-end=2026-06-05T00:00:00Z \
  [--mailbox=volunteers@adventurescientists.org] \
  [--dry-run]
```

## Behavior

For each Gmail message in the date window:
1. Check whether its provider record id already exists in `source_evidence_log`.
2. If present → log `skipped`, do not write.
3. If absent → fetch via `apiClient.getMessage`, map via `mapLiveGmailMessageToRecord`, run through the existing stage1 ingest pipeline. Log `captured`.

Idempotent: re-running the same window second time → 0 captured, N skipped.

## Closely modeled on the existing `recover-gmail-spam-window.ts`

Same Gmail API client setup, same ingest pipeline wiring, same logger interface, same CLI flag parsing pattern. Just without the `in:spam` query scope (and as Codex noticed mid-implementation, the spam-window script doesn't actually prepend `in:spam` either — both scripts now call `buildGmailListQuery(...)` with the window only).

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm boundaries` — green
- [x] PGlite integration test: 3 messages in window, 1 pre-seeded; first run → 1 skipped, 2 captured; second run → 3 skipped, 0 captured
- [ ] CI green
- [ ] After merge: run against today's gap window (`--window-start=2026-06-04T20:00:00Z --window-end=2026-06-05T00:00:00Z`) to recover the ~11 missed messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)