### PR TITLE
feat(worker): weekly cron that auto-drains superseded-projection staleness (#360)

### DIFF
--- a/apps/worker/src/jobs/reconcile-superseded-projections.ts
+++ b/apps/worker/src/jobs/reconcile-superseded-projections.ts
@@ -1,0 +1,108 @@
+import { quickAddJob, type Task } from "graphile-worker";
+
+import {
+  projectionRebuildBatchJobName,
+  projectionRebuildBatchPayloadSchema,
+  stage1JobVersion,
+} from "@as-comms/contracts";
+import type { Stage1Database } from "@as-comms/db";
+
+import { buildOperationId } from "../ops/helpers.js";
+import { reconcileSupersededProjections } from "../ops/reconcile-superseded-projections.js";
+
+export const reconcileSupersededProjectionsJobName =
+  "reconcile-superseded-projections" as const;
+
+interface SqlRunner {
+  unsafe<T extends readonly object[]>(query: string): Promise<T>;
+}
+
+export interface ReconcileSupersededProjectionsTaskDependencies {
+  readonly db: Stage1Database;
+  readonly sql: SqlRunner;
+  readonly connectionString: string;
+  readonly limit?: number;
+  readonly logger?: Pick<Console, "log" | "error">;
+  // Override for tests so the projection-rebuild enqueue is observable
+  // without spinning up a real graphile_worker schema.
+  readonly enqueueProjectionRebuild?: (input: {
+    readonly contactIds: readonly string[];
+  }) => Promise<{ readonly enqueuedJobId: string }>;
+}
+
+export function createReconcileSupersededProjectionsTask(
+  deps: ReconcileSupersededProjectionsTaskDependencies,
+): Task {
+  const logger = deps.logger ?? console;
+
+  return async () => {
+    const report = await reconcileSupersededProjections({
+      db: deps.db,
+      sql: deps.sql,
+      dryRun: false,
+      limit: deps.limit ?? null,
+      logger,
+      emitPlanEvent: false,
+    });
+
+    logger.log(
+      JSON.stringify({
+        event: "reconcile_superseded_projections.cron.completed",
+        targetCount: report.targetCount,
+        summary: report.summary,
+        errors: report.errorExamples.length,
+        contactCount: report.contactIds.length,
+      }),
+    );
+
+    if (report.contactIds.length === 0) {
+      return;
+    }
+
+    const enqueue =
+      deps.enqueueProjectionRebuild ??
+      (async (input) => {
+        const payload = projectionRebuildBatchPayloadSchema.parse({
+          version: stage1JobVersion,
+          jobId: buildOperationId(
+            "stage1:projection-rebuild:cron:job",
+          ),
+          correlationId: buildOperationId(
+            "stage1:projection-rebuild:cron:correlation",
+          ),
+          traceId: null,
+          batchId: buildOperationId(
+            "stage1:projection-rebuild:cron:batch",
+          ),
+          syncStateId: buildOperationId(
+            "stage1:projection-rebuild:cron:sync-state",
+          ),
+          attempt: 1,
+          maxAttempts: 3,
+          jobType: "projection_rebuild",
+          projection: "all",
+          contactIds: input.contactIds,
+          includeReviewOverlayRefresh: true,
+        });
+        const job = await quickAddJob(
+          { connectionString: deps.connectionString },
+          projectionRebuildBatchJobName,
+          payload,
+        );
+        // `job.id` is typed as a string by graphile-worker, but cast through
+        // unknown to keep the eslint @typescript-eslint/no-unnecessary-type-conversion
+        // rule happy if the upstream type changes.
+        return { enqueuedJobId: job.id as unknown as string };
+      });
+
+    const enqueued = await enqueue({ contactIds: report.contactIds });
+
+    logger.log(
+      JSON.stringify({
+        event: "reconcile_superseded_projections.cron.enqueued_rebuild",
+        contactCount: report.contactIds.length,
+        enqueuedJobId: enqueued.enqueuedJobId,
+      }),
+    );
+  };
+}

--- a/apps/worker/src/ops/reconcile-superseded-projections.ts
+++ b/apps/worker/src/ops/reconcile-superseded-projections.ts
@@ -43,16 +43,23 @@ export interface StaleCanonicalTarget {
   readonly sourceOccurredAt: string;
 }
 
-interface ReconcileSummary {
+export interface ReconcileSupersededProjectionsSummary {
   occurredAtUpdated: number;
   alreadyAligned: number;
   missingCanonical: number;
   errors: number;
 }
 
-interface ErrorExample {
+export interface ReconcileSupersededProjectionsErrorExample {
   readonly canonicalEventId: string;
   readonly message: string;
+}
+
+export interface ReconcileSupersededProjectionsReport {
+  readonly summary: ReconcileSupersededProjectionsSummary;
+  readonly errorExamples: readonly ReconcileSupersededProjectionsErrorExample[];
+  readonly contactIds: readonly string[];
+  readonly targetCount: number;
 }
 
 class DryRunRollback extends Error {
@@ -213,6 +220,98 @@ function buildSampleRows(
   }));
 }
 
+// Core reconciler — dependency-injected so both the CLI wrapper and the
+// Graphile-cron task share one code path. Returns the per-key outcomes plus
+// the distinct contact IDs that need a projection-rebuild to refresh their
+// timeline/inbox rows from the updated canonicals.
+export async function reconcileSupersededProjections(input: {
+  readonly db: Stage1Database;
+  readonly sql: SqlRunner;
+  readonly dryRun: boolean;
+  readonly limit: number | null;
+  readonly logger?: Pick<Console, "log" | "error">;
+  readonly emitPlanEvent?: boolean;
+}): Promise<ReconcileSupersededProjectionsReport> {
+  const logger = input.logger ?? console;
+  const targets = await loadStaleCanonicals({
+    sql: input.sql,
+    limit: input.limit,
+  });
+
+  const distinctContactIds = Array.from(
+    new Set(targets.map((target) => target.contactId)),
+  ).sort((left, right) => left.localeCompare(right));
+
+  if (input.emitPlanEvent !== false) {
+    logger.log(
+      JSON.stringify(
+        {
+          event: "reconcile_superseded_projections.plan",
+          dryRun: input.dryRun,
+          limit: input.limit,
+          targetCount: targets.length,
+          distinctContactCount: distinctContactIds.length,
+          sample: buildSampleRows(targets),
+        },
+        null,
+        2,
+      ),
+    );
+  }
+
+  const summary: ReconcileSupersededProjectionsSummary = {
+    occurredAtUpdated: 0,
+    alreadyAligned: 0,
+    missingCanonical: 0,
+    errors: 0,
+  };
+  const errorExamples: ReconcileSupersededProjectionsErrorExample[] = [];
+
+  for (const target of targets) {
+    try {
+      const outcome = await applyOccurredAtUpdate({
+        db: input.db,
+        target,
+        dryRun: input.dryRun,
+      });
+
+      switch (outcome) {
+        case "updated":
+          summary.occurredAtUpdated += 1;
+          break;
+        case "already_aligned":
+          summary.alreadyAligned += 1;
+          break;
+        case "missing_canonical":
+          summary.missingCanonical += 1;
+          break;
+      }
+    } catch (error) {
+      const resolvedError =
+        error instanceof Error ? error : new Error(String(error));
+      summary.errors += 1;
+
+      if (errorExamples.length < DEFAULT_SAMPLE_LIMIT) {
+        errorExamples.push({
+          canonicalEventId: target.canonicalEventId,
+          message: resolvedError.message,
+        });
+      }
+
+      logger.error(
+        `Failed updating canonical ${target.canonicalEventId}: ${resolvedError.message}`,
+      );
+    }
+  }
+
+  return {
+    summary,
+    errorExamples,
+    contactIds: distinctContactIds,
+    targetCount: targets.length,
+  };
+}
+
 export async function runReconcileSupersededProjectionsCommand(
   args: readonly string[] = process.argv.slice(2),
   env: NodeJS.ProcessEnv = process.env,
@@ -226,78 +325,17 @@ export async function runReconcileSupersededProjectionsCommand(
   });
 
   try {
-    const targets = await loadStaleCanonicals({
+    const report = await reconcileSupersededProjections({
+      db: connection.db,
       sql: connection.sql as unknown as SqlRunner,
+      dryRun,
       limit,
+      logger,
     });
 
-    const distinctContactIds = Array.from(
-      new Set(targets.map((target) => target.contactId)),
-    ).sort((left, right) => left.localeCompare(right));
-
-    logger.log(
-      JSON.stringify(
-        {
-          event: "reconcile_superseded_projections.plan",
-          dryRun,
-          limit,
-          targetCount: targets.length,
-          distinctContactCount: distinctContactIds.length,
-          sample: buildSampleRows(targets),
-        },
-        null,
-        2,
-      ),
-    );
-
-    if (targets.length === 0) {
+    if (report.targetCount === 0) {
       logger.log("No canonical-event rows have a stale occurred_at.");
       return;
-    }
-
-    const summary: ReconcileSummary = {
-      occurredAtUpdated: 0,
-      alreadyAligned: 0,
-      missingCanonical: 0,
-      errors: 0,
-    };
-    const errorExamples: ErrorExample[] = [];
-
-    for (const target of targets) {
-      try {
-        const outcome = await applyOccurredAtUpdate({
-          db: connection.db,
-          target,
-          dryRun,
-        });
-
-        switch (outcome) {
-          case "updated":
-            summary.occurredAtUpdated += 1;
-            break;
-          case "already_aligned":
-            summary.alreadyAligned += 1;
-            break;
-          case "missing_canonical":
-            summary.missingCanonical += 1;
-            break;
-        }
-      } catch (error) {
-        const resolvedError =
-          error instanceof Error ? error : new Error(String(error));
-        summary.errors += 1;
-
-        if (errorExamples.length < DEFAULT_SAMPLE_LIMIT) {
-          errorExamples.push({
-            canonicalEventId: target.canonicalEventId,
-            message: resolvedError.message,
-          });
-        }
-
-        logger.error(
-          `Failed updating canonical ${target.canonicalEventId}: ${resolvedError.message}`,
-        );
-      }
     }
 
     logger.log(
@@ -305,12 +343,12 @@ export async function runReconcileSupersededProjectionsCommand(
         {
           event: "reconcile_superseded_projections.completed",
           dryRun,
-          summary,
-          errorExamples,
-          contactsForProjectionRebuild: distinctContactIds,
+          summary: report.summary,
+          errorExamples: report.errorExamples,
+          contactsForProjectionRebuild: report.contactIds,
           rebuildCommandHint:
-            distinctContactIds.length > 0
-              ? `pnpm --filter @as-comms/worker run ops enqueue projection-rebuild --contact-ids ${distinctContactIds.join(",")} --projection all --include-review-overlay-refresh true`
+            report.contactIds.length > 0
+              ? `pnpm --filter @as-comms/worker run ops enqueue projection-rebuild --contact-ids ${report.contactIds.join(",")} --projection all --include-review-overlay-refresh true`
               : null,
         },
         null,

--- a/apps/worker/src/runtime.ts
+++ b/apps/worker/src/runtime.ts
@@ -67,6 +67,10 @@ import {
 import { createTaskList } from "./tasks.js";
 import { reconcileIdentityQueueJobName } from "./jobs/reconcile-identity-queue.js";
 import { reconcileStaleRunningJobName } from "./jobs/reconcile-stale-running.js";
+import {
+  reconcileSupersededProjectionsJobName,
+  type ReconcileSupersededProjectionsTaskDependencies,
+} from "./jobs/reconcile-superseded-projections.js";
 import { sweepPendingOutboundsJobName } from "./jobs/sweep-pending-outbounds.js";
 import { pollPostmarkSenderStatusJobName } from "./jobs/poll-postmark-sender-status/index.js";
 
@@ -162,6 +166,7 @@ export function buildWorkerCrontab(config: WorkerConfig): string {
     `0 10 * * * ${dedupHistoricalLedgerJobName} ?id=dedup-historical-ledger&max=1`,
     `30 10 * * * ${reconcileCaptureGapsJobName} ?id=capture-gap-reconcile&max=1`,
     `*/15 * * * * ${reconcileRoutingReviewQueueJobName} ?id=routing-review-queue-reconcile&max=1`,
+    `0 11 * * 0 ${reconcileSupersededProjectionsJobName} ?id=superseded-projections-reconcile&max=1`,
   ].join("\n");
 }
 
@@ -665,6 +670,11 @@ export async function createStage1WorkerRuntimeServices(
         repositories,
         syncState,
         leaseThresholdMs,
+      },
+      reconcileSupersededProjections: {
+        db: connection.db,
+        sql: connection.sql as unknown as ReconcileSupersededProjectionsTaskDependencies["sql"],
+        connectionString: config.connectionString,
       },
       reconcileStrandedCampaignRuns: {
         db: connection.db,

--- a/apps/worker/src/tasks.ts
+++ b/apps/worker/src/tasks.ts
@@ -38,6 +38,11 @@ import {
   type ReconcileStaleRunningTaskDependencies,
 } from "./jobs/reconcile-stale-running.js";
 import {
+  createReconcileSupersededProjectionsTask,
+  reconcileSupersededProjectionsJobName,
+  type ReconcileSupersededProjectionsTaskDependencies,
+} from "./jobs/reconcile-superseded-projections.js";
+import {
   createReconcileStrandedCampaignRunsTask,
   reconcileStrandedCampaignRunsJobName,
   type ReconcileStrandedCampaignRunsTaskDependencies,
@@ -86,6 +91,7 @@ export function createTaskList(
     readonly reconcileRoutingReviewQueue?: ReconcileRoutingReviewQueueTaskDependencies;
     readonly reconcileCaptureGaps?: ReconcileCaptureGapsTaskDependencies;
     readonly reconcileStaleRunning?: ReconcileStaleRunningTaskDependencies;
+    readonly reconcileSupersededProjections?: ReconcileSupersededProjectionsTaskDependencies;
     readonly reconcileStrandedCampaignRuns?: ReconcileStrandedCampaignRunsTaskDependencies;
     readonly synthesizeProjectKnowledge?: SynthesizeProjectKnowledgeDependencies;
     readonly pollPostmarkSenderStatus?: PollPostmarkSenderStatusDependencies;
@@ -148,6 +154,14 @@ export function createTaskList(
           [reconcileStaleRunningJobName]: createReconcileStaleRunningTask(
             input.reconcileStaleRunning
           )
+        }),
+    ...(input?.reconcileSupersededProjections === undefined
+      ? {}
+      : {
+          [reconcileSupersededProjectionsJobName]:
+            createReconcileSupersededProjectionsTask(
+              input.reconcileSupersededProjections,
+            ),
         }),
     ...(input?.reconcileStrandedCampaignRuns === undefined
       ? {}

--- a/apps/worker/test/reconcile-superseded-projections-cron.test.ts
+++ b/apps/worker/test/reconcile-superseded-projections-cron.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from "vitest";
+
+import { createReconcileSupersededProjectionsTask } from "../src/jobs/reconcile-superseded-projections.js";
+import { createTestWorkerContext } from "./helpers.js";
+
+interface PgliteShape {
+  query(query: string): Promise<{ readonly rows: readonly unknown[] }>;
+}
+
+function pgliteSqlRunner(client: PgliteShape) {
+  return {
+    async unsafe<T extends readonly object[]>(query: string): Promise<T> {
+      const result = await client.query(query);
+      return result.rows as unknown as T;
+    },
+  };
+}
+
+interface MockJobLogger {
+  log(entry: unknown): void;
+  error(entry: unknown): void;
+  readonly events: unknown[];
+}
+
+function createCapturedLogger(): MockJobLogger {
+  const events: unknown[] = [];
+  return {
+    events,
+    log: (entry: unknown) => {
+      const text = typeof entry === "string" ? entry : String(entry);
+      try {
+        events.push(JSON.parse(text));
+      } catch {
+        events.push(text);
+      }
+    },
+    error: () => {
+      // Silent for these tests; would surface as Stage1NonRetryableJobError
+      // up the stack if it mattered.
+    },
+  };
+}
+
+async function seedStaleLifecycle(input: {
+  readonly context: Awaited<ReturnType<typeof createTestWorkerContext>>;
+  readonly idempotencyKey: string;
+  readonly priorOccurredAt: string;
+  readonly newOccurredAt: string;
+}): Promise<{ readonly sourceEvidenceId: string; readonly contactId: string }> {
+  const { context, idempotencyKey, priorOccurredAt, newOccurredAt } = input;
+  const sourceEvidenceId = `sev:${idempotencyKey}`;
+  const contactId = `contact:salesforce:cron-${idempotencyKey.slice(-6)}`;
+
+  await context.repositories.contacts.upsert({
+    id: contactId,
+    salesforceContactId: `SF-${idempotencyKey.slice(-6)}`,
+    displayName: "Cron Test Volunteer",
+    primaryEmail: `${idempotencyKey.slice(-6)}@example.org`,
+    primaryPhone: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  });
+
+  await context.repositories.sourceEvidence.append({
+    id: sourceEvidenceId,
+    provider: "salesforce",
+    providerRecordType: "lifecycle_milestone",
+    providerRecordId: `a15VK${idempotencyKey.slice(-6)}`,
+    receivedAt: "2026-06-06T15:05:01.000Z",
+    occurredAt: newOccurredAt,
+    payloadRef: `salesforce://Expedition_Members__c/a15VK#milestone-${idempotencyKey.slice(-6)}`,
+    idempotencyKey,
+    checksum: `chk-corrected-${idempotencyKey.slice(-6)}`,
+  });
+
+  await context.repositories.canonicalEvents.upsert({
+    id: `cel:${idempotencyKey}`,
+    contactId,
+    eventType: "lifecycle.received_training",
+    channel: "lifecycle",
+    occurredAt: priorOccurredAt,
+    contentFingerprint: null,
+    sourceEvidenceId,
+    idempotencyKey: `canonical-event:${idempotencyKey}`,
+    provenance: {
+      primaryProvider: "salesforce",
+      primarySourceEvidenceId: sourceEvidenceId,
+      sourceRecordType: "lifecycle_milestone",
+      sourceRecordId: `a15VK${idempotencyKey.slice(-6)}`,
+      messageKind: null,
+      direction: null,
+      campaignRef: null,
+      threadRef: null,
+      winnerReason: "single_source",
+      supportingSourceEvidenceIds: [],
+      notes: null,
+    },
+    reviewState: "clear",
+  });
+
+  await context.repositories.sourceEvidenceQuarantine.record({
+    provider: "salesforce",
+    idempotencyKey,
+    checksum: `chk-prior-${idempotencyKey.slice(-6)}`,
+    attemptedAt: new Date("2026-06-06T15:05:01.000Z"),
+    reason: "superseded_canonical",
+    payloadRef: `salesforce://Expedition_Members__c/a15VK#prior-${idempotencyKey.slice(-6)}`,
+    details: {
+      id: `${sourceEvidenceId}:prior`,
+      provider: "salesforce",
+      providerRecordType: "lifecycle_milestone",
+      providerRecordId: `a15VK${idempotencyKey.slice(-6)}`,
+      receivedAt: "2026-04-02T20:35:04.000Z",
+      occurredAt: priorOccurredAt,
+      payloadRef: `salesforce://Expedition_Members__c/a15VK#prior-${idempotencyKey.slice(-6)}`,
+      idempotencyKey,
+      checksum: `chk-prior-${idempotencyKey.slice(-6)}`,
+    },
+  });
+
+  return { sourceEvidenceId, contactId };
+}
+
+describe("reconcile-superseded-projections cron task", () => {
+  it("updates canonical occurred_at + enqueues projection rebuild for affected contacts", async () => {
+    const context = await createTestWorkerContext();
+    try {
+      await seedStaleLifecycle({
+        context,
+        idempotencyKey:
+          "source-evidence:salesforce:lifecycle_milestone:cronXX:Expedition_Members__c.Date_Training_Sent__c",
+        priorOccurredAt: "2026-02-13T00:00:00.000Z",
+        newOccurredAt: "2026-02-18T00:00:00.000Z",
+      });
+      await seedStaleLifecycle({
+        context,
+        idempotencyKey:
+          "source-evidence:salesforce:lifecycle_milestone:cronYY:Expedition_Members__c.Date_Training_Completed__c",
+        priorOccurredAt: "2026-03-01T00:00:00.000Z",
+        newOccurredAt: "2026-03-05T00:00:00.000Z",
+      });
+
+      const logger = createCapturedLogger();
+      const enqueueCalls: { readonly contactIds: readonly string[] }[] = [];
+
+      const task = createReconcileSupersededProjectionsTask({
+        db: context.db,
+        sql: pgliteSqlRunner(context.client),
+        connectionString: "postgres://test/unused-when-mock-is-supplied",
+        logger,
+        enqueueProjectionRebuild: (input) => {
+          enqueueCalls.push(input);
+          return Promise.resolve({ enqueuedJobId: "test-rebuild-job-1" });
+        },
+      });
+
+      // Graphile tasks are invoked with (payload, helpers). Our task body
+      // ignores both since it derives all state from injected deps.
+      await task(
+        {},
+        {
+          job: { id: "test-job" },
+        } as unknown as Parameters<typeof task>[1],
+      );
+
+      // Canonical rows updated
+      const cronXX = await context.repositories.canonicalEvents.findById(
+        "cel:source-evidence:salesforce:lifecycle_milestone:cronXX:Expedition_Members__c.Date_Training_Sent__c",
+      );
+      const cronYY = await context.repositories.canonicalEvents.findById(
+        "cel:source-evidence:salesforce:lifecycle_milestone:cronYY:Expedition_Members__c.Date_Training_Completed__c",
+      );
+      expect(cronXX?.occurredAt).toBe("2026-02-18T00:00:00.000Z");
+      expect(cronYY?.occurredAt).toBe("2026-03-05T00:00:00.000Z");
+
+      // Cron emitted the completed event + enqueue event
+      const completed = logger.events.find(
+        (entry): entry is Record<string, unknown> =>
+          typeof entry === "object" &&
+          entry !== null &&
+          (entry as Record<string, unknown>).event ===
+            "reconcile_superseded_projections.cron.completed",
+      );
+      expect(completed).toMatchObject({
+        targetCount: 2,
+        summary: { occurredAtUpdated: 2 },
+        contactCount: 2,
+      });
+
+      const enqueued = logger.events.find(
+        (entry): entry is Record<string, unknown> =>
+          typeof entry === "object" &&
+          entry !== null &&
+          (entry as Record<string, unknown>).event ===
+            "reconcile_superseded_projections.cron.enqueued_rebuild",
+      );
+      expect(enqueued).toMatchObject({
+        contactCount: 2,
+        enqueuedJobId: "test-rebuild-job-1",
+      });
+
+      // Enqueue was called exactly once with both contact IDs
+      expect(enqueueCalls).toHaveLength(1);
+      expect(enqueueCalls[0]?.contactIds).toHaveLength(2);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("skips enqueue when nothing is stale", async () => {
+    const context = await createTestWorkerContext();
+    try {
+      const logger = createCapturedLogger();
+      const enqueueCalls: unknown[] = [];
+
+      const task = createReconcileSupersededProjectionsTask({
+        db: context.db,
+        sql: pgliteSqlRunner(context.client),
+        connectionString: "postgres://test/unused",
+        logger,
+        enqueueProjectionRebuild: () => {
+          enqueueCalls.push("called");
+          return Promise.resolve({ enqueuedJobId: "should-not-be-used" });
+        },
+      });
+
+      await task(
+        {},
+        { job: { id: "test-job" } } as unknown as Parameters<typeof task>[1],
+      );
+
+      const completed = logger.events.find(
+        (entry): entry is Record<string, unknown> =>
+          typeof entry === "object" &&
+          entry !== null &&
+          (entry as Record<string, unknown>).event ===
+            "reconcile_superseded_projections.cron.completed",
+      );
+      expect(completed).toMatchObject({
+        targetCount: 0,
+        contactCount: 0,
+      });
+
+      // No projection-rebuild dispatched when there's nothing to rebuild
+      expect(enqueueCalls).toHaveLength(0);
+      const enqueued = logger.events.find(
+        (entry): entry is Record<string, unknown> =>
+          typeof entry === "object" &&
+          entry !== null &&
+          (entry as Record<string, unknown>).event ===
+            "reconcile_superseded_projections.cron.enqueued_rebuild",
+      );
+      expect(enqueued).toBeUndefined();
+    } finally {
+      await context.dispose();
+    }
+  });
+});

--- a/apps/worker/test/stage1-runtime.test.ts
+++ b/apps/worker/test/stage1-runtime.test.ts
@@ -163,6 +163,7 @@ describe("Stage 1 worker runtime task registration", () => {
         `0 10 * * * ${dedupHistoricalLedgerJobName} ?id=dedup-historical-ledger&max=1`,
         `30 10 * * * ${reconcileCaptureGapsJobName} ?id=capture-gap-reconcile&max=1`,
         "*/15 * * * * reconcile-routing-review-queue ?id=routing-review-queue-reconcile&max=1",
+        "0 11 * * 0 reconcile-superseded-projections ?id=superseded-projections-reconcile&max=1",
       ].join("\n"),
     );
   });


### PR DESCRIPTION
## Summary

Follow-up to PRD [#360](https://github.com/nico-kneler-as/as-comms-platform/issues/360)'s downstream re-projection workstream. After the supersede policy shipped (PRs [#361](https://github.com/nico-kneler-as/as-comms-platform/pull/361) / [#364](https://github.com/nico-kneler-as/as-comms-platform/pull/364)), organic supersedes accumulate ~12 stale \`canonical_event_ledger.occurred_at\` rows per day — verified today across **336** lifecycle_milestone keys spanning May 10 → Jun 6.

The manual \`reconcile-superseded-projections --execute\` drains the current backlog (just ran it; all 336 aligned, projection-rebuild job 267465 enqueued for 45 contacts). But the pattern keeps regenerating because \`persistCanonicalEvent\` treats any field change as a conflict and refuses to update canonical \`occurred_at\` on the fly.

This PR adds a Graphile-cron-driven version of the same op so the drain runs **weekly** without operator intervention.

**Schedule**: Sundays at 11:00 UTC (low-traffic window, post-other-weekly batches).

## Shape of the change

- **Extract core**: \`reconcileSupersededProjections({db, sql, dryRun, limit})\` lifted out of the existing CLI wrapper so cron + CLI share one code path. CLI behavior unchanged.
- **New cron task** \`apps/worker/src/jobs/reconcile-superseded-projections.ts\`. Calls the core in execute mode, logs structured \`cron.completed\` + \`cron.enqueued_rebuild\` events, and dispatches a \`projection-rebuild\` Graphile job for the affected contacts to refresh timeline + inbox projections from the corrected canonicals.
- **Wire-up**: \`createTaskList\` registration + crontab line in \`runtime.ts\` + dependency injection in \`createStage1WorkerRuntimeServices\`.

## Cron task body

\`\`\`
1. Run reconcileSupersededProjections in execute mode (no limit, no dry-run)
2. Log cron.completed event with summary (occurredAtUpdated / alreadyAligned /
   missingCanonical / errors) + distinct contactCount
3. If contactIds is non-empty: dispatch a projection-rebuild Graphile job
   (projection=all, includeReviewOverlayRefresh=true) and log cron.enqueued_rebuild
4. If contactIds is empty: skip the dispatch silently — nothing to rebuild
\`\`\`

## Tests

- 2 new cases in \`reconcile-superseded-projections-cron.test.ts\`:
  - Seeds two stale canonicals, runs the task with a mock \`enqueueProjectionRebuild\`, asserts both canonical \`occurred_at\` updated AND the rebuild was enqueued exactly once with both contact IDs.
  - Empty-DB case: asserts \`cron.completed\` fires with targetCount=0 and no rebuild is dispatched.
- The mock-enqueue override is part of the public Dependencies interface so tests can observe the call without touching graphile_worker's schema (which PGlite doesn't have).
- Updated \`stage1-runtime.test.ts\` crontab assertion to include the new line.

## Test plan

- [x] \`pnpm --filter @as-comms/worker typecheck\` — clean
- [x] \`pnpm --filter @as-comms/worker lint\` — clean
- [x] \`pnpm --filter @as-comms/worker run test:unit\` — 63 files / 241 tests pass (incl. 2 new cron tests + updated crontab snapshot)
- [ ] CI green
- [ ] Architect review

## Why this matters operationally

Without the cron, this same conversation happens every month: "the logs page filled up again, what does it mean?" → "yep, same supersede pattern as last time, run the manual op". With this cron, the volunteer profile UI stays aligned with current Salesforce state without anyone noticing.

## Out of scope

- **Settings → Logs UI copy** still says "Provider replay collisions kept out of canonical history" / "canonical winner preserved" — misleading post-supersede (we now do latest-write-wins). That's the deferred UI follow-up from the original PRD; cosmetic, separate PR.
- **Other auto-firing ops modules**: noticed today that \`recompute-attachment-decoration\` and possibly others have the same unguarded top-level \`void main()\` pattern PR [#365](https://github.com/nico-kneler-as/as-comms-platform/pull/365) fixed for two modules. Quick follow-up cleanup; not blocking this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)