### PR TITLE
fix(ops): guard cli-import side-effect in recompute-attachment-decoration

### DIFF
--- a/apps/worker/src/ops/recompute-attachment-decoration.ts
+++ b/apps/worker/src/ops/recompute-attachment-decoration.ts
@@ -1,4 +1,5 @@
 import process from "node:process";
+import { pathToFileURL } from "node:url";
 
 import { and, asc, eq, sql } from "drizzle-orm";
 
@@ -215,9 +216,16 @@ async function main() {
   await runRecomputeAttachmentDecorationCommand();
 }
 
-void main().catch((error: unknown) => {
-  const resolvedError =
-    error instanceof Error ? error : new Error(String(error));
-  console.error(resolvedError.message);
-  process.exitCode = 1;
-});
+// Only auto-run when invoked as a CLI entry point. cli.ts imports
+// `runRecomputeAttachmentDecorationCommand` from this module; without
+// this guard, every cli.ts dispatch (e.g. reconcile-superseded-projections)
+// re-runs main() on import, which last fired across 291 attachment rows
+// during an unrelated ops command.
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  void main().catch((error: unknown) => {
+    const resolvedError =
+      error instanceof Error ? error : new Error(String(error));
+    console.error(resolvedError.message);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

Third instance of the same pattern PR [#365](https://github.com/nico-kneler-as/as-comms-platform/pull/365) fixed for \`merge-email-only-into-sf-anchored\` + \`mailchimp-capture-historical\`. Today's reconcile-superseded-projections drain showed \`recompute-attachment-decoration\` firing as a side-effect at import time — processed 291 attachment rows (110 recomputed, 181 unchanged) during an unrelated ops command.

Cause: cli.ts imports \`runRecomputeAttachmentDecorationCommand\` from the module, but the module ends with an unguarded top-level \`void main()\` — so every cli.ts dispatch re-runs main() on import.

Fix: same one-line ESM-entry-point guard as #365.

\`\`\`ts
if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
  void main().catch(...);
}
\`\`\`

## Scope

Just this one file. Six other ops modules still have unguarded \`void main()\` but **none are currently imported by cli.ts**, so they don't trigger the side-effect bug. If/when cli.ts imports any of them, we add the guard at that point.

## Test plan

- [x] \`pnpm --filter @as-comms/worker typecheck\` — clean
- [x] \`pnpm --filter @as-comms/worker lint\` — clean
- [x] \`pnpm --filter @as-comms/worker run test:unit\` — 62 files / 239 tests pass
- [ ] CI green
- [ ] Architect review

🤖 Generated with [Claude Code](https://claude.com/claude-code)