### PR TITLE
feat(worker): SF reconciliation orchestrator + weekly cron, dry-run mode (PRD #544 Brick 2b)

### DIFF
--- a/apps/worker/src/jobs/reconcile-salesforce-state.ts
+++ b/apps/worker/src/jobs/reconcile-salesforce-state.ts
@@ -1,0 +1,72 @@
+import type { Task } from "graphile-worker";
+
+import type { Stage1Database } from "@as-comms/db";
+import type { Stage1RepositoryBundle } from "@as-comms/domain";
+import type {
+  SalesforceApiClient,
+  SalesforceCaptureServiceConfig,
+} from "@as-comms/integrations";
+
+import {
+  reconcileSalesforceState,
+  type ReconcileSalesforceStateMode,
+} from "../ops/reconcile-salesforce-state.js";
+
+export const reconcileSalesforceStateJobName =
+  "reconcile-salesforce-state" as const;
+
+export interface ReconcileSalesforceStateTaskDependencies {
+  readonly db: Stage1Database;
+  readonly repositories: Stage1RepositoryBundle;
+  readonly apiClient: SalesforceApiClient;
+  readonly mode: ReconcileSalesforceStateMode;
+  readonly salesforceConfig: SalesforceCaptureServiceConfig;
+  readonly now?: () => Date;
+  readonly logger?: Pick<Console, "log" | "warn">;
+}
+
+export function createReconcileSalesforceStateTask(
+  dependencies: ReconcileSalesforceStateTaskDependencies,
+): Task {
+  const logger = dependencies.logger ?? console;
+
+  return () =>
+    reconcileSalesforceState({
+      db: dependencies.db,
+      repositories: dependencies.repositories,
+      apiClient: dependencies.apiClient,
+      mode: dependencies.mode,
+      salesforceConfig: dependencies.salesforceConfig,
+      ...(dependencies.now === undefined ? {} : { now: dependencies.now }),
+      logger,
+    }).then((report) => {
+      const totalErrors = report.runs.reduce(
+        (sum, run) => sum + run.errors.length,
+        0,
+      );
+
+      logger.log(
+        JSON.stringify({
+          event: "salesforce.reconciliation.run.summary",
+          entityCount: report.runs.length,
+          totalErrors,
+        }),
+      );
+
+      if (totalErrors > 0) {
+        logger.log(
+          JSON.stringify({
+            event: "salesforce.reconciliation.run.errors",
+            sample: report.runs
+              .flatMap((run) =>
+                run.errors.map((error) => ({
+                  entityType: run.entityType,
+                  ...error,
+                })),
+              )
+              .slice(0, 5),
+          }),
+        );
+      }
+    });
+}

--- a/apps/worker/src/ops/reconcile-salesforce-state.ts
+++ b/apps/worker/src/ops/reconcile-salesforce-state.ts
@@ -1,0 +1,234 @@
+import { randomUUID } from "node:crypto";
+
+import type { Stage1Database } from "@as-comms/db";
+import type { Stage1RepositoryBundle } from "@as-comms/domain";
+import type {
+  SalesforceApiClient,
+  SalesforceCaptureServiceConfig,
+} from "@as-comms/integrations";
+import {
+  diffSalesforceState,
+  type SalesforceRowSnapshot,
+} from "@as-comms/integrations";
+
+export type ReconcileSalesforceStateMode = "dry_run" | "enforce";
+
+export interface ReconcileSalesforceStateInput {
+  readonly db: Stage1Database;
+  readonly repositories: Stage1RepositoryBundle;
+  readonly apiClient: SalesforceApiClient;
+  readonly mode: ReconcileSalesforceStateMode;
+  readonly salesforceConfig: SalesforceCaptureServiceConfig;
+  readonly now?: () => Date;
+  readonly logger?: Pick<Console, "log" | "warn">;
+  /** SOQL IN-clause batch size. Default 500. */
+  readonly batchSize?: number;
+}
+
+export interface ReconcileSalesforceStateEntityReport {
+  readonly entityType: "contact" | "membership" | "project";
+  readonly mode: ReconcileSalesforceStateMode;
+  readonly scanned: number;
+  readonly confirmedPresent: number;
+  readonly markedDeleted: number;
+  readonly missingLocallyCount: number;
+  readonly errors: readonly {
+    readonly message: string;
+    readonly batchIndex: number;
+  }[];
+  readonly abortedReason: string | null;
+}
+
+export interface ReconcileSalesforceStateReport {
+  readonly runs: readonly ReconcileSalesforceStateEntityReport[];
+}
+
+interface ReconciliationEntityConfig {
+  readonly entityType: ReconcileSalesforceStateEntityReport["entityType"];
+  readonly objectName: string;
+  readonly repository:
+    | Stage1RepositoryBundle["contacts"]
+    | Stage1RepositoryBundle["contactMemberships"]
+    | Stage1RepositoryBundle["projectDimensions"];
+}
+
+function chunkValues<T>(
+  values: readonly T[],
+  chunkSize: number,
+): readonly (readonly T[])[] {
+  const chunks: T[][] = [];
+
+  for (let index = 0; index < values.length; index += chunkSize) {
+    chunks.push(values.slice(index, index + chunkSize));
+  }
+
+  return chunks;
+}
+
+function quoteSoqlId(id: string): string {
+  return `'${id}'`;
+}
+
+function buildIdBatchQuery(objectName: string, ids: readonly string[]): string {
+  return `SELECT Id, IsDeleted FROM ${objectName} WHERE Id IN (${ids
+    .map(quoteSoqlId)
+    .join(",")})`;
+}
+
+function toSalesforceSnapshots(
+  rows: readonly Record<string, unknown>[],
+): SalesforceRowSnapshot[] {
+  const snapshots: SalesforceRowSnapshot[] = [];
+
+  for (const row of rows) {
+    const id = row.Id;
+
+    if (typeof id !== "string" || id.trim().length === 0) {
+      continue;
+    }
+
+    snapshots.push({
+      id,
+      isDeleted: row.IsDeleted === true,
+    });
+  }
+
+  return snapshots;
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function reconcileEntity(
+  input: ReconcileSalesforceStateInput,
+  entity: ReconciliationEntityConfig,
+): Promise<ReconcileSalesforceStateEntityReport> {
+  const now = input.now ?? (() => new Date());
+  const logger = input.logger ?? console;
+  const batchSize = Math.max(1, Math.floor(input.batchSize ?? 500));
+  const runId = randomUUID();
+  const startedAt = now().toISOString();
+  const databaseIds = await entity.repository.listSalesforceAnchoredIds();
+  const errors: {
+    readonly message: string;
+    readonly batchIndex: number;
+  }[] = [];
+  const salesforceRows: SalesforceRowSnapshot[] = [];
+
+  for (const [batchIndex, batchIds] of chunkValues(databaseIds, batchSize).entries()) {
+    try {
+      const rows = await input.apiClient.queryAllIncludingDeleted(
+        buildIdBatchQuery(entity.objectName, batchIds),
+      );
+      salesforceRows.push(...toSalesforceSnapshots(rows as Record<string, unknown>[]));
+    } catch (error) {
+      const message = toErrorMessage(error);
+      const entry = {
+        message,
+        batchIndex,
+      } as const;
+
+      errors.push(entry);
+      logger.warn(
+        JSON.stringify({
+          event: "salesforce.reconciliation.batch_failed",
+          runId,
+          entityType: entity.entityType,
+          mode: input.mode,
+          batchIndex,
+          message,
+        }),
+      );
+    }
+  }
+
+  const diff = diffSalesforceState({
+    salesforceRows,
+    databaseIds,
+  });
+  const report: ReconcileSalesforceStateEntityReport = {
+    entityType: entity.entityType,
+    mode: input.mode,
+    scanned: databaseIds.length,
+    confirmedPresent: diff.presentInBoth.length,
+    markedDeleted: diff.deletedInSalesforce.length,
+    missingLocallyCount: diff.missingLocally.length,
+    errors,
+    abortedReason: null,
+  };
+
+  if (input.mode === "enforce") {
+    await entity.repository.markSalesforceDeleted({
+      salesforceIds: diff.deletedInSalesforce,
+      deletedAt: startedAt,
+    });
+    await entity.repository.markSalesforceReconciled({
+      salesforceIds: diff.presentInBoth,
+      reconciledAt: startedAt,
+    });
+  }
+
+  const completedAt = now().toISOString();
+  await input.repositories.salesforceReconciliationRuns.insert({
+    id: runId,
+    startedAt,
+    completedAt,
+    mode: input.mode,
+    entityType: entity.entityType,
+    scanned: report.scanned,
+    confirmedPresent: report.confirmedPresent,
+    markedDeleted: report.markedDeleted,
+    missingLocallyCount: report.missingLocallyCount,
+    errors: report.errors,
+    abortedReason: null,
+    createdAt: startedAt,
+    updatedAt: now().toISOString(),
+  });
+
+  logger.log(
+    JSON.stringify({
+      event: "salesforce.reconciliation.completed",
+      runId,
+      entityType: entity.entityType,
+      mode: input.mode,
+      scanned: report.scanned,
+      confirmedPresent: report.confirmedPresent,
+      markedDeleted: report.markedDeleted,
+      missingLocallyCount: report.missingLocallyCount,
+      errors: report.errors.length,
+    }),
+  );
+
+  return report;
+}
+
+export async function reconcileSalesforceState(
+  input: ReconcileSalesforceStateInput,
+): Promise<ReconcileSalesforceStateReport> {
+  const entities: readonly ReconciliationEntityConfig[] = [
+    {
+      entityType: "contact",
+      objectName: "Contact",
+      repository: input.repositories.contacts,
+    },
+    {
+      entityType: "membership",
+      objectName:
+        input.salesforceConfig.membershipObjectName ??
+        "Expedition_Members__c",
+      repository: input.repositories.contactMemberships,
+    },
+    {
+      entityType: "project",
+      objectName: "Campaign",
+      repository: input.repositories.projectDimensions,
+    },
+  ];
+
+  return {
+    runs: await Promise.all(
+      entities.map((entity) => reconcileEntity(input, entity)),
+    ),
+  };
+}

--- a/apps/worker/src/runtime.ts
+++ b/apps/worker/src/runtime.ts
@@ -25,6 +25,7 @@ import {
   createGmailCapturePort,
   createMailchimpCapturePort,
   createPostmarkClient,
+  createSalesforceApiClient,
   InlineTextFetcher,
   invokeModel,
   NotionPageFetcher,
@@ -32,6 +33,7 @@ import {
   createSimpleTextingCapturePort,
   ProviderCaptureConfigError,
   type FetchImplementation,
+  type SalesforceCaptureServiceConfig,
   WebPageFetcher,
 } from "@as-comms/integrations";
 
@@ -50,6 +52,10 @@ import { readPollPostmarkSenderStatusConfig } from "./jobs/poll-postmark-sender-
 import { dedupHistoricalLedgerJobName } from "./jobs/dedup-historical-ledger.js";
 import { reconcileCaptureGapsJobName } from "./jobs/reconcile-capture-gaps.js";
 import { reconcileRoutingReviewQueueJobName } from "./jobs/reconcile-routing-review-queue.js";
+import {
+  reconcileSalesforceStateJobName,
+  type ReconcileSalesforceStateTaskDependencies,
+} from "./jobs/reconcile-salesforce-state.js";
 import { reconcileStrandedCampaignRunsJobName } from "./jobs/reconcile-stranded-campaign-runs.js";
 import { type SynthesizeProjectKnowledgeDependencies } from "./jobs/synthesize-project-knowledge/index.js";
 import {
@@ -77,6 +83,8 @@ import { pollPostmarkSenderStatusJobName } from "./jobs/poll-postmark-sender-sta
 const defaultSyncStateLeaseThresholdMs = 5 * 60 * 1000;
 const mailchimpTransitionDiscoverySeedLookbackDays = 35;
 const defaultSynthesisRootPageId = "3278a912921180598688fce711ab0509";
+type ReconcileSalesforceStateMode =
+  ReconcileSalesforceStateTaskDependencies["mode"];
 
 function parseBooleanEnv(value: unknown): boolean {
   // Pass booleans through unchanged. The schema this preprocess feeds is
@@ -166,6 +174,7 @@ export function buildWorkerCrontab(config: WorkerConfig): string {
     `0 10 * * * ${dedupHistoricalLedgerJobName} ?id=dedup-historical-ledger&max=1`,
     `30 10 * * * ${reconcileCaptureGapsJobName} ?id=capture-gap-reconcile&max=1`,
     `*/15 * * * * ${reconcileRoutingReviewQueueJobName} ?id=routing-review-queue-reconcile&max=1`,
+    `0 6 * * 0 ${reconcileSalesforceStateJobName} ?id=sf-state-reconcile&max=1`,
     `0 11 * * 0 ${reconcileSupersededProjectionsJobName} ?id=superseded-projections-reconcile&max=1`,
   ].join("\n");
 }
@@ -199,6 +208,51 @@ function readOptionalTrimmedEnv(
 
   const trimmed = value.trim();
   return trimmed.length === 0 ? null : trimmed;
+}
+
+function readRequiredEnv(env: NodeJS.ProcessEnv, key: string): string {
+  const value = env[key];
+
+  if (value === undefined || value.trim().length === 0) {
+    throw new Error(`${key} is required.`);
+  }
+
+  return value.trim();
+}
+
+function readOptionalStringEnv(
+  env: NodeJS.ProcessEnv,
+  key: string,
+  defaultValue: string,
+): string {
+  return readOptionalTrimmedEnv(env[key]) ?? defaultValue;
+}
+
+function readOptionalNullableStringEnv(
+  env: NodeJS.ProcessEnv,
+  key: string,
+): string | null {
+  return readOptionalTrimmedEnv(env[key]);
+}
+
+function readOptionalPositiveIntegerEnv(
+  env: NodeJS.ProcessEnv,
+  key: string,
+  defaultValue: number,
+): number {
+  const rawValue = readOptionalTrimmedEnv(env[key]);
+
+  if (rawValue === null) {
+    return defaultValue;
+  }
+
+  const parsed = Number.parseInt(rawValue, 10);
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${key} must be a positive integer when provided.`);
+  }
+
+  return parsed;
 }
 
 function buildCampaignSendDependencies(input: {
@@ -275,6 +329,39 @@ function buildCampaignSendDependencies(input: {
   };
 }
 
+function buildReconcileSalesforceStateDependencies(input: {
+  readonly env: NodeJS.ProcessEnv;
+  readonly db: Stage1Database;
+  readonly repositories: ReturnType<typeof createStage1RepositoryBundleFromConnection>;
+}): ReconcileSalesforceStateTaskDependencies | undefined {
+  const requiredEnvs = [
+    "SALESFORCE_CAPTURE_TOKEN",
+    "SALESFORCE_LOGIN_URL",
+    "SALESFORCE_CLIENT_ID",
+    "SALESFORCE_USERNAME",
+    "SALESFORCE_JWT_PRIVATE_KEY",
+  ];
+
+  if (requiredEnvs.some((key) => !input.env[key]?.trim())) {
+    console.warn(
+      "Skipping reconcile-salesforce-state wiring — SF env config incomplete.",
+    );
+    return undefined;
+  }
+
+  const salesforceConfig = readSalesforceCaptureConfig(input.env);
+  const apiClient = createSalesforceApiClient(salesforceConfig);
+  const mode = parseReconcileMode(input.env.RECONCILE_SF_STATE_MODE);
+
+  return {
+    db: input.db,
+    repositories: input.repositories,
+    apiClient,
+    mode,
+    salesforceConfig,
+  };
+}
+
 function buildSynthesizeProjectKnowledgeDependencies(input: {
   readonly env: NodeJS.ProcessEnv;
   readonly fetchImplementation: FetchImplementation;
@@ -321,6 +408,122 @@ function buildSynthesizeProjectKnowledgeDependencies(input: {
     invokeModel: (payload) => invokeModel(anthropicClient, payload),
     db: input.db,
   };
+}
+
+function readSalesforceCaptureConfig(
+  env: NodeJS.ProcessEnv,
+): SalesforceCaptureServiceConfig {
+  return {
+    bearerToken: readRequiredEnv(env, "SALESFORCE_CAPTURE_TOKEN"),
+    loginUrl: readRequiredEnv(env, "SALESFORCE_LOGIN_URL"),
+    clientId: readRequiredEnv(env, "SALESFORCE_CLIENT_ID"),
+    username: readRequiredEnv(env, "SALESFORCE_USERNAME"),
+    jwtPrivateKey: readRequiredEnv(env, "SALESFORCE_JWT_PRIVATE_KEY"),
+    jwtExpirationSeconds: readOptionalPositiveIntegerEnv(
+      env,
+      "SALESFORCE_JWT_EXPIRATION_SECONDS",
+      180,
+    ),
+    apiVersion: readOptionalStringEnv(env, "SALESFORCE_API_VERSION", "61.0"),
+    contactCaptureMode: readOptionalStringEnv(
+      env,
+      "SALESFORCE_CONTACT_CAPTURE_MODE",
+      "delta_polling",
+    ) as "delta_polling" | "cdc_compatible",
+    membershipCaptureMode: readOptionalStringEnv(
+      env,
+      "SALESFORCE_MEMBERSHIP_CAPTURE_MODE",
+      "delta_polling",
+    ) as "delta_polling" | "cdc_compatible",
+    membershipObjectName: readOptionalStringEnv(
+      env,
+      "SALESFORCE_EXPEDITION_MEMBER_OBJECT",
+      "Expedition_Members__c",
+    ),
+    membershipContactField: readOptionalStringEnv(
+      env,
+      "SALESFORCE_EXPEDITION_MEMBER_CONTACT_FIELD",
+      "Contact__c",
+    ),
+    membershipProjectField: readOptionalStringEnv(
+      env,
+      "SALESFORCE_EXPEDITION_MEMBER_PROJECT_FIELD",
+      "Project__c",
+    ),
+    membershipProjectNameField: readOptionalStringEnv(
+      env,
+      "SALESFORCE_EXPEDITION_MEMBER_PROJECT_NAME_FIELD",
+      "Project__r.Name",
+    ),
+    membershipExpeditionField: readOptionalStringEnv(
+      env,
+      "SALESFORCE_EXPEDITION_MEMBER_EXPEDITION_FIELD",
+      "Expedition__c",
+    ),
+    membershipExpeditionNameField: readOptionalStringEnv(
+      env,
+      "SALESFORCE_EXPEDITION_MEMBER_EXPEDITION_NAME_FIELD",
+      "Expedition__r.Name",
+    ),
+    membershipRoleField: readOptionalNullableStringEnv(
+      env,
+      "SALESFORCE_EXPEDITION_MEMBER_ROLE_FIELD",
+    ),
+    membershipStatusField: readOptionalStringEnv(
+      env,
+      "SALESFORCE_EXPEDITION_MEMBER_STATUS_FIELD",
+      "Status__c",
+    ),
+    taskContactField: readOptionalStringEnv(
+      env,
+      "SALESFORCE_TASK_CONTACT_FIELD",
+      "WhoId",
+    ),
+    taskChannelField: readOptionalStringEnv(
+      env,
+      "SALESFORCE_TASK_CHANNEL_FIELD",
+      "TaskSubtype",
+    ),
+    taskEmailChannelValues: ["Email"],
+    taskSmsChannelValues: ["SMS", "Text"],
+    taskSnippetField: readOptionalStringEnv(
+      env,
+      "SALESFORCE_TASK_SNIPPET_FIELD",
+      "Description",
+    ),
+    taskOccurredAtField: readOptionalStringEnv(
+      env,
+      "SALESFORCE_TASK_OCCURRED_AT_FIELD",
+      "CreatedDate",
+    ),
+    taskCrossProviderKeyField: readOptionalNullableStringEnv(
+      env,
+      "SALESFORCE_TASK_CROSS_PROVIDER_KEY_FIELD",
+    ),
+    timeoutMs: readOptionalPositiveIntegerEnv(
+      env,
+      "SALESFORCE_CAPTURE_TIMEOUT_MS",
+      15_000,
+    ),
+  };
+}
+
+function parseReconcileMode(
+  value: string | undefined,
+): ReconcileSalesforceStateMode {
+  const trimmed = value?.trim();
+
+  if (trimmed === undefined || trimmed === "" || trimmed === "dry_run") {
+    return "dry_run";
+  }
+
+  if (trimmed === "enforce") {
+    return "enforce";
+  }
+
+  throw new Error(
+    `Invalid RECONCILE_SF_STATE_MODE value: "${trimmed}". Must be "dry_run" or "enforce".`,
+  );
 }
 
 function readMailchimpTransitionConfig(
@@ -523,6 +726,11 @@ export async function createStage1WorkerRuntimeServices(
   const postmarkSenderStatus = readPollPostmarkSenderStatusConfig(
     input?.env ?? process.env,
   );
+  const reconcileSalesforceState = buildReconcileSalesforceStateDependencies({
+    env: input?.env ?? process.env,
+    db: connection.db,
+    repositories,
+  });
   const campaignSend = buildCampaignSendDependencies({
     env: input?.env ?? process.env,
     campaigns,
@@ -671,6 +879,11 @@ export async function createStage1WorkerRuntimeServices(
         syncState,
         leaseThresholdMs,
       },
+      ...(reconcileSalesforceState === undefined
+        ? {}
+        : {
+            reconcileSalesforceState,
+          }),
       reconcileSupersededProjections: {
         db: connection.db,
         sql: connection.sql as unknown as ReconcileSupersededProjectionsTaskDependencies["sql"],

--- a/apps/worker/src/tasks.ts
+++ b/apps/worker/src/tasks.ts
@@ -38,6 +38,11 @@ import {
   type ReconcileStaleRunningTaskDependencies,
 } from "./jobs/reconcile-stale-running.js";
 import {
+  createReconcileSalesforceStateTask,
+  reconcileSalesforceStateJobName,
+  type ReconcileSalesforceStateTaskDependencies,
+} from "./jobs/reconcile-salesforce-state.js";
+import {
   createReconcileSupersededProjectionsTask,
   reconcileSupersededProjectionsJobName,
   type ReconcileSupersededProjectionsTaskDependencies,
@@ -91,6 +96,7 @@ export function createTaskList(
     readonly reconcileRoutingReviewQueue?: ReconcileRoutingReviewQueueTaskDependencies;
     readonly reconcileCaptureGaps?: ReconcileCaptureGapsTaskDependencies;
     readonly reconcileStaleRunning?: ReconcileStaleRunningTaskDependencies;
+    readonly reconcileSalesforceState?: ReconcileSalesforceStateTaskDependencies;
     readonly reconcileSupersededProjections?: ReconcileSupersededProjectionsTaskDependencies;
     readonly reconcileStrandedCampaignRuns?: ReconcileStrandedCampaignRunsTaskDependencies;
     readonly synthesizeProjectKnowledge?: SynthesizeProjectKnowledgeDependencies;
@@ -154,6 +160,14 @@ export function createTaskList(
           [reconcileStaleRunningJobName]: createReconcileStaleRunningTask(
             input.reconcileStaleRunning
           )
+        }),
+    ...(input?.reconcileSalesforceState === undefined
+      ? {}
+      : {
+          [reconcileSalesforceStateJobName]:
+            createReconcileSalesforceStateTask(
+              input.reconcileSalesforceState,
+            ),
         }),
     ...(input?.reconcileSupersededProjections === undefined
       ? {}

--- a/apps/worker/test/reconcile-salesforce-state.test.ts
+++ b/apps/worker/test/reconcile-salesforce-state.test.ts
@@ -1,0 +1,632 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  contacts,
+  contactMemberships,
+  projectDimensions,
+  salesforceReconciliationRuns,
+} from "@as-comms/db";
+import { asc, isNotNull } from "drizzle-orm";
+import type {
+  SalesforceApiClient,
+  SalesforceCaptureServiceConfig,
+} from "@as-comms/integrations";
+
+import { reconcileSalesforceState } from "../src/ops/reconcile-salesforce-state.js";
+import { createTestStage1Context } from "./helpers.js";
+
+const runTimestamp = "2026-06-13T06:00:00.000Z";
+
+function buildSalesforceConfig(): SalesforceCaptureServiceConfig {
+  return {
+    bearerToken: "capture-token",
+    loginUrl: "https://login.salesforce.com",
+    clientId: "client-id",
+    username: "worker@example.org",
+    jwtPrivateKey: "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----",
+    jwtExpirationSeconds: 180,
+    apiVersion: "61.0",
+    contactCaptureMode: "delta_polling",
+    membershipCaptureMode: "delta_polling",
+    membershipObjectName: "Expedition_Members__c",
+    membershipContactField: "Contact__c",
+    membershipProjectField: "Project__c",
+    membershipProjectNameField: "Project__r.Name",
+    membershipExpeditionField: "Expedition__c",
+    membershipExpeditionNameField: "Expedition__r.Name",
+    membershipRoleField: null,
+    membershipStatusField: "Status__c",
+    taskContactField: "WhoId",
+    taskChannelField: "TaskSubtype",
+    taskEmailChannelValues: ["Email"],
+    taskSmsChannelValues: ["SMS", "Text"],
+    taskSnippetField: "Description",
+    taskOccurredAtField: "CreatedDate",
+    taskCrossProviderKeyField: null,
+    timeoutMs: 15_000,
+  };
+}
+
+function parseSoql(input: string): {
+  readonly objectName: string;
+  readonly ids: readonly string[];
+} {
+  const objectNameMatch = /FROM\s+([A-Za-z0-9_]+)\s+WHERE/u.exec(input);
+
+  if (objectNameMatch?.[1] === undefined) {
+    throw new Error(`Could not parse object name from SOQL: ${input}`);
+  }
+
+  const ids = Array.from(input.matchAll(/'([^']+)'/gu), (match) => match[1] ?? "");
+
+  return {
+    objectName: objectNameMatch[1],
+    ids,
+  };
+}
+
+async function seedStandardFixture(
+  context: Awaited<ReturnType<typeof createTestStage1Context>>,
+): Promise<void> {
+  await Promise.all([
+    context.repositories.contacts.upsert({
+      id: "contact:present",
+      salesforceContactId: "003CONTACTPRESENT",
+      displayName: "Contact Present",
+      primaryEmail: "present@example.org",
+      primaryPhone: null,
+      createdAt: runTimestamp,
+      updatedAt: runTimestamp,
+    }),
+    context.repositories.contacts.upsert({
+      id: "contact:deleted",
+      salesforceContactId: "003CONTACTDELETED",
+      displayName: "Contact Deleted",
+      primaryEmail: "deleted@example.org",
+      primaryPhone: null,
+      createdAt: runTimestamp,
+      updatedAt: runTimestamp,
+    }),
+    context.repositories.contacts.upsert({
+      id: "contact:missing",
+      salesforceContactId: "003CONTACTMISSING",
+      displayName: "Contact Missing",
+      primaryEmail: "missing@example.org",
+      primaryPhone: null,
+      createdAt: runTimestamp,
+      updatedAt: runTimestamp,
+    }),
+    context.repositories.projectDimensions.upsert({
+      projectId: "701PROJECTPRESENT",
+      projectName: "Project Present",
+      source: "salesforce",
+    }),
+    context.repositories.projectDimensions.upsert({
+      projectId: "701PROJECTDELETED",
+      projectName: "Project Deleted",
+      source: "salesforce",
+    }),
+    context.repositories.projectDimensions.upsert({
+      projectId: "701PROJECTMISSING",
+      projectName: "Project Missing",
+      source: "salesforce",
+    }),
+  ]);
+
+  await Promise.all([
+    context.repositories.contactMemberships.upsert({
+      id: "membership:present",
+      contactId: "contact:present",
+      projectId: "701PROJECTPRESENT",
+      expeditionId: null,
+      salesforceMembershipId: "a15MEMBERSHIPPRESENT",
+      role: "volunteer",
+      status: "active",
+      source: "salesforce",
+      createdAt: runTimestamp,
+    }),
+    context.repositories.contactMemberships.upsert({
+      id: "membership:deleted",
+      contactId: "contact:deleted",
+      projectId: "701PROJECTDELETED",
+      expeditionId: null,
+      salesforceMembershipId: "a15MEMBERSHIPDELETED",
+      role: "volunteer",
+      status: "active",
+      source: "salesforce",
+      createdAt: runTimestamp,
+    }),
+    context.repositories.contactMemberships.upsert({
+      id: "membership:missing",
+      contactId: "contact:missing",
+      projectId: "701PROJECTMISSING",
+      expeditionId: null,
+      salesforceMembershipId: "a15MEMBERSHIPMISSING",
+      role: "volunteer",
+      status: "active",
+      source: "salesforce",
+      createdAt: runTimestamp,
+    }),
+  ]);
+}
+
+function buildStandardApiClient(): SalesforceApiClient {
+  return {
+    queryAll: vi.fn(() => Promise.resolve([])),
+    queryAllIncludingDeleted: vi.fn((soql: string) => {
+      const { objectName } = parseSoql(soql);
+
+      switch (objectName) {
+        case "Contact":
+          return Promise.resolve([
+            { Id: "003CONTACTPRESENT", IsDeleted: false },
+            { Id: "003CONTACTDELETED", IsDeleted: true },
+            { Id: "003CONTACTEXTRA", IsDeleted: false },
+          ]);
+        case "Expedition_Members__c":
+          return Promise.resolve([
+            { Id: "a15MEMBERSHIPPRESENT", IsDeleted: false },
+            { Id: "a15MEMBERSHIPDELETED", IsDeleted: true },
+            { Id: "a15MEMBERSHIPEXTRA", IsDeleted: false },
+          ]);
+        case "Campaign":
+          return Promise.resolve([
+            { Id: "701PROJECTPRESENT", IsDeleted: false },
+            { Id: "701PROJECTDELETED", IsDeleted: true },
+            { Id: "701PROJECTEXTRA", IsDeleted: false },
+          ]);
+        default:
+          throw new Error(`Unexpected object name: ${objectName}`);
+      }
+    }),
+  };
+}
+
+async function readRunRows(
+  context: Awaited<ReturnType<typeof createTestStage1Context>>,
+) {
+  return context.db
+    .select()
+    .from(salesforceReconciliationRuns)
+    .orderBy(asc(salesforceReconciliationRuns.entityType));
+}
+
+describe("reconcileSalesforceState", () => {
+  it("dry_run writes run-log rows but no tombstones or reconciled timestamps", async () => {
+    const context = await createTestStage1Context();
+
+    try {
+      await seedStandardFixture(context);
+
+      const report = await reconcileSalesforceState({
+        db: context.db,
+        repositories: context.repositories,
+        apiClient: buildStandardApiClient(),
+        mode: "dry_run",
+        salesforceConfig: buildSalesforceConfig(),
+        now: () => new Date(runTimestamp),
+        logger: {
+          log: () => undefined,
+          warn: () => undefined,
+        },
+      });
+
+      expect(report.runs).toEqual([
+        expect.objectContaining({
+          entityType: "contact",
+          mode: "dry_run",
+          scanned: 3,
+          confirmedPresent: 1,
+          markedDeleted: 2,
+          missingLocallyCount: 1,
+          errors: [],
+          abortedReason: null,
+        }),
+        expect.objectContaining({
+          entityType: "membership",
+          mode: "dry_run",
+          scanned: 3,
+          confirmedPresent: 1,
+          markedDeleted: 2,
+          missingLocallyCount: 1,
+          errors: [],
+          abortedReason: null,
+        }),
+        expect.objectContaining({
+          entityType: "project",
+          mode: "dry_run",
+          scanned: 3,
+          confirmedPresent: 1,
+          markedDeleted: 2,
+          missingLocallyCount: 1,
+          errors: [],
+          abortedReason: null,
+        }),
+      ]);
+
+      expect(await readRunRows(context)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            entityType: "contact",
+            mode: "dry_run",
+            scanned: 3,
+            confirmedPresent: 1,
+            markedDeleted: 2,
+            missingLocallyCount: 1,
+            errors: [],
+          }),
+          expect.objectContaining({
+            entityType: "membership",
+            mode: "dry_run",
+            scanned: 3,
+            confirmedPresent: 1,
+            markedDeleted: 2,
+            missingLocallyCount: 1,
+            errors: [],
+          }),
+          expect.objectContaining({
+            entityType: "project",
+            mode: "dry_run",
+            scanned: 3,
+            confirmedPresent: 1,
+            markedDeleted: 2,
+            missingLocallyCount: 1,
+            errors: [],
+          }),
+        ]),
+      );
+
+      expect(
+        await context.db
+          .select()
+          .from(contacts)
+          .where(isNotNull(contacts.salesforceDeletedAt)),
+      ).toHaveLength(0);
+      expect(
+        await context.db
+          .select()
+          .from(contactMemberships)
+          .where(isNotNull(contactMemberships.salesforceDeletedAt)),
+      ).toHaveLength(0);
+      expect(
+        await context.db
+          .select()
+          .from(projectDimensions)
+          .where(isNotNull(projectDimensions.salesforceDeletedAt)),
+      ).toHaveLength(0);
+      expect(
+        await context.db
+          .select()
+          .from(contacts)
+          .where(isNotNull(contacts.salesforceReconciledAt)),
+      ).toHaveLength(0);
+      expect(
+        await context.db
+          .select()
+          .from(contactMemberships)
+          .where(isNotNull(contactMemberships.salesforceReconciledAt)),
+      ).toHaveLength(0);
+      expect(
+        await context.db
+          .select()
+          .from(projectDimensions)
+          .where(isNotNull(projectDimensions.salesforceReconciledAt)),
+      ).toHaveLength(0);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("enforce writes tombstones, reconciled timestamps, and run-log rows", async () => {
+    const context = await createTestStage1Context();
+
+    try {
+      await seedStandardFixture(context);
+
+      await reconcileSalesforceState({
+        db: context.db,
+        repositories: context.repositories,
+        apiClient: buildStandardApiClient(),
+        mode: "enforce",
+        salesforceConfig: buildSalesforceConfig(),
+        now: () => new Date(runTimestamp),
+        logger: {
+          log: () => undefined,
+          warn: () => undefined,
+        },
+      });
+
+      expect(await readRunRows(context)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ entityType: "contact", mode: "enforce" }),
+          expect.objectContaining({
+            entityType: "membership",
+            mode: "enforce",
+          }),
+          expect.objectContaining({ entityType: "project", mode: "enforce" }),
+        ]),
+      );
+
+      await expect(
+        context.repositories.contacts.findById("contact:present"),
+      ).resolves.toMatchObject({
+        salesforceDeletedAt: null,
+        salesforceReconciledAt: runTimestamp,
+      });
+      await expect(
+        context.repositories.contacts.findById("contact:deleted"),
+      ).resolves.toMatchObject({
+        salesforceDeletedAt: runTimestamp,
+        salesforceReconciledAt: null,
+      });
+      await expect(
+        context.repositories.contacts.findById("contact:missing"),
+      ).resolves.toMatchObject({
+        salesforceDeletedAt: runTimestamp,
+        salesforceReconciledAt: null,
+      });
+
+      await expect(
+        context.repositories.contactMemberships.listByContactId("contact:present"),
+      ).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: "membership:present",
+            salesforceDeletedAt: null,
+            salesforceReconciledAt: runTimestamp,
+          }),
+        ]),
+      );
+      await expect(
+        context.repositories.contactMemberships.listByContactId("contact:deleted"),
+      ).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: "membership:deleted",
+            salesforceDeletedAt: runTimestamp,
+            salesforceReconciledAt: null,
+          }),
+        ]),
+      );
+      await expect(
+        context.repositories.contactMemberships.listByContactId("contact:missing"),
+      ).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: "membership:missing",
+            salesforceDeletedAt: runTimestamp,
+            salesforceReconciledAt: null,
+          }),
+        ]),
+      );
+
+      await expect(
+        context.repositories.projectDimensions.findById("701PROJECTPRESENT"),
+      ).resolves.toMatchObject({
+        salesforceDeletedAt: null,
+        salesforceReconciledAt: runTimestamp,
+      });
+      await expect(
+        context.repositories.projectDimensions.findById("701PROJECTDELETED"),
+      ).resolves.toMatchObject({
+        salesforceDeletedAt: runTimestamp,
+        salesforceReconciledAt: null,
+      });
+      await expect(
+        context.repositories.projectDimensions.findById("701PROJECTMISSING"),
+      ).resolves.toMatchObject({
+        salesforceDeletedAt: runTimestamp,
+        salesforceReconciledAt: null,
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("writes zero-everything run rows for an empty database", async () => {
+    const context = await createTestStage1Context();
+
+    try {
+      const report = await reconcileSalesforceState({
+        db: context.db,
+        repositories: context.repositories,
+        apiClient: buildStandardApiClient(),
+        mode: "dry_run",
+        salesforceConfig: buildSalesforceConfig(),
+        now: () => new Date(runTimestamp),
+        logger: {
+          log: () => undefined,
+          warn: () => undefined,
+        },
+      });
+
+      expect(report.runs).toEqual([
+        expect.objectContaining({
+          entityType: "contact",
+          scanned: 0,
+          confirmedPresent: 0,
+          markedDeleted: 0,
+          missingLocallyCount: 0,
+          errors: [],
+        }),
+        expect.objectContaining({
+          entityType: "membership",
+          scanned: 0,
+          confirmedPresent: 0,
+          markedDeleted: 0,
+          missingLocallyCount: 0,
+          errors: [],
+        }),
+        expect.objectContaining({
+          entityType: "project",
+          scanned: 0,
+          confirmedPresent: 0,
+          markedDeleted: 0,
+          missingLocallyCount: 0,
+          errors: [],
+        }),
+      ]);
+
+      expect(await readRunRows(context)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            entityType: "contact",
+            scanned: 0,
+            confirmedPresent: 0,
+            markedDeleted: 0,
+            missingLocallyCount: 0,
+            errors: [],
+          }),
+          expect.objectContaining({
+            entityType: "membership",
+            scanned: 0,
+            confirmedPresent: 0,
+            markedDeleted: 0,
+            missingLocallyCount: 0,
+            errors: [],
+          }),
+          expect.objectContaining({
+            entityType: "project",
+            scanned: 0,
+            confirmedPresent: 0,
+            markedDeleted: 0,
+            missingLocallyCount: 0,
+            errors: [],
+          }),
+        ]),
+      );
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("continues after a batch failure and records the batch error", async () => {
+    const context = await createTestStage1Context();
+    const queryAllIncludingDeleted = vi.fn(
+      (soql: string): Promise<readonly Record<string, unknown>[]> => {
+        const { objectName, ids } = parseSoql(soql);
+
+        if (objectName !== "Contact") {
+          return Promise.resolve([]);
+        }
+
+        const batchIndex = queryAllIncludingDeleted.mock.calls.filter(
+          ([call]) => parseSoql(call).objectName === "Contact",
+        ).length - 1;
+
+        if (batchIndex === 1) {
+          throw new Error("Synthetic batch failure");
+        }
+
+        return Promise.resolve(ids.map((id) => ({ Id: id, IsDeleted: false })));
+      },
+    );
+
+    try {
+      for (let index = 0; index < 1200; index += 1) {
+        const id = `003BATCH${index.toString().padStart(4, "0")}`;
+        await context.repositories.contacts.upsert({
+          id: `contact:${id}`,
+          salesforceContactId: id,
+          displayName: `Contact ${index.toString()}`,
+          primaryEmail: `contact-${index.toString()}@example.org`,
+          primaryPhone: null,
+          createdAt: runTimestamp,
+          updatedAt: runTimestamp,
+        });
+      }
+
+      await reconcileSalesforceState({
+        db: context.db,
+        repositories: context.repositories,
+        apiClient: {
+          queryAll: vi.fn(() => Promise.resolve([])),
+          queryAllIncludingDeleted,
+        },
+        mode: "dry_run",
+        salesforceConfig: buildSalesforceConfig(),
+        now: () => new Date(runTimestamp),
+        logger: {
+          log: () => undefined,
+          warn: () => undefined,
+        },
+      });
+
+      const runRows = await readRunRows(context);
+      const contactRun = runRows.find((row) => row.entityType === "contact");
+      const membershipRun = runRows.find((row) => row.entityType === "membership");
+      const projectRun = runRows.find((row) => row.entityType === "project");
+
+      expect(contactRun).toMatchObject({
+        scanned: 1200,
+      });
+      expect(contactRun?.errors).toEqual([
+        expect.objectContaining({
+          batchIndex: 1,
+          message: "Synthetic batch failure",
+        }),
+      ]);
+      expect(membershipRun?.errors).toEqual([]);
+      expect(projectRun?.errors).toEqual([]);
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  it("never sends a manual project id to Salesforce or tombstones it through the orchestrator path", async () => {
+    const context = await createTestStage1Context();
+    const queryAllIncludingDeleted = vi.fn(
+      (soql: string): Promise<readonly Record<string, unknown>[]> => {
+        const { objectName, ids } = parseSoql(soql);
+
+        if (objectName !== "Campaign") {
+          return Promise.resolve([]);
+        }
+
+        expect(ids).toEqual(["701PROJECTSALESFORCE"]);
+
+        return Promise.resolve([
+          { Id: "701PROJECTSALESFORCE", IsDeleted: false },
+          { Id: "701PROJECTMANUAL", IsDeleted: true },
+        ]);
+      },
+    );
+
+    try {
+      await context.repositories.projectDimensions.upsert({
+        projectId: "701PROJECTSALESFORCE",
+        projectName: "Salesforce Project",
+        source: "salesforce",
+      });
+      await context.repositories.projectDimensions.upsert({
+        projectId: "701PROJECTMANUAL",
+        projectName: "Manual Project",
+        source: "manual",
+      });
+
+      await reconcileSalesforceState({
+        db: context.db,
+        repositories: context.repositories,
+        apiClient: {
+          queryAll: vi.fn(() => Promise.resolve([])),
+          queryAllIncludingDeleted,
+        },
+        mode: "enforce",
+        salesforceConfig: buildSalesforceConfig(),
+        now: () => new Date(runTimestamp),
+        logger: {
+          log: () => undefined,
+          warn: () => undefined,
+        },
+      });
+
+      await expect(
+        context.repositories.projectDimensions.findById("701PROJECTMANUAL"),
+      ).resolves.toMatchObject({
+        salesforceDeletedAt: null,
+      });
+    } finally {
+      await context.dispose();
+    }
+  });
+});

--- a/apps/worker/test/stage1-runtime.test.ts
+++ b/apps/worker/test/stage1-runtime.test.ts
@@ -15,6 +15,7 @@ import {
   pollSalesforceLiveJobName,
 } from "../src/orchestration/tasks.js";
 import { reconcileStaleRunningJobName } from "../src/jobs/reconcile-stale-running.js";
+import { reconcileSalesforceStateJobName } from "../src/jobs/reconcile-salesforce-state.js";
 import { reconcileStrandedCampaignRunsJobName } from "../src/jobs/reconcile-stranded-campaign-runs.js";
 import { sweepPendingOutboundsJobName } from "../src/jobs/sweep-pending-outbounds.js";
 import { campaignEventsTailFinalizeJobName } from "../src/jobs/campaign-events-tail-finalize/index.js";
@@ -163,6 +164,7 @@ describe("Stage 1 worker runtime task registration", () => {
         `0 10 * * * ${dedupHistoricalLedgerJobName} ?id=dedup-historical-ledger&max=1`,
         `30 10 * * * ${reconcileCaptureGapsJobName} ?id=capture-gap-reconcile&max=1`,
         "*/15 * * * * reconcile-routing-review-queue ?id=routing-review-queue-reconcile&max=1",
+        `0 6 * * 0 ${reconcileSalesforceStateJobName} ?id=sf-state-reconcile&max=1`,
         "0 11 * * 0 reconcile-superseded-projections ?id=superseded-projections-reconcile&max=1",
       ].join("\n"),
     );

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -109,6 +109,7 @@ import {
   mapProjectDimensionToInsert,
   mapRoutingReviewRow,
   mapRoutingReviewToInsert,
+  mapSalesforceReconciliationRunToInsert,
   mapSalesforceEventContextRow,
   mapSalesforceEventContextToInsert,
   mapSmsMessageRow,
@@ -159,6 +160,7 @@ import {
   projectDimensions,
   routingReviewQueue,
   salesforceCommunicationDetails,
+  salesforceReconciliationRuns,
   salesforceEventContext,
   simpleTextingMessageDetails,
   suppressionList,
@@ -3866,6 +3868,14 @@ function createStage1RepositoriesInternal(
             "Expected Salesforce communication detail row to be returned.",
           ),
         );
+      },
+    },
+
+    salesforceReconciliationRuns: {
+      async insert(record) {
+        await db
+          .insert(salesforceReconciliationRuns)
+          .values(mapSalesforceReconciliationRunToInsert(record));
       },
     },
 

--- a/packages/domain/src/repositories.ts
+++ b/packages/domain/src/repositories.ts
@@ -23,6 +23,7 @@ import type {
   Provider,
   RoutingReviewCase,
   RoutingReviewReasonCode,
+  SalesforceReconciliationRunRecord,
   SalesforceCommunicationDetailRecord,
   SalesforceEventContextRecord,
   SimpleTextingMessageDetailRecord,
@@ -604,6 +605,15 @@ export interface SalesforceCommunicationDetailRepository {
   ): Promise<SalesforceCommunicationDetailRecord>;
 }
 
+export interface SalesforceReconciliationRunRepository {
+  /**
+   * Inserts a single run-log row recording the outcome of one entity's
+   * pass of the reconciliation orchestrator. Idempotent on the
+   * caller-provided `id` (the orchestrator generates fresh UUIDs per run).
+   */
+  insert(record: SalesforceReconciliationRunRecord): Promise<void>;
+}
+
 export interface SimpleTextingMessageDetailRepository {
   listBySourceEvidenceIds(
     sourceEvidenceIds: readonly string[],
@@ -959,6 +969,7 @@ export interface Stage1RepositoryBundle {
   readonly messageAttachments: MessageAttachmentRepository;
   readonly salesforceEventContext: SalesforceEventContextRepository;
   readonly salesforceCommunicationDetails: SalesforceCommunicationDetailRepository;
+  readonly salesforceReconciliationRuns: SalesforceReconciliationRunRepository;
   readonly simpleTextingMessageDetails: SimpleTextingMessageDetailRepository;
   readonly mailchimpCampaignActivityDetails: MailchimpCampaignActivityDetailRepository;
   readonly manualNoteDetails: ManualNoteDetailRepository;

--- a/packages/domain/test/normalization.test.ts
+++ b/packages/domain/test/normalization.test.ts
@@ -908,6 +908,9 @@ function buildContext(input: {
       upsert: (record: SalesforceCommunicationDetailRecord) =>
         Promise.resolve(record),
     },
+    salesforceReconciliationRuns: {
+      insert: () => Promise.resolve(),
+    },
     simpleTextingMessageDetails: {
       listBySourceEvidenceIds: () => Promise.resolve([]),
       upsert: (record: SimpleTextingMessageDetailRecord) =>

--- a/packages/domain/test/repositories.test.ts
+++ b/packages/domain/test/repositories.test.ts
@@ -163,6 +163,9 @@ describe("defineStage1RepositoryBundle", () => {
         listBySourceEvidenceIds: () => Promise.resolve([]),
         upsert: (record) => Promise.resolve(record),
       },
+      salesforceReconciliationRuns: {
+        insert: () => Promise.resolve(),
+      },
       simpleTextingMessageDetails: {
         listBySourceEvidenceIds: () => Promise.resolve([]),
         upsert: (record) => Promise.resolve(record),

--- a/packages/domain/test/stage3-last-inbound-alias.test.ts
+++ b/packages/domain/test/stage3-last-inbound-alias.test.ts
@@ -187,6 +187,9 @@ function buildRepositoryBundle(input: {
       listBySourceEvidenceIds: () => Promise.resolve([]),
       upsert: (record) => Promise.resolve(record),
     },
+    salesforceReconciliationRuns: {
+      insert: () => Promise.resolve(),
+    },
     simpleTextingMessageDetails: {
       listBySourceEvidenceIds: () => Promise.resolve([]),
       upsert: (record) => Promise.resolve(record),

--- a/packages/domain/test/timeline.test.ts
+++ b/packages/domain/test/timeline.test.ts
@@ -290,6 +290,9 @@ function createRepositoryBundle(input: {
         ),
       upsert: (record) => Promise.resolve(record),
     },
+    salesforceReconciliationRuns: {
+      insert: () => Promise.resolve(),
+    },
     simpleTextingMessageDetails: {
       listBySourceEvidenceIds: () => Promise.resolve([]),
       upsert: (record) => Promise.resolve(record),

--- a/packages/integrations/src/index.ts
+++ b/packages/integrations/src/index.ts
@@ -21,6 +21,7 @@ export * from "./capture-services/shared.js";
 export * from "./capture-services/gmail.js";
 export * from "./capture-services/mailchimp.js";
 export * from "./capture-services/salesforce.js";
+export * from "./capture-services/salesforce-state-diff.js";
 export * from "./providers/gmail.js";
 export * from "./providers/gmail-body.js";
 export * from "./providers/gmail-mbox.js";


### PR DESCRIPTION
## Summary

Brick 2b of [#544](https://github.com/nico-kneler-as/as-comms-platform/issues/544). Wires the Brick 2a building blocks into a working weekly reconciler — **in dry-run mode by default**. Brick 3 will flip the default to enforce and add the 5% delete safety cap + inbox selector filter.

- New `SalesforceReconciliationRunRepository` for writing rows into the `salesforce_reconciliation_runs` log table.
- New ops module orchestrating contacts → memberships → projects. Per entity: lists SF-anchored IDs, batches into SOQL `Id IN (...)` queries (500/batch), calls `queryAllIncludingDeleted`, runs `diffSalesforceState`, writes a run-log row, and (in enforce mode only) calls `markSalesforceDeleted` + `markSalesforceReconciled`. Per-batch failures are caught and recorded — one bad batch doesn't fail the whole entity.
- Cron entry `0 6 * * 0 reconcile-salesforce-state` (Saturday 11pm Mountain across DST).
- Mode controlled by `RECONCILE_SF_STATE_MODE` env var; default is `dry_run`. Runtime skips wiring with a `console.warn` when SF env config is incomplete (local dev without creds boots fine).

## Test plan

- [x] `pnpm typecheck` (16/16) green
- [x] `pnpm lint` (16/16) green
- [x] `pnpm boundaries` green
- [x] `reconcile-salesforce-state.test.ts` — 5/5 pass locally (dry_run, enforce, empty db, per-batch failure, source guard)
- [ ] CI runs the full worker + db test suites
- [ ] Post-merge: ship via Railway, then manually trigger the job once to verify the first dry-run report lands in `salesforce_reconciliation_runs` cleanly before flipping to enforce mode in Brick 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)