### PR TITLE
fix(broadcasts): suppress Postmark auto-unsub + append alias signature

### DIFF
--- a/apps/web/app/broadcasts/_lib/campaign-preview.ts
+++ b/apps/web/app/broadcasts/_lib/campaign-preview.ts
@@ -2,7 +2,10 @@ import type {
   CampaignKind,
   OrgSettingsRecord,
 } from "@as-comms/contracts";
-import { escapeHtml } from "@as-comms/domain";
+import {
+  buildPostmarkUnsubscribePlaceholderHtml,
+  escapeHtml,
+} from "@as-comms/domain";
 
 export function formatOrgAddress(input: OrgSettingsRecord): string | null {
   const line1 = input.physicalAddressLine1.trim();
@@ -55,6 +58,7 @@ export function buildCampaignFooterPreview(input: {
       input.footerAddress === null
         ? ""
         : `<div style="color:#64748b;font-size:12px;line-height:1.6;margin-top:8px;">${escapeHtml(input.footerAddress)}</div>`,
+      buildPostmarkUnsubscribePlaceholderHtml(),
     ].join(""),
     text: [linkLabels.join(" · "), textLinks, input.footerAddress].filter(Boolean).join("\n"),
   };

--- a/apps/web/app/broadcasts/actions.ts
+++ b/apps/web/app/broadcasts/actions.ts
@@ -15,6 +15,7 @@ import {
 } from "@as-comms/contracts";
 import {
   buildBroadcastPreheaderHtml,
+  buildBroadcastSignatureBlock,
   buildBroadcastUnsubscribeUrls,
   createAudienceResolver,
   createCampaignSendOrchestrator,
@@ -170,6 +171,11 @@ function trimNonEmpty(value: string | undefined): string | null {
   return trimmed === undefined || trimmed.length === 0 ? null : trimmed;
 }
 
+function normalizeAliasEmail(value: string | null): string | null {
+  const trimmed = value?.trim().toLowerCase() ?? "";
+  return trimmed.length === 0 ? null : trimmed;
+}
+
 function createCampaignSendOrchestratorForRepositories(input: {
   readonly campaigns: Stage1WebRuntime["campaigns"];
   readonly repositories: Stage1WebRuntime["repositories"];
@@ -188,6 +194,7 @@ function createCampaignSendOrchestratorForRepositories(input: {
       campaignRuns: input.campaigns.campaignRuns,
       audienceSnapshots: input.campaigns.audienceSnapshots,
       settingsProjects: input.settings.projects,
+      settingsAliases: input.settings.aliases,
       orgSettings: input.campaigns.orgSettings,
       auditEvidence: input.repositories.auditEvidence,
     },
@@ -564,6 +571,14 @@ export async function testSend(
       run.projectId === null
         ? null
         : (await runtime.settings.projects.findById(run.projectId))?.projectAlias ?? null;
+    const normalizedSenderAlias = normalizeAliasEmail(fromEmail);
+    const signatureBlock = buildBroadcastSignatureBlock(
+      normalizedSenderAlias === null
+        ? null
+        : (
+            await runtime.settings.aliases.findByAlias(normalizedSenderAlias)
+          )?.signature ?? null,
+    );
     const unsubscribeUrls = buildBroadcastUnsubscribeUrls({
       appUrl: origin,
       unsubscribeToken: `preview-${run.kind}`,
@@ -581,8 +596,10 @@ export async function testSend(
     const rendered = mergeRenderer.render(
       {
         subject: run.subjectTemplate ?? "",
-        bodyHtml: `${preheaderHtml}${run.bodyHtmlTemplate ?? ""}${footer.html}`,
-        bodyText: [run.bodyTextTemplate ?? "", footer.text].filter(Boolean).join("\n\n"),
+        bodyHtml: `${preheaderHtml}${run.bodyHtmlTemplate ?? ""}${signatureBlock.html}${footer.html}`,
+        bodyText: [run.bodyTextTemplate ?? "", signatureBlock.text, footer.text]
+          .filter((part) => part.trim().length > 0)
+          .join("\n\n"),
       },
       {
         firstName: sample.frozenFirstName,

--- a/apps/web/tests/unit/campaign-preview-helpers.test.ts
+++ b/apps/web/tests/unit/campaign-preview-helpers.test.ts
@@ -14,6 +14,7 @@ describe("buildCampaignFooterPreview", () => {
 
     expect(footer.html).toContain("Unsubscribe from PNW Biodiversity emails");
     expect(footer.text).toContain("Unsubscribe from PNW Biodiversity emails");
+    expect(footer.html.match(/\{\{\{ pm:unsubscribe \}\}\}/gu)).toHaveLength(1);
   });
 
   it("falls back to the project name when there is no alias", () => {

--- a/apps/worker/src/runtime.ts
+++ b/apps/worker/src/runtime.ts
@@ -257,6 +257,7 @@ function buildCampaignSendDependencies(input: {
         campaignRuns: input.campaigns.campaignRuns,
         audienceSnapshots: input.campaigns.audienceSnapshots,
         settingsProjects: input.settings.projects,
+        settingsAliases: input.settings.aliases,
         orgSettings: input.campaigns.orgSettings,
         auditEvidence: input.repositories.auditEvidence,
       },

--- a/packages/db/test/campaign-send-orchestrator.test.ts
+++ b/packages/db/test/campaign-send-orchestrator.test.ts
@@ -50,7 +50,12 @@ function buildDraftInput(
   };
 }
 
-async function seedProject(context: Stage1Context) {
+async function seedProject(
+  context: Stage1Context,
+  input: {
+    readonly signature?: string;
+  } = {},
+) {
   await context.repositories.projectDimensions.upsert({
     projectId: "project-1",
     projectName: "Project One",
@@ -69,7 +74,7 @@ async function seedProject(context: Stage1Context) {
   await context.settings.aliases.create({
     id: "alias-project-1",
     alias: "project-one@example.org",
-    signature: "",
+    signature: input.signature ?? "",
     projectId: "project-1",
     createdAt: new Date("2026-05-15T12:00:00.000Z"),
     updatedAt: new Date("2026-05-15T12:00:00.000Z"),
@@ -113,7 +118,13 @@ async function seedAudience(
 }
 
 function createMockPostmarkClient(input: {
-  onBatch?: (messages: readonly { readonly To: string }[]) => Promise<void> | void;
+  onBatch?: (
+    messages: readonly {
+      readonly To: string;
+      readonly HtmlBody?: string;
+      readonly TextBody?: string;
+    }[],
+  ) => Promise<void> | void;
   resultFor?: (email: string) => { readonly errorCode: number; readonly message: string };
   throwOnCall?: readonly number[];
 }) {
@@ -123,6 +134,8 @@ function createMockPostmarkClient(input: {
     async sendBatch(req: {
       readonly messages: readonly {
         readonly To: string;
+        readonly HtmlBody?: string;
+        readonly TextBody?: string;
       }[];
     }) {
       calls += 1;
@@ -166,6 +179,7 @@ function createOrchestrator(
         campaignRuns: campaigns.campaignRuns,
         audienceSnapshots: campaigns.audienceSnapshots,
         settingsProjects: context.settings.projects,
+        settingsAliases: context.settings.aliases,
         orgSettings: campaigns.orgSettings,
       },
       audienceResolver: createAudienceResolver({
@@ -411,5 +425,49 @@ describe("Campaign send orchestrator", () => {
     expect(
       snapshots.filter((snapshot) => snapshot.deliveryStatus === "sent"),
     ).toHaveLength(2);
+  });
+
+  it("appends the alias signature and hidden Postmark placeholder to sent bodies", async () => {
+    const context = await createTestStage1Context();
+    contexts.push(context);
+    await seedProject(context, {
+      signature: "Thanks,\n{{firstName}} Team",
+    });
+    await seedAudience(context, 1);
+    let capturedMessage:
+      | {
+          readonly HtmlBody?: string;
+          readonly TextBody?: string;
+        }
+      | undefined;
+    const runtime = createOrchestrator(
+      context,
+      createMockPostmarkClient({
+        onBatch(messages) {
+          capturedMessage = messages[0];
+        },
+      }),
+      1,
+    );
+    const run = await runtime.campaigns.campaignRuns.create(
+      buildDraftInput({ id: "run-signature-and-placeholder" }),
+    );
+
+    await runtime.orchestrator.freeze(
+      run.id,
+      new Date("2026-05-15T12:00:00.000Z"),
+    );
+    await runtime.orchestrator.processSendRequest(run.id);
+
+    expect(capturedMessage).toBeDefined();
+    const htmlBody = capturedMessage?.HtmlBody ?? "";
+    const textBody = capturedMessage?.TextBody ?? "";
+    expect(htmlBody).toContain(
+      '<p>Project One</p><p style="margin:16px 0;color:#0f172a;font-size:14px;line-height:1.6;">Thanks,<br>Volunteer Team</p><hr style="border:none;border-top:1px solid #e2e8f0;margin:24px 0 16px;">',
+    );
+    expect(textBody).toContain(
+      "project-one@example.org\n\nThanks,\nVolunteer Team\n\nUnsubscribe from project-one emails · Unsubscribe from all Adventure Scientists emails",
+    );
+    expect(htmlBody.match(/\{\{\{ pm:unsubscribe \}\}\}/gu)).toHaveLength(1);
   });
 });

--- a/packages/domain/src/broadcast-email-render.ts
+++ b/packages/domain/src/broadcast-email-render.ts
@@ -30,6 +30,28 @@ export function buildBroadcastPreheaderHtml(
   return `<div style="display:none;max-height:0;overflow:hidden;mso-hide:all;color:transparent;font-size:1px;line-height:1px;">${escapeHtml(trimmed)}</div>`;
 }
 
+export function buildPostmarkUnsubscribePlaceholderHtml(): string {
+  return '<div style="display:none;max-height:0;overflow:hidden;mso-hide:all;color:transparent;font-size:1px;line-height:1px;">{{{ pm:unsubscribe }}}</div>';
+}
+
+export function buildBroadcastSignatureBlock(signature: string | null): {
+  readonly text: string;
+  readonly html: string;
+} {
+  const trimmed = signature?.trim() ?? "";
+  if (trimmed.length === 0) {
+    return {
+      text: "",
+      html: "",
+    };
+  }
+
+  return {
+    text: trimmed,
+    html: `<p style="margin:16px 0;color:#0f172a;font-size:14px;line-height:1.6;">${escapeHtml(trimmed).replaceAll("\n", "<br>")}</p>`,
+  };
+}
+
 export function buildBroadcastUnsubscribeUrls(input: {
   readonly appUrl: string;
   readonly unsubscribeToken: string;

--- a/packages/domain/src/campaign-send-orchestrator.ts
+++ b/packages/domain/src/campaign-send-orchestrator.ts
@@ -16,14 +16,19 @@ import type {
 } from "./campaign-types.js";
 import {
   buildBroadcastPreheaderHtml,
+  buildBroadcastSignatureBlock,
   buildBroadcastUnsubscribeUrls,
+  buildPostmarkUnsubscribePlaceholderHtml,
   escapeHtml,
   formatBroadcastFromHeader,
 } from "./broadcast-email-render.js";
 import type { AudienceResolver } from "./audience-resolver.js";
 import type { ExclusionFilter } from "./exclusion-filter.js";
 import type { MergeRenderer } from "./merge-renderer.js";
-import type { SettingsProjectsRepository } from "./settings/repositories.js";
+import type {
+  ProjectAliasesRepository,
+  SettingsProjectsRepository,
+} from "./settings/repositories.js";
 
 export interface CampaignSendOrchestrator {
   freeze(
@@ -87,6 +92,7 @@ interface CampaignSendRepositories {
     ): Promise<AudienceSnapshotRecord>;
   };
   readonly settingsProjects: Pick<SettingsProjectsRepository, "findById">;
+  readonly settingsAliases: Pick<ProjectAliasesRepository, "findByAlias">;
   readonly orgSettings: {
     read(): Promise<OrgSettingsRecord>;
   };
@@ -142,11 +148,17 @@ function buildUnsubscribeFooter(input: {
       input.footerAddress === null
         ? ""
         : `<div style="color:#64748b;font-size:12px;line-height:1.6;margin-top:8px;">${escapeHtml(input.footerAddress)}</div>`,
+      buildPostmarkUnsubscribePlaceholderHtml(),
     ].join(""),
     text: [linkLabels.join(" · "), textLinks, input.footerAddress]
       .filter((part): part is string => part !== null && part.length > 0)
       .join("\n"),
   };
+}
+
+function normalizeAliasEmail(value: string | null): string | null {
+  const trimmed = value?.trim().toLowerCase() ?? "";
+  return trimmed.length === 0 ? null : trimmed;
 }
 
 function normalizeReason(reason: string): string | null {
@@ -409,6 +421,18 @@ export function createCampaignSendOrchestrator(deps: {
       const snapshots = (await deps.repositories.audienceSnapshots.listForRun(runId)).filter(
         (snapshot) => snapshot.deliveryStatus === "pending",
       );
+      const senderAliasEmail = normalizeAliasEmail(
+        run.fromEmail ?? snapshots[0]?.frozenAliasEmail ?? null,
+      );
+      const signatureBlock = buildBroadcastSignatureBlock(
+        senderAliasEmail === null
+          ? null
+          : (
+              await deps.repositories.settingsAliases.findByAlias(
+                senderAliasEmail,
+              )
+            )?.signature ?? null,
+      );
 
       for (let index = 0; index < snapshots.length; index += batchSize) {
         const stateCheck = await deps.repositories.campaignRuns.findById(runId);
@@ -479,9 +503,9 @@ export function createCampaignSendOrchestrator(deps: {
           const rendered = deps.mergeRenderer.render(
             {
               subject: run.subjectTemplate ?? "",
-              bodyHtml: `${preheaderHtml}${run.bodyHtmlTemplate ?? ""}${footer.html}`,
-              bodyText: [run.bodyTextTemplate ?? "", footer.text]
-                .filter((part) => part.length > 0)
+              bodyHtml: `${preheaderHtml}${run.bodyHtmlTemplate ?? ""}${signatureBlock.html}${footer.html}`,
+              bodyText: [run.bodyTextTemplate ?? "", signatureBlock.text, footer.text]
+                .filter((part) => part.trim().length > 0)
                 .join("\n\n"),
             },
             toMergeContext(member),

--- a/packages/domain/test/broadcast-email-render.test.ts
+++ b/packages/domain/test/broadcast-email-render.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildBroadcastPreheaderHtml,
+  buildBroadcastSignatureBlock,
+  buildPostmarkUnsubscribePlaceholderHtml,
   buildBroadcastUnsubscribeUrls,
   formatBroadcastFromHeader,
 } from "../src/broadcast-email-render.js";
@@ -33,6 +35,32 @@ describe("broadcast-email-render helpers", () => {
   it("returns an empty preheader wrapper for blank values", () => {
     expect(buildBroadcastPreheaderHtml("   ")).toBe("");
     expect(buildBroadcastPreheaderHtml(null)).toBe("");
+  });
+
+  it("builds the hidden Postmark unsubscribe placeholder wrapper", () => {
+    expect(buildPostmarkUnsubscribePlaceholderHtml()).toBe(
+      '<div style="display:none;max-height:0;overflow:hidden;mso-hide:all;color:transparent;font-size:1px;line-height:1px;">{{{ pm:unsubscribe }}}</div>',
+    );
+  });
+
+  it("builds a trimmed signature block for both text and html", () => {
+    expect(
+      buildBroadcastSignatureBlock("  Thanks,\nThe <AS> Team  "),
+    ).toEqual({
+      text: "Thanks,\nThe <AS> Team",
+      html: '<p style="margin:16px 0;color:#0f172a;font-size:14px;line-height:1.6;">Thanks,<br>The &lt;AS&gt; Team</p>',
+    });
+  });
+
+  it("skips empty signature blocks", () => {
+    expect(buildBroadcastSignatureBlock("   ")).toEqual({
+      text: "",
+      html: "",
+    });
+    expect(buildBroadcastSignatureBlock(null)).toEqual({
+      text: "",
+      html: "",
+    });
   });
 
   it("builds scoped and all unsubscribe URLs from the app origin", () => {


### PR DESCRIPTION
## Summary
Two scoped fixes building on #521 (broadcast email render polish):

1. **Suppress Postmark's auto-appended third unsubscribe link.** Postmark broadcast streams append a default unsubscribe footer at the bottom of every email unless they detect their `{{{ pm:unsubscribe }}}` placeholder somewhere in the body. There is **no Stream-level UI toggle** to disable this (confirmed the full Settings tab: Stream preferences / Server API / SMTP / Archive only). The `List-Unsubscribe` header from #521 alone is not sufficient.

   Fix: drop the placeholder inside a `display:none` div in the footer HTML. Postmark string-substitutes their URL into it (compliance satisfied), but recipients see only our custom unsubscribe links plus Gmail's inbox-level Unsubscribe button (from the `List-Unsubscribe` header in #521).

2. **Append the alias signature to broadcast bodies**, mirroring the inbox composer behavior. The `signature` column already exists on the alias record (`tables.ts:1144`) and the Settings UI editor for it already ships — **no schema migration, no UI changes.** Signature is appended with `\n\n` before the unsubscribe footer in both plain-text and HTML bodies. HTML form escapes the signature and replaces newlines with `<br>`. If the alias has no signature (empty/whitespace), nothing is appended.

## Files
- `packages/domain/src/broadcast-email-render.ts` — two new helpers: `buildPostmarkUnsubscribePlaceholderHtml` + `buildBroadcastSignatureBlock`.
- `packages/domain/src/campaign-send-orchestrator.ts` — production wiring: alias signature lookup once per run, placeholder in `buildUnsubscribeFooter`.
- `apps/web/app/broadcasts/actions.ts` — test-send wiring: same pattern.
- `apps/web/app/broadcasts/_lib/campaign-preview.ts` — placeholder in `buildCampaignFooterPreview`.
- `apps/worker/src/runtime.ts` — wire `settingsAliases` for the worker orchestrator.
- Tests: `packages/domain/test/broadcast-email-render.test.ts`, `packages/db/test/campaign-send-orchestrator.test.ts`, `apps/web/tests/unit/campaign-preview-helpers.test.ts`.

## Validation (local)
- `pnpm typecheck` — passed
- `pnpm lint` — passed
- `pnpm build` — passed
- Affected tests passed (broadcast-email-render, campaign-send-orchestrator, campaign-preview-helpers)
- Sanity-grep confirmed exactly **one** `{{{ pm:unsubscribe }}}` placeholder in the rendered footer HTML

## Test plan
- [ ] CI green
- [ ] Visual QA: send a test broadcast from an alias with a configured signature; verify (a) no third unsubscribe at bottom, (b) signature appears before the footer with proper line breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)