### PR TITLE
feat(worker/ops): backfill historical Drive attachments via Gmail re-fetch (PRD #517 Brick D)

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -30,6 +30,7 @@
     "ops:apply-mbox-direction-backfill": "tsx src/ops/cli.ts apply-mbox-direction-backfill",
     "ops:backfill-inbox-projection-coverage": "tsx src/ops/backfill-inbox-projection-coverage.ts",
     "ops:recover-gmail-date-window": "tsx src/ops/cli.ts recover-gmail-date-window",
+    "ops:backfill-drive-attachments": "tsx src/ops/cli.ts backfill-drive-attachments",
     "ops:enqueue-integration-backfill-gmail": "tsx src/ops/cli.ts enqueue-integration-backfill-gmail",
     "ops:recover-gmail-spam-window": "tsx src/ops/recover-gmail-spam-window.ts",
     "ops:recompute-attachment-decoration": "tsx src/ops/recompute-attachment-decoration.ts",

--- a/apps/worker/src/ops/backfill-drive-attachments.ts
+++ b/apps/worker/src/ops/backfill-drive-attachments.ts
@@ -1,0 +1,487 @@
+#!/usr/bin/env tsx
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+import { sql } from "drizzle-orm";
+
+import {
+  closeDatabaseConnection,
+  createDatabaseConnection,
+  createStage1RepositoryBundleFromConnection,
+  type Stage1Database,
+} from "@as-comms/db";
+import {
+  type MessageAttachmentInsert,
+  type Stage1RepositoryBundle,
+} from "@as-comms/domain";
+import {
+  buildGmailMessageDriveAttachmentId,
+  collectGmailDriveAttachments,
+  createGmailMailboxApiClient,
+  type GmailCaptureServiceConfig,
+  type GmailMailboxApiClient,
+} from "@as-comms/integrations";
+
+import { readStage1LaunchScopeGmailConfig } from "./config.js";
+import {
+  parseCliFlags,
+  readOptionalBooleanFlag,
+  readOptionalStringFlag,
+} from "./helpers.js";
+
+interface Logger {
+  log(...args: readonly unknown[]): void;
+  error(...args: readonly unknown[]): void;
+}
+
+interface DriveAttachmentCandidateRow {
+  readonly sourceEvidenceId: string;
+  readonly providerRecordId: string;
+  readonly capturedMailbox: string;
+}
+
+export interface BackfillDriveAttachmentsLogEntry {
+  readonly providerRecordId: string;
+  readonly sourceEvidenceId: string;
+  readonly capturedMailbox: string;
+  readonly outcome:
+    | "not-found-in-mailbox"
+    | "fetch-failed"
+    | "no-drive-attachments"
+    | "would-insert"
+    | "inserted"
+    | "skipped-existing";
+  readonly driveAttachmentCount: number;
+  readonly errorMessage?: string;
+}
+
+export interface BackfillDriveAttachmentsResult {
+  readonly dryRun: boolean;
+  readonly windowStart: string | null;
+  readonly windowEnd: string | null;
+  readonly candidatesScanned: number;
+  readonly driveAttachmentsInserted: number;
+  readonly messagesWithoutDriveAnchors: number;
+  readonly messagesNotFoundInMailbox: number;
+  readonly fetchFailures: number;
+}
+
+function readConnectionString(env: NodeJS.ProcessEnv): string {
+  const connectionString = env.WORKER_DATABASE_URL ?? env.DATABASE_URL;
+
+  if (connectionString === undefined || connectionString.trim().length === 0) {
+    throw new Error(
+      "DATABASE_URL or WORKER_DATABASE_URL is required for Stage 1 ops commands.",
+    );
+  }
+
+  return connectionString;
+}
+
+function readRequiredStringEnv(env: NodeJS.ProcessEnv, key: string): string {
+  const value = env[key];
+
+  if (value === undefined || value.trim().length === 0) {
+    throw new Error(`${key} is required for Drive attachment backfill.`);
+  }
+
+  return value.trim();
+}
+
+function parseWindowTimestamp(value: string, flagName: string): string {
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Flag --${flagName} must be a valid ISO-8601 timestamp.`);
+  }
+
+  return parsed.toISOString();
+}
+
+function parseNonNegativeIntegerFlag(
+  value: string | null,
+  flagName: string,
+  defaultValue: number,
+): number {
+  if (value === null) {
+    return defaultValue;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`Flag --${flagName} must be a non-negative integer.`);
+  }
+
+  return parsed;
+}
+
+function normalizeSqlResultRows<TRow>(
+  result:
+    | readonly TRow[]
+    | {
+        readonly rows?: readonly TRow[];
+      },
+): readonly TRow[] {
+  if (Array.isArray(result)) {
+    return result as readonly TRow[];
+  }
+
+  return (result as { readonly rows?: readonly TRow[] }).rows ?? [];
+}
+
+function buildDefaultWindowStart(now: Date): string {
+  return new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function buildGmailApiClientFromEnv(env: NodeJS.ProcessEnv): GmailMailboxApiClient {
+  const gmailConfig = readStage1LaunchScopeGmailConfig(env);
+  const clientConfig: GmailCaptureServiceConfig = {
+    bearerToken: "ops-backfill-drive-attachments",
+    liveAccount: gmailConfig.liveAccount,
+    projectInboxAliases: [...gmailConfig.projectInboxAliases],
+    oauthClientId: readRequiredStringEnv(env, "GMAIL_GOOGLE_OAUTH_CLIENT_ID"),
+    oauthClientSecret: readRequiredStringEnv(
+      env,
+      "GMAIL_GOOGLE_OAUTH_CLIENT_SECRET",
+    ),
+    oauthRefreshToken: readRequiredStringEnv(
+      env,
+      "GMAIL_GOOGLE_OAUTH_REFRESH_TOKEN",
+    ),
+    tokenUri:
+      env.GMAIL_GOOGLE_TOKEN_URI?.trim().length
+        ? env.GMAIL_GOOGLE_TOKEN_URI.trim()
+        : "https://oauth2.googleapis.com/token",
+    timeoutMs:
+      env.GMAIL_CAPTURE_TIMEOUT_MS === undefined
+        ? 15_000
+        : Number.parseInt(env.GMAIL_CAPTURE_TIMEOUT_MS, 10),
+  };
+
+  return createGmailMailboxApiClient(clientConfig);
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function logEntry(
+  logger: Logger,
+  entry: BackfillDriveAttachmentsLogEntry,
+): void {
+  logger.log(JSON.stringify(entry));
+}
+
+export async function loadDriveAttachmentBackfillCandidates(input: {
+  readonly db: Stage1Database;
+  readonly windowStart: string | null;
+  readonly windowEnd: string | null;
+  readonly mailbox: string | null;
+}): Promise<readonly DriveAttachmentCandidateRow[]> {
+  const result = await input.db.execute(sql<DriveAttachmentCandidateRow>`
+    SELECT
+      gmd.source_evidence_id AS "sourceEvidenceId",
+      gmd.provider_record_id AS "providerRecordId",
+      gmd.captured_mailbox AS "capturedMailbox"
+    FROM gmail_message_details gmd
+    LEFT JOIN message_attachments ma
+      ON ma.source_evidence_id = gmd.source_evidence_id
+    WHERE gmd.body_text_preview ~ E'\\\\[image:\\\\s'
+      AND ma.id IS NULL
+      AND gmd.captured_mailbox IS NOT NULL
+      AND (${input.windowStart}::timestamptz IS NULL OR gmd.created_at >= ${input.windowStart}::timestamptz)
+      AND (${input.windowEnd}::timestamptz IS NULL OR gmd.created_at < ${input.windowEnd}::timestamptz)
+      AND (${input.mailbox}::text IS NULL OR gmd.captured_mailbox = ${input.mailbox}::text)
+    GROUP BY gmd.source_evidence_id, gmd.provider_record_id, gmd.captured_mailbox
+    ORDER BY gmd.created_at ASC
+  `);
+
+  return normalizeSqlResultRows(
+    result as
+      | readonly DriveAttachmentCandidateRow[]
+      | {
+          readonly rows?: readonly DriveAttachmentCandidateRow[];
+        },
+  );
+}
+
+export async function backfillDriveAttachments(input: {
+  readonly repositories: Pick<
+    Stage1RepositoryBundle,
+    "messageAttachments" | "sourceEvidence"
+  >;
+  readonly db: Stage1Database;
+  readonly apiClient: GmailMailboxApiClient;
+  readonly windowStart: string | null;
+  readonly windowEnd: string | null;
+  readonly mailbox?: string | null;
+  readonly execute: boolean;
+  readonly rateLimitMs?: number;
+  readonly now?: () => Date;
+  readonly logger?: Logger;
+}): Promise<BackfillDriveAttachmentsResult> {
+  const logger = input.logger ?? console;
+  const rateLimitMs = input.rateLimitMs ?? 1000;
+  const candidates = await loadDriveAttachmentBackfillCandidates({
+    db: input.db,
+    windowStart: input.windowStart,
+    windowEnd: input.windowEnd,
+    mailbox: input.mailbox ?? null,
+  });
+
+  let driveAttachmentsInserted = 0;
+  let messagesWithoutDriveAnchors = 0;
+  let messagesNotFoundInMailbox = 0;
+  let fetchFailures = 0;
+  let isFirstCandidate = true;
+
+  for (const candidate of candidates) {
+    if (!isFirstCandidate && rateLimitMs > 0) {
+      await sleep(rateLimitMs);
+    }
+    isFirstCandidate = false;
+
+    let message: Awaited<ReturnType<GmailMailboxApiClient["getMessage"]>>;
+    try {
+      message = await input.apiClient.getMessage({
+        mailbox: candidate.capturedMailbox,
+        messageId: candidate.providerRecordId,
+      });
+    } catch (error) {
+      fetchFailures += 1;
+      logEntry(logger, {
+        providerRecordId: candidate.providerRecordId,
+        sourceEvidenceId: candidate.sourceEvidenceId,
+        capturedMailbox: candidate.capturedMailbox,
+        outcome: "fetch-failed",
+        driveAttachmentCount: 0,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+
+    if (message === null) {
+      messagesNotFoundInMailbox += 1;
+      logEntry(logger, {
+        providerRecordId: candidate.providerRecordId,
+        sourceEvidenceId: candidate.sourceEvidenceId,
+        capturedMailbox: candidate.capturedMailbox,
+        outcome: "not-found-in-mailbox",
+        driveAttachmentCount: 0,
+      });
+      continue;
+    }
+
+    const driveAttachments = collectGmailDriveAttachments(message.payload, {
+      messageIdentifier: candidate.providerRecordId,
+    });
+
+    if (driveAttachments.length === 0) {
+      messagesWithoutDriveAnchors += 1;
+      logEntry(logger, {
+        providerRecordId: candidate.providerRecordId,
+        sourceEvidenceId: candidate.sourceEvidenceId,
+        capturedMailbox: candidate.capturedMailbox,
+        outcome: "no-drive-attachments",
+        driveAttachmentCount: 0,
+      });
+      continue;
+    }
+
+    const existingAttachments =
+      await input.repositories.messageAttachments.findByMessageIds([
+        candidate.sourceEvidenceId,
+      ]);
+    const existingIds = new Set(existingAttachments.map((attachment) => attachment.id));
+    const rowsToInsert: MessageAttachmentInsert[] = [];
+
+    for (const driveAttachment of driveAttachments) {
+      const attachmentId = buildGmailMessageDriveAttachmentId({
+        messageId: candidate.providerRecordId,
+        driveFileId: driveAttachment.driveFileId,
+      });
+
+      if (existingIds.has(attachmentId)) {
+        continue;
+      }
+
+      rowsToInsert.push({
+        id: attachmentId,
+        provider: "drive",
+        gmailAttachmentId: null,
+        mimeType: "application/octet-stream",
+        filename: driveAttachment.filename,
+        sizeBytes: 0,
+        storageKey: null,
+        externalUrl: driveAttachment.driveUrl,
+        isDecoration: false,
+      });
+    }
+
+    if (rowsToInsert.length === 0) {
+      logEntry(logger, {
+        providerRecordId: candidate.providerRecordId,
+        sourceEvidenceId: candidate.sourceEvidenceId,
+        capturedMailbox: candidate.capturedMailbox,
+        outcome: "skipped-existing",
+        driveAttachmentCount: 0,
+      });
+      continue;
+    }
+
+    if (!input.execute) {
+      logEntry(logger, {
+        providerRecordId: candidate.providerRecordId,
+        sourceEvidenceId: candidate.sourceEvidenceId,
+        capturedMailbox: candidate.capturedMailbox,
+        outcome: "would-insert",
+        driveAttachmentCount: rowsToInsert.length,
+      });
+      continue;
+    }
+
+    await input.repositories.messageAttachments.upsertManyForMessage(
+      candidate.sourceEvidenceId,
+      rowsToInsert,
+    );
+    driveAttachmentsInserted += rowsToInsert.length;
+    logEntry(logger, {
+      providerRecordId: candidate.providerRecordId,
+      sourceEvidenceId: candidate.sourceEvidenceId,
+      capturedMailbox: candidate.capturedMailbox,
+      outcome: "inserted",
+      driveAttachmentCount: rowsToInsert.length,
+    });
+  }
+
+  return {
+    dryRun: !input.execute,
+    windowStart: input.windowStart,
+    windowEnd: input.windowEnd,
+    candidatesScanned: candidates.length,
+    driveAttachmentsInserted,
+    messagesWithoutDriveAnchors,
+    messagesNotFoundInMailbox,
+    fetchFailures,
+  };
+}
+
+export async function runBackfillDriveAttachments(input: {
+  readonly db: Stage1Database;
+  readonly repositories: Pick<
+    Stage1RepositoryBundle,
+    "messageAttachments" | "sourceEvidence"
+  >;
+  readonly windowStart: string | null;
+  readonly windowEnd: string | null;
+  readonly mailbox?: string | null;
+  readonly execute?: boolean;
+  readonly rateLimitMs?: number;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly logger?: Logger;
+}): Promise<BackfillDriveAttachmentsResult> {
+  const env = input.env ?? process.env;
+
+  return backfillDriveAttachments({
+    repositories: input.repositories,
+    db: input.db,
+    apiClient: buildGmailApiClientFromEnv(env),
+    windowStart: input.windowStart,
+    windowEnd: input.windowEnd,
+    mailbox: input.mailbox ?? null,
+    execute: input.execute ?? false,
+    ...(input.rateLimitMs === undefined
+      ? {}
+      : {
+          rateLimitMs: input.rateLimitMs,
+        }),
+    ...(input.logger === undefined ? {} : { logger: input.logger }),
+  });
+}
+
+export async function runBackfillDriveAttachmentsCommand(
+  args: readonly string[] = process.argv.slice(2),
+  env: NodeJS.ProcessEnv = process.env,
+  logger: Logger = console,
+): Promise<void> {
+  const flags = parseCliFlags(args);
+  const now = new Date();
+  const windowStart = parseWindowTimestamp(
+    readOptionalStringFlag(flags, "since") ?? buildDefaultWindowStart(now),
+    "since",
+  );
+  const rawWindowEnd = readOptionalStringFlag(flags, "until");
+  const windowEnd =
+    rawWindowEnd === null ? null : parseWindowTimestamp(rawWindowEnd, "until");
+  const execute = readOptionalBooleanFlag(flags, "execute", false);
+  const mailbox = readOptionalStringFlag(flags, "mailbox");
+  const rateLimitMs = parseNonNegativeIntegerFlag(
+    readOptionalStringFlag(flags, "rate-limit-ms"),
+    "rate-limit-ms",
+    1000,
+  );
+  const connection = createDatabaseConnection({
+    connectionString: readConnectionString(env),
+  });
+
+  try {
+    const repositories = createStage1RepositoryBundleFromConnection(connection);
+    const result = await runBackfillDriveAttachments({
+      db: connection.db,
+      repositories,
+      windowStart,
+      windowEnd,
+      mailbox,
+      execute,
+      rateLimitMs,
+      env,
+      logger,
+    });
+
+    logger.log(JSON.stringify(result, null, 2));
+  } finally {
+    await closeDatabaseConnection(connection);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  void runBackfillDriveAttachmentsCommand(process.argv.slice(2), process.env).catch(
+    (error: unknown) => {
+      const resolvedError =
+        error instanceof Error ? error : new Error(String(error));
+
+      console.error(
+        `[backfill-drive-attachments:fatal] ${resolvedError.message}`,
+      );
+      console.error(resolvedError.stack ?? "(no stack)");
+
+      const anyError = resolvedError as Error & Record<string, unknown>;
+      for (const key of [
+        "cause",
+        "code",
+        "detail",
+        "constraint",
+        "column",
+        "table",
+        "schema",
+        "severity",
+        "position",
+        "where",
+        "hint",
+        "errno",
+        "syscall",
+      ]) {
+        if (anyError[key] !== undefined) {
+          console.error(
+            `[backfill-drive-attachments:fatal:${key}] ${JSON.stringify(anyError[key])}`,
+          );
+        }
+      }
+
+      process.exitCode = 1;
+    },
+  );
+}

--- a/apps/worker/src/ops/cli.ts
+++ b/apps/worker/src/ops/cli.ts
@@ -39,6 +39,7 @@ import {
 import { runBackfillSalesforceCommunicationDetailsCommand } from "./backfill-salesforce-communication-details.js";
 import { runBackfillMembershipSfIdsCommand } from "./backfill-membership-sf-ids.js";
 import { runBackfillGmailMboxBodiesCommand } from "./backfill-gmail-mbox-bodies.js";
+import { runBackfillDriveAttachmentsCommand } from "./backfill-drive-attachments.js";
 import { runBackfillContentFingerprintCommand } from "./backfill-content-fingerprint.js";
 import { runBackfillGarbledMessageBodiesCommand } from "./backfill-garbled-message-bodies.js";
 import { runReExtractSignedEnvelopeBodiesCommand } from "./re-extract-signed-envelope-bodies.js";
@@ -503,6 +504,9 @@ async function main(): Promise<void> {
     case "backfill-gmail-mbox-bodies":
       await runBackfillGmailMboxBodiesCommand(rest, process.env);
       return;
+    case "backfill-drive-attachments":
+      await runBackfillDriveAttachmentsCommand(rest, process.env);
+      return;
     case "backfill-content-fingerprint":
       await runBackfillContentFingerprintCommand(rest, process.env);
       return;
@@ -583,7 +587,7 @@ async function main(): Promise<void> {
       return;
     default:
       throw new Error(
-        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-membership-sf-ids, backfill-gmail-mbox-bodies, backfill-content-fingerprint, backfill-garbled-message-bodies, re-extract-signed-envelope-bodies, backfill-mailchimp-campaign-body, mailchimp-capture-historical, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, detect-mbox-direction-misclassification, apply-mbox-direction-backfill, recover-orphan-gmail-details, recover-gmail-date-window, enqueue-integration-backfill-gmail, recover-gmail-spam-window, recompute-attachment-decoration, rebuild-inbox-projection-stuck-on-new, rebuild-inbox-projection-snippet-bias, backfill-canonical-event-audience, reprocess-pending-campaign-sends, dedup-historical-ledger, merge-email-only-into-sf-anchored, reconcile-identity-queue, reconcile-routing-review-queue, reclassify-sf-direction, reconcile-stale-canonical, reconcile-superseded-projections.",
+        "Unknown Stage 1 ops command. Use one of: check-config, enqueue, import-gmail-mbox, inspect, backfill-salesforce-communication-details, backfill-membership-sf-ids, backfill-gmail-mbox-bodies, backfill-drive-attachments, backfill-content-fingerprint, backfill-garbled-message-bodies, re-extract-signed-envelope-bodies, backfill-mailchimp-campaign-body, mailchimp-capture-historical, cleanup-gmail-draft-events, cleanup-salesforce-owner-scope, detect-mbox-direction-misclassification, apply-mbox-direction-backfill, recover-orphan-gmail-details, recover-gmail-date-window, enqueue-integration-backfill-gmail, recover-gmail-spam-window, recompute-attachment-decoration, rebuild-inbox-projection-stuck-on-new, rebuild-inbox-projection-snippet-bias, backfill-canonical-event-audience, reprocess-pending-campaign-sends, dedup-historical-ledger, merge-email-only-into-sf-anchored, reconcile-identity-queue, reconcile-routing-review-queue, reclassify-sf-direction, reconcile-stale-canonical, reconcile-superseded-projections.",
       );
   }
 }

--- a/apps/worker/test/backfill-drive-attachments.test.ts
+++ b/apps/worker/test/backfill-drive-attachments.test.ts
@@ -1,0 +1,592 @@
+import { describe, expect, it } from "vitest";
+import { sql } from "drizzle-orm";
+
+import {
+  buildGmailMessageDriveAttachmentId,
+  type GmailMailboxApiClient,
+  type GmailMessageMetadata,
+} from "@as-comms/integrations";
+
+import {
+  backfillDriveAttachments,
+  type BackfillDriveAttachmentsLogEntry,
+} from "../src/ops/backfill-drive-attachments.js";
+import { createTestWorkerContext } from "./helpers.js";
+
+function buildHtmlPayload(html: string): GmailMessageMetadata["payload"] {
+  return {
+    mimeType: "text/html",
+    filename: "",
+    headers: [
+      {
+        name: "Content-Type",
+        value: "text/html; charset=UTF-8",
+      },
+      {
+        name: "Content-Transfer-Encoding",
+        value: "7bit",
+      },
+    ],
+    body: {
+      data: Buffer.from(html, "utf8").toString("base64url"),
+    },
+    parts: [],
+  };
+}
+
+function buildGmailMessage(
+  messageId: string,
+  html: string,
+): GmailMessageMetadata {
+  return {
+    id: messageId,
+    threadId: `thread:${messageId}`,
+    labelIds: ["INBOX"],
+    snippet: "Drive link",
+    internalDate: String(Date.parse("2026-06-01T12:00:00.000Z")),
+    payload: buildHtmlPayload(html),
+  };
+}
+
+function buildDriveAnchorHtml(input: {
+  readonly driveFileId: string;
+  readonly filename: string;
+}): string {
+  return `<div><a href="https://drive.google.com/file/d/${input.driveFileId}/view">${input.filename}</a></div>`;
+}
+
+function createApiClientStub(input: {
+  readonly getMessage: GmailMailboxApiClient["getMessage"];
+}): GmailMailboxApiClient {
+  return {
+    listMessageIds: () => Promise.resolve([]),
+    getMessage: input.getMessage,
+  };
+}
+
+async function seedCandidateMessage(input: {
+  readonly context: Awaited<ReturnType<typeof createTestWorkerContext>>;
+  readonly sourceEvidenceId: string;
+  readonly providerRecordId: string;
+  readonly createdAt: string;
+  readonly capturedMailbox?: string;
+  readonly bodyTextPreview?: string;
+}): Promise<void> {
+  await input.context.repositories.sourceEvidence.append({
+    id: input.sourceEvidenceId,
+    provider: "gmail",
+    providerRecordType: "message",
+    providerRecordId: input.providerRecordId,
+    receivedAt: input.createdAt,
+    occurredAt: input.createdAt,
+    payloadRef: `gmail://volunteers%40example.org/messages/${input.providerRecordId}`,
+    idempotencyKey: input.sourceEvidenceId,
+    checksum: `checksum:${input.providerRecordId}`,
+  });
+
+  await input.context.repositories.gmailMessageDetails.upsert({
+    sourceEvidenceId: input.sourceEvidenceId,
+    providerRecordId: input.providerRecordId,
+    gmailThreadId: `thread:${input.providerRecordId}`,
+    rfc822MessageId: `<${input.providerRecordId}@example.org>`,
+    direction: "inbound",
+    subject: "Shared file",
+    fromHeader: "Volunteer <volunteer@example.org>",
+    toHeader: "Project <project@example.org>",
+    ccHeader: null,
+    fromEmails: [],
+    toEmails: [],
+    ccEmails: [],
+    bccEmails: [],
+    labelIds: ["INBOX"],
+    snippetClean: input.bodyTextPreview ?? "[image: shared-photo.jpg]",
+    bodyTextPreview: input.bodyTextPreview ?? "[image: shared-photo.jpg]",
+    capturedMailbox: input.capturedMailbox ?? "volunteers@example.org",
+    projectInboxAlias: "project@example.org",
+  });
+
+  await input.context.db.execute(sql`
+    update gmail_message_details
+    set created_at = ${input.createdAt}::timestamptz,
+        updated_at = ${input.createdAt}::timestamptz
+    where source_evidence_id = ${input.sourceEvidenceId}
+  `);
+}
+
+function createLoggerSink(logs: BackfillDriveAttachmentsLogEntry[]) {
+  return {
+    log(value: unknown) {
+      if (typeof value === "string") {
+        logs.push(JSON.parse(value) as BackfillDriveAttachmentsLogEntry);
+      }
+    },
+    error() {
+      return undefined;
+    },
+  };
+}
+
+describe("backfill-drive-attachments", () => {
+  it("lists dry-run candidates but writes no rows", async () => {
+    const context = await createTestWorkerContext();
+    const logs: BackfillDriveAttachmentsLogEntry[] = [];
+    const sourceEvidenceId = "source-evidence:gmail:message:drive-dry-run";
+
+    try {
+      await seedCandidateMessage({
+        context,
+        sourceEvidenceId,
+        providerRecordId: "drive-dry-run",
+        createdAt: "2026-05-28T00:00:00.000Z",
+      });
+
+      const result = await backfillDriveAttachments({
+        repositories: context.repositories,
+        db: context.db,
+        apiClient: createApiClientStub({
+          getMessage: ({ messageId }) =>
+            Promise.resolve(
+              buildGmailMessage(
+                messageId,
+                buildDriveAnchorHtml({
+                  driveFileId: "drive-file-dry-run",
+                  filename: "shared-photo.jpg",
+                }),
+              ),
+            ),
+        }),
+        windowStart: "2026-05-01T00:00:00.000Z",
+        windowEnd: null,
+        execute: false,
+        rateLimitMs: 0,
+        logger: createLoggerSink(logs),
+      });
+
+      expect(result).toMatchObject({
+        dryRun: true,
+        candidatesScanned: 1,
+        driveAttachmentsInserted: 0,
+        messagesWithoutDriveAnchors: 0,
+        messagesNotFoundInMailbox: 0,
+        fetchFailures: 0,
+      });
+      expect(logs).toContainEqual({
+        providerRecordId: "drive-dry-run",
+        sourceEvidenceId,
+        capturedMailbox: "volunteers@example.org",
+        outcome: "would-insert",
+        driveAttachmentCount: 1,
+      });
+      await expect(
+        context.repositories.messageAttachments.findByMessageIds([sourceEvidenceId]),
+      ).resolves.toEqual([]);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("inserts drive rows in execute mode", async () => {
+    const context = await createTestWorkerContext();
+    const sourceEvidenceId = "source-evidence:gmail:message:drive-execute";
+    const driveAttachmentId = buildGmailMessageDriveAttachmentId({
+      messageId: "drive-execute",
+      driveFileId: "drive-file-execute",
+    });
+
+    try {
+      await seedCandidateMessage({
+        context,
+        sourceEvidenceId,
+        providerRecordId: "drive-execute",
+        createdAt: "2026-05-28T00:00:00.000Z",
+      });
+
+      const result = await backfillDriveAttachments({
+        repositories: context.repositories,
+        db: context.db,
+        apiClient: createApiClientStub({
+          getMessage: ({ messageId }) =>
+            Promise.resolve(
+              buildGmailMessage(
+                messageId,
+                buildDriveAnchorHtml({
+                  driveFileId: "drive-file-execute",
+                  filename: "field-notes.pdf",
+                }),
+              ),
+            ),
+        }),
+        windowStart: "2026-05-01T00:00:00.000Z",
+        windowEnd: null,
+        execute: true,
+        rateLimitMs: 0,
+      });
+
+      expect(result).toMatchObject({
+        dryRun: false,
+        candidatesScanned: 1,
+        driveAttachmentsInserted: 1,
+      });
+      await expect(
+        context.repositories.messageAttachments.findByMessageIds([sourceEvidenceId]),
+      ).resolves.toMatchObject([
+        {
+          id: driveAttachmentId,
+          provider: "drive",
+          gmailAttachmentId: null,
+          mimeType: "application/octet-stream",
+          filename: "field-notes.pdf",
+          sizeBytes: 0,
+          storageKey: null,
+          externalUrl:
+            "https://drive.google.com/file/d/drive-file-execute/view",
+          isDecoration: false,
+        },
+      ]);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("is idempotent on repeated execute runs", async () => {
+    const context = await createTestWorkerContext();
+    const sourceEvidenceId = "source-evidence:gmail:message:drive-idempotent";
+
+    try {
+      await seedCandidateMessage({
+        context,
+        sourceEvidenceId,
+        providerRecordId: "drive-idempotent",
+        createdAt: "2026-05-28T00:00:00.000Z",
+      });
+
+      const apiClient = createApiClientStub({
+        getMessage: ({ messageId }) =>
+          Promise.resolve(
+            buildGmailMessage(
+              messageId,
+              buildDriveAnchorHtml({
+                driveFileId: "drive-file-idempotent",
+                filename: "shared-map.png",
+              }),
+            ),
+          ),
+      });
+
+      const firstRun = await backfillDriveAttachments({
+        repositories: context.repositories,
+        db: context.db,
+        apiClient,
+        windowStart: "2026-05-01T00:00:00.000Z",
+        windowEnd: null,
+        execute: true,
+        rateLimitMs: 0,
+      });
+      const secondRun = await backfillDriveAttachments({
+        repositories: context.repositories,
+        db: context.db,
+        apiClient,
+        windowStart: "2026-05-01T00:00:00.000Z",
+        windowEnd: null,
+        execute: true,
+        rateLimitMs: 0,
+      });
+
+      expect(firstRun.driveAttachmentsInserted).toBe(1);
+      expect(secondRun.driveAttachmentsInserted).toBe(0);
+      await expect(
+        context.repositories.messageAttachments.findByMessageIds([sourceEvidenceId]),
+      ).resolves.toHaveLength(1);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("skips messages with existing drive rows", async () => {
+    const context = await createTestWorkerContext();
+    const logs: BackfillDriveAttachmentsLogEntry[] = [];
+    const sourceEvidenceId = "source-evidence:gmail:message:drive-existing";
+    const existingAttachment = {
+      id: buildGmailMessageDriveAttachmentId({
+        messageId: "drive-existing",
+        driveFileId: "drive-file-existing",
+      }),
+      sourceEvidenceId,
+      provider: "drive" as const,
+      gmailAttachmentId: null,
+      mimeType: "application/octet-stream",
+      filename: "already-there.pdf",
+      sizeBytes: 0,
+      storageKey: null,
+      externalUrl:
+        "https://drive.google.com/file/d/drive-file-existing/view",
+      isDecoration: false,
+      createdAt: "2026-05-28T00:00:00.000Z",
+    };
+
+    try {
+      await seedCandidateMessage({
+        context,
+        sourceEvidenceId,
+        providerRecordId: "drive-existing",
+        createdAt: "2026-05-28T00:00:00.000Z",
+      });
+
+      const result = await backfillDriveAttachments({
+        repositories: {
+          ...context.repositories,
+          messageAttachments: {
+            ...context.repositories.messageAttachments,
+            findByMessageIds: () => Promise.resolve([existingAttachment]),
+          },
+        },
+        db: context.db,
+        apiClient: createApiClientStub({
+          getMessage: ({ messageId }) =>
+            Promise.resolve(
+              buildGmailMessage(
+                messageId,
+                buildDriveAnchorHtml({
+                  driveFileId: "drive-file-existing",
+                  filename: "already-there.pdf",
+                }),
+              ),
+            ),
+        }),
+        windowStart: "2026-05-01T00:00:00.000Z",
+        windowEnd: null,
+        execute: true,
+        rateLimitMs: 0,
+        logger: createLoggerSink(logs),
+      });
+
+      expect(result.driveAttachmentsInserted).toBe(0);
+      expect(logs).toContainEqual({
+        providerRecordId: "drive-existing",
+        sourceEvidenceId,
+        capturedMailbox: "volunteers@example.org",
+        outcome: "skipped-existing",
+        driveAttachmentCount: 0,
+      });
+      await expect(
+        context.repositories.messageAttachments.findByMessageIds([sourceEvidenceId]),
+      ).resolves.toEqual([]);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("skips messages whose payload has no drive anchors", async () => {
+    const context = await createTestWorkerContext();
+    const logs: BackfillDriveAttachmentsLogEntry[] = [];
+    const sourceEvidenceId = "source-evidence:gmail:message:no-drive-anchor";
+
+    try {
+      await seedCandidateMessage({
+        context,
+        sourceEvidenceId,
+        providerRecordId: "no-drive-anchor",
+        createdAt: "2026-05-28T00:00:00.000Z",
+      });
+
+      const result = await backfillDriveAttachments({
+        repositories: context.repositories,
+        db: context.db,
+        apiClient: createApiClientStub({
+          getMessage: ({ messageId }) =>
+            Promise.resolve(
+              buildGmailMessage(
+                messageId,
+                "<div><img src=\"cid:inline-image-1\" alt=\"inline image\"></div>",
+              ),
+            ),
+        }),
+        windowStart: "2026-05-01T00:00:00.000Z",
+        windowEnd: null,
+        execute: true,
+        rateLimitMs: 0,
+        logger: createLoggerSink(logs),
+      });
+
+      expect(result.messagesWithoutDriveAnchors).toBe(1);
+      expect(logs).toContainEqual({
+        providerRecordId: "no-drive-anchor",
+        sourceEvidenceId,
+        capturedMailbox: "volunteers@example.org",
+        outcome: "no-drive-attachments",
+        driveAttachmentCount: 0,
+      });
+      await expect(
+        context.repositories.messageAttachments.findByMessageIds([sourceEvidenceId]),
+      ).resolves.toEqual([]);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("skips messages not found in mailbox", async () => {
+    const context = await createTestWorkerContext();
+    const logs: BackfillDriveAttachmentsLogEntry[] = [];
+    const sourceEvidenceId = "source-evidence:gmail:message:not-found";
+
+    try {
+      await seedCandidateMessage({
+        context,
+        sourceEvidenceId,
+        providerRecordId: "not-found",
+        createdAt: "2026-05-28T00:00:00.000Z",
+      });
+
+      const result = await backfillDriveAttachments({
+        repositories: context.repositories,
+        db: context.db,
+        apiClient: createApiClientStub({
+          getMessage: () => Promise.resolve(null),
+        }),
+        windowStart: "2026-05-01T00:00:00.000Z",
+        windowEnd: null,
+        execute: true,
+        rateLimitMs: 0,
+        logger: createLoggerSink(logs),
+      });
+
+      expect(result.messagesNotFoundInMailbox).toBe(1);
+      expect(logs).toContainEqual({
+        providerRecordId: "not-found",
+        sourceEvidenceId,
+        capturedMailbox: "volunteers@example.org",
+        outcome: "not-found-in-mailbox",
+        driveAttachmentCount: 0,
+      });
+      await expect(
+        context.repositories.messageAttachments.findByMessageIds([sourceEvidenceId]),
+      ).resolves.toEqual([]);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("continues past fetch failures", async () => {
+    const context = await createTestWorkerContext();
+    const logs: BackfillDriveAttachmentsLogEntry[] = [];
+    const firstSourceEvidenceId =
+      "source-evidence:gmail:message:fetch-failure-first";
+    const secondSourceEvidenceId =
+      "source-evidence:gmail:message:fetch-failure-second";
+
+    try {
+      await seedCandidateMessage({
+        context,
+        sourceEvidenceId: firstSourceEvidenceId,
+        providerRecordId: "fetch-failure-first",
+        createdAt: "2026-05-28T00:00:00.000Z",
+      });
+      await seedCandidateMessage({
+        context,
+        sourceEvidenceId: secondSourceEvidenceId,
+        providerRecordId: "fetch-failure-second",
+        createdAt: "2026-05-29T00:00:00.000Z",
+      });
+
+      const result = await backfillDriveAttachments({
+        repositories: context.repositories,
+        db: context.db,
+        apiClient: createApiClientStub({
+          getMessage: ({ messageId }) => {
+            if (messageId === "fetch-failure-first") {
+              return Promise.reject(new Error("gmail exploded"));
+            }
+
+            return Promise.resolve(
+              buildGmailMessage(
+                messageId,
+                buildDriveAnchorHtml({
+                  driveFileId: "drive-file-second",
+                  filename: "shared-photo.jpg",
+                }),
+              ),
+            );
+          },
+        }),
+        windowStart: "2026-05-01T00:00:00.000Z",
+        windowEnd: null,
+        execute: true,
+        rateLimitMs: 0,
+        logger: createLoggerSink(logs),
+      });
+
+      expect(result).toMatchObject({
+        candidatesScanned: 2,
+        driveAttachmentsInserted: 1,
+        fetchFailures: 1,
+      });
+      expect(logs).toContainEqual({
+        providerRecordId: "fetch-failure-first",
+        sourceEvidenceId: firstSourceEvidenceId,
+        capturedMailbox: "volunteers@example.org",
+        outcome: "fetch-failed",
+        driveAttachmentCount: 0,
+        errorMessage: "gmail exploded",
+      });
+      expect(logs).toContainEqual({
+        providerRecordId: "fetch-failure-second",
+        sourceEvidenceId: secondSourceEvidenceId,
+        capturedMailbox: "volunteers@example.org",
+        outcome: "inserted",
+        driveAttachmentCount: 1,
+      });
+      await expect(
+        context.repositories.messageAttachments.findByMessageIds([
+          firstSourceEvidenceId,
+          secondSourceEvidenceId,
+        ]),
+      ).resolves.toHaveLength(1);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("applies the window filter to candidate selection", async () => {
+    const context = await createTestWorkerContext();
+
+    try {
+      await seedCandidateMessage({
+        context,
+        sourceEvidenceId: "source-evidence:gmail:message:drive-old",
+        providerRecordId: "drive-old",
+        createdAt: "2026-04-07T00:00:00.000Z",
+      });
+      await seedCandidateMessage({
+        context,
+        sourceEvidenceId: "source-evidence:gmail:message:drive-recent",
+        providerRecordId: "drive-recent",
+        createdAt: "2026-05-27T00:00:00.000Z",
+      });
+
+      const result = await backfillDriveAttachments({
+        repositories: context.repositories,
+        db: context.db,
+        apiClient: createApiClientStub({
+          getMessage: ({ messageId }) =>
+            Promise.resolve(
+              buildGmailMessage(
+                messageId,
+                buildDriveAnchorHtml({
+                  driveFileId: `drive-file-${messageId}`,
+                  filename: `${messageId}.pdf`,
+                }),
+              ),
+            ),
+        }),
+        windowStart: "2026-05-07T00:00:00.000Z",
+        windowEnd: null,
+        execute: false,
+        rateLimitMs: 0,
+      });
+
+      expect(result.candidatesScanned).toBe(1);
+    } finally {
+      await context.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Brick D of [PRD #517](https://github.com/nico-kneler-as/as-comms-platform/issues/517) — completes the chain.
- New `ops:backfill-drive-attachments` script + 8 PGlite integration tests.
- Walks `gmail_message_details` for candidates (plaintext `[image:` marker AND zero `message_attachments` rows), re-fetches each via the existing Gmail API client, runs Brick A's `collectGmailDriveAttachments` on the live payload, upserts `message_attachments` rows with `provider='drive'` via Brick B's repo.

### CLI flags

- `--since <iso>` — default = 30 days ago
- `--until <iso>` — default = no upper bound (up to now)
- `--execute` — default = false (dry-run); flip to actually write
- `--rate-limit-ms <number>` — default = 1000; `0` disables pacing
- `--mailbox <email>` — optional; scope to one captured mailbox

### Operator workflow

Architect plans to run dry-run first (~173 candidates per the architect's prod query, will take ~3 min at 1 req/sec), spot-check the `would-insert` log lines, then re-run with `--execute`.

## Test plan

- [x] `pnpm typecheck` — pass
- [x] `pnpm lint` — pass
- [x] `pnpm boundaries` — pass
- [x] `pnpm --filter @as-comms/worker exec vitest run test/backfill-drive-attachments.test.ts` — 8 tests pass
- [ ] CI test suite runs the new file
- [ ] Architect runs dry-run against prod, eyeballs output, then runs with `--execute`

## Sample stdout line (for prod grep)

```json
{"providerRecordId":"...","sourceEvidenceId":"source-evidence:gmail:message:...","capturedMailbox":"volunteers@adventurescientists.org","outcome":"inserted","driveAttachmentCount":1}
```

Outcomes: `inserted`, `would-insert`, `skipped-existing`, `no-drive-attachments`, `not-found-in-mailbox`, `fetch-failed`.

## Closes the PRD

Live captures (A) write Drive rows (B), the inbox renders them (C), and historical messages can now be filled retroactively (D). Hillie Larson's butternut email and the other ~172 candidates will surface their Drive chips after a single `--execute` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)