### PR TITLE
fix(broadcasts): allow Individual volunteers for HTML email + retire Phase A copy

### DIFF
--- a/apps/web/app/broadcasts/new/_components/launch-type-step.tsx
+++ b/apps/web/app/broadcasts/new/_components/launch-type-step.tsx
@@ -51,7 +51,7 @@ export function LaunchTypeStep({
     <section className="flex h-full flex-col">
       <StepHeader
         title="Choose the launch type"
-        description="Phase A ships the Normal Email path first; the wizard previews the full broadcast model so the next options are visible up front."
+        description="Pick how this broadcast goes out. Normal Email uses the Markdown composer; HTML Email opens the drag-and-drop editor. SMS arrives once carrier approval lands."
       />
 
       <div className="grid gap-3 md:grid-cols-3">

--- a/apps/web/app/broadcasts/new/_components/new-campaign-wizard.tsx
+++ b/apps/web/app/broadcasts/new/_components/new-campaign-wizard.tsx
@@ -33,7 +33,7 @@ const STEPS: readonly CampaignWizardStepDefinition[] = [
   {
     id: "launch",
     title: "Launch type",
-    subtitle: "Normal Email is the only active path in Phase A.",
+    subtitle: "Pick Normal Email for Markdown sends or HTML Email for the drag-and-drop composer.",
   },
   {
     id: "setup",
@@ -92,7 +92,7 @@ function readAudienceModesForLaunchType(
   launchType: LaunchType,
 ): readonly AudienceInitialFilter[] {
   return launchType === "html_email"
-    ? ["all_approved", "project_status"]
+    ? ["all_approved", "specific", "project_status"]
     : ["project_status", "specific"];
 }
 


### PR DESCRIPTION
Tiny follow-up to [PRD #536](https://github.com/nico-kneler-as/as-comms-platform/issues/536) surfaced while smoke-testing the merged HTML composer.

## Summary

- The "Individual volunteers" audience mode (`specific` / `contactIds`) shipped for Normal Email in Stage 5A and is the natural way to send a test HTML broadcast to yourself. PRD #536 Brick 0's design pass gated it off for `html_email` (only `all_approved` + `project_status` exposed) on the assumption HTML would always go to broad audiences. In practice it locks out test-targeting; add `"specific"` to the html_email allowlist.
- Two stale "Phase A" copy strings retired:
  - `new-campaign-wizard.tsx:36` — wizard rail Launch-type subtitle (was *"Normal Email is the only active path in Phase A."*)
  - `launch-type-step.tsx:54` — Step 1 StepHeader description (was *"Phase A ships the Normal Email path first…"*)

## What's not changed

- All the contactIds plumbing, the contact-picker UI, and the audience-resolver filtering — already shipped in Stage 5A, untouched here
- Default audience mode for `html_email` stays `all_approved` (the most common case for HTML)
- No tests modified — neither `audience-builder-step` nor `new-campaign-wizard` snapshot tests assert the allowlist contents

## Test plan

- [ ] CI typecheck / lint / boundaries pass (all green locally)
- [ ] Smoke: pick HTML Email → arrive at audience step → see three modes (All approved / Individual volunteers / Project + status); pick Individual volunteers → search for a contact → continue → Send Test to `nicolaskneler@gmail.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)