### PR TITLE
fix(broadcasts): use run.projectId for header chip project label

### DIFF
--- a/apps/web/app/broadcasts/[runId]/_lib/run-detail.ts
+++ b/apps/web/app/broadcasts/[runId]/_lib/run-detail.ts
@@ -407,7 +407,8 @@ function resolvePrimaryProjectLabel(input: {
   readonly projects: Awaited<ReturnType<typeof listProjects>>;
   readonly run: CampaignRunRecord;
 }): string | null {
-  const primaryProjectId = input.run.audienceCriteria.projectIds[0] ?? null;
+  const primaryProjectId =
+    input.run.projectId ?? input.run.audienceCriteria.projectIds[0] ?? null;
   const projectMeta = primaryProjectId
     ? input.projects.find((project) => project.projectId === primaryProjectId) ??
       null


### PR DESCRIPTION
## Summary

Follow-up to #532. The new detail-page header chip degrades to state-only (`[● Complete]` instead of `[● Killer Whales › Complete]`) on every project broadcast because `resolvePrimaryProjectLabel` reads from `run.audienceCriteria.projectIds[0]`, which is **always empty** when the run is built from the campaign-run projection.

The header path calls `buildProjectionRun(projection)` (`run-detail.ts:303`), which populates `projectId` from the top-level projection field but stores `audienceCriteria: audienceCriteriaSchema.parse({})` — i.e., no criteria at all.

The list page uses `row.projectId` (the projection's top-level field), which is why the list shows project names correctly while the detail header didn't.

Fix: prefer `run.projectId`, fall back to `run.audienceCriteria.projectIds[0]` as a safety net.

## Test plan

- [ ] After deploy, open a Complete project broadcast — header chip reads `[● Project Name › Complete]` (was just `[● Complete]`)
- [ ] Newsletter broadcasts still degrade to `[● State]` (no project assigned)
- [ ] Project broadcasts created from the wizard with project filter still work
- [ ] Project broadcasts created with explicit contact selection (the regression case) now work

🤖 Generated with [Claude Code](https://claude.com/claude-code)