### PR TITLE
fix(broadcasts): show save pending on Continue + fix preview paragraph spacing

### DIFF
--- a/apps/web/app/broadcasts/new/_components/compose-step.tsx
+++ b/apps/web/app/broadcasts/new/_components/compose-step.tsx
@@ -27,6 +27,12 @@ interface ComposeStepProps {
   readonly bodyPlaintext: string;
   readonly selectedAliasSignature: string;
   readonly frozen: boolean;
+  /**
+   * True while the draft-save server action triggered by Continue is in
+   * flight. Used to show a pending state on the primary button so the
+   * operator has visible feedback during the save → step-transition gap.
+   */
+  readonly continuePending?: boolean;
   readonly onSubjectChange: (value: string) => void;
   readonly onPreheaderChange: (value: string) => void;
   readonly onBodyChange: (value: {
@@ -43,6 +49,7 @@ export function ComposeStep({
   bodyPlaintext,
   selectedAliasSignature,
   frozen,
+  continuePending = false,
   onSubjectChange,
   onPreheaderChange,
   onBodyChange,
@@ -186,9 +193,10 @@ export function ComposeStep({
 
       <WizardFooter
         onBack={onBack}
-        primaryLabel="Continue"
+        primaryLabel={continuePending ? "Saving…" : "Continue"}
         primaryAction={onContinue}
         primaryDisabled={!canContinue}
+        primaryLoading={continuePending}
       />
     </section>
   );

--- a/apps/web/app/broadcasts/new/_components/new-campaign-wizard.tsx
+++ b/apps/web/app/broadcasts/new/_components/new-campaign-wizard.tsx
@@ -436,6 +436,7 @@ export function NewCampaignWizard({
     setToast,
     countLoading,
     audiencePreviewLoading,
+    savePending,
     startSaveTransition,
     submitPending,
     startSubmitTransition,
@@ -771,6 +772,7 @@ export function NewCampaignWizard({
                 bodyPlaintext={bodyPlaintext}
                 selectedAliasSignature={selectedAliasSignature}
                 frozen={frozen}
+                continuePending={savePending}
                 onSubjectChange={setSubject}
                 onPreheaderChange={setPreheader}
                 onBodyChange={(value) => {

--- a/apps/web/app/broadcasts/new/_components/preview-step.tsx
+++ b/apps/web/app/broadcasts/new/_components/preview-step.tsx
@@ -212,9 +212,17 @@ export function PreviewStep({
             ) : (
               <article className="rounded-lg border border-slate-200 bg-white p-5">
                 <div
+                  // Note: `prose` from @tailwindcss/typography is not
+                  // installed in this app, so we apply paragraph + link
+                  // styling via arbitrary selectors. The `[&_p]:my-3` rule
+                  // mirrors the ~1em <p> margin Gmail (and browser
+                  // defaults) apply, which Tailwind's Preflight reset
+                  // otherwise zeroes out, collapsing all paragraphs.
                   className={cn(
-                    "prose prose-sm max-w-none text-slate-800",
-                    "[&_a]:text-sky-700 [&_a]:underline [&_hr]:border-slate-200",
+                    "text-sm leading-relaxed text-slate-800",
+                    "[&_p]:my-3 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0",
+                    "[&_a]:text-sky-700 [&_a]:underline",
+                    "[&_hr]:border-slate-200",
                   )}
                   dangerouslySetInnerHTML={{ __html: sample.html }}
                 />

--- a/apps/web/app/broadcasts/new/_components/use-new-campaign-wizard-state.ts
+++ b/apps/web/app/broadcasts/new/_components/use-new-campaign-wizard-state.ts
@@ -930,6 +930,7 @@ export function useNewCampaignWizardState({
     setToast,
     countLoading,
     audiencePreviewLoading,
+    savePending,
     startSaveTransition,
     submitPending,
     startSubmitTransition,


### PR DESCRIPTION
## Summary
Two small wizard UX fixes surfaced during PR #526 verification.

## What changes
- **Continue button now shows pending state.** `useNewCampaignWizardState` already tracked `savePending` from `useTransition` but didn't return it. Now exposes it; `new-campaign-wizard` threads it to `ComposeStep` as `continuePending`; the WizardFooter shows the loading state (label flips to "Saving…", button disabled) for the duration of the draft-save server action. Closes the visual gap between clicking Continue and the Preview step's own "Rendering the live preview…" indicator.
- **Preview paragraph spacing now matches Gmail.** `PreviewStep` wrapped the rendered HTML in `<div class="prose prose-sm max-w-none …">`, but `@tailwindcss/typography` isn't installed in `apps/web`, so those classes are dead. Tailwind's Preflight then zeros `<p>` margins. Gmail applies browser-default ~1em margins, so the sent email looked correct but the in-app preview looked collapsed. Replaced the dead `prose` classes with explicit `[&_p]:my-3` arbitrary selectors.

## Out of scope
- Investigating the underlying server-action latency. PR #526 didn't add new DB lookups to either `saveCampaignWizardDraftAction` or `loadComposePreviewAction` — same work as before. Slowness is intrinsic to those paths (audience resolution + multiple alias/project lookups). Worth a separate profiling pass if it stays painful; quick win would be `Promise.all` parallelizing the three DB lookups in `loadComposePreviewAction`.

## Test plan
- [x] `pnpm typecheck` / `lint` / `boundaries` / `build` all green
- [ ] After deploy: click Continue from Compose step — see "Saving…" on the button until the Preview step takes over
- [ ] After deploy: in the Preview step, paragraphs in the rendered body have visible spacing between them (matching the sent email)

🤖 Generated with [Claude Code](https://claude.com/claude-code)