### PR TITLE
fix(broadcasts,inbox): single-escape sanitizer + show alias signature in composer/preview

### DIFF
--- a/apps/web/app/broadcasts/_lib/audience-data-source.ts
+++ b/apps/web/app/broadcasts/_lib/audience-data-source.ts
@@ -16,6 +16,8 @@ import {
   type PostmarkSenderStatus,
 } from "@as-comms/contracts";
 import {
+  buildBroadcastPreheaderHtml,
+  buildBroadcastSignatureBlock,
   createAudienceResolver,
   createMergeRenderer,
   type AudienceMember,
@@ -31,6 +33,7 @@ import {
   deriveInitials,
   formatOrgAddress,
 } from "./campaign-preview";
+import { normalizeAliasEmail } from "./normalize-alias-email";
 
 const EMPTY_AUDIENCE_CRITERIA = audienceCriteriaSchema.parse({});
 const RECENT_EXPEDITION_WINDOW_DAYS = 365;
@@ -146,6 +149,31 @@ export interface ComposePreviewData {
   readonly warningCount: number;
   readonly affectedContacts: readonly ComposePreviewWarningContact[];
   readonly footerAddress: string | null;
+}
+
+export async function loadSelectedAliasSignatureAction(input: {
+  readonly aliasEmail: string | null;
+}): Promise<UiResult<string>> {
+  await requireSession();
+
+  try {
+    const runtime = await getStage1WebRuntime();
+    const normalizedAliasEmail = normalizeAliasEmail(input.aliasEmail);
+    const signature =
+      normalizedAliasEmail === null
+        ? ""
+        : ((await runtime.settings.aliases.findByAlias(normalizedAliasEmail))
+            ?.signature ?? "");
+    return successResult(signature);
+  } catch (error) {
+    return errorResult(
+      "campaign_alias_signature_load_failed",
+      error instanceof Error
+        ? error.message
+        : "Unable to load the sender signature.",
+      true,
+    );
+  }
 }
 
 function newRequestId(): string {
@@ -288,7 +316,7 @@ function deriveProjectId(
     return null;
   }
 
-  return criteria.projectId ?? (criteria.projectIds[0] ?? null);
+  return criteria.projectId ?? criteria.projectIds[0] ?? null;
 }
 
 function toStoredAudienceCriteria(
@@ -302,7 +330,9 @@ function toStoredAudienceCriteria(
   };
 }
 
-function filterAudienceMembersBySelection<T extends { readonly contactId: string }>(
+function filterAudienceMembersBySelection<
+  T extends { readonly contactId: string },
+>(
   rows: readonly T[],
   criteria: AudienceCriteria & {
     readonly initialFilter?: "project_status" | "specific" | "all_approved";
@@ -371,7 +401,9 @@ async function createResolver() {
   });
 }
 
-function buildAllProjectsCriteria(projectIds: readonly string[]): AudienceCriteria {
+function buildAllProjectsCriteria(
+  projectIds: readonly string[],
+): AudienceCriteria {
   return audienceCriteriaSchema.parse({
     projectIds,
     statuses: [],
@@ -398,13 +430,15 @@ async function loadApprovedContactsAudience(
     return resolver.resolveAudience(criteria, at);
   }
 
-  const rows = await runtime.connection.sql<{
-    contactId: string;
-    displayName: string;
-    email: string;
-    projectId: string | null;
-    projectName: string | null;
-  }[]>`
+  const rows = await runtime.connection.sql<
+    {
+      contactId: string;
+      displayName: string;
+      email: string;
+      projectId: string | null;
+      projectName: string | null;
+    }[]
+  >`
     with ranked_memberships as (
       select
         cm.contact_id,
@@ -534,14 +568,18 @@ export async function getCampaignWizardDraft(
 export async function getAudienceBuilderBootstrap(): Promise<AudienceBuilderBootstrap> {
   await requireSession();
   const runtime = await getStage1WebRuntime();
-  const allConnectedProjects = (await runtime.settings.projects.listAll()).filter(
+  const allConnectedProjects = (
+    await runtime.settings.projects.listAll()
+  ).filter(
     (project) => project.isActive || project.connectedToProjectId !== null,
   );
   const activeProjects = allConnectedProjects.filter(
     (project) => project.isActive,
   );
   const projectsById = new Map(
-    allConnectedProjects.map((project) => [project.projectId, project] as const),
+    allConnectedProjects.map(
+      (project) => [project.projectId, project] as const,
+    ),
   );
 
   const projectOptions = allConnectedProjects
@@ -560,7 +598,9 @@ export async function getAudienceBuilderBootstrap(): Promise<AudienceBuilderBoot
         alias: project.projectAlias,
         projectAlias: project.projectAlias,
         aliasHint: normalizeAliasHint(
-          project.connectedToProjectId === null ? primaryEmail : hostPrimaryEmail,
+          project.connectedToProjectId === null
+            ? primaryEmail
+            : hostPrimaryEmail,
         ),
         connectedToProjectId: project.connectedToProjectId,
         isSubProject: project.connectedToProjectId !== null,
@@ -608,10 +648,12 @@ export async function getAudienceBuilderBootstrap(): Promise<AudienceBuilderBoot
   const minimumTouchedAt = new Date(
     Date.now() - RECENT_EXPEDITION_WINDOW_DAYS * 24 * 60 * 60 * 1000,
   );
-  const expeditionRows = await runtime.connection.sql<{
-    expeditionId: string;
-    expeditionName: string | null;
-  }[]>`
+  const expeditionRows = await runtime.connection.sql<
+    {
+      expeditionId: string;
+      expeditionName: string | null;
+    }[]
+  >`
     select
       cm.expedition_id as "expeditionId",
       ed.expedition_name as "expeditionName"
@@ -751,6 +793,7 @@ export async function loadComposePreviewAction(input: {
   };
   readonly fromEmail: string | null;
   readonly subjectTemplate: string;
+  readonly preheader: string;
   readonly bodyHtmlTemplate: string;
   readonly bodyTextTemplate: string;
   readonly sampleIndex: number;
@@ -788,7 +831,8 @@ export async function loadComposePreviewAction(input: {
       audience,
     );
     const normalizedSampleIndex =
-      ((input.sampleIndex % audience.length) + audience.length) % audience.length;
+      ((input.sampleIndex % audience.length) + audience.length) %
+      audience.length;
     const sample = audience[normalizedSampleIndex] ?? audience[0];
     const origin = await readRequestOrigin();
     const projectId =
@@ -796,7 +840,8 @@ export async function loadComposePreviewAction(input: {
     const projectAlias =
       projectId === null
         ? null
-        : (await runtime.settings.projects.findById(projectId))?.projectAlias ?? null;
+        : ((await runtime.settings.projects.findById(projectId))
+            ?.projectAlias ?? null);
     const footer = buildCampaignFooterPreview({
       kind: input.kind,
       projectName: sample?.frozenProjectName ?? null,
@@ -804,11 +849,21 @@ export async function loadComposePreviewAction(input: {
       footerAddress,
       origin,
     });
+    const normalizedSenderAlias = normalizeAliasEmail(input.fromEmail);
+    const signature =
+      normalizedSenderAlias === null
+        ? null
+        : ((await runtime.settings.aliases.findByAlias(normalizedSenderAlias))
+            ?.signature ?? null);
+    const signatureBlock = buildBroadcastSignatureBlock(signature);
+    const preheaderHtml = buildBroadcastPreheaderHtml(input.preheader);
     const rendered = mergeRenderer.render(
       {
         subject: input.subjectTemplate,
-        bodyHtml: `${input.bodyHtmlTemplate}${footer.html}`,
-        bodyText: [input.bodyTextTemplate, footer.text].filter(Boolean).join("\n\n"),
+        bodyHtml: `${preheaderHtml}${input.bodyHtmlTemplate}${signatureBlock.html}${footer.html}`,
+        bodyText: [input.bodyTextTemplate, signatureBlock.text, footer.text]
+          .filter((part) => part.trim().length > 0)
+          .join("\n\n"),
       },
       {
         firstName: sample?.frozenFirstName ?? null,
@@ -942,9 +997,10 @@ export async function searchProjectVolunteersAction(input: {
 
             return {
               contactId: contact.id,
-              name: contact.displayName.trim().length > 0
-                ? contact.displayName
-                : (contact.primaryEmail ?? contact.id),
+              name:
+                contact.displayName.trim().length > 0
+                  ? contact.displayName
+                  : (contact.primaryEmail ?? contact.id),
               email: contact.primaryEmail ?? "",
               project: project?.projectName ?? null,
               projectAlias: project?.projectAlias ?? null,
@@ -1058,31 +1114,37 @@ export async function saveCampaignWizardDraftAction(input: {
 
   try {
     const runtime = await getStage1WebRuntime();
-    const audienceCriteria = audienceCriteriaSchema.parse(input.audienceCriteria);
-    const updated = await runtime.campaigns.campaignRuns.updateDraft(input.runId, {
-      launchType: input.launchType,
-      kind: input.kind,
-      projectId: deriveProjectId(input.kind, audienceCriteria),
-      name: input.name,
-      fromEmail: input.fromEmail,
-      replyToEmail: input.replyToEmail,
-      subjectTemplate: input.subjectTemplate,
-      bodyHtmlTemplate: input.bodyHtmlTemplate,
-      bodyTextTemplate: input.bodyTextTemplate,
-      preheader: input.preheader,
-      audienceCriteria:
-        toStoredAudienceCriteria(
+    const audienceCriteria = audienceCriteriaSchema.parse(
+      input.audienceCriteria,
+    );
+    const updated = await runtime.campaigns.campaignRuns.updateDraft(
+      input.runId,
+      {
+        launchType: input.launchType,
+        kind: input.kind,
+        projectId: deriveProjectId(input.kind, audienceCriteria),
+        name: input.name,
+        fromEmail: input.fromEmail,
+        replyToEmail: input.replyToEmail,
+        subjectTemplate: input.subjectTemplate,
+        bodyHtmlTemplate: input.bodyHtmlTemplate,
+        bodyTextTemplate: input.bodyTextTemplate,
+        preheader: input.preheader,
+        audienceCriteria: toStoredAudienceCriteria(
           audienceCriteria,
         ) as CampaignRunRecord["audienceCriteria"],
-      audienceSize: input.audienceSize,
-      lastEditedByUserId: session.id,
-    });
+        audienceSize: input.audienceSize,
+        lastEditedByUserId: session.id,
+      },
+    );
 
     return successResult(mapDraftRecord(updated, session.email));
   } catch (error) {
     return errorResult(
       "campaign_draft_save_failed",
-      error instanceof Error ? error.message : "Unable to save the broadcast draft.",
+      error instanceof Error
+        ? error.message
+        : "Unable to save the broadcast draft.",
       true,
     );
   }

--- a/apps/web/app/broadcasts/_lib/normalize-alias-email.ts
+++ b/apps/web/app/broadcasts/_lib/normalize-alias-email.ts
@@ -1,0 +1,4 @@
+export function normalizeAliasEmail(value: string | null): string | null {
+  const trimmed = value?.trim().toLowerCase() ?? "";
+  return trimmed.length === 0 ? null : trimmed;
+}

--- a/apps/web/app/broadcasts/actions.ts
+++ b/apps/web/app/broadcasts/actions.ts
@@ -40,6 +40,7 @@ import {
   buildCampaignFooterPreview,
   formatOrgAddress,
 } from "./_lib/campaign-preview";
+import { normalizeAliasEmail } from "./_lib/normalize-alias-email";
 import {
   listRunRecipients,
   type RecipientFilter,
@@ -118,12 +119,15 @@ async function appendCampaignAudit(input: {
   readonly detail: string;
   readonly metadataJson?: Record<string, unknown>;
   readonly auditEvidence?: Pick<
-    Awaited<ReturnType<typeof getStage1WebRuntime>>["repositories"]["auditEvidence"],
+    Awaited<
+      ReturnType<typeof getStage1WebRuntime>
+    >["repositories"]["auditEvidence"],
     "append"
   >;
 }) {
   const auditEvidence =
-    input.auditEvidence ?? (await getStage1WebRuntime()).repositories.auditEvidence;
+    input.auditEvidence ??
+    (await getStage1WebRuntime()).repositories.auditEvidence;
   await auditEvidence.append({
     id: randomUUID(),
     actorType: input.actorType,
@@ -169,11 +173,6 @@ function buildLivePostmarkClient() {
 function trimNonEmpty(value: string | undefined): string | null {
   const trimmed = value?.trim();
   return trimmed === undefined || trimmed.length === 0 ? null : trimmed;
-}
-
-function normalizeAliasEmail(value: string | null): string | null {
-  const trimmed = value?.trim().toLowerCase() ?? "";
-  return trimmed.length === 0 ? null : trimmed;
 }
 
 function createCampaignSendOrchestratorForRepositories(input: {
@@ -229,7 +228,10 @@ async function createCampaignOrchestrator() {
 }
 
 async function enqueueCampaignSendJob(input: {
-  readonly db: Pick<NonNullable<Stage1WebRuntime["connection"]>["db"], "execute">;
+  readonly db: Pick<
+    NonNullable<Stage1WebRuntime["connection"]>["db"],
+    "execute"
+  >;
   readonly runId: string;
   readonly scheduledAt?: Date;
 }): Promise<void> {
@@ -262,8 +264,10 @@ async function enqueueCampaignSendJob(input: {
   `);
 }
 
-async function assertCampaignAdmin():
-  Promise<{ readonly ok: true; readonly userId: string } | { readonly ok: false; readonly error: UiError }> {
+async function assertCampaignAdmin(): Promise<
+  | { readonly ok: true; readonly userId: string }
+  | { readonly ok: false; readonly error: UiError }
+> {
   try {
     const user = await requireAdmin();
     return {
@@ -306,7 +310,9 @@ async function validateVerifiedSender(input: {
     return errorResult("campaign_sender_unverified", input.failureMessage);
   }
 
-  const hasVerifiedSender = (await input.runtime.settings.projects.listAll()).some(
+  const hasVerifiedSender = (
+    await input.runtime.settings.projects.listAll()
+  ).some(
     (project) =>
       readPrimaryEmail(project)?.trim().toLowerCase() === normalizedEmail &&
       project.postmarkSenderStatus === "verified",
@@ -333,10 +339,9 @@ async function readRequestOrigin(): Promise<string> {
   return `${protocol}://${host}`;
 }
 
-function filterAudienceMembersBySelectedContacts<T extends { readonly contactId: string }>(
-  rows: readonly T[],
-  contactIds: readonly string[],
-): readonly T[] {
+function filterAudienceMembersBySelectedContacts<
+  T extends { readonly contactId: string },
+>(rows: readonly T[], contactIds: readonly string[]): readonly T[] {
   if (contactIds.length === 0) {
     return rows;
   }
@@ -367,7 +372,8 @@ export async function sendNow(
     const senderError = await validateVerifiedSender({
       runtime,
       email: run.fromEmail,
-      failureMessage: "Choose a verified sender alias before sending this broadcast.",
+      failureMessage:
+        "Choose a verified sender alias before sending this broadcast.",
     });
     if (senderError !== null) {
       return senderError;
@@ -415,7 +421,9 @@ export async function sendNow(
   } catch (error) {
     return errorResult(
       "campaign_send_failed",
-      error instanceof Error ? error.message : "Unable to start the broadcast send.",
+      error instanceof Error
+        ? error.message
+        : "Unable to start the broadcast send.",
       true,
     );
   }
@@ -445,7 +453,8 @@ export async function schedule(
     const senderError = await validateVerifiedSender({
       runtime,
       email: run.fromEmail,
-      failureMessage: "Choose a verified sender alias before scheduling this broadcast.",
+      failureMessage:
+        "Choose a verified sender alias before scheduling this broadcast.",
     });
     if (senderError !== null) {
       return senderError;
@@ -494,7 +503,9 @@ export async function schedule(
   } catch (error) {
     return errorResult(
       "campaign_schedule_failed",
-      error instanceof Error ? error.message : "Unable to schedule the broadcast.",
+      error instanceof Error
+        ? error.message
+        : "Unable to schedule the broadcast.",
       true,
     );
   }
@@ -507,13 +518,15 @@ export async function testSend(
   const session = await requireSession();
 
   try {
-    const parsed = z.object({
-      runId: z.string().trim().min(1),
-      recipientEmail: z.string().trim().email(),
-    }).parse({
-      runId,
-      recipientEmail,
-    });
+    const parsed = z
+      .object({
+        runId: z.string().trim().min(1),
+        recipientEmail: z.string().trim().email(),
+      })
+      .parse({
+        runId,
+        recipientEmail,
+      });
     const client = buildLivePostmarkClient();
     if (client === null) {
       return errorResult(
@@ -565,19 +578,21 @@ export async function testSend(
       );
     }
 
-    const footerAddress = formatOrgAddress(await runtime.campaigns.orgSettings.read());
+    const footerAddress = formatOrgAddress(
+      await runtime.campaigns.orgSettings.read(),
+    );
     const origin = await readRequestOrigin();
     const projectAlias =
       run.projectId === null
         ? null
-        : (await runtime.settings.projects.findById(run.projectId))?.projectAlias ?? null;
+        : ((await runtime.settings.projects.findById(run.projectId))
+            ?.projectAlias ?? null);
     const normalizedSenderAlias = normalizeAliasEmail(fromEmail);
     const signatureBlock = buildBroadcastSignatureBlock(
       normalizedSenderAlias === null
         ? null
-        : (
-            await runtime.settings.aliases.findByAlias(normalizedSenderAlias)
-          )?.signature ?? null,
+        : ((await runtime.settings.aliases.findByAlias(normalizedSenderAlias))
+            ?.signature ?? null),
     );
     const unsubscribeUrls = buildBroadcastUnsubscribeUrls({
       appUrl: origin,
@@ -699,11 +714,16 @@ export async function cancelDraft(
 
   try {
     const runtime = await getStage1WebRuntime();
-    await runtime.campaigns.campaignRuns.transitionState(runId, "draft", "cancelled", {
-      cancelledAt: new Date().toISOString(),
-      cancelledReason: "Draft cancelled before launch.",
-      lastEditedByUserId: admin.userId,
-    });
+    await runtime.campaigns.campaignRuns.transitionState(
+      runId,
+      "draft",
+      "cancelled",
+      {
+        cancelledAt: new Date().toISOString(),
+        cancelledReason: "Draft cancelled before launch.",
+        lastEditedByUserId: admin.userId,
+      },
+    );
 
     return {
       ok: true,
@@ -764,7 +784,9 @@ export async function cancel(
   } catch (error) {
     return errorResult(
       "campaign_cancel_failed",
-      error instanceof Error ? error.message : "Unable to cancel the broadcast.",
+      error instanceof Error
+        ? error.message
+        : "Unable to cancel the broadcast.",
       true,
     );
   }
@@ -825,7 +847,9 @@ export async function duplicateCampaignRun(
   } catch (error) {
     return errorResult(
       "campaign_duplicate_failed",
-      error instanceof Error ? error.message : "Unable to duplicate the broadcast.",
+      error instanceof Error
+        ? error.message
+        : "Unable to duplicate the broadcast.",
       true,
     );
   }

--- a/apps/web/app/broadcasts/new/_components/compose-step.tsx
+++ b/apps/web/app/broadcasts/new/_components/compose-step.tsx
@@ -25,6 +25,7 @@ interface ComposeStepProps {
   readonly subject: string;
   readonly preheader: string;
   readonly bodyPlaintext: string;
+  readonly selectedAliasSignature: string;
   readonly frozen: boolean;
   readonly onSubjectChange: (value: string) => void;
   readonly onPreheaderChange: (value: string) => void;
@@ -40,6 +41,7 @@ export function ComposeStep({
   subject,
   preheader,
   bodyPlaintext,
+  selectedAliasSignature,
   frozen,
   onSubjectChange,
   onPreheaderChange,
@@ -120,6 +122,13 @@ export function ComposeStep({
           onClearErrors={() => undefined}
           frameClassName="overflow-hidden rounded-none border-0"
           contentClassName="min-h-[300px] bg-white px-4 py-3 text-sm leading-6"
+          bottomSlot={
+            selectedAliasSignature.length > 0 ? (
+              <div className="px-4 pb-3 pt-2 whitespace-pre-line text-[13px] leading-relaxed text-slate-500">
+                {selectedAliasSignature}
+              </div>
+            ) : undefined
+          }
           toolbarFooter={({ activeCommands, onCommand, insertText }) => (
             <div className="border-t border-slate-200 bg-slate-50/70">
               <div className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-200 px-3 py-1.5">

--- a/apps/web/app/broadcasts/new/_components/new-campaign-wizard.tsx
+++ b/apps/web/app/broadcasts/new/_components/new-campaign-wizard.tsx
@@ -133,9 +133,7 @@ export function deriveInitialFilter(
   return undefined;
 }
 
-export function kindForAudienceMode(
-  mode: AudienceInitialFilter,
-): CampaignKind {
+export function kindForAudienceMode(mode: AudienceInitialFilter): CampaignKind {
   return mode === "all_approved" ? "newsletter" : "project";
 }
 
@@ -237,8 +235,7 @@ export function deriveSuggestedSenderEmail(input: {
   return (
     input.bootstrap.senderOptions.find(
       (option) =>
-        option.projectId === projectId &&
-        option.status === "verified",
+        option.projectId === projectId && option.status === "verified",
     )?.email ?? null
   );
 }
@@ -251,10 +248,12 @@ export function readAliasProjectsForSender(
     return [];
   }
 
-  const hostProjectId = senderOption.connectedToProjectId ?? senderOption.projectId;
+  const hostProjectId =
+    senderOption.connectedToProjectId ?? senderOption.projectId;
   const group =
-    bootstrap.projects.find((candidate) => candidate.host.id === hostProjectId) ??
-    null;
+    bootstrap.projects.find(
+      (candidate) => candidate.host.id === hostProjectId,
+    ) ?? null;
   if (group === null) {
     return [];
   }
@@ -391,6 +390,7 @@ export function NewCampaignWizard({
     setBodyPlaintext,
     bodyHtml,
     setBodyHtml,
+    selectedAliasSignature,
     criteria,
     setCriteria,
     hasPickedAudienceMode,
@@ -769,6 +769,7 @@ export function NewCampaignWizard({
                 subject={subject}
                 preheader={preheader}
                 bodyPlaintext={bodyPlaintext}
+                selectedAliasSignature={selectedAliasSignature}
                 frozen={frozen}
                 onSubjectChange={setSubject}
                 onPreheaderChange={setPreheader}

--- a/apps/web/app/broadcasts/new/_components/use-new-campaign-wizard-state.ts
+++ b/apps/web/app/broadcasts/new/_components/use-new-campaign-wizard-state.ts
@@ -19,6 +19,7 @@ import type {
 import {
   loadComposePreviewAction,
   loadMemberStatusCountsForProjects,
+  loadSelectedAliasSignatureAction,
   previewAudienceAction,
   resolveAudienceCountAction,
   searchProjectVolunteersAction,
@@ -50,7 +51,9 @@ function defaultAudienceModeForLaunchType(
   return launchType === "html_email" ? "all_approved" : "project_status";
 }
 
-function hasAppliedAudienceFilters(criteria: CampaignAudienceCriteria): boolean {
+function hasAppliedAudienceFilters(
+  criteria: CampaignAudienceCriteria,
+): boolean {
   if (criteria.initialFilter === undefined) {
     return false;
   }
@@ -175,8 +178,9 @@ function readAliasProjectsForSender(
   const hostProjectId =
     senderOption.connectedToProjectId ?? senderOption.projectId;
   const group =
-    bootstrap.projects.find((candidate) => candidate.host.id === hostProjectId) ??
-    null;
+    bootstrap.projects.find(
+      (candidate) => candidate.host.id === hostProjectId,
+    ) ?? null;
   if (group === null) {
     return [];
   }
@@ -275,6 +279,7 @@ export function useNewCampaignWizardState({
     draft.bodyTextTemplate ?? "",
   );
   const [bodyHtml, setBodyHtml] = useState(draft.bodyHtmlTemplate ?? "");
+  const [selectedAliasSignature, setSelectedAliasSignature] = useState("");
   const [criteria, setCriteria] = useState<CampaignAudienceCriteria>({
     ...draft.audienceCriteria,
     projectId:
@@ -344,7 +349,8 @@ export function useNewCampaignWizardState({
   const [countLoading, setCountLoading] = useState(false);
   const [audiencePreviewLoading, setAudiencePreviewLoading] = useState(false);
   const [, startCountTransition] = useTransition();
-  const [composePreviewPending, startComposePreviewTransition] = useTransition();
+  const [composePreviewPending, startComposePreviewTransition] =
+    useTransition();
   const [, startStatusCountsTransition] = useTransition();
   const [volunteerSearchPending, startVolunteerSearchTransition] =
     useTransition();
@@ -356,6 +362,7 @@ export function useNewCampaignWizardState({
   const audiencePreviewRequestRef = useRef(0);
   const volunteerSearchRequestRef = useRef(0);
   const composePreviewRequestRef = useRef(0);
+  const signatureRequestRef = useRef(0);
   const savedFingerprintRef = useRef("");
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const previousLaunchTypeRef = useRef(draft.launchType);
@@ -552,6 +559,21 @@ export function useNewCampaignWizardState({
   }, [fromEmail]);
 
   useEffect(() => {
+    const requestId = ++signatureRequestRef.current;
+
+    void (async () => {
+      const result = await loadSelectedAliasSignatureAction({
+        aliasEmail: fromEmail,
+      });
+      if (requestId !== signatureRequestRef.current) {
+        return;
+      }
+
+      setSelectedAliasSignature(result.ok ? result.data : "");
+    })();
+  }, [fromEmail]);
+
+  useEffect(() => {
     if (!hasPickedAudienceMode || criteria.initialFilter !== "project_status") {
       setStatusCounts({});
       setStatusCountsLoading(false);
@@ -570,7 +592,8 @@ export function useNewCampaignWizardState({
     setStatusCountsLoading(true);
     setStatusCountsErrorMessage(null);
     startStatusCountsTransition(async () => {
-      const result = await loadMemberStatusCountsForProjects(selectedProjectIds);
+      const result =
+        await loadMemberStatusCountsForProjects(selectedProjectIds);
       if (requestId !== statusCountsRequestRef.current) {
         return;
       }
@@ -692,7 +715,10 @@ export function useNewCampaignWizardState({
       return;
     }
 
-    if (aliasProjectIds.length === 0 || volunteerSearchQuery.trim().length < 2) {
+    if (
+      aliasProjectIds.length === 0 ||
+      volunteerSearchQuery.trim().length < 2
+    ) {
       setVolunteerSearchRows([]);
       setVolunteerSearchErrorMessage(null);
       return;
@@ -743,6 +769,7 @@ export function useNewCampaignWizardState({
           criteria: toActionCriteria(criteria),
           fromEmail,
           subjectTemplate: subject,
+          preheader,
           bodyHtmlTemplate: bodyHtml,
           bodyTextTemplate: bodyPlaintext,
           sampleIndex,
@@ -774,6 +801,7 @@ export function useNewCampaignWizardState({
     currentStep,
     fromEmail,
     kind,
+    preheader,
     sampleIndex,
     subject,
   ]);
@@ -856,6 +884,7 @@ export function useNewCampaignWizardState({
     setBodyPlaintext,
     bodyHtml,
     setBodyHtml,
+    selectedAliasSignature,
     criteria,
     setCriteria,
     hasPickedAudienceMode,

--- a/apps/web/src/lib/html-sanitizer.ts
+++ b/apps/web/src/lib/html-sanitizer.ts
@@ -108,7 +108,7 @@ export function sanitizeComposerHtml(input: string): string {
       continue;
     }
 
-    output += escapeHtml(input.slice(cursor, tagStart));
+    output += input.slice(cursor, tagStart);
     cursor = tagStart + rawTag.length;
 
     if (tagName === null) {
@@ -157,7 +157,7 @@ export function sanitizeComposerHtml(input: string): string {
   }
 
   if (strippedContentTag === null) {
-    output += escapeHtml(input.slice(cursor));
+    output += input.slice(cursor);
   }
 
   return output.trim();

--- a/apps/web/tests/unit/campaign-audience-step.test.tsx
+++ b/apps/web/tests/unit/campaign-audience-step.test.tsx
@@ -73,8 +73,9 @@ function setupDom() {
   globalThis.HTMLInputElement = dom.window.HTMLInputElement;
   globalThis.MouseEvent = dom.window.MouseEvent;
   globalThis.Event = dom.window.Event;
-  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
-    true;
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
 
   const container = document.createElement("div");
   document.body.append(container);
@@ -286,7 +287,9 @@ describe("AudienceBuilderStep initial filter gate", () => {
   });
 
   it("disables continue when the live audience is zero", () => {
-    const invalidMarkup = renderToStaticMarkup(<AudienceBuilderStep {...baseProps} />);
+    const invalidMarkup = renderToStaticMarkup(
+      <AudienceBuilderStep {...baseProps} />,
+    );
     const validMarkup = renderToStaticMarkup(
       <AudienceBuilderStep
         {...baseProps}
@@ -344,9 +347,9 @@ describe("AudienceBuilderStep initial filter gate", () => {
     expect(document.body.textContent).not.toContain("Audience filters");
     expect(document.body.textContent).not.toContain("Find volunteers");
 
-    const projectStatusButton = Array.from(document.querySelectorAll("button")).find(
-      (button) => button.textContent.includes("Project / status"),
-    );
+    const projectStatusButton = Array.from(
+      document.querySelectorAll("button"),
+    ).find((button) => button.textContent.includes("Project / status"));
     if (!(projectStatusButton instanceof HTMLButtonElement)) {
       throw new Error("Project / status chooser button not found");
     }
@@ -355,7 +358,9 @@ describe("AudienceBuilderStep initial filter gate", () => {
       projectStatusButton.click();
     });
 
-    const tablist = document.querySelector('[role="tablist"][aria-label="Audience mode"]');
+    const tablist = document.querySelector(
+      '[role="tablist"][aria-label="Audience mode"]',
+    );
     if (!(tablist instanceof HTMLElement)) {
       throw new Error("Audience mode segmented control not found");
     }
@@ -442,6 +447,9 @@ describe("AudienceBuilderStep initial filter gate", () => {
     vi.doMock("../../app/broadcasts/_lib/audience-data-source", () => ({
       loadMemberStatusCountsForProjects,
       loadComposePreviewAction,
+      loadSelectedAliasSignatureAction: vi.fn(() =>
+        Promise.resolve({ ok: true as const, data: "" }),
+      ),
       previewAudienceAction,
       resolveAudienceCountAction,
       saveCampaignWizardDraftAction,
@@ -453,34 +461,38 @@ describe("AudienceBuilderStep initial filter gate", () => {
       testSend: vi.fn(),
     }));
     vi.doMock("../../app/broadcasts/new/_components/launch-type-step", () => ({
-      LaunchTypeStep: ({
-        onContinue,
-      }: {
-        readonly onContinue: () => void;
-      }) => <button onClick={onContinue}>Launch continue</button>,
-    }));
-    vi.doMock("../../app/broadcasts/new/_components/name-and-sender-step", () => ({
-      NameAndSenderStep: ({
-        onContinue,
-      }: {
-        readonly onContinue: () => void;
-      }) => <button onClick={onContinue}>Sender continue</button>,
-    }));
-    vi.doMock("../../app/broadcasts/new/_components/audience-builder-step", () => ({
-      AudienceBuilderStep: ({
-        onStatusToggle,
-      }: {
-        readonly onStatusToggle: (status: string) => void;
-      }) => (
-        <button
-          onClick={() => {
-            onStatusToggle("Waitlist");
-          }}
-        >
-          Toggle Waitlist
-        </button>
+      LaunchTypeStep: ({ onContinue }: { readonly onContinue: () => void }) => (
+        <button onClick={onContinue}>Launch continue</button>
       ),
     }));
+    vi.doMock(
+      "../../app/broadcasts/new/_components/name-and-sender-step",
+      () => ({
+        NameAndSenderStep: ({
+          onContinue,
+        }: {
+          readonly onContinue: () => void;
+        }) => <button onClick={onContinue}>Sender continue</button>,
+      }),
+    );
+    vi.doMock(
+      "../../app/broadcasts/new/_components/audience-builder-step",
+      () => ({
+        AudienceBuilderStep: ({
+          onStatusToggle,
+        }: {
+          readonly onStatusToggle: (status: string) => void;
+        }) => (
+          <button
+            onClick={() => {
+              onStatusToggle("Waitlist");
+            }}
+          >
+            Toggle Waitlist
+          </button>
+        ),
+      }),
+    );
     vi.doMock("../../app/broadcasts/new/_components/compose-step", () => ({
       ComposeStep: () => <div>Compose</div>,
     }));
@@ -494,9 +506,8 @@ describe("AudienceBuilderStep initial filter gate", () => {
       WizardRail: () => null,
     }));
 
-    const { NewCampaignWizard } = await import(
-      "../../app/broadcasts/new/_components/new-campaign-wizard"
-    );
+    const { NewCampaignWizard } =
+      await import("../../app/broadcasts/new/_components/new-campaign-wizard");
 
     const bootstrap: AudienceBuilderBootstrap = {
       projects: [
@@ -566,7 +577,11 @@ describe("AudienceBuilderStep initial filter gate", () => {
 
     act(() => {
       root?.render(
-        <NewCampaignWizard bootstrap={bootstrap} draft={draft} isAdmin={true} />,
+        <NewCampaignWizard
+          bootstrap={bootstrap}
+          draft={draft}
+          isAdmin={true}
+        />,
       );
     });
     await settleAsyncWork();
@@ -598,11 +613,12 @@ describe("AudienceBuilderStep initial filter gate", () => {
     await settleAsyncWork();
 
     expect(loadMemberStatusCountsForProjects).toHaveBeenCalledTimes(1);
-    const initialAudienceCountCalls = resolveAudienceCountAction.mock.calls.length;
+    const initialAudienceCountCalls =
+      resolveAudienceCountAction.mock.calls.length;
 
-    const toggleWaitlistButton = Array.from(document.querySelectorAll("button")).find(
-      (button) => button.textContent === "Toggle Waitlist",
-    );
+    const toggleWaitlistButton = Array.from(
+      document.querySelectorAll("button"),
+    ).find((button) => button.textContent === "Toggle Waitlist");
     if (!(toggleWaitlistButton instanceof HTMLButtonElement)) {
       throw new Error("Toggle Waitlist button not found");
     }
@@ -700,6 +716,9 @@ describe("AudienceBuilderStep initial filter gate", () => {
     vi.doMock("../../app/broadcasts/_lib/audience-data-source", () => ({
       loadMemberStatusCountsForProjects,
       loadComposePreviewAction,
+      loadSelectedAliasSignatureAction: vi.fn(() =>
+        Promise.resolve({ ok: true as const, data: "" }),
+      ),
       previewAudienceAction,
       resolveAudienceCountAction,
       saveCampaignWizardDraftAction,
@@ -711,19 +730,20 @@ describe("AudienceBuilderStep initial filter gate", () => {
       testSend: vi.fn(),
     }));
     vi.doMock("../../app/broadcasts/new/_components/launch-type-step", () => ({
-      LaunchTypeStep: ({
-        onContinue,
-      }: {
-        readonly onContinue: () => void;
-      }) => <button onClick={onContinue}>Launch continue</button>,
+      LaunchTypeStep: ({ onContinue }: { readonly onContinue: () => void }) => (
+        <button onClick={onContinue}>Launch continue</button>
+      ),
     }));
-    vi.doMock("../../app/broadcasts/new/_components/name-and-sender-step", () => ({
-      NameAndSenderStep: ({
-        onContinue,
-      }: {
-        readonly onContinue: () => void;
-      }) => <button onClick={onContinue}>Sender continue</button>,
-    }));
+    vi.doMock(
+      "../../app/broadcasts/new/_components/name-and-sender-step",
+      () => ({
+        NameAndSenderStep: ({
+          onContinue,
+        }: {
+          readonly onContinue: () => void;
+        }) => <button onClick={onContinue}>Sender continue</button>,
+      }),
+    );
     vi.doMock("../../app/broadcasts/new/_components/compose-step", () => ({
       ComposeStep: () => <div>Compose</div>,
     }));
@@ -738,9 +758,8 @@ describe("AudienceBuilderStep initial filter gate", () => {
     }));
     vi.doUnmock("../../app/broadcasts/new/_components/audience-builder-step");
 
-    const { NewCampaignWizard } = await import(
-      "../../app/broadcasts/new/_components/new-campaign-wizard"
-    );
+    const { NewCampaignWizard } =
+      await import("../../app/broadcasts/new/_components/new-campaign-wizard");
 
     const bootstrap: AudienceBuilderBootstrap = {
       projects: [
@@ -800,7 +819,11 @@ describe("AudienceBuilderStep initial filter gate", () => {
 
     act(() => {
       root?.render(
-        <NewCampaignWizard bootstrap={bootstrap} draft={draft} isAdmin={true} />,
+        <NewCampaignWizard
+          bootstrap={bootstrap}
+          draft={draft}
+          isAdmin={true}
+        />,
       );
     });
     await settleAsyncWork();
@@ -925,6 +948,9 @@ describe("AudienceBuilderStep initial filter gate", () => {
     vi.doMock("../../app/broadcasts/_lib/audience-data-source", () => ({
       loadMemberStatusCountsForProjects,
       loadComposePreviewAction,
+      loadSelectedAliasSignatureAction: vi.fn(() =>
+        Promise.resolve({ ok: true as const, data: "" }),
+      ),
       previewAudienceAction,
       resolveAudienceCountAction,
       saveCampaignWizardDraftAction,
@@ -936,19 +962,20 @@ describe("AudienceBuilderStep initial filter gate", () => {
       testSend: vi.fn(),
     }));
     vi.doMock("../../app/broadcasts/new/_components/launch-type-step", () => ({
-      LaunchTypeStep: ({
-        onContinue,
-      }: {
-        readonly onContinue: () => void;
-      }) => <button onClick={onContinue}>Launch continue</button>,
+      LaunchTypeStep: ({ onContinue }: { readonly onContinue: () => void }) => (
+        <button onClick={onContinue}>Launch continue</button>
+      ),
     }));
-    vi.doMock("../../app/broadcasts/new/_components/name-and-sender-step", () => ({
-      NameAndSenderStep: ({
-        onContinue,
-      }: {
-        readonly onContinue: () => void;
-      }) => <button onClick={onContinue}>Sender continue</button>,
-    }));
+    vi.doMock(
+      "../../app/broadcasts/new/_components/name-and-sender-step",
+      () => ({
+        NameAndSenderStep: ({
+          onContinue,
+        }: {
+          readonly onContinue: () => void;
+        }) => <button onClick={onContinue}>Sender continue</button>,
+      }),
+    );
     vi.doMock("../../app/broadcasts/new/_components/compose-step", () => ({
       ComposeStep: () => <div>Compose</div>,
     }));
@@ -962,9 +989,8 @@ describe("AudienceBuilderStep initial filter gate", () => {
       WizardRail: () => null,
     }));
 
-    const { NewCampaignWizard } = await import(
-      "../../app/broadcasts/new/_components/new-campaign-wizard"
-    );
+    const { NewCampaignWizard } =
+      await import("../../app/broadcasts/new/_components/new-campaign-wizard");
 
     const bootstrap: AudienceBuilderBootstrap = {
       projects: [
@@ -1034,7 +1060,11 @@ describe("AudienceBuilderStep initial filter gate", () => {
 
     act(() => {
       root?.render(
-        <NewCampaignWizard bootstrap={bootstrap} draft={draft} isAdmin={true} />,
+        <NewCampaignWizard
+          bootstrap={bootstrap}
+          draft={draft}
+          isAdmin={true}
+        />,
       );
     });
     await settleAsyncWork();
@@ -1065,8 +1095,10 @@ describe("AudienceBuilderStep initial filter gate", () => {
     await settleAsyncWork();
     await settleAsyncWork();
 
-    const projectButtons = Array.from(document.querySelectorAll("button")).filter(
-      (button) => button.getAttribute("aria-label")?.startsWith("Choose project "),
+    const projectButtons = Array.from(
+      document.querySelectorAll("button"),
+    ).filter((button) =>
+      button.getAttribute("aria-label")?.startsWith("Choose project "),
     );
 
     expect(projectButtons).toHaveLength(2);

--- a/apps/web/tests/unit/campaign-compose-step.test.tsx
+++ b/apps/web/tests/unit/campaign-compose-step.test.tsx
@@ -12,12 +12,9 @@ vi.mock("lucide-react", () => ({
 }));
 
 vi.mock("@/components/ui/button", () => ({
-  Button: ({
-    children,
-    ...props
-  }: {
-    readonly children: React.ReactNode;
-  }) => <button {...props}>{children}</button>,
+  Button: ({ children, ...props }: { readonly children: React.ReactNode }) => (
+    <button {...props}>{children}</button>
+  ),
 }));
 
 vi.mock("@/components/ui/input", () => ({
@@ -86,6 +83,7 @@ const baseProps: React.ComponentProps<typeof ComposeStep> = {
   subject: "",
   preheader: "",
   bodyPlaintext: "",
+  selectedAliasSignature: "",
   frozen: false,
   onSubjectChange: () => undefined,
   onPreheaderChange: () => undefined,

--- a/apps/web/tests/unit/composer-html-sanitizer.test.ts
+++ b/apps/web/tests/unit/composer-html-sanitizer.test.ts
@@ -18,6 +18,9 @@ describe("composer html sanitizer", () => {
   });
 
   it("keeps safe email presentation tags without preserving attributes", () => {
+    expect(sanitizeComposerHtml("<p>Msg &amp; data</p>")).toBe(
+      "<p>Msg &amp; data</p>",
+    );
     expect(sanitizeComposerHtml("<blockquote>quoted</blockquote>")).toBe(
       "<blockquote>quoted</blockquote>",
     );

--- a/apps/web/tests/unit/new-campaign-wizard.test.tsx
+++ b/apps/web/tests/unit/new-campaign-wizard.test.tsx
@@ -10,6 +10,7 @@ const saveCampaignWizardDraftActionMock = vi.hoisted(() => vi.fn());
 const resolveAudienceCountActionMock = vi.hoisted(() => vi.fn());
 const previewAudienceActionMock = vi.hoisted(() => vi.fn());
 const loadComposePreviewActionMock = vi.hoisted(() => vi.fn());
+const loadSelectedAliasSignatureActionMock = vi.hoisted(() => vi.fn());
 const loadMemberStatusCountsForProjectsMock = vi.hoisted(() => vi.fn());
 const searchProjectVolunteersActionMock = vi.hoisted(() => vi.fn());
 const testSendMock = vi.hoisted(() => vi.fn());
@@ -19,6 +20,7 @@ const sendNowMock = vi.hoisted(() => vi.fn());
 vi.mock("../../app/broadcasts/_lib/audience-data-source", () => ({
   loadComposePreviewAction: loadComposePreviewActionMock,
   loadMemberStatusCountsForProjects: loadMemberStatusCountsForProjectsMock,
+  loadSelectedAliasSignatureAction: loadSelectedAliasSignatureActionMock,
   previewAudienceAction: previewAudienceActionMock,
   resolveAudienceCountAction: resolveAudienceCountActionMock,
   saveCampaignWizardDraftAction: saveCampaignWizardDraftActionMock,
@@ -141,7 +143,10 @@ vi.mock("../../app/broadcasts/new/_components/audience-builder-step", () => ({
       value: "project_status" | "specific" | "all_approved",
     ) => void;
     readonly onVolunteerSearchQueryChange: (value: string) => void;
-    readonly previewRows: readonly { readonly contactId: string; readonly name: string }[];
+    readonly previewRows: readonly {
+      readonly contactId: string;
+      readonly name: string;
+    }[];
     readonly volunteerSearchQuery: string;
     readonly volunteerSearchRows: readonly {
       readonly contactId: string;
@@ -203,11 +208,7 @@ vi.mock("../../app/broadcasts/new/_components/audience-builder-step", () => ({
       <button type="button" aria-label="audience-back" onClick={onBack}>
         Back
       </button>
-      <button
-        type="button"
-        aria-label="audience-continue"
-        onClick={onContinue}
-      >
+      <button type="button" aria-label="audience-continue" onClick={onContinue}>
         Continue
       </button>
     </section>
@@ -219,15 +220,18 @@ vi.mock("../../app/broadcasts/new/_components/compose-step", () => ({
     onBack,
     onContinue,
     onSubjectChange,
+    selectedAliasSignature,
     subject,
   }: {
     readonly onBack: () => void;
     readonly onContinue: () => void;
     readonly onSubjectChange: (value: string) => void;
+    readonly selectedAliasSignature: string;
     readonly subject: string;
   }) => (
     <section data-testid="compose-step">
       <div>ComposeStep</div>
+      <div data-testid="compose-signature">{selectedAliasSignature}</div>
       <input
         aria-label="broadcast-subject"
         value={subject}
@@ -333,7 +337,11 @@ import type {
   CampaignWizardDraftData,
   ComposePreviewData,
 } from "../../app/broadcasts/_lib/audience-data-source";
-import type { CampaignKind, ExpeditionMemberStatus, LaunchType } from "@as-comms/contracts";
+import type {
+  CampaignKind,
+  ExpeditionMemberStatus,
+  LaunchType,
+} from "@as-comms/contracts";
 
 const workerRequire = createRequire(import.meta.url);
 const { JSDOM } = workerRequire("jsdom") as {
@@ -523,8 +531,9 @@ function setupDom() {
   globalThis.HTMLInputElement = dom.window.HTMLInputElement;
   globalThis.Event = dom.window.Event;
   globalThis.MouseEvent = dom.window.MouseEvent;
-  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
-    true;
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
 
   const container = document.createElement("div");
   document.body.append(container);
@@ -553,7 +562,9 @@ async function renderWizard({
 }
 
 function getByTestId(testId: string): HTMLElement {
-  const element = document.querySelector<HTMLElement>(`[data-testid="${testId}"]`);
+  const element = document.querySelector<HTMLElement>(
+    `[data-testid="${testId}"]`,
+  );
   if (element === null) {
     throw new Error(`Missing element with test id "${testId}"`);
   }
@@ -561,7 +572,9 @@ function getByTestId(testId: string): HTMLElement {
 }
 
 function getByLabelText(label: string): HTMLElement {
-  const element = document.querySelector<HTMLElement>(`[aria-label="${label}"]`);
+  const element = document.querySelector<HTMLElement>(
+    `[aria-label="${label}"]`,
+  );
   if (element === null) {
     throw new Error(`Missing element with aria-label "${label}"`);
   }
@@ -624,6 +637,10 @@ beforeEach(() => {
   loadComposePreviewActionMock.mockResolvedValue({
     ok: true,
     data: buildComposePreviewData(),
+  });
+  loadSelectedAliasSignatureActionMock.mockResolvedValue({
+    ok: true,
+    data: "Adventure Scientists\n123 Main St",
   });
   loadMemberStatusCountsForProjectsMock.mockResolvedValue({
     ok: true,
@@ -733,6 +750,32 @@ describe("NewCampaignWizard", () => {
     expect(getByTestId("status-label").textContent).toBe("Unsaved changes");
   });
 
+  it("loads the alias signature and includes preheader in compose preview requests", async () => {
+    vi.useFakeTimers();
+
+    await renderWizard({
+      draft: buildDraft({
+        fromEmail: "forests@adventurescientists.org",
+        preheader: "Preview copy",
+      }),
+    });
+
+    await goToComposeStep();
+    await advanceTimersBy(200);
+
+    expect(getByTestId("compose-signature").textContent).toBe(
+      "Adventure Scientists\n123 Main St",
+    );
+    expect(loadSelectedAliasSignatureActionMock).toHaveBeenCalledWith({
+      aliasEmail: "forests@adventurescientists.org",
+    });
+    expect(loadComposePreviewActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preheader: "Preview copy",
+      }),
+    );
+  });
+
   it("moves save state through saving, saved, and idle after autosave succeeds", async () => {
     vi.useFakeTimers();
     const deferred = createDeferred<ReturnType<typeof buildSaveResult>>();
@@ -753,9 +796,7 @@ describe("NewCampaignWizard", () => {
       throw new Error("Expected saveCampaignWizardDraftAction to be called.");
     }
 
-    deferred.resolve(
-      buildSaveResult(saveInput),
-    );
+    deferred.resolve(buildSaveResult(saveInput));
     await flush();
 
     expect(getByTestId("status-label").textContent).toBe("Saved");
@@ -776,7 +817,9 @@ describe("NewCampaignWizard", () => {
     await advanceTimersBy(300);
 
     expect(searchProjectVolunteersActionMock).toHaveBeenCalled();
-    expect(getByTestId("volunteer-rows").textContent).toContain("Alice Example");
+    expect(getByTestId("volunteer-rows").textContent).toContain(
+      "Alice Example",
+    );
 
     await click("go-step-0");
     await click("set-launch-html");


### PR DESCRIPTION
## Summary
Two fixes surfaced during today's broadcast testing:

1. **`sanitizeComposerHtml` was double-escaping text between tags.** Tiptap's `getHTML()` output and `plaintextToComposerHtml` both already escape special chars, but `html-sanitizer.ts:111` re-ran `escapeHtml()` on text segments — turning `&amp;` into `&amp;amp;`. Gmail decoded once and recipients saw literal `&amp;`. Affects all composer-driven email bodies (inbox + broadcasts).

   Fix: stop re-escaping. Added a regression test that asserts `<p>Msg &amp; data</p>` round-trips as `<p>Msg &amp; data</p>` (single-escaped).

2. **Broadcast composer + preview didn't show the alias signature.** The inbox composer displays the signature in a read-only `bottomSlot` below the editor; broadcasts didn't have it. The wizard preview pipeline also omitted the signature, so operators saw a different result in-app than what their recipients received.

   Fix: mirror the inbox pattern. The wizard state hook loads the selected alias's `signature` field on alias change; compose-step renders it via the same `bottomSlot` JSX shape; the preview path injects `buildBroadcastSignatureBlock` + preheader matching the production send. Storage and edit-via-Settings unchanged (consistent with inbox).

Refactor: extracted `normalize-alias-email.ts` so the alias-lookup key is shared between the send paths and the new composer/preview paths.

## Validation
- `pnpm typecheck` — passed
- `pnpm lint` — passed
- `pnpm build` — passed
- Affected tests passed (composer-html-sanitizer, new-campaign-wizard, campaign-audience-step, campaign-compose-step)

## Test plan
- [ ] CI green
- [ ] Visual: open broadcast composer with an alias whose signature is configured → signature appears below the body in the same muted style as the inbox composer
- [ ] Preview the broadcast → signature appears between body and unsubscribe footer
- [ ] Type `Msg & data` in the body → recipient sees `Msg & data`, not `Msg &amp; data`

🤖 Generated with [Claude Code](https://claude.com/claude-code)