### PR TITLE
fix(broadcasts): tighten audience step layout + full-bleed HTML composer

### DIFF
--- a/apps/web/app/broadcasts/new/_components/audience-builder-step.tsx
+++ b/apps/web/app/broadcasts/new/_components/audience-builder-step.tsx
@@ -139,13 +139,12 @@ export function AudienceBuilderStep({
 
   return (
     <section className="flex h-full flex-col">
-      <StepHeader
-        title="Build the audience"
-        description="Live counts update from canonical contacts as you refine the audience mode, filters, and volunteer selection."
-      />
+      <StepHeader title="Build the audience" />
 
       <div className="space-y-4">
-        <AudienceCountPanel countState={countState} loading={countLoading} />
+        {hasPickedMode ? (
+          <AudienceCountPanel countState={countState} loading={countLoading} />
+        ) : null}
 
         {hasPickedMode ? (
           <>
@@ -252,7 +251,7 @@ function InitialFilterSelector({
       <div
         role="radiogroup"
         aria-label="Audience mode"
-        className="grid gap-3 px-4 py-4 lg:grid-cols-2"
+        className="grid gap-3 px-4 py-4 lg:grid-cols-3"
       >
         {modes.map((mode) => {
           const selected = value === mode;

--- a/apps/web/app/broadcasts/new/_components/new-campaign-wizard.tsx
+++ b/apps/web/app/broadcasts/new/_components/new-campaign-wizard.tsx
@@ -709,7 +709,14 @@ export function NewCampaignWizard({
         ) : null}
 
         <div className="flex-1 overflow-y-auto bg-white px-4 py-5 sm:px-6 lg:px-8 lg:py-6">
-          <div className="mx-auto flex min-h-full w-full max-w-3xl flex-col">
+          <div
+            className={cn(
+              "flex min-h-full w-full flex-col",
+              currentStep === 3 && launchType === "html_email"
+                ? null
+                : "mx-auto max-w-3xl",
+            )}
+          >
             {currentStep === 0 ? (
               <LaunchTypeStep
                 value={launchType}

--- a/apps/web/app/broadcasts/new/_components/wizard-shell.tsx
+++ b/apps/web/app/broadcasts/new/_components/wizard-shell.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils";
 
 interface StepHeaderProps {
   readonly title: string;
-  readonly description: string;
+  readonly description?: string;
   readonly rightSlot?: ReactNode;
 }
 
@@ -23,9 +23,11 @@ export function StepHeader({
         <h2 className="text-balance text-xl font-semibold tracking-tight text-slate-900">
           {title}
         </h2>
-        <p className="mt-2 max-w-2xl text-pretty text-[13px] leading-relaxed text-slate-500">
-          {description}
-        </p>
+        {description ? (
+          <p className="mt-2 max-w-2xl text-pretty text-[13px] leading-relaxed text-slate-500">
+            {description}
+          </p>
+        ) : null}
       </div>
       {rightSlot ? <div className="shrink-0">{rightSlot}</div> : null}
     </header>


### PR DESCRIPTION
Visual polish on the broadcast wizard surfaced after [PRD #536](https://github.com/nico-kneler-as/as-comms-platform/issues/536) operators started using the HTML composer end-to-end.

## Audience step

Before: 2-column grid wrapped the third mode card onto its own row. The \"Live counts update from canonical contacts...\" subtitle and a \"Pick an audience mode to start.\" empty-state banner both filled space without doing useful work pre-selection.

After: all three mode cards fit in one row at \`lg:\` breakpoints. The subtitle is gone. The audience count panel only renders once a mode has been picked — where it shows live recipient counts and remains useful.

\`StepHeader\`'s \`description\` prop becomes optional. No other usages affected.

## Compose step (HTML email)

Before: the wizard content column is \`max-w-3xl\` (768px). Unlayer's three-pane layout (tools rail + 600px canvas + properties rail ≈ 900px) was crammed inside that, forcing internal scrolling and a boxed-in feel.

After: when \`launchType === 'html_email'\` AND \`currentStep === 3\` (Compose), drop the \`max-w-3xl\` / \`mx-auto\` constraint and let the column take the full available width (viewport minus the wizard rail). All other steps and the \`normal_email\` path keep the existing constrained width.

## Test plan

- [ ] CI typecheck / lint / boundaries pass (all green locally)
- [ ] Smoke: audience step shows three modes in one row, no subtitle, no \"Pick a mode\" banner
- [ ] Smoke: pick a mode → audience count panel appears with live counts
- [ ] Smoke: HTML compose step fills the available width; editor's three panes have room to breathe
- [ ] Regression: Normal Email path renders unchanged on every step

🤖 Generated with [Claude Code](https://claude.com/claude-code)