### PR TITLE
feat(integrations): capture Drive attachments from Gmail HTML body (PRD #517 Brick A)

### DIFF
--- a/packages/integrations/src/capture-services/gmail.ts
+++ b/packages/integrations/src/capture-services/gmail.ts
@@ -21,6 +21,7 @@ import {
 } from "../providers/gmail-record-builder.js";
 import {
   collectGmailAttachmentMetadata,
+  collectGmailDriveAttachments,
   collectGmailHtmlCidReferences,
   cleanGmailBodyPreviewText,
   extractDsnOriginalMessageId,
@@ -443,6 +444,10 @@ export async function mapLiveGmailMessageToRecord(input: {
       ? cleanedGmailSnippet
       : null;
   const attachmentMetadata = collectGmailAttachmentMetadata(input.message.payload);
+  const driveAttachmentMetadata = collectGmailDriveAttachments(
+    input.message.payload,
+    { messageIdentifier: input.message.id },
+  );
   const htmlBodyCidReferences = collectGmailHtmlCidReferences(
     input.message.payload,
     {
@@ -469,6 +474,7 @@ export async function mapLiveGmailMessageToRecord(input: {
     bodyTextPreview: usableSnippetFallback ?? bodyPreviewResult.bodyTextPreview,
     bodyKind: usableSnippetFallback === null ? bodyPreviewResult.bodyKind : "plaintext",
     attachmentMetadata,
+    driveAttachmentMetadata,
     htmlBodyCidReferences,
     internalDate: input.message.internalDate,
     headers,

--- a/packages/integrations/src/providers/gmail-body.ts
+++ b/packages/integrations/src/providers/gmail-body.ts
@@ -87,6 +87,13 @@ export interface GmailAttachmentMetadata {
   readonly contentId: string | null;
 }
 
+export interface GmailDriveAttachmentMetadata {
+  readonly driveFileId: string;
+  readonly driveUrl: string;
+  readonly filename: string | null;
+  readonly mimeType: "application/vnd.gmail-drive-attachment";
+}
+
 const ENCRYPTED_MESSAGE_PLACEHOLDER =
   "[Encrypted message — open in Gmail to read]";
 const BINARY_FALLBACK_PLACEHOLDER =
@@ -945,6 +952,92 @@ export function collectGmailHtmlCidReferences(
 
   walk(payload, 0);
   return [...references].sort((left, right) => left.localeCompare(right));
+}
+
+export function collectGmailDriveAttachments(
+  payload: GmailApiMessagePart,
+  options?: {
+    readonly messageIdentifier?: string | null;
+  },
+): readonly GmailDriveAttachmentMetadata[] {
+  const attachments: GmailDriveAttachmentMetadata[] = [];
+  const seenDriveFileIds = new Set<string>();
+  const context = createGmailMimeBudgetContext(options?.messageIdentifier);
+  const decodeState: GmailMimeDecodeState = {
+    decodedBytes: 0,
+    budgetExceeded: false,
+  };
+  const driveAnchorPattern =
+    /<a\b[^>]*?href=(["'])(https?:\/\/drive\.google\.com\/file\/d\/([^/"']*)\/[^"']*)\1[^>]*>([\s\S]*?)<\/a>/giu;
+
+  function walk(part: GmailApiMessagePart, depth: number): void {
+    if (depth > context.bounds.maxDepth || decodeState.budgetExceeded) {
+      return;
+    }
+
+    const mimeType = normalizeMimeType(part.mimeType);
+
+    if (mimeType === "text/html" && !isAttachmentPart(part)) {
+      const decodedHtml = decodePartBodyToString(part, context, decodeState);
+
+      if (decodedHtml !== null) {
+        for (const match of decodedHtml.matchAll(driveAnchorPattern)) {
+          const driveUrl = match[2]?.trim() ?? "";
+          const driveFileId = match[3]?.trim() ?? "";
+
+          if (driveFileId.length === 0) {
+            console.warn("Drive attachment parse failed.", {
+              event: "drive_attachment.parse_failed",
+              gmailMessageId: options?.messageIdentifier ?? null,
+              reason: "empty_drive_file_id",
+            });
+            continue;
+          }
+
+          if (/[\/\s]/u.test(driveFileId)) {
+            console.warn("Drive attachment parse failed.", {
+              event: "drive_attachment.parse_failed",
+              gmailMessageId: options?.messageIdentifier ?? null,
+              reason: "invalid_drive_file_id",
+            });
+            continue;
+          }
+
+          if (seenDriveFileIds.has(driveFileId)) {
+            continue;
+          }
+
+          seenDriveFileIds.add(driveFileId);
+
+          const anchorText = decodeHtmlEntities(
+            (match[4] ?? "").replace(/<[^>]+>/gu, " "),
+          ).trim();
+          const filename = anchorText.length > 0 ? anchorText : null;
+
+          attachments.push({
+            driveFileId,
+            driveUrl,
+            filename,
+            mimeType: "application/vnd.gmail-drive-attachment",
+          });
+
+          console.info("Drive attachment captured.", {
+            event: "drive_attachment.captured",
+            gmailMessageId: options?.messageIdentifier ?? null,
+            driveFileId,
+            filename,
+          });
+        }
+      }
+    }
+
+    for (const childPart of part.parts ?? []) {
+      walk(childPart, depth + 1);
+    }
+  }
+
+  walk(payload, 0);
+  return attachments;
 }
 
 function collectCandidateBodyPartsInternal(

--- a/packages/integrations/src/providers/gmail-record-builder.ts
+++ b/packages/integrations/src/providers/gmail-record-builder.ts
@@ -3,7 +3,10 @@ import { createHash } from "node:crypto";
 import libmime from "libmime";
 
 import { gmailMessageRecordSchema, type GmailRecord } from "./gmail.js";
-import type { GmailAttachmentMetadata } from "./gmail-body.js";
+import type {
+  GmailAttachmentMetadata,
+  GmailDriveAttachmentMetadata
+} from "./gmail-body.js";
 
 export interface GmailProviderCloseMessageInput {
   readonly recordId: string;
@@ -27,6 +30,7 @@ export interface GmailProviderCloseMessageInput {
   readonly internalAddresses: readonly string[];
   readonly projectInboxAliases: readonly string[];
   readonly attachmentMetadata?: readonly GmailAttachmentMetadata[];
+  readonly driveAttachmentMetadata?: readonly GmailDriveAttachmentMetadata[];
   readonly htmlBodyCidReferences?: readonly string[];
   readonly projectInboxAliasOverride?: string | null;
   readonly treatCapturedMailboxAsProjectInbox?: boolean;
@@ -473,6 +477,7 @@ export function buildGmailMessageRecord(
         ? null
         : `rfc822:${rfc822MessageId.toLowerCase()}`,
     attachmentMetadata: input.attachmentMetadata ?? [],
+    driveAttachmentMetadata: input.driveAttachmentMetadata ?? [],
     htmlBodyCidReferences: input.htmlBodyCidReferences ?? [],
   });
 }

--- a/packages/integrations/src/providers/gmail.ts
+++ b/packages/integrations/src/providers/gmail.ts
@@ -76,6 +76,16 @@ export const gmailMessageRecordSchema = z.object({
       }),
     )
     .default([]),
+  driveAttachmentMetadata: z
+    .array(
+      z.object({
+        driveFileId: z.string().min(1),
+        driveUrl: z.string().min(1),
+        filename: nullableStringSchema,
+        mimeType: z.literal("application/vnd.gmail-drive-attachment"),
+      }),
+    )
+    .default([]),
   htmlBodyCidReferences: stringArraySchema.default([]),
 });
 export type GmailMessageRecord = z.infer<typeof gmailMessageRecordSchema>;

--- a/packages/integrations/test/gmail-body-extraction.test.ts
+++ b/packages/integrations/test/gmail-body-extraction.test.ts
@@ -40,6 +40,7 @@ vi.mock("mailparser", async () => {
 import {
   cleanGmailBodyPreviewText,
   collectGmailAttachmentMetadata,
+  collectGmailDriveAttachments,
   collectGmailHtmlCidReferences,
   extractDsnOriginalMessageId,
   extractGmailBodyPreviewFromMimeMessageResult,
@@ -312,6 +313,311 @@ describe("Gmail body extraction", () => {
     };
 
     expect(collectGmailHtmlCidReferences(payload)).toEqual(["abc@x", "def@x"]);
+  });
+
+  it("captures a single Drive anchor", () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const payload: GmailApiMessagePart = {
+      mimeType: "multipart/alternative",
+      parts: [
+        {
+          mimeType: "text/html",
+          body: {
+            data: encodeBase64Url(
+              '<a href="https://drive.google.com/file/d/abc123/view?usp=drive_link">IMG_2634.jpeg</a>',
+            ),
+          },
+        },
+      ],
+    };
+
+    expect(
+      collectGmailDriveAttachments(payload, {
+        messageIdentifier: "gmail-drive-single",
+      }),
+    ).toEqual([
+      {
+        driveFileId: "abc123",
+        driveUrl:
+          "https://drive.google.com/file/d/abc123/view?usp=drive_link",
+        filename: "IMG_2634.jpeg",
+        mimeType: "application/vnd.gmail-drive-attachment",
+      },
+    ]);
+    expect(infoSpy).toHaveBeenCalledWith(
+      "Drive attachment captured.",
+      expect.objectContaining({
+        event: "drive_attachment.captured",
+        gmailMessageId: "gmail-drive-single",
+        driveFileId: "abc123",
+        filename: "IMG_2634.jpeg",
+      }),
+    );
+  });
+
+  it("captures multiple Drive anchors in insertion order", () => {
+    const payload: GmailApiMessagePart = {
+      mimeType: "multipart/alternative",
+      parts: [
+        {
+          mimeType: "text/html",
+          body: {
+            data: encodeBase64Url(
+              [
+                '<a href="https://drive.google.com/file/d/id-1/view">one.jpg</a>',
+                '<a href="https://drive.google.com/file/d/id-2/view">two.jpg</a>',
+                '<a href="https://drive.google.com/file/d/id-3/view">three.jpg</a>',
+                '<a href="https://drive.google.com/file/d/id-4/view">four.jpg</a>',
+                '<a href="https://drive.google.com/file/d/id-5/view">five.jpg</a>',
+              ].join(" "),
+            ),
+          },
+        },
+      ],
+    };
+
+    expect(collectGmailDriveAttachments(payload)).toEqual([
+      {
+        driveFileId: "id-1",
+        driveUrl: "https://drive.google.com/file/d/id-1/view",
+        filename: "one.jpg",
+        mimeType: "application/vnd.gmail-drive-attachment",
+      },
+      {
+        driveFileId: "id-2",
+        driveUrl: "https://drive.google.com/file/d/id-2/view",
+        filename: "two.jpg",
+        mimeType: "application/vnd.gmail-drive-attachment",
+      },
+      {
+        driveFileId: "id-3",
+        driveUrl: "https://drive.google.com/file/d/id-3/view",
+        filename: "three.jpg",
+        mimeType: "application/vnd.gmail-drive-attachment",
+      },
+      {
+        driveFileId: "id-4",
+        driveUrl: "https://drive.google.com/file/d/id-4/view",
+        filename: "four.jpg",
+        mimeType: "application/vnd.gmail-drive-attachment",
+      },
+      {
+        driveFileId: "id-5",
+        driveUrl: "https://drive.google.com/file/d/id-5/view",
+        filename: "five.jpg",
+        mimeType: "application/vnd.gmail-drive-attachment",
+      },
+    ]);
+  });
+
+  it("dedupes anchors with the same driveFileId", () => {
+    const payload: GmailApiMessagePart = {
+      mimeType: "multipart/alternative",
+      parts: [
+        {
+          mimeType: "text/html",
+          body: {
+            data: encodeBase64Url(
+              [
+                '<a href="https://drive.google.com/file/d/shared-id/view">first-name.jpg</a>',
+                '<a href="https://drive.google.com/file/d/shared-id/preview">second-name.jpg</a>',
+              ].join(" "),
+            ),
+          },
+        },
+      ],
+    };
+
+    expect(collectGmailDriveAttachments(payload)).toEqual([
+      {
+        driveFileId: "shared-id",
+        driveUrl: "https://drive.google.com/file/d/shared-id/view",
+        filename: "first-name.jpg",
+        mimeType: "application/vnd.gmail-drive-attachment",
+      },
+    ]);
+  });
+
+  it("decodes html entities in a Drive attachment filename", () => {
+    const payload: GmailApiMessagePart = {
+      mimeType: "multipart/alternative",
+      parts: [
+        {
+          mimeType: "text/html",
+          body: {
+            data: encodeBase64Url(
+              '<a href="https://drive.google.com/file/d/xyz/view">Photo &amp; notes.png</a>',
+            ),
+          },
+        },
+      ],
+    };
+
+    expect(collectGmailDriveAttachments(payload)).toEqual([
+      {
+        driveFileId: "xyz",
+        driveUrl: "https://drive.google.com/file/d/xyz/view",
+        filename: "Photo & notes.png",
+        mimeType: "application/vnd.gmail-drive-attachment",
+      },
+    ]);
+  });
+
+  it("stores a null filename when the Drive anchor text is empty", () => {
+    const payload: GmailApiMessagePart = {
+      mimeType: "multipart/alternative",
+      parts: [
+        {
+          mimeType: "text/html",
+          body: {
+            data: encodeBase64Url(
+              '<a href="https://drive.google.com/file/d/empty/view"></a>',
+            ),
+          },
+        },
+      ],
+    };
+
+    expect(collectGmailDriveAttachments(payload)).toEqual([
+      {
+        driveFileId: "empty",
+        driveUrl: "https://drive.google.com/file/d/empty/view",
+        filename: null,
+        mimeType: "application/vnd.gmail-drive-attachment",
+      },
+    ]);
+  });
+
+  it("strips nested html from Drive anchor text", () => {
+    const payload: GmailApiMessagePart = {
+      mimeType: "multipart/alternative",
+      parts: [
+        {
+          mimeType: "text/html",
+          body: {
+            data: encodeBase64Url(
+              '<a href="https://drive.google.com/file/d/nested/view"><span>real_name.jpg</span></a>',
+            ),
+          },
+        },
+      ],
+    };
+
+    expect(collectGmailDriveAttachments(payload)).toEqual([
+      {
+        driveFileId: "nested",
+        driveUrl: "https://drive.google.com/file/d/nested/view",
+        filename: "real_name.jpg",
+        mimeType: "application/vnd.gmail-drive-attachment",
+      },
+    ]);
+  });
+
+  it("ignores non-Drive urls", () => {
+    const payload: GmailApiMessagePart = {
+      mimeType: "multipart/alternative",
+      parts: [
+        {
+          mimeType: "text/html",
+          body: {
+            data: encodeBase64Url(
+              [
+                '<a href="https://docs.google.com/document/d/abc/edit">Doc</a>',
+                '<a href="https://example.org/file/d/abc/view">Other</a>',
+              ].join(" "),
+            ),
+          },
+        },
+      ],
+    };
+
+    expect(collectGmailDriveAttachments(payload)).toEqual([]);
+  });
+
+  it("ignores anchors inside text/plain parts", () => {
+    const payload: GmailApiMessagePart = {
+      mimeType: "multipart/alternative",
+      parts: [
+        buildTextBodyPart(
+          '<a href="https://drive.google.com/file/d/plain-ignored/view">plain.txt</a>',
+        ),
+      ],
+    };
+
+    expect(collectGmailDriveAttachments(payload)).toEqual([]);
+  });
+
+  it("ignores anchors inside attachment parts", () => {
+    const payload: GmailApiMessagePart = {
+      mimeType: "multipart/mixed",
+      parts: [
+        {
+          mimeType: "text/html",
+          filename: "x.html",
+          headers: [
+            { name: "Content-Type", value: "text/html; charset=utf-8" },
+            {
+              name: "Content-Disposition",
+              value: 'attachment; filename="x.html"',
+            },
+          ],
+          body: {
+            data: encodeBase64Url(
+              '<a href="https://drive.google.com/file/d/attached/view">attached.html</a>',
+            ),
+          },
+        },
+      ],
+    };
+
+    expect(collectGmailDriveAttachments(payload)).toEqual([]);
+  });
+
+  it("returns an empty array when no Drive anchors exist", () => {
+    const payload: GmailApiMessagePart = {
+      mimeType: "multipart/alternative",
+      parts: [
+        {
+          mimeType: "text/html",
+          body: {
+            data: encodeBase64Url("<p>No attachments here.</p>"),
+          },
+        },
+      ],
+    };
+
+    expect(collectGmailDriveAttachments(payload)).toEqual([]);
+  });
+
+  it("warns and skips malformed Drive file ids", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const payload: GmailApiMessagePart = {
+      mimeType: "multipart/alternative",
+      parts: [
+        {
+          mimeType: "text/html",
+          body: {
+            data: encodeBase64Url(
+              '<a href="https://drive.google.com/file/d//view">x</a>',
+            ),
+          },
+        },
+      ],
+    };
+
+    expect(
+      collectGmailDriveAttachments(payload, {
+        messageIdentifier: "gmail-drive-malformed",
+      }),
+    ).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Drive attachment parse failed.",
+      expect.objectContaining({
+        event: "drive_attachment.parse_failed",
+        gmailMessageId: "gmail-drive-malformed",
+      }),
+    );
   });
 
   it("treats a text/plain part containing decoded binary noise as a binary fallback", async () => {

--- a/packages/integrations/test/stage1-gmail-capture-service.test.ts
+++ b/packages/integrations/test/stage1-gmail-capture-service.test.ts
@@ -533,6 +533,97 @@ describe("Gmail capture service", () => {
     expect(record.bodyTextPreview).toHaveLength(longBody.length);
   });
 
+  it("threads captured Drive anchors into the Gmail record", async () => {
+    const service = createGmailCaptureService(
+      {
+        bearerToken: "gmail-token",
+        liveAccount: "volunteers@example.org",
+        projectInboxAliases: ["project-oceans@example.org"],
+        oauthClientId: "gmail-oauth-client-id",
+        oauthClientSecret: "gmail-oauth-client-secret",
+        oauthRefreshToken: "gmail-oauth-refresh-token"
+      },
+      {
+        apiClient: {
+          listMessageIds: () => Promise.resolve(["gmail-drive-anchor-1"]),
+          getMessage: ({ messageId }) =>
+            Promise.resolve({
+              id: messageId,
+              threadId: "thread-drive-anchor-1",
+              labelIds: ["INBOX"],
+              snippet: "Drive file shared",
+              internalDate: String(Date.parse("2026-01-05T00:00:00.000Z")),
+              payload: {
+                mimeType: "multipart/alternative",
+                headers: [
+                  { name: "From", value: "Volunteer <volunteer@example.org>" },
+                  {
+                    name: "To",
+                    value: "Project Oceans <project-oceans@example.org>"
+                  },
+                  { name: "Subject", value: "Shared files" },
+                  {
+                    name: "Message-ID",
+                    value: "<gmail-drive-anchor-1@example.org>"
+                  },
+                  { name: "Date", value: "Mon, 05 Jan 2026 00:00:00 +0000" },
+                ],
+                parts: [
+                  {
+                    mimeType: "text/html",
+                    headers: [
+                      {
+                        name: "Content-Type",
+                        value: 'text/html; charset="UTF-8"'
+                      },
+                    ],
+                    body: {
+                      data: Buffer.from(
+                        '<a href="https://drive.google.com/file/d/abc123/view?usp=drive_link">IMG_2634.jpeg</a>',
+                        "utf8",
+                      ).toString("base64url"),
+                    },
+                  },
+                ],
+              },
+            })
+        },
+        now: () => new Date("2026-01-05T00:01:00.000Z")
+      }
+    );
+
+    const result = await service.captureLiveBatch({
+      version: 1,
+      jobId: "job:gmail:live:drive-anchor",
+      correlationId: "corr:gmail:live:drive-anchor",
+      traceId: null,
+      batchId: "batch:gmail:live:drive-anchor",
+      syncStateId: "sync:gmail:live:drive-anchor",
+      attempt: 1,
+      maxAttempts: 3,
+      provider: "gmail",
+      mode: "live",
+      jobType: "live_ingest",
+      cursor: null,
+      checkpoint: null,
+      windowStart: "2026-01-05T00:00:00.000Z",
+      windowEnd: "2026-01-05T00:05:00.000Z",
+      recordIds: [],
+      maxRecords: 25
+    });
+
+    const record = gmailMessageRecordSchema.parse(result.records[0]);
+    expect(record.driveAttachmentMetadata).toEqual([
+      {
+        driveFileId: "abc123",
+        driveUrl:
+          "https://drive.google.com/file/d/abc123/view?usp=drive_link",
+        filename: "IMG_2634.jpeg",
+        mimeType: "application/vnd.gmail-drive-attachment",
+      },
+    ]);
+  });
+
   it("captures spam-labeled inbound Gmail messages and preserves the SPAM label", async () => {
     const service = createGmailCaptureService(
       {


### PR DESCRIPTION
## Summary

- Brick A of [PRD #517](https://github.com/nico-kneler-as/as-comms-platform/issues/517).
- Adds `collectGmailDriveAttachments` in `packages/integrations/src/providers/gmail-body.ts` — walks `text/html` MIME parts (skipping attachments + over-depth) and extracts `<a href="https://drive.google.com/file/d/{id}/...">filename</a>` anchors. Dedupes by `driveFileId`, decodes HTML entities + strips nested tags in anchor text, emits telemetry on capture and parse failure.
- Threads `driveAttachmentMetadata` through `gmailMessageRecordSchema`, `GmailProviderCloseMessageInput`, `buildGmailMessageRecord`, and `mapLiveGmailMessageToRecord`. The custom MIME marker `application/vnd.gmail-drive-attachment` is locked in via `z.literal(...)` so Brick B can discriminate.
- No body-preview extraction or MIME-attachment behavior changes. Storage (Brick B), rendering (Brick C), and backfill (Brick D) follow.

## Test plan

- [x] `pnpm typecheck` — pass
- [x] `pnpm lint` — pass
- [x] `pnpm boundaries` — pass
- [ ] CI test suite runs all unit tests (`gmail-body-extraction.test.ts` adds 11 cases for the parser; `stage1-gmail-capture-service.test.ts` adds 1 wiring case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)