### PR TITLE
feat(inbox): Drafts folder in filter + drafts list view (PRD #553 Brick C)

### DIFF
--- a/apps/web/app/inbox/_components/icons.tsx
+++ b/apps/web/app/inbox/_components/icons.tsx
@@ -69,6 +69,7 @@ export {
   ListOrdered as ListOrderedIcon,
   Upload as UploadIcon,
   FileIcon as FileDocIcon,
+  FilePen as FileEditIcon,
   Eye as EyeIcon,
   MousePointerClick as MousePointerClickIcon,
   Flag as FlagIcon,

--- a/apps/web/app/inbox/_components/inbox-client-provider.tsx
+++ b/apps/web/app/inbox/_components/inbox-client-provider.tsx
@@ -11,6 +11,7 @@ import {
 
 import type { AiDraftRequestPayload, AiDraftResponseVm } from "../actions";
 import type {
+  InboxDraftListItemViewModel,
   InboxComposerAliasOption,
   InboxComposerForwardContext,
   InboxComposerReplyContext,
@@ -155,6 +156,7 @@ interface InboxClientState {
   readonly composerAliases: readonly InboxComposerAliasOption[];
   readonly composerPane: ComposerPaneState;
   readonly composerView: ComposerViewState;
+  readonly drafts: readonly InboxDraftListItemViewModel[];
   readonly openNewDraft: () => void;
   readonly openReplyDraft: (
     replyContext: InboxComposerReplyContext,
@@ -164,6 +166,11 @@ interface InboxClientState {
     forwardContext: InboxComposerForwardContext,
     initialTab?: "email",
   ) => void;
+  readonly openExistingDraft: (draft: InboxDraftListItemViewModel) => void;
+  readonly upsertDraft: (draft: InboxDraftListItemViewModel) => void;
+  readonly removeDraft: (draftId: string) => void;
+  readonly pendingExistingDraft: InboxDraftListItemViewModel | null;
+  readonly clearPendingExistingDraft: () => void;
   readonly closeComposer: () => void;
   readonly minimizeComposer: () => void;
   readonly expandComposer: () => void;
@@ -217,11 +224,13 @@ const InboxClientContext = createContext<InboxClientState | null>(null);
 export function InboxClientProvider({
   children,
   composerAliases,
+  initialDrafts,
   currentActorId,
   operatorDisplayName = currentActorId,
 }: {
   readonly children: ReactNode;
   readonly composerAliases: readonly InboxComposerAliasOption[];
+  readonly initialDrafts: readonly InboxDraftListItemViewModel[];
   readonly currentActorId: string;
   readonly operatorDisplayName?: string;
 }) {
@@ -235,6 +244,9 @@ export function InboxClientProvider({
     mode: "closed",
   });
   const [composerView, setComposerView] = useState<ComposerViewState>("closed");
+  const [drafts, setDrafts] = useState(initialDrafts);
+  const [pendingExistingDraft, setPendingExistingDraft] =
+    useState<InboxDraftListItemViewModel | null>(null);
   const [composerStatus, setComposerStatus] = useState<ComposerStatus>("idle");
   const [composerErrors, setComposerErrors] = useState<
     readonly ComposerValidationError[]
@@ -333,6 +345,7 @@ export function InboxClientProvider({
   }, []);
 
   const openNewDraft = useCallback(() => {
+    setPendingExistingDraft(null);
     setComposerPane((previous) =>
       reduceComposerPane(previous, {
         type: "open-new-draft",
@@ -348,6 +361,7 @@ export function InboxClientProvider({
       replyContext: InboxComposerReplyContext,
       initialTab: "email" | "note" = "email",
     ) => {
+      setPendingExistingDraft(null);
       setComposerPane((previous) =>
         reduceComposerPane(previous, {
           type: "open-reply",
@@ -367,6 +381,7 @@ export function InboxClientProvider({
       forwardContext: InboxComposerForwardContext,
       initialTab: "email" = "email",
     ) => {
+      setPendingExistingDraft(null);
       setComposerPane((previous) =>
         reduceComposerPane(previous, {
           type: "open-forward",
@@ -381,7 +396,55 @@ export function InboxClientProvider({
     [],
   );
 
+  const openExistingDraft = useCallback((draft: InboxDraftListItemViewModel) => {
+    if (draft.paneMode === "replying" && draft.replyContext !== null) {
+      setComposerPane({
+        mode: "replying",
+        replyContext: draft.replyContext,
+        initialTab: draft.channel === "note" ? "note" : "email",
+      });
+    } else if (
+      draft.paneMode === "forwarding" &&
+      draft.forwardContext !== null
+    ) {
+      setComposerPane({
+        mode: "forwarding",
+        forwardContext: draft.forwardContext,
+        initialTab: "email",
+      });
+    } else {
+      setComposerPane({
+        mode: "new-draft",
+        initialTab: "email",
+      });
+    }
+
+    setPendingExistingDraft(draft);
+    setComposerView("modal");
+    setComposerStatus("idle");
+    setComposerErrors([]);
+  }, []);
+
+  const upsertDraft = useCallback((draft: InboxDraftListItemViewModel) => {
+    setDrafts((previous) =>
+      [draft, ...previous.filter((entry) => entry.id !== draft.id)].sort(
+        (left, right) =>
+          right.updatedAt.localeCompare(left.updatedAt) ||
+          right.id.localeCompare(left.id),
+      ),
+    );
+  }, []);
+
+  const removeDraft = useCallback((draftId: string) => {
+    setDrafts((previous) => previous.filter((draft) => draft.id !== draftId));
+  }, []);
+
+  const clearPendingExistingDraft = useCallback(() => {
+    setPendingExistingDraft(null);
+  }, []);
+
   const closeComposer = useCallback(() => {
+    setPendingExistingDraft(null);
     setComposerView("closed");
     setComposerPane((previous) =>
       reduceComposerPane(previous, {
@@ -628,9 +691,15 @@ export function InboxClientProvider({
       composerAliases,
       composerPane,
       composerView,
+      drafts,
       openNewDraft,
       openReplyDraft,
       openForwardDraft,
+      openExistingDraft,
+      upsertDraft,
+      removeDraft,
+      pendingExistingDraft,
+      clearPendingExistingDraft,
       closeComposer,
       minimizeComposer,
       expandComposer,
@@ -678,9 +747,15 @@ export function InboxClientProvider({
       composerAliases,
       composerPane,
       composerView,
+      drafts,
       openNewDraft,
       openReplyDraft,
       openForwardDraft,
+      openExistingDraft,
+      upsertDraft,
+      removeDraft,
+      pendingExistingDraft,
+      clearPendingExistingDraft,
       closeComposer,
       minimizeComposer,
       expandComposer,

--- a/apps/web/app/inbox/_components/inbox-drafts-list.tsx
+++ b/apps/web/app/inbox/_components/inbox-drafts-list.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useTransition } from "react";
+
+import { EmptyState } from "@/components/ui/empty-state";
+import { deleteComposerDraftAction } from "@/src/server/composer/drafts";
+import { cn } from "@/lib/utils";
+
+import { useInboxClient } from "./inbox-client-provider";
+import {
+  FileEditIcon,
+  MailIcon,
+  NoteIcon,
+  PhoneIcon,
+  TrashIcon,
+} from "./icons";
+
+function formatRelativeTime(timestamp: string): string {
+  const target = new Date(timestamp).getTime();
+  const now = Date.now();
+  const deltaMs = Math.max(0, now - target);
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+
+  if (deltaMs < hour) {
+    const minutes = Math.max(1, Math.floor(deltaMs / minute));
+    return `${minutes.toString()}m ago`;
+  }
+
+  if (deltaMs < day) {
+    const hours = Math.floor(deltaMs / hour);
+    return `${hours.toString()}h ago`;
+  }
+
+  const days = Math.floor(deltaMs / day);
+
+  if (days === 1) {
+    return "yesterday";
+  }
+
+  if (days < 7) {
+    return `${days.toString()}d ago`;
+  }
+
+  if (days < 30) {
+    return `${Math.floor(days / 7).toString()}w ago`;
+  }
+
+  if (days < 365) {
+    return `${Math.floor(days / 30).toString()}mo ago`;
+  }
+
+  return `${Math.floor(days / 365).toString()}y ago`;
+}
+
+function buildPreview(bodyPlaintext: string): string {
+  const normalized = bodyPlaintext.replace(/\s+/gu, " ").trim();
+  return normalized.slice(0, 100);
+}
+
+function resolveRecipientLabel(input: {
+  readonly recipientDisplayName: string | null;
+  readonly recipientEmail: string | null;
+  readonly recipientPhone: string | null;
+}): string {
+  return (
+    input.recipientDisplayName ??
+    input.recipientEmail ??
+    input.recipientPhone ??
+    "(no recipient)"
+  );
+}
+
+export function InboxDraftsList() {
+  const { drafts, openExistingDraft, removeDraft } = useInboxClient();
+
+  if (drafts.length === 0) {
+    return (
+      <EmptyState
+        icon={<FileEditIcon className="size-6" />}
+        title="No drafts"
+        description="New drafts will appear here automatically as you type."
+      />
+    );
+  }
+
+  return (
+    <ul className="divide-y divide-slate-100" data-testid="drafts-list">
+      {drafts.map((draft) => (
+        <InboxDraftRow
+          key={draft.id}
+          draft={draft}
+          onOpen={() => {
+            openExistingDraft(draft);
+          }}
+          onDiscardOptimistic={() => {
+            removeDraft(draft.id);
+          }}
+        />
+      ))}
+    </ul>
+  );
+}
+
+function InboxDraftRow({
+  draft,
+  onOpen,
+  onDiscardOptimistic,
+}: {
+  readonly draft: ReturnType<typeof useInboxClient>["drafts"][number];
+  readonly onOpen: () => void;
+  readonly onDiscardOptimistic: () => void;
+}) {
+  const [isDiscarding, startDiscardTransition] = useTransition();
+  const ChannelIcon =
+    draft.channel === "email"
+      ? MailIcon
+      : draft.channel === "sms"
+        ? PhoneIcon
+        : NoteIcon;
+  const channelLabel =
+    draft.channel === "email"
+      ? "Email"
+      : draft.channel === "sms"
+        ? "SMS"
+        : "Note";
+  const recipientLabel = resolveRecipientLabel({
+    recipientDisplayName: draft.recipientDisplayName,
+    recipientEmail: draft.recipientEmail,
+    recipientPhone: draft.recipientPhone,
+  });
+  const subject = draft.subject.trim().length > 0 ? draft.subject : "(no subject)";
+  const preview = buildPreview(draft.bodyPlaintext);
+
+  return (
+    <li
+      className="group relative flex items-start gap-2 px-4 py-3 hover:bg-slate-50"
+      data-testid={`draft-row:${draft.id}`}
+    >
+      <button
+        type="button"
+        className="min-w-0 flex-1 text-left"
+        onClick={onOpen}
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          <p className="truncate text-[13.5px] font-semibold text-slate-900">
+            {recipientLabel}
+          </p>
+          <span className="inline-flex shrink-0 items-center gap-1 rounded-md bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium text-slate-600">
+            <ChannelIcon className="size-3" />
+            {channelLabel}
+          </span>
+          {draft.selectedAlias ? (
+            <span className="inline-flex shrink-0 items-center rounded-md bg-sky-50 px-1.5 py-0.5 text-[10px] font-medium text-sky-700">
+              {draft.selectedAlias}
+            </span>
+          ) : null}
+        </div>
+        <div className="mt-1 flex items-center gap-2 text-[12px]">
+          <p className="truncate font-medium text-slate-700">{subject}</p>
+          {preview.length > 0 ? (
+            <>
+              <span className="text-slate-300">·</span>
+              <p className="truncate text-slate-500">{preview}</p>
+            </>
+          ) : null}
+        </div>
+        <p className="mt-1 text-[11px] text-slate-400">
+          Last edited {formatRelativeTime(draft.updatedAt)}
+        </p>
+      </button>
+
+      <button
+        type="button"
+        aria-label={`Discard draft ${subject}`}
+        className={cn(
+          "mt-0.5 inline-flex size-8 shrink-0 items-center justify-center rounded-md text-slate-400 transition hover:bg-rose-50 hover:text-rose-700",
+          "opacity-100 sm:opacity-0 sm:group-hover:opacity-100",
+          isDiscarding ? "pointer-events-none opacity-100" : "",
+        )}
+        onClick={() => {
+          startDiscardTransition(() => {
+            onDiscardOptimistic();
+            void deleteComposerDraftAction({ id: draft.id });
+          });
+        }}
+      >
+        <TrashIcon className="size-3.5" />
+      </button>
+    </li>
+  );
+}

--- a/apps/web/app/inbox/_components/inbox-filter-list.tsx
+++ b/apps/web/app/inbox/_components/inbox-filter-list.tsx
@@ -21,6 +21,7 @@ import type {
 import {
   ArchiveBoxIcon,
   ChevronDownIcon,
+  FileEditIcon,
   FlagIcon,
   InboxIcon,
   MailOpenIcon,
@@ -33,6 +34,7 @@ const FILTER_ICON: Record<InboxFilterId, LucideIcon | null> = {
   "follow-up": FlagIcon,
   sent: SendIcon,
   archived: ArchiveBoxIcon,
+  drafts: FileEditIcon,
 };
 
 interface InboxFilterListProps {
@@ -62,7 +64,7 @@ export const InboxFilterList = forwardRef<HTMLDivElement, InboxFilterListProps>(
   ) {
   const filterById = new Map(filters.map((filter) => [filter.id, filter]));
   const primaryFilters = ["inbox", "unread", "follow-up"] as const;
-  const secondaryFilters = ["archived", "sent"] as const;
+  const secondaryFilters = ["archived", "drafts", "sent"] as const;
   const selectedProject =
     selectedProjectId === null
       ? null

--- a/apps/web/app/inbox/_components/inbox-list.tsx
+++ b/apps/web/app/inbox/_components/inbox-list.tsx
@@ -44,6 +44,7 @@ import {
   XIcon,
 } from "./icons";
 import { InboxFilterList } from "./inbox-filter-list";
+import { InboxDraftsList } from "./inbox-drafts-list";
 import { QueueLoadingSkeleton, QueueLoadMoreSkeleton } from "./inbox-loading";
 import { InboxRow } from "./inbox-row";
 import { InboxUnifiedSearchRow } from "./inbox-unified-search-row";
@@ -56,6 +57,7 @@ interface ListColumnProps {
 const STATE_HEADER_LABEL: Partial<Record<InboxFilterId, string>> = {
   unread: "Unread",
   "follow-up": "Pending",
+  drafts: "Drafts",
   sent: "Sent",
   archived: "Archived",
 };
@@ -213,13 +215,14 @@ export function InboxList({
   const urlFilter = searchParams.get("filter");
   const urlProjectId = searchParams.get("projectId");
   const urlProjectIds = searchParams.getAll("projectId");
+  const [activeFilter, setActiveFilter] = useState(initialFilterId);
   const rawSearchQuery = search.query.trim();
   const normalizedQuery = rawSearchQuery;
   const isSearchThresholdMet = rawSearchQuery.length >= 3;
+  const isDraftsFilter = activeFilter === "drafts";
   const isServerSearchActive =
-    isSearchThresholdMet && normalizedQuery.length >= 3;
+    !isDraftsFilter && isSearchThresholdMet && normalizedQuery.length >= 3;
   const serverQuery = isServerSearchActive ? normalizedQuery : null;
-  const [activeFilter, setActiveFilter] = useState(initialFilterId);
   const [selectedProjectId, setSelectedProjectId] = useState(
     urlProjectId ?? initialList.selectedProjectId ?? null,
   );
@@ -497,6 +500,13 @@ export function InboxList({
       return;
     }
 
+    if (isDraftsFilter) {
+      setQueueLoading(false);
+      setQueueError(null);
+      setSearchResult(null);
+      return;
+    }
+
     if (
       activeFilter === "inbox" &&
       selectedProjectId === null
@@ -533,6 +543,7 @@ export function InboxList({
   }, [
     activeFilter,
     initialFilterCountById,
+    isDraftsFilter,
     isServerSearchActive,
     loadFilterPage,
     loadUnifiedSearchPage,
@@ -546,6 +557,12 @@ export function InboxList({
 
     if (isServerSearchActive && serverQuery !== null) {
       void loadUnifiedSearchPage(serverQuery);
+      return;
+    }
+
+    if (latestShellState.activeFilter === "drafts") {
+      setQueueError(null);
+      setSearchResult(null);
       return;
     }
 
@@ -585,6 +602,7 @@ export function InboxList({
   // Pagination only applies to the folder-filtered list — the unified search
   // returns the top 25 per section in v1 with no cursor.
   const canLoadMore =
+    !isDraftsFilter &&
     !isServerSearchActive &&
     currentList.page.hasMore &&
     currentList.page.nextCursor !== null;
@@ -597,7 +615,8 @@ export function InboxList({
   const activeProjects = currentList.activeProjects;
   const hasActiveFilters =
     activeFilter !== "inbox" || selectedProjectId !== null;
-  const shouldShowSearchSummary = search.isActive && isSearchThresholdMet;
+  const shouldShowSearchSummary =
+    !isDraftsFilter && search.isActive && isSearchThresholdMet;
   const unreadCount = currentList.totals.unread;
   const headerTitle = useMemo(
     () =>
@@ -938,6 +957,8 @@ export function InboxList({
               activeContactId={activeContactId}
             />
           )
+        ) : isDraftsFilter ? (
+          <InboxDraftsList />
         ) : displayItems.length === 0 ? (
           <QueueEmptyState
             onSwitchToFollowUp={() => {

--- a/apps/web/app/inbox/_components/inbox-shell.tsx
+++ b/apps/web/app/inbox/_components/inbox-shell.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import type {
+  InboxDraftListItemViewModel,
   InboxFilterId,
   InboxListViewModel,
   InboxComposerAliasOption,
@@ -19,6 +20,7 @@ import { InboxWorkspace } from "./inbox-workspace";
 
 interface ShellProps {
   readonly initialList: InboxListViewModel;
+  readonly initialDrafts: readonly InboxDraftListItemViewModel[];
   readonly initialFilterId: InboxFilterId;
   readonly composerAliases: readonly InboxComposerAliasOption[];
   readonly outboundRateUsdPerSegment: number;
@@ -45,6 +47,7 @@ interface ShellProps {
  */
 export function InboxShell({
   initialList,
+  initialDrafts,
   initialFilterId,
   composerAliases,
   outboundRateUsdPerSegment,
@@ -58,6 +61,7 @@ export function InboxShell({
   return (
     <InboxClientProvider
       composerAliases={composerAliases}
+      initialDrafts={initialDrafts}
       currentActorId={currentActorId}
       operatorDisplayName={operator.displayName}
     >

--- a/apps/web/app/inbox/_hooks/use-composer-draft-state.ts
+++ b/apps/web/app/inbox/_hooks/use-composer-draft-state.ts
@@ -18,8 +18,14 @@ import {
   type StoredComposerDraft,
 } from "../_lib/composer-draft-storage";
 import { resolveDefaultAlias, type ComposerPaneState } from "../_lib/composer-ui";
-import type { InboxComposerAliasOption } from "../_lib/view-models";
+import type {
+  InboxComposerAliasOption,
+  InboxComposerForwardContext,
+  InboxComposerReplyContext,
+  InboxDraftListItemViewModel,
+} from "../_lib/view-models";
 import { resolveRecipientEmailAddress } from "../_components/composer-shared";
+import { useInboxClient } from "../_components/inbox-client-provider";
 import {
   INITIAL_COMPOSER_DRAFT_STATE,
   reduceComposerDraft,
@@ -188,6 +194,48 @@ function removeDraftFromCache(
   return (drafts ?? []).filter((draft) => draft.id !== draftId);
 }
 
+function toDraftListItemViewModel(input: {
+  readonly draft: ComposerDraftRecord;
+  readonly composerPane: ComposerPaneState;
+  readonly state: ComposerDraftState;
+  readonly replyContext: InboxComposerReplyContext | null;
+  readonly forwardContext: InboxComposerForwardContext | null;
+}): InboxDraftListItemViewModel {
+  const recipientDisplayName =
+    input.state.activeTab === "sms"
+      ? input.state.smsRecipient?.kind === "contact"
+        ? input.state.smsRecipient.displayName
+        : null
+      : input.composerPane.mode === "replying"
+        ? (input.replyContext?.contactDisplayName ?? null)
+        : input.state.recipient?.kind === "contact"
+          ? input.state.recipient.displayName
+          : null;
+
+  return {
+    id: input.draft.id,
+    paneMode:
+      input.draft.paneMode === "new-draft" ? "new_draft" : input.draft.paneMode,
+    channel: input.draft.channel,
+    recipientContactId: input.draft.recipientContactId,
+    recipientEmail: input.draft.recipientEmail,
+    recipientPhone: input.draft.recipientPhone,
+    recipientDisplayName,
+    subject: input.draft.subject,
+    bodyPlaintext: input.draft.bodyPlaintext,
+    bodyHtml: input.draft.bodyHtml,
+    selectedAlias: input.draft.selectedAlias,
+    cc: input.draft.cc,
+    bcc: input.draft.bcc,
+    attachments: input.draft.attachments,
+    aiDirective: input.draft.aiDirective,
+    replyContext: input.composerPane.mode === "replying" ? input.replyContext : null,
+    forwardContext:
+      input.composerPane.mode === "forwarding" ? input.forwardContext : null,
+    updatedAt: input.draft.updatedAt,
+  };
+}
+
 export function useComposerDraftState({
   composerPane,
   composerAliases,
@@ -206,6 +254,12 @@ export function useComposerDraftState({
     reduceComposerDraft,
     INITIAL_COMPOSER_DRAFT_STATE,
   );
+  const {
+    clearPendingExistingDraft,
+    pendingExistingDraft,
+    removeDraft,
+    upsertDraft,
+  } = useInboxClient();
   const [availableDrafts, setAvailableDrafts] = useState<
     readonly ComposerDraftRecord[] | null
   >(null);
@@ -297,6 +351,40 @@ export function useComposerDraftState({
       cancelled = true;
     };
   }, [composerPane]);
+
+  useEffect(() => {
+    if (composerPane.mode === "closed" || pendingExistingDraft === null) {
+      return;
+    }
+
+    draftIdRef.current = pendingExistingDraft.id;
+    dispatch({
+      type: "HYDRATE_FROM_STORED_DRAFT",
+      draft: {
+        id: pendingExistingDraft.id,
+        paneMode:
+          pendingExistingDraft.paneMode === "new_draft"
+            ? "new-draft"
+            : pendingExistingDraft.paneMode,
+        channel: pendingExistingDraft.channel,
+        subject: pendingExistingDraft.subject,
+        bodyPlaintext: pendingExistingDraft.bodyPlaintext,
+        bodyHtml: pendingExistingDraft.bodyHtml,
+        selectedAlias: pendingExistingDraft.selectedAlias,
+        cc: pendingExistingDraft.cc,
+        bcc: pendingExistingDraft.bcc,
+        attachments: pendingExistingDraft.attachments,
+        updatedAt: Date.parse(pendingExistingDraft.updatedAt),
+        aiDirective: pendingExistingDraft.aiDirective,
+        recipientContactId: pendingExistingDraft.recipientContactId,
+        recipientEmail: pendingExistingDraft.recipientEmail,
+        recipientPhone: pendingExistingDraft.recipientPhone,
+        replyContextThreadCursor: pendingExistingDraft.replyContext?.threadCursor ?? null,
+        forwardContext: pendingExistingDraft.forwardContext,
+      },
+    });
+    clearPendingExistingDraft();
+  }, [clearPendingExistingDraft, composerPane.mode, pendingExistingDraft]);
 
   useEffect(() => {
     if (composerPane.mode === "closed" || availableDrafts === null) {
@@ -446,6 +534,7 @@ export function useComposerDraftState({
             setAvailableDrafts((currentDrafts) =>
               removeDraftFromCache(currentDrafts, existingDraftId),
             );
+            removeDraft(existingDraftId);
             return;
           }
 
@@ -475,6 +564,15 @@ export function useComposerDraftState({
         setAvailableDrafts((currentDrafts) =>
           upsertDraftCache(currentDrafts, result.data),
         );
+        upsertDraft(
+          toDraftListItemViewModel({
+            draft: result.data,
+            composerPane,
+            state,
+            replyContext,
+            forwardContext,
+          }),
+        );
       })();
     }, 750);
 
@@ -488,8 +586,10 @@ export function useComposerDraftState({
     baselineSubject,
     composerPane,
     forwardContext,
+    removeDraft,
     replyContext,
     state,
+    upsertDraft,
   ]);
 
   return {

--- a/apps/web/app/inbox/_lib/filters.ts
+++ b/apps/web/app/inbox/_lib/filters.ts
@@ -21,6 +21,7 @@ export const INBOX_FILTERS: readonly FilterDefinition[] = [
   { id: "unread", label: "Unread", hint: "New inbound message" },
   { id: "follow-up", label: "Pending", hint: "Flagged by you" },
   { id: "archived", label: "Archived", hint: "Hidden from inbox" },
+  { id: "drafts", label: "Drafts", hint: "Saved while you type" },
   { id: "sent", label: "Sent", hint: "Last outbound 1:1 message" },
 ];
 

--- a/apps/web/app/inbox/_lib/selectors.ts
+++ b/apps/web/app/inbox/_lib/selectors.ts
@@ -3530,7 +3530,9 @@ async function readInboxListCacheData(input: {
   // unrelated inbox or archived rows.
   const primaryFilterForLoader: RepoFilter = isSearchActive
     ? "visible"
-    : input.filterId;
+    : input.filterId === "drafts"
+      ? "inbox"
+      : input.filterId;
   const [
     primaryProjectionPage,
     attentionScanProjectionPage,
@@ -4861,6 +4863,8 @@ function matchesServerFilter(
       return item.isUnread;
     case "follow-up":
       return item.needsFollowUp;
+    case "drafts":
+      return false;
     case "sent":
       return item.lastOutboundAt !== null;
     case "archived":

--- a/apps/web/app/inbox/_lib/view-models.ts
+++ b/apps/web/app/inbox/_lib/view-models.ts
@@ -26,6 +26,7 @@ export type InboxFilterId =
   | "inbox"
   | "unread"
   | "follow-up"
+  | "drafts"
   | "sent"
   | "archived";
 
@@ -33,6 +34,7 @@ export const INBOX_FILTER_IDS: readonly InboxFilterId[] = [
   "inbox",
   "unread",
   "follow-up",
+  "drafts",
   "sent",
   "archived",
 ];
@@ -432,6 +434,31 @@ export interface InboxComposerForwardContext {
   readonly originalBodyPlaintext: string;
   readonly originalBodyHtml: string | null;
   readonly defaultAlias: string | null;
+}
+
+export interface InboxDraftListItemViewModel {
+  readonly id: string;
+  readonly paneMode: "new_draft" | "replying" | "forwarding";
+  readonly channel: "email" | "sms" | "note";
+  readonly recipientContactId: string | null;
+  readonly recipientEmail: string | null;
+  readonly recipientPhone: string | null;
+  readonly recipientDisplayName: string | null;
+  readonly subject: string;
+  readonly bodyPlaintext: string;
+  readonly bodyHtml: string;
+  readonly selectedAlias: string | null;
+  readonly cc: readonly string[];
+  readonly bcc: readonly string[];
+  readonly attachments: readonly {
+    readonly filename: string;
+    readonly size: number;
+    readonly contentType: string;
+  }[];
+  readonly aiDirective: string;
+  readonly replyContext: InboxComposerReplyContext | null;
+  readonly forwardContext: InboxComposerForwardContext | null;
+  readonly updatedAt: string;
 }
 
 export interface InboxDetailTimelinePageViewModel {

--- a/apps/web/app/inbox/layout.tsx
+++ b/apps/web/app/inbox/layout.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 
 import { requireSession } from "@/src/server/auth/session";
 import { readWebEnv } from "@/src/server/env";
+import { getInboxDraftList } from "@/src/server/inbox/drafts";
 
 import { InboxShell } from "./_components/inbox-shell";
 import {
@@ -49,8 +50,9 @@ export default async function InboxLayout({
   });
   const env = readWebEnv();
 
-  const [list, composerAliases, smsSenders, healthBanner] = await Promise.all([
+  const [list, drafts, composerAliases, smsSenders, healthBanner] = await Promise.all([
     getInboxList("inbox"),
+    getInboxDraftList({ limit: 50 }),
     getInboxComposerAliases(),
     env.SMS_ENABLED ? getInboxSmsSenders() : Promise.resolve([]),
     getInboxIntegrationHealthBanner(),
@@ -59,6 +61,7 @@ export default async function InboxLayout({
   return (
     <InboxShell
       initialList={list}
+      initialDrafts={drafts}
       initialFilterId="inbox"
       composerAliases={composerAliases}
       outboundRateUsdPerSegment={env.TWILIO_OUTBOUND_RATE_USD_PER_SEGMENT}

--- a/apps/web/src/server/inbox/drafts.ts
+++ b/apps/web/src/server/inbox/drafts.ts
@@ -1,0 +1,210 @@
+import type { ContactRecord, TimelineItem } from "@as-comms/contracts";
+import { filterItemsAtOrAfterPlatformFullCaptureCutover } from "@/app/_lib/cutover";
+import { listComposerDraftsAction } from "@/src/server/composer/drafts";
+import { getStage1WebRuntime } from "@/src/server/stage1-runtime";
+import type {
+  InboxComposerReplyContext,
+  InboxDraftListItemViewModel,
+} from "@/app/inbox/_lib/view-models";
+
+const PLACEHOLDER_BODY_PREVIEWS = new Set([
+  "[Encrypted message — open in Gmail to read]",
+  "[Message body could not be extracted — open in Gmail]",
+]);
+
+const REPLY_SUBJECT_PREFIX_PATTERN = /^\s*(?:(?:re|fwd?)\s*:\s*)+/i;
+
+function normalizeInlineText(value: string | null): string | null {
+  if (value === null) {
+    return null;
+  }
+
+  const trimmed = value.replace(/\s+/gu, " ").trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+function buildReplySubject(subject: string | null): string {
+  const normalizedSubject = normalizeInlineText(subject);
+
+  if (normalizedSubject === null) {
+    return "";
+  }
+
+  const trimmedSubject = normalizeInlineText(
+    normalizedSubject.replace(REPLY_SUBJECT_PREFIX_PATTERN, ""),
+  );
+
+  return trimmedSubject === null ? "" : `Re: ${trimmedSubject}`;
+}
+
+function extractEmailAddresses(headerValue: string | null): readonly string[] {
+  if (headerValue === null) {
+    return [];
+  }
+
+  return Array.from(
+    new Set(
+      [...headerValue.matchAll(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/giu)]
+        .map((match) => match[0].trim().toLowerCase())
+        .filter((value) => value.length > 0),
+    ),
+  );
+}
+
+function buildReplyContext(input: {
+  readonly contact: ContactRecord;
+  readonly timelineItems: readonly TimelineItem[];
+  readonly defaultAlias: string | null;
+  readonly preferredThreadCursor: string | null;
+}): InboxComposerReplyContext {
+  const visibleTimelineItems = filterItemsAtOrAfterPlatformFullCaptureCutover(
+    input.timelineItems,
+  );
+  const inboundEmails = [...visibleTimelineItems]
+    .reverse()
+    .filter(
+      (item): item is Extract<TimelineItem, { family: "one_to_one_email" }> =>
+        item.family === "one_to_one_email" && item.direction === "inbound",
+    );
+  const latestInboundEmail = inboundEmails[0];
+  const preferredInboundEmail =
+    input.preferredThreadCursor === null
+      ? null
+      : (inboundEmails.find(
+          (item) => item.canonicalEventId === input.preferredThreadCursor,
+        ) ?? null);
+  const latestQuotableInboundEmail = inboundEmails.find(
+    (item) => !PLACEHOLDER_BODY_PREVIEWS.has((item.bodyPreview ?? "").trim()),
+  );
+  const replyAnchor = preferredInboundEmail ?? latestQuotableInboundEmail ?? null;
+
+  if (latestInboundEmail === undefined) {
+    return {
+      contactId: input.contact.id,
+      contactDisplayName: input.contact.displayName,
+      contactPrimaryPhone: input.contact.primaryPhone,
+      subject: "",
+      threadCursor: null,
+      threadId: null,
+      inReplyToRfc822: null,
+      defaultAlias: input.defaultAlias,
+      cc: [],
+    };
+  }
+
+  return {
+    contactId: input.contact.id,
+    contactDisplayName: input.contact.displayName,
+    contactPrimaryPhone: input.contact.primaryPhone,
+    subject: buildReplySubject((replyAnchor ?? latestInboundEmail).subject),
+    threadCursor: replyAnchor?.canonicalEventId ?? null,
+    threadId: (replyAnchor ?? latestInboundEmail).threadId ?? null,
+    inReplyToRfc822: (replyAnchor ?? latestInboundEmail).rfc822MessageId ?? null,
+    defaultAlias: input.defaultAlias,
+    cc: extractEmailAddresses((replyAnchor ?? latestInboundEmail).ccHeader),
+  };
+}
+
+function resolveRecipientDisplayName(input: {
+  readonly contact: ContactRecord | null;
+  readonly recipientEmail: string | null;
+  readonly recipientPhone: string | null;
+}): string | null {
+  return (
+    input.contact?.displayName ??
+    input.recipientEmail ??
+    input.recipientPhone ??
+    null
+  );
+}
+
+export async function getInboxDraftList(input: {
+  readonly limit: number;
+}): Promise<readonly InboxDraftListItemViewModel[]> {
+  const result = await listComposerDraftsAction({ limit: input.limit });
+
+  if (!result.ok) {
+    console.error("[inbox/drafts] failed to list composer drafts", result);
+    return [];
+  }
+
+  const runtime = await getStage1WebRuntime();
+  const recipientContactIds = Array.from(
+    new Set(
+      result.data.drafts
+        .map((draft) => draft.recipientContactId)
+        .filter((contactId): contactId is string => contactId !== null),
+    ),
+  );
+  const contacts = await Promise.all(
+    recipientContactIds.map(async (contactId) => [
+      contactId,
+      await runtime.repositories.contacts.findById(contactId),
+    ] as const),
+  );
+  const contactById = new Map(contacts);
+  const timelineItemsByContactId = new Map(
+    await Promise.all(
+      recipientContactIds.map(async (contactId) => [
+        contactId,
+        await runtime.timelinePresentation.listTimelineItemsByContactId(contactId),
+      ] as const),
+    ),
+  );
+
+  return result.data.drafts
+    .map((draft) => {
+      const contact =
+        draft.recipientContactId === null
+          ? null
+          : (contactById.get(draft.recipientContactId) ?? null);
+
+      return {
+        id: draft.id,
+        paneMode: draft.paneMode === "new-draft" ? "new_draft" : draft.paneMode,
+        channel: draft.channel,
+        recipientContactId: draft.recipientContactId,
+        recipientEmail: draft.recipientEmail,
+        recipientPhone: draft.recipientPhone,
+        recipientDisplayName: resolveRecipientDisplayName({
+          contact,
+          recipientEmail: draft.recipientEmail,
+          recipientPhone: draft.recipientPhone,
+        }),
+        subject: draft.subject,
+        bodyPlaintext: draft.bodyPlaintext,
+        bodyHtml: draft.bodyHtml,
+        selectedAlias: draft.selectedAlias,
+        cc: draft.cc,
+        bcc: draft.bcc,
+        attachments: draft.attachments,
+        aiDirective: draft.aiDirective,
+        replyContext:
+          draft.paneMode === "replying" && draft.recipientContactId !== null
+            ? (() => {
+                const contact = contactById.get(draft.recipientContactId) ?? null;
+                const timelineItems =
+                  timelineItemsByContactId.get(draft.recipientContactId) ?? [];
+
+                if (contact === null) {
+                  return null;
+                }
+
+                return buildReplyContext({
+                  contact,
+                  timelineItems,
+                  defaultAlias: draft.selectedAlias,
+                  preferredThreadCursor: draft.replyContextThreadCursor,
+                });
+              })()
+            : null,
+        forwardContext: draft.forwardContext,
+        updatedAt: draft.updatedAt,
+      } satisfies InboxDraftListItemViewModel;
+    })
+    .sort(
+      (left, right) =>
+        right.updatedAt.localeCompare(left.updatedAt) ||
+        right.id.localeCompare(left.id),
+    );
+}

--- a/apps/web/tests/unit/composer-canonical-modal.test.tsx
+++ b/apps/web/tests/unit/composer-canonical-modal.test.tsx
@@ -52,6 +52,7 @@ vi.mock("lucide-react", () => ({
   CornerUpLeft: iconMock("CornerUpLeft"),
   Database: iconMock("Database"),
   Eye: iconMock("Eye"),
+  FilePen: iconMock("FilePen"),
   FileIcon: iconMock("FileIcon"),
   FileText: iconMock("FileText"),
   Flag: iconMock("Flag"),
@@ -779,6 +780,7 @@ function TestApp() {
   return (
     <InboxClientProvider
       composerAliases={composerAliases}
+      initialDrafts={[]}
       currentActorId="user:operator"
     >
       <InboxKeyboardProvider>

--- a/apps/web/tests/unit/inbox-drafts-list.test.tsx
+++ b/apps/web/tests/unit/inbox-drafts-list.test.tsx
@@ -1,0 +1,264 @@
+import { createRequire } from "node:module";
+import React, { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { InboxClientProvider, useInboxClient } from "../../app/inbox/_components/inbox-client-provider";
+import { InboxDraftsList } from "../../app/inbox/_components/inbox-drafts-list";
+import type { InboxDraftListItemViewModel } from "../../app/inbox/_lib/view-models";
+
+Object.assign(globalThis, { React });
+
+const workerRequire = createRequire(import.meta.url);
+const { JSDOM } = workerRequire("jsdom") as {
+  readonly JSDOM: new (
+    html?: string,
+    options?: { readonly url?: string },
+  ) => {
+    readonly window: Window & typeof globalThis;
+  };
+};
+
+const deleteComposerDraftActionMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    ok: true,
+    data: { deletedCount: 1 },
+  }),
+);
+
+function iconMock(name: string) {
+  return (props: Record<string, unknown>) =>
+    createElement("svg", { "data-icon": name, ...props });
+}
+
+vi.mock("lucide-react", () => ({
+  FilePen: iconMock("FilePen"),
+  Mail: iconMock("Mail"),
+  Phone: iconMock("Phone"),
+  FileText: iconMock("FileText"),
+  Trash2: iconMock("Trash2"),
+}));
+
+vi.mock("@/src/server/composer/drafts", () => ({
+  deleteComposerDraftAction: deleteComposerDraftActionMock,
+}));
+
+function DraftProbe() {
+  const { composerPane, pendingExistingDraft } = useInboxClient();
+
+  return (
+    <output data-testid="draft-probe">
+      {composerPane.mode}:{pendingExistingDraft?.id ?? "none"}
+    </output>
+  );
+}
+
+const drafts: readonly InboxDraftListItemViewModel[] = [
+  {
+    id: "draft-email",
+    paneMode: "new_draft",
+    channel: "email",
+    recipientContactId: "contact-1",
+    recipientEmail: "maya@example.org",
+    recipientPhone: null,
+    recipientDisplayName: "Maya Lee",
+    subject: "Trip logistics",
+    bodyPlaintext: "Email body preview for the first draft.",
+    bodyHtml: "<p>Email body preview for the first draft.</p>",
+    selectedAlias: "forests@adventurescientists.org",
+    cc: [],
+    bcc: [],
+    attachments: [],
+    aiDirective: "",
+    replyContext: null,
+    forwardContext: null,
+    updatedAt: "2026-06-19T10:00:00.000Z",
+  },
+  {
+    id: "draft-sms",
+    paneMode: "replying",
+    channel: "sms",
+    recipientContactId: "contact-2",
+    recipientEmail: null,
+    recipientPhone: "+14065550123",
+    recipientDisplayName: "Alex Stone",
+    subject: "",
+    bodyPlaintext: "SMS body preview for the second draft.",
+    bodyHtml: "",
+    selectedAlias: null,
+    cc: [],
+    bcc: [],
+    attachments: [],
+    aiDirective: "",
+    replyContext: {
+      contactId: "contact-2",
+      contactDisplayName: "Alex Stone",
+      contactPrimaryPhone: "+14065550123",
+      subject: "Re: Trail question",
+      threadCursor: "event-2",
+      threadId: "thread-2",
+      inReplyToRfc822: "message-2",
+      defaultAlias: "forests@adventurescientists.org",
+      cc: [],
+    },
+    forwardContext: null,
+    updatedAt: "2026-06-19T11:00:00.000Z",
+  },
+  {
+    id: "draft-note",
+    paneMode: "replying",
+    channel: "note",
+    recipientContactId: "contact-3",
+    recipientEmail: null,
+    recipientPhone: null,
+    recipientDisplayName: "Robin North",
+    subject: "",
+    bodyPlaintext: "Note body preview for the third draft.",
+    bodyHtml: "",
+    selectedAlias: null,
+    cc: [],
+    bcc: [],
+    attachments: [],
+    aiDirective: "",
+    replyContext: {
+      contactId: "contact-3",
+      contactDisplayName: "Robin North",
+      contactPrimaryPhone: null,
+      subject: "",
+      threadCursor: null,
+      threadId: null,
+      inReplyToRfc822: null,
+      defaultAlias: null,
+      cc: [],
+    },
+    forwardContext: null,
+    updatedAt: "2026-06-19T12:00:00.000Z",
+  },
+];
+
+interface Session {
+  readonly container: HTMLElement;
+  readonly root: Root;
+  readonly cleanup: () => Promise<void>;
+}
+
+let activeSession: Session | null = null;
+
+async function mount(inputDrafts: readonly InboxDraftListItemViewModel[]): Promise<Session> {
+  const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+    url: "http://localhost/inbox",
+  });
+
+  Object.assign(globalThis, {
+    window: dom.window,
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    MouseEvent: dom.window.MouseEvent,
+  });
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(
+      <InboxClientProvider
+        composerAliases={[]}
+        initialDrafts={inputDrafts}
+        currentActorId="user-1"
+      >
+        <DraftProbe />
+        <InboxDraftsList />
+      </InboxClientProvider>,
+    );
+    await Promise.resolve();
+  });
+
+  const session = {
+    container,
+    root,
+    cleanup: async () => {
+      await act(async () => {
+        root.unmount();
+        await Promise.resolve();
+      });
+      dom.window.close();
+    },
+  };
+  activeSession = session;
+  return session;
+}
+
+afterEach(async () => {
+  deleteComposerDraftActionMock.mockClear();
+  await activeSession?.cleanup();
+  activeSession = null;
+});
+
+describe("inbox drafts list", () => {
+  it("renders the empty state when there are no drafts", async () => {
+    const session = await mount([]);
+
+    expect(session.container.textContent).toContain("No drafts");
+    expect(session.container.textContent).toContain(
+      "New drafts will appear here automatically as you type.",
+    );
+  });
+
+  it("renders email, sms, and note draft rows", async () => {
+    const session = await mount(drafts);
+
+    expect(session.container.textContent).toContain("Maya Lee");
+    expect(session.container.textContent).toContain("forests@adventurescientists.org");
+    expect(session.container.textContent).toContain("Trip logistics");
+    expect(session.container.textContent).toContain(
+      "Email body preview for the first draft.",
+    );
+    expect(session.container.textContent).toContain("SMS");
+    expect(session.container.textContent).toContain("Alex Stone");
+    expect(session.container.textContent).toContain("Note");
+    expect(session.container.textContent).toContain("Robin North");
+  });
+
+  it("opens the matching draft and switches the pane to the recorded mode", async () => {
+    const session = await mount(drafts);
+    const row = session.container.querySelector<HTMLElement>(
+      "[data-testid='draft-row:draft-note'] button",
+    );
+
+    if (row === null) {
+      throw new Error("draft row button not found");
+    }
+
+    await act(async () => {
+      row.click();
+      await Promise.resolve();
+    });
+
+    expect(
+      session.container.querySelector("[data-testid='draft-probe']")?.textContent,
+    ).toBe("replying:draft-note");
+  });
+
+  it("discards a draft row after calling deleteComposerDraftAction", async () => {
+    const session = await mount(drafts);
+    const discardButton = session.container.querySelector<HTMLButtonElement>(
+      "[data-testid='draft-row:draft-note'] [aria-label='Discard draft (no subject)']",
+    );
+
+    if (discardButton === null) {
+      throw new Error("discard button not found");
+    }
+
+    await act(async () => {
+      discardButton.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(deleteComposerDraftActionMock).toHaveBeenCalledWith({ id: "draft-note" });
+    expect(session.container.textContent).not.toContain("Robin North");
+  });
+});

--- a/apps/web/tests/unit/inbox-list-shell.test.tsx
+++ b/apps/web/tests/unit/inbox-list-shell.test.tsx
@@ -107,6 +107,7 @@ vi.mock("@/components/ui/dropdown-menu", () => {
 vi.mock("../../app/inbox/_components/icons", () => ({
   ArchiveBoxIcon: iconMock("ArchiveBoxIcon"),
   ChevronDownIcon: iconMock("ChevronDownIcon"),
+  FileEditIcon: iconMock("FileEditIcon"),
   FlagIcon: iconMock("FlagIcon"),
   FilterIcon: iconMock("FilterIcon"),
   InboxIcon: iconMock("InboxIcon"),
@@ -119,6 +120,13 @@ vi.mock("../../app/inbox/_components/icons", () => ({
   SearchXIcon: iconMock("SearchXIcon"),
   SendIcon: iconMock("SendIcon"),
   XIcon: iconMock("XIcon"),
+}));
+
+vi.mock("@/src/server/composer/drafts", () => ({
+  deleteComposerDraftAction: vi.fn().mockResolvedValue({
+    ok: true,
+    data: { deletedCount: 1 },
+  }),
 }));
 
 import {
@@ -252,6 +260,7 @@ function buildList(
       { id: "unread", label: "Unread", count: 3, hint: null },
       { id: "follow-up", label: "Pending", count: 2, hint: null },
       { id: "archived", label: "Archived", count: null, hint: null },
+      { id: "drafts", label: "Drafts", count: null, hint: null },
       { id: "sent", label: "Sent", count: null, hint: null },
     ],
     totals: {
@@ -313,7 +322,11 @@ async function mountInboxList(
 
   const renderList = (nextSearchProbe?: SearchProbeState) => {
     root.render(
-      <InboxClientProvider composerAliases={[]} currentActorId="user-1">
+      <InboxClientProvider
+        composerAliases={[]}
+        initialDrafts={[]}
+        currentActorId="user-1"
+      >
         {nextSearchProbe ? <SearchStateProbe {...nextSearchProbe} /> : null}
         <InboxList initialList={initialList} />
       </InboxClientProvider>,
@@ -596,6 +609,33 @@ describe("Inbox list shell", () => {
       filterButton.querySelector("[data-filter-active-indicator='true']"),
     ).not.toBeNull();
     expect(session.container.textContent).not.toContain("All projects");
+  });
+
+  it("highlights the drafts filter when drafts is active", async () => {
+    const session = await mountInboxList();
+    const filterButton = findButtonByLabel(session.container, "Filters");
+
+    await act(async () => {
+      filterButton.click();
+      await Promise.resolve();
+    });
+
+    const draftsButton = findButtonByText(session.container, "Drafts");
+
+    await act(async () => {
+      draftsButton.click();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      filterButton.click();
+      await Promise.resolve();
+    });
+
+    expect(findButtonByText(session.container, "Drafts").getAttribute("aria-pressed")).toBe("true");
+    expect(session.container.textContent).toContain("Drafts");
+
+    await session.cleanup();
   });
 
   it("collapses the filter pane when a pointerdown fires outside it", async () => {

--- a/apps/web/tests/unit/inbox-optimistic-send.test.tsx
+++ b/apps/web/tests/unit/inbox-optimistic-send.test.tsx
@@ -206,6 +206,7 @@ async function renderHarness(props: {
           InboxClientProvider,
           {
             composerAliases: [],
+            initialDrafts: [],
             currentActorId: "user-1",
             operatorDisplayName: "Operator Name",
             children: createElement(Harness, nextProps),

--- a/apps/web/tests/unit/inbox-selectors.test.ts
+++ b/apps/web/tests/unit/inbox-selectors.test.ts
@@ -1710,6 +1710,10 @@ describe("real inbox selectors", () => {
       label: "Archived",
       count: null,
     });
+    expect(filtersById.get("drafts")).toMatchObject({
+      label: "Drafts",
+      count: null,
+    });
     expect(filtersById.get("sent")).toMatchObject({
       label: "Sent",
       count: null,


### PR DESCRIPTION
## Summary
Brick C of [PRD #553](https://github.com/nico-kneler-as/as-comms-platform/issues/553). Surfaces the server-persisted composer drafts (Brick B) in the inbox UI — closes out the Drafts folder epic.

- **Drafts** entry in the inbox filter dropdown, between Archived and Sent.
- **Drafts list view** rendered inside the existing inbox shell when the drafts filter is active. Rows show recipient (contact-anchored → display name; otherwise email/phone), alias chip, channel chip (email/SMS/note), subject, body preview, last-edited relative time.
- **Click → open** in composer pre-hydrated with the saved state (reply/forward context restored when applicable). `openExistingDraft(draft)` on the inbox client provider; `use-composer-draft-state.ts` consumes the pending draft on next render and sets `draftIdRef` so subsequent saves UPDATE, not INSERT.
- **Discard from list** — trash affordance calls `deleteComposerDraftAction({ id })` and optimistically removes the row.
- Empty state copy when there are no drafts.

## Architecture
- New server selector `apps/web/src/server/inbox/drafts.ts` wraps `listComposerDraftsAction` (Brick B) and resolves `recipient_contact_id` against the inbox composition root for contact display names — keeps the existing boundary discipline.
- New client component `apps/web/app/inbox/_components/inbox-drafts-list.tsx`.
- Adds `FileEdit as FileEditIcon` to the inbox icon barrel; mock allowlists updated.

## What's NOT in this PR
- One-time localStorage "abandon" toast — deferred (optional polish in the brief).
- Drafts count badge on the filter row — explicitly deferred.

## Test plan
- [x] `pnpm typecheck` (16/16)
- [x] `pnpm lint` (16/16)
- [x] `pnpm boundaries`
- [x] `pnpm test:unit` (16/16 green; new `inbox-drafts-list.test.tsx`; updates to inbox-list-shell / inbox-selectors / canonical-modal mocks)
- [x] `pnpm build` (layout.tsx touched — Next.js routes verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)