### PR TITLE
fix(inbox): restore AI draft window proportions + flip Polish input source

### DIFF
--- a/apps/web/app/inbox/_components/composer-ai-draft-window.tsx
+++ b/apps/web/app/inbox/_components/composer-ai-draft-window.tsx
@@ -244,7 +244,7 @@ export function ComposerAiDraftWindow({
 
       <div className="min-w-0 px-3 pb-2.5 pt-2">
         {showsEmptyState ? (
-          <div className="space-y-2">
+          <div className="flex min-w-0 items-start gap-2">
             <textarea
               autoFocus
               value={directiveText}
@@ -269,7 +269,7 @@ export function ComposerAiDraftWindow({
                 accentClasses.textareaFocus,
               )}
             />
-            <div className="flex flex-wrap items-center gap-2">
+            <div className="flex shrink-0 flex-col gap-1.5">
               <DraftActionTrigger
                 disabled={runDraftDisabled}
                 disabledReason={runDraftDisabledReason}

--- a/apps/web/app/inbox/_components/inbox-composer.tsx
+++ b/apps/web/app/inbox/_components/inbox-composer.tsx
@@ -290,10 +290,9 @@ export function InboxComposerDetailPane({
         : !selectedAliasAiConfigured
           ? "AI is not configured for this project. Set it up in Settings → Integrations."
           : null;
-  const polishDisabled =
-    (state.activeTab === "sms" ? state.smsBody : state.body).trim().length === 0;
+  const polishDisabled = state.aiDirective.trim().length === 0;
   const polishDisabledReason = polishDisabled
-    ? "Type a message below to polish it."
+    ? "Type something to polish."
     : null;
   const aiWarningMessage = resolveAiWarningMessage(aiDraft);
   const sendAndSaveAvailability = resolveSendAndSaveForAiAvailability({

--- a/apps/web/app/inbox/_hooks/use-ai-draft-run.ts
+++ b/apps/web/app/inbox/_hooks/use-ai-draft-run.ts
@@ -194,22 +194,19 @@ export function useAiDraftRun({
       return;
     }
 
-    const operatorBody =
-      baseRequest.channel === "sms" ? state.smsBody.trim() : state.body.trim();
+    const operatorBody = state.aiDirective.trim();
 
     if (operatorBody.length === 0) {
       return;
     }
 
-    const operatorPrompt = state.aiDirective.trim();
     const request = {
       ...baseRequest,
       mode: "polish" as const,
       operatorBody,
-      operatorPrompt: operatorPrompt.length > 0 ? operatorPrompt : null,
+      operatorPrompt: null,
     };
-    const prompt =
-      request.operatorPrompt ?? "Polish the current draft";
+    const prompt = "Polish the current draft";
 
     startAiGeneration({ request, prompt });
 

--- a/apps/web/tests/unit/composer-canonical-modal.test.tsx
+++ b/apps/web/tests/unit/composer-canonical-modal.test.tsx
@@ -403,10 +403,10 @@ vi.mock("../../app/inbox/_components/composer-detail-surfaces", () => ({
                 "button",
                 {
                   type: "button",
-                  disabled: body.trim().length === 0,
+                  disabled: aiDirective.trim().length === 0,
                   title:
-                    body.trim().length === 0
-                      ? "Type a message below to polish it."
+                    aiDirective.trim().length === 0
+                      ? "Type something to polish."
                       : undefined,
                 },
                 "Polish",
@@ -1063,7 +1063,7 @@ describe("composer canonical modal", () => {
     expect(getByText("Draft with AI")).not.toBeNull();
     expect(getByText("Polish")).not.toBeNull();
     expect(getByText("Polish").getAttribute("title")).toBe(
-      "Type a message below to polish it.",
+      "Type something to polish.",
     );
 
     await click(getByText("Show Cc"));

--- a/apps/web/tests/unit/use-ai-draft-run.test.ts
+++ b/apps/web/tests/unit/use-ai-draft-run.test.ts
@@ -240,12 +240,12 @@ describe("useAiDraftRun", () => {
     expect(startAiTransition).toHaveBeenCalledOnce();
   });
 
-  it("runPolish dispatches a polish-mode request with operatorBody from state.body", () => {
+  it("runPolish dispatches a polish-mode request with operatorBody from state.aiDirective", () => {
     const startAiGeneration = vi.fn();
     const startAiTransition = vi.fn();
     const { controls } = setup({
-      body: "thx for reaching out. i can send that shortly.",
-      aiDirective: "more professional",
+      body: "existing body should not be used",
+      aiDirective: "thx for reaching out. i can send that shortly.",
       startAiGeneration,
       startAiTransition,
     });
@@ -261,18 +261,19 @@ describe("useAiDraftRun", () => {
         channel: "email",
         mode: "polish",
         operatorBody: "thx for reaching out. i can send that shortly.",
-        operatorPrompt: "more professional",
+        operatorPrompt: null,
       },
-      prompt: "more professional",
+      prompt: "Polish the current draft",
     });
     expect(startAiTransition).toHaveBeenCalledOnce();
   });
 
-  it("runPolish is a no-op when state.body is empty", () => {
+  it("runPolish is a no-op when state.aiDirective is empty", () => {
     const startAiGeneration = vi.fn();
     const startAiTransition = vi.fn();
     const { controls } = setup({
-      body: "   ",
+      body: "body text should be ignored",
+      aiDirective: "   ",
       startAiGeneration,
       startAiTransition,
     });


### PR DESCRIPTION
## Summary
Operator review of PR #552 flagged two issues — both fixed here in a single small frontend PR.

### Layout regression
The Polish landing in #552 collapsed the prominent empty-state row into a stacked vertical layout, visibly shrinking the AI draft window. Restored:
- Textarea returns to full-width with the original min-height
- The two action triggers (Draft with AI + Polish) now sit in a narrow column on the right, stacked vertically — same right-anchored visual rhythm as before Polish existed
- Polish visual weight unchanged (still secondary)

### Polish input-source flip
Polish previously read `state.body` and was disabled when body was empty. New mental model: the AI draft window's intent textarea (`state.aiDirective`) is the **single AI input** — both buttons act on it.

- `runPolish` reads `state.aiDirective.trim()` as `operatorBody`
- `polishDisabled` checks `state.aiDirective.trim().length === 0`
- Tooltip copy: `"Type something to polish."` (the previous "below" hint is wrong now)
- Composer body field is no longer read by any AI button

Server prompt (`buildPolishPrompt`) needed no change — the wire field name `operatorBody` still describes the text to polish; only the client input source flipped.

## Test plan
- [x] `pnpm typecheck` (16/16)
- [x] `pnpm lint` (16/16)
- [x] `pnpm boundaries`
- [x] `pnpm test:unit` (16/16, hook + canonical-modal tests updated)
- [ ] Manual: type intent into AI draft textarea → Polish enables → click → polished draft generated against the intent text
- [ ] Manual: empty intent → Polish disabled with "Type something to polish." tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)