### PR TITLE
fix(composer,ai): preserve explicit sender alias + suppress AI draft signature

### DIFF
--- a/apps/web/app/inbox/_hooks/composer-draft-reducer.ts
+++ b/apps/web/app/inbox/_hooks/composer-draft-reducer.ts
@@ -262,12 +262,14 @@ export function reduceComposerDraft(
       return clearErrors({
         ...state,
         recipient: action.recipient,
-        selectedAlias: action.isReplying
-          ? state.selectedAlias
-          : resolveDefaultAlias({
-              recipient: action.recipient,
-              aliases: action.aliases,
-            }),
+        selectedAlias:
+          state.selectedAlias ??
+          (action.isReplying
+            ? null
+            : resolveDefaultAlias({
+                recipient: action.recipient,
+                aliases: action.aliases,
+              })),
       });
     case "SET_CC":
       return clearErrors({ ...state, cc: action.recipients });

--- a/apps/web/src/server/ai/prompt-builder.ts
+++ b/apps/web/src/server/ai/prompt-builder.ts
@@ -70,10 +70,10 @@ function renderChannelInstructionBlock(input: {
   }
 
   if (input.intent === "new") {
-    return "You are drafting a brand-new outbound email to a volunteer. The operator is starting a new conversation — do NOT phrase this as a reply, do NOT begin with 'Thanks for reaching out' or any reply-style opener, and do NOT reference any inbound message as if it triggered this. The thread history below is background context only. Use only the information above and the operator's directive (if any). Never invent facts.";
+    return "You are drafting a brand-new outbound email to a volunteer. The operator is starting a new conversation — do NOT phrase this as a reply, do NOT begin with 'Thanks for reaching out' or any reply-style opener, and do NOT reference any inbound message as if it triggered this. The thread history below is background context only. Use only the information above and the operator's directive (if any). Never invent facts. Do NOT include a sign-off or signature line — the composer appends the operator's alias signature automatically. End the draft with the last sentence of the message body.";
   }
 
-  return "You are drafting a reply to a volunteer. Use only the information above and the inbound message (if present). Never invent facts.";
+  return "You are drafting a reply to a volunteer. Use only the information above and the inbound message (if present). Never invent facts. Do NOT include a sign-off or signature line — the composer appends the operator's alias signature automatically. End the draft with the last sentence of the message body.";
 }
 
 function buildSystemPrompt(

--- a/apps/web/test/server/ai/prompt-builder.test.ts
+++ b/apps/web/test/server/ai/prompt-builder.test.ts
@@ -82,28 +82,28 @@ describe("prompt builder", () => {
           {
             "content": "Inbound message:
       Can you send the current field kit list?
-      
+
       Recent thread context:
       - 2026-04-23T08:00:00.000Z | outbound email
       Subject: Re: Whitebark kit
       Body: Happy to help with the kit list.
-      
+
       Output ONLY the final reply text. Do not include any preamble, sign-off commentary, or marker text OTHER than the contradiction marker if triggered.",
             "role": "user",
           },
         ],
         "system": "[Tier 1 Voice Instructions]
       Use a warm, direct, field-ready voice.
-      
+
       [Tier 2 Project Context]
       Whitebark volunteers should get the latest field kit guidance.
-      
+
       [Tier 3 Canonical Examples]
       (No approved canonical examples are available.)
-      
+
       The examples above are pattern support, not templates. Never copy any example verbatim. Adapt the style and structure to the current volunteer and project context.
-      
-      You are drafting a reply to a volunteer. Use only the information above and the inbound message (if present). Never invent facts.",
+
+      You are drafting a reply to a volunteer. Use only the information above and the inbound message (if present). Never invent facts. Do NOT include a sign-off or signature line — the composer appends the operator's alias signature automatically. End the draft with the last sentence of the message body.",
       }
     `);
     expect(prompt.system).toContain(
@@ -129,7 +129,7 @@ describe("prompt builder", () => {
           {
             "content": "Inbound message:
       Can you send the current field kit list?
-      
+
       Recent thread context:
       - 2026-04-23T08:00:00.000Z | outbound email
       Subject: Re: Whitebark kit
@@ -137,25 +137,25 @@ describe("prompt builder", () => {
 
       Operator directive:
       Tell her the revised field kit will ship tomorrow.
-      
+
       Expand the operator's directive into a complete reply in the voice and context above. If the directive contradicts the project context, produce the draft as directed AND emit a clear marker that the operator should reconfirm. Example marker: [NOTE: directive may conflict with project context, please verify X].
-      
+
       Output ONLY the final reply text. Do not include any preamble, sign-off commentary, or marker text OTHER than the contradiction marker if triggered.",
             "role": "user",
           },
         ],
         "system": "[Tier 1 Voice Instructions]
       Use a warm, direct, field-ready voice.
-      
+
       [Tier 2 Project Context]
       Whitebark volunteers should get the latest field kit guidance.
-      
+
       [Tier 3 Canonical Examples]
       (No approved canonical examples are available.)
-      
+
       The examples above are pattern support, not templates. Never copy any example verbatim. Adapt the style and structure to the current volunteer and project context.
-      
-      You are drafting a reply to a volunteer. Use only the information above and the inbound message (if present). Never invent facts.",
+
+      You are drafting a reply to a volunteer. Use only the information above and the inbound message (if present). Never invent facts. Do NOT include a sign-off or signature line — the composer appends the operator's alias signature automatically. End the draft with the last sentence of the message body.",
       }
     `);
   });
@@ -179,7 +179,7 @@ describe("prompt builder", () => {
           {
             "content": "Inbound message:
       Can you send the current field kit list?
-      
+
       Recent thread context:
       - 2026-04-23T08:00:00.000Z | outbound email
       Subject: Re: Whitebark kit
@@ -187,28 +187,28 @@ describe("prompt builder", () => {
 
       Previous draft:
       Thanks for checking in.
-      
+
       Reprompt direction:
       Make it warmer and add the ship date.
-      
+
       Revise the previous draft in light of the direction. Keep the voice and grounding constraints.
-      
+
       Output ONLY the final reply text. Do not include any preamble, sign-off commentary, or marker text OTHER than the contradiction marker if triggered.",
             "role": "user",
           },
         ],
         "system": "[Tier 1 Voice Instructions]
       Use a warm, direct, field-ready voice.
-      
+
       [Tier 2 Project Context]
       Whitebark volunteers should get the latest field kit guidance.
-      
+
       [Tier 3 Canonical Examples]
       (No approved canonical examples are available.)
-      
+
       The examples above are pattern support, not templates. Never copy any example verbatim. Adapt the style and structure to the current volunteer and project context.
-      
-      You are drafting a reply to a volunteer. Use only the information above and the inbound message (if present). Never invent facts.",
+
+      You are drafting a reply to a volunteer. Use only the information above and the inbound message (if present). Never invent facts. Do NOT include a sign-off or signature line — the composer appends the operator's alias signature automatically. End the draft with the last sentence of the message body.",
       }
     `);
   });
@@ -237,28 +237,28 @@ describe("prompt builder", () => {
           {
             "content": "Inbound message:
       Can you send the current field kit list?
-      
+
       Recent thread context:
       - 2026-04-23T08:00:00.000Z | outbound email
       Subject: Re: Whitebark kit
       Body: Happy to help with the kit list.
-      
+
       Output ONLY the final reply text. Do not include any preamble, sign-off commentary, or marker text OTHER than the contradiction marker if triggered.",
             "role": "user",
           },
         ],
         "system": "[Tier 1 Voice Instructions]
       (No global voice instructions are available.)
-      
+
       [Tier 2 Project Context]
       (No project-specific context is available.)
-      
+
       [Tier 3 Canonical Examples]
       (No approved canonical examples are available.)
-      
+
       The examples above are pattern support, not templates. Never copy any example verbatim. Adapt the style and structure to the current volunteer and project context.
-      
-      You are drafting a reply to a volunteer. Use only the information above and the inbound message (if present). Never invent facts.",
+
+      You are drafting a reply to a volunteer. Use only the information above and the inbound message (if present). Never invent facts. Do NOT include a sign-off or signature line — the composer appends the operator's alias signature automatically. End the draft with the last sentence of the message body.",
       }
     `);
   });

--- a/apps/web/tests/unit/composer-draft-reducer.test.ts
+++ b/apps/web/tests/unit/composer-draft-reducer.test.ts
@@ -17,6 +17,16 @@ const aliases = [
     isAiConfigured: true,
     hasCachedContent: true,
   },
+  {
+    id: "alias-2",
+    alias: "orcas@adventuresci.org",
+    projectId: "project-2",
+    projectName: "Orcas",
+    signature: "Best,\nOrcas Team",
+    isAiReady: true,
+    isAiConfigured: true,
+    hasCachedContent: true,
+  },
 ] as const;
 
 describe("composer draft reducer", () => {
@@ -67,12 +77,33 @@ describe("composer draft reducer", () => {
     });
   });
 
-  it("recomputes the alias when a net-new recipient changes", () => {
+  it("SET_RECIPIENT preserves an explicit selectedAlias in net-new flow", () => {
     const state = reduceComposerDraft(
       {
         ...INITIAL_COMPOSER_DRAFT_STATE,
-        selectedAlias: "old@adventuresci.org",
+        selectedAlias: "orcas@adventuresci.org",
       },
+      {
+        type: "SET_RECIPIENT",
+        isReplying: false,
+        aliases,
+        recipient: {
+          kind: "contact",
+          contactId: "contact-1",
+          displayName: "Ada Lovelace",
+          primaryEmail: "ada@example.org",
+          primaryProjectName: "Forest",
+          salesforceContactId: "sf-1",
+        },
+      },
+    );
+
+    expect(state.selectedAlias).toBe("orcas@adventuresci.org");
+  });
+
+  it("SET_RECIPIENT resolves default alias when selectedAlias is null and isReplying is false", () => {
+    const state = reduceComposerDraft(
+      INITIAL_COMPOSER_DRAFT_STATE,
       {
         type: "SET_RECIPIENT",
         isReplying: false,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -57,6 +57,10 @@ export default defineConfig({
     include: [
       "apps/web/app/**/*.test.ts",
       "apps/web/app/**/*.test.tsx",
+      "apps/web/test/**/*.test.ts",
+      "apps/web/test/**/*.test.tsx",
+      "apps/web/tests/**/*.test.ts",
+      "apps/web/tests/**/*.test.tsx",
       "scripts/**/*.test.ts",
       "scripts/**/*.test.tsx",
       "test/**/*.test.ts",


### PR DESCRIPTION
## Summary
Two small composer/AI bugs:

- **Bug #2 — Sender alias clears when picking recipient.** In the net-new composer flow, picking a recipient called `resolveDefaultAlias` and silently overwrote the user's explicit alias choice. Fix: `selectedAlias ?? (isReplying ? null : resolveDefaultAlias(...))` — only resolve a default when no alias has been picked yet.
- **Bug #4 — Double signature on AI drafts.** Email system prompt had no "no signature" instruction (SMS did), so the model emitted its own sign-off and the composer then appended the alias signature → two sign-offs in the approved body. Fix: append explicit "do NOT include a sign-off or signature line" to both email branches of `renderChannelInstructionBlock`.

Also: `vitest.config.ts` now includes `apps/web/tests/**` so root-level vitest invocations discover the same files turbo's apps/web cwd already picks up via the relative `tests/**` pattern.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm boundaries`
- [x] `pnpm test:unit` (16/16 packages green; new reducer tests added; prompt-builder inline snapshots updated to reflect the new email-branch instruction)
- [ ] Manual: net-new composer → pick alias → pick recipient → alias stays selected
- [ ] Manual: pick alias with signature → click Draft with AI → approve → only one sign-off in body

🤖 Generated with [Claude Code](https://claude.com/claude-code)