### PR TITLE
feat(inbox,ai): include Tier 1 team voice guidelines in Polish prompt

### DIFF
--- a/apps/web/src/server/ai/retriever.ts
+++ b/apps/web/src/server/ai/retriever.ts
@@ -124,6 +124,15 @@ function buildTierFourGrounding(
   };
 }
 
+export async function loadGeneralVoiceEntry(
+  repositories: Pick<Stage1RepositoryBundle, "aiKnowledge">,
+) {
+  return repositories.aiKnowledge.findByScope({
+    scope: "global",
+    scopeKey: null,
+  });
+}
+
 export async function retrieveGrounding(
   repositories: AiRetrieverRepositories,
   input: Pick<
@@ -135,10 +144,7 @@ export async function retrieveGrounding(
   const [contact, generalTraining, projectContext, canonicalEvents] =
     await Promise.all([
       repositories.contacts.findById(input.contactId),
-      repositories.aiKnowledge.findByScope({
-        scope: "global",
-        scopeKey: null,
-      }),
+      loadGeneralVoiceEntry(repositories),
       input.projectId === null
         ? Promise.resolve(null)
         : // Connected sub-projects (per PR #388) clear their own

--- a/apps/web/src/server/composer/polish.ts
+++ b/apps/web/src/server/composer/polish.ts
@@ -6,6 +6,8 @@ import { z } from "zod";
 
 import { requireSession } from "@/src/server/auth/session";
 import { getAiProviderConfig } from "@/src/server/ai/provider";
+import { loadGeneralVoiceEntry } from "@/src/server/ai/retriever";
+import { getStage1WebRuntime } from "@/src/server/stage1-runtime";
 import type { UiResult } from "@/src/server/ui-result";
 
 const polishTextActionInputSchema = z.object({
@@ -20,6 +22,27 @@ const EMAIL_POLISH_SYSTEM_PROMPT =
 const SMS_POLISH_SYSTEM_PROMPT =
   "You are a text-polishing assistant for SMS. The operator will give you a draft SMS. Polish it: fix grammar and typos, tighten phrasing, and improve clarity while preserving the meaning and the facts. Keep it concise — target ~140 characters and never exceed 320 (two segments). Plain text only — no markdown, no signature, no salutation if the draft doesn't have one. Return only the polished text — no preamble, no commentary, no quotation marks around the output.";
 const SMS_POLISH_MAX_TOKENS = 120;
+
+function buildPolishSystemPrompt(input: {
+  readonly channel: "email" | "sms";
+  readonly generalVoiceContent: string | null;
+}): string {
+  const barePrompt =
+    input.channel === "sms"
+      ? SMS_POLISH_SYSTEM_PROMPT
+      : EMAIL_POLISH_SYSTEM_PROMPT;
+
+  if (input.generalVoiceContent === null || input.generalVoiceContent.trim() === "") {
+    return barePrompt;
+  }
+
+  return [
+    "[Tier 1 Voice Instructions]",
+    input.generalVoiceContent.trim(),
+    "",
+    barePrompt,
+  ].join("\n");
+}
 
 function unauthorizedError(requestId: string): UiResult<never> {
   return {
@@ -81,6 +104,7 @@ export async function polishTextAction(input: {
   }
 
   const provider = getAiProviderConfig();
+  const runtime = await getStage1WebRuntime();
 
   if (provider.invokeModel === null) {
     return {
@@ -93,12 +117,13 @@ export async function polishTextAction(input: {
   }
 
   try {
+    const generalVoiceEntry = await loadGeneralVoiceEntry(runtime.repositories);
     const modelResult = await provider.invokeModel({
       model: provider.model,
-      system:
-        parsedInput.data.channel === "sms"
-          ? SMS_POLISH_SYSTEM_PROMPT
-          : EMAIL_POLISH_SYSTEM_PROMPT,
+      system: buildPolishSystemPrompt({
+        channel: parsedInput.data.channel,
+        generalVoiceContent: generalVoiceEntry?.content ?? null,
+      }),
       messages: [
         {
           role: "user",

--- a/apps/web/tests/unit/composer-polish-action.test.ts
+++ b/apps/web/tests/unit/composer-polish-action.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const requireSession = vi.hoisted(() => vi.fn());
 const getAiProviderConfig = vi.hoisted(() => vi.fn());
 const invokeModel = vi.hoisted(() => vi.fn());
+const getStage1WebRuntime = vi.hoisted(() => vi.fn());
+const loadGeneralVoiceEntry = vi.hoisted(() => vi.fn());
 
 vi.mock("@/src/server/auth/session", () => ({
   requireSession,
@@ -12,6 +14,14 @@ vi.mock("@/src/server/ai/provider", () => ({
   getAiProviderConfig,
 }));
 
+vi.mock("@/src/server/stage1-runtime", () => ({
+  getStage1WebRuntime,
+}));
+
+vi.mock("@/src/server/ai/retriever", () => ({
+  loadGeneralVoiceEntry,
+}));
+
 import { polishTextAction } from "../../src/server/composer/polish";
 
 describe("polishTextAction", () => {
@@ -19,6 +29,12 @@ describe("polishTextAction", () => {
     requireSession.mockReset();
     requireSession.mockResolvedValue({ id: "user:nico" });
     invokeModel.mockReset();
+    getStage1WebRuntime.mockReset();
+    getStage1WebRuntime.mockResolvedValue({
+      repositories: {},
+    });
+    loadGeneralVoiceEntry.mockReset();
+    loadGeneralVoiceEntry.mockResolvedValue(null);
     getAiProviderConfig.mockReset();
     getAiProviderConfig.mockReturnValue({
       model: "claude-sonnet-4-6",
@@ -29,6 +45,19 @@ describe("polishTextAction", () => {
       estimateCostUsd: vi.fn(),
     });
   });
+
+  function getInvokedSystemPrompt(): string {
+    const invocation = invokeModel.mock.calls.at(-1)?.[0] as
+      | { readonly system: string }
+      | undefined;
+
+    expect(invocation).toBeDefined();
+    if (invocation === undefined) {
+      throw new Error("Expected invokeModel to be called.");
+    }
+
+    return invocation.system;
+  }
 
   it("returns a validation envelope for empty text", async () => {
     const result = await polishTextAction({
@@ -97,7 +126,56 @@ describe("polishTextAction", () => {
     });
   });
 
-  it("sends the exact sms system prompt", async () => {
+  it("prepends Tier 1 voice instructions when available for email", async () => {
+    loadGeneralVoiceEntry.mockResolvedValue({
+      content: "Team voice: warm, direct, no em-dashes, no buzzword preamble.",
+    });
+    invokeModel.mockResolvedValue({
+      text: "Polished email",
+      usage: { inputTokens: 10, outputTokens: 5 },
+      stopReason: "end_turn",
+      model: "claude-sonnet-4-6",
+    });
+
+    await polishTextAction({
+      text: "Raw body text",
+      channel: "email",
+    });
+
+    const systemPrompt = getInvokedSystemPrompt();
+    expect(systemPrompt).toContain("[Tier 1 Voice Instructions]");
+    expect(systemPrompt).toContain(
+      "Team voice: warm, direct, no em-dashes, no buzzword preamble.",
+    );
+    expect(systemPrompt).toContain("You are a text-polishing assistant.");
+  });
+
+  it("falls back to the bare prompt when Tier 1 is missing", async () => {
+    loadGeneralVoiceEntry.mockResolvedValue(null);
+    invokeModel.mockResolvedValue({
+      text: "Polished email",
+      usage: { inputTokens: 10, outputTokens: 5 },
+      stopReason: "end_turn",
+      model: "claude-sonnet-4-6",
+    });
+
+    await polishTextAction({
+      text: "Raw body text",
+      channel: "email",
+    });
+
+    expect(invokeModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        system:
+          "You are a text-polishing assistant. The operator will give you a draft message. Polish it: fix grammar and typos, tighten phrasing, and improve clarity while preserving the meaning, the facts, and the operator's voice. Do NOT add new information. Do NOT remove substantive content. Do NOT append a signature or sign-off. Return only the polished text — no preamble, no commentary, no quotation marks around the output.",
+      }),
+    );
+  });
+
+  it("prepends Tier 1 voice instructions for the sms variant", async () => {
+    loadGeneralVoiceEntry.mockResolvedValue({
+      content: "Team voice: warm, direct, no em-dashes, no buzzword preamble.",
+    });
     invokeModel.mockResolvedValue({
       text: "Polished sms",
       usage: { inputTokens: 8, outputTokens: 4 },
@@ -110,10 +188,10 @@ describe("polishTextAction", () => {
       channel: "sms",
     });
 
+    const systemPrompt = getInvokedSystemPrompt();
     expect(invokeModel).toHaveBeenCalledWith({
       model: "claude-sonnet-4-6",
-      system:
-        "You are a text-polishing assistant for SMS. The operator will give you a draft SMS. Polish it: fix grammar and typos, tighten phrasing, and improve clarity while preserving the meaning and the facts. Keep it concise — target ~140 characters and never exceed 320 (two segments). Plain text only — no markdown, no signature, no salutation if the draft doesn't have one. Return only the polished text — no preamble, no commentary, no quotation marks around the output.",
+      system: systemPrompt,
       messages: [
         {
           role: "user",
@@ -123,6 +201,12 @@ describe("polishTextAction", () => {
       maxTokens: 120,
       temperature: 0.3,
     });
+    expect(systemPrompt).toContain(
+      "Team voice: warm, direct, no em-dashes, no buzzword preamble.",
+    );
+    expect(systemPrompt).toContain(
+      "Keep it concise — target ~140 characters and never exceed 320 (two segments).",
+    );
   });
 
   it("returns the trimmed model output on success", async () => {


### PR DESCRIPTION
## Summary
Polish was producing em-dashes and other AI tells because it ran on a hardcoded minimal prompt with no team voice context. Draft-with-AI already loads a **Tier 1 general voice** entry from `ai_knowledge_entries` (`scope = 'global'`) — the rules that say "no em-dashes, warm and direct, no AI-style preamble." Polish should honor those same rules.

This PR wires Tier 1 into Polish — and only Tier 1. No Tier 2 project knowledge, no Tier 3 canonical examples, no contact / thread / inbound context. Polish stays a pure text utility; it just knows how the team writes.

## Changes
- **`retriever.ts`**: extracted `loadGeneralVoiceEntry()` so the global Tier 1 lookup is shared between the full bundle loader (Draft-with-AI) and Polish. Single source of truth, no drift.
- **`polish.ts`**: calls the helper, prepends Tier 1 content as a `[Tier 1 Voice Instructions]` block before the email/SMS polish-specific instructions. Polish instructions ("Return only the polished text…") stay verbatim and come after, so they apply on top of the voice rules. If no Tier 1 entry exists, Polish falls back to the bare prompt (never blocks or errors).
- **Tests**: new cases cover Tier 1 present, Tier 1 missing, and SMS variant with Tier 1 included.

## Test plan
- [x] `pnpm typecheck` (16/16)
- [x] `pnpm lint` (16/16)
- [x] `pnpm boundaries`
- [x] `pnpm test:unit` (16/16 — first run had a flaky timeout in unrelated `settings-selectors.test.ts`; clean on re-run)
- [ ] Manual: type a rough body containing nothing AI-like → click Polish → output should match team voice (no em-dashes, no "Certainly!" / "I hope this helps!" patterns) per the existing Tier 1 rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)