### PR TITLE
feat(inbox): add "Edit prompt" button to AI draft window

### DIFF
--- a/apps/web/app/inbox/_components/composer-ai-draft-window.tsx
+++ b/apps/web/app/inbox/_components/composer-ai-draft-window.tsx
@@ -12,6 +12,7 @@ import { FOCUS_RING, TRANSITION } from "@/app/_lib/design-tokens-v2";
 import { cn } from "@/lib/utils";
 
 import {
+  ArrowLeftIcon,
   CheckIcon,
   LoaderIcon,
   RotateCcwIcon,
@@ -173,6 +174,7 @@ export function ComposerAiDraftWindow({
   onOpenReprompt,
   onSubmitReprompt,
   onCancelReprompt,
+  onEditPrompt,
   onDiscard,
   onApprove,
 }: {
@@ -190,6 +192,7 @@ export function ComposerAiDraftWindow({
   readonly onOpenReprompt: () => void;
   readonly onSubmitReprompt: () => void;
   readonly onCancelReprompt: () => void;
+  readonly onEditPrompt: () => void;
   readonly onDiscard: () => void;
   readonly onApprove: () => void;
 }) {
@@ -331,6 +334,15 @@ export function ComposerAiDraftWindow({
           )}
         >
           <div className="ml-auto flex items-center gap-1">
+            {!isReprompting ? (
+              <AiDraftActionButton
+                onClick={onEditPrompt}
+                disabled={!canUseDraftActions}
+              >
+                <ArrowLeftIcon className="size-3.5" />
+                Edit prompt
+              </AiDraftActionButton>
+            ) : null}
             <AiDraftActionButton
               onClick={isReprompting ? onCancelReprompt : onOpenReprompt}
               disabled={!canUseDraftActions}

--- a/apps/web/app/inbox/_components/composer-detail-surfaces.tsx
+++ b/apps/web/app/inbox/_components/composer-detail-surfaces.tsx
@@ -297,6 +297,7 @@ export function ComposerEmailSurface({
   onAiDirectiveChange,
   onAiEdited,
   onDiscardAi,
+  onEditPromptAi,
   onOpenReprompt,
   onCancelReprompt,
   onApproveAi,
@@ -366,6 +367,7 @@ export function ComposerEmailSurface({
   readonly onAiDirectiveChange: (value: string) => void;
   readonly onAiEdited: () => void;
   readonly onDiscardAi: () => void;
+  readonly onEditPromptAi: () => void;
   readonly onOpenReprompt: () => void;
   readonly onCancelReprompt: () => void;
   readonly onApproveAi: () => void;
@@ -552,6 +554,7 @@ export function ComposerEmailSurface({
                   onDirectiveTextChange={onAiDirectiveChange}
                   onRepromptTextChange={onRepromptTextChange}
                   onRunDraft={onRunAiDraft}
+                  onEditPrompt={onEditPromptAi}
                   onOpenReprompt={onOpenReprompt}
                   onSubmitReprompt={onReprompt}
                   onCancelReprompt={onCancelReprompt}
@@ -760,6 +763,7 @@ export function ComposerSmsSurface({
   onAiDirectiveChange,
   onAiEdited,
   onDiscardAi,
+  onEditPromptAi,
   onOpenReprompt,
   onCancelReprompt,
   onApproveAi,
@@ -797,6 +801,7 @@ export function ComposerSmsSurface({
   readonly onAiDirectiveChange: (value: string) => void;
   readonly onAiEdited: () => void;
   readonly onDiscardAi: () => void;
+  readonly onEditPromptAi: () => void;
   readonly onOpenReprompt: () => void;
   readonly onCancelReprompt: () => void;
   readonly onApproveAi: () => void;
@@ -928,6 +933,7 @@ export function ComposerSmsSurface({
           onDirectiveTextChange={onAiDirectiveChange}
           onRepromptTextChange={onRepromptTextChange}
           onRunDraft={onRunAiDraft}
+          onEditPrompt={onEditPromptAi}
           onOpenReprompt={onOpenReprompt}
           onSubmitReprompt={onReprompt}
           onCancelReprompt={onCancelReprompt}

--- a/apps/web/app/inbox/_components/icons.tsx
+++ b/apps/web/app/inbox/_components/icons.tsx
@@ -35,6 +35,7 @@ export {
   CornerUpLeft as CornerUpLeftIcon,
   CornerUpRight as CornerUpRightIcon,
   ArrowRight as ArrowRightIcon,
+  ArrowLeft as ArrowLeftIcon,
   X as XIcon,
   LogOut as LogOutIcon,
   Loader2 as LoaderIcon,

--- a/apps/web/app/inbox/_components/inbox-client-provider.tsx
+++ b/apps/web/app/inbox/_components/inbox-client-provider.tsx
@@ -201,6 +201,7 @@ interface InboxClientState {
   readonly markAiDraftEdited: () => void;
   readonly restoreAiDraft: () => void;
   readonly discardAiDraft: () => void;
+  readonly editPromptAiDraft: () => void;
   readonly markAiDraftReprompting: () => void;
   readonly repromptAi: (input: {
     readonly request: AiDraftRequestPayload;
@@ -552,6 +553,10 @@ export function InboxClientProvider({
     setAiDraft(INITIAL_AI_DRAFT);
   }, []);
 
+  const editPromptAiDraft = useCallback(() => {
+    setAiDraft(INITIAL_AI_DRAFT);
+  }, []);
+
   const markAiDraftReprompting = useCallback(() => {
     setAiDraft((previous) => ({
       ...previous,
@@ -645,6 +650,7 @@ export function InboxClientProvider({
       markAiDraftEdited,
       restoreAiDraft,
       discardAiDraft,
+      editPromptAiDraft,
       markAiDraftReprompting,
       repromptAi,
       setAiUnavailable,
@@ -692,6 +698,7 @@ export function InboxClientProvider({
       markAiDraftEdited,
       restoreAiDraft,
       discardAiDraft,
+      editPromptAiDraft,
       markAiDraftReprompting,
       repromptAi,
       setAiUnavailable,

--- a/apps/web/app/inbox/_components/inbox-composer.tsx
+++ b/apps/web/app/inbox/_components/inbox-composer.tsx
@@ -163,6 +163,7 @@ export function InboxComposerDetailPane({
     approveAiDraft,
     markAiDraftEdited,
     discardAiDraft,
+    editPromptAiDraft,
     markAiDraftReprompting,
     repromptAi,
     cancelReprompt,
@@ -343,6 +344,7 @@ export function InboxComposerDetailPane({
   const {
     runAiDraft,
     discardAi,
+    editPromptAi,
     regenerateAi,
     openReprompt,
     cancelAiReprompt,
@@ -359,6 +361,7 @@ export function InboxComposerDetailPane({
     markAiDraftReviewable,
     approveAiDraft,
     discardAiDraft,
+    editPromptAiDraft,
     markAiDraftReprompting,
     repromptAi,
     cancelReprompt,
@@ -581,6 +584,7 @@ export function InboxComposerDetailPane({
               }}
               onAiEdited={markAiDraftEdited}
               onDiscardAi={discardAi}
+              onEditPromptAi={editPromptAi}
               onOpenReprompt={openReprompt}
               onCancelReprompt={cancelAiReprompt}
               onApproveAi={approveAi}
@@ -680,6 +684,7 @@ export function InboxComposerDetailPane({
               }}
               onAiEdited={markAiDraftEdited}
               onDiscardAi={discardAi}
+              onEditPromptAi={editPromptAi}
               onOpenReprompt={openReprompt}
               onCancelReprompt={cancelAiReprompt}
               onApproveAi={approveAi}

--- a/apps/web/app/inbox/_hooks/use-ai-draft-run.ts
+++ b/apps/web/app/inbox/_hooks/use-ai-draft-run.ts
@@ -26,6 +26,7 @@ export function useAiDraftRun({
   markAiDraftReviewable,
   approveAiDraft,
   discardAiDraft,
+  editPromptAiDraft,
   markAiDraftReprompting,
   repromptAi,
   cancelReprompt,
@@ -52,6 +53,7 @@ export function useAiDraftRun({
   }) => void;
   readonly approveAiDraft: () => void;
   readonly discardAiDraft: () => void;
+  readonly editPromptAiDraft: () => void;
   readonly markAiDraftReprompting: () => void;
   readonly repromptAi: (input: {
     readonly request: AiDraftRequestPayload;
@@ -183,6 +185,12 @@ export function useAiDraftRun({
     dispatch({ type: "SET_REPROMPT_TEXT", value: "" });
   };
 
+  const editPromptAi = () => {
+    clearComposerErrors();
+    editPromptAiDraft();
+    dispatch({ type: "SET_REPROMPT_TEXT", value: "" });
+  };
+
   const regenerateAi = () => {
     if (state.repromptText.trim().length === 0) {
       return;
@@ -227,6 +235,7 @@ export function useAiDraftRun({
   return {
     runAiDraft,
     discardAi,
+    editPromptAi,
     regenerateAi,
     openReprompt,
     cancelAiReprompt,

--- a/apps/web/tests/unit/ai-draft-preview-approve.test.tsx
+++ b/apps/web/tests/unit/ai-draft-preview-approve.test.tsx
@@ -12,6 +12,7 @@ function iconMock(name: string) {
 
 vi.mock("lucide-react", () => ({
   AlertCircle: iconMock("AlertCircle"),
+  ArrowLeft: iconMock("ArrowLeft"),
   BookOpen: iconMock("BookOpen"),
   Check: iconMock("Check"),
   Flag: iconMock("Flag"),
@@ -221,7 +222,7 @@ function getButton(name: string): HTMLButtonElement {
 
 function DraftHarness() {
   const [aiDraft, setAiDraft] = useState(initialAiDraft);
-  const [directiveText, setDirectiveText] = useState("");
+  const [directiveText, setDirectiveText] = useState("Draft a concise follow-up");
   const [repromptText, setRepromptText] = useState("");
   const [body, setBody] = useState("");
 
@@ -289,6 +290,10 @@ function DraftHarness() {
           setRepromptText("");
           setAiDraft(initialAiDraft);
         }}
+        onEditPrompt={() => {
+          setRepromptText("");
+          setAiDraft(initialAiDraft);
+        }}
         onApprove={() => {
           setBody(aiDraft.generatedText);
           setStatus("inserted");
@@ -321,6 +326,27 @@ describe("AI draft preview approval panel", () => {
       "Hi Maya,\n\nThanks for checking in.",
     );
     expect(document.body.textContent).toContain("AI draft");
+  });
+
+  it("returns to the prompt editor with the original intent when edit prompt is clicked", async () => {
+    await mount(createElement(DraftHarness));
+
+    await click(getButton("Finish generation"));
+    expect(document.body.textContent).toContain("Edit prompt");
+    expect(document.querySelector("textarea")?.textContent ?? "").not.toContain(
+      "Draft a concise follow-up",
+    );
+
+    await click(getButton("Edit prompt"));
+
+    const textarea = document.querySelector<HTMLTextAreaElement>("textarea");
+    expect(textarea).toBeInstanceOf(HTMLTextAreaElement);
+    if (textarea === null) {
+      throw new Error("Expected prompt textarea.");
+    }
+    expect(textarea.value).toBe("Draft a concise follow-up");
+    expect(document.body.textContent).toContain("Draft with AI");
+    expect(document.body.textContent).not.toContain("Reprompt");
   });
 
   // TODO: re-enable after JSDOM event handler shim is added — Radix DismissableLayer

--- a/apps/web/tests/unit/inbox-composer-send-menu.test.tsx
+++ b/apps/web/tests/unit/inbox-composer-send-menu.test.tsx
@@ -255,6 +255,7 @@ function iconMock(name: string) {
 
 vi.mock("../../app/inbox/_components/icons", () => ({
   AlertCircleIcon: iconMock("AlertCircle"),
+  ArrowLeftIcon: iconMock("ArrowLeft"),
   BoldIcon: iconMock("Bold"),
   BookOpenIcon: iconMock("BookOpen"),
   ChevronDownIcon: iconMock("ChevronDown"),
@@ -348,6 +349,7 @@ const baseProps: ComposerEmailSurfaceProps = {
   onAiDirectiveChange: vi.fn(),
   onAiEdited: vi.fn(),
   onDiscardAi: vi.fn(),
+  onEditPromptAi: vi.fn(),
   onOpenReprompt: vi.fn(),
   onCancelReprompt: vi.fn(),
   onApproveAi: vi.fn(),
@@ -404,6 +406,7 @@ const baseSmsProps: ComposerSmsSurfaceProps = {
   onAiDirectiveChange: vi.fn(),
   onAiEdited: vi.fn(),
   onDiscardAi: vi.fn(),
+  onEditPromptAi: vi.fn(),
   onOpenReprompt: vi.fn(),
   onCancelReprompt: vi.fn(),
   onApproveAi: vi.fn(),

--- a/apps/web/tests/unit/use-ai-draft-run.test.ts
+++ b/apps/web/tests/unit/use-ai-draft-run.test.ts
@@ -42,6 +42,7 @@ function setup(input?: {
 }) {
   const dispatch = vi.fn();
   const approveAiDraft = vi.fn();
+  const editPromptAiDraft = vi.fn();
   const startAiGeneration = input?.startAiGeneration ?? vi.fn();
   const controls = useAiDraftRun({
     state: {
@@ -97,6 +98,7 @@ function setup(input?: {
     markAiDraftReviewable: vi.fn(),
     approveAiDraft,
     discardAiDraft: vi.fn(),
+    editPromptAiDraft,
     markAiDraftReprompting: vi.fn(),
     repromptAi: vi.fn(),
     cancelReprompt: vi.fn(),
@@ -112,6 +114,7 @@ function setup(input?: {
   return {
     dispatch,
     approveAiDraft,
+    editPromptAiDraft,
     startAiGeneration,
     controls,
   };
@@ -233,5 +236,17 @@ describe("useAiDraftRun", () => {
       prompt: "Draft with AI",
     });
     expect(startAiTransition).toHaveBeenCalledOnce();
+  });
+
+  it("editPromptAi resets the aiDraft to idle but does not clear the composer's aiDirective", () => {
+    const { dispatch, editPromptAiDraft, controls } = setup();
+
+    controls.editPromptAi();
+
+    expect(editPromptAiDraft).toHaveBeenCalledOnce();
+    expect(dispatch).not.toHaveBeenCalledWith({
+      type: "SET_AI_DIRECTIVE",
+      value: "",
+    });
   });
 });


### PR DESCRIPTION
## Summary
After generating an AI draft, the operator can now click **Edit prompt** (← icon) to return to the empty state with their original intent text intact, edit it, and re-run from scratch.

Distinct from Reprompt:
- **Reprompt** → provide an additive direction on the existing draft ("warmer", "shorter")
- **Edit prompt** → reset the draft, edit the original intent itself, run again

## Changes
- New `editPromptAiDraft` setter on the AI draft state (resets aiDraft, leaves `aiDirective` intact)
- New `editPromptAi` handler in `useAiDraftRun`
- New button in the AI draft footer (visible in `reviewable` status, hidden during `reprompting`), wired through both email and SMS surfaces
- Added `ArrowLeft as ArrowLeftIcon` to the inbox icon barrel
- Unit tests cover the new handler + rendered button

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm boundaries`
- [x] `pnpm test:unit` (16/16 packages green; new unit tests added)
- [ ] Manual: Draft with AI → reviewable state → click Edit prompt → intent text preserved → edit → Draft with AI → new draft
- [ ] Manual: SMS draft also exposes Edit prompt and round-trips correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)