### PR TITLE
feat(inbox): render Drive attachments as inbox chips (PRD #517 Brick C)

### DIFF
--- a/apps/web/app/inbox/_components/inbox-timeline-bubble.tsx
+++ b/apps/web/app/inbox/_components/inbox-timeline-bubble.tsx
@@ -123,12 +123,19 @@ function MessageAttachments({
     return null;
   }
 
-  const imageAttachments = attachments.filter((attachment) =>
-    attachment.proxyUrl !== null && attachment.mimeType.startsWith("image/"),
+  const imageAttachments = attachments.filter(
+    (attachment) =>
+      attachment.provider === "gmail" &&
+      attachment.proxyUrl !== null &&
+      attachment.mimeType.startsWith("image/"),
+  );
+  const driveAttachments = attachments.filter(
+    (attachment) => attachment.provider === "drive",
   );
   const fileAttachments = attachments.filter(
     (attachment) =>
-      attachment.proxyUrl === null || !attachment.mimeType.startsWith("image/"),
+      attachment.provider !== "drive" &&
+      (attachment.proxyUrl === null || !attachment.mimeType.startsWith("image/")),
   );
 
   return (
@@ -170,6 +177,37 @@ function MessageAttachments({
                   />
                 </DialogContent>
               </Dialog>
+            );
+          })}
+        </div>
+      ) : null}
+
+      {driveAttachments.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {driveAttachments.map((attachment, index) => {
+            const label = attachmentLabel(attachment.filename);
+            const attachmentKey = attachment.id ?? `drive-${String(index)}`;
+
+            if (attachment.externalUrl === null) {
+              return null;
+            }
+
+            return (
+              <a
+                key={attachmentKey}
+                href={attachment.externalUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={`Open ${label} in Google Drive`}
+                className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 transition-colors duration-150 ease-out hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2"
+              >
+                <FileDocIcon className="size-3.5 shrink-0" />
+                <span className="max-w-[16rem] truncate">{label}</span>
+                <span className="rounded-md border border-slate-200 bg-slate-50 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-slate-500">
+                  Drive
+                </span>
+                <ArrowUpRightIcon className="size-3 shrink-0 text-slate-400" />
+              </a>
             );
           })}
         </div>

--- a/apps/web/app/inbox/_hooks/use-composer-submit.ts
+++ b/apps/web/app/inbox/_hooks/use-composer-submit.ts
@@ -71,6 +71,7 @@ function resolveSupplementaryRecipientEmails(input: {
 function toOptimisticAttachment(attachment: AttachmentDraft, index: number) {
   return {
     id: `optimistic-attachment:${attachment.id}:${String(index)}`,
+    provider: "gmail" as const,
     mimeType: attachment.contentType,
     filename: attachment.filename,
     sizeBytes: attachment.size,
@@ -78,6 +79,7 @@ function toOptimisticAttachment(attachment: AttachmentDraft, index: number) {
       attachment.contentBase64 === null
         ? ""
         : `data:${attachment.contentType};base64,${attachment.contentBase64}`,
+    externalUrl: null,
   };
 }
 

--- a/apps/web/app/inbox/_lib/message-formatting.ts
+++ b/apps/web/app/inbox/_lib/message-formatting.ts
@@ -209,7 +209,10 @@ export function stripDriveAttachmentBareFilenames(
     .map((name) => name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
     .join("|");
   const pattern = new RegExp(`^\\s*(?:${escaped})\\s*$`, "gmu");
-  return value.replace(pattern, "").replace(/\n{3,}/g, "\n\n");
+  return value
+    .replace(pattern, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .replace(/^\s+|\s+$/g, "");
 }
 
 function isLikelyPreviewNoise(value: string): boolean {

--- a/apps/web/app/inbox/_lib/message-formatting.ts
+++ b/apps/web/app/inbox/_lib/message-formatting.ts
@@ -197,6 +197,21 @@ export function stripInlineImagePlaceholders(value: string): string {
     .replace(/\n{3,}/g, "\n\n");
 }
 
+export function stripDriveAttachmentBareFilenames(
+  value: string,
+  driveFilenames: readonly string[],
+): string {
+  if (driveFilenames.length === 0) {
+    return value;
+  }
+
+  const escaped = driveFilenames
+    .map((name) => name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    .join("|");
+  const pattern = new RegExp(`^\\s*(?:${escaped})\\s*$`, "gmu");
+  return value.replace(pattern, "").replace(/\n{3,}/g, "\n\n");
+}
+
 function isLikelyPreviewNoise(value: string): boolean {
   const normalized = value.trim();
 

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -29,6 +29,7 @@ import {
   parseCommunicationPreview,
   resolvePreferredMessagePreview,
   sanitizePreviewText,
+  stripDriveAttachmentBareFilenames,
   stripInlineImagePlaceholders,
   stripDuplicateOutboundEcho,
   stripSignature,
@@ -2380,9 +2381,36 @@ function buildTimelineEntry(input: {
           }),
         })
       : resolvedBody;
+  const attachments =
+    input.item.family === "one_to_one_email"
+      ? buildEmailAttachmentsForEntry({
+          canonical:
+            input.attachmentsByCanonicalEventId.get(
+              input.item.canonicalEventId,
+            ) ?? [],
+          pending: input.item.pendingAttachmentMetadata ?? [],
+          itemDirection: input.item.direction,
+          canonicalEventId: input.item.canonicalEventId,
+          inboundFirstOccurrenceOnThread:
+            input.item.threadId !== null && input.item.threadId.length > 0
+              ? (input.inboundFirstOccurrenceByThread.get(input.item.threadId) ??
+                null)
+              : null,
+        })
+      : [];
   const renderableEmailBody =
     input.item.family === "one_to_one_email"
-      ? stripInlineImagePlaceholders(bodyWithDuplicateOutboundEchoStripped)
+      ? stripDriveAttachmentBareFilenames(
+          stripInlineImagePlaceholders(bodyWithDuplicateOutboundEchoStripped),
+          attachments
+            .filter(
+              (
+                attachment,
+              ): attachment is (typeof attachment & { readonly filename: string }) =>
+                attachment.provider === "drive" && attachment.filename !== null,
+            )
+            .map((attachment) => attachment.filename),
+        )
       : bodyWithDuplicateOutboundEchoStripped;
   const hasRenderableEmailContent =
     kind === "inbound-email" || kind === "outbound-email"
@@ -2413,23 +2441,6 @@ function buildTimelineEntry(input: {
           input.item.canonicalEventId ===
             input.inboxProjection.lastCanonicalEventId
         : false;
-  const attachments =
-    input.item.family === "one_to_one_email"
-      ? buildEmailAttachmentsForEntry({
-          canonical:
-            input.attachmentsByCanonicalEventId.get(
-              input.item.canonicalEventId,
-            ) ?? [],
-          pending: input.item.pendingAttachmentMetadata ?? [],
-          itemDirection: input.item.direction,
-          canonicalEventId: input.item.canonicalEventId,
-          inboundFirstOccurrenceOnThread:
-            input.item.threadId !== null && input.item.threadId.length > 0
-              ? (input.inboundFirstOccurrenceByThread.get(input.item.threadId) ??
-                null)
-              : null,
-        })
-      : [];
   const headerProjectLabel =
     input.item.family === "one_to_one_email"
       ? resolveHeaderProjectLabel({
@@ -2727,13 +2738,29 @@ function buildEmailAttachmentsForEntry(input: {
 
       return firstOccurrenceCanonicalEventId === input.canonicalEventId;
     })
-    .map((attachment) => ({
-      id: attachment.id,
-      mimeType: attachment.mimeType,
-      filename: attachment.filename,
-      sizeBytes: attachment.sizeBytes,
-      proxyUrl: `/api/attachments/${encodeURIComponent(attachment.id)}`,
-    }));
+    .map((attachment) => {
+      if (attachment.provider === "drive") {
+        return {
+          id: attachment.id,
+          provider: "drive" as const,
+          mimeType: attachment.mimeType,
+          filename: attachment.filename,
+          sizeBytes: attachment.sizeBytes,
+          proxyUrl: null,
+          externalUrl: attachment.externalUrl,
+        };
+      }
+
+      return {
+        id: attachment.id,
+        provider: "gmail" as const,
+        mimeType: attachment.mimeType,
+        filename: attachment.filename,
+        sizeBytes: attachment.sizeBytes,
+        proxyUrl: `/api/attachments/${encodeURIComponent(attachment.id)}`,
+        externalUrl: null,
+      };
+    });
 
   if (canonicalAttachments.length > 0) {
     return canonicalAttachments;
@@ -2742,10 +2769,12 @@ function buildEmailAttachmentsForEntry(input: {
   if (input.pending.length > 0) {
     return input.pending.map((attachment) => ({
       id: null,
+      provider: "pending" as const,
       mimeType: attachment.contentType,
       filename: attachment.filename,
       sizeBytes: attachment.sizeBytes,
       proxyUrl: null,
+      externalUrl: null,
     }));
   }
 

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -279,10 +279,12 @@ export interface InboxTimelineEntryViewModel {
   readonly attachmentCount: number;
   readonly attachments: readonly {
     readonly id: string | null;
+    readonly provider: "gmail" | "drive" | "pending";
     readonly mimeType: string;
     readonly filename: string | null;
     readonly sizeBytes: number;
     readonly proxyUrl: string | null;
+    readonly externalUrl: string | null;
   }[];
   readonly campaignActivity: readonly InboxTimelineCampaignActivityViewModel[];
   readonly noteId?: string | null;

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -7854,7 +7854,18 @@ describe("real inbox selectors", () => {
 
     const detail = await getInboxDetail("contact:mixed-attachments");
 
+    // Selector orders attachments by id ascending; "att:drive:..." sorts
+    // before "att:gmail:..." alphabetically.
     expect(detail?.timeline[0]?.attachments).toEqual([
+      {
+        id: "att:drive:mixed-attachment-email-1:0/2",
+        provider: "drive",
+        mimeType: "image/jpeg",
+        filename: "IMG_2634.jpeg",
+        sizeBytes: 0,
+        proxyUrl: null,
+        externalUrl: "https://drive.google.com/file/d/mixed/view",
+      },
       {
         id: "att:gmail:mixed-attachment-email-1:0/1",
         provider: "gmail",
@@ -7864,15 +7875,6 @@ describe("real inbox selectors", () => {
         proxyUrl:
           "/api/attachments/att%3Agmail%3Amixed-attachment-email-1%3A0%2F1",
         externalUrl: null,
-      },
-      {
-        id: "att:drive:mixed-attachment-email-1:0/2",
-        provider: "drive",
-        mimeType: "image/jpeg",
-        filename: "IMG_2634.jpeg",
-        sizeBytes: 0,
-        proxyUrl: null,
-        externalUrl: "https://drive.google.com/file/d/mixed/view",
       },
     ]);
   });
@@ -7896,7 +7898,16 @@ describe("real inbox selectors", () => {
       direction: "inbound",
       subject: "Drive photo",
       snippet: "Hi!",
-      bodyTextPreview: ["Hi!", "", "IMG_2634.jpeg", "", "thanks"].join("\n"),
+      // Trailing line is a substantive sentence so the existing signature
+      // stripper (which strips a bare "thanks" suffix) doesn't remove it
+      // before the Drive bare-filename strip runs.
+      bodyTextPreview: [
+        "Hi!",
+        "",
+        "IMG_2634.jpeg",
+        "",
+        "Photo from yesterday's survey.",
+      ].join("\n"),
     });
     await seedInboxProjection(runtime.context, {
       contactId: "contact:drive-body-strip",
@@ -7923,7 +7934,9 @@ describe("real inbox selectors", () => {
 
     const detail = await getInboxDetail("contact:drive-body-strip");
 
-    expect(detail?.timeline[0]?.body).toBe("Hi!\n\nthanks");
+    expect(detail?.timeline[0]?.body).toBe(
+      "Hi!\n\nPhoto from yesterday's survey.",
+    );
   });
 
   it("leaves unrelated bare filenames alone when there is no matching Drive attachment", async () => {
@@ -7945,7 +7958,13 @@ describe("real inbox selectors", () => {
       direction: "inbound",
       subject: "No Drive match",
       snippet: "Hi!",
-      bodyTextPreview: ["Hi!", "", "IMG_2634.jpeg", "", "thanks"].join("\n"),
+      bodyTextPreview: [
+        "Hi!",
+        "",
+        "IMG_2634.jpeg",
+        "",
+        "Photo from yesterday's survey.",
+      ].join("\n"),
     });
     await seedInboxProjection(runtime.context, {
       contactId: "contact:drive-body-unrelated",
@@ -7962,7 +7981,9 @@ describe("real inbox selectors", () => {
 
     const detail = await getInboxDetail("contact:drive-body-unrelated");
 
-    expect(detail?.timeline[0]?.body).toBe("Hi!\n\nIMG_2634.jpeg\n\nthanks");
+    expect(detail?.timeline[0]?.body).toBe(
+      "Hi!\n\nIMG_2634.jpeg\n\nPhoto from yesterday's survey.",
+    );
   });
 
   it("treats bare Drive filename stripping as case-sensitive", async () => {
@@ -7984,7 +8005,13 @@ describe("real inbox selectors", () => {
       direction: "inbound",
       subject: "Case-sensitive",
       snippet: "Hi!",
-      bodyTextPreview: ["Hi!", "", "img_2634.jpeg", "", "thanks"].join("\n"),
+      bodyTextPreview: [
+        "Hi!",
+        "",
+        "img_2634.jpeg",
+        "",
+        "Photo from yesterday's survey.",
+      ].join("\n"),
     });
     await seedInboxProjection(runtime.context, {
       contactId: "contact:drive-body-case",
@@ -8011,7 +8038,9 @@ describe("real inbox selectors", () => {
 
     const detail = await getInboxDetail("contact:drive-body-case");
 
-    expect(detail?.timeline[0]?.body).toBe("Hi!\n\nimg_2634.jpeg\n\nthanks");
+    expect(detail?.timeline[0]?.body).toBe(
+      "Hi!\n\nimg_2634.jpeg\n\nPhoto from yesterday's survey.",
+    );
   });
 
   it("strips multiple matching Drive filenames from the rendered body", async () => {

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -74,6 +74,7 @@ import {
   sortMembershipsByCreatedAt,
   stripSignature,
 } from "../../app/inbox/_lib/selectors";
+import { stripDriveAttachmentBareFilenames } from "../../app/inbox/_lib/message-formatting";
 import { InboxContactRail } from "../../app/inbox/_components/inbox-contact-rail";
 import type {
   InboxListItemViewModel,
@@ -7197,10 +7198,12 @@ describe("real inbox selectors", () => {
     expect(detail?.timeline[0]?.attachments).toEqual([
       {
         id: "att:gmail:attachment-email-1:0/2",
+        provider: "gmail",
         mimeType: "application/pdf",
         filename: "packet.pdf",
         sizeBytes: 4567,
         proxyUrl: "/api/attachments/att%3Agmail%3Aattachment-email-1%3A0%2F2",
+        externalUrl: null,
       },
     ]);
   });
@@ -7375,11 +7378,13 @@ describe("real inbox selectors", () => {
     expect(detail?.timeline[0]?.attachments).toEqual([
       {
         id: "att:gmail:karen-attachment-email-1:0/1",
+        provider: "gmail",
         mimeType: "image/png",
         filename: "trail distance.png",
         sizeBytes: 4321,
         proxyUrl:
           "/api/attachments/att%3Agmail%3Akaren-attachment-email-1%3A0%2F1",
+        externalUrl: null,
       },
     ]);
   });
@@ -7642,10 +7647,12 @@ describe("real inbox selectors", () => {
     expect(pendingEntry?.attachments).toEqual([
       {
         id: null,
+        provider: "pending",
         mimeType: "application/zip",
         filename: "x.zip",
         sizeBytes: 1234,
         proxyUrl: null,
+        externalUrl: null,
       },
     ]);
   });
@@ -7725,12 +7732,365 @@ describe("real inbox selectors", () => {
     expect(canonicalEntry?.attachments).toEqual([
       {
         id: "att:gmail:canonical-attachment-email-1:0/1",
+        provider: "gmail",
         mimeType: "application/pdf",
         filename: "canonical.pdf",
         sizeBytes: 4567,
         proxyUrl:
           "/api/attachments/att%3Agmail%3Acanonical-attachment-email-1%3A0%2F1",
+        externalUrl: null,
       },
     ]);
+  });
+
+  it("surfaces Drive attachments with an external URL instead of a proxy URL", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:drive-attachment",
+      salesforceContactId: "003-drive-attachment",
+      displayName: "Drive Attachment Test",
+      primaryEmail: "drive@example.org",
+      primaryPhone: null,
+    });
+    const latest = await seedInboxEmailEvent(runtime.context, {
+      id: "drive-attachment-email-1",
+      contactId: "contact:drive-attachment",
+      occurredAt: "2026-05-28T15:00:00.000Z",
+      direction: "inbound",
+      subject: "Photo update",
+      snippet: "See the Drive attachment.",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:drive-attachment",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-05-28T15:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-05-28T15:00:00.000Z",
+      snippet: "See the Drive attachment.",
+      lastCanonicalEventId: latest.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+    await seedInboxMessageAttachment(runtime.context, {
+      sourceEvidenceId: "source:drive-attachment-email-1",
+      id: "att:drive:drive-attachment-email-1:0/1",
+      provider: "drive",
+      mimeType: "image/jpeg",
+      filename: "IMG_2634.jpeg",
+      sizeBytes: 0,
+      storageKey: null,
+      externalUrl: "https://drive.google.com/file/d/abc/view",
+    });
+
+    const detail = await getInboxDetail("contact:drive-attachment");
+
+    expect(detail?.timeline[0]?.attachments).toEqual([
+      {
+        id: "att:drive:drive-attachment-email-1:0/1",
+        provider: "drive",
+        mimeType: "image/jpeg",
+        filename: "IMG_2634.jpeg",
+        sizeBytes: 0,
+        proxyUrl: null,
+        externalUrl: "https://drive.google.com/file/d/abc/view",
+      },
+    ]);
+  });
+
+  it("keeps Drive and Gmail attachments distinct in the same entry", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:mixed-attachments",
+      salesforceContactId: "003-mixed-attachments",
+      displayName: "Mixed Attachment Test",
+      primaryEmail: "mixed@example.org",
+      primaryPhone: null,
+    });
+    const latest = await seedInboxEmailEvent(runtime.context, {
+      id: "mixed-attachment-email-1",
+      contactId: "contact:mixed-attachments",
+      occurredAt: "2026-05-28T16:00:00.000Z",
+      direction: "inbound",
+      subject: "Mixed files",
+      snippet: "One Gmail file and one Drive file.",
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:mixed-attachments",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-05-28T16:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-05-28T16:00:00.000Z",
+      snippet: "One Gmail file and one Drive file.",
+      lastCanonicalEventId: latest.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+    await seedInboxMessageAttachment(runtime.context, {
+      sourceEvidenceId: "source:mixed-attachment-email-1",
+      id: "att:gmail:mixed-attachment-email-1:0/1",
+      mimeType: "application/pdf",
+      filename: "packet.pdf",
+      sizeBytes: 4567,
+      storageKey: "gmail/mixed/att:gmail:mixed-attachment-email-1:0/1",
+    });
+    await seedInboxMessageAttachment(runtime.context, {
+      sourceEvidenceId: "source:mixed-attachment-email-1",
+      id: "att:drive:mixed-attachment-email-1:0/2",
+      provider: "drive",
+      mimeType: "image/jpeg",
+      filename: "IMG_2634.jpeg",
+      sizeBytes: 0,
+      storageKey: null,
+      externalUrl: "https://drive.google.com/file/d/mixed/view",
+    });
+
+    const detail = await getInboxDetail("contact:mixed-attachments");
+
+    expect(detail?.timeline[0]?.attachments).toEqual([
+      {
+        id: "att:gmail:mixed-attachment-email-1:0/1",
+        provider: "gmail",
+        mimeType: "application/pdf",
+        filename: "packet.pdf",
+        sizeBytes: 4567,
+        proxyUrl:
+          "/api/attachments/att%3Agmail%3Amixed-attachment-email-1%3A0%2F1",
+        externalUrl: null,
+      },
+      {
+        id: "att:drive:mixed-attachment-email-1:0/2",
+        provider: "drive",
+        mimeType: "image/jpeg",
+        filename: "IMG_2634.jpeg",
+        sizeBytes: 0,
+        proxyUrl: null,
+        externalUrl: "https://drive.google.com/file/d/mixed/view",
+      },
+    ]);
+  });
+
+  it("strips bare Drive filenames from rendered email bodies", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:drive-body-strip",
+      salesforceContactId: "003-drive-body-strip",
+      displayName: "Drive Body Strip Test",
+      primaryEmail: "drive-body@example.org",
+      primaryPhone: null,
+    });
+    const latest = await seedInboxEmailEvent(runtime.context, {
+      id: "drive-body-strip-1",
+      contactId: "contact:drive-body-strip",
+      occurredAt: "2026-05-28T17:00:00.000Z",
+      direction: "inbound",
+      subject: "Drive photo",
+      snippet: "Hi!",
+      bodyTextPreview: ["Hi!", "", "IMG_2634.jpeg", "", "thanks"].join("\n"),
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:drive-body-strip",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-05-28T17:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-05-28T17:00:00.000Z",
+      snippet: "Hi!",
+      lastCanonicalEventId: latest.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+    await seedInboxMessageAttachment(runtime.context, {
+      sourceEvidenceId: "source:drive-body-strip-1",
+      id: "att:drive:drive-body-strip-1:0/1",
+      provider: "drive",
+      mimeType: "image/jpeg",
+      filename: "IMG_2634.jpeg",
+      sizeBytes: 0,
+      storageKey: null,
+      externalUrl: "https://drive.google.com/file/d/body-strip/view",
+    });
+
+    const detail = await getInboxDetail("contact:drive-body-strip");
+
+    expect(detail?.timeline[0]?.body).toBe("Hi!\n\nthanks");
+  });
+
+  it("leaves unrelated bare filenames alone when there is no matching Drive attachment", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:drive-body-unrelated",
+      salesforceContactId: "003-drive-body-unrelated",
+      displayName: "Drive Body Unrelated Test",
+      primaryEmail: "drive-unrelated@example.org",
+      primaryPhone: null,
+    });
+    const latest = await seedInboxEmailEvent(runtime.context, {
+      id: "drive-body-unrelated-1",
+      contactId: "contact:drive-body-unrelated",
+      occurredAt: "2026-05-28T18:00:00.000Z",
+      direction: "inbound",
+      subject: "No Drive match",
+      snippet: "Hi!",
+      bodyTextPreview: ["Hi!", "", "IMG_2634.jpeg", "", "thanks"].join("\n"),
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:drive-body-unrelated",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-05-28T18:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-05-28T18:00:00.000Z",
+      snippet: "Hi!",
+      lastCanonicalEventId: latest.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+
+    const detail = await getInboxDetail("contact:drive-body-unrelated");
+
+    expect(detail?.timeline[0]?.body).toBe("Hi!\n\nIMG_2634.jpeg\n\nthanks");
+  });
+
+  it("treats bare Drive filename stripping as case-sensitive", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:drive-body-case",
+      salesforceContactId: "003-drive-body-case",
+      displayName: "Drive Body Case Test",
+      primaryEmail: "drive-case@example.org",
+      primaryPhone: null,
+    });
+    const latest = await seedInboxEmailEvent(runtime.context, {
+      id: "drive-body-case-1",
+      contactId: "contact:drive-body-case",
+      occurredAt: "2026-05-28T19:00:00.000Z",
+      direction: "inbound",
+      subject: "Case-sensitive",
+      snippet: "Hi!",
+      bodyTextPreview: ["Hi!", "", "img_2634.jpeg", "", "thanks"].join("\n"),
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:drive-body-case",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-05-28T19:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-05-28T19:00:00.000Z",
+      snippet: "Hi!",
+      lastCanonicalEventId: latest.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+    await seedInboxMessageAttachment(runtime.context, {
+      sourceEvidenceId: "source:drive-body-case-1",
+      id: "att:drive:drive-body-case-1:0/1",
+      provider: "drive",
+      mimeType: "image/jpeg",
+      filename: "IMG_2634.jpeg",
+      sizeBytes: 0,
+      storageKey: null,
+      externalUrl: "https://drive.google.com/file/d/case/view",
+    });
+
+    const detail = await getInboxDetail("contact:drive-body-case");
+
+    expect(detail?.timeline[0]?.body).toBe("Hi!\n\nimg_2634.jpeg\n\nthanks");
+  });
+
+  it("strips multiple matching Drive filenames from the rendered body", async () => {
+    if (runtime === null) {
+      throw new Error("Expected inbox test runtime");
+    }
+
+    await seedInboxContact(runtime.context, {
+      contactId: "contact:drive-body-multiple",
+      salesforceContactId: "003-drive-body-multiple",
+      displayName: "Drive Body Multiple Test",
+      primaryEmail: "drive-multiple@example.org",
+      primaryPhone: null,
+    });
+    const latest = await seedInboxEmailEvent(runtime.context, {
+      id: "drive-body-multiple-1",
+      contactId: "contact:drive-body-multiple",
+      occurredAt: "2026-05-28T20:00:00.000Z",
+      direction: "inbound",
+      subject: "Multiple Drive files",
+      snippet: "Files attached.",
+      bodyTextPreview: [
+        "file-1.pdf",
+        "file-2.pdf",
+        "",
+        "Notes",
+        "",
+        "file-3.pdf",
+        "file-4.pdf",
+        "file-5.pdf",
+      ].join("\n"),
+    });
+    await seedInboxProjection(runtime.context, {
+      contactId: "contact:drive-body-multiple",
+      bucket: "New",
+      needsFollowUp: false,
+      hasUnresolved: false,
+      lastInboundAt: "2026-05-28T20:00:00.000Z",
+      lastOutboundAt: null,
+      lastActivityAt: "2026-05-28T20:00:00.000Z",
+      snippet: "Files attached.",
+      lastCanonicalEventId: latest.canonicalEventId,
+      lastEventType: "communication.email.inbound",
+    });
+    for (const filename of [
+      "file-1.pdf",
+      "file-2.pdf",
+      "file-3.pdf",
+      "file-4.pdf",
+      "file-5.pdf",
+    ]) {
+      await seedInboxMessageAttachment(runtime.context, {
+        sourceEvidenceId: "source:drive-body-multiple-1",
+        id: `att:drive:drive-body-multiple-1:${filename}`,
+        provider: "drive",
+        mimeType: "application/pdf",
+        filename,
+        sizeBytes: 0,
+        storageKey: null,
+        externalUrl: `https://drive.google.com/file/d/${filename}/view`,
+      });
+    }
+
+    const detail = await getInboxDetail("contact:drive-body-multiple");
+
+    expect(detail?.timeline[0]?.body).toBe("Notes");
+  });
+
+  it("keeps stripDriveAttachmentBareFilenames idempotent", () => {
+    const value = ["Hi!", "", "IMG_2634.jpeg", "", "thanks"].join("\n");
+    const filenames = ["IMG_2634.jpeg"] as const;
+
+    const strippedOnce = stripDriveAttachmentBareFilenames(value, filenames);
+    const strippedTwice = stripDriveAttachmentBareFilenames(
+      strippedOnce,
+      filenames,
+    );
+
+    expect(strippedOnce).toBe("Hi!\n\nthanks");
+    expect(strippedTwice).toBe(strippedOnce);
   });
 });

--- a/apps/web/tests/unit/inbox-stage1-helpers.ts
+++ b/apps/web/tests/unit/inbox-stage1-helpers.ts
@@ -185,31 +185,46 @@ export async function seedInboxMessageAttachment(
   input: {
     readonly sourceEvidenceId: string;
     readonly id: string;
+    readonly provider?: "gmail" | "drive";
     readonly mimeType: string;
     readonly filename: string | null;
     readonly sizeBytes: number;
-    readonly storageKey: string;
+    readonly storageKey: string | null;
+    readonly externalUrl?: string | null;
     readonly gmailAttachmentId?: string;
     readonly isDecoration?: boolean;
   },
 ): Promise<void> {
   const isDecoration = input.isDecoration ?? false;
+  const provider = input.provider ?? "gmail";
+  const attachment =
+    provider === "drive"
+      ? {
+          id: input.id,
+          provider: "drive" as const,
+          gmailAttachmentId: null,
+          mimeType: input.mimeType,
+          filename: input.filename,
+          sizeBytes: input.sizeBytes,
+          storageKey: null,
+          externalUrl: input.externalUrl ?? "",
+          isDecoration,
+        }
+      : {
+          id: input.id,
+          provider: "gmail" as const,
+          gmailAttachmentId: input.gmailAttachmentId ?? `gmail:${input.id}`,
+          mimeType: input.mimeType,
+          filename: input.filename,
+          sizeBytes: input.sizeBytes,
+          storageKey: input.storageKey ?? "",
+          externalUrl: null,
+          isDecoration,
+        };
 
   await context.repositories.messageAttachments.upsertManyForMessage(
     input.sourceEvidenceId,
-    [
-      {
-        id: input.id,
-        provider: "gmail",
-        gmailAttachmentId: input.gmailAttachmentId ?? `gmail:${input.id}`,
-        mimeType: input.mimeType,
-        filename: input.filename,
-        sizeBytes: input.sizeBytes,
-        storageKey: input.storageKey,
-        externalUrl: null,
-        isDecoration,
-      },
-    ],
+    [attachment],
   );
 }
 

--- a/apps/web/tests/unit/inbox-timeline-bubble.test.tsx
+++ b/apps/web/tests/unit/inbox-timeline-bubble.test.tsx
@@ -220,24 +220,30 @@ describe("MessageBubble attachments", () => {
           attachments: [
             {
               id: "image-1",
+              provider: "gmail",
               mimeType: "image/jpeg",
               filename: "field-photo.jpg",
               sizeBytes: 1234,
               proxyUrl: "/api/attachments/image-1",
+              externalUrl: null,
             },
             {
               id: "image-2",
+              provider: "gmail",
               mimeType: "image/png",
               filename: "map.png",
               sizeBytes: 5678,
               proxyUrl: "/api/attachments/image-2",
+              externalUrl: null,
             },
             {
               id: "pdf-1",
+              provider: "gmail",
               mimeType: "application/pdf",
               filename: "packet.pdf",
               sizeBytes: 91011,
               proxyUrl: "/api/attachments/pdf-1",
+              externalUrl: null,
             },
           ],
         }),
@@ -261,10 +267,12 @@ describe("MessageBubble attachments", () => {
           attachments: [
             {
               id: "pdf-null",
+              provider: "gmail",
               mimeType: "application/pdf",
               filename: null,
               sizeBytes: 2048,
               proxyUrl: "/api/attachments/pdf-null",
+              externalUrl: null,
             },
           ],
         }),
@@ -274,6 +282,32 @@ describe("MessageBubble attachments", () => {
 
     expect(markup).toContain("Download Attachment");
     expect(markup).toContain(">Attachment<");
+  });
+
+  it("renders Drive attachments as external chips with a Drive badge", () => {
+    const markup = renderToStaticMarkup(
+      createElement(MessageBubble, {
+        entry: buildEntry({
+          attachmentCount: 1,
+          attachments: [
+            {
+              id: "drive-1",
+              provider: "drive",
+              mimeType: "image/jpeg",
+              filename: "IMG_2634.jpeg",
+              sizeBytes: 0,
+              proxyUrl: null,
+              externalUrl: "https://drive.google.com/file/d/abc/view",
+            },
+          ],
+        }),
+        direction: "inbound",
+      }),
+    );
+
+    expect(markup).toContain("https://drive.google.com/file/d/abc/view");
+    expect(markup).toContain("Open IMG_2634.jpeg in Google Drive");
+    expect(markup).toContain(">Drive<");
   });
 });
 


### PR DESCRIPTION
## Summary

- Brick C of [PRD #517](https://github.com/nico-kneler-as/as-comms-platform/issues/517).
- **View model**: extends `InboxTimelineEntryViewModel.attachments` with `provider: 'gmail' | 'drive' | 'pending'` and `externalUrl: string | null`.
- **Selectors**: `buildEmailAttachmentsForEntry` branches by `attachment.provider` — gmail rows produce proxy chips, drive rows produce external-link chips, pending rows keep the in-flight composer behavior.
- **Body formatter**: new `stripDriveAttachmentBareFilenames` helper in `message-formatting.ts`. Runs after `stripInlineImagePlaceholders` so both `[image: …]` markers AND bare-filename duplicates that correspond to captured Drive attachments are stripped from the rendered body. Line-exact, case-sensitive, idempotent, no-op on empty filename list.
- **Bubble**: third render section between image previews and file chips — pill with `FileDocIcon` + filename + small "Drive" badge + external-link arrow, opens in new tab with `rel="noopener noreferrer"`. If the operator isn't logged into Drive or doesn't have access, Drive's own UI handles it.

After this PR: new captures with Drive attachments show clickable chips. Backfill of historical messages ships as Brick D.

## Test plan

- [x] `pnpm typecheck` — pass
- [x] `pnpm lint` — pass
- [x] `pnpm boundaries` — pass
- [x] `pnpm --filter @as-comms/web build` — pass
- [ ] CI test suite — 7 new selector tests (`inbox-selectors.test.ts`), 1 new bubble test (`inbox-timeline-bubble.test.tsx`), 8 existing fixtures updated for the new view-model fields

## Follow-up

- Brick D: backfill recent 30 days of captured messages via Gmail OAuth re-fetch (~173 candidates per the architect's prod count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)