### PR TITLE
fix(composer,broadcasts): real test sends + auto-prefix link URLs

### DIFF
--- a/apps/web/app/broadcasts/actions.ts
+++ b/apps/web/app/broadcasts/actions.ts
@@ -608,8 +608,12 @@ export async function testSend(
       },
     );
 
+    // The wizard's "Send test" surface posts to this action and the operator
+    // expects the message to land in the recipient's inbox. The sandbox token
+    // (`isTest: true`) only validates the request shape and does NOT deliver,
+    // which historically caused "I sent a test but never got it" confusion —
+    // route through the real server token so the test is a real send.
     await client.sendBatch({
-      isTest: true,
       messages: [
         {
           From: fromHeader,

--- a/apps/web/app/inbox/_components/composer-editor-surface.tsx
+++ b/apps/web/app/inbox/_components/composer-editor-surface.tsx
@@ -36,7 +36,31 @@ function promptForLinkUrl(): string | null {
   }
 
   const trimmed = url.trim();
-  return /^(https?:\/\/|mailto:)/iu.test(trimmed) ? trimmed : null;
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  // Already has an accepted scheme — pass through unchanged.
+  if (/^(https?:\/\/|mailto:)/iu.test(trimmed)) {
+    return trimmed;
+  }
+
+  // Bare email → mailto:
+  if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/u.test(trimmed)) {
+    return `mailto:${trimmed}`;
+  }
+
+  // Looks like a domain (no whitespace, contains a dot, no scheme) →
+  // auto-prefix https:// rather than silently dropping the link, which is
+  // the most common cause of "the link button doesn't work."
+  if (!/\s/u.test(trimmed) && trimmed.includes(".")) {
+    return `https://${trimmed}`;
+  }
+
+  window.alert(
+    `"${trimmed}" doesn't look like a valid URL. Use https://, http://, or mailto:.`,
+  );
+  return null;
 }
 
 export function ComposerField({


### PR DESCRIPTION
## Summary
Two small UX fixes surfaced during today's first real broadcast sends:

1. **Wizard "Send test" now actually delivers email.** It was routing through Postmark's sandbox token (`POSTMARK_API_TEST`), which validates the request shape but **does not deliver mail**. Operators saw "Test sent to X" and nothing arrived. Drop `isTest: true` so the test uses the real server token.

2. **Composer Link toolbar button no longer silently fails.** `promptForLinkUrl` (shared between inbox + broadcast composers) returned `null` for any URL that didn't start with `http://`, `https://`, or `mailto:`, which routed to `chain.unsetLink().run()` and silently removed any link. Typing `example.com` looked like the button was broken.
   - Bare domains (`example.com`) auto-prefix `https://`
   - Bare emails (`me@example.com`) auto-prefix `mailto:`
   - Truly malformed input now shows an alert instead of silently failing

Fix #2 lives in `apps/web/app/inbox/_components/composer-editor-surface.tsx` and benefits both the inbox composer and the broadcast composer (same component).

## Validation
- `pnpm typecheck` — passed
- `pnpm lint` — passed

## Test plan
- [ ] CI green
- [ ] Send a real test from the broadcast wizard — it lands in your inbox.
- [ ] Open broadcast composer → select text → click Link → type `example.com` → link applied as `https://example.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)