### PR TITLE
feat(integrations,db,domain): SF reconciliation building blocks (PRD #544 Brick 2a)

### DIFF
--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -764,10 +764,9 @@ function mapMailchimpCampaignActivityDetailRowLocal(
   return {
     sourceEvidenceId: row.sourceEvidenceId,
     providerRecordId: row.providerRecordId,
-    activityType:
-      normalizeMailchimpActivityType(
-        row.activityType,
-      ) as MailchimpCampaignActivityDetailRecord["activityType"],
+    activityType: normalizeMailchimpActivityType(
+      row.activityType,
+    ) as MailchimpCampaignActivityDetailRecord["activityType"],
     campaignId: row.campaignId,
     audienceId: row.audienceId,
     memberId: row.memberId,
@@ -815,7 +814,9 @@ function mapMailchimpRecipientRow(
 ): MailchimpRecipientRow {
   const eventAt = row.latestEventAt;
   const isoLatestEventAt =
-    eventAt instanceof Date ? eventAt.toISOString() : new Date(String(eventAt)).toISOString();
+    eventAt instanceof Date
+      ? eventAt.toISOString()
+      : new Date(String(eventAt)).toISOString();
   return {
     memberId: row.memberId,
     email: row.email,
@@ -1993,7 +1994,10 @@ function createStage1RepositoriesInternal(
           .leftJoin(
             canonicalEventAudience,
             and(
-              eq(canonicalEventAudience.canonicalEventId, canonicalEventLedger.id),
+              eq(
+                canonicalEventAudience.canonicalEventId,
+                canonicalEventLedger.id,
+              ),
               eq(canonicalEventAudience.contactId, contactId),
             ),
           )
@@ -2453,6 +2457,58 @@ function createStage1RepositoriesInternal(
           .orderBy(asc(contacts.id));
 
         return rows.map(mapContactRow);
+      },
+
+      async listSalesforceAnchoredIds() {
+        const rows = await db
+          .select({ id: contacts.salesforceContactId })
+          .from(contacts)
+          .where(
+            and(
+              isNotNull(contacts.salesforceContactId),
+              isNull(contacts.salesforceDeletedAt),
+            ),
+          )
+          .orderBy(asc(contacts.salesforceContactId));
+
+        return rows
+          .map((row) => row.id)
+          .filter((id): id is string => id !== null);
+      },
+
+      async markSalesforceDeleted(input) {
+        if (input.salesforceIds.length === 0) {
+          return 0;
+        }
+
+        const result = await db
+          .update(contacts)
+          .set({ salesforceDeletedAt: new Date(input.deletedAt) })
+          .where(
+            and(
+              inArray(contacts.salesforceContactId, [...input.salesforceIds]),
+              isNull(contacts.salesforceDeletedAt),
+            ),
+          )
+          .returning({ id: contacts.id });
+
+        return result.length;
+      },
+
+      async markSalesforceReconciled(input) {
+        if (input.salesforceIds.length === 0) {
+          return 0;
+        }
+
+        const result = await db
+          .update(contacts)
+          .set({ salesforceReconciledAt: new Date(input.reconciledAt) })
+          .where(
+            inArray(contacts.salesforceContactId, [...input.salesforceIds]),
+          )
+          .returning({ id: contacts.id });
+
+        return result.length;
       },
 
       async searchByQuery(input) {
@@ -2938,40 +2994,44 @@ function createStage1RepositoriesInternal(
         }
 
         return {
-          canonicalEventsRepointed:
-            normalizeSqlResultRows<{ readonly id: string }>(
-              canonicalEventsResult as {
-                readonly rows?: readonly { readonly id: string }[];
-              },
-            ).length,
-          timelineRowsRepointed:
-            normalizeSqlResultRows<{ readonly id: string }>(
-              timelineRowsResult as {
-                readonly rows?: readonly { readonly id: string }[];
-              },
-            ).length,
+          canonicalEventsRepointed: normalizeSqlResultRows<{
+            readonly id: string;
+          }>(
+            canonicalEventsResult as {
+              readonly rows?: readonly { readonly id: string }[];
+            },
+          ).length,
+          timelineRowsRepointed: normalizeSqlResultRows<{
+            readonly id: string;
+          }>(
+            timelineRowsResult as {
+              readonly rows?: readonly { readonly id: string }[];
+            },
+          ).length,
           notesRepointed: normalizeSqlResultRows<{ readonly id: string }>(
             noteRowsResult as {
               readonly rows?: readonly { readonly id: string }[];
             },
           ).length,
-          routingRowsRepointed:
-            normalizeSqlResultRows<{ readonly id: string }>(
-              routingRowsResult as {
-                readonly rows?: readonly { readonly id: string }[];
-              },
-            ).length,
-          identityCasesRepointed:
-            normalizeSqlResultRows<{ readonly id: string }>(
-              identityCasesResult as {
-                readonly rows?: readonly { readonly id: string }[];
-              },
-            ).length,
+          routingRowsRepointed: normalizeSqlResultRows<{ readonly id: string }>(
+            routingRowsResult as {
+              readonly rows?: readonly { readonly id: string }[];
+            },
+          ).length,
+          identityCasesRepointed: normalizeSqlResultRows<{
+            readonly id: string;
+          }>(
+            identityCasesResult as {
+              readonly rows?: readonly { readonly id: string }[];
+            },
+          ).length,
           audienceRowsRepointed: normalizeSqlResultRows<{
             readonly canonical_event_id: string;
           }>(
             audienceRowsResult as {
-              readonly rows?: readonly { readonly canonical_event_id: string }[];
+              readonly rows?: readonly {
+                readonly canonical_event_id: string;
+              }[];
             },
           ).length,
           contactDeleted: true,
@@ -3067,6 +3127,63 @@ function createStage1RepositoriesInternal(
           );
 
         return rows.map(mapContactMembershipRow);
+      },
+
+      async listSalesforceAnchoredIds() {
+        const rows = await db
+          .select({ id: contactMemberships.salesforceMembershipId })
+          .from(contactMemberships)
+          .where(
+            and(
+              eq(contactMemberships.source, "salesforce"),
+              isNotNull(contactMemberships.salesforceMembershipId),
+              isNull(contactMemberships.salesforceDeletedAt),
+            ),
+          )
+          .orderBy(asc(contactMemberships.salesforceMembershipId));
+
+        return rows
+          .map((row) => row.id)
+          .filter((id): id is string => id !== null);
+      },
+
+      async markSalesforceDeleted(input) {
+        if (input.salesforceIds.length === 0) {
+          return 0;
+        }
+
+        const result = await db
+          .update(contactMemberships)
+          .set({ salesforceDeletedAt: new Date(input.deletedAt) })
+          .where(
+            and(
+              inArray(contactMemberships.salesforceMembershipId, [
+                ...input.salesforceIds,
+              ]),
+              isNull(contactMemberships.salesforceDeletedAt),
+            ),
+          )
+          .returning({ id: contactMemberships.id });
+
+        return result.length;
+      },
+
+      async markSalesforceReconciled(input) {
+        if (input.salesforceIds.length === 0) {
+          return 0;
+        }
+
+        const result = await db
+          .update(contactMemberships)
+          .set({ salesforceReconciledAt: new Date(input.reconciledAt) })
+          .where(
+            inArray(contactMemberships.salesforceMembershipId, [
+              ...input.salesforceIds,
+            ]),
+          )
+          .returning({ id: contactMemberships.id });
+
+        return result.length;
       },
 
       async upsert(record) {
@@ -3175,6 +3292,60 @@ function createStage1RepositoriesInternal(
           .orderBy(asc(projectDimensions.projectId));
 
         return rows.map(mapProjectDimensionRow);
+      },
+
+      async listSalesforceAnchoredIds() {
+        const rows = await db
+          .select({ id: projectDimensions.projectId })
+          .from(projectDimensions)
+          .where(
+            and(
+              eq(projectDimensions.source, "salesforce"),
+              isNull(projectDimensions.salesforceDeletedAt),
+            ),
+          )
+          .orderBy(asc(projectDimensions.projectId));
+
+        return rows.map((row) => row.id);
+      },
+
+      async markSalesforceDeleted(input) {
+        if (input.salesforceIds.length === 0) {
+          return 0;
+        }
+
+        const result = await db
+          .update(projectDimensions)
+          .set({ salesforceDeletedAt: new Date(input.deletedAt) })
+          .where(
+            and(
+              inArray(projectDimensions.projectId, [...input.salesforceIds]),
+              eq(projectDimensions.source, "salesforce"),
+              isNull(projectDimensions.salesforceDeletedAt),
+            ),
+          )
+          .returning({ id: projectDimensions.projectId });
+
+        return result.length;
+      },
+
+      async markSalesforceReconciled(input) {
+        if (input.salesforceIds.length === 0) {
+          return 0;
+        }
+
+        const result = await db
+          .update(projectDimensions)
+          .set({ salesforceReconciledAt: new Date(input.reconciledAt) })
+          .where(
+            and(
+              inArray(projectDimensions.projectId, [...input.salesforceIds]),
+              eq(projectDimensions.source, "salesforce"),
+            ),
+          )
+          .returning({ id: projectDimensions.projectId });
+
+        return result.length;
       },
 
       async listConnectedProjects(hostProjectId) {
@@ -5722,9 +5893,7 @@ function createStage2RepositoriesInternal(
 
           const priorAlias = existing.projectAlias?.trim() ?? "";
           const priorAliasNormalized = priorAlias.toLowerCase();
-          const nextAliasNormalized = (projectAlias ?? "")
-            .trim()
-            .toLowerCase();
+          const nextAliasNormalized = (projectAlias ?? "").trim().toLowerCase();
           const previousAliases = existing.previousAliases;
           const previousAliasesNormalized = new Set(
             previousAliases.map((alias) => alias.trim().toLowerCase()),
@@ -6358,7 +6527,8 @@ type AudienceSnapshotRow = typeof audienceSnapshots.$inferSelect;
 type ContactConsentRow = typeof contactConsent.$inferSelect;
 type SuppressionListRow = typeof suppressionList.$inferSelect;
 type OrgSettingsRow = typeof orgSettings.$inferSelect;
-type PostmarkWebhookDeadLetterRow = typeof postmarkWebhookDeadLetter.$inferSelect;
+type PostmarkWebhookDeadLetterRow =
+  typeof postmarkWebhookDeadLetter.$inferSelect;
 
 interface CampaignRunProjectionRowDb {
   readonly runId: string;
@@ -6656,9 +6826,7 @@ function mapPostmarkWebhookDeadLetterRow(
 function isTerminalWebhookDeadLetterFailureKind(
   failureKind: WebhookDeadLetterFailureKind,
 ): boolean {
-  return (
-    failureKind === "schema_error" || failureKind === "unknown_event_type"
-  );
+  return failureKind === "schema_error" || failureKind === "unknown_event_type";
 }
 
 function clampWebhookDeadLetterListLimit(limit: number | undefined): number {

--- a/packages/db/test/stage1-repositories.test.ts
+++ b/packages/db/test/stage1-repositories.test.ts
@@ -125,18 +125,20 @@ async function seedTimelineFanoutEvent(input: {
     reviewState: "clear",
   });
 
-  const timelineProjection = await input.repositories.timelineProjection.upsert({
-    id: `timeline:${input.eventId}`,
-    contactId: input.anchorContactId,
-    canonicalEventId: input.eventId,
-    occurredAt: input.occurredAt,
-    sortKey: `${input.occurredAt}::${input.eventId}`,
-    eventType: canonicalEvent.eventType,
-    summary: input.summary ?? input.eventId,
-    channel: "email",
-    primaryProvider: "gmail",
-    reviewState: "clear",
-  });
+  const timelineProjection = await input.repositories.timelineProjection.upsert(
+    {
+      id: `timeline:${input.eventId}`,
+      contactId: input.anchorContactId,
+      canonicalEventId: input.eventId,
+      occurredAt: input.occurredAt,
+      sortKey: `${input.occurredAt}::${input.eventId}`,
+      eventType: canonicalEvent.eventType,
+      summary: input.summary ?? input.eventId,
+      channel: "email",
+      primaryProvider: "gmail",
+      reviewState: "clear",
+    },
+  );
 
   return {
     canonicalEvent,
@@ -626,19 +628,22 @@ describe("Stage 1 DB repositories", () => {
       checksum: "checksum-drive-attachment",
     });
 
-    await repositories.messageAttachments.upsertManyForMessage(sourceEvidence.id, [
-      {
-        id: "att:drive:gmail-drive-attachment:drive-file-1",
-        provider: "drive",
-        gmailAttachmentId: null,
-        mimeType: "application/octet-stream",
-        filename: "shared-file.pdf",
-        sizeBytes: 0,
-        storageKey: null,
-        externalUrl: "https://drive.google.com/file/d/drive-file-1/view",
-        isDecoration: false,
-      },
-    ]);
+    await repositories.messageAttachments.upsertManyForMessage(
+      sourceEvidence.id,
+      [
+        {
+          id: "att:drive:gmail-drive-attachment:drive-file-1",
+          provider: "drive",
+          gmailAttachmentId: null,
+          mimeType: "application/octet-stream",
+          filename: "shared-file.pdf",
+          sizeBytes: 0,
+          storageKey: null,
+          externalUrl: "https://drive.google.com/file/d/drive-file-1/view",
+          isDecoration: false,
+        },
+      ],
+    );
 
     await expect(
       repositories.messageAttachments.findById(
@@ -667,30 +672,33 @@ describe("Stage 1 DB repositories", () => {
       checksum: "checksum-mixed-attachments",
     });
 
-    await repositories.messageAttachments.upsertManyForMessage(sourceEvidence.id, [
-      {
-        id: "att:gmail:gmail-mixed-attachments:0/1",
-        provider: "gmail",
-        gmailAttachmentId: "gmail-attachment-1",
-        mimeType: "image/png",
-        filename: "image001.png",
-        sizeBytes: 2048,
-        storageKey: "gmail/ab/att:gmail:gmail-mixed-attachments:0/1",
-        externalUrl: null,
-        isDecoration: true,
-      },
-      {
-        id: "att:drive:gmail-mixed-attachments:drive-file-2",
-        provider: "drive",
-        gmailAttachmentId: null,
-        mimeType: "application/octet-stream",
-        filename: "shared-file.pdf",
-        sizeBytes: 0,
-        storageKey: null,
-        externalUrl: "https://drive.google.com/file/d/drive-file-2/view",
-        isDecoration: false,
-      },
-    ]);
+    await repositories.messageAttachments.upsertManyForMessage(
+      sourceEvidence.id,
+      [
+        {
+          id: "att:gmail:gmail-mixed-attachments:0/1",
+          provider: "gmail",
+          gmailAttachmentId: "gmail-attachment-1",
+          mimeType: "image/png",
+          filename: "image001.png",
+          sizeBytes: 2048,
+          storageKey: "gmail/ab/att:gmail:gmail-mixed-attachments:0/1",
+          externalUrl: null,
+          isDecoration: true,
+        },
+        {
+          id: "att:drive:gmail-mixed-attachments:drive-file-2",
+          provider: "drive",
+          gmailAttachmentId: null,
+          mimeType: "application/octet-stream",
+          filename: "shared-file.pdf",
+          sizeBytes: 0,
+          storageKey: null,
+          externalUrl: "https://drive.google.com/file/d/drive-file-2/view",
+          isDecoration: false,
+        },
+      ],
+    );
 
     await expect(
       repositories.messageAttachments.findByMessageIds([sourceEvidence.id]),
@@ -1246,7 +1254,10 @@ describe("Stage 1 DB repositories", () => {
       source: "salesforce",
     });
 
-    const activatedProject = await settings.projects.setActive("project_1", true);
+    const activatedProject = await settings.projects.setActive(
+      "project_1",
+      true,
+    );
 
     expect(activatedProject).toMatchObject({
       projectId: "project_1",
@@ -2101,13 +2112,15 @@ describe("Stage 1 DB repositories", () => {
       createdAt: "2026-04-05T10:00:00.000Z",
     });
 
-    const pnwRows = await repositories.inboxProjection.listPageOrderedByRecency({
-      filter: "visible",
-      order: "last-inbound",
-      limit: 10,
-      cursor: null,
-      projectId: "project:pnw-bio",
-    });
+    const pnwRows = await repositories.inboxProjection.listPageOrderedByRecency(
+      {
+        filter: "visible",
+        order: "last-inbound",
+        limit: 10,
+        cursor: null,
+        projectId: "project:pnw-bio",
+      },
+    );
     const whitebarkRows =
       await repositories.inboxProjection.listPageOrderedByRecency({
         filter: "visible",
@@ -2408,51 +2421,42 @@ describe("Stage 1 DB repositories", () => {
       lastEventType: "communication.email.inbound",
     });
 
-    const hostARows = await repositories.inboxProjection.listPageOrderedByRecency({
-      filter: "visible",
-      order: "last-inbound",
-      limit: 10,
-      cursor: null,
-      projectId: "project:host-a",
-    });
-    const subBRows = await repositories.inboxProjection.listPageOrderedByRecency(
-      {
+    const hostARows =
+      await repositories.inboxProjection.listPageOrderedByRecency({
+        filter: "visible",
+        order: "last-inbound",
+        limit: 10,
+        cursor: null,
+        projectId: "project:host-a",
+      });
+    const subBRows =
+      await repositories.inboxProjection.listPageOrderedByRecency({
         filter: "visible",
         order: "last-inbound",
         limit: 10,
         cursor: null,
         projectId: "project:sub-b",
-      },
-    );
-    const hostDRows = await repositories.inboxProjection.listPageOrderedByRecency(
-      {
+      });
+    const hostDRows =
+      await repositories.inboxProjection.listPageOrderedByRecency({
         filter: "visible",
         order: "last-inbound",
         limit: 10,
         cursor: null,
         projectId: "project:host-d",
-      },
-    );
+      });
 
     // Filtering by host A returns: direct member, sub-project member, alias-only.
     expect(new Set(hostARows.map((row) => row.contactId))).toEqual(
-      new Set([
-        "contact:in-host-a",
-        "contact:in-sub-b",
-        "contact:alias-only",
-      ]),
+      new Set(["contact:in-host-a", "contact:in-sub-b", "contact:alias-only"]),
     );
     // Filtering by the sub-project's own id is not the operator-facing path —
     // it should match only the contact whose membership is on that exact id
     // (existing case 1) and NOT the host or other host's contacts. The sub
     // does not have a host of its own, so no rollup happens here.
-    expect(subBRows.map((row) => row.contactId)).toEqual([
-      "contact:in-sub-b",
-    ]);
+    expect(subBRows.map((row) => row.contactId)).toEqual(["contact:in-sub-b"]);
     // Cross-host isolation: host D's filter must not include host A's family.
-    expect(hostDRows.map((row) => row.contactId)).toEqual([
-      "contact:in-sub-c",
-    ]);
+    expect(hostDRows.map((row) => row.contactId)).toEqual(["contact:in-sub-c"]);
   });
 
   it("repoints canonical_event_audience rows when merging an email-only contact into an anchored one", async () => {
@@ -2638,5 +2642,530 @@ describe("Stage 1 DB repositories", () => {
 
     // Exactly two rows total — one repointed, one survivor of the collision.
     expect(surviving.rows.length).toBe(2);
+  });
+});
+
+describe("contacts.listSalesforceAnchoredIds + markSalesforceDeleted + markSalesforceReconciled", () => {
+  it("lists only non-tombstoned salesforce-anchored contacts", async () => {
+    const { repositories } = await createTestStage1Context();
+
+    await repositories.contacts.upsert({
+      id: "contact:salesforce:001",
+      salesforceContactId: "001A",
+      displayName: "SF Contact A",
+      primaryEmail: "sf-a@example.org",
+      primaryPhone: null,
+      createdAt: "2026-06-01T00:00:00.000Z",
+      updatedAt: "2026-06-01T00:00:00.000Z",
+    });
+    await repositories.contacts.upsert({
+      id: "contact:salesforce:002",
+      salesforceContactId: "002B",
+      displayName: "SF Contact B",
+      primaryEmail: "sf-b@example.org",
+      primaryPhone: null,
+      salesforceDeletedAt: "2026-06-02T00:00:00.000Z",
+      createdAt: "2026-06-01T00:00:00.000Z",
+      updatedAt: "2026-06-01T00:00:00.000Z",
+    });
+    await repositories.contacts.upsert({
+      id: "contact:local:003",
+      salesforceContactId: null,
+      displayName: "Local Contact",
+      primaryEmail: "local@example.org",
+      primaryPhone: null,
+      createdAt: "2026-06-01T00:00:00.000Z",
+      updatedAt: "2026-06-01T00:00:00.000Z",
+    });
+
+    await expect(
+      repositories.contacts.listSalesforceAnchoredIds(),
+    ).resolves.toEqual(["001A"]);
+  });
+
+  it("returns an empty salesforce anchor list for an empty contacts table", async () => {
+    const { repositories } = await createTestStage1Context();
+
+    await expect(
+      repositories.contacts.listSalesforceAnchoredIds(),
+    ).resolves.toEqual([]);
+  });
+
+  it("marks salesforce contacts deleted idempotently", async () => {
+    const { repositories } = await createTestStage1Context();
+    const deletedAt = "2026-06-03T12:34:56.000Z";
+
+    await repositories.contacts.upsert({
+      id: "contact:salesforce:001",
+      salesforceContactId: "001A",
+      displayName: "SF Contact A",
+      primaryEmail: "sf-a@example.org",
+      primaryPhone: null,
+      createdAt: "2026-06-01T00:00:00.000Z",
+      updatedAt: "2026-06-01T00:00:00.000Z",
+    });
+    await repositories.contacts.upsert({
+      id: "contact:salesforce:002",
+      salesforceContactId: "002B",
+      displayName: "SF Contact B",
+      primaryEmail: "sf-b@example.org",
+      primaryPhone: null,
+      createdAt: "2026-06-01T00:00:00.000Z",
+      updatedAt: "2026-06-01T00:00:00.000Z",
+    });
+
+    await expect(
+      repositories.contacts.markSalesforceDeleted({
+        salesforceIds: ["001A", "002B"],
+        deletedAt,
+      }),
+    ).resolves.toBe(2);
+    await expect(
+      repositories.contacts.findById("contact:salesforce:001"),
+    ).resolves.toMatchObject({
+      salesforceDeletedAt: deletedAt,
+    });
+    await expect(
+      repositories.contacts.findById("contact:salesforce:002"),
+    ).resolves.toMatchObject({
+      salesforceDeletedAt: deletedAt,
+    });
+
+    await expect(
+      repositories.contacts.markSalesforceDeleted({
+        salesforceIds: ["001A", "002B"],
+        deletedAt,
+      }),
+    ).resolves.toBe(0);
+    await expect(
+      repositories.contacts.markSalesforceDeleted({
+        salesforceIds: [],
+        deletedAt,
+      }),
+    ).resolves.toBe(0);
+    await expect(
+      repositories.contacts.markSalesforceDeleted({
+        salesforceIds: ["does-not-exist"],
+        deletedAt,
+      }),
+    ).resolves.toBe(0);
+  });
+
+  it("marks salesforce contacts reconciled and refreshes the timestamp on repeat runs", async () => {
+    const { repositories } = await createTestStage1Context();
+    const firstReconciledAt = "2026-06-04T08:00:00.000Z";
+    const secondReconciledAt = "2026-06-04T09:00:00.000Z";
+
+    await repositories.contacts.upsert({
+      id: "contact:salesforce:001",
+      salesforceContactId: "001A",
+      displayName: "SF Contact A",
+      primaryEmail: "sf-a@example.org",
+      primaryPhone: null,
+      createdAt: "2026-06-01T00:00:00.000Z",
+      updatedAt: "2026-06-01T00:00:00.000Z",
+    });
+
+    await expect(
+      repositories.contacts.markSalesforceReconciled({
+        salesforceIds: ["001A"],
+        reconciledAt: firstReconciledAt,
+      }),
+    ).resolves.toBe(1);
+    await expect(
+      repositories.contacts.findById("contact:salesforce:001"),
+    ).resolves.toMatchObject({
+      salesforceDeletedAt: null,
+      salesforceReconciledAt: firstReconciledAt,
+    });
+
+    await expect(
+      repositories.contacts.markSalesforceReconciled({
+        salesforceIds: ["001A"],
+        reconciledAt: secondReconciledAt,
+      }),
+    ).resolves.toBe(1);
+    await expect(
+      repositories.contacts.findById("contact:salesforce:001"),
+    ).resolves.toMatchObject({
+      salesforceDeletedAt: null,
+      salesforceReconciledAt: secondReconciledAt,
+    });
+
+    await expect(
+      repositories.contacts.markSalesforceReconciled({
+        salesforceIds: [],
+        reconciledAt: secondReconciledAt,
+      }),
+    ).resolves.toBe(0);
+  });
+});
+
+describe("contactMemberships.listSalesforceAnchoredIds + markSalesforceDeleted + markSalesforceReconciled", () => {
+  async function seedMembershipParents(
+    repositories: Stage1TestRepositories,
+  ): Promise<void> {
+    await repositories.contacts.upsert({
+      id: "contact:membership:001",
+      salesforceContactId: "003-membership-001",
+      displayName: "Membership Contact",
+      primaryEmail: "membership@example.org",
+      primaryPhone: null,
+      createdAt: "2026-06-01T00:00:00.000Z",
+      updatedAt: "2026-06-01T00:00:00.000Z",
+    });
+    await repositories.projectDimensions.upsert({
+      projectId: "project:membership:001",
+      projectName: "Membership Project",
+      source: "salesforce",
+    });
+    await repositories.projectDimensions.upsert({
+      projectId: "project:membership:manual",
+      projectName: "Manual Membership Project",
+      source: "manual",
+    });
+  }
+
+  it("lists only non-tombstoned salesforce membership ids", async () => {
+    const { repositories } = await createTestStage1Context();
+    await seedMembershipParents(repositories);
+
+    await repositories.contactMemberships.upsert({
+      id: "membership:salesforce:001",
+      contactId: "contact:membership:001",
+      projectId: "project:membership:001",
+      expeditionId: null,
+      salesforceMembershipId: "a15VK00000AkA3RYAV",
+      role: "volunteer",
+      status: "active",
+      source: "salesforce",
+      createdAt: "2026-06-01T00:00:00.000Z",
+    });
+    await repositories.contactMemberships.upsert({
+      id: "membership:salesforce:002",
+      contactId: "contact:membership:001",
+      projectId: "project:membership:001",
+      expeditionId: null,
+      salesforceMembershipId: "a15VK00000AkA3SYAV",
+      role: "volunteer",
+      status: "active",
+      source: "salesforce",
+      salesforceDeletedAt: "2026-06-02T00:00:00.000Z",
+      createdAt: "2026-06-01T00:00:00.000Z",
+    });
+    await repositories.contactMemberships.upsert({
+      id: "membership:manual:003",
+      contactId: "contact:membership:001",
+      projectId: "project:membership:manual",
+      expeditionId: null,
+      salesforceMembershipId: null,
+      role: "volunteer",
+      status: "active",
+      source: "manual",
+      createdAt: "2026-06-01T00:00:00.000Z",
+    });
+
+    await expect(
+      repositories.contactMemberships.listSalesforceAnchoredIds(),
+    ).resolves.toEqual(["a15VK00000AkA3RYAV"]);
+  });
+
+  it("returns an empty salesforce membership list for an empty table", async () => {
+    const { repositories } = await createTestStage1Context();
+
+    await expect(
+      repositories.contactMemberships.listSalesforceAnchoredIds(),
+    ).resolves.toEqual([]);
+  });
+
+  it("marks salesforce memberships deleted idempotently", async () => {
+    const { repositories } = await createTestStage1Context();
+    const deletedAt = "2026-06-03T12:34:56.000Z";
+    await seedMembershipParents(repositories);
+
+    await repositories.contactMemberships.upsert({
+      id: "membership:salesforce:001",
+      contactId: "contact:membership:001",
+      projectId: "project:membership:001",
+      expeditionId: null,
+      salesforceMembershipId: "a15VK00000AkA3RYAV",
+      role: "volunteer",
+      status: "active",
+      source: "salesforce",
+      createdAt: "2026-06-01T00:00:00.000Z",
+    });
+    await repositories.contactMemberships.upsert({
+      id: "membership:salesforce:002",
+      contactId: "contact:membership:001",
+      projectId: "project:membership:001",
+      expeditionId: null,
+      salesforceMembershipId: "a15VK00000AkA3SYAV",
+      role: "volunteer",
+      status: "active",
+      source: "salesforce",
+      createdAt: "2026-06-01T00:00:00.000Z",
+    });
+
+    await expect(
+      repositories.contactMemberships.markSalesforceDeleted({
+        salesforceIds: ["a15VK00000AkA3RYAV", "a15VK00000AkA3SYAV"],
+        deletedAt,
+      }),
+    ).resolves.toBe(2);
+    await expect(
+      repositories.contactMemberships.listByContactId("contact:membership:001"),
+    ).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "membership:salesforce:001",
+          salesforceDeletedAt: deletedAt,
+        }),
+        expect.objectContaining({
+          id: "membership:salesforce:002",
+          salesforceDeletedAt: deletedAt,
+        }),
+      ]),
+    );
+
+    await expect(
+      repositories.contactMemberships.markSalesforceDeleted({
+        salesforceIds: ["a15VK00000AkA3RYAV", "a15VK00000AkA3SYAV"],
+        deletedAt,
+      }),
+    ).resolves.toBe(0);
+    await expect(
+      repositories.contactMemberships.markSalesforceDeleted({
+        salesforceIds: [],
+        deletedAt,
+      }),
+    ).resolves.toBe(0);
+    await expect(
+      repositories.contactMemberships.markSalesforceDeleted({
+        salesforceIds: ["does-not-exist"],
+        deletedAt,
+      }),
+    ).resolves.toBe(0);
+  });
+
+  it("marks salesforce memberships reconciled and refreshes the timestamp on repeat runs", async () => {
+    const { repositories } = await createTestStage1Context();
+    const firstReconciledAt = "2026-06-04T08:00:00.000Z";
+    const secondReconciledAt = "2026-06-04T09:00:00.000Z";
+    await seedMembershipParents(repositories);
+
+    await repositories.contactMemberships.upsert({
+      id: "membership:salesforce:001",
+      contactId: "contact:membership:001",
+      projectId: "project:membership:001",
+      expeditionId: null,
+      salesforceMembershipId: "a15VK00000AkA3RYAV",
+      role: "volunteer",
+      status: "active",
+      source: "salesforce",
+      createdAt: "2026-06-01T00:00:00.000Z",
+    });
+
+    await expect(
+      repositories.contactMemberships.markSalesforceReconciled({
+        salesforceIds: ["a15VK00000AkA3RYAV"],
+        reconciledAt: firstReconciledAt,
+      }),
+    ).resolves.toBe(1);
+    await expect(
+      repositories.contactMemberships.listByContactId("contact:membership:001"),
+    ).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "membership:salesforce:001",
+          salesforceDeletedAt: null,
+          salesforceReconciledAt: firstReconciledAt,
+        }),
+      ]),
+    );
+
+    await expect(
+      repositories.contactMemberships.markSalesforceReconciled({
+        salesforceIds: ["a15VK00000AkA3RYAV"],
+        reconciledAt: secondReconciledAt,
+      }),
+    ).resolves.toBe(1);
+    await expect(
+      repositories.contactMemberships.listByContactId("contact:membership:001"),
+    ).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "membership:salesforce:001",
+          salesforceDeletedAt: null,
+          salesforceReconciledAt: secondReconciledAt,
+        }),
+      ]),
+    );
+
+    await expect(
+      repositories.contactMemberships.markSalesforceReconciled({
+        salesforceIds: [],
+        reconciledAt: secondReconciledAt,
+      }),
+    ).resolves.toBe(0);
+  });
+});
+
+describe("projectDimensions.listSalesforceAnchoredIds + markSalesforceDeleted + markSalesforceReconciled", () => {
+  it("lists only non-tombstoned salesforce project ids", async () => {
+    const { repositories } = await createTestStage1Context();
+
+    await repositories.projectDimensions.upsert({
+      projectId: "campaign:001A",
+      projectName: "Salesforce Campaign A",
+      source: "salesforce",
+    });
+    await repositories.projectDimensions.upsert({
+      projectId: "campaign:002B",
+      projectName: "Salesforce Campaign B",
+      source: "salesforce",
+      salesforceDeletedAt: "2026-06-02T00:00:00.000Z",
+    });
+    await repositories.projectDimensions.upsert({
+      projectId: "manual-003",
+      projectName: "Manual Project",
+      source: "manual",
+    });
+
+    await expect(
+      repositories.projectDimensions.listSalesforceAnchoredIds(),
+    ).resolves.toEqual(["campaign:001A"]);
+  });
+
+  it("returns an empty salesforce project list for an empty table", async () => {
+    const { repositories } = await createTestStage1Context();
+
+    await expect(
+      repositories.projectDimensions.listSalesforceAnchoredIds(),
+    ).resolves.toEqual([]);
+  });
+
+  it("marks salesforce projects deleted idempotently", async () => {
+    const { repositories } = await createTestStage1Context();
+    const deletedAt = "2026-06-03T12:34:56.000Z";
+
+    await repositories.projectDimensions.upsert({
+      projectId: "campaign:001A",
+      projectName: "Salesforce Campaign A",
+      source: "salesforce",
+    });
+    await repositories.projectDimensions.upsert({
+      projectId: "campaign:002B",
+      projectName: "Salesforce Campaign B",
+      source: "salesforce",
+    });
+
+    await expect(
+      repositories.projectDimensions.markSalesforceDeleted({
+        salesforceIds: ["campaign:001A", "campaign:002B"],
+        deletedAt,
+      }),
+    ).resolves.toBe(2);
+    await expect(
+      repositories.projectDimensions.findById("campaign:001A"),
+    ).resolves.toMatchObject({
+      salesforceDeletedAt: deletedAt,
+    });
+    await expect(
+      repositories.projectDimensions.findById("campaign:002B"),
+    ).resolves.toMatchObject({
+      salesforceDeletedAt: deletedAt,
+    });
+
+    await expect(
+      repositories.projectDimensions.markSalesforceDeleted({
+        salesforceIds: ["campaign:001A", "campaign:002B"],
+        deletedAt,
+      }),
+    ).resolves.toBe(0);
+    await expect(
+      repositories.projectDimensions.markSalesforceDeleted({
+        salesforceIds: [],
+        deletedAt,
+      }),
+    ).resolves.toBe(0);
+    await expect(
+      repositories.projectDimensions.markSalesforceDeleted({
+        salesforceIds: ["does-not-exist"],
+        deletedAt,
+      }),
+    ).resolves.toBe(0);
+  });
+
+  it("does not tombstone manual project rows when the source guard rejects them", async () => {
+    const { repositories } = await createTestStage1Context();
+    const deletedAt = "2026-06-03T12:34:56.000Z";
+
+    await repositories.projectDimensions.upsert({
+      projectId: "shared-id-001",
+      projectName: "Salesforce Campaign A",
+      source: "salesforce",
+    });
+    await repositories.projectDimensions.upsert({
+      projectId: "manual-001",
+      projectName: "Manual Project",
+      source: "manual",
+    });
+
+    await expect(
+      repositories.projectDimensions.markSalesforceDeleted({
+        salesforceIds: ["manual-001"],
+        deletedAt,
+      }),
+    ).resolves.toBe(0);
+    await expect(
+      repositories.projectDimensions.findById("manual-001"),
+    ).resolves.toMatchObject({
+      salesforceDeletedAt: null,
+    });
+  });
+
+  it("marks salesforce projects reconciled and refreshes the timestamp on repeat runs", async () => {
+    const { repositories } = await createTestStage1Context();
+    const firstReconciledAt = "2026-06-04T08:00:00.000Z";
+    const secondReconciledAt = "2026-06-04T09:00:00.000Z";
+
+    await repositories.projectDimensions.upsert({
+      projectId: "campaign:001A",
+      projectName: "Salesforce Campaign A",
+      source: "salesforce",
+    });
+
+    await expect(
+      repositories.projectDimensions.markSalesforceReconciled({
+        salesforceIds: ["campaign:001A"],
+        reconciledAt: firstReconciledAt,
+      }),
+    ).resolves.toBe(1);
+    await expect(
+      repositories.projectDimensions.findById("campaign:001A"),
+    ).resolves.toMatchObject({
+      salesforceDeletedAt: null,
+      salesforceReconciledAt: firstReconciledAt,
+    });
+
+    await expect(
+      repositories.projectDimensions.markSalesforceReconciled({
+        salesforceIds: ["campaign:001A"],
+        reconciledAt: secondReconciledAt,
+      }),
+    ).resolves.toBe(1);
+    await expect(
+      repositories.projectDimensions.findById("campaign:001A"),
+    ).resolves.toMatchObject({
+      salesforceDeletedAt: null,
+      salesforceReconciledAt: secondReconciledAt,
+    });
+
+    await expect(
+      repositories.projectDimensions.markSalesforceReconciled({
+        salesforceIds: [],
+        reconciledAt: secondReconciledAt,
+      }),
+    ).resolves.toBe(0);
   });
 });

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -306,6 +306,36 @@ export interface ContactRepository {
   findByPrimaryPhone(phoneE164: string): Promise<ContactRecord | null>;
   listAll(): Promise<readonly ContactRecord[]>;
   listByIds(ids: readonly string[]): Promise<readonly ContactRecord[]>;
+  /**
+   * Returns the SF Contact IDs (e.g. `003VK00000mE06CYAS`) for every
+   * SF-anchored contact in our DB that has NOT been tombstoned. Used by
+   * the weekly reconciler to ask Salesforce "are these still there?"
+   *
+   * Excludes:
+   * - Contacts with `salesforce_contact_id IS NULL` (email-only / phone-only)
+   * - Contacts with `salesforce_deleted_at IS NOT NULL` (already tombstoned)
+   */
+  listSalesforceAnchoredIds(): Promise<readonly string[]>;
+  /**
+   * Sets `salesforce_deleted_at = deletedAt` on every row whose
+   * `salesforce_contact_id` is in the input list AND whose
+   * `salesforce_deleted_at IS NULL` (idempotent: re-running won't
+   * overwrite an earlier tombstone timestamp). Returns rows updated.
+   */
+  markSalesforceDeleted(input: {
+    readonly salesforceIds: readonly string[];
+    readonly deletedAt: string;
+  }): Promise<number>;
+  /**
+   * Sets `salesforce_reconciled_at = reconciledAt` on every row whose
+   * `salesforce_contact_id` is in the input list. Does NOT clear
+   * `salesforce_deleted_at` (un-tombstone is out of scope; if needed,
+   * future ops can clear it manually). Returns rows updated.
+   */
+  markSalesforceReconciled(input: {
+    readonly salesforceIds: readonly string[];
+    readonly reconciledAt: string;
+  }): Promise<number>;
   searchByQuery(input: {
     readonly query: string;
     readonly limit: number;
@@ -347,6 +377,15 @@ export interface ContactMembershipRepository {
   listByContactIds(
     contactIds: readonly string[],
   ): Promise<readonly ContactMembershipRecord[]>;
+  listSalesforceAnchoredIds(): Promise<readonly string[]>;
+  markSalesforceDeleted(input: {
+    readonly salesforceIds: readonly string[];
+    readonly deletedAt: string;
+  }): Promise<number>;
+  markSalesforceReconciled(input: {
+    readonly salesforceIds: readonly string[];
+    readonly reconciledAt: string;
+  }): Promise<number>;
   upsert(record: ContactMembershipRecord): Promise<ContactMembershipRecord>;
 }
 
@@ -424,6 +463,15 @@ export interface ProjectDimensionRepository {
   listByIds(
     projectIds: readonly string[],
   ): Promise<readonly ProjectDimensionRecord[]>;
+  listSalesforceAnchoredIds(): Promise<readonly string[]>;
+  markSalesforceDeleted(input: {
+    readonly salesforceIds: readonly string[];
+    readonly deletedAt: string;
+  }): Promise<number>;
+  markSalesforceReconciled(input: {
+    readonly salesforceIds: readonly string[];
+    readonly reconciledAt: string;
+  }): Promise<number>;
   /**
    * Returns active projects whose `connected_to_project_id` points at the
    * given host. Ordered by project name.

--- a/packages/domain/test/normalization.test.ts
+++ b/packages/domain/test/normalization.test.ts
@@ -358,7 +358,9 @@ function buildContext(input: {
       Stage1RepositoryBundle["expeditionDimensions"]["upsert"]
     >[0],
   ) => void;
-  readonly onPendingOutboundConfirmed?: (record: PendingComposerOutboundRecord) => void;
+  readonly onPendingOutboundConfirmed?: (
+    record: PendingComposerOutboundRecord,
+  ) => void;
 }): TestContext {
   interface StoredInternalNote {
     readonly id: string;
@@ -373,7 +375,9 @@ function buildContext(input: {
   const contactRecords = new Map(
     (input.contacts ?? [contact]).map((entry) => [entry.id, entry]),
   );
-  const contactIdentityRecords = [...(input.contactIdentities ?? [emailIdentity])];
+  const contactIdentityRecords = [
+    ...(input.contactIdentities ?? [emailIdentity]),
+  ];
   const contactMembershipRecords = [...(input.contactMemberships ?? [])];
   const sourceEvidenceById = new Map(
     input.events.map((event) => [
@@ -401,10 +405,9 @@ function buildContext(input: {
   const canonicalEventsById = new Map(
     input.events.map((event) => [event.id, event]),
   );
-  const timelineRowsByCanonicalEventId = new Map<
-    string,
-    TimelineProjectionRow
-  >((input.timelineRows ?? []).map((row) => [row.canonicalEventId, row]));
+  const timelineRowsByCanonicalEventId = new Map<string, TimelineProjectionRow>(
+    (input.timelineRows ?? []).map((row) => [row.canonicalEventId, row]),
+  );
   const canonicalEventAudienceRowsByKey = new Map<
     string,
     CanonicalEventAudienceRecord
@@ -443,7 +446,8 @@ function buildContext(input: {
   const inboxProjectionByContactId = new Map(
     [
       ...(input.inboxProjections ?? []),
-      ...(input.existingProjection === undefined || input.existingProjection === null
+      ...(input.existingProjection === undefined ||
+      input.existingProjection === null
         ? []
         : [input.existingProjection]),
     ].map((projection) => [projection.contactId, projection]),
@@ -451,9 +455,12 @@ function buildContext(input: {
   let inboxSaveCount = 0;
 
   const listContacts = (): ContactRecord[] =>
-    [...contactRecords.values()].sort((left, right) => left.id.localeCompare(right.id));
-  const listContactIdentities = (): ContactIdentityRecord[] =>
-    [...contactIdentityRecords];
+    [...contactRecords.values()].sort((left, right) =>
+      left.id.localeCompare(right.id),
+    );
+  const listContactIdentities = (): ContactIdentityRecord[] => [
+    ...contactIdentityRecords,
+  ];
   const getInboxProjection = (contactId: string): InboxProjectionRow | null =>
     inboxProjectionByContactId.get(contactId) ?? null;
 
@@ -468,7 +475,8 @@ function buildContext(input: {
         const existing = sourceEvidenceByIdempotencyKey.get(
           record.idempotencyKey,
         );
-        const updated = existing === undefined ? record : { ...record, id: existing.id };
+        const updated =
+          existing === undefined ? record : { ...record, id: existing.id };
         sourceEvidenceById.set(updated.id, updated);
         sourceEvidenceByIdempotencyKey.set(updated.idempotencyKey, updated);
         return Promise.resolve(updated);
@@ -605,8 +613,9 @@ function buildContext(input: {
         ),
       findByPrimaryPhone: (phoneE164) =>
         Promise.resolve(
-          listContacts().find((contact) => contact.primaryPhone === phoneE164) ??
-            null,
+          listContacts().find(
+            (contact) => contact.primaryPhone === phoneE164,
+          ) ?? null,
         ),
       listAll: () => Promise.resolve(listContacts()),
       listByIds: (ids) =>
@@ -615,6 +624,9 @@ function buildContext(input: {
             .map((id) => contactRecords.get(id))
             .filter((entry): entry is ContactRecord => entry !== undefined),
         ),
+      listSalesforceAnchoredIds: () => Promise.resolve([]),
+      markSalesforceDeleted: () => Promise.resolve(0),
+      markSalesforceReconciled: () => Promise.resolve(0),
       searchByQuery: () => Promise.resolve(listContacts()),
       searchInboxUnified: () =>
         Promise.resolve({
@@ -645,7 +657,10 @@ function buildContext(input: {
       }
 
       let timelineRowsRepointed = 0;
-      for (const [canonicalEventId, row] of timelineRowsByCanonicalEventId.entries()) {
+      for (const [
+        canonicalEventId,
+        row,
+      ] of timelineRowsByCanonicalEventId.entries()) {
         if (row.contactId !== mergeInput.emailOnlyContactId) {
           continue;
         }
@@ -698,13 +713,16 @@ function buildContext(input: {
                   ? mergeInput.anchoredContactId
                   : contactId,
               )
-              .filter((contactId) => contactId !== mergeInput.emailOnlyContactId),
+              .filter(
+                (contactId) => contactId !== mergeInput.emailOnlyContactId,
+              ),
           ),
         ];
 
         if (
           nextAnchoredContactId === identityCase.anchoredContactId &&
-          nextCandidateContactIds.length === identityCase.candidateContactIds.length &&
+          nextCandidateContactIds.length ===
+            identityCase.candidateContactIds.length &&
           nextCandidateContactIds.every(
             (contactId, index) =>
               contactId === identityCase.candidateContactIds[index],
@@ -721,10 +739,19 @@ function buildContext(input: {
         });
       }
 
-      const contactDeleted = contactRecords.delete(mergeInput.emailOnlyContactId);
+      const contactDeleted = contactRecords.delete(
+        mergeInput.emailOnlyContactId,
+      );
       inboxProjectionByContactId.delete(mergeInput.emailOnlyContactId);
-      for (let index = contactIdentityRecords.length - 1; index >= 0; index -= 1) {
-        if (contactIdentityRecords[index]?.contactId === mergeInput.emailOnlyContactId) {
+      for (
+        let index = contactIdentityRecords.length - 1;
+        index >= 0;
+        index -= 1
+      ) {
+        if (
+          contactIdentityRecords[index]?.contactId ===
+          mergeInput.emailOnlyContactId
+        ) {
           contactIdentityRecords.splice(index, 1);
         }
       }
@@ -780,6 +807,9 @@ function buildContext(input: {
             contactIds.includes(record.contactId),
           ),
         ),
+      listSalesforceAnchoredIds: () => Promise.resolve([]),
+      markSalesforceDeleted: () => Promise.resolve(0),
+      markSalesforceReconciled: () => Promise.resolve(0),
       upsert: (record: ContactMembershipRecord) => {
         input.onContactMembershipUpsert?.(record);
         const existingIndex = contactMembershipRecords.findIndex(
@@ -819,6 +849,9 @@ function buildContext(input: {
       listActive: () => Promise.resolve([]),
       listAllProjectAliases: () => Promise.resolve(input.projectAliases ?? []),
       listByIds: () => Promise.resolve([]),
+      listSalesforceAnchoredIds: () => Promise.resolve([]),
+      markSalesforceDeleted: () => Promise.resolve(0),
+      markSalesforceReconciled: () => Promise.resolve(0),
       listConnectedProjects: () => Promise.resolve([]),
       listAvailableConnectionCandidates: () => Promise.resolve([]),
       findEffectiveAiKnowledge: () => Promise.resolve(null),
@@ -1212,8 +1245,7 @@ function buildContext(input: {
         Promise.resolve(
           auditEvidenceRecords.filter(
             (record) =>
-              record.entityType === entityType &&
-              record.entityId === entityId,
+              record.entityType === entityType && record.entityId === entityId,
           ),
         ),
       listByEntities: ({ entityType, entityIds }) =>
@@ -2336,7 +2368,9 @@ describe("identity resolution hardening", () => {
     expect(context.getTimelineRow(strandedInbound.id)?.contactId).toBe(
       sfAnchoredContact.id,
     );
-    expect(context.getInboxProjectionForContact(emailOnlyContact.id)).toBeNull();
+    expect(
+      context.getInboxProjectionForContact(emailOnlyContact.id),
+    ).toBeNull();
 
     const anchoredProjection = context.getInboxProjectionForContact(
       sfAnchoredContact.id,
@@ -2345,14 +2379,16 @@ describe("identity resolution hardening", () => {
     expect(anchoredProjection?.lastInboundAt).toBe(strandedInbound.occurredAt);
 
     expect(
-      context.getAuditEvidence().find(
-        (record) =>
-          record.policyCode ===
-            "stage1.identity.auto_merge_email_only_into_salesforce_anchored" &&
-          record.entityType === "contact_merge" &&
-          record.entityId ===
-            `${emailOnlyContact.id}->${sfAnchoredContact.id}`,
-      ),
+      context
+        .getAuditEvidence()
+        .find(
+          (record) =>
+            record.policyCode ===
+              "stage1.identity.auto_merge_email_only_into_salesforce_anchored" &&
+            record.entityType === "contact_merge" &&
+            record.entityId ===
+              `${emailOnlyContact.id}->${sfAnchoredContact.id}`,
+        ),
     ).toBeDefined();
   });
 
@@ -2482,15 +2518,19 @@ describe("identity resolution hardening", () => {
       contactIdentities: [legacyIdentity],
     });
 
-    const resolved = await context.normalization.ensureCanonicalContactForEmail({
-      emailAddress: "or-rural-coordinator@example.org",
-      createdAt: "2026-05-31T12:00:00.000Z",
-      source: "gmail",
-      observedDisplayName: "Scotty Stalp",
-    });
+    const resolved = await context.normalization.ensureCanonicalContactForEmail(
+      {
+        emailAddress: "or-rural-coordinator@example.org",
+        createdAt: "2026-05-31T12:00:00.000Z",
+        source: "gmail",
+        observedDisplayName: "Scotty Stalp",
+      },
+    );
 
     expect(resolved.displayName).toBe("Scotty Stalp");
-    expect(context.getContact(legacyContact.id)?.displayName).toBe("Scotty Stalp");
+    expect(context.getContact(legacyContact.id)?.displayName).toBe(
+      "Scotty Stalp",
+    );
   });
 
   it("updates an existing contact when displayName equals the primary email", async () => {
@@ -2510,12 +2550,14 @@ describe("identity resolution hardening", () => {
       contactIdentities: [emailNamedIdentity],
     });
 
-    const resolved = await context.normalization.ensureCanonicalContactForEmail({
-      emailAddress: "or-rural-coordinator@example.org",
-      createdAt: "2026-05-31T12:00:00.000Z",
-      source: "gmail",
-      observedDisplayName: "Scotty Stalp",
-    });
+    const resolved = await context.normalization.ensureCanonicalContactForEmail(
+      {
+        emailAddress: "or-rural-coordinator@example.org",
+        createdAt: "2026-05-31T12:00:00.000Z",
+        source: "gmail",
+        observedDisplayName: "Scotty Stalp",
+      },
+    );
 
     expect(resolved.displayName).toBe("Scotty Stalp");
     expect(context.getContact(emailNamedContact.id)?.displayName).toBe(
@@ -2541,12 +2583,14 @@ describe("identity resolution hardening", () => {
       ],
     });
 
-    const resolved = await context.normalization.ensureCanonicalContactForEmail({
-      emailAddress: "or-rural-coordinator@example.org",
-      createdAt: "2026-05-31T12:00:00.000Z",
-      source: "gmail",
-      observedDisplayName: "Scotty Stalp",
-    });
+    const resolved = await context.normalization.ensureCanonicalContactForEmail(
+      {
+        emailAddress: "or-rural-coordinator@example.org",
+        createdAt: "2026-05-31T12:00:00.000Z",
+        source: "gmail",
+        observedDisplayName: "Scotty Stalp",
+      },
+    );
 
     expect(resolved.displayName).toBe("Scott Stalp");
   });
@@ -2642,7 +2686,9 @@ describe("identity resolution hardening", () => {
         identity: {
           salesforceContactId: null,
           volunteerIdPlainValues: [],
-          normalizedEmails: [...(input?.identityEmails ?? ["sender@example.org"])],
+          normalizedEmails: [
+            ...(input?.identityEmails ?? ["sender@example.org"]),
+          ],
           normalizedPhones: [],
         },
         supportingSources: [],
@@ -2902,7 +2948,9 @@ describe("pending composer outbound reconciliation", () => {
     });
 
     if (fingerprint === null) {
-      throw new Error("Expected fingerprint to be computed for pending outbound.");
+      throw new Error(
+        "Expected fingerprint to be computed for pending outbound.",
+      );
     }
 
     const context = buildContext({
@@ -2972,7 +3020,9 @@ describe("pending composer outbound reconciliation", () => {
     });
 
     if (fingerprint === null) {
-      throw new Error("Expected fingerprint to be computed for pending outbound.");
+      throw new Error(
+        "Expected fingerprint to be computed for pending outbound.",
+      );
     }
 
     const context = buildContext({
@@ -3062,12 +3112,12 @@ describe("pending composer outbound reconciliation", () => {
 
     expect(result.outcome).toBe("applied");
     expect(confirmedRows).toHaveLength(0);
-    expect(context.getPendingOutbound("pending:already-linked-rfc822")).toMatchObject(
-      {
-        status: "confirmed",
-        reconciledEventId: "event:existing-link",
-      },
-    );
+    expect(
+      context.getPendingOutbound("pending:already-linked-rfc822"),
+    ).toMatchObject({
+      status: "confirmed",
+      reconciledEventId: "event:existing-link",
+    });
 
     const matchedLog = consoleLog.mock.calls
       .map(([entry]) => JSON.parse(String(entry)) as Record<string, unknown>)

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -76,6 +76,9 @@ describe("defineStage1RepositoryBundle", () => {
         findByPrimaryPhone: () => Promise.resolve(contact),
         listAll: () => Promise.resolve([contact]),
         listByIds: () => Promise.resolve([contact]),
+        listSalesforceAnchoredIds: () => Promise.resolve([]),
+        markSalesforceDeleted: () => Promise.resolve(0),
+        markSalesforceReconciled: () => Promise.resolve(0),
         searchByQuery: () => Promise.resolve([contact]),
         searchInboxUnified: () =>
           Promise.resolve({
@@ -93,6 +96,9 @@ describe("defineStage1RepositoryBundle", () => {
       contactMemberships: {
         listByContactId: () => Promise.resolve([]),
         listByContactIds: () => Promise.resolve([]),
+        listSalesforceAnchoredIds: () => Promise.resolve([]),
+        markSalesforceDeleted: () => Promise.resolve(0),
+        markSalesforceReconciled: () => Promise.resolve(0),
         upsert: (record) => Promise.resolve(record),
       },
       smsMessages: {
@@ -121,6 +127,9 @@ describe("defineStage1RepositoryBundle", () => {
         listActive: () => Promise.resolve([]),
         listAllProjectAliases: () => Promise.resolve([]),
         listByIds: () => Promise.resolve([]),
+        listSalesforceAnchoredIds: () => Promise.resolve([]),
+        markSalesforceDeleted: () => Promise.resolve(0),
+        markSalesforceReconciled: () => Promise.resolve(0),
         listConnectedProjects: () => Promise.resolve([]),
         listAvailableConnectionCandidates: () => Promise.resolve([]),
         findEffectiveAiKnowledge: () => Promise.resolve(null),
@@ -171,7 +180,8 @@ describe("defineStage1RepositoryBundle", () => {
             unsubscribed: 0,
             distinctMembers: 0,
           }),
-        listRecipientsForCampaign: () => Promise.resolve({ rows: [], total: 0 }),
+        listRecipientsForCampaign: () =>
+          Promise.resolve({ rows: [], total: 0 }),
       },
       manualNoteDetails: {
         listBySourceEvidenceIds: () => Promise.resolve([]),
@@ -282,7 +292,7 @@ describe("defineStage1RepositoryBundle", () => {
             total: 0,
             latestUpdatedAt: null,
             latestSortKey: null,
-        }),
+          }),
         upsert: (record) => Promise.resolve(record),
       },
       canonicalEventAudience: {

--- a/packages/domain/test/stage3-last-inbound-alias.test.ts
+++ b/packages/domain/test/stage3-last-inbound-alias.test.ts
@@ -95,6 +95,9 @@ function buildRepositoryBundle(input: {
       findByPrimaryPhone: () => Promise.resolve(contact),
       listAll: () => Promise.resolve([contact]),
       listByIds: () => Promise.resolve([contact]),
+      listSalesforceAnchoredIds: () => Promise.resolve([]),
+      markSalesforceDeleted: () => Promise.resolve(0),
+      markSalesforceReconciled: () => Promise.resolve(0),
       searchByQuery: () => Promise.resolve([contact]),
       searchInboxUnified: () =>
         Promise.resolve({
@@ -112,6 +115,9 @@ function buildRepositoryBundle(input: {
     contactMemberships: {
       listByContactId: () => Promise.resolve([]),
       listByContactIds: () => Promise.resolve([]),
+      listSalesforceAnchoredIds: () => Promise.resolve([]),
+      markSalesforceDeleted: () => Promise.resolve(0),
+      markSalesforceReconciled: () => Promise.resolve(0),
       upsert: (record) => Promise.resolve(record),
     },
     smsMessages: {
@@ -140,6 +146,9 @@ function buildRepositoryBundle(input: {
       listActive: () => Promise.resolve([]),
       listAllProjectAliases: () => Promise.resolve([]),
       listByIds: () => Promise.resolve([]),
+      listSalesforceAnchoredIds: () => Promise.resolve([]),
+      markSalesforceDeleted: () => Promise.resolve(0),
+      markSalesforceReconciled: () => Promise.resolve(0),
       listConnectedProjects: () => Promise.resolve([]),
       listAvailableConnectionCandidates: () => Promise.resolve([]),
       findEffectiveAiKnowledge: () => Promise.resolve(null),
@@ -305,7 +314,7 @@ function buildRepositoryBundle(input: {
           total: 0,
           latestUpdatedAt: null,
           latestSortKey: null,
-      }),
+        }),
       upsert: (record) => Promise.resolve(record),
     },
     canonicalEventAudience: {

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -172,6 +172,9 @@ function createRepositoryBundle(input: {
       findByPrimaryPhone: () => Promise.resolve(contact),
       listAll: () => Promise.resolve([contact]),
       listByIds: () => Promise.resolve([contact]),
+      listSalesforceAnchoredIds: () => Promise.resolve([]),
+      markSalesforceDeleted: () => Promise.resolve(0),
+      markSalesforceReconciled: () => Promise.resolve(0),
       searchByQuery: () => Promise.resolve([contact]),
       searchInboxUnified: () =>
         Promise.resolve({
@@ -189,6 +192,9 @@ function createRepositoryBundle(input: {
     contactMemberships: {
       listByContactId: () => Promise.resolve([]),
       listByContactIds: () => Promise.resolve([]),
+      listSalesforceAnchoredIds: () => Promise.resolve([]),
+      markSalesforceDeleted: () => Promise.resolve(0),
+      markSalesforceReconciled: () => Promise.resolve(0),
       upsert: (record) => Promise.resolve(record),
     },
     smsMessages: {
@@ -217,6 +223,9 @@ function createRepositoryBundle(input: {
       listActive: () => Promise.resolve([]),
       listAllProjectAliases: () => Promise.resolve([]),
       listByIds: () => Promise.resolve([]),
+      listSalesforceAnchoredIds: () => Promise.resolve([]),
+      markSalesforceDeleted: () => Promise.resolve(0),
+      markSalesforceReconciled: () => Promise.resolve(0),
       listConnectedProjects: () => Promise.resolve([]),
       listAvailableConnectionCandidates: () => Promise.resolve([]),
       findEffectiveAiKnowledge: () => Promise.resolve(null),
@@ -1858,15 +1867,15 @@ describe("Stage 1 timeline presenter", () => {
               : repositories.contacts.findById(contactId),
           ),
         listByIds: (contactIds) =>
-          Promise.all(contactIds.map((contactId) => {
-            if (contactId === audienceContact.id) {
-              return Promise.resolve(audienceContact);
-            }
+          Promise.all(
+            contactIds.map((contactId) => {
+              if (contactId === audienceContact.id) {
+                return Promise.resolve(audienceContact);
+              }
 
-            return repositories.contacts.findById(contactId);
-          })).then((contacts) =>
-            contacts.filter((contact) => contact !== null),
-          ),
+              return repositories.contacts.findById(contactId);
+            }),
+          ).then((contacts) => contacts.filter((contact) => contact !== null)),
       },
       canonicalEvents: {
         ...repositories.canonicalEvents,
@@ -1888,12 +1897,15 @@ describe("Stage 1 timeline presenter", () => {
             : repositories.timelineProjection.listByContactId(contactId),
       },
     });
-    const presenter = createStage1TimelinePresentationService(fanoutRepositories);
+    const presenter =
+      createStage1TimelinePresentationService(fanoutRepositories);
     const warnSpy = vi
       .spyOn(console, "warn")
       .mockImplementation(() => undefined);
 
-    const items = await presenter.listTimelineItemsByContactId(audienceContact.id);
+    const items = await presenter.listTimelineItemsByContactId(
+      audienceContact.id,
+    );
     const page = await presenter.listTimelineItemsPageByContactId(
       audienceContact.id,
       {

--- a/packages/integrations/src/capture-services/salesforce-state-diff.ts
+++ b/packages/integrations/src/capture-services/salesforce-state-diff.ts
@@ -1,0 +1,67 @@
+export interface SalesforceRowSnapshot {
+  /** Salesforce record ID (e.g. `003VK00000mE06CYAS`). */
+  readonly id: string;
+  /** True if Salesforce returned this row with `IsDeleted = true`. */
+  readonly isDeleted: boolean;
+}
+
+export interface SalesforceStateDiff {
+  /** SF IDs that exist in both SF (non-deleted) and our DB. */
+  readonly presentInBoth: readonly string[];
+  /**
+   * SF IDs we have locally where SF either returned `IsDeleted = true`
+   * OR did not return the row at all. Both cases mean: tombstone our
+   * row. (We can't distinguish "soft-deleted" from "purged from Recycle
+   * Bin" cleanly enough to matter for reconciliation.)
+   */
+  readonly deletedInSalesforce: readonly string[];
+  /**
+   * SF IDs that exist in SF (non-deleted) but not in our DB. Logged
+   * for visibility; Brick 2b doesn't act on these (re-ingest is a v2
+   * concern).
+   */
+  readonly missingLocally: readonly string[];
+}
+
+export function diffSalesforceState(input: {
+  readonly salesforceRows: readonly SalesforceRowSnapshot[];
+  readonly databaseIds: readonly string[];
+}): SalesforceStateDiff {
+  const salesforceRowsById = new Map<string, boolean>();
+  for (const row of input.salesforceRows) {
+    salesforceRowsById.set(row.id, row.isDeleted);
+  }
+
+  const databaseIdSet = new Set(input.databaseIds);
+  const presentInBoth: string[] = [];
+  const deletedInSalesforce: string[] = [];
+
+  for (const databaseId of databaseIdSet) {
+    const salesforceDeleted = salesforceRowsById.get(databaseId);
+    if (salesforceDeleted === false) {
+      presentInBoth.push(databaseId);
+      continue;
+    }
+
+    deletedInSalesforce.push(databaseId);
+  }
+
+  const missingLocally: string[] = [];
+  for (const [salesforceId, isDeleted] of salesforceRowsById) {
+    if (isDeleted || databaseIdSet.has(salesforceId)) {
+      continue;
+    }
+
+    missingLocally.push(salesforceId);
+  }
+
+  presentInBoth.sort();
+  deletedInSalesforce.sort();
+  missingLocally.sort();
+
+  return {
+    presentInBoth,
+    deletedInSalesforce,
+    missingLocally,
+  };
+}

--- a/packages/integrations/src/capture-services/salesforce.ts
+++ b/packages/integrations/src/capture-services/salesforce.ts
@@ -111,6 +111,16 @@ export interface SalesforceTaskChannelConfig {
 
 export interface SalesforceApiClient {
   queryAll(soql: string): Promise<readonly SalesforceRow[]>;
+  /**
+   * Hits Salesforce's `/services/data/v<api>/queryAll` endpoint, which
+   * unlike `/query` returns rows where `IsDeleted = true` and rows
+   * where `IsArchived = true`. Use this for reconciliation queries
+   * that need to distinguish "still exists" from "soft-deleted" from
+   * "missing entirely." For all other reads, prefer `queryAll` (the
+   * existing method, despite the name, hits `/query` and excludes
+   * deleted rows).
+   */
+  queryAllIncludingDeleted(soql: string): Promise<readonly SalesforceRow[]>;
 }
 
 interface SalesforceAccessTokenCacheEntry {
@@ -700,6 +710,66 @@ export function createSalesforceApiClient(
       const records: SalesforceRow[] = [];
       let nextUrl = new URL(
         `/services/data/v${parsedConfig.apiVersion}/query?q=${encodeURIComponent(soql)}`,
+        token.instanceUrl,
+      ).toString();
+
+      while (nextUrl.length > 0) {
+        const response = await fetchImplementation(nextUrl, {
+          headers: {
+            authorization: `Bearer ${token.accessToken}`,
+            accept: "application/json",
+          },
+          signal: AbortSignal.timeout(parsedConfig.timeoutMs),
+        });
+
+        if (!response.ok) {
+          const errorBodyText = await response.text();
+          const errorBodyPreview = errorBodyText.slice(0, 1000);
+          throw new Error(
+            `Salesforce query failed with status ${String(response.status)}. Body: ${errorBodyPreview}. SOQL: ${soql.slice(0, 500)}`,
+          );
+        }
+
+        const queryPayload: unknown = JSON.parse(await response.text());
+        const queryResponse = salesforceQueryResponseSchema.parse(queryPayload);
+        records.push(...queryResponse.records);
+        if (queryResponse.nextRecordsUrl === undefined) {
+          nextUrl = "";
+          continue;
+        }
+
+        const resolvedNextUrl = new URL(
+          queryResponse.nextRecordsUrl,
+          token.instanceUrl,
+        );
+        if (resolvedNextUrl.origin !== expectedInstanceOrigin) {
+          throw new SalesforcePaginationOriginError({
+            expectedOrigin: expectedInstanceOrigin,
+            resolvedUrl: resolvedNextUrl.toString(),
+            reason: "origin",
+          });
+        }
+
+        if (!resolvedNextUrl.pathname.startsWith("/services/data/")) {
+          throw new SalesforcePaginationOriginError({
+            expectedOrigin: expectedInstanceOrigin,
+            resolvedUrl: resolvedNextUrl.toString(),
+            reason: "path",
+          });
+        }
+
+        nextUrl = resolvedNextUrl.toString();
+      }
+
+      return records;
+    },
+
+    async queryAllIncludingDeleted(soql) {
+      const token = await getAccessToken();
+      const expectedInstanceOrigin = new URL(token.instanceUrl).origin;
+      const records: SalesforceRow[] = [];
+      let nextUrl = new URL(
+        `/services/data/v${parsedConfig.apiVersion}/queryAll?q=${encodeURIComponent(soql)}`,
         token.instanceUrl,
       ).toString();
 

--- a/packages/integrations/test/salesforce-state-diff.test.ts
+++ b/packages/integrations/test/salesforce-state-diff.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  diffSalesforceState,
+  type SalesforceRowSnapshot,
+} from "../src/capture-services/salesforce-state-diff.js";
+
+describe("diffSalesforceState", () => {
+  it("returns empty partitions when both inputs are empty", () => {
+    expect(
+      diffSalesforceState({
+        salesforceRows: [],
+        databaseIds: [],
+      }),
+    ).toEqual({
+      presentInBoth: [],
+      deletedInSalesforce: [],
+      missingLocally: [],
+    });
+  });
+
+  it("places all ids in presentInBoth when every db row exists in salesforce", () => {
+    const salesforceRows: readonly SalesforceRowSnapshot[] = [
+      { id: "001A", isDeleted: false },
+      { id: "002B", isDeleted: false },
+    ];
+
+    expect(
+      diffSalesforceState({
+        salesforceRows,
+        databaseIds: ["001A", "002B"],
+      }),
+    ).toEqual({
+      presentInBoth: ["001A", "002B"],
+      deletedInSalesforce: [],
+      missingLocally: [],
+    });
+  });
+
+  it("treats salesforce soft-deleted rows as deleted locally", () => {
+    const salesforceRows: readonly SalesforceRowSnapshot[] = [
+      { id: "001A", isDeleted: false },
+      { id: "002B", isDeleted: true },
+    ];
+
+    expect(
+      diffSalesforceState({
+        salesforceRows,
+        databaseIds: ["001A", "002B"],
+      }),
+    ).toEqual({
+      presentInBoth: ["001A"],
+      deletedInSalesforce: ["002B"],
+      missingLocally: [],
+    });
+  });
+
+  it("treats database ids missing from salesforce as deleted", () => {
+    expect(
+      diffSalesforceState({
+        salesforceRows: [{ id: "001A", isDeleted: false }],
+        databaseIds: ["001A", "002B"],
+      }),
+    ).toEqual({
+      presentInBoth: ["001A"],
+      deletedInSalesforce: ["002B"],
+      missingLocally: [],
+    });
+  });
+
+  it("reports non-deleted salesforce-only ids as missing locally", () => {
+    expect(
+      diffSalesforceState({
+        salesforceRows: [{ id: "003C", isDeleted: false }],
+        databaseIds: [],
+      }),
+    ).toEqual({
+      presentInBoth: [],
+      deletedInSalesforce: [],
+      missingLocally: ["003C"],
+    });
+  });
+
+  it("drops deleted salesforce-only ids silently", () => {
+    expect(
+      diffSalesforceState({
+        salesforceRows: [{ id: "004D", isDeleted: true }],
+        databaseIds: [],
+      }),
+    ).toEqual({
+      presentInBoth: [],
+      deletedInSalesforce: [],
+      missingLocally: [],
+    });
+  });
+
+  it("deduplicates duplicate database ids", () => {
+    expect(
+      diffSalesforceState({
+        salesforceRows: [{ id: "001A", isDeleted: false }],
+        databaseIds: ["001A", "001A", "001A"],
+      }),
+    ).toEqual({
+      presentInBoth: ["001A"],
+      deletedInSalesforce: [],
+      missingLocally: [],
+    });
+  });
+
+  it("uses last-write-wins for duplicate salesforce ids with conflicting delete flags", () => {
+    expect(
+      diffSalesforceState({
+        salesforceRows: [
+          { id: "001A", isDeleted: true },
+          { id: "001A", isDeleted: false },
+        ],
+        databaseIds: ["001A"],
+      }),
+    ).toEqual({
+      presentInBoth: ["001A"],
+      deletedInSalesforce: [],
+      missingLocally: [],
+    });
+  });
+
+  it("sorts every output partition ascending", () => {
+    expect(
+      diffSalesforceState({
+        salesforceRows: [
+          { id: "d", isDeleted: false },
+          { id: "b", isDeleted: false },
+          { id: "z", isDeleted: false },
+        ],
+        databaseIds: ["d", "c", "b"],
+      }),
+    ).toEqual({
+      presentInBoth: ["b", "d"],
+      deletedInSalesforce: ["c"],
+      missingLocally: ["z"],
+    });
+  });
+
+  it("partitions a realistic mixed scenario exactly", () => {
+    expect(
+      diffSalesforceState({
+        salesforceRows: [
+          { id: "a", isDeleted: true },
+          { id: "b", isDeleted: false },
+          { id: "c", isDeleted: false },
+          { id: "f", isDeleted: false },
+          { id: "g", isDeleted: true },
+        ],
+        databaseIds: ["a", "b", "c", "d", "e"],
+      }),
+    ).toEqual({
+      presentInBoth: ["b", "c"],
+      deletedInSalesforce: ["a", "d", "e"],
+      missingLocally: ["f"],
+    });
+  });
+});

--- a/packages/integrations/test/stage1-salesforce-capture-service.test.ts
+++ b/packages/integrations/test/stage1-salesforce-capture-service.test.ts
@@ -106,6 +106,15 @@ function createFetchFromService(
   };
 }
 
+function createStubSalesforceApiClient(
+  queryAll: SalesforceApiClient["queryAll"],
+): SalesforceApiClient {
+  return {
+    queryAll,
+    queryAllIncludingDeleted: queryAll,
+  };
+}
+
 function createFakeSalesforceApiClient(): SalesforceApiClient {
   const contactRow = {
     Id: "003-stage1",
@@ -144,53 +153,47 @@ function createFakeSalesforceApiClient(): SalesforceApiClient {
     LastModifiedDate: "2026-01-05T00:03:00.000Z",
   };
 
-  return {
-    queryAll(soql) {
-      if (soql.includes(" FROM Contact ")) {
-        if (soql.includes(" WHERE Id IN ")) {
-          return Promise.resolve(
-            soql.includes("'003-stage1'") ? [contactRow] : [],
-          );
-        }
-
-        return Promise.resolve([contactRow]);
+  return createStubSalesforceApiClient((soql) => {
+    if (soql.includes(" FROM Contact ")) {
+      if (soql.includes(" WHERE Id IN ")) {
+        return Promise.resolve(
+          soql.includes("'003-stage1'") ? [contactRow] : [],
+        );
       }
 
-      if (soql.includes(" FROM Task ")) {
-        if (soql.includes(" WHERE Id IN ")) {
-          return Promise.resolve(
-            soql.includes("'00T-task-1'") ? [taskRow] : [],
-          );
-        }
+      return Promise.resolve([contactRow]);
+    }
 
-        if (soql.includes(" WHERE WhoId IN ")) {
-          return Promise.resolve(
-            soql.includes("'003-stage1'") ? [taskRow] : [],
-          );
-        }
-
-        return Promise.resolve([taskRow]);
+    if (soql.includes(" FROM Task ")) {
+      if (soql.includes(" WHERE Id IN ")) {
+        return Promise.resolve(soql.includes("'00T-task-1'") ? [taskRow] : []);
       }
 
-      if (soql.includes(" FROM Expedition_Members__c ")) {
-        if (soql.includes(" WHERE Id IN ")) {
-          return Promise.resolve(
-            soql.includes("'a01-membership-1'") ? [membershipRow] : [],
-          );
-        }
-
-        if (soql.includes(" WHERE Contact__c IN ")) {
-          return Promise.resolve(
-            soql.includes("'003-stage1'") ? [membershipRow] : [],
-          );
-        }
-
-        return Promise.resolve([membershipRow]);
+      if (soql.includes(" WHERE WhoId IN ")) {
+        return Promise.resolve(soql.includes("'003-stage1'") ? [taskRow] : []);
       }
 
-      return Promise.resolve([]);
-    },
-  };
+      return Promise.resolve([taskRow]);
+    }
+
+    if (soql.includes(" FROM Expedition_Members__c ")) {
+      if (soql.includes(" WHERE Id IN ")) {
+        return Promise.resolve(
+          soql.includes("'a01-membership-1'") ? [membershipRow] : [],
+        );
+      }
+
+      if (soql.includes(" WHERE Contact__c IN ")) {
+        return Promise.resolve(
+          soql.includes("'003-stage1'") ? [membershipRow] : [],
+        );
+      }
+
+      return Promise.resolve([membershipRow]);
+    }
+
+    return Promise.resolve([]);
+  });
 }
 
 function extractQuotedIds(soql: string): string[] {
@@ -226,12 +229,10 @@ describe("Salesforce capture service", () => {
     const service = createSalesforceCaptureService(
       createSalesforceServiceConfig(),
       {
-        apiClient: {
-          queryAll: () => {
-            queryCount += 1;
-            return Promise.resolve([]);
-          },
-        },
+        apiClient: createStubSalesforceApiClient(() => {
+          queryCount += 1;
+          return Promise.resolve([]);
+        }),
       },
     );
 
@@ -273,11 +274,9 @@ describe("Salesforce capture service", () => {
     const service = createSalesforceCaptureService(
       createSalesforceServiceConfig(),
       {
-        apiClient: {
-          queryAll: () => {
-            throw new Error("Salesforce query failed");
-          },
-        },
+        apiClient: createStubSalesforceApiClient(() => {
+          throw new Error("Salesforce query failed");
+        }),
       },
     );
 
@@ -315,54 +314,52 @@ describe("Salesforce capture service", () => {
     const service = createSalesforceCaptureService(
       createSalesforceServiceConfig(),
       {
-        apiClient: {
-          queryAll(soql) {
-            if (soql.includes(" FROM Contact ")) {
-              return Promise.resolve([
-                {
-                  Id: "003-stage1",
-                  Name: "Stage One Volunteer",
-                  Email: "volunteer@example.org",
-                  CreatedDate: "2026-01-01T00:00:00.000Z",
-                  LastModifiedDate: "2026-01-05T00:00:00.000Z"
-                }
-              ]);
-            }
+        apiClient: createStubSalesforceApiClient((soql) => {
+          if (soql.includes(" FROM Contact ")) {
+            return Promise.resolve([
+              {
+                Id: "003-stage1",
+                Name: "Stage One Volunteer",
+                Email: "volunteer@example.org",
+                CreatedDate: "2026-01-01T00:00:00.000Z",
+                LastModifiedDate: "2026-01-05T00:00:00.000Z",
+              },
+            ]);
+          }
 
-            if (soql.includes(" FROM Task ")) {
-              return Promise.resolve([
-                {
-                  Id: "00T-task-oversized-1",
-                  WhoId: "003-stage1",
-                  OwnerId: "005-nim-admin",
-                  Owner: {
-                    Name: "Nim Admin",
-                    Username: "admin+1@adventurescientists.org"
-                  },
-                  TaskSubtype: "Email",
-                  Subject: "Outbound follow-up",
-                  Description: "x".repeat(100_001),
-                  CreatedDate: "2026-01-05T00:02:00.000Z",
-                  LastModifiedDate: "2026-01-05T00:03:00.000Z"
-                }
-              ]);
-            }
+          if (soql.includes(" FROM Task ")) {
+            return Promise.resolve([
+              {
+                Id: "00T-task-oversized-1",
+                WhoId: "003-stage1",
+                OwnerId: "005-nim-admin",
+                Owner: {
+                  Name: "Nim Admin",
+                  Username: "admin+1@adventurescientists.org",
+                },
+                TaskSubtype: "Email",
+                Subject: "Outbound follow-up",
+                Description: "x".repeat(100_001),
+                CreatedDate: "2026-01-05T00:02:00.000Z",
+                LastModifiedDate: "2026-01-05T00:03:00.000Z",
+              },
+            ]);
+          }
 
-            if (soql.includes(" FROM Expedition_Members__c ")) {
-              return Promise.resolve([]);
-            }
-
+          if (soql.includes(" FROM Expedition_Members__c ")) {
             return Promise.resolve([]);
           }
-        }
-      }
+
+          return Promise.resolve([]);
+        }),
+      },
     );
 
     const response = await service.handleHttpRequest({
       method: "POST",
       path: "/live",
       headers: {
-        authorization: "Bearer salesforce-token"
+        authorization: "Bearer salesforce-token",
       },
       bodyText: JSON.stringify({
         version: 1,
@@ -381,13 +378,13 @@ describe("Salesforce capture service", () => {
         windowStart: "2026-01-01T00:00:00.000Z",
         windowEnd: "2026-01-06T00:00:00.000Z",
         recordIds: [],
-        maxRecords: 25
-      })
+        maxRecords: 25,
+      }),
     });
 
     expect(response.status).toBe(400);
     expect(JSON.parse(response.body)).toMatchObject({
-      error: "invalid_request"
+      error: "invalid_request",
     });
   });
 
@@ -397,12 +394,10 @@ describe("Salesforce capture service", () => {
     const service = createSalesforceCaptureService(
       createSalesforceServiceConfig(),
       {
-        apiClient: {
-          queryAll: (soql) => {
-            queries.push(soql);
-            return baseApiClient.queryAll(soql);
-          },
-        },
+        apiClient: createStubSalesforceApiClient((soql) => {
+          queries.push(soql);
+          return baseApiClient.queryAll(soql);
+        }),
         now: () => new Date("2026-01-05T00:05:00.000Z"),
       },
     );
@@ -518,12 +513,10 @@ describe("Salesforce capture service", () => {
     const service = createSalesforceCaptureService(
       createSalesforceServiceConfig(),
       {
-        apiClient: {
-          queryAll: (soql) => {
-            queries.push(soql);
-            return baseApiClient.queryAll(soql);
-          },
-        },
+        apiClient: createStubSalesforceApiClient((soql) => {
+          queries.push(soql);
+          return baseApiClient.queryAll(soql);
+        }),
         now: () => new Date("2026-01-05T00:05:00.000Z"),
       },
     );
@@ -575,12 +568,10 @@ describe("Salesforce capture service", () => {
     const service = createSalesforceCaptureService(
       createSalesforceServiceConfig(),
       {
-        apiClient: {
-          queryAll: (soql) => {
-            queries.push(soql);
-            return baseApiClient.queryAll(soql);
-          },
-        },
+        apiClient: createStubSalesforceApiClient((soql) => {
+          queries.push(soql);
+          return baseApiClient.queryAll(soql);
+        }),
         now: () => new Date("2026-01-05T00:05:00.000Z"),
       },
     );
@@ -633,12 +624,10 @@ describe("Salesforce capture service", () => {
     const service = createSalesforceCaptureService(
       createSalesforceServiceConfig(),
       {
-        apiClient: {
-          queryAll: (soql) => {
-            queries.push(soql);
-            return baseApiClient.queryAll(soql);
-          },
-        },
+        apiClient: createStubSalesforceApiClient((soql) => {
+          queries.push(soql);
+          return baseApiClient.queryAll(soql);
+        }),
         now: () => new Date("2026-01-05T00:05:00.000Z"),
       },
     );
@@ -726,12 +715,10 @@ describe("Salesforce capture service", () => {
         membershipRoleField: null,
       },
       {
-        apiClient: {
-          queryAll: (soql) => {
-            queries.push(soql);
-            return baseApiClient.queryAll(soql);
-          },
-        },
+        apiClient: createStubSalesforceApiClient((soql) => {
+          queries.push(soql);
+          return baseApiClient.queryAll(soql);
+        }),
         now: () => new Date("2026-01-05T00:05:00.000Z"),
       },
     );
@@ -817,53 +804,51 @@ describe("Salesforce capture service", () => {
     const service = createSalesforceCaptureService(
       createSalesforceServiceConfig(),
       {
-        apiClient: {
-          queryAll: (soql) => {
-            if (soql.includes(" FROM Contact ")) {
-              if (soql.includes(" WHERE Id IN ")) {
-                return Promise.resolve(
-                  soql.includes("'003-auto'") ? [contactRow] : [],
-                );
-              }
-
-              return Promise.resolve([contactRow]);
+        apiClient: createStubSalesforceApiClient((soql) => {
+          if (soql.includes(" FROM Contact ")) {
+            if (soql.includes(" WHERE Id IN ")) {
+              return Promise.resolve(
+                soql.includes("'003-auto'") ? [contactRow] : [],
+              );
             }
 
-            if (soql.includes(" FROM Task ")) {
-              if (soql.includes(" WHERE Id IN ")) {
-                return Promise.resolve(
-                  soql.includes("'a01-membership-auto'") ? [] : [],
-                );
-              }
+            return Promise.resolve([contactRow]);
+          }
 
-              if (soql.includes(" WHERE WhoId IN ")) {
-                return Promise.resolve(
-                  soql.includes("'003-auto'") ? [autoEmailTaskRow] : [],
-                );
-              }
-
-              return Promise.resolve([autoEmailTaskRow]);
+          if (soql.includes(" FROM Task ")) {
+            if (soql.includes(" WHERE Id IN ")) {
+              return Promise.resolve(
+                soql.includes("'a01-membership-auto'") ? [] : [],
+              );
             }
 
-            if (soql.includes(" FROM Expedition_Members__c ")) {
-              if (soql.includes(" WHERE Id IN ")) {
-                return Promise.resolve(
-                  soql.includes("'a01-membership-auto'") ? [membershipRow] : [],
-                );
-              }
-
-              if (soql.includes(" WHERE Contact__c IN ")) {
-                return Promise.resolve(
-                  soql.includes("'003-auto'") ? [membershipRow] : [],
-                );
-              }
-
-              return Promise.resolve([membershipRow]);
+            if (soql.includes(" WHERE WhoId IN ")) {
+              return Promise.resolve(
+                soql.includes("'003-auto'") ? [autoEmailTaskRow] : [],
+              );
             }
 
-            return Promise.resolve([]);
-          },
-        },
+            return Promise.resolve([autoEmailTaskRow]);
+          }
+
+          if (soql.includes(" FROM Expedition_Members__c ")) {
+            if (soql.includes(" WHERE Id IN ")) {
+              return Promise.resolve(
+                soql.includes("'a01-membership-auto'") ? [membershipRow] : [],
+              );
+            }
+
+            if (soql.includes(" WHERE Contact__c IN ")) {
+              return Promise.resolve(
+                soql.includes("'003-auto'") ? [membershipRow] : [],
+              );
+            }
+
+            return Promise.resolve([membershipRow]);
+          }
+
+          return Promise.resolve([]);
+        }),
         now: () => new Date("2026-01-05T00:05:00.000Z"),
       },
     );
@@ -921,12 +906,10 @@ describe("Salesforce capture service", () => {
     const service = createSalesforceCaptureService(
       createSalesforceServiceConfig(),
       {
-        apiClient: {
-          queryAll: (soql) => {
-            queries.push(soql);
-            return baseApiClient.queryAll(soql);
-          },
-        },
+        apiClient: createStubSalesforceApiClient((soql) => {
+          queries.push(soql);
+          return baseApiClient.queryAll(soql);
+        }),
         now: () => new Date("2026-01-05T00:05:00.000Z"),
       },
     );
@@ -1057,31 +1040,29 @@ describe("Salesforce capture service", () => {
     const service = createSalesforceCaptureService(
       createSalesforceServiceConfig(),
       {
-        apiClient: {
-          queryAll: (soql) => {
-            queries.push(soql);
+        apiClient: createStubSalesforceApiClient((soql) => {
+          queries.push(soql);
 
-            if (soql.includes(" FROM Contact ")) {
-              return Promise.resolve([contactRow]);
-            }
+          if (soql.includes(" FROM Contact ")) {
+            return Promise.resolve([contactRow]);
+          }
 
-            if (soql.includes(" FROM Expedition_Members__c ")) {
-              return Promise.resolve([membershipRow]);
-            }
+          if (soql.includes(" FROM Expedition_Members__c ")) {
+            return Promise.resolve([membershipRow]);
+          }
 
-            if (soql.includes(" FROM Task ")) {
-              return Promise.resolve(
-                soql.includes(
-                  "Owner.Username IN ('admin+1@adventurescientists.org')",
-                )
-                  ? []
-                  : [humanEmailTaskRow],
-              );
-            }
+          if (soql.includes(" FROM Task ")) {
+            return Promise.resolve(
+              soql.includes(
+                "Owner.Username IN ('admin+1@adventurescientists.org')",
+              )
+                ? []
+                : [humanEmailTaskRow],
+            );
+          }
 
-            return Promise.resolve([]);
-          },
-        },
+          return Promise.resolve([]);
+        }),
         now: () => new Date("2026-01-05T00:05:00.000Z"),
       },
     );
@@ -1157,48 +1138,46 @@ describe("Salesforce capture service", () => {
     const service = createSalesforceCaptureService(
       createSalesforceServiceConfig(),
       {
-        apiClient: {
-          queryAll: (soql) => {
-            if (
-              soql.includes(
-                "FROM Expedition_Members__c WHERE Contact__c != null AND ((",
-              )
-            ) {
-              return Promise.resolve(membershipRows);
-            }
+        apiClient: createStubSalesforceApiClient((soql) => {
+          if (
+            soql.includes(
+              "FROM Expedition_Members__c WHERE Contact__c != null AND ((",
+            )
+          ) {
+            return Promise.resolve(membershipRows);
+          }
 
-            if (soql.includes("FROM Task ")) {
-              return Promise.resolve([]);
-            }
-
-            if (
-              soql.includes("FROM Contact WHERE LastModifiedDate >=") &&
-              !soql.includes(" WHERE Id IN ")
-            ) {
-              return Promise.resolve([]);
-            }
-
-            if (soql.includes("FROM Contact WHERE Id IN ")) {
-              const ids = extractQuotedIds(soql);
-              contactChunkSizes.push(ids.length);
-              return Promise.resolve(
-                contactRows.filter((row) => ids.includes(row.Id)),
-              );
-            }
-
-            if (
-              soql.includes("FROM Expedition_Members__c WHERE Contact__c IN ")
-            ) {
-              const ids = extractQuotedIds(soql);
-              membershipChunkSizes.push(ids.length);
-              return Promise.resolve(
-                membershipRows.filter((row) => ids.includes(row.Contact__c)),
-              );
-            }
-
+          if (soql.includes("FROM Task ")) {
             return Promise.resolve([]);
-          },
-        },
+          }
+
+          if (
+            soql.includes("FROM Contact WHERE LastModifiedDate >=") &&
+            !soql.includes(" WHERE Id IN ")
+          ) {
+            return Promise.resolve([]);
+          }
+
+          if (soql.includes("FROM Contact WHERE Id IN ")) {
+            const ids = extractQuotedIds(soql);
+            contactChunkSizes.push(ids.length);
+            return Promise.resolve(
+              contactRows.filter((row) => ids.includes(row.Id)),
+            );
+          }
+
+          if (
+            soql.includes("FROM Expedition_Members__c WHERE Contact__c IN ")
+          ) {
+            const ids = extractQuotedIds(soql);
+            membershipChunkSizes.push(ids.length);
+            return Promise.resolve(
+              membershipRows.filter((row) => ids.includes(row.Contact__c)),
+            );
+          }
+
+          return Promise.resolve([]);
+        }),
         now: () => new Date("2026-01-20T00:00:00.000Z"),
       },
     );


### PR DESCRIPTION
## Summary

Brick 2a of [#544](https://github.com/nico-kneler-as/as-comms-platform/issues/544). Three lowest-level building blocks of the weekly SF↔DB reconciliation pipeline — each testable in isolation. **Brick 2b will assemble them into the ops orchestrator + Graphile cron.**

- `queryAllIncludingDeleted(soql)` on `SalesforceApiClient` — actually hits SF's `/queryAll` endpoint (vs. the misnamed existing `queryAll` which hits `/query`). Renaming the existing method is a separate cleanup, not on this PR.
- Pure `diffSalesforceState` module — takes \"what SF returned\" + \"what our DB has\" and partitions into `presentInBoth` / `deletedInSalesforce` / `missingLocally`. Treats \"SF returned IsDeleted=true\" and \"SF didn't return the row at all\" as the same bucket (both mean tombstone). 10 unit tests cover every branch including dedup, conflicting flags, and the realistic mixed scenario.
- Three new repository methods × three repos (`contacts`, `contactMemberships`, `projectDimensions`): `listSalesforceAnchoredIds()`, `markSalesforceDeleted({salesforceIds, deletedAt})`, `markSalesforceReconciled({salesforceIds, reconciledAt})`. The mark-deleted method is idempotent (only NULL→ts transitions are counted). For `projectDimensions` the mark methods include a `source='salesforce'` guard so non-SF rows that happen to share `project_id` values can't be accidentally tombstoned.

Test-stub adaptations across `packages/domain/test/*` and `packages/integrations/test/stage1-salesforce-capture-service.test.ts` are mechanical: extending the interface forces every mock to add the new methods so types compile.

## Test plan

- [x] `pnpm typecheck` (16/16) green from repo root
- [x] `pnpm lint` (16/16) green from repo root  
- [x] `pnpm boundaries` green from repo root
- [x] `salesforce-state-diff.test.ts` — 10/10 pass locally
- [ ] Full CI runs all new repository integration tests in `stage1-repositories.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)