### PR TITLE
fix(composer): allow sms: and tel: URL schemes in link prompt

### DIFF
--- a/apps/web/app/inbox/_components/composer-editor-surface.tsx
+++ b/apps/web/app/inbox/_components/composer-editor-surface.tsx
@@ -41,7 +41,10 @@ function promptForLinkUrl(): string | null {
   }
 
   // Already has an accepted scheme — pass through unchanged.
-  if (/^(https?:\/\/|mailto:)/iu.test(trimmed)) {
+  // `sms:` and `tel:` are included because they're the standard URI schemes
+  // for tap-to-text and tap-to-call links (supported by Gmail / iOS Mail /
+  // most modern clients), which we use for SMS opt-in / phone CTAs.
+  if (/^(https?:\/\/|mailto:|sms:|tel:)/iu.test(trimmed)) {
     return trimmed;
   }
 
@@ -58,7 +61,7 @@ function promptForLinkUrl(): string | null {
   }
 
   window.alert(
-    `"${trimmed}" doesn't look like a valid URL. Use https://, http://, or mailto:.`,
+    `"${trimmed}" doesn't look like a valid URL. Use https://, http://, mailto:, sms:, or tel:.`,
   );
   return null;
 }


### PR DESCRIPTION
## Summary
Hit during today's broadcast test send: an SMS opt-in CTA using `sms:+14062891988?body=START` was rejected by the link-prompt validator with "doesn't look like a valid URL." `sms:` and `tel:` are standard URI schemes that Gmail, iOS Mail, and Outlook all render as tap-to-text / tap-to-call links.

Extend the accepted-scheme regex in `composer-editor-surface.tsx` to include `sms:` and `tel:`, and update the alert copy.

Fixes both the inbox composer and the broadcast composer (same prompt).

## Validation
- `pnpm typecheck` — passed
- `pnpm lint` — passed

## Test plan
- [ ] CI green
- [ ] Composer Link button → type `sms:+14062891988?body=START` → link applied as-is
- [ ] Composer Link button → type `tel:+14062891988` → link applied as-is
- [ ] Existing behavior unchanged for `example.com`, `https://`, `mailto:`

🤖 Generated with [Claude Code](https://claude.com/claude-code)