### PR TITLE
fix(postmark): send bare-array body to /email/batch

### DIFF
--- a/packages/integrations/src/providers/postmark.ts
+++ b/packages/integrations/src/providers/postmark.ts
@@ -374,11 +374,11 @@ export function createPostmarkClient(opts: {
     async sendBatch(req) {
       assertBatchSize(req.messages);
 
-      const payload = {
-        Messages: req.messages.map((message) => ({
-          ...message,
-        })),
-      };
+      // Postmark `/email/batch` expects a bare JSON array of messages;
+      // only `/email/batchWithTemplates` takes a `{ Messages: [...] }`
+      // wrapper. Sending the wrapped shape here yields a 422 with the
+      // surprising `Message: "Invalid JSON"` text.
+      const messages = req.messages.map((message) => ({ ...message }));
       const token = req.isTest ? POSTMARK_TEST_TOKEN : opts.serverToken;
       const results = await executeJsonRequest<readonly PostmarkBatchSendResult[]>(
         req.isTest
@@ -387,7 +387,7 @@ export function createPostmarkClient(opts: {
               method: "POST",
               token,
               tokenHeader: "X-Postmark-Server-Token",
-              body: payload,
+              body: messages,
               extraHeaders: { "X-AS-Test": "true" },
               retry5xx: true,
             }
@@ -396,7 +396,7 @@ export function createPostmarkClient(opts: {
               method: "POST",
               token,
               tokenHeader: "X-Postmark-Server-Token",
-              body: payload,
+              body: messages,
               retry5xx: true,
             },
       );

--- a/packages/integrations/test/postmark-client.test.ts
+++ b/packages/integrations/test/postmark-client.test.ts
@@ -157,10 +157,11 @@ describe("PostmarkClient — sendBatch", () => {
     const headers = init?.headers as Record<string, string>;
     expect(headers["X-Postmark-Server-Token"]).toBe(TEST_SERVER_TOKEN);
     expect(headers["X-AS-Test"]).toBeUndefined();
-    const sentBody = JSON.parse(init?.body as string) as {
-      Messages: unknown[];
-    };
-    expect(sentBody.Messages).toHaveLength(1);
+    // Postmark `/email/batch` requires a bare array — not a `{ Messages: [...] }`
+    // wrapper (that shape is reserved for `/email/batchWithTemplates`).
+    const sentBody = JSON.parse(init?.body as string) as unknown[];
+    expect(Array.isArray(sentBody)).toBe(true);
+    expect(sentBody).toHaveLength(1);
   });
 
   it("adds the X-AS-Test header and uses the test token when isTest is true", async () => {


### PR DESCRIPTION
## Summary
Postmark's `/email/batch` endpoint expects a **bare JSON array** of message objects, not a `{ Messages: [...] }` wrapper — that shape is reserved for `/email/batchWithTemplates`. The previous code wrapped the array, which Postmark rejected with `422 / Message: "Invalid JSON"`.

**First real Postmark traffic on this path surfaced the bug today** (a test send + a scheduled broadcast both failed identically). `sendBatch` is the single call site for both the wizard test-send action (`testSend` in `apps/web/app/broadcasts/actions.ts`) and the worker's `campaign-send-orchestrator`, so the same body-shape bug took out both surfaces.

## Fix
- `packages/integrations/src/providers/postmark.ts` — pass `req.messages` (a bare array) as the request body instead of `{ Messages: req.messages }`.
- Comment added at the call site so the bug can't be re-introduced.

## Why it slipped through
The existing unit test mocked `fetch` and asserted the wrong shape (`sentBody.Messages`), so it passed locally for weeks while the prod call would have failed. **Test updated** to assert a bare array (with `Array.isArray`) so a regression to the wrapped shape would now fail in CI.

## Validation
- `pnpm typecheck` — passed
- `pnpm lint` — passed
- `packages/integrations` vitest — **199/199 passed** (incl. updated `postmark-client.test.ts`)
- `pnpm build` skipped: no route / page / config files changed (per memory rule for build-only-on-route-change); CI will run it.

## Test plan
- [ ] CI green
- [ ] Re-run the wizard test send to `nicolaskneler@gmail.com` — Postmark should now accept the request
- [ ] Stranded "Nico TEST" scheduled run may need a manual nudge after deploy (stranded-run reconcile cron should also pick it up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)