### PR TITLE
fix(broadcasts): friendly From, alias in unsubscribe, preheader, List-Unsubscribe headers

### DIFF
--- a/apps/web/app/broadcasts/_lib/audience-data-source.ts
+++ b/apps/web/app/broadcasts/_lib/audience-data-source.ts
@@ -791,9 +791,16 @@ export async function loadComposePreviewAction(input: {
       ((input.sampleIndex % audience.length) + audience.length) % audience.length;
     const sample = audience[normalizedSampleIndex] ?? audience[0];
     const origin = await readRequestOrigin();
+    const projectId =
+      input.criteria.projectId ?? input.criteria.projectIds[0] ?? null;
+    const projectAlias =
+      projectId === null
+        ? null
+        : (await runtime.settings.projects.findById(projectId))?.projectAlias ?? null;
     const footer = buildCampaignFooterPreview({
       kind: input.kind,
       projectName: sample?.frozenProjectName ?? null,
+      projectAlias,
       footerAddress,
       origin,
     });

--- a/apps/web/app/broadcasts/_lib/campaign-preview.ts
+++ b/apps/web/app/broadcasts/_lib/campaign-preview.ts
@@ -2,6 +2,7 @@ import type {
   CampaignKind,
   OrgSettingsRecord,
 } from "@as-comms/contracts";
+import { escapeHtml } from "@as-comms/domain";
 
 export function formatOrgAddress(input: OrgSettingsRecord): string | null {
   const line1 = input.physicalAddressLine1.trim();
@@ -15,18 +16,10 @@ export function formatOrgAddress(input: OrgSettingsRecord): string | null {
   return parts.length === 0 ? null : parts.join(" • ");
 }
 
-function escapeHtml(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
-}
-
 export function buildCampaignFooterPreview(input: {
   readonly kind: CampaignKind;
   readonly projectName: string | null;
+  readonly projectAlias: string | null;
   readonly footerAddress: string | null;
   readonly origin: string;
 }): {
@@ -36,7 +29,7 @@ export function buildCampaignFooterPreview(input: {
   const scopedLabel =
     input.kind === "newsletter"
       ? "Unsubscribe from the AS newsletter"
-      : `Unsubscribe from ${input.projectName ?? "this project"} emails`;
+      : `Unsubscribe from ${input.projectAlias ?? input.projectName ?? "this project"} emails`;
   const scopedHref = `${input.origin}/u/preview-${input.kind}`;
   const allHref = `${input.origin}/u/preview-all`;
   const linkLabels =

--- a/apps/web/app/broadcasts/actions.ts
+++ b/apps/web/app/broadcasts/actions.ts
@@ -14,9 +14,12 @@ import {
   sendNowInputSchema,
 } from "@as-comms/contracts";
 import {
+  buildBroadcastPreheaderHtml,
+  buildBroadcastUnsubscribeUrls,
   createAudienceResolver,
   createCampaignSendOrchestrator,
   createExclusionFilter,
+  formatBroadcastFromHeader,
   createMergeRenderer,
 } from "@as-comms/domain";
 import { createPostmarkClient } from "@as-comms/integrations";
@@ -556,17 +559,29 @@ export async function testSend(
     }
 
     const footerAddress = formatOrgAddress(await runtime.campaigns.orgSettings.read());
+    const origin = await readRequestOrigin();
+    const projectAlias =
+      run.projectId === null
+        ? null
+        : (await runtime.settings.projects.findById(run.projectId))?.projectAlias ?? null;
+    const unsubscribeUrls = buildBroadcastUnsubscribeUrls({
+      appUrl: origin,
+      unsubscribeToken: `preview-${run.kind}`,
+    });
     const footer = buildCampaignFooterPreview({
       kind: run.kind,
       projectName: sample.frozenProjectName,
+      projectAlias,
       footerAddress,
-      origin: await readRequestOrigin(),
+      origin,
     });
+    const fromHeader = formatBroadcastFromHeader(fromEmail, projectAlias);
+    const preheaderHtml = buildBroadcastPreheaderHtml(run.preheader);
     const mergeRenderer = createMergeRenderer();
     const rendered = mergeRenderer.render(
       {
         subject: run.subjectTemplate ?? "",
-        bodyHtml: `${run.bodyHtmlTemplate ?? ""}${footer.html}`,
+        bodyHtml: `${preheaderHtml}${run.bodyHtmlTemplate ?? ""}${footer.html}`,
         bodyText: [run.bodyTextTemplate ?? "", footer.text].filter(Boolean).join("\n\n"),
       },
       {
@@ -580,7 +595,7 @@ export async function testSend(
       isTest: true,
       messages: [
         {
-          From: fromEmail,
+          From: fromHeader,
           To: parsed.recipientEmail,
           ...(run.replyToEmail === null ? {} : { ReplyTo: run.replyToEmail }),
           Subject: rendered.subject,
@@ -592,6 +607,16 @@ export async function testSend(
             campaignType: "test",
             operatorUserId: session.id,
           },
+          Headers: [
+            {
+              Name: "List-Unsubscribe",
+              Value: `<${unsubscribeUrls.scopedHref}>`,
+            },
+            {
+              Name: "List-Unsubscribe-Post",
+              Value: "List-Unsubscribe=One-Click",
+            },
+          ],
         },
       ],
     });

--- a/apps/web/tests/unit/campaign-preview-helpers.test.ts
+++ b/apps/web/tests/unit/campaign-preview-helpers.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { buildCampaignFooterPreview } from "../../app/broadcasts/_lib/campaign-preview";
+
+describe("buildCampaignFooterPreview", () => {
+  it("uses the project alias in the scoped unsubscribe label when available", () => {
+    const footer = buildCampaignFooterPreview({
+      kind: "project",
+      projectName: "Passive Acoustic Monitoring of Pacific Northwest Forests",
+      projectAlias: "PNW Biodiversity",
+      footerAddress: null,
+      origin: "https://as.example.org",
+    });
+
+    expect(footer.html).toContain("Unsubscribe from PNW Biodiversity emails");
+    expect(footer.text).toContain("Unsubscribe from PNW Biodiversity emails");
+  });
+
+  it("falls back to the project name when there is no alias", () => {
+    const footer = buildCampaignFooterPreview({
+      kind: "project",
+      projectName: "Beech Leaf Disease",
+      projectAlias: null,
+      footerAddress: null,
+      origin: "https://as.example.org",
+    });
+
+    expect(footer.html).toContain("Unsubscribe from Beech Leaf Disease emails");
+    expect(footer.text).toContain("Unsubscribe from Beech Leaf Disease emails");
+  });
+});

--- a/packages/domain/src/broadcast-email-render.ts
+++ b/packages/domain/src/broadcast-email-render.ts
@@ -1,0 +1,43 @@
+export function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+export function formatBroadcastFromHeader(
+  senderEmail: string,
+  projectAlias: string | null,
+): string {
+  const trimmedAlias = projectAlias?.trim() ?? "";
+  const displayName =
+    trimmedAlias.length > 0
+      ? `Adventure Scientists – ${trimmedAlias}`
+      : "Adventure Scientists";
+  return `"${displayName}" <${senderEmail}>`;
+}
+
+export function buildBroadcastPreheaderHtml(
+  preheader: string | null,
+): string {
+  const trimmed = preheader?.trim() ?? "";
+  if (trimmed.length === 0) {
+    return "";
+  }
+
+  return `<div style="display:none;max-height:0;overflow:hidden;mso-hide:all;color:transparent;font-size:1px;line-height:1px;">${escapeHtml(trimmed)}</div>`;
+}
+
+export function buildBroadcastUnsubscribeUrls(input: {
+  readonly appUrl: string;
+  readonly unsubscribeToken: string;
+}): { readonly scopedHref: string; readonly allHref: string } {
+  const base = input.appUrl.replace(/\/+$/u, "");
+  const encoded = encodeURIComponent(input.unsubscribeToken);
+  return {
+    scopedHref: `${base}/u/${encoded}`,
+    allHref: `${base}/u/${encoded}/all`,
+  };
+}

--- a/packages/domain/src/campaign-send-orchestrator.ts
+++ b/packages/domain/src/campaign-send-orchestrator.ts
@@ -14,6 +14,12 @@ import type {
   AudienceMember,
   MergeContext,
 } from "./campaign-types.js";
+import {
+  buildBroadcastPreheaderHtml,
+  buildBroadcastUnsubscribeUrls,
+  escapeHtml,
+  formatBroadcastFromHeader,
+} from "./broadcast-email-render.js";
 import type { AudienceResolver } from "./audience-resolver.js";
 import type { ExclusionFilter } from "./exclusion-filter.js";
 import type { MergeRenderer } from "./merge-renderer.js";
@@ -47,6 +53,10 @@ interface PostmarkClientLike {
       readonly TextBody?: string;
       readonly MessageStream?: string;
       readonly Metadata?: Record<string, string>;
+      readonly Headers?: readonly {
+        readonly Name: string;
+        readonly Value: string;
+      }[];
     }[];
   }): Promise<{ readonly results: readonly PostmarkBatchSendResult[] }>;
 }
@@ -85,15 +95,6 @@ interface CampaignSendRepositories {
   };
 }
 
-function escapeHtml(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
-}
-
 function formatOrgAddress(input: OrgSettingsRecord): string | null {
   const line1 = input.physicalAddressLine1.trim();
   const line2 = input.physicalAddressLine2.trim();
@@ -109,6 +110,7 @@ function formatOrgAddress(input: OrgSettingsRecord): string | null {
 function buildUnsubscribeFooter(input: {
   readonly kind: CampaignKind;
   readonly projectName: string | null;
+  readonly projectAlias: string | null;
   readonly footerAddress: string | null;
   readonly scopedHref: string;
   readonly allHref: string;
@@ -116,7 +118,7 @@ function buildUnsubscribeFooter(input: {
   const scopedLabel =
     input.kind === "newsletter"
       ? "Unsubscribe from the AS newsletter"
-      : `Unsubscribe from ${input.projectName ?? "this project"} emails`;
+      : `Unsubscribe from ${input.projectAlias ?? input.projectName ?? "this project"} emails`;
   const allLabel = "Unsubscribe from all Adventure Scientists emails";
 
   const linkLabels =
@@ -144,18 +146,6 @@ function buildUnsubscribeFooter(input: {
     text: [linkLabels.join(" · "), textLinks, input.footerAddress]
       .filter((part): part is string => part !== null && part.length > 0)
       .join("\n"),
-  };
-}
-
-function buildUnsubscribeUrls(input: {
-  readonly appUrl: string;
-  readonly unsubscribeToken: string;
-}): { readonly scopedHref: string; readonly allHref: string } {
-  const base = input.appUrl.replace(/\/+$/u, "");
-  const encoded = encodeURIComponent(input.unsubscribeToken);
-  return {
-    scopedHref: `${base}/u/${encoded}`,
-    allHref: `${base}/u/${encoded}/all`,
   };
 }
 
@@ -410,6 +400,11 @@ export function createCampaignSendOrchestrator(deps: {
 
       const orgSettings = await deps.repositories.orgSettings.read();
       const footerAddress = formatOrgAddress(orgSettings);
+      const projectAlias =
+        run.projectId === null
+          ? null
+          : (await deps.repositories.settingsProjects.findById(run.projectId))
+              ?.projectAlias ?? null;
 
       const snapshots = (await deps.repositories.audienceSnapshots.listForRun(runId)).filter(
         (snapshot) => snapshot.deliveryStatus === "pending",
@@ -433,6 +428,10 @@ export function createCampaignSendOrchestrator(deps: {
             readonly TextBody: string;
             readonly MessageStream: "broadcast";
             readonly Metadata: Record<string, string>;
+            readonly Headers: readonly {
+              readonly Name: string;
+              readonly Value: string;
+            }[];
           };
         }[] = [];
 
@@ -462,22 +461,25 @@ export function createCampaignSendOrchestrator(deps: {
             continue;
           }
 
-          const unsubscribeUrls = buildUnsubscribeUrls({
+          const unsubscribeUrls = buildBroadcastUnsubscribeUrls({
             appUrl,
             unsubscribeToken: snapshot.unsubscribeToken,
           });
           const footer = buildUnsubscribeFooter({
             kind: run.kind,
             projectName: snapshot.frozenProjectName,
+            projectAlias,
             footerAddress,
             scopedHref: unsubscribeUrls.scopedHref,
             allHref: unsubscribeUrls.allHref,
           });
+          const preheaderHtml = buildBroadcastPreheaderHtml(run.preheader);
+          const fromHeader = formatBroadcastFromHeader(sender, projectAlias);
 
           const rendered = deps.mergeRenderer.render(
             {
               subject: run.subjectTemplate ?? "",
-              bodyHtml: `${run.bodyHtmlTemplate ?? ""}${footer.html}`,
+              bodyHtml: `${preheaderHtml}${run.bodyHtmlTemplate ?? ""}${footer.html}`,
               bodyText: [run.bodyTextTemplate ?? "", footer.text]
                 .filter((part) => part.length > 0)
                 .join("\n\n"),
@@ -488,7 +490,7 @@ export function createCampaignSendOrchestrator(deps: {
           messages.push({
             snapshot,
             payload: {
-              From: sender,
+              From: fromHeader,
               To: snapshot.frozenEmail,
               ...(run.replyToEmail === null ? {} : { ReplyTo: run.replyToEmail }),
               Subject: rendered.subject,
@@ -500,6 +502,16 @@ export function createCampaignSendOrchestrator(deps: {
                 audienceSnapshotId: snapshot.id,
                 contactId: snapshot.contactId,
               },
+              Headers: [
+                {
+                  Name: "List-Unsubscribe",
+                  Value: `<${unsubscribeUrls.scopedHref}>`,
+                },
+                {
+                  Name: "List-Unsubscribe-Post",
+                  Value: "List-Unsubscribe=One-Click",
+                },
+              ],
             },
           });
         }

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./audience-resolver.js";
+export * from "./broadcast-email-render.js";
 export * from "./canonical-event-audience.js";
 export * from "./campaign-run-projection.js";
 export * from "./campaign-send-orchestrator.js";

--- a/packages/domain/test/broadcast-email-render.test.ts
+++ b/packages/domain/test/broadcast-email-render.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildBroadcastPreheaderHtml,
+  buildBroadcastUnsubscribeUrls,
+  formatBroadcastFromHeader,
+} from "../src/broadcast-email-render.js";
+
+describe("broadcast-email-render helpers", () => {
+  it("formats a friendly From header with the project alias when present", () => {
+    expect(
+      formatBroadcastFromHeader(
+        "pnwbio@adventurescientists.org",
+        "PNW Biodiversity",
+      ),
+    ).toBe(
+      '"Adventure Scientists – PNW Biodiversity" <pnwbio@adventurescientists.org>',
+    );
+  });
+
+  it("falls back to the org name when no project alias exists", () => {
+    expect(
+      formatBroadcastFromHeader("news@adventurescientists.org", null),
+    ).toBe('"Adventure Scientists" <news@adventurescientists.org>');
+  });
+
+  it("injects a hidden preheader and escapes HTML-sensitive characters", () => {
+    expect(buildBroadcastPreheaderHtml("  Fish & <Forest>  ")).toBe(
+      '<div style="display:none;max-height:0;overflow:hidden;mso-hide:all;color:transparent;font-size:1px;line-height:1px;">Fish &amp; &lt;Forest&gt;</div>',
+    );
+  });
+
+  it("returns an empty preheader wrapper for blank values", () => {
+    expect(buildBroadcastPreheaderHtml("   ")).toBe("");
+    expect(buildBroadcastPreheaderHtml(null)).toBe("");
+  });
+
+  it("builds scoped and all unsubscribe URLs from the app origin", () => {
+    expect(
+      buildBroadcastUnsubscribeUrls({
+        appUrl: "https://as.example.org/",
+        unsubscribeToken: "token/with spaces",
+      }),
+    ).toEqual({
+      scopedHref: "https://as.example.org/u/token%2Fwith%20spaces",
+      allHref: "https://as.example.org/u/token%2Fwith%20spaces/all",
+    });
+  });
+});

--- a/packages/integrations/test/postmark-client.test.ts
+++ b/packages/integrations/test/postmark-client.test.ts
@@ -164,6 +164,53 @@ describe("PostmarkClient — sendBatch", () => {
     expect(sentBody).toHaveLength(1);
   });
 
+  it("preserves custom message headers in the batch payload", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      buildResponse({ body: [] }),
+    );
+    const client = createPostmarkClient({
+      serverToken: TEST_SERVER_TOKEN,
+      webhookSigningSecret: TEST_SECRET,
+      fetchImpl,
+    });
+
+    await client.sendBatch({
+      messages: [
+        {
+          ...buildBatchMessage(),
+          Headers: [
+            {
+              Name: "List-Unsubscribe",
+              Value: "<https://as.example.org/u/token>",
+            },
+            {
+              Name: "List-Unsubscribe-Post",
+              Value: "List-Unsubscribe=One-Click",
+            },
+          ],
+        },
+      ],
+    });
+
+    const [, init] = fetchImpl.mock.calls[0] ?? [];
+    const sentBody = JSON.parse(init?.body as string) as {
+      readonly Headers?: readonly {
+        readonly Name: string;
+        readonly Value: string;
+      }[];
+    }[];
+    expect(sentBody[0]?.Headers).toEqual([
+      {
+        Name: "List-Unsubscribe",
+        Value: "<https://as.example.org/u/token>",
+      },
+      {
+        Name: "List-Unsubscribe-Post",
+        Value: "List-Unsubscribe=One-Click",
+      },
+    ]);
+  });
+
   it("adds the X-AS-Test header and uses the test token when isTest is true", async () => {
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
       buildResponse({ body: [] }),


### PR DESCRIPTION
## Summary
- add a shared broadcast email render helper so production send and test send both use a friendly quoted From header, hidden HTML preheader injection, and consistent unsubscribe URL generation
- use the live settings project alias in broadcast footer labels and preview/test-send callers, falling back to the project name only when no alias exists
- attach RFC 8058 List-Unsubscribe headers to broadcast and test-send Postmark payloads, with tests covering header passthrough and preview/footer label changes

## User-visible effects
- Gmail and other clients show "Adventure Scientists" or "Adventure Scientists – {project alias}" instead of the raw sender local-part
- the project unsubscribe footer uses the short alias when one exists, making the opt-out copy match the sender identity volunteers see
- inbox snippets use the saved preheader instead of grabbing the first body text
- Gmail/Outlook can use the one-click unsubscribe headers and Postmark no longer needs to append its own fallback link

## Validation
- pnpm typecheck
- pnpm lint
- pnpm build
- package-scoped unit tests for domain render helpers, web footer preview helpers, and Postmark batch header passthrough